### PR TITLE
feat: Integrate Trino 477 Docker image into Hudi docker demo environment

### DIFF
--- a/docker/compose/docker-compose_hadoop334_hive313_spark353_arm64.yml
+++ b/docker/compose/docker-compose_hadoop334_hive313_spark353_arm64.yml
@@ -270,6 +270,17 @@ services:
     depends_on:
       - minio
 
+  trino:
+    image: apachehudi/trino477:latest
+    container_name: trino
+    depends_on:
+      - hivemetastore
+      - minio
+    ports:
+      - "8085:8080"
+    volumes:
+      - ${HUDI_WS}:/var/hoodie/ws
+
 volumes:
   namenode:
   historyserver:

--- a/docker/hoodie/hadoop/hive_base/Dockerfile
+++ b/docker/hoodie/hadoop/hive_base/Dockerfile
@@ -36,6 +36,9 @@ RUN echo "Hive URL is :${HIVE_URL}" && wget ${HIVE_URL} -O hive.tar.gz && \
 	wget https://jdbc.postgresql.org/download/postgresql-9.4.1212.jar -O $HIVE_HOME/lib/postgresql-jdbc.jar && \
 	rm hive.tar.gz && mkdir -p /var/hoodie/ws/docker/hoodie/hadoop/hive_base/target/
 
+RUN wget -O "${HIVE_HOME}/lib/hadoop-aws-3.3.4.jar" https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar && \
+    wget -O "${HIVE_HOME}/lib/aws-java-sdk-bundle-1.12.734.jar" https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.734/aws-java-sdk-bundle-1.12.734.jar
+
 #Spark should be compiled with Hive to be able to use it
 #hive-site.xml should be copied to $SPARK_HOME/conf folder
 

--- a/docker/hoodie/hadoop/hive_base/conf/hive-site.xml
+++ b/docker/hoodie/hadoop/hive_base/conf/hive-site.xml
@@ -59,4 +59,36 @@
   	<name>hive.server2.logging.operation.enabled</name>
   	<value>true</value>
     </property>
+    <property>
+       <name>metastore.thrift.uris</name>
+       <value>thrift://hivemetastore:9083</value>
+    </property>
+    <property>
+       <name>metastore.task.threads.always</name>
+       <value>org.apache.hadoop.hive.metastore.events.EventCleanerTask</value>
+    </property>
+    <property>
+       <name>metastore.expression.proxy</name>
+       <value>org.apache.hadoop.hive.metastore.DefaultPartitionExpressionProxy</value>
+    </property>
+    <property>
+       <name>fs.s3a.impl</name>
+       <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+    </property>
+    <property>
+       <name>fs.s3a.access.key</name>
+       <value>minio</value>
+    </property>
+    <property>
+       <name>fs.s3a.secret.key</name>
+       <value>minio123</value>
+    </property>
+    <property>
+       <name>fs.s3a.endpoint</name>
+       <value>http://minio:9090</value>
+    </property>
+    <property>
+       <name>fs.s3a.path.style.access</name>
+       <value>true</value>
+    </property>
 </configuration>

--- a/docker/hoodie/hadoop/trino477/Dockerfile
+++ b/docker/hoodie/hadoop/trino477/Dockerfile
@@ -1,0 +1,22 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG TRINO_VERSION=${TRINO_VERSION:-477}
+
+FROM trinodb/trino:${TRINO_VERSION}
+
+# Copy Trino configuration
+COPY conf/trino /etc/trino

--- a/docker/hoodie/hadoop/trino477/conf/hadoop/core-site.xml
+++ b/docker/hoodie/hadoop/trino477/conf/hadoop/core-site.xml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration>
+
+    <property>
+    	<name>hadoop.security.authentication</name>
+    	<value>simple</value>
+    </property>
+
+    <property>
+    	<name>hadoop.security.authorization</name>
+    	<value>false</value>
+    </property>
+
+    <property>
+    	<name>hadoop.user.name</name>
+    	<value>trino</value>
+    </property>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://namenode:8020</value>
+        <description>The name of the default file system.  A URI whose
+            scheme and authority determine the FileSystem implementation.  The
+            uri's scheme determines the config property (fs.SCHEME.impl) naming
+            the FileSystem implementation class.  The uri's authority is used to
+            determine the host, port, etc. for a filesystem.</description>
+    </property>
+
+</configuration>

--- a/docker/hoodie/hadoop/trino477/conf/hadoop/hdfs-site.xml
+++ b/docker/hoodie/hadoop/trino477/conf/hadoop/hdfs-site.xml
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+    <!-- NameNode RPC service, required by Trino/Hive/Spark -->
+    <property>
+        <name>dfs.namenode.rpc-address</name>
+        <value>namenode:8020</value>
+    </property>
+
+    <property>
+        <name>dfs.namenode.http-address</name>
+        <value>namenode:50070</value>
+        <description>
+            The address and the base port where the dfs namenode web ui will listen on.
+        </description>
+    </property>
+
+</configuration>

--- a/docker/hoodie/hadoop/trino477/conf/trino/catalog/hive.properties
+++ b/docker/hoodie/hadoop/trino477/conf/trino/catalog/hive.properties
@@ -1,0 +1,18 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+
+connector.name=hive
+hive.metastore.uri=thrift://hivemetastore:9083

--- a/docker/hoodie/hadoop/trino477/conf/trino/catalog/hudi.properties
+++ b/docker/hoodie/hadoop/trino477/conf/trino/catalog/hudi.properties
@@ -1,0 +1,25 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+
+connector.name=hudi
+hive.metastore.uri=thrift://hivemetastore:9083
+# S3 / MinIO configuration
+fs.native-s3.enabled=true
+s3.aws-access-key=minio
+s3.aws-secret-key=minio123
+s3.endpoint=http://minio:9090
+s3.path-style-access=true
+s3.region=us-east-1

--- a/docker/hoodie/hadoop/trino477/conf/trino/jvm.config
+++ b/docker/hoodie/hadoop/trino477/conf/trino/jvm.config
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+-server
+-Xmx16G
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+UseGCOverheadLimit
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:OnOutOfMemoryError=kill -9 %p
+-Djdk.attach.allowAttachSelf=true

--- a/docker/hoodie/hadoop/trino477/conf/trino/log.properties
+++ b/docker/hoodie/hadoop/trino477/conf/trino/log.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+io.trinosql=DEBUG
+io.trino=DEBUG
+io.trino.hudi=DEBUG


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR adds Trino 477 as a supported query engine in the Hudi Docker demo project.

### Summary and Changelog

This change integrates Trino 477 Docker image into the Hudi Docker demo, enabling users to run queries against Hudi tables using the latest Trino version out of the box.

- Added Trino 477 Docker image from Docker Hub
- Updated Docker Compose configuration to include Trino service
- Configured Trino catalogs/connectors for Hudi integration
- Verified Trino startup and basic query functionality against Hudi tables

### Impact

None

### Risk Level

none

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
