### PR TITLE
feat: Introduce the configuration for forcibly triggering timeline compaction

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
@@ -102,6 +102,14 @@ public class HoodieArchivalConfig extends HoodieConfig {
       .withDocumentation("If enabled, archival will proceed beyond savepoint, skipping savepoint commits."
           + " If disabled, archival will stop at the earliest savepoint commit.");
 
+  public static final ConfigProperty<Boolean> TIMELINE_COMPACTION_FORCED = ConfigProperty
+      .key("hoodie.timeline.compaction.forced")
+      .defaultValue(true)
+      .markAdvanced()
+      .withDocumentation("If enabled, timeline compaction will be forced to run during archival of timeline."
+          + " This helps in reducing the number of files in the archived timeline, at the cost of"
+          + " additional compaction time during archival.");
+
   public static final ConfigProperty<Long> TIMELINE_COMPACTION_TARGET_FILE_MAX_BYTES = ConfigProperty
         .key("hoodie.timeline.compaction.target.file.max.bytes")
         .defaultValue(1000L * 1024 * 1024)
@@ -195,6 +203,11 @@ public class HoodieArchivalConfig extends HoodieConfig {
 
     public Builder withArchiveBeyondSavepoint(boolean archiveBeyondSavepoint) {
       archivalConfig.setValue(ARCHIVE_BEYOND_SAVEPOINT, String.valueOf(archiveBeyondSavepoint));
+      return this;
+    }
+
+    public Builder withTimelineCompactionForced(boolean timelineCompactionForced) {
+      archivalConfig.setValue(TIMELINE_COMPACTION_FORCED, String.valueOf(timelineCompactionForced));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1916,6 +1916,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE);
   }
 
+  public boolean isTimelineCompactionForced() {
+    return getBoolean(HoodieArchivalConfig.TIMELINE_COMPACTION_FORCED);
+  }
+
   public Boolean shouldCleanBootstrapBaseFile() {
     return getBoolean(HoodieCleanConfig.CLEANER_BOOTSTRAP_BASE_FILE_ENABLE);
   }


### PR DESCRIPTION
1. Introduce the configuration for forcibly triggering timeline compaction

### Describe the issue this Pull Request addresses

closes #17778 

### Summary and Changelog

1. Introduce the configuration for forcibly triggering timeline compaction
### Impact

none

### Risk Level

low

### Documentation Update

none

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
