### PR TITLE
fix: Fix the timeline compaction blocked caused by the archived file being too large

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/LSMTimelineWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/LSMTimelineWriter.java
@@ -396,7 +396,7 @@ public class LSMTimelineWriter {
         // stop once we reach the batch size
         break;
       }
-      if (totalFileLen > writeConfig.getTimelineArchivedFileMaxSize()) {
+      if (totalFileLen > writeConfig.getTimelineCompactionTargetFileMaxBytes()) {
         if (candidates.size() < 2) {
           // reset if we have not reached the minimum files num to compact
           totalFileLen = 0L;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
@@ -102,8 +102,8 @@ public class HoodieArchivalConfig extends HoodieConfig {
       .withDocumentation("If enabled, archival will proceed beyond savepoint, skipping savepoint commits."
           + " If disabled, archival will stop at the earliest savepoint commit.");
 
-  public static final ConfigProperty<Long> TIMELINE_ARCHIVED_FILE_MAX_SIZE = ConfigProperty
-        .key("hoodie.timeline.archived.file.max.size")
+  public static final ConfigProperty<Long> TIMELINE_COMPACTION_TARGET_FILE_MAX_BYTES = ConfigProperty
+        .key("hoodie.timeline.compaction.target.file.max.bytes")
         .defaultValue(1000L * 1024 * 1024)
         .markAdvanced()
         .withDocumentation("Max size (in bytes) for each archived timeline file.");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1739,8 +1739,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieArchivalConfig.TIMELINE_COMPACTION_BATCH_SIZE);
   }
 
-  public long getTimelineArchivedFileMaxSize() {
-    return getLong(HoodieArchivalConfig.TIMELINE_ARCHIVED_FILE_MAX_SIZE);
+  public long getTimelineCompactionTargetFileMaxBytes() {
+    return getLong(HoodieArchivalConfig.TIMELINE_COMPACTION_TARGET_FILE_MAX_BYTES);
   }
 
   public int getParquetSmallFileLimit() {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -728,7 +728,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
   @Test
   public void testCompactionWithLargeL0File() throws Exception {
     HoodieWriteConfig writeConfig = initTestTableAndGetWriteConfig(true, 4, 5, 2, 3);
-    writeConfig.setValue(HoodieArchivalConfig.TIMELINE_ARCHIVED_FILE_MAX_SIZE.key(), "3200");
+    writeConfig.setValue(HoodieArchivalConfig.TIMELINE_COMPACTION_TARGET_FILE_MAX_BYTES.key(), "3200");
     // do ingestion and trigger archive actions here.
     for (int i = 1; i < 19; i++) {
       testTable.doWriteOperation(


### PR DESCRIPTION


### Describe the issue this Pull Request addresses

closes #17783 

### Summary and Changelog

1. Fix the timeline compaction blocked caused by the archived file being too large

### Impact

bugfix

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
