### PR TITLE
refactor: Add Lombok annotations to hudi-timeline-service

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/HttpRequestClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/HttpRequestClient.java
@@ -78,7 +78,7 @@ public class HttpRequestClient {
     queryParameters.forEach(builder::addParameter);
 
     String url = builder.toString();
-    log.debug("Sending request : ( {} )", url);
+    log.debug("Sending request: ( {} )", url);
     Response response;
     int timeout = this.timeoutSecs * 1000; // msec
     switch (method) {

--- a/hudi-timeline-service/pom.xml
+++ b/hudi-timeline-service/pom.xml
@@ -72,6 +72,12 @@
       <artifactId>log4j-1.2-api</artifactId>
     </dependency>
 
+    <!-- Lombok -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+
     <!-- Hoodie -->
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/RequestHandler.java
@@ -52,9 +52,8 @@ import io.javalin.Javalin;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -71,10 +70,10 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * Main REST Handler class that handles and delegates calls to timeline relevant handlers.
  */
+@Slf4j
 public class RequestHandler {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
-  private static final Logger LOG = LoggerFactory.getLogger(RequestHandler.class);
   private static final TypeReference<List<String>> LIST_TYPE_REFERENCE = new TypeReference<List<String>>() {
   };
 
@@ -133,8 +132,8 @@ public class RequestHandler {
     final long jsonifyTime = timer.endTimer();
     metricsRegistry.add("WRITE_VALUE_CNT", 1);
     metricsRegistry.add("WRITE_VALUE_TIME", jsonifyTime);
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Jsonify TimeTaken={}", jsonifyTime);
+    if (log.isDebugEnabled()) {
+      log.debug("Jsonify TimeTaken={}", jsonifyTime);
     }
     return result;
   }
@@ -585,7 +584,7 @@ public class RequestHandler {
       try {
         ugi = UserGroupInformation.getCurrentUser();
       } catch (Exception e) {
-        LOG.error("Fail to get ugi", e);
+        log.error("Fail to get ugi", e);
         throw new HoodieException(e);
       }
     }
@@ -632,9 +631,9 @@ public class RequestHandler {
         } catch (RuntimeException re) {
           success = false;
           if (re instanceof BadRequestResponse) {
-            LOG.warn("Bad request response due to client view behind server view. {}", re.getMessage());
+            log.warn("Bad request response due to client view behind server view. {}", re.getMessage());
           } else {
-            LOG.error("Got runtime exception servicing request {}", context.queryString(), re);
+            log.error("Got runtime exception servicing request {}", context.queryString(), re);
           }
           throw re;
         } finally {
@@ -646,8 +645,8 @@ public class RequestHandler {
           metricsRegistry.add("TOTAL_CHECK_TIME", finalCheckTimeTaken);
           metricsRegistry.add("TOTAL_API_CALLS", 1);
 
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("TimeTakenMillis[Total={}, Refresh={}, handle={}, Check={}], Success={}, Query={}, Host={}, synced={}",
+          if (log.isDebugEnabled()) {
+            log.debug("TimeTakenMillis[Total={}, Refresh={}, handle={}, Check={}], Success={}, Query={}, Host={}, synced={}",
                     timeTakenMillis, refreshCheckTimeTaken, handleTimeTaken, finalCheckTimeTaken, success, context.queryString(), context.host(), synced);
           }
         }
@@ -664,8 +663,8 @@ public class RequestHandler {
       String timelineHashFromClient = getTimelineHashParam(ctx);
       HoodieTimeline localTimeline =
           viewManager.getFileSystemView(basePath).getTimeline().filterCompletedOrMajorOrMinorCompactionInstants();
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Client [ LastTs={}, TimelineHash={}], localTimeline={}",lastKnownInstantFromClient, timelineHashFromClient, localTimeline.getInstants());
+      if (log.isDebugEnabled()) {
+        log.debug("Client [ LastTs={}, TimelineHash={}], localTimeline={}",lastKnownInstantFromClient, timelineHashFromClient, localTimeline.getInstants());
       }
 
       if ((!localTimeline.getInstantsAsStream().findAny().isPresent())
@@ -693,8 +692,8 @@ public class RequestHandler {
         if (isLocalViewBehind(ctx)) {
           String lastKnownInstantFromClient = getLastInstantTsParam(ctx);
           HoodieTimeline localTimeline = viewManager.getFileSystemView(basePath).getTimeline();
-          if (LOG.isInfoEnabled()) {
-            LOG.info("Syncing view as client passed last known instant {} as last known instant but server has the following last instant on timeline: {}",
+          if (log.isInfoEnabled()) {
+            log.info("Syncing view as client passed last known instant {} as last known instant but server has the following last instant on timeline: {}",
                 lastKnownInstantFromClient, localTimeline.lastInstant());
           }
           view.sync();

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/AsyncTimelineServerBasedDetectionStrategy.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/AsyncTimelineServerBasedDetectionStrategy.java
@@ -24,8 +24,7 @@ import org.apache.hudi.exception.HoodieEarlyConflictDetectionException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.timeline.service.handlers.MarkerHandler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ConcurrentModificationException;
 import java.util.Set;
@@ -39,9 +38,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * trying to do early conflict detection by asynchronously and periodically checking
  * write conflict among multiple writers based on the timeline-server-based markers.
  */
+@Slf4j
 public class AsyncTimelineServerBasedDetectionStrategy extends TimelineServerBasedDetectionStrategy {
-
-  private static final Logger LOG = LoggerFactory.getLogger(AsyncTimelineServerBasedDetectionStrategy.class);
 
   private final AtomicBoolean hasConflict = new AtomicBoolean(false);
   private ScheduledExecutorService asyncDetectorExecutor;

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/BatchedMarkerCreationContext.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/BatchedMarkerCreationContext.java
@@ -18,40 +18,22 @@
 
 package org.apache.hudi.timeline.service.handlers.marker;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.util.List;
 
 /**
  * Input of batch processing of marker creation requests for a single marker directory.
  */
+@AllArgsConstructor
+@Getter
 public class BatchedMarkerCreationContext {
+
   private final String markerDir;
   private final MarkerDirState markerDirState;
   // List of marker creation futures to process
   private final List<MarkerCreationFuture> futures;
   // File index to use to write markers
   private final int fileIndex;
-
-  public BatchedMarkerCreationContext(String markerDir, MarkerDirState markerDirState,
-                                      List<MarkerCreationFuture> futures, int fileIndex) {
-    this.markerDir = markerDir;
-    this.markerDirState = markerDirState;
-    this.futures = futures;
-    this.fileIndex = fileIndex;
-  }
-
-  public String getMarkerDir() {
-    return markerDir;
-  }
-
-  public MarkerDirState getMarkerDirState() {
-    return markerDirState;
-  }
-
-  public List<MarkerCreationFuture> getFutures() {
-    return futures;
-  }
-
-  public int getFileIndex() {
-    return fileIndex;
-  }
 }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/BatchedMarkerCreationRunnable.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/BatchedMarkerCreationRunnable.java
@@ -20,16 +20,15 @@ package org.apache.hudi.timeline.service.handlers.marker;
 
 import org.apache.hudi.common.util.HoodieTimer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
 /**
  * A runnable for batch processing marker creation requests.
  */
+@Slf4j
 public class BatchedMarkerCreationRunnable implements Runnable {
-  private static final Logger LOG = LoggerFactory.getLogger(BatchedMarkerCreationRunnable.class);
 
   private final List<BatchedMarkerCreationContext> requestContextList;
 
@@ -39,13 +38,13 @@ public class BatchedMarkerCreationRunnable implements Runnable {
 
   @Override
   public void run() {
-    LOG.debug("Start processing create marker requests");
+    log.debug("Start processing create marker requests");
     HoodieTimer timer = HoodieTimer.start();
 
     for (BatchedMarkerCreationContext requestContext : requestContextList) {
       requestContext.getMarkerDirState().processMarkerCreationRequests(
           requestContext.getFutures(), requestContext.getFileIndex());
     }
-    LOG.debug("Finish batch processing of create marker requests in {} ms", timer.endTimer());
+    log.debug("Finish batch processing of create marker requests in {} ms", timer.endTimer());
   }
 }

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/MarkerBasedEarlyConflictDetectionRunnable.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/MarkerBasedEarlyConflictDetectionRunnable.java
@@ -29,8 +29,7 @@ import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.timeline.service.handlers.MarkerHandler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -40,8 +39,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class MarkerBasedEarlyConflictDetectionRunnable implements Runnable {
-  private static final Logger LOG = LoggerFactory.getLogger(MarkerBasedEarlyConflictDetectionRunnable.class);
 
   private final MarkerHandler markerHandler;
   private final String markerDir;
@@ -113,10 +112,10 @@ public class MarkerBasedEarlyConflictDetectionRunnable implements Runnable {
       if (!currentFileIDs.isEmpty()
           || (checkCommitConflict && MarkerUtils.hasCommitConflict(activeTimeline,
           currentInstantAllMarkers.stream().map(MarkerUtils::makerToPartitionAndFileID).collect(Collectors.toSet()), completedCommits))) {
-        LOG.error("Conflict writing detected based on markers!\nConflict markers: {}\nTable markers: {}", currentInstantAllMarkers, tableMarkers);
+        log.error("Conflict writing detected based on markers!\nConflict markers: {}\nTable markers: {}", currentInstantAllMarkers, tableMarkers);
         hasConflict.compareAndSet(false, true);
       }
-      LOG.info("Finish batching marker-based conflict detection in {} ms", timer.endTimer());
+      log.info("Finish batching marker-based conflict detection in {} ms", timer.endTimer());
 
     } catch (IOException e) {
       throw new HoodieIOException("IOException occurs during checking marker conflict");

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/MarkerCreationFuture.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/handlers/marker/MarkerCreationFuture.java
@@ -21,20 +21,24 @@ package org.apache.hudi.timeline.service.handlers.marker;
 import org.apache.hudi.common.util.HoodieTimer;
 
 import io.javalin.http.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Future for async marker creation request.
  */
+@Getter
+@Slf4j
 public class MarkerCreationFuture extends CompletableFuture<String> {
-  private static final Logger LOG = LoggerFactory.getLogger(MarkerCreationFuture.class);
+
   private final Context context;
   private final String markerDirPath;
   private final String markerName;
-  private boolean result;
+  private boolean isSuccessful;
+  @Getter(AccessLevel.NONE)
   private final HoodieTimer timer;
 
   public MarkerCreationFuture(Context context, String markerDirPath, String markerName) {
@@ -43,27 +47,11 @@ public class MarkerCreationFuture extends CompletableFuture<String> {
     this.context = context;
     this.markerDirPath = markerDirPath;
     this.markerName = markerName;
-    this.result = false;
+    this.isSuccessful = false;
   }
 
-  public Context getContext() {
-    return context;
-  }
-
-  public String getMarkerDirPath() {
-    return markerDirPath;
-  }
-
-  public String getMarkerName() {
-    return markerName;
-  }
-
-  public boolean isSuccessful() {
-    return result;
-  }
-
-  public void setResult(boolean result) {
-    LOG.debug("Request queued for {} ms", timer.endTimer());
-    this.result = result;
+  public void setIsSuccessful(boolean isSuccessful) {
+    log.debug("Request queued for {} ms", timer.endTimer());
+    this.isSuccessful = isSuccessful;
   }
 }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TimelineServiceTestHarness.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/TimelineServiceTestHarness.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 
+import lombok.Setter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.http.HttpResponse;
 import org.apache.http.NoHttpResponseException;
@@ -47,6 +48,7 @@ import java.util.Map;
 public class TimelineServiceTestHarness extends TimelineService {
 
   private static final String PROXY_ALL_URLS = "/*";
+  @Setter
   private int numberOfSimulatedConnectionFailures;
   private Option<Server> server;
   private int serverPort;
@@ -60,10 +62,6 @@ public class TimelineServiceTestHarness extends TimelineService {
         globalFileSystemViewManager);
     server = Option.empty();
     serverPort = 0;
-  }
-
-  public void setNumberOfSimulatedConnectionFailures(int numberOfSimulatedConnectionFailures) {
-    this.numberOfSimulatedConnectionFailures = numberOfSimulatedConnectionFailures;
   }
 
   @Override

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
@@ -40,10 +40,9 @@ import org.apache.hudi.timeline.service.TimelineServiceTestHarness;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -53,15 +52,14 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Bring up a remote Timeline Server and run all test-cases of TestHoodieTableFileSystemView against it.
  */
+@Slf4j
 public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSystemView {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestRemoteHoodieTableFileSystemView.class);
   private static int DEFAULT_READ_TIMEOUT_SECS = 60;
 
   private TimelineService server = null;
@@ -92,7 +90,7 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }
-    LOG.info("Connecting to Timeline Server :{}", server.getServerPort());
+    log.info("Connecting to Timeline Server: {}", server.getServerPort());
     view = initFsView(metaClient, server.getServerPort(), false);
     return view;
   }

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/handlers/marker/TestMarkerBasedEarlyConflictDetectionRunnable.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/handlers/marker/TestMarkerBasedEarlyConflictDetectionRunnable.java
@@ -27,14 +27,13 @@ import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.timeline.service.handlers.MarkerHandler;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
@@ -57,9 +56,8 @@ import static org.mockito.Mockito.when;
 /**
  * Tests {@link MarkerBasedEarlyConflictDetectionRunnable}.
  */
+@Slf4j
 public class TestMarkerBasedEarlyConflictDetectionRunnable extends HoodieCommonTestHarness {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestMarkerBasedEarlyConflictDetectionRunnable.class);
 
   @BeforeEach
   public void setUp() throws Exception {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR refactors the `hudi-timeline-service` modules to reduce boilerplate code by leveraging Project Lombok annotations. Specifically, it replaces explicit `Logger` instantiation, manual getter/setter methods, and empty constructors with their equivalent Lombok annotations (`@Slf4j`, `@Getter`, `@Setter`,`@NoArgsConstructor`, `@AllArgsConstructor`, `@Data`, `@Value`, `@ToString`).

This improves code readability and maintainability without altering the runtime logic.

### Summary and Changelog

This change introduces the Lombok dependency to the `hudi-timeline-service` modules and refactors several classes to utilize Lombok annotations.

- Added Lombok annotations wherever possible to `hudi-timeline-service` modules.

### Impact

- **Public API:** None.
- **User Experience:** No visible change for end-users.
- **Performance:** No impact (compile-time code generation).
- **Code Health:** Reduces lines of code and standardizes logging/accessor patterns.

### Risk Level

none

(This is a pure refactoring change involving standard library annotations; no business logic was modified.)

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
