### PR TITLE
fix: Make MDT cleaner/rollback/finalize-write parallelism configurable

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -124,13 +124,6 @@ public class HoodieMetadataWriteUtils {
   // from the metadata payload schema.
   public static final String RECORD_KEY_FIELD_NAME = HoodieMetadataPayload.KEY_FIELD_NAME;
 
-  // MDT writes are always prepped. Hence, insert and upsert shuffle parallelism are not important to be configured. Same for delete
-  // parallelism as deletes are not used.
-  // The finalize, cleaner and rollback tasks will operate on each fileGroup so their parallelism should be as large as the total file groups.
-  // But it's not possible to accurately get the file group count here so keeping these values large enough. This parallelism would
-  // any ways be limited by the executor counts.
-  private static final int MDT_DEFAULT_PARALLELISM = 512;
-
   // File groups in each partition are fixed at creation time and we do not want them to be split into multiple files
   // ever. Hence, we use a very large basefile size in metadata table. The actual size of the HFiles created will
   // eventually depend on the number of file groups selected for each partition (See estimateFileGroupCount function)
@@ -186,7 +179,7 @@ public class HoodieMetadataWriteUtils {
     HoodieCleanConfig.Builder cleanConfigBuilder = HoodieCleanConfig.newBuilder()
         .withAsyncClean(DEFAULT_METADATA_ASYNC_CLEAN)
         .withAutoClean(false)
-        .withCleanerParallelism(MDT_DEFAULT_PARALLELISM)
+        .withCleanerParallelism(writeConfig.getMetadataConfig().getCleanerParallelism())
         .withFailedWritesCleaningPolicy(failedWritesCleaningPolicy)
         .withMaxCommitsBeforeCleaning(writeConfig.getCleanTriggerMaxCommits())
         .withCleanOptimizationWithLocalEngineEnabled(
@@ -265,8 +258,8 @@ public class HoodieMetadataWriteUtils {
             .withBloomFilterFpp(writeConfig.getMetadataConfig().getBloomFilterFpp())
             .withBloomFilterDynamicMaxEntries(writeConfig.getMetadataConfig().getDynamicBloomFilterMaxNumEntries())
             .build())
-        .withRollbackParallelism(MDT_DEFAULT_PARALLELISM)
-        .withFinalizeWriteParallelism(MDT_DEFAULT_PARALLELISM)
+        .withRollbackParallelism(writeConfig.getMetadataConfig().getRollbackParallelism())
+        .withFinalizeWriteParallelism(writeConfig.getMetadataConfig().getFinalizeWriteParallelism())
         .withKeyGenerator(HoodieTableMetadataKeyGenerator.class.getCanonicalName())
         .withPopulateMetaFields(DEFAULT_METADATA_POPULATE_META_FIELDS)
         .withWriteStatusClass(FailOnFirstErrorWriteStatus.class)

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
@@ -67,11 +67,14 @@ public class TestHoodieMetadataWriteUtils {
 
   @Test
   public void testCreateMetadataWriteConfigForCleaner() {
+    Properties properties = new Properties();
+    properties.setProperty(HoodieMetadataConfig.CLEANER_PARALLELISM.key(), "1000");
     HoodieWriteConfig writeConfig1 = HoodieWriteConfig.newBuilder()
         .withPath("/tmp/")
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
             .retainCommits(5).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withProperties(properties).build())
         .build();
 
     HoodieWriteConfig metadataWriteConfig1 = HoodieMetadataWriteUtils.createMetadataWriteConfig(writeConfig1, HoodieFailedWritesCleaningPolicy.EAGER,
@@ -81,6 +84,7 @@ public class TestHoodieMetadataWriteUtils {
     assertEquals(1, metadataWriteConfig1.getCleanTriggerMaxCommits());
     // default value already greater than data cleaner commits retained * 1.2
     assertEquals(HoodieMetadataConfig.DEFAULT_METADATA_CLEANER_COMMITS_RETAINED, metadataWriteConfig1.getCleanerCommitsRetained());
+    assertEquals(1000, metadataWriteConfig1.getCleanerParallelism());
 
     assertNotEquals(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS, metadataWriteConfig1.getCleanerPolicy());
     assertNotEquals(HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS, metadataWriteConfig1.getCleanerPolicy());
@@ -527,5 +531,36 @@ public class TestHoodieMetadataWriteUtils {
     } else {
       assertNull(metadataWriteConfig.getLockProviderClass());
     }
+  }
+
+  @Test
+  public void testParallelismConfigs() {
+    // default
+    testMetadataConfig(false, 512, 512, 512);
+    // overrides
+    testMetadataConfig(true, 10, 20, 10);
+    testMetadataConfig(true, 1000, 2000, 1000);
+  }
+
+  private void testMetadataConfig(boolean setParallelismConfigs, int cleanerParallelism, int rollbackParallelism, int finalizeWriteParallelism) {
+    Properties properties = new Properties();
+    if (setParallelismConfigs) {
+      properties.setProperty(HoodieMetadataConfig.CLEANER_PARALLELISM.key(), Integer.toString(cleanerParallelism));
+      properties.setProperty(HoodieMetadataConfig.ROLLBACK_PARALLELISM.key(), Integer.toString(rollbackParallelism));
+      properties.setProperty(HoodieMetadataConfig.FINALIZE_WRITE_PARALLELISM.key(), Integer.toString(finalizeWriteParallelism));
+    }
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
+            .retainCommits(5).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().withProperties(properties).build())
+        .build();
+    HoodieWriteConfig metadataWriteConfig = HoodieMetadataWriteUtils.createMetadataWriteConfig(writeConfig, HoodieFailedWritesCleaningPolicy.EAGER,
+        HoodieTableVersion.EIGHT);
+
+    assertEquals(cleanerParallelism, metadataWriteConfig.getCleanerParallelism());
+    assertEquals(rollbackParallelism, metadataWriteConfig.getRollbackParallelism());
+    assertEquals(finalizeWriteParallelism, metadataWriteConfig.getFinalizeWriteParallelism());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -683,6 +683,27 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "with the actual record count stored in the metadata table. This validation runs in a distributed manner "
           + "using the compute engine. Disabled by default as it adds overhead to the initialization process.");
 
+  public static final ConfigProperty<Integer> CLEANER_PARALLELISM = ConfigProperty
+      .key(METADATA_PREFIX + ".cleaner.parallelism")
+      .defaultValue(512)
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("Cleaner parallelism to use for metadata table.");
+
+  public static final ConfigProperty<Integer> ROLLBACK_PARALLELISM = ConfigProperty
+      .key(METADATA_PREFIX + ".rollback.parallelism")
+      .defaultValue(512)
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("Rollback parallelism to use for metadata table.");
+
+  public static final ConfigProperty<Integer> FINALIZE_WRITE_PARALLELISM = ConfigProperty
+      .key(METADATA_PREFIX + ".finalize.writes.parallelism")
+      .defaultValue(512)
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("Finalize write parallelism to use for metadata table.");
+
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
@@ -1018,6 +1039,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     checkArgument(indexName.startsWith(PARTITION_NAME_EXPRESSION_INDEX_PREFIX)
         || indexName.startsWith(PARTITION_NAME_SECONDARY_INDEX_PREFIX), "Unexpected index name to drop: " + indexName);
     return subIndexNameToDrop.contains(indexName);
+  }
+
+  public int getCleanerParallelism() {
+    return getInt(CLEANER_PARALLELISM);
+  }
+
+  public int getRollbackParallelism() {
+    return getInt(ROLLBACK_PARALLELISM);
+  }
+
+  public int getFinalizeWriteParallelism() {
+    return getInt(FINALIZE_WRITE_PARALLELISM);
   }
 
   public static class Builder {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -687,21 +687,21 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".cleaner.parallelism")
       .defaultValue(512)
       .markAdvanced()
-      .sinceVersion("1.2.0")
+      .sinceVersion("1.3.0")
       .withDocumentation("Cleaner parallelism to use for metadata table.");
 
   public static final ConfigProperty<Integer> ROLLBACK_PARALLELISM = ConfigProperty
       .key(METADATA_PREFIX + ".rollback.parallelism")
       .defaultValue(512)
       .markAdvanced()
-      .sinceVersion("1.2.0")
+      .sinceVersion("1.3.0")
       .withDocumentation("Rollback parallelism to use for metadata table.");
 
   public static final ConfigProperty<Integer> FINALIZE_WRITE_PARALLELISM = ConfigProperty
       .key(METADATA_PREFIX + ".finalize.writes.parallelism")
       .defaultValue(512)
       .markAdvanced()
-      .sinceVersion("1.2.0")
+      .sinceVersion("1.3.0")
       .withDocumentation("Finalize write parallelism to use for metadata table.");
 
   public long getMaxLogFileSize() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests {@link HoodieMetadataConfig}.
  */
 class TestHoodieMetadataConfig {
-
   @Test
   void testGetRecordPreparationParallelism() {
     // Test default value

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests {@link HoodieMetadataConfig}.
  */
 class TestHoodieMetadataConfig {
+
   @Test
   void testGetRecordPreparationParallelism() {
     // Test default value
@@ -268,5 +269,39 @@ class TestHoodieMetadataConfig {
         HoodieMetadataConfig.newBuilder()
             .withTableServiceManagerEnabled(true)
             .build());
+  }
+
+  @Test
+  public void testCleanerRollbackParallelism() {
+    // Test default value
+    HoodieMetadataConfig config = HoodieMetadataConfig.newBuilder().build();
+    assertEquals(512, config.getCleanerParallelism());
+    assertEquals(512, config.getRollbackParallelism());
+    assertEquals(512, config.getFinalizeWriteParallelism());
+
+    // Test custom value
+    Properties props = new Properties();
+    props.put(HoodieMetadataConfig.CLEANER_PARALLELISM.key(), "100");
+    props.put(HoodieMetadataConfig.ROLLBACK_PARALLELISM.key(), "100");
+    props.put(HoodieMetadataConfig.FINALIZE_WRITE_PARALLELISM.key(), "100");
+    HoodieMetadataConfig configWithCustomValue = HoodieMetadataConfig.newBuilder()
+        .fromProperties(props)
+        .build();
+    assertEquals(100, configWithCustomValue.getCleanerParallelism());
+    assertEquals(100, configWithCustomValue.getRollbackParallelism());
+    assertEquals(100, configWithCustomValue.getFinalizeWriteParallelism());
+
+    // Test zero value
+    Properties propsZero = new Properties();
+    props = new Properties();
+    props.put(HoodieMetadataConfig.CLEANER_PARALLELISM.key(), "0");
+    props.put(HoodieMetadataConfig.ROLLBACK_PARALLELISM.key(), "0");
+    props.put(HoodieMetadataConfig.FINALIZE_WRITE_PARALLELISM.key(), "0");
+    configWithCustomValue = HoodieMetadataConfig.newBuilder()
+        .fromProperties(props)
+        .build();
+    assertEquals(0, configWithCustomValue.getCleanerParallelism());
+    assertEquals(0, configWithCustomValue.getRollbackParallelism());
+    assertEquals(0, configWithCustomValue.getFinalizeWriteParallelism());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The metadata table previously hard-coded its cleaner, rollback, and finalize-write parallelism to a constant (`MDT_DEFAULT_PARALLELISM = 512`) inside `HoodieMetadataWriteUtils`. At TB scale where the MDT has many file groups, operators may want to tune these independently (e.g., to bound driver/executor footprint). With the constant, this required source changes.

### Summary and Changelog

Expose three new metadata-table-scoped configs in `HoodieMetadataConfig`, each defaulting to `512` to preserve existing behavior:
- `hoodie.metadata.cleaner.parallelism`
- `hoodie.metadata.rollback.parallelism`
- `hoodie.metadata.finalize.writes.parallelism`

Wire them through `HoodieMetadataWriteUtils.createMetadataWriteConfig()` via the new getters (`getCleanerParallelism`, `getRollbackParallelism`, `getFinalizeWriteParallelism`). Drop the now-redundant `MDT_DEFAULT_PARALLELISM` constant.

Added `TestHoodieMetadataConfig#testCleanerRollbackParallelism` covering default, custom, and zero values. Added `TestHoodieMetadataWriteUtils` coverage for the wiring through `createMetadataWriteConfig`.

### Impact

No default-behavior change — same `512` values apply unless an operator overrides them. New configs are marked `advanced` for power users tuning MDT operations on very large tables.

### Risk Level

low

### Documentation Update

Three new config keys are documented inline in `HoodieMetadataConfig` (description + `sinceVersion`). No website update needed since these are advanced operator-facing knobs.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
