### PR TITLE
refactor: Remove Builder from DynamoDbBasedLockConfig

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProvider.java
@@ -46,8 +46,7 @@ public class DynamoDBBasedLockProvider extends DynamoDBBasedLockProviderBase {
 
   @Override
   public String getDynamoDBPartitionKey(LockConfiguration lockConfiguration) {
-    DynamoDbBasedLockConfig config = new DynamoDbBasedLockConfig.Builder()
-        .fromProperties(lockConfiguration.getConfig()).build();
+    DynamoDbBasedLockConfig config = DynamoDbBasedLockConfig.from(lockConfiguration.getConfig());
     ValidationUtils.checkArgument(
         config.contains(DYNAMODB_LOCK_PARTITION_KEY),
         "Config key is not found: " + DYNAMODB_LOCK_PARTITION_KEY.key());

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProviderBase.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedLockProviderBase.java
@@ -80,9 +80,7 @@ public abstract class DynamoDBBasedLockProviderBase implements LockProvider<Lock
   protected volatile LockItem lock;
 
   protected DynamoDBBasedLockProviderBase(final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf, DynamoDbClient dynamoDB) {
-    this.dynamoDbBasedLockConfig = new DynamoDbBasedLockConfig.Builder()
-        .fromProperties(lockConfiguration.getConfig())
-        .build();
+    this.dynamoDbBasedLockConfig = DynamoDbBasedLockConfig.from(lockConfiguration.getConfig());
     this.tableName = dynamoDbBasedLockConfig.getString(DynamoDbBasedLockConfig.DYNAMODB_LOCK_TABLE_NAME);
     long leaseDuration = dynamoDbBasedLockConfig.getInt(DynamoDbBasedLockConfig.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY);
     dynamoDBPartitionKey = getDynamoDBPartitionKey(lockConfiguration);

--- a/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/config/DynamoDbBasedLockConfig.java
@@ -28,6 +28,8 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.RegionMetadata;
 import software.amazon.awssdk.services.dynamodb.model.BillingMode;
@@ -41,11 +43,8 @@ import software.amazon.awssdk.services.dynamodb.model.BillingMode;
     description = "Configs that control DynamoDB based locking mechanisms required for concurrency control "
         + " between writers to a Hudi table. Concurrency between Hudi's own table services "
         + " are auto managed internally.")
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class DynamoDbBasedLockConfig extends HoodieConfig {
-
-  public static DynamoDbBasedLockConfig.Builder newBuilder() {
-    return new DynamoDbBasedLockConfig.Builder();
-  }
 
   // configs for DynamoDb based locks
   public static final String DYNAMODB_BASED_LOCK_PROPERTY_PREFIX = LockConfiguration.LOCK_PREFIX + "dynamodb.";
@@ -132,31 +131,12 @@ public class DynamoDbBasedLockConfig extends HoodieConfig {
       .sinceVersion("0.10.0")
       .withDocumentation("Lock Acquire Wait Timeout in milliseconds");
 
-  /**
-   * Builder for {@link DynamoDbBasedLockConfig}.
-   */
-  public static class Builder {
-    private final DynamoDbBasedLockConfig lockConfig = new DynamoDbBasedLockConfig();
-
-    public DynamoDbBasedLockConfig build() {
-      lockConfig.setDefaults(DynamoDbBasedLockConfig.class.getName());
-      checkRequiredProps();
-      return lockConfig;
-    }
-
-    public Builder fromProperties(TypedProperties props) {
-      lockConfig.getProps().putAll(props);
-      return this;
-    }
-
-    private void checkRequiredProps() {
-      String errorMsg = "Config key is not found: ";
-      ValidationUtils.checkArgument(
-          lockConfig.contains(DYNAMODB_LOCK_TABLE_NAME.key()),
-          errorMsg + DYNAMODB_LOCK_TABLE_NAME.key());
-      ValidationUtils.checkArgument(
-          lockConfig.contains(DYNAMODB_LOCK_REGION.key()),
-          errorMsg + DYNAMODB_LOCK_REGION.key());
-    }
+  public static DynamoDbBasedLockConfig from(TypedProperties properties) {
+    DynamoDbBasedLockConfig config = new DynamoDbBasedLockConfig();
+    config.getProps().putAll(properties);
+    config.setDefaults(DynamoDbBasedLockConfig.class.getName());
+    ValidationUtils.checkArgument(config.contains(DYNAMODB_LOCK_TABLE_NAME.key()), "Config key is not found: " + DYNAMODB_LOCK_TABLE_NAME.key());
+    ValidationUtils.checkArgument(config.contains(DYNAMODB_LOCK_REGION.key()), "Config key is not found: " + DYNAMODB_LOCK_REGION.key());
+    return config;
   }
 }


### PR DESCRIPTION
- Remove Builder that is not following builder pattern at all
- Remove Builder that is just wrapping TypedProperties

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Refactoring Hudi class to remove boilerplate codes. 
`DynamoDbBasedLockConfig` has a Builder class, but it is not following the builder pattern at all, which makes it impossible for us to use the`@Builder` annotation.

The "Builder" is just wrapping a `TypedProperties` object and doing validation, where no individual fields to set.

As such, this refactoring removes the misapplied pattern, and hence code smell


### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

Remove code smell caused by misapplied design pattern used.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

Improve code quality.
As we are systematically going down each module to remove builder patterns, this will help remove false-positives of builder classes that can be replaced by Lombok's `@Builder` that will be flagged too.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

None.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None.

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
