### PR TITLE
docs: Improve the annotation format of examples

### DIFF
--- a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala
+++ b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala
@@ -34,9 +34,10 @@ import scala.collection.JavaConverters._
  * Simple examples of [[org.apache.hudi.DefaultSource]]
  *
  * To run this example, you should
+ *  <pre>
  *   1. For running in IDE, set VM options `-Dspark.master=local[2]`
- *      2. For running in shell, using `spark-submit`
- *
+ *   2. For running in shell, using `spark-submit`
+ *  </pre>
  * Usage: HoodieWriteClientExample <tablePath> <tableName>.
  * <tablePath> and <tableName> describe root path of hudi and table name
  * for example, `HoodieDataSourceExample file:///tmp/hoodie/hudi_cow_table hudi_cow_table`

--- a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala
+++ b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala
@@ -38,8 +38,10 @@ import scala.collection.JavaConverters._
 /**
  * Simple example to run a compaction job for MOR table.
  * To run this example, you should:
+ * <pre>
  *   1. For running in IDE, set VM options `-Dspark.master=local[2]`
  *   2. For running in shell, using `spark-submit`
+ * </pre>
  *
  * Usage: HoodieMorCompactionJob <tablePath> <tableName>.
  * <tablePath> and <tableName> describe root path of hudi and table name


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
Improve the annotation format of examples to improve readability


### Summary and Changelog

Improve doc readability

### Impact

None
### Risk Level

None

### Documentation Update

**Before：**
<img width="1388" height="260" alt="image" src="https://github.com/user-attachments/assets/9d985982-fa02-4752-8d85-e8613f060408" />

**After：**
<img width="1276" height="298" alt="image" src="https://github.com/user-attachments/assets/198e7435-3071-40a3-b38f-f74feead61c9" />


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
