### PR TITLE
refactor: Add Lombok Builders to HoodieFileGroupReader, InputSplit, ReaderParameters

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
@@ -242,10 +242,12 @@ public class HoodieLogFileCommand {
           Option.empty(),
           Option.empty(),
           fileGroupReaderProperties);
-      try (HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>newBuilder()
+      try (HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>builder()
           .withReaderContext(readerContext)
           .withHoodieTableMetaClient(HoodieCLI.getTableMetaClient())
-          .withFileSlice(fileSlice)
+          .withBaseFileOption(fileSlice.getBaseFile())
+          .withLogFiles(fileSlice.getLogFiles())
+          .withPartitionPath(fileSlice.getPartitionPath())
           .withDataSchema(readerSchema)
           .withRequestedSchema(readerSchema)
           .withLatestCommitTime(client.getActiveTimeline().getCommitAndReplaceTimeline().lastInstant().map(HoodieInstant::requestedTime).orElse(HoodieInstantTimeGenerator.getCurrentInstantTimeStr()))

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -319,14 +319,16 @@ public class HoodieIndexUtils {
       Option<InternalSchema> internalSchemaOption = SerDeHelper.fromJson(config.getInternalSchema());
       FileSlice fileSlice = fileSliceOption.get();
       HoodieReaderContext<R> readerContext = readerContextFactory.getContext();
-      HoodieFileGroupReader<R> fileGroupReader = HoodieFileGroupReader.<R>newBuilder()
+      HoodieFileGroupReader<R> fileGroupReader = HoodieFileGroupReader.<R>builder()
           .withReaderContext(readerContext)
           .withHoodieTableMetaClient(metaClient)
           .withLatestCommitTime(instantTime.get())
-          .withFileSlice(fileSlice)
+          .withBaseFileOption(fileSlice.getBaseFile())
+          .withLogFiles(fileSlice.getLogFiles())
+          .withPartitionPath(fileSlice.getPartitionPath())
           .withDataSchema(dataSchema)
           .withRequestedSchema(dataSchema)
-          .withInternalSchema(internalSchemaOption)
+          .withInternalSchemaOpt(internalSchemaOption)
           .withProps(metaClient.getTableConfig().getProps())
           .build();
       try {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedAppendHandle.java
@@ -82,10 +82,20 @@ public class FileGroupReaderBasedAppendHandle<T, I, K, O> extends HoodieAppendHa
         new HoodieLogFile(new StoragePath(FSUtils.constructAbsolutePath(
             config.getBasePath(), operation.getPartitionPath()), logFileName)));
     // Initializes the record iterator, log compaction requires writing the deletes into the delete block of the resulting log file.
-    try (HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>newBuilder().withReaderContext(readerContext).withHoodieTableMetaClient(hoodieTable.getMetaClient())
-        .withLatestCommitTime(instantTime).withPartitionPath(partitionPath).withLogFiles(logFiles).withBaseFileOption(Option.empty()).withDataSchema(writeSchemaWithMetaFields)
-        .withRequestedSchema(writeSchemaWithMetaFields).withInternalSchema(internalSchemaOption).withProps(props).withEmitDelete(true)
-        .withShouldUseRecordPosition(usePosition).withSortOutput(hoodieTable.requireSortedRecords())
+    try (HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>builder()
+        .withReaderContext(readerContext)
+        .withHoodieTableMetaClient(hoodieTable.getMetaClient())
+        .withLatestCommitTime(instantTime)
+        .withPartitionPath(partitionPath)
+        .withLogFiles(logFiles)
+        .withBaseFileOption(Option.empty())
+        .withDataSchema(writeSchemaWithMetaFields)
+        .withRequestedSchema(writeSchemaWithMetaFields)
+        .withInternalSchemaOpt(internalSchemaOption)
+        .withProps(props)
+        .withEmitDelete(true)
+        .withShouldUseRecordPosition(usePosition)
+        .withSortOutput(hoodieTable.requireSortedRecords())
         // instead of using config.enableOptimizedLogBlocksScan(), we set to true as log compaction blocks only supported in scanV2
         .build()) {
       recordItr = new CloseableMappingIterator<>(fileGroupReader.getLogRecordsOnly(), record -> {
@@ -96,7 +106,7 @@ public class FileGroupReaderBasedAppendHandle<T, I, K, O> extends HoodieAppendHa
       header.put(HoodieLogBlock.HeaderMetadataType.COMPACTED_BLOCK_TIMES,
           StringUtils.join(fileGroupReader.getValidBlockInstants(), ","));
       super.doAppend();
-      this.readStats = fileGroupReader.getStats();
+      this.readStats = fileGroupReader.getReadStats();
     } catch (IOException e) {
       throw new HoodieIOException("Failed to initialize file group reader for " + fileId, e);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
@@ -301,7 +301,7 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
 
         // The stats of inserts, updates, and deletes are updated once at the end
         // These will be set in the write stat when closing the merge handle
-        this.readStats = fileGroupReader.getStats();
+        this.readStats = fileGroupReader.getReadStats();
         this.insertRecordsWritten = readStats.getNumInserts();
         this.updatedRecordsWritten = readStats.getNumUpdates();
         this.recordsDeleted = readStats.getNumDeletes();
@@ -318,10 +318,10 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
 
   private HoodieFileGroupReader<T> getFileGroupReader(boolean usePosition, Option<InternalSchema> internalSchemaOption, TypedProperties props,
                                                         Option<Stream<HoodieLogFile>> logFileStreamOpt, Iterator<HoodieRecord<T>> incomingRecordsItr) {
-    HoodieFileGroupReader.Builder<T> fileGroupBuilder = HoodieFileGroupReader.<T>newBuilder().withReaderContext(readerContext).withHoodieTableMetaClient(hoodieTable.getMetaClient())
+    HoodieFileGroupReader.HoodieFileGroupReaderBuilder<T> fileGroupBuilder = HoodieFileGroupReader.<T>builder().withReaderContext(readerContext).withHoodieTableMetaClient(hoodieTable.getMetaClient())
         .withLatestCommitTime(maxInstantTime).withPartitionPath(partitionPath).withBaseFileOption(Option.ofNullable(baseFileToMerge))
         .withDataSchema(writeSchemaWithMetaFields).withRequestedSchema(writeSchemaWithMetaFields)
-        .withInternalSchema(internalSchemaOption).withProps(props)
+        .withInternalSchemaOpt(internalSchemaOption).withProps(props)
         .withShouldUseRecordPosition(usePosition).withSortOutput(hoodieTable.requireSortedRecords())
         .withFileGroupUpdateCallback(createCallback());
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -997,14 +997,16 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       HoodieSchema requestedSchema = metaClient.getTableConfig().populateMetaFields() ? getRecordKeySchema()
           : HoodieSchemaUtils.projectSchema(dataSchema, Arrays.asList(metaClient.getTableConfig().getRecordKeyFields().orElse(new String[0])));
       Option<InternalSchema> internalSchemaOption = SerDeHelper.fromJson(dataWriteConfig.getInternalSchema());
-      HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>newBuilder()
+      HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>builder()
           .withReaderContext(readerContext)
           .withHoodieTableMetaClient(metaClient)
-          .withFileSlice(fileSlice)
+          .withBaseFileOption(fileSlice.getBaseFile())
+          .withLogFiles(fileSlice.getLogFiles())
+          .withPartitionPath(fileSlice.getPartitionPath())
           .withLatestCommitTime(instantTime.get())
           .withDataSchema(dataSchema)
           .withRequestedSchema(requestedSchema)
-          .withInternalSchema(internalSchemaOption)
+          .withInternalSchemaOpt(internalSchemaOption)
           .withShouldUseRecordPosition(false)
           .withProps(metaClient.getTableConfig().getProps())
           .build();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/ClusteringExecutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/ClusteringExecutionStrategy.java
@@ -142,9 +142,18 @@ public abstract class ClusteringExecutionStrategy<T, I, K, O> implements Seriali
                                                                    ReaderContextFactory<R> readerContextFactory, String instantTime,
                                                                    TypedProperties properties, boolean usePosition) {
     HoodieReaderContext<R> readerContext = readerContextFactory.getContext();
-    return HoodieFileGroupReader.<R>newBuilder()
-        .withReaderContext(readerContext).withHoodieTableMetaClient(metaClient).withLatestCommitTime(instantTime)
-        .withFileSlice(fileSlice).withDataSchema(readerSchema).withRequestedSchema(readerSchema).withInternalSchema(internalSchemaOption)
-        .withShouldUseRecordPosition(usePosition).withProps(properties).build();
+    return HoodieFileGroupReader.<R>builder()
+        .withReaderContext(readerContext)
+        .withHoodieTableMetaClient(metaClient)
+        .withLatestCommitTime(instantTime)
+        .withBaseFileOption(fileSlice.getBaseFile())
+        .withLogFiles(fileSlice.getLogFiles())
+        .withPartitionPath(fileSlice.getPartitionPath())
+        .withDataSchema(readerSchema)
+        .withRequestedSchema(readerSchema)
+        .withInternalSchemaOpt(internalSchemaOption)
+        .withShouldUseRecordPosition(usePosition)
+        .withProps(properties)
+        .build();
   }
 }

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -946,7 +946,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(HoodieSchema.fromAvroSchema(HoodieMetadataRecord.getClassSchema()));
     HoodieAvroReaderContext readerContext = new HoodieAvroReaderContext(metadataMetaClient.getStorageConf(), metadataMetaClient.getTableConfig(), Option.empty(), Option.empty(),
         new TypedProperties());
-    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>newBuilder()
+    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metadataMetaClient)
         .withLogFiles(logFiles.stream())

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -335,7 +335,7 @@ public class SparkMetadataWriterUtils {
       baseFileOption = Option.empty();
       logFileStream = Stream.of(new HoodieLogFile(filePath));
     }
-    HoodieFileGroupReader<InternalRow> fileGroupReader = HoodieFileGroupReader.<InternalRow>newBuilder()
+    HoodieFileGroupReader<InternalRow> fileGroupReader = HoodieFileGroupReader.<InternalRow>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metaClient)
         .withDataSchema(tableSchema)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDMetadataWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDMetadataWriteClient.java
@@ -218,10 +218,12 @@ public class TestSparkRDDMetadataWriteClient extends HoodieClientTestBase {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(metadataSchema);
 
     HoodieAvroReaderContext readerContext = new HoodieAvroReaderContext(metadataMetaClient.getStorageConf(), metadataMetaClient.getTableConfig(), Option.of(instantRange), Option.of(predicate));
-    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>newBuilder()
+    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metadataMetaClient)
-        .withFileSlice(fileSlice)
+        .withBaseFileOption(fileSlice.getBaseFile())
+        .withLogFiles(fileSlice.getLogFiles())
+        .withPartitionPath(fileSlice.getPartitionPath())
         .withLatestCommitTime(validMetadataInstant)
         .withRequestedSchema(metadataSchema)
         .withDataSchema(schema)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedTableMetadata.java
@@ -560,7 +560,7 @@ public class TestHoodieBackedTableMetadata extends TestHoodieMetadataBase {
   private void verifyMetadataMergedRecords(HoodieTableMetaClient metadataMetaClient, List<HoodieLogFile> logFiles, String latestCommitTimestamp, HoodieWriteConfig metadataTableWriteConfig) {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(HoodieSchema.fromAvroSchema(HoodieMetadataRecord.getClassSchema()));
     HoodieAvroReaderContext readerContext = new HoodieAvroReaderContext(metadataMetaClient.getStorageConf(), metadataMetaClient.getTableConfig(), Option.empty(), Option.empty());
-    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>newBuilder()
+    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metadataMetaClient)
         .withLogFiles(logFiles.stream())

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/ReaderParameters.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/ReaderParameters.java
@@ -19,78 +19,38 @@
 
 package org.apache.hudi.common.table.read;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
 /**
  * Parameters for how the reader should process the FileGroup while reading.
  */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
 public class ReaderParameters {
+
   // Rely on the position of the record in the file instead of the record keys while merging data between base and log files
-  private final boolean useRecordPosition;
+  @Getter(AccessLevel.NONE)
+  @Builder.Default
+  private final boolean shouldUseRecordPosition = false;
   // Whether to emit delete records while reading
-  private final boolean emitDelete;
+  @Builder.Default
+  private final boolean emitDeletes = false;
   // Whether to sort the output records while reading, this implicitly requires the base file to be sorted
-  private final boolean sortOutput;
+  @Builder.Default
+  private final boolean sortOutputs = false;
   // Allows to consider inflight instants while merging log records using HoodieMergedLogRecordReader
   // The inflight instants need to be considered while updating RLI records. RLI needs to fetch the revived
   // and deleted keys from the log files written as part of active data commit. During the RLI update,
-  // the allowInflightInstants flag would need to be set to true. This would ensure the HoodieMergedLogRecordReader
+  // the inflightInstantsAllowed flag would need to be set to true. This would ensure the HoodieMergedLogRecordReader
   // considers the log records which are inflight.
-  private final boolean allowInflightInstants;
+  @Builder.Default
+  private final boolean inflightInstantsAllowed = false;
 
-  private ReaderParameters(boolean useRecordPosition, boolean emitDelete, boolean sortOutput, boolean allowInflightInstants) {
-    this.useRecordPosition = useRecordPosition;
-    this.emitDelete = emitDelete;
-    this.sortOutput = sortOutput;
-    this.allowInflightInstants = allowInflightInstants;
-  }
-
-  public boolean useRecordPosition() {
-    return useRecordPosition;
-  }
-
-  public boolean emitDeletes() {
-    return emitDelete;
-  }
-
-  public boolean sortOutputs() {
-    return sortOutput;
-  }
-
-  public boolean allowInflightInstants() {
-    return allowInflightInstants;
-  }
-
-  static Builder builder() {
-    return new Builder();
-  }
-
-  static class Builder {
-    private boolean shouldUseRecordPosition = false;
-    private boolean emitDelete = false;
-    private boolean sortOutput = false;
-    private boolean allowInflightInstants = false;
-
-    public Builder shouldUseRecordPosition(boolean shouldUseRecordPosition) {
-      this.shouldUseRecordPosition = shouldUseRecordPosition;
-      return this;
-    }
-
-    public Builder emitDeletes(boolean emitDelete) {
-      this.emitDelete = emitDelete;
-      return this;
-    }
-
-    public Builder sortOutputs(boolean sortOutput) {
-      this.sortOutput = sortOutput;
-      return this;
-    }
-
-    public Builder allowInflightInstants(boolean allowInflightInstants) {
-      this.allowInflightInstants = allowInflightInstants;
-      return this;
-    }
-
-    public ReaderParameters build() {
-      return new ReaderParameters(shouldUseRecordPosition, emitDelete, sortOutput, allowInflightInstants);
-    }
+  public boolean shouldUseRecordPosition() {
+    return shouldUseRecordPosition;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/DefaultFileGroupRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/DefaultFileGroupRecordBufferLoader.java
@@ -62,15 +62,15 @@ class DefaultFileGroupRecordBufferLoader<T> extends LogScanningRecordBufferLoade
                                                                             Option<BaseFileUpdateCallback<T>> fileGroupUpdateCallback) {
     boolean isSkipMerge = ConfigUtils.getStringWithAltKeys(props, HoodieReaderConfig.MERGE_TYPE, true).equalsIgnoreCase(HoodieReaderConfig.REALTIME_SKIP_MERGE);
     Option<PartialUpdateMode> partialUpdateModeOpt = hoodieTableMetaClient.getTableConfig().getPartialUpdateMode();
-    UpdateProcessor<T> updateProcessor = UpdateProcessor.create(readStats, readerContext, readerParameters.emitDeletes(), fileGroupUpdateCallback, props);
+    UpdateProcessor<T> updateProcessor = UpdateProcessor.create(readStats, readerContext, readerParameters.isEmitDeletes(), fileGroupUpdateCallback, props);
     FileGroupRecordBuffer<T> recordBuffer;
     if (isSkipMerge) {
       recordBuffer = new UnmergedFileGroupRecordBuffer<>(
           readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateModeOpt, props, readStats);
-    } else if (readerParameters.sortOutputs()) {
+    } else if (readerParameters.isSortOutputs()) {
       recordBuffer = new SortedKeyBasedFileGroupRecordBuffer<>(
           readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateModeOpt, props, orderingFieldNames, updateProcessor);
-    } else if (readerParameters.useRecordPosition() && inputSplit.getBaseFileOption().isPresent()) {
+    } else if (readerParameters.shouldUseRecordPosition() && inputSplit.getBaseFileOption().isPresent()) {
       recordBuffer = new PositionBasedFileGroupRecordBuffer<>(
           readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateModeOpt, inputSplit.getBaseFileOption().get().getCommitTime(), props,
           orderingFieldNames, updateProcessor);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/LogScanningRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/LogScanningRecordBufferLoader.java
@@ -48,7 +48,7 @@ abstract class LogScanningRecordBufferLoader {
         .withInstantRange(readerContext.getInstantRange())
         .withPartition(inputSplit.getPartitionPath())
         .withRecordBuffer(recordBuffer)
-        .withAllowInflightInstants(readerParameters.allowInflightInstants())
+        .withAllowInflightInstants(readerParameters.isInflightInstantsAllowed())
         .withMetaClient(hoodieTableMetaClient)
         .build()) {
       readStats.setTotalLogReadTimeMs(logRecordReader.getTotalTimeTakenToReadAndMergeBlocks());

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/ReusableFileGroupRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/ReusableFileGroupRecordBufferLoader.java
@@ -58,7 +58,7 @@ public class ReusableFileGroupRecordBufferLoader<T> extends LogScanningRecordBuf
                                                                                          ReaderParameters readerParameters,
                                                                                          HoodieReadStats readStats,
                                                                                          Option<BaseFileUpdateCallback<T>> fileGroupUpdateCallback) {
-    UpdateProcessor<T> updateProcessor = UpdateProcessor.create(readStats, readerContext, readerParameters.emitDeletes(), fileGroupUpdateCallback, props);
+    UpdateProcessor<T> updateProcessor = UpdateProcessor.create(readStats, readerContext, readerParameters.isEmitDeletes(), fileGroupUpdateCallback, props);
     Option<PartialUpdateMode> partialUpdateModeOpt = hoodieTableMetaClient.getTableConfig().getPartialUpdateMode();
     if (cachedResults == null) {
       // Create an initial buffer to process the log files

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/StreamingFileGroupRecordBufferLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/StreamingFileGroupRecordBufferLoader.java
@@ -67,9 +67,9 @@ public class StreamingFileGroupRecordBufferLoader<T> implements FileGroupRecordB
     readerContext.getSchemaHandler().setSchemaForUpdates(recordSchema);
     HoodieTableConfig tableConfig = hoodieTableMetaClient.getTableConfig();
     Option<PartialUpdateMode> partialUpdateModeOpt = tableConfig.getPartialUpdateMode();
-    UpdateProcessor<T> updateProcessor = UpdateProcessor.create(readStats, readerContext, readerParameters.emitDeletes(), fileGroupUpdateCallback, props);
+    UpdateProcessor<T> updateProcessor = UpdateProcessor.create(readStats, readerContext, readerParameters.isEmitDeletes(), fileGroupUpdateCallback, props);
     FileGroupRecordBuffer<T> recordBuffer;
-    if (readerParameters.sortOutputs()) {
+    if (readerParameters.isSortOutputs()) {
       recordBuffer = new SortedKeyBasedFileGroupRecordBuffer<>(
           readerContext, hoodieTableMetaClient, readerContext.getMergeMode(), partialUpdateModeOpt, props, orderingFieldNames, updateProcessor);
     } else {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -601,11 +601,13 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
         baseFileReaders,
         fileGroupReaderProps);
 
-    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>newBuilder()
+    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metadataMetaClient)
         .withLatestCommitTime(latestMetadataInstantTime)
-        .withFileSlice(fileSlice)
+        .withBaseFileOption(fileSlice.getBaseFile())
+        .withLogFiles(fileSlice.getLogFiles())
+        .withPartitionPath(fileSlice.getPartitionPath())
         .withDataSchema(SCHEMA)
         .withRequestedSchema(SCHEMA)
         .withProps(fileGroupReaderProps)

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1809,7 +1809,7 @@ public class HoodieTableMetadataUtil {
       properties.setProperty(HoodieReaderConfig.MERGE_TYPE.key(), REALTIME_SKIP_MERGE);
       // Currently only avro is fully supported for extracting column ranges (see HUDI-8585)
       HoodieReaderContext readerContext = new HoodieAvroReaderContext(datasetMetaClient.getStorageConf(), datasetMetaClient.getTableConfig(), Option.empty(), Option.empty());
-      HoodieFileGroupReader fileGroupReader = HoodieFileGroupReader.newBuilder()
+      HoodieFileGroupReader fileGroupReader = HoodieFileGroupReader.builder()
           .withReaderContext(readerContext)
           .withHoodieTableMetaClient(datasetMetaClient)
           .withLogFiles(Stream.of(logFile))
@@ -2568,10 +2568,12 @@ public class HoodieTableMetadataUtil {
       final String partition = partitionAndBaseFile.getKey();
       final FileSlice fileSlice = partitionAndBaseFile.getValue();
       if (!fileSlice.getBaseFile().isPresent()) {
-        HoodieFileGroupReader fileGroupReader = HoodieFileGroupReader.<T>newBuilder()
+        HoodieFileGroupReader fileGroupReader = HoodieFileGroupReader.<T>builder()
             .withReaderContext(readerContextFactory.getContext())
             .withHoodieTableMetaClient(metaClient)
-            .withFileSlice(fileSlice)
+            .withBaseFileOption(fileSlice.getBaseFile())
+            .withLogFiles(fileSlice.getLogFiles())
+            .withPartitionPath(fileSlice.getPartitionPath())
             .withDataSchema(tableSchema)
             .withRequestedSchema(HoodieSchemaUtils.getRecordKeySchema())
             .withLatestCommitTime(latestCommitTime)

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -1040,15 +1040,17 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
                                                             HoodieSchema schema,
                                                             FileSlice fileSlice,
                                                             int start, TypedProperties props, boolean sortOutput) {
-    return HoodieFileGroupReader.<T>newBuilder()
+    return HoodieFileGroupReader.<T>builder()
         .withReaderContext(getHoodieReaderContext(tablePath, schema, storageConf, metaClient))
         .withHoodieTableMetaClient(metaClient)
         .withLatestCommitTime(metaClient.getActiveTimeline().lastInstant().get().requestedTime())
-        .withFileSlice(fileSlice)
+        .withBaseFileOption(fileSlice.getBaseFile())
+        .withLogFiles(fileSlice.getLogFiles())
+        .withPartitionPath(fileSlice.getPartitionPath())
         .withDataSchema(schema)
         .withRequestedSchema(schema)
         .withProps(props)
-        .withStart(start)
+        .withStart((long) start)
         .withLength(fileSlice.getTotalFileSize())
         .withShouldUseRecordPosition(false)
         .withAllowInflightInstants(false)

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/BaseTestFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/BaseTestFileGroupRecordBuffer.java
@@ -149,7 +149,7 @@ public class BaseTestFileGroupRecordBuffer {
       when(inputSplit.hasNoRecordsToMerge()).thenReturn(false);
       when(inputSplit.getRecordIterator()).thenReturn(fileGroupRecordBufferItrOpt.get());
       ReaderParameters readerParameters = mock(ReaderParameters.class);
-      when(readerParameters.sortOutputs()).thenReturn(false);
+      when(readerParameters.isSortOutputs()).thenReturn(false);
       return (KeyBasedFileGroupRecordBuffer<IndexedRecord>) recordBufferLoader.getRecordBuffer(readerContext, mockMetaClient.getStorage(), inputSplit,
           orderingFieldNames, mockMetaClient, props, readerParameters, readStats, Option.empty()).getKey();
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java
@@ -90,12 +90,12 @@ public class TestFileGroupRecordBufferLoader extends BaseTestFileGroupRecordBuff
     }
     ReaderParameters readerParameters = mock(ReaderParameters.class);
     if (fileGroupRecordBufferType.contains("Sorted")) {
-      when(readerParameters.sortOutputs()).thenReturn(true);
+      when(readerParameters.isSortOutputs()).thenReturn(true);
     }
     if (fileGroupRecordBufferType.contains("Position")) {
       HoodieBaseFile baseFile = mock(HoodieBaseFile.class);
       when(inputSplit.getBaseFileOption()).thenReturn(Option.of(baseFile));
-      when(readerParameters.useRecordPosition()).thenReturn(true);
+      when(readerParameters.shouldUseRecordPosition()).thenReturn(true);
     }
 
     Option<BaseFileUpdateCallback> fileGroupUpdateCallback = Option.empty();

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
@@ -141,7 +141,7 @@ class TestSortedKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuf
     when(inputSplit.hasNoRecordsToMerge()).thenReturn(false);
     when(inputSplit.getRecordIterator()).thenReturn(inputRecords.iterator());
     ReaderParameters readerParameters = mock(ReaderParameters.class);
-    when(readerParameters.sortOutputs()).thenReturn(true);
+    when(readerParameters.isSortOutputs()).thenReturn(true);
     SortedKeyBasedFileGroupRecordBuffer fileGroupRecordBuffer  = (SortedKeyBasedFileGroupRecordBuffer<IndexedRecord>) recordBufferLoader
         .getRecordBuffer(readerContext, mockMetaClient.getStorage(), inputSplit, Collections.singletonList("ts"), mockMetaClient, properties,
             readerParameters, readStats, Option.empty()).getKey();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
@@ -132,14 +132,16 @@ public class FormatUtils {
     final TypedProperties typedProps = FlinkClientUtil.getReadProps(metaClient.getTableConfig(), writeConfig);
     typedProps.put(HoodieReaderConfig.MERGE_TYPE.key(), mergeType);
 
-    return HoodieFileGroupReader.<RowData>newBuilder()
+    return HoodieFileGroupReader.<RowData>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metaClient)
         .withLatestCommitTime(latestInstant)
-        .withFileSlice(fileSlice)
+        .withBaseFileOption(fileSlice.getBaseFile())
+        .withLogFiles(fileSlice.getLogFiles())
+        .withPartitionPath(fileSlice.getPartitionPath())
         .withDataSchema(tableSchema)
         .withRequestedSchema(requiredSchema)
-        .withInternalSchema(Option.ofNullable(internalSchemaManager.getQuerySchema()))
+        .withInternalSchemaOpt(Option.ofNullable(internalSchemaManager.getQuerySchema()))
         .withProps(typedProps)
         .withShouldUseRecordPosition(false)
         .withEmitDelete(emitDelete)

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/reader/HoodieFileGroupReaderTestHarness.java
@@ -137,11 +137,14 @@ public class HoodieFileGroupReaderTestHarness extends HoodieCommonTestHarness {
     properties.setProperty(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key(),  basePath + "/" + HoodieTableMetaClient.TEMPFOLDER_NAME);
     properties.setProperty(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(), ExternalSpillableMap.DiskMapType.ROCKS_DB.name());
     properties.setProperty(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), "false");
-    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>newBuilder()
+    FileSlice fileSlice = fileSliceOpt.orElseThrow(() -> new IllegalArgumentException("FileSlice is not present"));
+    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metaClient)
         .withLatestCommitTime("1000") // Not used internally.
-        .withFileSlice(fileSliceOpt.orElseThrow(() -> new IllegalArgumentException("FileSlice is not present")))
+        .withBaseFileOption(fileSlice.getBaseFile())
+        .withLogFiles(fileSlice.getLogFiles())
+        .withPartitionPath(fileSlice.getPartitionPath())
         .withDataSchema(HOODIE_SCHEMA)
         .withRequestedSchema(HOODIE_SCHEMA)
         .withProps(properties)

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieFileGroupReaderBasedRecordReader.java
@@ -145,11 +145,13 @@ public class HoodieFileGroupReaderBasedRecordReader implements RecordReader<Null
     LOG.debug("Creating HoodieFileGroupReaderRecordReader with tableBasePath={}, latestCommitTime={}, fileSplit={}", tableBasePath, latestCommitTime, fileSplit.getPath());
     FileSlice fileSlice = getFileSliceFromSplit(fileSplit, getFs(tableBasePath, jobConfCopy), tableBasePath);
     this.containsBaseFile = fileSlice.getBaseFile().isPresent();
-    this.recordIterator = HoodieFileGroupReader.<ArrayWritable>newBuilder()
+    this.recordIterator = HoodieFileGroupReader.<ArrayWritable>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metaClient)
         .withLatestCommitTime(latestCommitTime)
-        .withFileSlice(fileSlice)
+        .withBaseFileOption(fileSlice.getBaseFile())
+        .withLogFiles(fileSlice.getLogFiles())
+        .withPartitionPath(fileSlice.getPartitionPath())
         .withDataSchema(tableSchema)
         .withRequestedSchema(requestedSchema)
         .withProps(props)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
@@ -172,7 +172,7 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
           val requestedSchema = requiredSchema.schema
           val instantRange = InstantRange.builder().rangeType(RangeType.EXACT_MATCH).explicitInstants(validInstants.value).build()
           val readerContext = new HoodieAvroReaderContext(storageConf, metaClient.getTableConfig, HOption.of(instantRange), HOption.empty().asInstanceOf[HOption[HPredicate]])
-          val fileGroupReader: HoodieFileGroupReader[IndexedRecord] = HoodieFileGroupReader.newBuilder()
+          val fileGroupReader: HoodieFileGroupReader[IndexedRecord] = HoodieFileGroupReader.builder()
             .withReaderContext(readerContext)
             .withHoodieTableMetaClient(metaClient)
             .withLatestCommitTime(tableState.latestCommitTimestamp.orNull)
@@ -182,13 +182,13 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
             .withProps(properties)
             .withDataSchema(tableSchema.schema)
             .withRequestedSchema(requestedSchema)
-            .withInternalSchema(HOption.ofNullable(tableSchema.internalSchema.orNull))
+            .withInternalSchemaOpt(HOption.ofNullable(tableSchema.internalSchema.orNull))
             .build()
           convertAvroToRowIterator(fileGroupReader.getClosableIterator, requestedSchema)
         } else {
           val readerContext = new SparkFileFormatInternalRowReaderContext(fileGroupBaseFileReader.value, optionalFilters,
             Seq.empty, storageConf, metaClient.getTableConfig)
-          val fileGroupReader = HoodieFileGroupReader.newBuilder()
+          val fileGroupReader = HoodieFileGroupReader.builder()
             .withReaderContext(readerContext)
             .withHoodieTableMetaClient(metaClient)
             .withLatestCommitTime(tableState.latestCommitTimestamp.orNull)
@@ -198,7 +198,7 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
             .withProps(properties)
             .withDataSchema(tableSchema.schema)
             .withRequestedSchema(requiredSchema.schema)
-            .withInternalSchema(HOption.ofNullable(tableSchema.internalSchema.orNull))
+            .withInternalSchemaOpt(HOption.ofNullable(tableSchema.internalSchema.orNull))
             .build()
           convertCloseableIterator(fileGroupReader.getClosableIterator)
         }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -513,13 +513,15 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
   }
 
   private def loadFileSlice(fileSlice: FileSlice, readerContext: SparkFileFormatInternalRowReaderContext): Iterator[BufferedRecord[InternalRow]] = {
-    val fileGroupReader = HoodieFileGroupReader.newBuilder()
+    val fileGroupReader = HoodieFileGroupReader.builder()
       .withReaderContext(readerContext)
       .withHoodieTableMetaClient(metaClient)
-      .withFileSlice(fileSlice)
+      .withBaseFileOption(fileSlice.getBaseFile)
+      .withLogFiles(fileSlice.getLogFiles)
+      .withPartitionPath(fileSlice.getPartitionPath)
       .withDataSchema(schema)
       .withRequestedSchema(schema)
-      .withInternalSchema(toJavaOption(originTableSchema.internalSchema))
+      .withInternalSchemaOpt(toJavaOption(originTableSchema.internalSchema))
       .withProps(readerProperties)
       .withLatestCommitTime(split.changes.last.getInstant)
       .build()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -313,14 +313,16 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
               } else {
                 0
               }
-              val reader = HoodieFileGroupReader.newBuilder()
+              val reader = HoodieFileGroupReader.builder()
                 .withReaderContext(readerContext)
                 .withHoodieTableMetaClient(metaClient)
                 .withLatestCommitTime(queryTimestamp)
-                .withFileSlice(fileSlice)
+                .withBaseFileOption(fileSlice.getBaseFile)
+                .withLogFiles(fileSlice.getLogFiles)
+                .withPartitionPath(fileSlice.getPartitionPath)
                 .withDataSchema(dataSchema)
                 .withRequestedSchema(requestedSchema)
-                .withInternalSchema(internalSchemaOpt)
+                .withInternalSchemaOpt(internalSchemaOpt)
                 .withProps(props)
                 .withStart(file.start)
                 .withLength(baseFileLength)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/PartitionBucketIndexManager.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/PartitionBucketIndexManager.scala
@@ -225,14 +225,16 @@ class PartitionBucketIndexManager extends BaseProcedure
           // instantiate other supporting cast
           val internalSchemaOption: Option[InternalSchema] = Option.empty()
           // instantiate FG reader
-          val fileGroupReader = HoodieFileGroupReader.newBuilder()
+          val fileGroupReader = HoodieFileGroupReader.builder()
             .withReaderContext(readerContextFactory.getContext)
             .withHoodieTableMetaClient(metaClient)
             .withLatestCommitTime(latestInstantTime.requestedTime())
-            .withFileSlice(fileSlice)
+            .withBaseFileOption(fileSlice.getBaseFile)
+            .withLogFiles(fileSlice.getLogFiles)
+            .withPartitionPath(fileSlice.getPartitionPath)
             .withDataSchema(tableSchemaWithMetaFields)
             .withRequestedSchema(tableSchemaWithMetaFields)
-            .withInternalSchema(internalSchemaOption) // not support evolution of schema for now
+            .withInternalSchemaOpt(internalSchemaOption) // not support evolution of schema for now
             .withProps(metaClient.getTableConfig.getProps)
             .withShouldUseRecordPosition(false)
             .build()

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -712,7 +712,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       TypedProperties properties = new TypedProperties();
       // configure un-merged log file reader
       HoodieReaderContext readerContext = context.getReaderContextFactory(metaClient).getContext();
-      HoodieFileGroupReader reader = HoodieFileGroupReader.newBuilder()
+      HoodieFileGroupReader reader = HoodieFileGroupReader.builder()
           .withReaderContext(readerContext)
           .withDataSchema(writerSchemaOpt.get())
           .withRequestedSchema(writerSchemaOpt.get())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -1664,7 +1664,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
                                            String latestCommitTimestamp) {
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(HoodieSchema.fromAvroSchema(HoodieMetadataRecord.getClassSchema()));
     HoodieAvroReaderContext readerContext = new HoodieAvroReaderContext(metadataMetaClient.getStorageConf(), metadataMetaClient.getTableConfig(), Option.empty(), Option.empty());
-    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>newBuilder()
+    HoodieFileGroupReader<IndexedRecord> fileGroupReader = HoodieFileGroupReader.<IndexedRecord>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(metadataMetaClient)
         .withLogFiles(logFiles.stream())


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Add Lombok Builders to:
1. HoodieFileGroupReader
2. InputSplit
3. ReaderParameters

This change removes boilerplate code and standardises builder patterns used.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

Add Lombok Builders to:
1. HoodieFileGroupReader
2. InputSplit
3. ReaderParameters

Update usages and fixed compilation errors

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Improve developer experience.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->
None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
