### PR TITLE
fix: disable retries in s3/gcs storage lock clients for storage based LP

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/S3StorageLockClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/S3StorageLockClient.java
@@ -244,10 +244,11 @@ public class S3StorageLockClient implements StorageLockClient {
   }
 
   private static S3Client createS3Client(Region region, long timeoutSecs, Properties props) {
-    // Set the timeout, credentials, and region
+    // Set the timeout, credentials, and region with no retries
     return S3Client.builder()
         .overrideConfiguration(
-            b -> b.apiCallTimeout(Duration.ofSeconds(timeoutSecs)))
+            b -> b.apiCallTimeout(Duration.ofSeconds(timeoutSecs))
+                  .retryStrategy(r -> r.maxAttempts(1)))
         .credentialsProvider(HoodieAWSCredentialsProviderFactory.getAwsCredentialsProvider(props))
         .region(region).build();
   }

--- a/hudi-gcp/src/main/java/org/apache/hudi/gcp/transaction/lock/GCSStorageLockClient.java
+++ b/hudi-gcp/src/main/java/org/apache/hudi/gcp/transaction/lock/GCSStorageLockClient.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -98,9 +99,16 @@ public class GCSStorageLockClient implements StorageLockClient {
 
   private static Functions.Function1<Properties, Storage> createDefaultGcsClient() {
     return (props) -> {
-      // Provide the option to customize the timeouts later on.
-      // For now, defaults suffice
-      return StorageOptions.newBuilder().build().getService();
+      // Configure with no retries - only one attempt per operation
+      RetrySettings retrySettings =
+          StorageOptions.getDefaultRetrySettings()
+              .toBuilder()
+              .setMaxAttempts(1)
+              .build();
+      return StorageOptions.newBuilder()
+          .setRetrySettings(retrySettings)
+          .build()
+          .getService();
     };
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Issue: https://github.com/apache/hudi/issues/14373

### Summary and Changelog

The storage LP should not use retries because DFS may not handle SDK retries idempotently. We have seen this at least for AWS S3.

### Impact

Any s3/gcs failures will not be retried for storage LP. However we have automatic retries for lock renewal code path, therefore no issue.

### Risk Level

Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
