### PR TITLE
perf(index): Use Set instead of ArrayList to reduce memory overhead in key lookup

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyLookupHandle.java
@@ -31,8 +31,8 @@ import org.apache.hudi.table.HoodieTable;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
@@ -95,7 +95,7 @@ public class HoodieKeyLookupHandle<T, I, K, O> extends HoodieReadHandle<T, I, K,
     log.debug("#The candidate row keys for {} => {}", partitionPathFileIDPair, candidateRecordKeys);
 
     HoodieBaseFile baseFile = getLatestBaseFile();
-    Collection<Pair<String, Long>> matchingKeysAndPositions = HoodieIndexUtils.filterKeysFromFile(
+    List<Pair<String, Long>> matchingKeysAndPositions = HoodieIndexUtils.filterKeysFromFile(
         baseFile.getStoragePath(), candidateRecordKeys, hoodieTable.getStorage());
     log.info("Total records ({}), bloom filter candidates ({})/fp({}), actual matches ({})", totalKeysChecked,
             candidateRecordKeys.size(), candidateRecordKeys.size() - matchingKeysAndPositions.size(), matchingKeysAndPositions.size());


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR optimizes the bloom index key lookup by using `Set` instead of `ArrayList` for storing candidate record keys. ArrayList has large memory overhead which occurs when the ArrayList grows beyond its initially allocated size. Set is better suited to an exists check and avoids the need to copy the collection when calling `filterRowKeys()`.

### Summary and Changelog

- Changed `candidateRecordKeys` in `HoodieKeyLookupHandle` from `ArrayList<String>` to `HashSet<String>`
- Updated `filterKeysFromFile` method signature in `HoodieIndexUtils` to accept `Set<String>` instead of `List<String>`
- Removed unnecessary `.stream().collect(Collectors.toSet())` call since the input is already a Set

### Impact

No public API changes. This is an internal optimization that reduces memory overhead when looking up a large number of keys during bloom index operations.

### Risk Level

low - This is a straightforward type change from ArrayList to HashSet with no behavioral changes. The Set semantics are actually more appropriate since we're checking for key existence.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable