### PR TITLE
[HUDI-9088] Fix unnecessary scanning of target table in MERGE INTO on Spark

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -667,7 +667,7 @@ object DataSourceWriteOptions {
     .defaultValue("true")
     .markAdvanced()
     .sinceVersion("0.14.0")
-    .withDocumentation("Controls whether spark sql prepped update, delete, and merge are enabled.")
+    .withDocumentation("Controls whether spark sql prepped update and delete are enabled.")
 
   val OVERWRITE_MODE: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.overwrite.mode")

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -275,11 +275,11 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       sparkSession.conf.set("spark.sql.crossJoin.enabled","true")
     }
 
-    val projectedJoinedDF: DataFrame = projectedJoinedDataset
     // Create the write parameters
     val props = buildMergeIntoConfig(hoodieCatalogTable)
+    val processedInputDf: DataFrame = getProcessedInputDf
     // Do the upsert
-    executeUpsert(projectedJoinedDF, props)
+    executeUpsert(processedInputDf, props)
     // Refresh the table in the catalog
     sparkSession.catalog.refreshTable(hoodieCatalogTable.table.qualifiedName)
 
@@ -289,6 +289,10 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
   private val updatingActions: Seq[UpdateAction] = mergeInto.matchedActions.collect { case u: UpdateAction => u}
   private val insertingActions: Seq[InsertAction] = mergeInto.notMatchedActions.collect { case u: InsertAction => u}
   private val deletingActions: Seq[DeleteAction] = mergeInto.matchedActions.collect { case u: DeleteAction => u}
+
+  private def hasPrimaryKey(): Boolean = {
+    hoodieCatalogTable.tableConfig.getRecordKeyFields.isPresent
+  }
 
   /**
    * Here we're adjusting incoming (source) dataset in case its schema is divergent from
@@ -328,29 +332,30 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
    * <li>{@code ts = source.sts}</li>
    * </ul>
    */
-  def projectedJoinedDataset: DataFrame = {
+  private def getProcessedInputDf: DataFrame = {
     val resolver = sparkSession.sessionState.analyzer.resolver
 
-    // We want to join the source and target tables.
-    // Then we want to project the output so that we have the meta columns from the target table
-    // followed by the data columns of the source table
-    val tableMetaCols = mergeInto.targetTable.output.filter(a => isMetaField(a.name))
-    val joinData = sparkAdapter.getCatalystPlanUtils.createMITJoin(mergeInto.sourceTable, mergeInto.targetTable, LeftOuter, Some(mergeInto.mergeCondition), "NONE")
-    val incomingDataCols = joinData.output.filterNot(mergeInto.targetTable.outputSet.contains)
-    // for pkless table, we need to project the meta columns
-    val hasPrimaryKey = hoodieCatalogTable.tableConfig.getRecordKeyFields.isPresent
-    val projectedJoinPlan = if (!hasPrimaryKey || sparkSession.sqlContext.conf.getConfString(SPARK_SQL_OPTIMIZED_WRITES.key(), "false") == "true") {
+    // For pkless table, we need to project the meta columns by joining with the target table;
+    // for a Hudi table with record key, we use the source table and rely on Hudi's tagging
+    // to identify inserts, updates, and deletes to avoid the join
+    val inputPlan = if (!hasPrimaryKey()) {
+      // We want to join the source and target tables.
+      // Then we want to project the output so that we have the meta columns from the target table
+      // followed by the data columns of the source table
+      val tableMetaCols = mergeInto.targetTable.output.filter(a => isMetaField(a.name))
+      val joinData = sparkAdapter.getCatalystPlanUtils.createMITJoin(mergeInto.sourceTable, mergeInto.targetTable, LeftOuter, Some(mergeInto.mergeCondition), "NONE")
+      val incomingDataCols = joinData.output.filterNot(mergeInto.targetTable.outputSet.contains)
       Project(tableMetaCols ++ incomingDataCols, joinData)
     } else {
-      Project(incomingDataCols, joinData)
+      mergeInto.sourceTable
     }
 
-    val projectedJoinOutput = projectedJoinPlan.output
+    val inputPlanAttributes = inputPlan.output
 
     val requiredAttributesMap = recordKeyAttributeToConditionExpression ++ preCombineAttributeAssociatedExpression
 
     val (existingAttributesMap, missingAttributesMap) = requiredAttributesMap.partition {
-      case (keyAttr, _) => projectedJoinOutput.exists(attr => resolver(keyAttr.name, attr.name))
+      case (keyAttr, _) => inputPlanAttributes.exists(attr => resolver(keyAttr.name, attr.name))
     }
 
     // This is to handle the situation where condition is something like "s0.s_id = t0.id" so In the source table
@@ -362,7 +367,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     //       them according to aforementioned heuristic) to meet Hudi's requirements
     val additionalColumns: Seq[NamedExpression] =
       missingAttributesMap.flatMap {
-        case (keyAttr, sourceExpression) if !projectedJoinOutput.exists(attr => resolver(attr.name, keyAttr.name)) =>
+        case (keyAttr, sourceExpression) if !inputPlanAttributes.exists(attr => resolver(attr.name, keyAttr.name)) =>
           Seq(Alias(sourceExpression, keyAttr.name)())
 
         case _ => Seq()
@@ -372,7 +377,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     // matches to that one of the target table. This is necessary b/c unlike Spark, Avro is case-sensitive
     // and therefore would fail downstream if case of corresponding columns don't match
     val existingAttributes = existingAttributesMap.map(_._1)
-    val adjustedSourceTableOutput = projectedJoinOutput.map { attr =>
+    val adjustedSourceTableOutput = inputPlanAttributes.map { attr =>
       existingAttributes.find(keyAttr => resolver(keyAttr.name, attr.name)) match {
         // To align the casing we just rename the attribute to match that one of the
         // target table
@@ -381,7 +386,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       }
     }
 
-    val amendedPlan = Project(adjustedSourceTableOutput ++ additionalColumns, projectedJoinPlan)
+    val amendedPlan = Project(adjustedSourceTableOutput ++ additionalColumns, inputPlan)
 
     Dataset.ofRows(sparkSession, amendedPlan)
   }
@@ -575,7 +580,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     // NOTE: We're relying on [[sourceDataset]] here instead of [[mergeInto.sourceTable]],
     //       as it could be amended to add missing primary-key and/or pre-combine columns.
     //       Please check [[sourceDataset]] scala-doc for more details
-    (projectedJoinedDataset.queryExecution.analyzed.output ++ mergeInto.targetTable.output).filterNot(a => isMetaField(a.name))
+    (getProcessedInputDf.queryExecution.analyzed.output ++ mergeInto.targetTable.output).filterNot(a => isMetaField(a.name))
   }
 
   private def resolvesToSourceAttribute(expr: Expression): Boolean = {
@@ -618,9 +623,8 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     val preCombineField = hoodieCatalogTable.preCombineKey.getOrElse("")
     val hiveSyncConfig = buildHiveSyncConfig(sparkSession, hoodieCatalogTable, tableConfig)
     // for pkless tables, we need to enable optimized merge
-    val hasPrimaryKey = tableConfig.getRecordKeyFields.isPresent
-    val enableOptimizedMerge = if (!hasPrimaryKey) "true" else sparkSession.sqlContext.conf.getConfString(SPARK_SQL_OPTIMIZED_WRITES.key(), "false")
-    val keyGeneratorClassName = if (enableOptimizedMerge == "true") {
+    val isPrimaryKeylessTable = !hasPrimaryKey()
+    val keyGeneratorClassName = if (isPrimaryKeylessTable) {
       classOf[MergeIntoKeyGenerator].getCanonicalName
     } else {
       classOf[SqlKeyGenerator].getCanonicalName
@@ -658,7 +662,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
       CANONICALIZE_SCHEMA.key -> "false",
       SCHEMA_ALLOW_AUTO_EVOLUTION_COLUMN_DROP.key -> "true",
       HoodieSparkSqlWriter.SQL_MERGE_INTO_WRITES.key -> "true",
-      HoodieWriteConfig.SPARK_SQL_MERGE_INTO_PREPPED_KEY -> enableOptimizedMerge,
+      HoodieWriteConfig.SPARK_SQL_MERGE_INTO_PREPPED_KEY -> isPrimaryKeylessTable.toString,
       HoodieWriteConfig.COMBINE_BEFORE_UPSERT.key() -> (!StringUtils.isNullOrEmpty(preCombineField)).toString
     )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/TestMergeIntoTable.scala
@@ -21,101 +21,144 @@ import org.apache.hudi.DataSourceWriteOptions.SPARK_SQL_OPTIMIZED_WRITES
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.{DataSourceReadOptions, HoodieDataSourceHelpers, HoodieSparkUtils, ScalaAssertionSupport}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField}
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.slf4j.LoggerFactory
 
 class TestMergeIntoTable extends HoodieSparkSqlTestBase with ScalaAssertionSupport {
 
   test("Test MergeInto Basic") {
     Seq(true, false).foreach { sparkSqlOptimizedWrites =>
       withRecordType()(withTempDir { tmp =>
-        spark.sql("set hoodie.payload.combined.schema.validate = false")
-        val tableName = generateTableName
-        // Create table
-        spark.sql(
-          s"""
-             |create table $tableName (
-             |  id int,
-             |  name string,
-             |  price double,
-             |  ts long
-             |) using hudi
-             | location '${tmp.getCanonicalPath}'
-             | tblproperties (
-             |  primaryKey ='id',
-             |  preCombineField = 'ts'
-             | )
+        withSparkSqlSessionConfig("hoodie.payload.combined.schema.validate" -> "false",
+          // Column stats and partition stats need to be disabled to validate
+          // that there is no full target table scan during MERGE INTO
+          "hoodie.metadata.index.column.stats.enable" -> "false",
+          "hoodie.metadata.index.partition.stats.enable" -> "false") {
+          val tableName = generateTableName
+          // Create table
+          spark.sql(
+            s"""
+               |create table $tableName (
+               |  id int,
+               |  name string,
+               |  price double,
+               |  ts int,
+               |  partition string
+               |) using hudi
+               | partitioned by (partition)
+               | location '${tmp.getCanonicalPath}'
+               | tblproperties (
+               |  primaryKey ='id',
+               |  preCombineField = 'ts'
+               | )
        """.stripMargin)
 
-        // test with optimized sql merge enabled / disabled.
-        spark.sql(s"set ${SPARK_SQL_OPTIMIZED_WRITES.key()}=$sparkSqlOptimizedWrites")
-
-        // First merge with a extra input field 'flag' (insert a new record)
-        spark.sql(
-          s"""
-             | merge into $tableName
-             | using (
-             |  select 1 as id, 'a1' as name, 10 as price, 1000 as ts, '1' as flag
-             | ) s0
-             | on s0.id = $tableName.id
-             | when matched and flag = '1' then update set
-             | id = s0.id, name = s0.name, price = s0.price, ts = s0.ts
-             | when not matched and flag = '1' then insert *
+          // test with optimized sql merge enabled / disabled.
+          spark.sql(s"set ${SPARK_SQL_OPTIMIZED_WRITES.key()}=$sparkSqlOptimizedWrites")
+          val structFields = List(
+            StructField("id", IntegerType, nullable = true),
+            StructField("name", StringType, nullable = true),
+            StructField("price", DoubleType, nullable = true),
+            StructField("ts", IntegerType, nullable = true),
+            StructField("partition", StringType, nullable = true))
+          // First merge with a extra input field 'flag' (insert a new record)
+          spark.sql(
+            s"""
+               | merge into $tableName
+               | using (
+               |  select 1 as id, 'a1' as name, 10 as price, 1000 as ts, 'p1' as partition, '1' as flag
+               |  union
+               |  select 2 as id, 'a2' as name, 20 as price, 1000 as ts, 'p2' as partition, '1' as flag
+               |  union
+               |  select 3 as id, 'a3' as name, 30 as price, 1000 as ts, 'p3' as partition, '1' as flag
+               | ) s0
+               | on s0.id = $tableName.id
+               | when matched and flag = '1' then update set
+               | id = s0.id, name = s0.name, price = s0.price, ts = s0.ts
+               | when not matched and flag = '1' then insert *
        """.stripMargin)
-        checkAnswer(s"select id, name, price, ts from $tableName")(
-          Seq(1, "a1", 10.0, 1000)
-        )
+          validateTableSchema(tableName, structFields)
+          checkAnswer(s"select id, name, price, ts, partition from $tableName")(
+            Seq(1, "a1", 10.0, 1000, "p1"),
+            Seq(2, "a2", 20.0, 1000, "p2"),
+            Seq(3, "a3", 30.0, 1000, "p3")
+          )
 
-        // Second merge (update the record)
-        spark.sql(
-          s"""
-             | merge into $tableName
-             | using (
-             |  select 1 as id, 'a1' as name, 10 as price, 1001 as ts
-             | ) s0
-             | on s0.id = $tableName.id
-             | when matched then update set
-             | id = s0.id, name = s0.name, price = s0.price + $tableName.price, ts = s0.ts
-             | when not matched then insert *
-       """.stripMargin)
-        checkAnswer(s"select id, name, price, ts from $tableName")(
-          Seq(1, "a1", 20.0, 1001)
-        )
+          // Second merge (update the record) with different field names in the source
+          spark.sql(
+            s"""
+               | merge into $tableName
+               | using (
+               |  select 1 as _id, 'a1' as name, 10 as _price, 1001 as _ts, 'p1' as partition
+               | ) s0
+               | on s0._id = $tableName.id
+               | when matched then update set
+               | id = s0._id, name = s0.name, price = s0._price + $tableName.price, ts = s0._ts
+               | """.stripMargin)
+          validateTableSchema(tableName, structFields)
+          checkAnswer(s"select id, name, price, ts, partition from $tableName")(
+            Seq(1, "a1", 20.0, 1001, "p1"),
+            Seq(2, "a2", 20.0, 1000, "p2"),
+            Seq(3, "a3", 30.0, 1000, "p3")
+          )
 
-        // the third time merge (update & insert the record)
-        spark.sql(
-          s"""
-             | merge into $tableName
-             | using (
-             |  select * from (
-             |  select 1 as id, 'a1' as name, 10 as price, 1002 as ts
-             |  union all
-             |  select 2 as id, 'a2' as name, 12 as price, 1001 as ts
-             |  )
-             | ) s0
-             | on s0.id = $tableName.id
-             | when matched then update set
-             | id = s0.id, name = s0.name, price = s0.price + $tableName.price, ts = s0.ts
-             | when not matched and s0.id % 2 = 0 then insert *
+          // the third time merge (update & insert the record)
+          spark.sql(
+            s"""
+               | merge into $tableName
+               | using (
+               |  select * from (
+               |  select 1 as id, 'a1' as name, 10 as price, 1002 as ts, 'p1' as partition
+               |  union all
+               |  select 4 as id, 'a4' as name, 40 as price, 1001 as ts, 'p4' as partition
+               |  )
+               | ) s0
+               | on s0.id = $tableName.id
+               | when matched then update set
+               | id = s0.id, name = s0.name, price = s0.price + $tableName.price, ts = s0.ts
+               | when not matched and s0.id % 2 = 0 then insert *
        """.stripMargin)
-        checkAnswer(s"select id, name, price, ts from $tableName")(
-          Seq(1, "a1", 30.0, 1002),
-          Seq(2, "a2", 12.0, 1001)
-        )
+          validateTableSchema(tableName, structFields)
+          checkAnswer(s"select id, name, price, ts, partition from $tableName")(
+            Seq(1, "a1", 30.0, 1002, "p1"),
+            Seq(2, "a2", 20.0, 1000, "p2"),
+            Seq(3, "a3", 30.0, 1000, "p3"),
+            Seq(4, "a4", 40.0, 1001, "p4")
+          )
 
-        // the fourth merge (delete the record)
-        spark.sql(
-          s"""
-             | merge into $tableName
-             | using (
-             |  select 1 as id, 'a1' as name, 12 as price, 1003 as ts
-             | ) s0
-             | on s0.id = $tableName.id
-             | when matched and s0.id != 1 then update set
-             |    id = s0.id, name = s0.name, price = s0.price, ts = s0.ts
-             | when matched and s0.id = 1 then delete
-             | when not matched then insert *
+          // Validate that MERGE INTO only scan affected partitions in the target table
+          // Corrupt the files in other partitions not receiving updates
+          val (metaClient, fsv) = HoodieSparkSqlTestBase.getMetaClientAndFileSystemView(tmp.getCanonicalPath)
+          Seq("p2", "p3", "p4").map(e => "partition=" + e).foreach(partition => {
+            assertTrue(fsv.getLatestFileSlices(partition).count() > 0)
+            fsv.getLatestFileSlices(partition).forEach(fileSlice => {
+              if (fileSlice.getBaseFile.isPresent) {
+                HoodieSparkSqlTestBase.replaceWithEmptyFile(
+                  spark.sessionState.newHadoopConf(), fileSlice.getBaseFile.get().getHadoopPath)
+              }
+              fileSlice.getLogFiles.forEach(logFile =>
+                HoodieSparkSqlTestBase.replaceWithEmptyFile(
+                  spark.sessionState.newHadoopConf(), logFile.getPath)
+              )
+            })
+          })
+          // the fourth merge (delete the record)
+          spark.sql(
+            s"""
+               | merge into $tableName
+               | using (
+               |  select 1 as id, 'a1' as name, 12 as price, 1003 as ts, 'p1' as partition
+               | ) s0
+               | on s0.id = $tableName.id
+               | when matched and s0.id != 1 then update set
+               |    id = s0.id, name = s0.name, price = s0.price, ts = s0.ts
+               | when matched and s0.id = 1 then delete
+               | when not matched then insert *
        """.stripMargin)
-        val cnt = spark.sql(s"select * from $tableName where id = 1").count()
-        assertResult(0)(cnt)
+          val cnt = spark.sql(s"select * from $tableName where partition = 'p1'").count()
+          assertResult(0)(cnt)
+        }
       })
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
@@ -1,0 +1,612 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.index
+
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieSparkUtils}
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode}
+import org.apache.hudi.common.model.WriteOperationType
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils}
+import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
+import org.apache.hudi.metadata.HoodieMetadataPayload.SECONDARY_INDEX_RECORD_KEY_SEPARATOR
+import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX
+import org.apache.hudi.metadata.SecondaryIndexKeyUtils
+import org.apache.hudi.storage.StoragePath
+
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.JavaConverters._
+
+class TestSecondaryIndex extends HoodieSparkSqlTestBase {
+
+  var instantTime: AtomicInteger = new AtomicInteger(1)
+  val metadataOpts: Map[String, String] = Map(
+    HoodieMetadataConfig.ENABLE.key -> "true",
+    HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key -> "true"
+  )
+  val commonOpts: Map[String, String] = Map(
+    "hoodie.insert.shuffle.parallelism" -> "4",
+    "hoodie.upsert.shuffle.parallelism" -> "4",
+    RECORDKEY_FIELD.key -> "_row_key",
+    PARTITIONPATH_FIELD.key -> "partition_path",
+    PRECOMBINE_FIELD.key -> "timestamp",
+    HoodieClusteringConfig.INLINE_CLUSTERING.key -> "true",
+    HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key -> "4",
+    HoodieCompactionConfig.INLINE_COMPACT.key() -> "true",
+    HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key() -> "3",
+    HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> "org.apache.hudi.common.model.OverwriteWithLatestAvroPayload",
+    DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> RecordMergeMode.COMMIT_TIME_ORDERING.name()
+  ) ++ metadataOpts
+
+  test("Test Create/Show/Drop Secondary Index with External Table") {
+    withTempDir { tmp =>
+      Seq("cow", "mor").foreach { tableType =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long
+             |) using hudi
+             | options (
+             |  primaryKey ='id',
+             |  type = '$tableType',
+             |  preCombineField = 'ts',
+             |  hoodie.metadata.enable = 'true',
+             |  hoodie.metadata.record.index.enable = 'true',
+             |  hoodie.metadata.index.secondary.enable = 'true',
+             |  hoodie.datasource.write.payload.class = 'org.apache.hudi.common.model.OverwriteWithLatestAvroPayload'
+             | )
+             | partitioned by(ts)
+             | location '$basePath'
+       """.stripMargin)
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+
+        spark.sql(s"""DROP TABLE if exists $tableName""")
+        // Use the same base path as above
+        spark.sql(
+          s"""CREATE TABLE $tableName USING hudi options (
+             |     hoodie.metadata.record.index.enable = 'true'
+             | ) LOCATION '$basePath'""".stripMargin)
+
+        spark.sql(s"insert into $tableName values(2, 'a2', 10, 1001)")
+        spark.sql(s"insert into $tableName values(3, 'a3', 10, 1002)")
+        checkAnswer(s"show indexes from default.$tableName")(
+          Seq("column_stats", "column_stats", ""),
+          Seq("partition_stats", "partition_stats", ""),
+          Seq("record_index", "record_index", "")
+        )
+
+        // Secondary index can not be created for two columns at once
+        checkException(s"create index idx_name_price on $tableName (name,price)")(
+          "Only one column can be indexed for functional or secondary index."
+        )
+        // Secondary index is created by default for non record key column when index type is not specified
+        spark.sql(s"create index idx_name on $tableName (name)")
+        checkAnswer(s"show indexes from default.$tableName")(
+          Seq("column_stats", "column_stats", ""),
+          Seq("partition_stats", "partition_stats", ""),
+          Seq("secondary_index_idx_name", "secondary_index", "name"),
+          Seq("record_index", "record_index", "")
+        )
+
+        spark.sql(s"create index idx_price on $tableName (price)")
+        // Create an index with the occupied name
+        checkException(s"create index idx_price on $tableName (price)")(
+          "Index already exists: idx_price"
+        )
+
+        // Both indexes should be shown
+        checkAnswer(s"show indexes from $tableName")(
+          Seq("column_stats", "column_stats", ""),
+          Seq("partition_stats", "partition_stats", ""),
+          Seq("secondary_index_idx_name", "secondary_index", "name"),
+          Seq("secondary_index_idx_price", "secondary_index", "price"),
+          Seq("record_index", "record_index", "")
+        )
+
+        checkAnswer(s"drop index idx_name on $tableName")()
+        // show index shows only one index after dropping
+        checkAnswer(s"show indexes from $tableName")(
+          Seq("column_stats", "column_stats", ""),
+          Seq("partition_stats", "partition_stats", ""),
+          Seq("secondary_index_idx_price", "secondary_index", "price"),
+          Seq("record_index", "record_index", "")
+        )
+
+        // can not drop already dropped index
+        checkException(s"drop index idx_name on $tableName")("Index does not exist: idx_name")
+        // create index again
+        spark.sql(s"create index idx_name on $tableName (name)")
+        // drop index should work now
+        checkAnswer(s"drop index idx_name on $tableName")()
+        checkAnswer(s"show indexes from $tableName")(
+          Seq("column_stats", "column_stats", ""),
+          Seq("partition_stats", "partition_stats", ""),
+          Seq("secondary_index_idx_price", "secondary_index", "price"),
+          Seq("record_index", "record_index", "")
+        )
+
+        // Drop the second index and show index should show no index
+        // Try a partial delete scenario where table config does not have the partition path
+        val metaClient = HoodieTableMetaClient.builder()
+          .setBasePath(basePath)
+          .setConf(HoodieTestUtils.getDefaultStorageConf)
+          .build()
+        assertFalse(metaClient.getTableConfig.getRelativeIndexDefinitionPath.get().contains(metaClient.getBasePath))
+        assertTrue(metaClient.getIndexDefinitionPath.contains(metaClient.getBasePath.toString))
+        val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.values().stream()
+          .filter(indexDefn => indexDefn.getIndexType.equals(PARTITION_NAME_SECONDARY_INDEX)).findFirst().get()
+
+        metaClient.getTableConfig.setMetadataPartitionState(metaClient, indexDefinition.getIndexName, false)
+        checkAnswer(s"drop index idx_price on $tableName")()
+        checkAnswer(s"show indexes from $tableName")(
+          Seq("column_stats", "column_stats", ""),
+          Seq("partition_stats", "partition_stats", ""),
+          Seq("record_index", "record_index", "")
+        )
+
+        // Drop the record index and show index should show no index
+        checkAnswer(s"drop index record_index on $tableName")()
+        checkAnswer(s"drop index column_stats on $tableName")()
+        checkAnswer(s"drop index partition_stats on $tableName")()
+        checkAnswer(s"show indexes from $tableName")()
+
+        checkException(s"drop index idx_price on $tableName")("Index does not exist: idx_price")
+
+        checkExceptionContain(s"create index idx_price_1 on $tableName (field_not_exist)")(
+          "Missing field field_not_exist"
+        )
+      }
+    }
+  }
+
+  test("Test Secondary Index Creation With hudi_metadata TVF") {
+    withTempDir {
+      tmp => {
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+
+        createTempTableAndInsert(tableName, basePath)
+
+        // validate record_index created successfully
+        val metadataDF = spark.sql(s"select key from hudi_metadata('$basePath') where type=5")
+        assert(metadataDF.count() == 2)
+
+        var metaClient = HoodieTableMetaClient.builder()
+          .setBasePath(basePath)
+          .setConf(HoodieTestUtils.getDefaultStorageConf)
+          .build()
+        assert(metaClient.getTableConfig.getMetadataPartitions.contains("record_index"))
+        // create secondary index
+        spark.sql(s"create index idx_city on $tableName (city)")
+        metaClient = HoodieTableMetaClient.builder()
+          .setBasePath(basePath)
+          .setConf(HoodieTestUtils.getDefaultStorageConf)
+          .build()
+        assert(metaClient.getTableConfig.getMetadataPartitions.contains("secondary_index_idx_city"))
+        assert(metaClient.getTableConfig.getMetadataPartitions.contains("record_index"))
+
+        checkAnswer(s"select key, SecondaryIndexMetadata.isDeleted from hudi_metadata('$basePath') where type=7")(
+          Seq(s"austin${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}e96c4396-3fad-413a-a942-4cb36106d720", false),
+          Seq(s"san_francisco${SECONDARY_INDEX_RECORD_KEY_SEPARATOR}334e26e9-8355-45cc-97c6-c31daf0df330", false)
+        )
+      }
+    }
+  }
+
+  test("Test Secondary Index Creation Failure For Multiple Fields") {
+    withTempDir {
+      tmp => {
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+
+        createTempTableAndInsert(tableName, basePath)
+
+        // validate record_index created successfully
+        val metadataDF = spark.sql(s"select key from hudi_metadata('$basePath') where type=5")
+        assert(metadataDF.count() == 2)
+
+        val metaClient = HoodieTableMetaClient.builder()
+          .setBasePath(basePath)
+          .setConf(HoodieTestUtils.getDefaultStorageConf)
+          .build()
+        assert(metaClient.getTableConfig.getMetadataPartitions.contains("record_index"))
+        // create secondary index throws error when trying to create on multiple fields at a time
+        checkException(sql = s"create index idx_city on $tableName (city,state)")(
+          "Only one column can be indexed for functional or secondary index."
+        )
+      }
+    }
+  }
+
+  test("Test Secondary Index With Updates Compaction Clustering Deletes") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      // Step 1: Initial Insertion of Records
+      val dataGen = new HoodieTestDataGenerator()
+      val hudiOpts: Map[String, String] = loadInitialBatchAndCreateSecondaryIndex(tableName, basePath, dataGen)
+
+      // Verify initial state of secondary index
+      val initialKeys = spark.sql(s"select _row_key from $tableName limit 5").collect().map(_.getString(0))
+      validateSecondaryIndex(basePath, tableName, initialKeys)
+      val initialRecordsCount = spark.sql(s"select _row_key from $tableName").count()
+
+      // Step 3: Perform Update Operations on Subset of Records
+      var updateRecords = recordsToStrings(dataGen.generateUniqueUpdates(getInstantTime, 10, HoodieTestDataGenerator.TRIP_FLATTENED_SCHEMA)).asScala
+      var updateDf = spark.read.json(spark.sparkContext.parallelize(updateRecords.toSeq, 2))
+      updateDf.write.format("hudi")
+        .options(hudiOpts)
+        .option(OPERATION.key, UPSERT_OPERATION_OPT_VAL)
+        .mode(SaveMode.Append)
+        .save(basePath)
+      // Verify secondary index after updates
+      var updateKeys = updateDf.select("_row_key").collect().map(_.getString(0))
+      validateSecondaryIndex(basePath, tableName, updateKeys)
+
+      // Step 4: Trigger Compaction with this update as the compaction frequency is set to 3 commits
+      updateRecords = recordsToStrings(dataGen.generateUniqueUpdates(getInstantTime, 10, HoodieTestDataGenerator.TRIP_FLATTENED_SCHEMA)).asScala
+      updateDf = spark.read.json(spark.sparkContext.parallelize(updateRecords.toSeq, 2))
+      updateDf.write.format("hudi")
+        .options(hudiOpts)
+        .option(OPERATION.key, UPSERT_OPERATION_OPT_VAL)
+        .mode(SaveMode.Append)
+        .save(basePath)
+      // Verify compaction
+      var metaClient = HoodieTableMetaClient.builder()
+        .setBasePath(basePath)
+        .setConf(HoodieTestUtils.getDefaultStorageConf)
+        .build()
+      assertTrue(metaClient.getActiveTimeline.getCommitTimeline.filterCompletedInstants.lastInstant.isPresent)
+      // Verify secondary index after compaction
+      updateKeys = updateDf.select("_row_key").collect().map(_.getString(0))
+      validateSecondaryIndex(basePath, tableName, updateKeys)
+      // Verify count of records
+      assertEquals(initialRecordsCount, spark.sql(s"select _row_key from $tableName").count())
+
+      // Step 5: Trigger Clustering with this update as the clustering frequency is set to 4 commits
+      updateRecords = recordsToStrings(dataGen.generateUniqueUpdates(getInstantTime, 10, HoodieTestDataGenerator.TRIP_FLATTENED_SCHEMA)).asScala
+      updateDf = spark.read.json(spark.sparkContext.parallelize(updateRecords.toSeq, 2))
+      updateDf.write.format("hudi")
+        .options(hudiOpts)
+        .option(OPERATION.key, UPSERT_OPERATION_OPT_VAL)
+        .mode(SaveMode.Append)
+        .save(basePath)
+      // Verify clustering
+      metaClient = HoodieTableMetaClient.reload(metaClient)
+      assertTrue(metaClient.getActiveTimeline.getCompletedReplaceTimeline.lastInstant.isPresent)
+      // Verify secondary index after clustering
+      updateKeys = updateDf.select("_row_key").collect().map(_.getString(0))
+      validateSecondaryIndex(basePath, tableName, updateKeys)
+
+      // Step 6: Perform Deletes on Records and Validate Secondary Index
+      val deleteKeys = initialKeys.take(1) // pick a subset of keys to delete
+      val deleteDf = spark.read.format("hudi").load(basePath).filter(s"_row_key in ('${deleteKeys.mkString("','")}')")
+      deleteDf.write.format("hudi")
+        .options(hudiOpts)
+        .option(OPERATION.key, DELETE_OPERATION_OPT_VAL)
+        .mode(SaveMode.Append)
+        .save(basePath)
+      // Verify secondary index for deletes
+      validateSecondaryIndex(basePath, tableName, deleteKeys, hasDeleteKeys = true)
+      // Verify for non deleted keys
+      val nonDeletedKeys = initialKeys.diff(deleteKeys)
+      validateSecondaryIndex(basePath, tableName, nonDeletedKeys)
+
+      // Step 7: Final Update and Validation
+      val finalUpdateRecords = recordsToStrings(dataGen.generateUniqueUpdates(getInstantTime, 10, HoodieTestDataGenerator.TRIP_FLATTENED_SCHEMA)).asScala
+      val finalUpdateDf = spark.read.json(spark.sparkContext.parallelize(finalUpdateRecords.toSeq, 2))
+      finalUpdateDf.write.format("hudi")
+        .options(hudiOpts)
+        .option(OPERATION.key, UPSERT_OPERATION_OPT_VAL)
+        .mode(SaveMode.Append)
+        .save(basePath)
+      // Verify secondary index after final updates
+      val finalUpdateKeys = finalUpdateDf.select("_row_key").collect().map(_.getString(0))
+      validateSecondaryIndex(basePath, tableName, nonDeletedKeys)
+      validateSecondaryIndex(basePath, tableName, finalUpdateKeys)
+      dataGen.close()
+    }
+  }
+
+  test("Test Secondary Index With Overwrite and Delete Partition") {
+    withTempDir { tmp =>
+      Seq(
+        WriteOperationType.INSERT_OVERWRITE.value(),
+        WriteOperationType.INSERT_OVERWRITE_TABLE.value(),
+        WriteOperationType.DELETE_PARTITION.value()
+      ).foreach { operationType =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        // Step 1: Initial Insertion of Records
+        val dataGen = new HoodieTestDataGenerator()
+        val hudiOpts: Map[String, String] = loadInitialBatchAndCreateSecondaryIndex(tableName, basePath, dataGen)
+
+        // Verify initial state of secondary index
+        val initialKeys = spark.sql(s"select _row_key from $tableName limit 5").collect().map(_.getString(0))
+        validateSecondaryIndex(basePath, tableName, initialKeys)
+
+        // Step 3: Perform Update Operations on Subset of Records
+        val records = recordsToStrings(dataGen.generateUniqueUpdates(getInstantTime, 10, HoodieTestDataGenerator.TRIP_FLATTENED_SCHEMA)).asScala
+        val df = spark.read.json(spark.sparkContext.parallelize(records.toSeq, 2))
+        // Verify secondary index update fails
+        checkException(() => df.write.format("hudi")
+          .options(hudiOpts)
+          .option(OPERATION.key, operationType)
+          .mode(SaveMode.Append)
+          .save(basePath))(
+          "Can not perform operation " + WriteOperationType.fromValue(operationType) + " on secondary index")
+        // disable secondary index and retry
+        df.write.format("hudi")
+          .options(hudiOpts)
+          .option(HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key, "false")
+          .option(OPERATION.key, operationType)
+          .mode(SaveMode.Append)
+          .save(basePath)
+        dataGen.close()
+      }
+    }
+  }
+
+  test("Test Secondary Index With Time Travel Query") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      // Step 1: Initial Insertion of Records
+      val dataGen = new HoodieTestDataGenerator()
+      val numInserts = 5
+      val hudiOpts: Map[String, String] = loadInitialBatchAndCreateSecondaryIndex(tableName, basePath, dataGen, numInserts)
+
+      // Verify initial state of secondary index
+      val initialKeys = spark.sql(s"select _row_key from $tableName limit 5").collect().map(_.getString(0))
+      validateSecondaryIndex(basePath, tableName, initialKeys)
+
+      // Step 3: Perform Update Operations on Subset of Records
+      val updateRecords = recordsToStrings(dataGen.generateUniqueUpdates(getInstantTime, 1, HoodieTestDataGenerator.TRIP_FLATTENED_SCHEMA)).asScala
+      val updateDf = spark.read.json(spark.sparkContext.parallelize(updateRecords.toSeq, 1))
+      val updateKeys = updateDf.select("_row_key").collect().map(_.getString(0))
+      val recordKeyToUpdate = updateKeys.head
+      val initialSecondaryKey = spark.sql(
+        s"SELECT key FROM hudi_metadata('$basePath') WHERE type=7 AND key LIKE '%$SECONDARY_INDEX_RECORD_KEY_SEPARATOR$recordKeyToUpdate'"
+      ).collect().map(indexKey => SecondaryIndexKeyUtils.getSecondaryKeyFromSecondaryIndexKey(indexKey.getString(0))).head
+      // update the record
+      updateDf.write.format("hudi")
+        .options(hudiOpts)
+        .option(OPERATION.key, UPSERT_OPERATION_OPT_VAL)
+        .mode(SaveMode.Append)
+        .save(basePath)
+      // Verify secondary index after updates
+      validateSecondaryIndex(basePath, tableName, updateKeys)
+
+      // Step 4: Perform Time Travel Query
+      // get the first instant on the timeline
+      val metaClient = HoodieTableMetaClient.builder()
+        .setBasePath(basePath)
+        .setConf(HoodieTestUtils.getDefaultStorageConf)
+        .build()
+      val firstInstant = metaClient.reloadActiveTimeline().filterCompletedInstants().firstInstant().get()
+      // do a time travel query with data skipping enabled
+      val readOpts = hudiOpts ++ Map(
+        HoodieMetadataConfig.ENABLE.key -> "true",
+        DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true"
+      )
+      val timeTravelDF = spark.read.format("hudi")
+        .options(readOpts)
+        .option("as.of.instant", firstInstant.requestedTime)
+        .load(basePath)
+      assertEquals(numInserts, timeTravelDF.count())
+      // updated record should still show in time travel view
+      assertEquals(1, timeTravelDF.where(s"_row_key = '$recordKeyToUpdate'").count())
+      // rider field (secondary key) should point to previous value
+      val secondaryKey = timeTravelDF.where(s"_row_key = '$recordKeyToUpdate'").select("rider").collect().head.getString(0)
+      assertEquals(initialSecondaryKey, secondaryKey)
+
+      // Perform Deletes on Records and Validate Secondary Index
+      val deleteDf = spark.read.format("hudi").load(basePath).filter(s"_row_key in ('${updateKeys.mkString("','")}')")
+      // Get fileId for the delete record
+      val deleteFileId = deleteDf.select("_hoodie_file_name").collect().head.getString(0)
+      deleteDf.write.format("hudi")
+        .options(hudiOpts)
+        .option(OPERATION.key, DELETE_OPERATION_OPT_VAL)
+        .mode(SaveMode.Append)
+        .save(basePath)
+      // Verify secondary index for deletes
+      validateSecondaryIndex(basePath, tableName, updateKeys, hasDeleteKeys = true)
+      // Corrupt the data file that was written for the delete key in the first instant.
+      // We are doing it to guard against a scenario where time travel query unintentionally looks up secondary index,
+      // according to which the data file is supposed to be skipped. Consider following scenario:
+      // 1. A record is deleted that was inserted in the first instant.
+      // 2. Secondary index gets updated and as per the latest snapshot of the index should not have the deleted record.
+      // 3. A time travel query is performed with data skipping enabled.
+      // 4. If it was to look up the secondary index, it would have skipped the data file, but the data file is still present.
+      // 5. Time travel query should throw an exception in this case.
+      val firstCommitMetadata = metaClient.reloadActiveTimeline().readCommitMetadataToAvro(firstInstant)
+      val partitionToWriteStats = firstCommitMetadata.getPartitionToWriteStats.asScala.mapValues(_.asScala.toList)
+      // Find the path for the given fileId
+      val matchingPath: Option[String] = partitionToWriteStats.values.flatten
+        .find(_.getFileId == deleteFileId)
+        .map(_.getPath)
+      assertTrue(matchingPath.isDefined)
+      // Corrupt the data file
+      val dataFile = new StoragePath(basePath, matchingPath.get)
+      HoodieSparkSqlTestBase.replaceWithEmptyFile(metaClient.getStorage, dataFile)
+      // Time travel query should now throw an exception
+      checkExceptionContain(() => spark.read.format("hudi")
+        .options(readOpts)
+        .option("as.of.instant", firstInstant.requestedTime)
+        .load(basePath).count())(s"${dataFile.toString} is not a Parquet file")
+
+      dataGen.close()
+    }
+  }
+
+  /**
+   * Test secondary index with auto generation of record keys
+   */
+  test("Test Secondary Index With Auto Record Key Generation") {
+    withTempDir { tmp =>
+      val tableName = generateTableName + s"_si_auto_keygen"
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+
+      spark.sql("set hoodie.fileIndex.dataSkippingFailureMode=strict")
+
+      spark.sql(
+        s"""
+           CREATE TABLE $tableName (
+           |    ts LONG,
+           |    id STRING,
+           |    rider STRING,
+           |    driver STRING,
+           |    fare DOUBLE,
+           |    dateDefault STRING,
+           |    date STRING,
+           |    city STRING,
+           |    state STRING
+           |) USING HUDI
+           |options(
+           |    type = 'mor',
+           |    hoodie.metadata.enable = 'true',
+           |    hoodie.enable.data.skipping = 'true',
+           |    hoodie.metadata.record.index.enable = 'true',
+           |    hoodie.datasource.write.payload.class = 'org.apache.hudi.common.model.OverwriteWithLatestAvroPayload'
+           |)
+           |PARTITIONED BY (state)
+           |location '$basePath'
+           |""".stripMargin)
+
+      spark.sql("set hoodie.parquet.small.file.limit=0")
+      if (HoodieSparkUtils.gteqSpark3_4) {
+        spark.sql("set spark.sql.defaultColumn.enabled=false")
+      }
+
+      spark.sql(
+        s"""
+           |INSERT INTO $tableName(ts, id, rider, driver, fare, dateDefault, date, city, state) VALUES
+           |  (1695414520,'trip2','rider-C','driver-M',27.70,'2024-11-30 01:30:40', '2024-11-30', 'sunnyvale','california'),
+           |  (1699349649,'trip5','rider-A','driver-Q',3.32, '2019-11-30 01:30:40', '2019-11-30', 'san_diego','texas')
+           |""".stripMargin)
+
+      // create secondary index
+      spark.sql(s"CREATE INDEX idx_city on $tableName (city)")
+      // validate secondary index
+      var expectedSecondaryKeys = spark.sql(s"SELECT _hoodie_record_key, city from $tableName")
+        .collect().map(row => SecondaryIndexKeyUtils.constructSecondaryIndexKey(row.getString(1), row.getString(0)))
+      var actualSecondaryKeys = spark.sql(s"SELECT key FROM hudi_metadata('$basePath') WHERE type=7 AND key LIKE '%$SECONDARY_INDEX_RECORD_KEY_SEPARATOR%'")
+        .collect().map(indexKey => indexKey.getString(0))
+      assertEquals(expectedSecondaryKeys.toSet, actualSecondaryKeys.toSet)
+
+      // update record
+      spark.sql(s"UPDATE $tableName SET city = 'san_francisco' WHERE rider = 'rider-C'")
+      // validate secondary index
+      expectedSecondaryKeys = spark.sql(s"SELECT _hoodie_record_key, city from $tableName")
+        .collect().map(row => SecondaryIndexKeyUtils.constructSecondaryIndexKey(row.getString(1), row.getString(0)))
+      actualSecondaryKeys = spark.sql(s"SELECT key FROM hudi_metadata('$basePath') WHERE type=7 AND key LIKE '%$SECONDARY_INDEX_RECORD_KEY_SEPARATOR%'")
+        .collect().map(indexKey => indexKey.getString(0))
+      assertEquals(expectedSecondaryKeys.toSet, actualSecondaryKeys.toSet)
+    }
+  }
+
+  private def loadInitialBatchAndCreateSecondaryIndex(tableName: String, basePath: String, dataGen: HoodieTestDataGenerator, numInserts: Integer = 50) = {
+    val initialRecords = recordsToStrings(dataGen.generateInserts(getInstantTime, numInserts, true)).asScala
+    val initialDf = spark.read.json(spark.sparkContext.parallelize(initialRecords.toSeq, 2))
+    val hudiOpts = commonOpts ++ Map(TABLE_TYPE.key -> "MERGE_ON_READ", HoodieWriteConfig.TBL_NAME.key -> tableName)
+    initialDf.write.format("hudi")
+      .options(hudiOpts)
+      .option(OPERATION.key, INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    // Step 2: Create table and secondary index on 'rider' column
+    spark.sql(s"CREATE TABLE $tableName USING hudi LOCATION '$basePath'")
+    spark.sql(s"create index idx_rider on $tableName (rider)")
+    hudiOpts
+  }
+
+  private def validateSecondaryIndex(basePath: String, tableName: String, recordKeys: Array[String], hasDeleteKeys: Boolean = false): Unit = {
+    // Check secondary index metadata for the selected keys
+    recordKeys.foreach { key =>
+      val secondaryKeys = spark.sql(
+        s"SELECT key FROM hudi_metadata('$basePath') WHERE type=7 AND key LIKE '%$SECONDARY_INDEX_RECORD_KEY_SEPARATOR$key'"
+      ).collect().map(indexKey => SecondaryIndexKeyUtils.getSecondaryKeyFromSecondaryIndexKey(indexKey.getString(0)))
+
+      // Ensure secondary keys are correctly present or deleted
+      if (hasDeleteKeys) {
+        assertTrue(secondaryKeys.isEmpty)
+      } else {
+        assertTrue(secondaryKeys.nonEmpty, s"Secondary index entry missing for key: $key")
+        secondaryKeys.foreach { secKey =>
+          assert(
+            spark.sql(s"SELECT _row_key FROM $tableName WHERE _row_key = '$key'").count() > 0,
+            s"Record key '$key' with secondary key '$secKey' should be present in the data but is missing"
+          )
+        }
+      }
+    }
+  }
+
+  private def getInstantTime: String = {
+    String.format("%03d", new Integer(instantTime.incrementAndGet()))
+  }
+
+  private def createTempTableAndInsert(tableName: String, basePath: String) = {
+    spark.sql(
+      s"""
+         |create table $tableName (
+         |  ts bigint,
+         |  id string,
+         |  rider string,
+         |  driver string,
+         |  fare int,
+         |  city string,
+         |  state string
+         |) using hudi
+         | options (
+         |  primaryKey ='id',
+         |  type = 'mor',
+         |  preCombineField = 'ts',
+         |  hoodie.metadata.enable = 'true',
+         |  hoodie.metadata.record.index.enable = 'true',
+         |  hoodie.metadata.index.secondary.enable = 'true',
+         |  hoodie.datasource.write.recordkey.field = 'id',
+         |  hoodie.datasource.write.payload.class = "org.apache.hudi.common.model.OverwriteWithLatestAvroPayload"
+         | )
+         | partitioned by(state)
+         | location '$basePath'
+       """.stripMargin)
+    spark.sql(
+      s"""
+         | insert into $tableName
+         | values
+         | (1695159649087, '334e26e9-8355-45cc-97c6-c31daf0df330', 'rider-A', 'driver-K', 19, 'san_francisco', 'california'),
+         | (1695091554787, 'e96c4396-3fad-413a-a942-4cb36106d720', 'rider-B', 'driver-M', 27, 'austin', 'texas')
+         | """.stripMargin
+    )
+  }
+}


### PR DESCRIPTION
### Change Logs

Cherry-picked: https://github.com/apache/hudi/pull/12934

This PR fixes the unnecessary scanning of the target table in MERGE INTO statement in Spark by only using the source table as the input if the target table has a record key (before this change the source and target table is left joined, causing all partitions in the target table to be scanned unnecessarily, if the source table only contains data targeting a handful of partitions). For primary-keyless table the logic is not changed, i.e., the source and target table is left joined to get the meta column values for prepped upsert in MERGE INTO.

Spark SQL for testing:

create database MIT_partition_pruning5;
use MIT_partition_pruning5;
CREATE TABLE merge_source (
    ts BIGINT,
    uuid STRING,
    fare DOUBLE,
    city STRING
) USING PARQUET;

INSERT INTO merge_source
VALUES
(1695159649087,'334e26e9-8355-45cc-97c6-c31daf0df330',19.10,'san_francisco');

CREATE TABLE hudi_table (
    ts BIGINT,
    uuid STRING,
    rider STRING,
    driver STRING,
    fare DOUBLE,
    city STRING
) USING HUDI
PARTITIONED BY (city)
OPTIONS ( 
  primaryKey 'uuid', 
  hoodie.datasource.write.operation 'upsert', 
  hoodie.datasource.write.precombine.field 'ts', 
  hoodie.datasource.write.recordkey.field 'uuid',
  hoodie.table.name 'MIT_partition_pruning'
  );

INSERT INTO hudi_table
VALUES
(1695159649087,'334e26e9-8355-45cc-97c6-c31daf0df330','rider-A','driver-K',19.10,'san_francisco'),
(1695091554788,'e96c4396-3fad-413a-a942-4cb36106d721','rider-C','driver-M',27.70 ,'san_francisco'),
(1695046462179,'9909a8b1-2d15-4d3d-8ec9-efc48c536a00','rider-D','driver-L',33.90 ,'san_francisco'),
(1695332066204,'1dced545-862b-4ceb-8b43-d2a568f6616b','rider-E','driver-O',93.50,'san_francisco');


INSERT INTO hudi_table
SELECT 
    1695115999911 AS timestamp,  -- Creating unique timestamps based on the counter
    uuid() AS uuid,
    CONCAT('rider-', CAST(65 + (counter % 26) AS STRING)) AS rider,
    CONCAT('driver-', CAST(75 + (counter % 26) AS STRING)) AS driver,
    ROUND(rand() * (100 - 10) + 10, 2) AS amount,  -- Random fare between 10 and 100
    concat('p', CAST((counter % 300) AS STRING)) AS city
FROM (SELECT explode(sequence(1, 1000000)) AS counter) A;

MERGE INTO hudi_table AS target
USING merge_source AS source
ON target.uuid = source.uuid
and target.city = source.city
WHEN MATCHED THEN UPDATE SET target.fare = target.fare
;

### Impact
Improves performance of MERGE INTO on Spark

### Risk level
low. Performance improvement only. Existing tests have guarded the correctness of MERGE INTO statement.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
