### PR TITLE
feat: Use official Kafka docker images

### DIFF
--- a/docker/compose/docker-compose_hadoop334_hive313_spark353_amd64.yml
+++ b/docker/compose/docker-compose_hadoop334_hive313_spark353_amd64.yml
@@ -147,15 +147,26 @@ services:
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: 'bitnami/kafka:3.4.1'
+    image: 'apache/kafka:3.7.2'
     platform: linux/amd64
     hostname: kafkabroker
     container_name: kafkabroker
     ports:
       - "9092:9092" # Kafka Broker
     environment:
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
+      - 'KAFKA_NODE_ID=1'
+      - 'KAFKA_PROCESS_ROLES=broker,controller'
+      - 'KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093,PLAINTEXT_HOST://0.0.0.0:9092'
+      - 'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafkabroker:29092,PLAINTEXT_HOST://localhost:9092'
+      - 'KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER'
+      - 'KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      - 'KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT'
+      - 'KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafkabroker:9093'
+      - 'KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1'
+      - 'KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1'
+      - 'KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1'
+      - 'KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0'
+      - 'KAFKA_NUM_PARTITIONS=3'
   sparkmaster:
     image: apachehudi/hudi-hadoop_3.3.4-hive_3.1.3-sparkmaster_3.5.3:latest
     platform: linux/amd64

--- a/docker/demo/config/kafka-source.properties
+++ b/docker/demo/config/kafka-source.properties
@@ -24,5 +24,5 @@ hoodie.streamer.schemaprovider.target.schema.file=/var/demo/config/schema.avsc
 # Kafka Source
 hoodie.streamer.source.kafka.topic=stock_ticks
 #Kafka props
-bootstrap.servers=kafkabroker:9092
+bootstrap.servers=kafkabroker:29092
 auto.offset.reset=earliest


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The currently used Bitnami Kafka and ZooKeeper images are being phased out of free public accessibility and moving toward a paid subscription model (Bitnami Secure Images). This has led to issues with image availability, lack of regular security updates for free users.

By adopting the official Apache Kafka distribution images, we align Hudi’s ecosystem with the upstream project's lifecycle, ensure long-term maintainability, and leverage images maintained directly by the Apache Software Foundation.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

This PR replaces all references to Bitnami Kafka and ZooKeeper images with the official apache/kafka distribution.

* Updated Image References: Swapped bitnami/kafka and bitnami/zookeeper for apache/kafka.
* Configuration Alignment: Refactored docker-compose.yml files to use official Apache environment variable naming conventions (e.g., transitioning from KAFKA_CFG_* to standard Kafka property mappings).

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact
Low
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
None
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
