### PR TITLE
fix(HUDI-9597): Do not evolve schema if reconciled schema keeps unchanged except version id

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/InternalSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/InternalSchema.java
@@ -289,6 +289,16 @@ public class InternalSchema implements Serializable {
     return record.equals(that.record);
   }
 
+  public boolean equalsIgnoringVersion(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof InternalSchema)) {
+      return false;
+    }
+    InternalSchema that = (InternalSchema) o;
+    return record.equals(that.record);
+  }
+
   @Override
   public int hashCode() {
     return record.hashCode();

--- a/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/AvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/internal/schema/utils/AvroSchemaEvolutionUtils.java
@@ -113,7 +113,12 @@ public class AvroSchemaEvolutionUtils {
       typeChange.updateColumnType(col, inComingInternalSchema.findType(col));
     });
 
-    return SchemaChangeUtils.applyTableChanges2Schema(internalSchemaAfterAddColumns, typeChange);
+    InternalSchema evolvedSchema = SchemaChangeUtils.applyTableChanges2Schema(internalSchemaAfterAddColumns, typeChange);
+    // If evolvedSchema is exactly the same as the oldSchema, except the version number, return the old schema
+    if (evolvedSchema.equalsIgnoringVersion(oldTableSchema)) {
+      return oldTableSchema;
+    }
+    return evolvedSchema;
   }
 
   public static Schema reconcileSchema(Schema incomingSchema, Schema oldTableSchema) {

--- a/hudi-common/src/test/java/org/apache/hudi/internal/schema/utils/TestAvroSchemaEvolutionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/internal/schema/utils/TestAvroSchemaEvolutionUtils.java
@@ -537,4 +537,27 @@ public class TestAvroSchemaEvolutionUtils {
         .reconcileSchema(incomingSchema, AvroInternalSchemaConverter.convert(schema)), "schemaNameFallback");
     Assertions.assertEquals(simpleReconcileSchema, simpleCheckSchema);
   }
+
+  @Test
+  public void testNotEvolveSchemaIfReconciledSchemaUnchanged() {
+    // a: boolean, c: long, c_1: long, d: date
+    Schema oldSchema = create("simple",
+        new Schema.Field("a", AvroInternalSchemaConverter.nullableSchema(Schema.create(Schema.Type.BOOLEAN)), null, JsonProperties.NULL_VALUE),
+        new Schema.Field("b", AvroInternalSchemaConverter.nullableSchema(Schema.create(Schema.Type.INT)), null, JsonProperties.NULL_VALUE),
+        new Schema.Field("c", AvroInternalSchemaConverter.nullableSchema(Schema.create(Schema.Type.LONG)), null, JsonProperties.NULL_VALUE),
+        new Schema.Field("d", AvroInternalSchemaConverter.nullableSchema(LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT))), null, JsonProperties.NULL_VALUE));
+    // incoming schema is part of old schema
+    // a: boolean, b: int, c: long
+    Schema incomingSchema = create("simple",
+        new Schema.Field("a", AvroInternalSchemaConverter.nullableSchema(Schema.create(Schema.Type.BOOLEAN)), null, JsonProperties.NULL_VALUE),
+        new Schema.Field("b", AvroInternalSchemaConverter.nullableSchema(Schema.create(Schema.Type.INT)), null, JsonProperties.NULL_VALUE),
+        new Schema.Field("c", AvroInternalSchemaConverter.nullableSchema(Schema.create(Schema.Type.LONG)), null, JsonProperties.NULL_VALUE));
+
+    InternalSchema oldInternalSchema = AvroInternalSchemaConverter.convert(oldSchema);
+    // set a non-default schema id for old table schema, e.g., 2.
+    oldInternalSchema.setSchemaId(2);
+    InternalSchema evolvedSchema = AvroSchemaEvolutionUtils.reconcileSchema(incomingSchema, oldInternalSchema);
+    // the evolved schema should be the old table schema, since there is no type change at all.
+    Assertions.assertEquals(oldInternalSchema, evolvedSchema);
+  }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Cherry-picked from https://github.com/apache/hudi/pull/13731

### Summary and Changelog

Do not evolve schema if reconciled schema keeps unchanged except version id

### Impact
Fix unnecessary persistence for history internal schema.

### Risk Level
low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
