### PR TITLE
fix: Handle all exception types when fetching table path on reads

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -81,8 +81,8 @@ public class DataSourceUtils {
         if (tablePath.isPresent()) {
           return tablePath.get().toString();
         }
-      } catch (HoodieException he) {
-        log.warn("Error trying to get table path from {}", path.toString(), he);
+      } catch (Exception e) {
+        log.warn("Error trying to get table path from {}", path.toString(), e);
       }
     }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR fixes an issue where non-`HoodieException` errors during table path resolution would cause read operations to fail. In cloud environments, permission issues can manifest as `StatusRuntimeException` instead of the expected `IOException` or `HoodieException`, causing the exception handler to miss these cases and propagate them up the stack.

The fix broadens the exception handling to catch all exception types, ensuring graceful degradation regardless of the underlying storage system's exception hierarchy.

### Summary and Changelog

Users gain more reliable read operations in cloud environments where permission or connectivity issues may throw non-standard exception types.

  **Changes:**
  - Changed exception handling in `DataSourceUtils.doGetTablePath()` from catching `HoodieException` to catching all `Exception` types
  - Maintains existing behavior of logging warning and continuing to next path when table path resolution fails

### Impact

**User-Facing Changes:**
  Improved reliability when reading Hudi tables in cloud environments, particularly when dealing with permission issues or storage connectivity problems.

  **Performance Impact:**
  None - this is purely an exception handling change.

### Risk Level

  **Low** - The change broadens exception handling to be more defensive, which improves reliability without changing the core logic. The existing behavior of logging and continuing is preserved, just
  applied to a wider range of exceptions.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
