### PR TITLE
test: Fix flaky test in TestHoodieClientMultiWriter

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -49,6 +49,7 @@ import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.table.view.FileSystemViewStorageType;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.testutils.InProcessTimeGenerator;
 import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.io.util.FileIOUtils;
 import org.apache.hudi.common.util.Option;
@@ -703,19 +704,19 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
 
     // Create the first commit
     SparkRDDWriteClient<?> client = getHoodieWriteClient(cfg);
-    createCommitWithInsertsForPartition(cfg, client, "000", "001", 100, "2016/03/01");
+    String firstCommitTime = InProcessTimeGenerator.createNewInstantTime();
+    createCommitWithInsertsForPartition(cfg, client, "000", firstCommitTime, 100, "2016/03/01");
     client.close();
     int numConcurrentWriters = 5;
     ExecutorService executors = Executors.newFixedThreadPool(numConcurrentWriters);
 
     List<Future<?>> futures = new ArrayList<>(numConcurrentWriters);
     for (int loop = 0; loop < numConcurrentWriters; loop++) {
-      String newCommitTime = "00" + (loop + 2);
       String partition = "2016/03/0" + (loop + 2);
       futures.add(executors.submit(() -> {
         try {
           SparkRDDWriteClient<?> writeClient = getHoodieWriteClient(cfg);
-          createCommitWithInsertsForPartition(cfg, writeClient, "001", newCommitTime, 100, partition);
+          createCommitWithInsertsForPartition(cfg, writeClient, "001", InProcessTimeGenerator.createNewInstantTime(), 100, partition);
           writeClient.close();
         } catch (Exception e) {
           throw new RuntimeException(e);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The test `TestHoodieClientMultiWriter#testMultiWriterWithInsertsToDistinctPartitions` uses hardcoded sequential instant times ("002", "003", "004", "005", "006") for 5 concurrent writers. Since the writers ran concurrently without coordination, there was no guarantee they would start and complete in order. If writer "004" started first, subsequent attempts would create "002" or "003", which is not realistic.

### Summary and Changelog

This PR fixes the test to use `InProcessTimeGenerator.createNewInstantTime()` for the each commit.

### Impact

Test improvement.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
