### PR TITLE
perf: improve performance for S3 meta event source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -57,6 +57,13 @@ public class CloudSourceConfig extends HoodieConfig {
           + "Multiple API calls with this batch size are sent to cloud events queue, until we consume hoodie.streamer.source.cloud.meta.max.num.messages.per.sync"
           + "from the queue or hoodie.streamer.source.cloud.meta.max.fetch.time.per.sync.ms amount of time has passed or queue is empty. ");
 
+  public static final ConfigProperty<Integer> META_EVENTS_PER_PARTITION = ConfigProperty
+      .key(STREAMER_CONFIG_PREFIX + "source.cloud.meta.events.per.partition")
+      .defaultValue(10000)
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("Number of metadata events to be grouped into a single partition while creating dataframe from metadata events.");
+
   public static final ConfigProperty<Integer> MAX_NUM_MESSAGES_PER_SYNC = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.meta.max.num.messages.per.sync")
       .defaultValue(1000)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelector.java
@@ -155,26 +155,26 @@ public class TestCloudObjectsSelector extends HoodieSparkClientTestHarness {
         (CloudObjectsSelector) ReflectionUtils.loadClass(clazz.getName(), props);
 
     // setup lists
-    List<Message> testSingleList = new ArrayList<>();
-    testSingleList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "1")).build());
-    testSingleList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "2")).build());
-    testSingleList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "3")).build());
-    testSingleList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "4")).build());
-    testSingleList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "5")).build());
+    List<CloudObjectsSelector.MessageTracker> testSingleList = new ArrayList<>();
+    testSingleList.add(new CloudObjectsSelector.MessageTracker(Message.builder().attributesWithStrings(createAttributeMap("id", "1")).build()));
+    testSingleList.add(new CloudObjectsSelector.MessageTracker(Message.builder().attributesWithStrings(createAttributeMap("id", "2")).build()));
+    testSingleList.add(new CloudObjectsSelector.MessageTracker(Message.builder().attributesWithStrings(createAttributeMap("id", "3")).build()));
+    testSingleList.add(new CloudObjectsSelector.MessageTracker(Message.builder().attributesWithStrings(createAttributeMap("id", "4")).build()));
+    testSingleList.add(new CloudObjectsSelector.MessageTracker(Message.builder().attributesWithStrings(createAttributeMap("id", "5")).build()));
 
-    List<Message> expectedFirstList = new ArrayList<>();
-    expectedFirstList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "1")).build());
-    expectedFirstList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "2")).build());
+    List<CloudObjectsSelector.MessageTracker> expectedFirstList = new ArrayList<>();
+    expectedFirstList.add(testSingleList.get(0));
+    expectedFirstList.add(testSingleList.get(1));
 
-    List<Message> expectedSecondList = new ArrayList<>();
-    expectedSecondList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "3")).build());
-    expectedSecondList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "4")).build());
+    List<CloudObjectsSelector.MessageTracker> expectedSecondList = new ArrayList<>();
+    expectedSecondList.add(testSingleList.get(2));
+    expectedSecondList.add(testSingleList.get(3));
 
-    List<Message> expectedFinalList = new ArrayList<>();
-    expectedFinalList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "5")).build());
+    List<CloudObjectsSelector.MessageTracker> expectedFinalList = new ArrayList<>();
+    expectedFinalList.add(testSingleList.get(4));
 
     //  test the return values
-    List<List<Message>> partitionedList = selector.createListPartitions(testSingleList, 2);
+    List<List<CloudObjectsSelector.MessageTracker>> partitionedList = selector.createListPartitions(testSingleList, 2);
 
     assertEquals(3, partitionedList.size());
     assertEquals(expectedFirstList, partitionedList.get(0));
@@ -190,12 +190,12 @@ public class TestCloudObjectsSelector extends HoodieSparkClientTestHarness {
         (CloudObjectsSelector) ReflectionUtils.loadClass(clazz.getName(), props);
 
     // setup lists
-    List<Message> testSingleList = new ArrayList<>();
-    testSingleList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "1")).build());
-    testSingleList.add(Message.builder().attributesWithStrings(createAttributeMap("id", "2")).build());
+    List<CloudObjectsSelector.MessageTracker> testSingleList = new ArrayList<>();
+    testSingleList.add(new CloudObjectsSelector.MessageTracker(Message.builder().attributesWithStrings(createAttributeMap("id", "1")).build()));
+    testSingleList.add(new CloudObjectsSelector.MessageTracker(Message.builder().attributesWithStrings(createAttributeMap("id", "2")).build()));
 
     //  test the return values
-    List<List<Message>> partitionedList = selector.createListPartitions(testSingleList, 0);
+    List<List<CloudObjectsSelector.MessageTracker>> partitionedList = selector.createListPartitions(testSingleList, 0);
 
     assertEquals(0, partitionedList.size());
   }
@@ -208,17 +208,17 @@ public class TestCloudObjectsSelector extends HoodieSparkClientTestHarness {
         (CloudObjectsSelector) ReflectionUtils.loadClass(clazz.getName(), props);
 
     // setup lists
-    List<Message> testSingleList = new ArrayList<>();
+    List<CloudObjectsSelector.MessageTracker> testSingleList = new ArrayList<>();
     testSingleList.add(
-            Message.builder()
-                    .attributesWithStrings(createAttributeMap("MessageId", "1"))
-                    .attributesWithStrings(createAttributeMap("ReceiptHandle", "1"))
-                    .build());
+        new CloudObjectsSelector.MessageTracker(Message.builder()
+            .attributesWithStrings(createAttributeMap("MessageId", "1"))
+            .attributesWithStrings(createAttributeMap("ReceiptHandle", "1"))
+            .build()));
     testSingleList.add(
-            Message.builder()
-                    .attributesWithStrings(createAttributeMap("MessageId", "2"))
-                    .attributesWithStrings(createAttributeMap("ReceiptHandle", "1"))
-                    .build());
+        new CloudObjectsSelector.MessageTracker(Message.builder()
+            .attributesWithStrings(createAttributeMap("MessageId", "2"))
+            .attributesWithStrings(createAttributeMap("ReceiptHandle", "1"))
+            .build()));
 
     deleteMessagesInQueue(sqs);
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestS3EventsMetaSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestS3EventsMetaSelector.java
@@ -40,7 +40,6 @@ import org.mockito.MockitoAnnotations;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse;
-import software.amazon.awssdk.services.sqs.model.Message;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -92,12 +91,12 @@ public class TestS3EventsMetaSelector extends HoodieSparkClientTestHarness {
     S3EventsMetaSelector selector = (S3EventsMetaSelector) ReflectionUtils.loadClass(clazz.getName(), props);
     // setup s3 record
     String bucket = "test-bucket";
-    String key = "part%3Dpart%2Bpart%24part%A3part%23part%26part%3Fpart%7Epart%25.snappy.parquet";
+    String key = "part%3Dpart%2Bpart%24part%C2%A3part%23part%26part%3Fpart%7Epart%25.snappy.parquet";
     String keyRes = "part=part+part$part£part#part&part?part~part%.snappy.parquet";
     Path path = new Path(bucket, key);
     CloudObjectTestUtils.setMessagesInQueue(sqs, path);
 
-    List<Message> processed = new ArrayList<>();
+    List<CloudObjectsSelector.MessageTracker> processed = new ArrayList<>();
 
     // test the return values
     Pair<List<String>, Checkpoint> eventFromQueue =
@@ -125,7 +124,7 @@ public class TestS3EventsMetaSelector extends HoodieSparkClientTestHarness {
                 .attributesWithStrings(attribute)
                 .build());
 
-    List<Message> processed = new ArrayList<>();
+    List<CloudObjectsSelector.MessageTracker> processed = new ArrayList<>();
     Pair<List<String>, Checkpoint> eventFromQueue =
         selector.getNextEventsFromQueue(sqs, Option.empty(), processed);
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
There are a few performance issues in the current implementation of the S3 events source for the HoodieStreamer that contribute to increased memory usage and inefficient CPU usage. 

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
- Use a single ObjectMapper instance instead of creating one per record
- Use a leaner POJO to keep track of the information for deleting the message instead of keeping the full message content in memory
- Allow the user to configure a number of partitions that the dataset outputs for better parallelism for the source
- Use a url decoder instead of repeated replace calls

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Improves performance, especially around the parsing of the s3 events

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
