### PR TITLE
chore: Include table name in FileSystemBackedTableMetadata stage names

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -63,14 +63,14 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
 
   private static final int DEFAULT_LISTING_PARALLELISM = 1500;
 
-  private final HoodieTableConfig tableConfig;
+  private final String tableName;
   private final boolean hiveStylePartitioningEnabled;
   private final boolean urlEncodePartitioningEnabled;
 
   public FileSystemBackedTableMetadata(HoodieEngineContext engineContext, HoodieTableConfig tableConfig,
                                        HoodieStorage storage, String datasetBasePath) {
     super(engineContext, storage, datasetBasePath);
-    this.tableConfig = tableConfig;
+    this.tableName = tableConfig.getTableName();
     this.hiveStylePartitioningEnabled = Boolean.parseBoolean(tableConfig.getHiveStylePartitioningEnable());
     this.urlEncodePartitioningEnabled = Boolean.parseBoolean(tableConfig.getUrlEncodePartitioning());
   }
@@ -83,7 +83,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
     StoragePath metaPath =
         new StoragePath(dataBasePath, HoodieTableMetaClient.METAFOLDER_NAME);
     HoodieTableConfig tableConfig = new HoodieTableConfig(storage, metaPath);
-    this.tableConfig = tableConfig;
+    this.tableName = tableConfig.getTableName();
     this.hiveStylePartitioningEnabled =
         Boolean.parseBoolean(tableConfig.getHiveStylePartitioningEnable());
     this.urlEncodePartitioningEnabled =
@@ -161,7 +161,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
 
       // List all directories in parallel
       engineContext.setJobStatus(this.getClass().getSimpleName(),
-          "Listing all partitions on " + this.tableConfig.getTableName()
+          "Listing all partitions on " + this.tableName
               + " with prefix " + relativePathPrefix);
       // Need to use serializable file status here, see HUDI-5936
       List<StoragePathInfo> dirToFileListing = engineContext.flatMap(pathsToList, path -> {
@@ -252,7 +252,7 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
 
     engineContext.setJobStatus(this.getClass().getSimpleName(),
         "Listing all files in " + partitionPaths.size() + " partitions from "
-            + this.tableConfig.getTableName());
+            + this.tableName);
     // Need to use serializable file status here, see HUDI-5936
     List<Pair<String, List<StoragePathInfo>>> partitionToFiles =
         engineContext.map(new ArrayList<>(partitionPaths),


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR improves debugging experience for Spark queries involving multiple Hudi tables (especially joins) by including the table name in the job stage names displayed in the Spark UI. Previously, stage names only showed generic messages like "Listing all partitions with prefix X" or "Listing all files in N partitions", making it difficult to identify which table was being processed when multiple tables were involved in a single query.

### Summary and Changelog

Users gain better observability in the Spark UI when debugging queries involving multiple Hudi tables.

  **Changes:**
  - Storing `tableName` as a class field in `FileSystemBackedTableMetadata`
  - Updated `setJobStatus` calls to include table name in stage descriptions:
    - "Listing all partitions with prefix X" → "Listing all partitions on {tableName} with prefix X"
    - "Listing all files in N partitions" → "Listing all files in N partitions from {tableName}"

### Impact

 **User-Facing Changes:**
  Improved Spark UI stage names that now include the table name, making it easier to debug and monitor queries involving multiple Hudi tables, particularly join operations.

  **Performance Impact:**
  None - this is purely a logging/observability change.

### Risk Level

**None** - This change only affects stage name labels in the Spark UI and does not modify any functional logic.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
