### PR TITLE
[MINOR] Remove duplicate shade relocation

### DIFF
--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -104,11 +104,6 @@
                   <pattern>org.objenesis.</pattern>
                   <shadedPattern>org.apache.hudi.org.objenesis.</shadedPattern>
                 </relocation>
-
-                <relocation>
-                  <pattern>org.apache.parquet.avro.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.parquet.avro.</shadedPattern>
-                </relocation>
                 <relocation>
                   <pattern>org.apache.avro.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

hudi-presto-bundle had two Maven Shade relocation rules for the same pattern (org.apache.parquet.avro.*). This is redundant (same result with the default prefix) and can be confusing/order-dependent when the bootstrap prefix is changed by profiles.

### Summary and Changelog

Simplify shading configuration by keeping a single relocation for org.apache.parquet.avro.*.

Removed the duplicated hard-coded relocation to org.apache.hudi.org.apache.parquet.avro.*
Kept the existing relocation using ${presto.bundle.bootstrap.shade.prefix}

### Impact

NONE

### Risk Level

low — build-time configuration cleanup only; no runtime logic changes.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
