### PR TITLE
feat: Introduce inflight record index cache for bucket assigning

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -274,6 +274,14 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(".*")
       .withDescription("Whether to load partitions in state if partition path matching， default `*`");
 
+  @AdvancedConfig
+  public static final ConfigOption<Long> INDEX_RLI_CACHE_SIZE = ConfigOptions
+      .key("index.rli.cache.size")
+      .longType()
+      .defaultValue(100L) // default 100 MB
+      .withDescription("Maximum memory in MB for the inflight record index cache during one checkpoint interval.\n"
+          + "When record level index is used to assign bucket, record locations will first be cached before the record index is committed.");
+
   // ------------------------------------------------------------------------
   //  Read Options
   // ------------------------------------------------------------------------
@@ -628,14 +636,6 @@ public class FlinkOptions extends HoodieConfig {
       .intType()
       .noDefaultValue()
       .withDescription("Parallelism of tasks that do bucket assign, default same as the write task parallelism");
-
-  @AdvancedConfig
-  public static final ConfigOption<Long> BUCKET_ASSIGN_INFLIGHT_INDEX_CACHE_SIZE = ConfigOptions
-      .key("write.bucket_assign.inflight.cache.size")
-      .longType()
-      .defaultValue(100L) // default 100 MB
-      .withDescription("Maximum memory in MB for the inflight record index cache during one checkpoint interval.\n"
-          + "When record level index is used to assign bucket, record locations will first be cached before the record index is committed.");
 
   @AdvancedConfig
   public static final ConfigOption<Integer> WRITE_TASKS = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordIndexCache.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordIndexCache.java
@@ -53,7 +53,7 @@ public class RecordIndexCache implements Closeable {
   public RecordIndexCache(Configuration conf, long initCheckpointId) {
     this.caches = new TreeMap<>(Comparator.reverseOrder());
     this.writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
-    this.maxCacheSizeInBytes = conf.get(FlinkOptions.BUCKET_ASSIGN_INFLIGHT_INDEX_CACHE_SIZE) * 1024 * 1024;
+    this.maxCacheSizeInBytes = conf.get(FlinkOptions.INDEX_RLI_CACHE_SIZE) * 1024 * 1024;
     addCheckpointCache(initCheckpointId);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordIndexCache.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordIndexCache.java
@@ -52,7 +52,7 @@ public class TestRecordIndexCache {
   @BeforeEach
   void setUp() {
     Configuration conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
-    conf.set(FlinkOptions.BUCKET_ASSIGN_INFLIGHT_INDEX_CACHE_SIZE, 100L); // 100MB cache size
+    conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 100L); // 100MB cache size
     this.cache = new RecordIndexCache(conf, 1L);
   }
 
@@ -220,7 +220,7 @@ public class TestRecordIndexCache {
   void testSpillToDisk() throws IOException {
     // Create a new cache with a very small size to force spilling
     Configuration conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
-    conf.set(FlinkOptions.BUCKET_ASSIGN_INFLIGHT_INDEX_CACHE_SIZE, 1L); // 1MB cache size to force spilling
+    conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L); // 1MB cache size to force spilling
 
     try (RecordIndexCache smallCache = new RecordIndexCache(conf, 1L)) {
       String recordKeyPrefix = "key";
@@ -247,7 +247,7 @@ public class TestRecordIndexCache {
   void testSpillWithMultipleCheckpoints() throws IOException {
     // Create a new cache with a very small size to force spilling
     Configuration conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
-    conf.set(FlinkOptions.BUCKET_ASSIGN_INFLIGHT_INDEX_CACHE_SIZE, 1L); // 1MB cache size to force spilling
+    conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L); // 1MB cache size to force spilling
 
     try (RecordIndexCache smallCache = new RecordIndexCache(conf, 1L)) {
       // Add records to multiple checkpoints


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Add access cache to support efficient lookup of RLI for flink writer, fixes #17809

### Summary and Changelog

Add access cache to support efficient lookup of RLI for flink writer.

### Impact

Basic component for supporting bucket assign based on RLI.

### Risk Level

low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
