### PR TITLE
fix: Check for existing SparkContext before creating new one in CLI

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
@@ -28,6 +28,7 @@ import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.launcher.SparkLauncher;
+import org.apache.spark.sql.SparkSession;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -124,7 +125,8 @@ public class SparkUtil {
   }
 
   public static JavaSparkContext initJavaSparkContext(SparkConf sparkConf) {
-    JavaSparkContext jsc = new JavaSparkContext(sparkConf);
+    SparkSession spark = SparkSession.builder().config(sparkConf).getOrCreate();
+    JavaSparkContext jsc = JavaSparkContext.fromSparkContext(spark.sparkContext());
     jsc.hadoopConfiguration().setBoolean(HoodieCliSparkConfig.CLI_PARQUET_ENABLE_SUMMARY_METADATA, false);
     HadoopFSUtils.prepareHadoopConf(jsc.hadoopConfiguration());
     return jsc;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR fixes an issue in Hudi CLI where attempting to create multiple `JavaSparkContext` instances would fail with "Only one SparkContext should be running in this JVM" error. The problem occurred because the code directly instantiated a new `JavaSparkContext` without checking if one already existed. Since, it is a public method and if engineers create custom hudi-cli commands and they access this method it can throw "Only one SparkContext should be running" error.

The fix uses `SparkSession.builder().getOrCreate()` which properly handles existing contexts, and then obtains the `JavaSparkContext` from the session.

### Summary and Changelog

Users can now run multiple Hudi CLI commands that require Spark without encountering SparkContext initialization errors.

  **Changes:**
  - Modified `SparkUtil.initJavaSparkContext()` to use `SparkSession.builder().getOrCreate()` instead of directly creating `JavaSparkContext`
  - Added `SparkSession` import
  - Changed from `new JavaSparkContext(sparkConf)` to `JavaSparkContext.fromSparkContext(spark.sparkContext())`

### Impact

None - this change only affects context creation logic.

### Risk Level

  **Low** - This change uses the recommended pattern for obtaining a SparkContext via SparkSession, which is more robust than direct instantiation. The `getOrCreate()` method ensures we reuse existing contexts when available and only create new ones when necessary.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
