### PR TITLE
[HUDI] FIX: Fixed incomplete cleanup of temporary directories generat…

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -261,6 +261,15 @@ public class HiveTestUtil {
       failedReleases.add("ZKService");
     }
 
+    // 在所有服务关闭后，在关闭文件系统之前删除临时目录
+    if (basePath != null && fileSystem != null) {
+      try {
+        fileSystem.delete(new Path(basePath), true);
+      } catch (Exception e) {
+        LOG.warn("Failed to delete temporary directory using FileSystem: " + basePath, e);
+      }
+    }
+
     try {
       if (fileSystem != null) {
         fileSystem.close();


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
This PR fixes the issue that temporary directories generated by unit tests are not completely cleaned up after test execution, which leads to disk space exhaustion.
Currently, the cleanup problem of the temporary directory spark-d701ee5e-8690-4d45-a5eb-c335d228b161_cache_layer has been resolved.
### Summary and Changelog
 **Summary** 
Added directory cleanup logic in the shutdown method of HiveTestUtil to fix incomplete cleanup of test-generated temporary directories.

 **Changelog** 

- Problem Root Cause: Tests using HiveTestUtil call setUp() in @BeforeEach to create temporary directories, and clear() in @AfterEach to delete them. However, HoodieTableMetaClient.withPropertyBuilder() is invoked after deletion, which recreates the directory and causes incomplete cleanup.
- Solution: Added temporary directory cleanup logic in the shutdown method of HiveTestUtil to ensure the directory is fully removed after all test-related operations.

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

- No impact on public APIs or user-facing features.
- This change only affects the cleanup logic of unit tests using HiveTestUtil, avoiding disk space waste caused by residual temporary directories.

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
none
The modification only adds cleanup logic in the test utility class and does not involve core business logic changes.
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update
none
No new features, configurations or user-facing changes are introduced, so no documentation update is required.
<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
