### PR TITLE
refactor: Add Lombok annotations to hudi-utilities (Part 3)

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
@@ -44,12 +44,12 @@ import org.apache.hudi.util.SparkKeyGenUtils;
 import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -71,9 +71,8 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 /**
  * Performs bootstrap from a non-hudi source.
  */
+@Slf4j
 public class BootstrapExecutor implements Serializable {
-
-  private static final Logger LOG = LoggerFactory.getLogger(BootstrapExecutor.class);
 
   /**
    * Config.
@@ -103,6 +102,7 @@ public class BootstrapExecutor implements Serializable {
   /**
    * Bootstrap Configuration.
    */
+  @Getter
   private final HoodieWriteConfig bootstrapConfig;
 
   /**
@@ -146,7 +146,7 @@ public class BootstrapExecutor implements Serializable {
       builder = builder.withSchema(schemaProvider.getTargetHoodieSchema().toString());
     }
     this.bootstrapConfig = builder.build();
-    LOG.info("Created bootstrap executor with configs : " + bootstrapConfig.getProps());
+    log.info("Created bootstrap executor with configs: {}", bootstrapConfig.getProps());
   }
 
   /**
@@ -189,7 +189,7 @@ public class BootstrapExecutor implements Serializable {
     Path basePath = new Path(cfg.targetBasePath);
     if (fs.exists(basePath)) {
       if (cfg.bootstrapOverwrite) {
-        LOG.info("Target base path already exists, overwrite it");
+        log.info("Target base path already exists, overwrite it");
         fs.delete(basePath, true);
       } else {
         throw new HoodieException("target base path already exists at " + cfg.targetBasePath
@@ -243,9 +243,5 @@ public class BootstrapExecutor implements Serializable {
     }
 
     builder.initTable(HadoopFSUtils.getStorageConfWithCopy(jssc.hadoopConfiguration()), cfg.targetBasePath);
-  }
-
-  public HoodieWriteConfig getBootstrapConfig() {
-    return bootstrapConfig;
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/DefaultStreamContext.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/DefaultStreamContext.java
@@ -21,28 +21,18 @@ package org.apache.hudi.utilities.streamer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * The default implementation for the StreamContext interface,
  * composes SchemaProvider and SourceProfileSupplier currently,
  * can be extended for other arguments in the future.
  */
+@AllArgsConstructor
+@Getter
 public class DefaultStreamContext implements StreamContext {
 
   private final SchemaProvider schemaProvider;
   private final Option<SourceProfileSupplier> sourceProfileSupplier;
-
-  public DefaultStreamContext(SchemaProvider schemaProvider, Option<SourceProfileSupplier> sourceProfileSupplier) {
-    this.schemaProvider = schemaProvider;
-    this.sourceProfileSupplier = sourceProfileSupplier;
-  }
-
-  @Override
-  public SchemaProvider getSchemaProvider() {
-    return schemaProvider;
-  }
-
-  @Override
-  public Option<SourceProfileSupplier> getSourceProfileSupplier() {
-    return sourceProfileSupplier;
-  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorEvent.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/ErrorEvent.java
@@ -19,45 +19,16 @@
 
 package org.apache.hudi.utilities.streamer;
 
-import java.util.Objects;
+import lombok.Value;
 
 /**
  * Error event is an event triggered during write or processing failure of a record.
  */
+@Value
 public class ErrorEvent<T> {
 
-  private final ErrorReason reason;
-  private final T payload;
-
-  public ErrorEvent(T payload, ErrorReason reason) {
-    this.payload = payload;
-    this.reason = reason;
-  }
-
-  public T getPayload() {
-    return payload;
-  }
-
-  public ErrorReason getReason() {
-    return reason;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ErrorEvent<?> that = (ErrorEvent<?>) o;
-    return reason == that.reason && Objects.equals(payload, that.payload);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(reason, payload);
-  }
+  T payload;
+  ErrorReason reason;
 
   /**
    * The reason behind write or processing failure of a record

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamerUtils.java
@@ -54,6 +54,7 @@ import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory;
 import org.apache.hudi.util.SparkKeyGenUtils;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -64,8 +65,6 @@ import org.apache.spark.sql.HoodieInternalRowUtils;
 import org.apache.spark.sql.avro.HoodieAvroDeserializer;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -79,9 +78,8 @@ import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_ENABLE_VALIDAT
 /**
  * Util class for HoodieStreamer.
  */
+@Slf4j
 public class HoodieStreamerUtils {
-
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieStreamerUtils.class);
 
   /**
    * Generates HoodieRecords for the avro data read from source.
@@ -111,7 +109,7 @@ public class HoodieStreamerUtils {
         records = avroRDD.mapPartitions(
             (FlatMapFunction<Iterator<GenericRecord>, Either<HoodieRecord,String>>) genericRecordIterator -> {
               TaskContext taskContext = TaskContext.get();
-              LOG.info("Creating HoodieRecords with stageId : {}, stage attempt no: {}, taskId : {}, task attempt no : {}, task attempt id : {} ",
+              log.info("Creating HoodieRecords with stageId : {}, stage attempt no: {}, taskId : {}, task attempt no : {}, task attempt id : {} ",
                   taskContext.stageId(), taskContext.stageAttemptNumber(), taskContext.partitionId(), taskContext.attemptNumber(),
                   taskContext.taskAttemptId());
               if (autoGenerateRecordKeys) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/NoNewDataTerminationStrategy.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/NoNewDataTerminationStrategy.java
@@ -23,16 +23,14 @@ import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.api.java.JavaRDD;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Post writer termination strategy for deltastreamer in continuous mode. This strategy is based on no new data for consecutive number of times.
  */
+@Slf4j
 public class NoNewDataTerminationStrategy implements PostWriteTerminationStrategy {
-
-  private static final Logger LOG = LoggerFactory.getLogger(NoNewDataTerminationStrategy.class);
 
   public static final String MAX_ROUNDS_WITHOUT_NEW_DATA_TO_SHUTDOWN = "max.rounds.without.new.data.to.shutdown";
   public static final int DEFAULT_MAX_ROUNDS_WITHOUT_NEW_DATA_TO_SHUTDOWN = 3;
@@ -48,7 +46,7 @@ public class NoNewDataTerminationStrategy implements PostWriteTerminationStrateg
   public boolean shouldShutdown(Option<JavaRDD<WriteStatus>> writeStatuses) {
     numTimesNoNewData = writeStatuses.isPresent() ? 0 : numTimesNoNewData + 1;
     if (numTimesNoNewData >= numTimesNoNewDataToShutdown) {
-      LOG.info("Shutting down on continuous mode as there is no new data for " + numTimesNoNewData);
+      log.info("Shutting down on continuous mode as there is no new data for {}", numTimesNoNewData);
       return true;
     }
     return false;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SchedulerConfGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SchedulerConfGenerator.java
@@ -24,9 +24,8 @@ import org.apache.hudi.async.AsyncCompactService;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.util.Option;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.SparkConf;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -42,9 +41,8 @@ import static org.apache.hudi.async.AsyncClusteringService.CLUSTERING_POOL_NAME;
  * Utility Class to generate Spark Scheduling allocation file. This kicks in only when user sets
  * spark.scheduler.mode=FAIR at spark-submit time
  */
+@Slf4j
 public class SchedulerConfGenerator {
-
-  private static final Logger LOG = LoggerFactory.getLogger(SchedulerConfGenerator.class);
 
   public static final String DELTASYNC_POOL_NAME = HoodieStreamer.STREAMSYNC_POOL_NAME;
   public static final String COMPACT_POOL_NAME = AsyncCompactService.COMPACT_POOL_NAME;
@@ -106,10 +104,10 @@ public class SchedulerConfGenerator {
       String sparkSchedulingConfFile = generateAndStoreConfig(cfg.deltaSyncSchedulingWeight,
           cfg.compactSchedulingWeight, cfg.deltaSyncSchedulingMinShare, cfg.compactSchedulingMinShare,
           cfg.clusterSchedulingWeight, cfg.clusterSchedulingMinShare);
-      LOG.info("Spark scheduling config file {}", sparkSchedulingConfFile);
+      log.info("Spark scheduling config file {}", sparkSchedulingConfFile);
       additionalSparkConfigs.put(SparkConfigs.SPARK_SCHEDULER_ALLOCATION_FILE_KEY(), sparkSchedulingConfFile);
     } else {
-      LOG.warn("Job Scheduling Configs will not be in effect as spark.scheduler.mode "
+      log.warn("Job Scheduling Configs will not be in effect as spark.scheduler.mode "
           + "is not set to FAIR at instantiation time. Continuing without scheduling configs");
     }
     return additionalSparkConfigs;
@@ -135,7 +133,7 @@ public class SchedulerConfGenerator {
     }
     // SPARK-35083 introduces remote scheduler pool files, so the file must include scheme since Spark 3.2
     String path = tempConfigFile.toURI().toString();
-    LOG.info("Configs written to file " + path);
+    log.info("Configs written to file {}", path);
     return path;
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SourceFormatAdapter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SourceFormatAdapter.java
@@ -43,6 +43,8 @@ import org.apache.hudi.utilities.sources.helpers.RowConverter;
 import org.apache.hudi.utilities.sources.helpers.SanitizationUtils;
 
 import com.google.protobuf.Message;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Column;
@@ -73,12 +75,15 @@ import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABL
  */
 public class SourceFormatAdapter implements Closeable {
 
+  @Getter
   private final Source source;
   private boolean shouldSanitize = SANITIZE_SCHEMA_FIELD_NAMES.defaultValue();
 
   private  boolean wrapWithException = ROW_THROW_EXPLICIT_EXCEPTIONS.defaultValue();
+  @Getter(AccessLevel.PRIVATE)
   private String invalidCharMask = SCHEMA_FIELD_NAME_INVALID_CHAR_MASK.defaultValue();
 
+  @Getter(AccessLevel.PRIVATE)
   private boolean useJava8api = (boolean) SQLConf.DATETIME_JAVA8API_ENABLED().defaultValue().get();
 
 
@@ -111,18 +116,6 @@ public class SourceFormatAdapter implements Closeable {
   }
 
   /**
-   * Replacement mask for invalid characters encountered in avro names.
-   * @return sanitized value.
-   */
-  private String getInvalidCharMask() {
-    return invalidCharMask;
-  }
-
-  private boolean getUseJava8api() {
-    return useJava8api;
-  }
-
-  /**
    * transform input rdd of json string to generic records with support for adding error events to error table
    * @param inputBatch
    * @return
@@ -144,7 +137,7 @@ public class SourceFormatAdapter implements Closeable {
 
   private JavaRDD<Row> transformJsonToRowRdd(InputBatch<JavaRDD<String>> inputBatch) {
     MercifulJsonConverter.clearCache(inputBatch.getSchemaProvider().getSourceHoodieSchema().getFullName());
-    RowConverter convertor = new RowConverter(inputBatch.getSchemaProvider().getSourceHoodieSchema(), isFieldNameSanitizingEnabled(), getInvalidCharMask(), getUseJava8api());
+    RowConverter convertor = new RowConverter(inputBatch.getSchemaProvider().getSourceHoodieSchema(), isFieldNameSanitizingEnabled(), getInvalidCharMask(), isUseJava8api());
     return inputBatch.getBatch().map(rdd -> {
       if (errorTableWriter.isPresent()) {
         JavaRDD<Either<Row, String>> javaRDD = rdd.map(convertor::fromJsonToRowWithError);
@@ -321,10 +314,6 @@ public class SourceFormatAdapter implements Closeable {
       default:
         throw new IllegalArgumentException("Unknown source type (" + source.getSourceType() + ")");
     }
-  }
-
-  public Source getSource() {
-    return source;
   }
 
   @Override

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -112,11 +112,13 @@ import org.apache.hudi.utilities.schema.SchemaSet;
 import org.apache.hudi.utilities.schema.SimpleSchemaProvider;
 import org.apache.hudi.utilities.sources.InputBatch;
 import org.apache.hudi.utilities.sources.Source;
-import org.apache.hudi.utilities.streamer.HoodieStreamer.Config;
 import org.apache.hudi.utilities.streamer.validator.SparkStreamerValidatorUtils;
 import org.apache.hudi.utilities.transform.Transformer;
 
 import com.codahale.metrics.Timer;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -128,8 +130,6 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.storage.StorageLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -177,16 +177,17 @@ import static org.apache.hudi.utilities.streamer.StreamerCheckpointUtils.getLate
 /**
  * Sync's one batch of data to hoodie table.
  */
+@Slf4j
 public class StreamSync implements Serializable, Closeable {
 
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory.getLogger(StreamSync.class);
   private static final String NULL_PLACEHOLDER = "[null]";
   public static final String CHECKPOINT_IGNORE_KEY = "deltastreamer.checkpoint.ignore_key";
 
   /**
    * Delta Sync Config.
    */
+  @Getter
   private final HoodieStreamer.Config cfg;
 
   /**
@@ -214,6 +215,7 @@ public class StreamSync implements Serializable, Closeable {
   /**
    * Filesystem used.
    */
+  @Getter
   private transient HoodieStorage storage;
 
   /**
@@ -236,6 +238,7 @@ public class StreamSync implements Serializable, Closeable {
    *
    * NOTE: These properties are already consolidated w/ CLI provided config-overrides
    */
+  @Getter
   private final TypedProperties props;
 
   /**
@@ -246,6 +249,7 @@ public class StreamSync implements Serializable, Closeable {
   /**
    * Timeline with completed commits, including both .commit and .deltacommit.
    */
+  @Getter
   private transient Option<HoodieTimeline> commitsTimelineOpt;
 
   // all commits timeline, including all (commits, delta commits, compaction, clean, savepoint, rollback, replace commits, index)
@@ -270,6 +274,7 @@ public class StreamSync implements Serializable, Closeable {
   private Option<BaseErrorTableWriter> errorTableWriter = Option.empty();
   private HoodieErrorTableConfig.ErrorWriteFailureStrategy errorWriteFailureStrategy;
 
+  @Getter
   private transient HoodieIngestionMetrics metrics;
   private transient HoodieMetrics hoodieMetrics;
 
@@ -394,7 +399,7 @@ public class StreamSync implements Serializable, Closeable {
         }
         return metaClient;
       } catch (HoodieIOException e) {
-        LOG.warn("Full exception msg {}", e.getMessage());
+        log.warn("Full exception msg {}", e.getMessage());
         if (e.getMessage().contains("Could not load Hoodie properties") && e.getMessage().contains(HoodieTableConfig.HOODIE_PROPERTIES_FILE)) {
           String basePathWithForwardSlash = cfg.targetBasePath.endsWith("/") ? cfg.targetBasePath :
               String.format("%s/", cfg.targetBasePath);
@@ -409,7 +414,7 @@ public class StreamSync implements Serializable, Closeable {
                   && storage.exists(new StoragePath(pathToHoodiePropsBackup));
 
           if (!hoodiePropertiesExists) {
-            LOG.warn("Base path exists, but table is not fully initialized. Re-initializing again");
+            log.warn("Base path exists, but table is not fully initialized. Re-initializing again");
             HoodieTableMetaClient metaClientToValidate = initializeEmptyTable();
             // reload the timeline from metaClient and validate that its empty table. If there are any instants found, then we should fail the pipeline, bcoz hoodie.properties got deleted by mistake.
             if (metaClientToValidate.reloadActiveTimeline().countInstants() > 0) {
@@ -552,7 +557,7 @@ public class StreamSync implements Serializable, Closeable {
           || (newTargetSchema != null && !processedSchema.isSchemaPresent(newTargetSchema))) {
         String sourceStr = newSourceSchema == null ? NULL_PLACEHOLDER : newSourceSchema.toString(true);
         String targetStr = newTargetSchema == null ? NULL_PLACEHOLDER : newTargetSchema.toString(true);
-        LOG.info("Seeing new schema. Source: {}, Target: {}", sourceStr, targetStr);
+        log.info("Seeing new schema. Source: {}, Target: {}", sourceStr, targetStr);
         // We need to recreate write client with new schema and register them.
         reInitWriteClient(newSourceSchema, newTargetSchema, inputBatch.getBatch(), metaClient);
         if (newSourceSchema != null) {
@@ -607,7 +612,7 @@ public class StreamSync implements Serializable, Closeable {
   public Pair<InputBatch, Boolean> readFromSource(HoodieTableMetaClient metaClient) throws IOException {
     // Retrieve the previous round checkpoints, if any
     Option<Checkpoint> checkpointToResume = StreamerCheckpointUtils.resolveCheckpointToResumeFrom(commitsTimelineOpt, cfg, props, metaClient);
-    LOG.info("Checkpoint to resume from : {}", checkpointToResume);
+    log.info("Checkpoint to resume from : {}", checkpointToResume);
 
     int maxRetryCount = cfg.retryOnSourceFailures ? cfg.maxRetryCount : 1;
     int curRetryCount = 0;
@@ -620,11 +625,11 @@ public class StreamSync implements Serializable, Closeable {
           throw e;
         }
         try {
-          LOG.error("Exception thrown while fetching data from source. Msg : " + e.getMessage() + ", class : " + e.getClass() + ", cause : " + e.getCause());
-          LOG.error("Sleeping for " + (cfg.retryIntervalSecs) + " before retrying again. Current retry count " + curRetryCount + ", max retry count " + cfg.maxRetryCount);
+          log.error("Exception thrown while fetching data from source. Msg : {}, class : {}, cause : {}", e.getMessage(), e.getClass(), e.getCause());
+          log.error("Sleeping for {} before retrying again. Current retry count {}, max retry count {}", cfg.retryIntervalSecs, curRetryCount, cfg.maxRetryCount);
           Thread.sleep(cfg.retryIntervalSecs * 1000);
         } catch (InterruptedException ex) {
-          LOG.error("Ignoring InterruptedException while waiting to retry on source failure " + e.getMessage());
+          log.error("Ignoring InterruptedException while waiting to retry on source failure {}", e.getMessage());
         }
       }
     }
@@ -648,8 +653,8 @@ public class StreamSync implements Serializable, Closeable {
 
     // handle no new data and no change in checkpoint
     if (!cfg.allowCommitOnNoCheckpointChange && checkpoint.equals(resumeCheckpoint.orElse(null))) {
-      LOG.info("No new data, source checkpoint has not changed. Nothing to commit. Old checkpoint=("
-          + resumeCheckpoint + "). New Checkpoint=(" + checkpoint + ")");
+      log.info("No new data, source checkpoint has not changed. Nothing to commit. Old checkpoint=({}). New Checkpoint=({})",
+          resumeCheckpoint, checkpoint);
       String commitActionType = CommitUtils.getCommitActionType(cfg.operation, HoodieTableType.valueOf(cfg.tableType));
       hoodieMetrics.updateMetricsForEmptyData(commitActionType);
       return null;
@@ -756,7 +761,7 @@ public class StreamSync implements Serializable, Closeable {
           inputBatchForWriter = new InputBatch<>(inputBatchNeedsDeduceSchema.getBatch(), inputBatchNeedsDeduceSchema.getCheckpointForNextBatch(),
               getDeducedSchemaProvider(inputBatchNeedsDeduceSchema.getSchemaProvider().getTargetHoodieSchema(), inputBatchNeedsDeduceSchema.getSchemaProvider(), metaClient));
         } else {
-          LOG.warn("Row-writer is enabled but cannot be used due to the target schema");
+          log.warn("Row-writer is enabled but cannot be used due to the target schema");
         }
       }
       // if row writer was enabled but the target schema prevents us from using it, do not use the row writer
@@ -913,7 +918,7 @@ public class StreamSync implements Serializable, Closeable {
                 writeClient.rollback(instantTime);
                 throw new HoodieStreamerWriteException("Error table commit failed for instant " + instantTime);
               case LOG_ERROR:
-                LOG.error("Error table write failed for instant {}", instantTime);
+                log.error("Error table write failed for instant {}", instantTime);
                 break;
               default:
                 throw new HoodieStreamerWriteException("Write failure strategy not implemented for " + errorWriteFailureStrategy);
@@ -933,7 +938,7 @@ public class StreamSync implements Serializable, Closeable {
             SparkStreamerValidatorUtils.runValidators(props, instantTime, writeStatuses,
                 checkpointCommitMetadata, metaClient);
           } catch (HoodieValidationException e) {
-            LOG.error("Pre-commit validators failed for instant {}", instantTime, e);
+            log.error("Pre-commit validators failed for instant {}", instantTime, e);
             writeClient.rollback(instantTime);
             throw new HoodieStreamerWriteException("Pre-commit validators failed for instant " + instantTime, e);
           }
@@ -943,11 +948,11 @@ public class StreamSync implements Serializable, Closeable {
         SuccessfulRecordCounter.Counts counts = SuccessfulRecordCounter.compute(
             writeStatuses, errorTableWriteStatusRDDOpt, isErrorTableWriteUnificationEnabled);
         totalSuccessfulRecords.set(counts.getTotalSuccessfulRecords());
-        LOG.info("instantTime={}, totalRecords={}, totalErrorRecords={}, totalSuccessfulRecords={}",
+        log.info("instantTime={}, totalRecords={}, totalErrorRecords={}, totalSuccessfulRecords={}",
             instantTime, counts.getTotalRecords(), counts.getTotalErrorRecords(),
             counts.getTotalSuccessfulRecords());
         if (counts.getTotalRecords() == 0) {
-          LOG.info("No new data, perform empty commit.");
+          log.info("No new data, perform empty commit.");
         }
 
         // Step 4: Apply the legacy HSWSV write-error gate.
@@ -960,10 +965,10 @@ public class StreamSync implements Serializable, Closeable {
         // failure-policy story.
         if (counts.hasErrors()) {
           if (cfg.commitOnErrors) {
-            LOG.warn("Some records failed to be merged but forcing commit since commitOnErrors set. Errors/Total={}/{}",
+            log.warn("Some records failed to be merged but forcing commit since commitOnErrors set. Errors/Total={}/{}",
                 counts.getTotalErrorRecords(), counts.getTotalRecords());
           } else {
-            LOG.error("Delta Sync found errors when writing. Errors/Total={}/{}",
+            log.error("Delta Sync found errors when writing. Errors/Total={}/{}",
                 counts.getTotalErrorRecords(), counts.getTotalRecords());
             WriteErrorReporter.logTopErrors(writeStatuses);
             // Roll back the inflight data-table instant so it doesn't leak under LAZY
@@ -983,7 +988,7 @@ public class StreamSync implements Serializable, Closeable {
       }
       releaseResourcesInvoked = true;
       if (success) {
-        LOG.info("Commit " + instantTime + " successful!");
+        log.info("Commit {} successful!", instantTime);
         this.formatAdapter.getSource().onCommit(inputBatch.getCheckpointForNextBatch() != null
             ? inputBatch.getCheckpointForNextBatch().getCheckpointKey() : null);
         // Schedule compaction if needed
@@ -994,10 +999,10 @@ public class StreamSync implements Serializable, Closeable {
         if ((totalSuccessfulRecords.get() > 0) || cfg.forceEmptyMetaSync) {
           runMetaSync();
         } else {
-          LOG.info(String.format("Not running metaSync totalSuccessfulRecords=%d", totalSuccessfulRecords.get()));
+          log.info("Not running metaSync totalSuccessfulRecords={}", totalSuccessfulRecords.get());
         }
       } else {
-        LOG.info("Commit " + instantTime + " failed!");
+        log.info("Commit {} failed!", instantTime);
         throw new HoodieStreamerWriteException("Commit " + instantTime + " failed!");
       }
 
@@ -1051,7 +1056,7 @@ public class StreamSync implements Serializable, Closeable {
         if (!retryEnabled) {
           throw ie;
         }
-        LOG.error("Got error trying to start a new commit. Retrying after sleeping for a sec", ie);
+        log.error("Got error trying to start a new commit. Retrying after sleeping for a sec", ie);
         retryNum++;
         try {
           Thread.sleep(1000);
@@ -1131,10 +1136,10 @@ public class StreamSync implements Serializable, Closeable {
     if (cfg.enableHiveSync) {
       cfg.enableMetaSync = true;
       syncClientToolClasses.add(HiveSyncTool.class.getName());
-      LOG.info("When set --enable-hive-sync will use HiveSyncTool for backward compatibility");
+      log.info("When set --enable-hive-sync will use HiveSyncTool for backward compatibility");
     }
     if (cfg.enableMetaSync && !syncClientToolClasses.isEmpty()) {
-      LOG.debug("[MetaSync] Starting sync");
+      log.debug("[MetaSync] Starting sync");
       HoodieTableMetaClient metaClient;
       try {
         metaClient = initializeMetaClient();
@@ -1158,7 +1163,7 @@ public class StreamSync implements Serializable, Closeable {
       Map<String, HoodieException> failedMetaSyncs = new HashMap<>();
       for (String impl : syncClientToolClasses) {
         if (impl.trim().isEmpty()) {
-          LOG.warn("Cannot run MetaSync with empty class name");
+          log.warn("Cannot run MetaSync with empty class name");
           continue;
         }
 
@@ -1183,10 +1188,10 @@ public class StreamSync implements Serializable, Closeable {
     long timeMs = metaSyncTimeNanos / 1000000L;
     String timeString = String.format("and took %d s %d ms ", timeMs / 1000L, timeMs % 1000L);
     if (metaSyncException.isPresent()) {
-      LOG.error("[MetaSync] SyncTool class {} failed with exception {} {}", impl.trim(), metaSyncException.get(), timeString);
+      log.error("[MetaSync] SyncTool class {} failed with exception {} {}", impl.trim(), metaSyncException.get(), timeString);
       failedMetaSyncs.put(impl, metaSyncException.get());
     } else {
-      LOG.info("[MetaSync] SyncTool class {} completed successfully {}", impl.trim(), timeString);
+      log.info("[MetaSync] SyncTool class {} completed successfully {}", impl.trim(), timeString);
     }
   }
 
@@ -1204,7 +1209,7 @@ public class StreamSync implements Serializable, Closeable {
   }
 
   private void reInitWriteClient(HoodieSchema sourceSchema, HoodieSchema targetSchema, Option<JavaRDD<HoodieRecord>> recordsOpt, HoodieTableMetaClient metaClient) throws IOException {
-    LOG.info("Setting up new Hoodie Write Client");
+    log.info("Setting up new Hoodie Write Client");
     if (HoodieStreamerUtils.isDropPartitionColumns(props)) {
       targetSchema = org.apache.hudi.common.schema.HoodieSchemaUtils.removeFields(targetSchema, HoodieStreamerUtils.getPartitionColumns(props));
     }
@@ -1350,7 +1355,7 @@ public class StreamSync implements Serializable, Closeable {
           if (tableSchema.isPresent()) {
             newWriteSchema = tableSchema.get();
           } else {
-            LOG.warn("Could not fetch schema from table. Falling back to using target schema from schema provider");
+            log.warn("Could not fetch schema from table. Falling back to using target schema from schema provider");
           }
         }
       }
@@ -1376,7 +1381,7 @@ public class StreamSync implements Serializable, Closeable {
       schemas.add(targetSchema);
     }
     if (!schemas.isEmpty()) {
-      LOG.debug("Registering Schema: {}", schemas);
+      log.debug("Registering Schema: {}", schemas);
       // Use the underlying spark context in case the java context is changed during runtime
       hoodieSparkContext.getJavaSparkContext().sc().getConf()
           .registerAvroSchemas(JavaScalaConverters.convertJavaListToScalaList(schemas.stream().map(HoodieSchema::toAvroSchema).collect(Collectors.toList())).toList());
@@ -1397,7 +1402,7 @@ public class StreamSync implements Serializable, Closeable {
       formatAdapter.close();
     }
 
-    LOG.info("Shutting down embedded timeline server");
+    log.info("Shutting down embedded timeline server");
     if (embeddedTimelineService.isPresent()) {
       embeddedTimelineService.get().stopForBasePath(cfg.targetBasePath);
     }
@@ -1406,26 +1411,6 @@ public class StreamSync implements Serializable, Closeable {
       metrics.shutdown();
     }
 
-  }
-
-  public HoodieStorage getStorage() {
-    return storage;
-  }
-
-  public TypedProperties getProps() {
-    return props;
-  }
-
-  public Config getCfg() {
-    return cfg;
-  }
-
-  public Option<HoodieTimeline> getCommitsTimelineOpt() {
-    return commitsTimelineOpt;
-  }
-
-  public HoodieIngestionMetrics getMetrics() {
-    return metrics;
   }
 
   /**
@@ -1454,24 +1439,15 @@ public class StreamSync implements Serializable, Closeable {
     }
   }
 
+  @Getter
   class WriteClientWriteResult {
+
+    @Setter
     private Map<String, List<String>> partitionToReplacedFileIds = Collections.emptyMap();
     private final JavaRDD<WriteStatus> writeStatusRDD;
 
     public WriteClientWriteResult(JavaRDD<WriteStatus> writeStatusRDD) {
       this.writeStatusRDD = writeStatusRDD;
-    }
-
-    public Map<String, List<String>> getPartitionToReplacedFileIds() {
-      return partitionToReplacedFileIds;
-    }
-
-    public void setPartitionToReplacedFileIds(Map<String, List<String>> partitionToReplacedFileIds) {
-      this.partitionToReplacedFileIds = partitionToReplacedFileIds;
-    }
-
-    public JavaRDD<WriteStatus> getWriteStatusRDD() {
-      return writeStatusRDD;
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
@@ -40,8 +40,7 @@ import org.apache.hudi.exception.HoodieUpgradeDowngradeException;
 import org.apache.hudi.utilities.config.KafkaSourceConfig;
 import org.apache.hudi.utilities.exception.HoodieStreamerException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
@@ -54,8 +53,8 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.compareTim
 import static org.apache.hudi.common.util.ConfigUtils.removeConfigFromProps;
 import static org.apache.hudi.table.upgrade.UpgradeDowngrade.needsUpgradeOrDowngrade;
 
+@Slf4j
 public class StreamerCheckpointUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(StreamerCheckpointUtils.class);
 
   /**
    * The first phase of checkpoint resolution - read the checkpoint configs from 2 sources and resolve
@@ -116,7 +115,7 @@ public class StreamerCheckpointUtils {
 
   private static Option<Checkpoint> useCkpFromOverrideConfigIfAny(
       HoodieStreamer.Config streamerConfig, TypedProperties props, Option<Checkpoint> checkpoint) {
-    LOG.debug("Checkpoint from config: {}", streamerConfig.checkpoint);
+    log.debug("Checkpoint from config: {}", streamerConfig.checkpoint);
     if (!checkpoint.isPresent() && streamerConfig.checkpoint != null) {
       int writeTableVersion = ConfigUtils.getIntWithAltKeys(props, HoodieWriteConfig.WRITE_TABLE_VERSION);
       checkpoint = Option.of(buildCheckpointFromConfigOverride(streamerConfig.sourceClassName, writeTableVersion, streamerConfig.checkpoint));
@@ -157,7 +156,7 @@ public class StreamerCheckpointUtils {
       if (commitMetadataOption.isPresent()) {
         HoodieCommitMetadata commitMetadata = commitMetadataOption.get();
         Checkpoint checkpointFromCommit = CheckpointUtils.getCheckpoint(commitMetadata);
-        LOG.debug("Checkpoint reset from metadata: {}", checkpointFromCommit.getCheckpointResetKey());
+        log.debug("Checkpoint reset from metadata: {}", checkpointFromCommit.getCheckpointResetKey());
         if (ignoreCkpCfgPrevailsOverCkpFromPrevCommit(streamerConfig, checkpointFromCommit)) {
           // we ignore any existing checkpoint and start ingesting afresh
           resumeCheckpoint = Option.empty();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/TableExecutionContext.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/TableExecutionContext.java
@@ -21,66 +21,22 @@ package org.apache.hudi.utilities.streamer;
 
 import org.apache.hudi.common.config.TypedProperties;
 
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Wrapper over TableConfig objects.
  * Useful for incrementally syncing multiple tables one by one via HoodieMultiTableStreamer.java class.
  */
+@Getter
+@Setter
+@EqualsAndHashCode
 public class TableExecutionContext {
 
   private TypedProperties properties;
+  @EqualsAndHashCode.Exclude
   private HoodieStreamer.Config config;
   private String database;
   private String tableName;
-
-  public HoodieStreamer.Config getConfig() {
-    return config;
-  }
-
-  public void setConfig(HoodieStreamer.Config config) {
-    this.config = config;
-  }
-
-  public String getDatabase() {
-    return database;
-  }
-
-  public void setDatabase(String database) {
-    this.database = database;
-  }
-
-  public String getTableName() {
-    return tableName;
-  }
-
-  public void setTableName(String tableName) {
-    this.tableName = tableName;
-  }
-
-  public TypedProperties getProperties() {
-    return properties;
-  }
-
-  public void setProperties(TypedProperties properties) {
-    this.properties = properties;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    TableExecutionContext that = (TableExecutionContext) o;
-    return Objects.equals(properties, that.properties) && Objects.equals(database, that.database) && Objects.equals(tableName, that.tableName);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(properties, database, tableName);
-  }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
@@ -68,6 +68,8 @@ import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 import org.apache.hudi.testutils.HoodieSparkClientTestBase;
 import org.apache.hudi.testutils.SparkRDDValidationUtils;
 
+import lombok.AccessLevel;
+import lombok.Setter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -1345,6 +1347,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
     }
   }
 
+  @Setter(AccessLevel.PACKAGE)
   class MockHoodieMetadataTableValidator extends HoodieMetadataTableValidator {
 
     private List<String> metadataPartitionsToReturn;
@@ -1353,18 +1356,6 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
 
     public MockHoodieMetadataTableValidator(JavaSparkContext jsc, Config cfg) {
       super(jsc, cfg);
-    }
-
-    void setMetadataPartitionsToReturn(List<String> metadataPartitionsToReturn) {
-      this.metadataPartitionsToReturn = metadataPartitionsToReturn;
-    }
-
-    void setFsPartitionsToReturn(List<String> fsPartitionsToReturn) {
-      this.fsPartitionsToReturn = fsPartitionsToReturn;
-    }
-
-    void setPartitionCreationTime(Option<String> partitionCreationTime) {
-      this.partitionCreationTime = partitionCreationTime;
     }
 
     @Override
@@ -1449,6 +1440,7 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
   /**
    * Class to assist with testing a false positive case with RLI validation.
    */
+  @Setter
   static class MockHoodieMetadataTableValidatorForRli extends HoodieMetadataTableValidator {
 
     private String destFilePath;
@@ -1465,14 +1457,6 @@ public class TestHoodieMetadataTableValidator extends HoodieSparkClientTestBase 
       // move the completed file back to ".hoodie" to simuate the false positive case.
       new File(destFilePath).renameTo(new File(originalFilePath));
       return super.getRecordLocationsFromRLI(sparkEngineContext, basePath, latestCompletedCommit);
-    }
-
-    public void setDestFilePath(String destFilePath) {
-      this.destFilePath = destFilePath;
-    }
-
-    public void setOriginalFilePath(String originalFilePath) {
-      this.originalFilePath = originalFilePath;
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieRepairTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieRepairTool.java
@@ -33,6 +33,7 @@ import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.testutils.providers.SparkProvider;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.HoodieSparkKryoRegistrar$;
 import org.apache.spark.SparkConf;
@@ -45,8 +46,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.security.SecureRandom;
@@ -67,8 +66,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Slf4j
 public class TestHoodieRepairTool extends HoodieCommonTestHarness implements SparkProvider {
-  private static final Logger LOG = LoggerFactory.getLogger(TestHoodieRepairTool.class);
+
   // Instant time -> List<Pair<relativePartitionPath, fileId>>
   private static final Map<String, List<Pair<String, String>>> BASE_FILE_INFO = new HashMap<>();
   private static final Map<String, List<Pair<String, String>>> LOG_FILE_INFO = new HashMap<>();
@@ -385,7 +385,7 @@ public class TestHoodieRepairTool extends HoodieCommonTestHarness implements Spa
               storage.create(path, false);
             }
           } catch (IOException e) {
-            LOG.error("Error creating file: " + path);
+            log.error("Error creating file: {}", path);
           }
           return path.toString();
         })

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -57,6 +57,7 @@ import org.apache.hudi.utilities.streamer.HoodieStreamer;
 import org.apache.hudi.utilities.testutils.KafkaTestUtils;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -67,8 +68,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -91,9 +90,8 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.createMetaClient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Slf4j
 public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
-
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieDeltaStreamerTestBase.class);
 
   static final Random RANDOM = new Random();
   static final String PROPS_FILENAME_TEST_SOURCE = "test-source.properties";
@@ -706,7 +704,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertAtleastNCompactionCommits(int minExpected, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage, tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getCommitAndReplaceTimeline().filterCompletedInstants();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numCompactionCommits = timeline.countInstants();
       assertTrue(minExpected <= numCompactionCommits, "Got=" + numCompactionCommits + ", exp >=" + minExpected);
     }
@@ -714,7 +712,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertAtleastNDeltaCommits(int minExpected, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
       assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
@@ -722,7 +720,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertAtleastNCompactionCommitsAfterCommit(int minExpected, String lastSuccessfulCommit, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getCommitAndReplaceTimeline().findInstantsAfter(lastSuccessfulCommit).filterCompletedInstants();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numCompactionCommits = timeline.countInstants();
       assertTrue(minExpected <= numCompactionCommits, "Got=" + numCompactionCommits + ", exp >=" + minExpected);
     }
@@ -730,7 +728,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertAtleastNDeltaCommitsAfterCommit(int minExpected, String lastSuccessfulCommit, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.reloadActiveTimeline().getDeltaCommitTimeline().findInstantsAfter(lastSuccessfulCommit).filterCompletedInstants();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
       assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
@@ -757,9 +755,9 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
           try {
             Thread.sleep(2000);
             ret = condition.apply(true);
-            LOG.info("Condition completed successfully");
+            log.info("Condition completed successfully");
           } catch (Throwable error) {
-            LOG.debug("Got error waiting for condition", error);
+            log.debug("Got error waiting for condition", error);
             ret = false;
           }
         }
@@ -777,7 +775,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
         try {
           Thread.sleep(5);
         } catch (Throwable error) {
-          LOG.debug("Got error waiting for condition", error);
+          log.debug("Got error waiting for condition", error);
         }
       }
     }
@@ -785,7 +783,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertAtLeastNCommits(int minExpected, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().filterCompletedInstants();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
       assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
@@ -793,7 +791,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertAtLeastNReplaceCommits(int minExpected, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getCompletedReplaceTimeline();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
       assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
@@ -801,7 +799,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertPendingIndexCommit(String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.reloadActiveTimeline().getAllCommitsTimeline().filterPendingIndexTimeline();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numIndexCommits = timeline.countInstants();
       assertEquals(1, numIndexCommits, "Got=" + numIndexCommits + ", exp=1");
     }
@@ -809,7 +807,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertCompletedIndexCommit(String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.reloadActiveTimeline().getAllCommitsTimeline().filterCompletedIndexTimeline();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numIndexCommits = timeline.countInstants();
       assertEquals(1, numIndexCommits, "Got=" + numIndexCommits + ", exp=1");
     }
@@ -817,7 +815,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertNoReplaceCommits(String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getCompletedReplaceTimeline();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
       assertEquals(0, numDeltaCommits, "Got=" + numDeltaCommits + ", exp =" + 0);
     }
@@ -825,7 +823,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertAtLeastNClusterRequests(int minExpected, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().filterPendingClusteringTimeline();
-      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
       assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
@@ -833,7 +831,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     static void assertAtLeastNCommitsAfterRollback(int minExpectedRollback, int minExpectedCommits, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage.getConf(), tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getRollbackTimeline().filterCompletedInstants();
-      LOG.info("Rollback Timeline Instants={}", meta.getActiveTimeline().getInstants());
+      log.info("Rollback Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numRollbackCommits = timeline.countInstants();
       assertTrue(minExpectedRollback <= numRollbackCommits, "Got=" + numRollbackCommits + ", exp >=" + minExpectedRollback);
       HoodieInstant firstRollback = timeline.getInstants().get(0);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/MockConfigurationHotUpdateStrategy.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/MockConfigurationHotUpdateStrategy.java
@@ -23,8 +23,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.streamer.ConfigurationHotUpdateStrategy;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
 
@@ -33,8 +32,8 @@ import static org.apache.hudi.config.HoodieWriteConfig.UPSERT_PARALLELISM_VALUE;
 /**
  * ConfigurationHotUpdateStrategy for test purpose.
  */
+@Slf4j
 public class MockConfigurationHotUpdateStrategy extends ConfigurationHotUpdateStrategy implements Serializable {
-  private static final Logger LOG = LoggerFactory.getLogger(MockConfigurationHotUpdateStrategy.class);
 
   public MockConfigurationHotUpdateStrategy(HoodieDeltaStreamer.Config cfg, TypedProperties properties) {
     super(cfg, properties);
@@ -46,7 +45,7 @@ public class MockConfigurationHotUpdateStrategy extends ConfigurationHotUpdateSt
       long upsertShuffleParallelism = currentProps.getLong(UPSERT_PARALLELISM_VALUE.key());
       TypedProperties newProps = TypedProperties.copy(currentProps);
       newProps.setProperty(UPSERT_PARALLELISM_VALUE.key(), String.valueOf(upsertShuffleParallelism + 5));
-      LOG.info("update {} from [{}] to [{}]", UPSERT_PARALLELISM_VALUE.key(), upsertShuffleParallelism, upsertShuffleParallelism + 5);
+      log.info("update {} from [{}] to [{}]", UPSERT_PARALLELISM_VALUE.key(), upsertShuffleParallelism, upsertShuffleParallelism + 5);
       return Option.of(newProps);
     }
     return Option.empty();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -127,6 +127,7 @@ import org.apache.hudi.utilities.transform.SqlQueryBasedTransformer;
 import org.apache.hudi.utilities.transform.Transformer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
@@ -156,8 +157,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -206,9 +205,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 /**
  * Basic tests against {@link HoodieDeltaStreamer}, by issuing bulk_inserts, upserts, inserts. Check counts at the end.
  */
+@Slf4j
 public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestHoodieDeltaStreamer.class);
 
   private void addRecordMerger(HoodieRecordType type, List<String> hoodieConfig) {
     if (type == HoodieRecordType.SPARK) {
@@ -433,7 +431,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       deltaStreamer.sync();
     }, "Should error out when setting the key generator class property to an invalid value");
     // expected
-    LOG.warn("Expected error during getting the key generator", e);
+    log.warn("Expected error during getting the key generator", e);
     assertTrue(e.getMessage().contains("Unable to load class"));
   }
 
@@ -483,7 +481,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       syncOnce(TestHelpers.makeConfig(basePath + "/not_a_table", WriteOperationType.BULK_INSERT));
     }, "Should error out when pointed out at a dir thats not a table");
     // expected
-    LOG.debug("Expected error during table creation", e);
+    log.debug("Expected error during table creation", e);
   }
 
   @ParameterizedTest
@@ -560,7 +558,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     cfg.targetBasePath = newDatasetBasePath;
     syncOnce(cfg);
     Dataset<Row> res = sqlContext.read().format("org.apache.hudi").load(newDatasetBasePath);
-    LOG.info("Schema : {}", res.schema());
+    log.info("Schema : {}", res.schema());
 
     assertRecordCount(1950, newDatasetBasePath, sqlContext);
     res.registerTempTable("bootstrapped");
@@ -1546,7 +1544,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       try {
         ds.sync();
       } catch (Exception ex) {
-        LOG.warn("DS continuous job failed, hence not proceeding with condition check for " + jobId);
+        log.warn("DS continuous job failed, hence not proceeding with condition check for {}", jobId);
         throw new RuntimeException(ex.getMessage(), ex);
       }
     });
@@ -1944,19 +1942,19 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
             buildIndexerConfig(tableBasePath, ds.getConfig().targetTableName, null, UtilHelpers.SCHEDULE, "COLUMN_STATS"));
         scheduleIndexInstantTime = scheduleIndexingJob.doSchedule();
       } catch (Exception e) {
-        LOG.info("Schedule indexing failed", e);
+        log.info("Schedule indexing failed", e);
         return false;
       }
       if (scheduleIndexInstantTime.isPresent()) {
         TestHelpers.assertPendingIndexCommit(tableBasePath);
-        LOG.info("Schedule indexing success, now build index with instant time " + scheduleIndexInstantTime.get());
+        log.info("Schedule indexing success, now build index with instant time {}", scheduleIndexInstantTime.get());
         HoodieIndexer runIndexingJob = new HoodieIndexer(jsc,
             buildIndexerConfig(tableBasePath, ds.getConfig().targetTableName, scheduleIndexInstantTime.get(), UtilHelpers.EXECUTE, "COLUMN_STATS"));
         runIndexingJob.start(0);
-        LOG.info("Metadata indexing success");
+        log.info("Metadata indexing success");
         TestHelpers.assertCompletedIndexCommit(tableBasePath);
       } else {
-        LOG.warn("Metadata indexing failed");
+        log.warn("Metadata indexing failed");
       }
       return true;
     });
@@ -1984,7 +1982,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
                 Arrays.asList(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key() + "=true", HoodieWriteConfig.MARKERS_TYPE.key() + "=DIRECT")));
         scheduleIndexInstantTime = scheduleIndexingJob.doSchedule();
         TestHelpers.assertPendingIndexCommit(tableBasePath);
-        LOG.info("Schedule indexing success, now build index with instant time " + scheduleIndexInstantTime.get());
+        log.info("Schedule indexing success, now build index with instant time {}", scheduleIndexInstantTime.get());
         // Wait for a pending commit before starting execution phase for the executor. This ensures that indexer waits for the commit to complete.
         TestHelpers.waitFor(() -> {
           HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storage.getConf(), tableBasePath);
@@ -1995,7 +1993,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
             buildIndexerConfig(tableBasePath, ds.getConfig().targetTableName, scheduleIndexInstantTime.get(), UtilHelpers.EXECUTE, "RECORD_INDEX",
                 Arrays.asList(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key() + "=true", HoodieWriteConfig.MARKERS_TYPE.key() + "=DIRECT")));
         runIndexingJob.start(0);
-        LOG.info("Metadata indexing success");
+        log.info("Metadata indexing success");
         TestHelpers.assertCompletedIndexCommit(tableBasePath);
         // Assert no pending commits before indexing instant
         HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storage.getConf(), tableBasePath);
@@ -2044,7 +2042,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
             buildIndexerConfig(tableBasePath, ds.getConfig().targetTableName, null, UtilHelpers.SCHEDULE, "RECORD_INDEX"));
         scheduleIndexInstantTime = scheduleIndexingJob.doSchedule();
         TestHelpers.assertPendingIndexCommit(tableBasePath);
-        LOG.info("Schedule indexing success, now build index with instant time " + scheduleIndexInstantTime.get());
+        log.info("Schedule indexing success, now build index with instant time {}", scheduleIndexInstantTime.get());
         // Wait for clustering instant to be scheduled before starting execution phase of the executor
         TestHelpers.waitFor(() -> {
           HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(storage, tableBasePath);
@@ -2061,7 +2059,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
           boolean res = JavaTestUtils.checkNestedExceptionContains(t, "Index catchup failed");
           assertTrue(res, "Indexing catchup task should have timed out");
         }
-        LOG.info("Metadata indexing timed out");
+        log.info("Metadata indexing timed out");
       } catch (Exception e) {
         fail("Indexing job should not have failed", e);
       }
@@ -2091,19 +2089,19 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
             initialHoodieClusteringJob(tableBasePath, null, true, null);
         scheduleClusteringInstantTime = scheduleClusteringJob.doSchedule();
       } catch (Exception e) {
-        LOG.warn("Schedule clustering failed", e);
+        log.warn("Schedule clustering failed", e);
         Assertions.fail("Schedule clustering failed", e);
       }
       if (scheduleClusteringInstantTime.isPresent()) {
-        LOG.info("Schedule clustering success, now cluster with instant time " + scheduleClusteringInstantTime.get());
+        log.info("Schedule clustering success, now cluster with instant time {}", scheduleClusteringInstantTime.get());
         HoodieClusteringJob.Config clusterClusteringConfig = buildHoodieClusteringUtilConfig(tableBasePath,
             shouldPassInClusteringInstantTime ? scheduleClusteringInstantTime.get() : null, false);
         HoodieClusteringJob clusterClusteringJob = new HoodieClusteringJob(jsc, clusterClusteringConfig);
         clusterClusteringJob.cluster(clusterClusteringConfig.retry);
         TestHelpers.assertAtLeastNReplaceCommits(1, tableBasePath);
-        LOG.info("Cluster success");
+        log.info("Cluster success");
       } else {
-        LOG.warn("Clustering execution failed");
+        log.warn("Clustering execution failed");
         Assertions.fail("Clustering execution failed");
       }
     } else {
@@ -2273,15 +2271,15 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       try {
         int result = scheduleClusteringJob.cluster(0);
         if (result == 0) {
-          LOG.info("Cluster success");
+          log.info("Cluster success");
         } else {
-          LOG.warn("Cluster failed");
+          log.warn("Cluster failed");
           if (!runningMode.toLowerCase().equals(UtilHelpers.EXECUTE)) {
             return false;
           }
         }
       } catch (Exception e) {
-        LOG.warn("ScheduleAndExecute clustering failed", e);
+        log.warn("ScheduleAndExecute clustering failed", e);
         exception = e;
         if (!runningMode.equalsIgnoreCase(UtilHelpers.EXECUTE)) {
           return false;
@@ -2441,13 +2439,13 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       try {
         int counter = 2;
         while (counter < 100) { // lets keep going. if the test times out, we will cancel the future within finally. So, safe to generate 100 batches.
-          LOG.info("Generating data for batch {}", counter);
+          log.info("Generating data for batch {}", counter);
           prepareParquetDFSFiles(100, PARQUET_SOURCE_ROOT, Integer.toString(counter) + ".parquet", false, null, null, makeDatesAmbiguous);
           counter++;
           Thread.sleep(2000);
         }
       } catch (Exception ex) {
-        LOG.warn("Input data generation failed", ex);
+        log.warn("Input data generation failed", ex);
         throw new RuntimeException(ex.getMessage(), ex);
       }
     });
@@ -2591,7 +2589,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     Exception e = assertThrows(HoodieException.class, () -> {
       syncOnce(new HoodieDeltaStreamer(cfg, jsc, fs, hiveServer.getHiveConf()));
     }, "Should error out when schema provider is not provided");
-    LOG.debug("Expected error during reading data from source ", e);
+    log.debug("Expected error during reading data from source ", e);
     assertTrue(e.getMessage().contains("Schema provider is required for this operation and for the source of interest. "
         + "Please set '--schemaprovider-class' in the top level HoodieStreamer config for the source of interest. "
         + "Based on the schema provider class chosen, additional configs might be required. "
@@ -2823,7 +2821,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     // Ensure it is empty
     HoodieCommitMetadata commitMetadata =
         mClient.getActiveTimeline().readCommitMetadata(newLastFinished);
-    LOG.info("New Commit Metadata={}", commitMetadata);
+    log.info("New Commit Metadata={}", commitMetadata);
     assertTrue(commitMetadata.getPartitionToWriteStats().isEmpty());
 
     // Try UPSERT with filterDupes true. Expect exception
@@ -3339,7 +3337,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         try {
           fs.delete(entry.getPath());
         } catch (IOException e) {
-          LOG.warn("Failed to delete " + entry.getPath().toString(), e);
+          log.warn("Failed to delete: {}", entry.getPath().toString(), e);
         }
       });
     }
@@ -3515,7 +3513,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     Exception e = assertThrows(AnalysisException.class, () -> {
       testCsvDFSSource(false, '\t', false, Collections.singletonList(TripsWithDistanceTransformer.class.getName()));
     }, "Should error out when doing the transformation.");
-    LOG.debug("Expected error during transformation", e);
+    log.debug("Expected error during transformation", e);
     // First message for Spark 3.4 and above, second message for Spark 3.3, third message for Spark 3.2 and below
     assertTrue(
         e.getMessage().contains("[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter "
@@ -3882,9 +3880,9 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         .build();
     Properties hoodieProps = new Properties();
     hoodieProps.load(fs.open(new Path(cfg.targetBasePath + "/.hoodie/hoodie.properties")));
-    LOG.info("old props: {}", hoodieProps);
+    log.info("old props: {}", hoodieProps);
     hoodieProps.put("hoodie.table.type", HoodieTableType.MERGE_ON_READ.name());
-    LOG.info("new props: {}", hoodieProps);
+    log.info("new props: {}", hoodieProps);
     StoragePath metaPathDir = new StoragePath(metaClient.getBasePath(), HoodieTableMetaClient.METAFOLDER_NAME);
     HoodieTableConfig.create(metaClient.getStorage(), metaPathDir, hoodieProps);
 
@@ -3953,9 +3951,9 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         .build();
     Properties hoodieProps = new Properties();
     hoodieProps.load(fs.open(new Path(cfg.targetBasePath + "/.hoodie/hoodie.properties")));
-    LOG.info("old props: " + hoodieProps);
+    log.info("Old props: {}", hoodieProps);
     hoodieProps.put("hoodie.table.type", HoodieTableType.COPY_ON_WRITE.name());
-    LOG.info("new props: " + hoodieProps);
+    log.info("New props: {}", hoodieProps);
     StoragePath metaPathDir = new StoragePath(metaClient.getBasePath(), ".hoodie");
     HoodieTableConfig.create(metaClient.getStorage(), metaPathDir, hoodieProps);
 
@@ -4249,13 +4247,13 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
   /**
    * Return empty table.
    */
+  @Slf4j
   public static class DropAllTransformer implements Transformer {
-    private static final Logger LOG = LoggerFactory.getLogger(DropAllTransformer.class);
 
     @Override
     public Dataset apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset,
                          TypedProperties properties) {
-      LOG.info("DropAllTransformer called !!");
+      log.info("DropAllTransformer called !!");
       return sparkSession.createDataFrame(jsc.emptyRDD(), rowDataset.schema());
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -38,13 +38,12 @@ import org.apache.hudi.utilities.config.SourceTestConfig;
 import org.apache.hudi.utilities.sources.TestDataSource;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,9 +67,8 @@ import static org.apache.hudi.config.HoodieWriteConfig.UPSERT_PARALLELISM_VALUE;
 import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer.CHECKPOINT_KEY;
 import static org.apache.hudi.utilities.deltastreamer.TestHoodieDeltaStreamer.deltaStreamerTestRunner;
 
+@Slf4j
 public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerTestBase {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestHoodieDeltaStreamerWithMultiWriter.class);
 
   String basePath;
   String propsFilePath;
@@ -413,7 +411,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
           deltaStreamerTestRunner(ingestionJob, cfgIngestionJob, conditionForRegularIngestion, jobId);
         } catch (Throwable ex) {
           continuousFailed.set(true);
-          LOG.error("Continuous job failed " + ex.getMessage());
+          log.error("Continuous job failed {}", ex.getMessage());
           throw new RuntimeException(ex);
         }
       });
@@ -424,7 +422,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
           awaitCondition(new GetCommitsAfterInstant(tableBasePath, lastSuccessfulCommit));
           backfillJob.sync();
         } catch (Throwable ex) {
-          LOG.error("Backfilling job failed " + ex.getMessage());
+          log.error("Backfilling job failed {}", ex.getMessage());
           backfillFailed.set(true);
           throw new RuntimeException(ex);
         }
@@ -443,7 +441,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         // expected ConcurrentModificationException since ingestion & backfill will have overlapping writes
         if (!continuousFailed.get()) {
           // if backfill job failed, shutdown the continuous job.
-          LOG.warn("Calling shutdown on ingestion job since the backfill job has failed for " + jobId);
+          log.warn("Calling shutdown on ingestion job since the backfill job has failed for {}", jobId);
           ingestionJob.shutdownGracefully();
         } else {
           // both backfill and ingestion job cannot fail.
@@ -452,14 +450,14 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
       } else if (expectConflict && continuousFailed.get() && e.getCause().getMessage().contains("Ingestion service was shut down with exception")) {
         // incase of regular ingestion job failing, ConcurrentModificationException is not throw all the way.
         if (!backfillFailed.get()) {
-          LOG.warn("Calling shutdown on backfill job since the ingstion/continuous job has failed for " + jobId);
+          log.warn("Calling shutdown on backfill job since the ingstion/continuous job has failed for {}", jobId);
           backfillJob.shutdownGracefully();
         } else {
           // both backfill and ingestion job cannot fail.
           throw new HoodieException("Both backfilling and ingestion job failed ", e);
         }
       } else {
-        LOG.error("Conflict happened, but not expected " + e.getCause().getMessage());
+        log.error("Conflict happened, but not expected {}", e.getCause().getMessage());
         throw e;
       }
     } finally {
@@ -495,7 +493,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         soFar += 500;
       }
     }
-    LOG.warn("Awaiting completed in " + (System.currentTimeMillis() - startTime));
+    log.warn("Awaiting completed in {}", System.currentTimeMillis() - startTime);
   }
 
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieMultiTableDeltaStreamer.java
@@ -34,9 +34,8 @@ import org.apache.hudi.utilities.sources.TestDataSource;
 import org.apache.hudi.utilities.streamer.TableExecutionContext;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -49,9 +48,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Slf4j
 public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBase {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestHoodieMultiTableDeltaStreamer.class);
 
   static class TestHelpers {
 
@@ -104,7 +102,7 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
     Exception e = assertThrows(HoodieException.class, () -> {
       new HoodieMultiTableDeltaStreamer(cfg, jsc);
     }, "Should fail when hive sync table not provided with enableHiveSync flag");
-    LOG.debug("Expected error when creating table execution objects", e);
+    log.debug("Expected error when creating table execution objects", e);
     assertTrue(e.getMessage().contains("Meta sync table field not provided!"));
   }
 
@@ -114,7 +112,7 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
     Exception e = assertThrows(IllegalArgumentException.class, () -> {
       new HoodieMultiTableDeltaStreamer(cfg, jsc);
     }, "Should fail when invalid props file is provided");
-    LOG.debug("Expected error when creating table execution objects", e);
+    log.debug("Expected error when creating table execution objects", e);
     assertTrue(e.getMessage().contains("Please provide valid common config file path!"));
   }
 
@@ -124,7 +122,7 @@ public class TestHoodieMultiTableDeltaStreamer extends HoodieDeltaStreamerTestBa
     Exception e = assertThrows(IllegalArgumentException.class, () -> {
       new HoodieMultiTableDeltaStreamer(cfg, jsc);
     }, "Should fail when invalid table config props file path is provided");
-    LOG.debug("Expected error when creating table execution objects", e);
+    log.debug("Expected error when creating table execution objects", e);
     assertTrue(e.getMessage().contains("Please provide valid table config file path!"));
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHiveSchemaProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHiveSchemaProvider.java
@@ -29,6 +29,7 @@ import org.apache.hudi.utilities.schema.HiveSchemaProvider;
 import org.apache.hudi.utilities.testutils.SparkClientFunctionalTestHarnessWithHiveSupport;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.junit.jupiter.api.Assertions;
@@ -36,8 +37,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -46,9 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * Basic tests against {@link HiveSchemaProvider}.
  */
+@Slf4j
 @Tag("functional")
 public class TestHiveSchemaProvider extends SparkClientFunctionalTestHarnessWithHiveSupport {
-  private static final Logger LOG = LoggerFactory.getLogger(TestHiveSchemaProvider.class);
+
   private static final TypedProperties PROPS = new TypedProperties();
   private static final String SOURCE_SCHEMA_TABLE_NAME = "schema_registry.source_schema_tab";
   private static final String TARGET_SCHEMA_TABLE_NAME = "schema_registry.target_schema_tab";
@@ -75,7 +75,7 @@ public class TestHiveSchemaProvider extends SparkClientFunctionalTestHarnessWith
         assertNotNull(originalField);
       }
     } catch (HoodieException e) {
-      LOG.error("Failed to get source schema. ", e);
+      log.error("Failed to get source schema. ", e);
       throw e;
     }
   }
@@ -97,7 +97,7 @@ public class TestHiveSchemaProvider extends SparkClientFunctionalTestHarnessWith
         assertNotNull(originalField);
       }
     } catch (HoodieException e) {
-      LOG.error("Failed to get source/target schema. ", e);
+      log.error("Failed to get source/target schema. ", e);
       throw e;
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestJdbcbasedSchemaProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestJdbcbasedSchemaProvider.java
@@ -26,11 +26,10 @@ import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.schema.JdbcbasedSchemaProvider;
 import org.apache.hudi.utilities.testutils.UtilitiesTestBase;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -43,10 +42,10 @@ import static org.apache.hudi.utilities.testutils.JdbcTestUtils.JDBC_URL;
 import static org.apache.hudi.utilities.testutils.JdbcTestUtils.JDBC_USER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Slf4j
 @Tag("functional")
 public class TestJdbcbasedSchemaProvider extends SparkClientFunctionalTestHarness {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TestJdbcbasedSchemaProvider.class);
   private static final TypedProperties PROPS = new TypedProperties();
 
   @BeforeAll
@@ -67,7 +66,7 @@ public class TestJdbcbasedSchemaProvider extends SparkClientFunctionalTestHarnes
       HoodieSchema sourceSchema = UtilHelpers.createSchemaProvider(JdbcbasedSchemaProvider.class.getName(), PROPS, jsc()).getSourceHoodieSchema();
       assertEquals(sourceSchema.toString().toUpperCase(), HoodieSchema.parse(UtilitiesTestBase.Helpers.readFile("streamer-config/source-jdbc.avsc")).toString().toUpperCase());
     } catch (HoodieException e) {
-      LOG.error("Failed to get connection through jdbc. ", e);
+      log.error("Failed to get connection through jdbc. ", e);
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -50,6 +50,7 @@ import org.apache.hudi.table.storage.HoodieStorageLayout;
 import org.apache.hudi.testutils.providers.SparkProvider;
 import org.apache.hudi.utilities.HoodieCompactor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.HoodieSparkKryoRegistrar$;
 import org.apache.spark.SparkConf;
@@ -61,8 +62,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -79,9 +78,8 @@ import static org.apache.hudi.utilities.multitable.MultiTableServiceUtils.Consta
  * Tests for HoodieMultiTableServicesMain
  * @see HoodieMultiTableServicesMain
  */
+@Slf4j
 class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implements SparkProvider {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestHoodieMultiTableServicesMain.class);
 
   protected boolean initialized = false;
 
@@ -155,10 +153,10 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
     new Thread(() -> {
       try {
         Thread.sleep(10000);
-        LOG.info("Shutdown the table services");
+        log.info("Shutdown the table services");
         main.cancel();
       } catch (InterruptedException e) {
-        LOG.warn("InterruptedException: ", e);
+        log.warn("InterruptedException: ", e);
       }
     }).start();
     main.startServices();
@@ -193,10 +191,10 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
     new Thread(() -> {
       try {
         Thread.sleep(10000);
-        LOG.info("Shutdown the table services");
+        log.info("Shutdown the table services");
         main.cancel();
       } catch (InterruptedException e) {
-        LOG.warn("InterruptedException: ", e);
+        log.warn("InterruptedException: ", e);
       }
     }).start();
     try {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/BaseTestKafkaSource.java
@@ -33,6 +33,9 @@ import org.apache.hudi.utilities.streamer.SourceProfile;
 import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 import org.apache.hudi.utilities.testutils.KafkaTestUtils;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -323,27 +326,14 @@ public abstract class BaseTestKafkaSource extends SparkClientFunctionalTestHarne
     verify(metrics, times(2)).updateStreamerSourceBytesToBeIngestedInSyncRound(Long.MAX_VALUE);
   }
 
+  @AllArgsConstructor
+  @Getter
   static class TestSourceProfile implements SourceProfile<Long> {
 
     private final long maxSourceBytes;
     private final int sourcePartitions;
+    @Getter(AccessLevel.NONE)
     private final long numEvents;
-
-    public TestSourceProfile(long maxSourceBytes, int sourcePartitions, long numEvents) {
-      this.maxSourceBytes = maxSourceBytes;
-      this.sourcePartitions = sourcePartitions;
-      this.numEvents = numEvents;
-    }
-
-    @Override
-    public long getMaxSourceBytes() {
-      return maxSourceBytes;
-    }
-
-    @Override
-    public int getSourcePartitions() {
-      return sourcePartitions;
-    }
 
     @Override
     public Long getSourceSpecificContext() {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSourceHarness.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/S3EventsHoodieIncrSourceHarness.java
@@ -56,6 +56,9 @@ import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.api.java.JavaRDD;
@@ -279,26 +282,14 @@ public class S3EventsHoodieIncrSourceHarness extends SparkClientFunctionalTestHa
     readAndAssert(missingCheckpointStrategy, checkpointToPull, sourceLimit, expectedCheckpoint, typedProperties);
   }
 
+  @AllArgsConstructor
+  @Getter
   static class TestSourceProfile implements SourceProfile<Long> {
+
     private final long maxSourceBytes;
     private final int sourcePartitions;
+    @Getter(AccessLevel.NONE)
     private final long bytesPerPartition;
-
-    public TestSourceProfile(long maxSourceBytes, int sourcePartitions, long bytesPerPartition) {
-      this.maxSourceBytes = maxSourceBytes;
-      this.sourcePartitions = sourcePartitions;
-      this.bytesPerPartition = bytesPerPartition;
-    }
-
-    @Override
-    public long getMaxSourceBytes() {
-      return maxSourceBytes;
-    }
-
-    @Override
-    public int getSourcePartitions() {
-      return sourcePartitions;
-    }
 
     @Override
     public Long getSourceSpecificContext() {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestDataSource.java
@@ -24,12 +24,11 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.testutils.sources.AbstractBaseTestSource;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,9 +36,9 @@ import java.util.stream.Collectors;
 /**
  * An implementation of {@link Source}, that emits test upserts.
  */
+@Slf4j
 public class TestDataSource extends AbstractBaseTestSource {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TestDataSource.class);
   public static boolean returnEmptyBatch = false;
   public static Option<String> recordInstantTime = Option.empty();
   private static int counter = 0;
@@ -56,14 +55,14 @@ public class TestDataSource extends AbstractBaseTestSource {
 
     int nextCommitNum = lastCheckpoint.map(s -> Integer.parseInt(s.getCheckpointKey()) + 1).orElse(0);
     String instantTime = String.format("%05d", nextCommitNum);
-    LOG.info("Source Limit is set to " + sourceLimit);
+    log.info("Source Limit is set to {}", sourceLimit);
 
     // No new data.
     if (sourceLimit <= 0 || returnEmptyBatch) {
-      LOG.warn("Return no new data from Test Data source " + counter + ", source limit " + sourceLimit);
+      log.warn("Return no new data from Test Data source {}, source limit {}", counter, sourceLimit);
       return new InputBatch<>(Option.empty(), lastCheckpoint.orElse(null));
     } else {
-      LOG.warn("Returning valid data from Test Data source " + counter + ", source limit " + sourceLimit);
+      log.warn("Returning valid data from Test Data source {}, source limit {}", counter, sourceLimit);
     }
     counter++;
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestGcsEventsHoodieIncrSource.java
@@ -57,6 +57,7 @@ import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.api.java.JavaRDD;
@@ -73,8 +74,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -96,6 +95,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Slf4j
 public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
   private static final HoodieSchema GCS_METADATA_SCHEMA = SchemaTestUtil.getSchemaFromResource(
@@ -121,8 +121,6 @@ public class TestGcsEventsHoodieIncrSource extends SparkClientFunctionalTestHarn
   protected Option<SchemaProvider> schemaProvider;
   private HoodieTableMetaClient metaClient;
   private JavaSparkContext jsc;
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestGcsEventsHoodieIncrSource.class);
 
   @BeforeEach
   public void setUp() throws IOException {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -67,6 +67,9 @@ import org.apache.hudi.utilities.streamer.SourceProfile;
 import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 
 import com.codahale.metrics.MetricRegistry;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -1092,27 +1095,14 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     );
   }
 
+  @AllArgsConstructor
+  @Getter
   static class TestSourceProfile implements SourceProfile<Integer> {
 
     private final long maxSourceBytes;
     private final int sourcePartitions;
+    @Getter(AccessLevel.NONE)
     private final int numInstantsPerFetch;
-
-    public TestSourceProfile(long maxSourceBytes, int sourcePartitions, int numInstantsPerFetch) {
-      this.maxSourceBytes = maxSourceBytes;
-      this.sourcePartitions = sourcePartitions;
-      this.numInstantsPerFetch = numInstantsPerFetch;
-    }
-
-    @Override
-    public long getMaxSourceBytes() {
-      return maxSourceBytes;
-    }
-
-    @Override
-    public int getSourcePartitions() {
-      return sourcePartitions;
-    }
 
     @Override
     public Integer getSourceSpecificContext() {
@@ -1120,18 +1110,12 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
     }
   }
 
+  @AllArgsConstructor
+  @Getter
   static class WriteResult {
+
     private HoodieInstant instant;
     private List<HoodieRecord> records;
-
-    WriteResult(HoodieInstant instant, List<HoodieRecord> records) {
-      this.instant = instant;
-      this.records = records;
-    }
-
-    public HoodieInstant getInstant() {
-      return instant;
-    }
 
     public String getInstantTime() {
       return instant.requestedTime();
@@ -1139,10 +1123,6 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
 
     public String getCompletionTime() {
       return instant.getCompletionTime();
-    }
-
-    public List<HoodieRecord> getRecords() {
-      return records;
     }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/JdbcTestUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/JdbcTestUtils.java
@@ -23,9 +23,8 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -39,9 +38,8 @@ import java.util.Objects;
 /**
  * Helper class used in testing {@link org.apache.hudi.utilities.sources.JdbcSource}.
  */
+@Slf4j
 public class JdbcTestUtils {
-
-  private static final Logger LOG = LoggerFactory.getLogger(JdbcTestUtils.class);
 
   public static final String JDBC_URL = "jdbc:h2:mem:test_mem";
   public static final String JDBC_DRIVER = "org.h2.Driver";
@@ -99,7 +97,7 @@ public class JdbcTestUtils {
             insertStatement.setDouble(9, Double.parseDouble(((GenericRecord) record.get("fare")).get("amount").toString()));
             insertStatement.addBatch();
           } catch (SQLException e) {
-            LOG.warn(e.getMessage());
+            log.warn(e.getMessage());
           }
         });
     insertStatement.executeBatch();
@@ -137,7 +135,7 @@ public class JdbcTestUtils {
             updateStatement.setString(10, r.get("_row_key").toString());
             updateStatement.addBatch();
           } catch (SQLException e) {
-            LOG.warn(e.getMessage());
+            log.warn(e.getMessage());
           }
         });
     updateStatement.executeBatch();
@@ -149,7 +147,7 @@ public class JdbcTestUtils {
     try (Statement statement = connection.createStatement()) {
       statement.executeUpdate(query);
     } catch (SQLException e) {
-      LOG.error(message);
+      log.error(message);
     }
   }
 
@@ -159,7 +157,7 @@ public class JdbcTestUtils {
         statement.close();
       }
     } catch (SQLException e) {
-      LOG.error("Error while closing statement. " + e.getMessage());
+      log.error("Error while closing statement. {}", e.getMessage());
     }
   }
 
@@ -169,7 +167,7 @@ public class JdbcTestUtils {
         connection.close();
       }
     } catch (SQLException e) {
-      LOG.error("Error while closing connection. " + e.getMessage());
+      log.error("Error while closing connection. {}", e.getMessage());
     }
   }
 
@@ -179,7 +177,7 @@ public class JdbcTestUtils {
       rs.next();
       return rs.getInt(1);
     } catch (SQLException e) {
-      LOG.warn("Error while counting records. " + e.getMessage());
+      log.warn("Error while counting records. {}", e.getMessage());
       return 0;
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/UtilitiesTestBase.java
@@ -53,6 +53,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema.Builder;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -79,8 +80,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -110,8 +109,8 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
  * Abstract test that provides a dfs & spark contexts.
  *
  */
+@Slf4j
 public class UtilitiesTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(UtilitiesTestBase.class);
   @TempDir
   protected static java.nio.file.Path sharedTempDir;
   protected static FileSystem fs;
@@ -256,7 +255,7 @@ public class UtilitiesTestBase {
     }
 
     if (!failedReleases.isEmpty()) {
-      LOG.error("Exception happened during releasing: " + String.join(",", failedReleases));
+      log.error("Exception happened during releasing: {}", String.join(",", failedReleases));
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR refactors the `hudi-utilities` module to reduce boilerplate code by leveraging Project Lombok annotations. Specifically, it replaces explicit `Logger` instantiation, manual getter/setter methods, and empty constructors with their equivalent Lombok annotations (`@Slf4j`, `@Getter`, `@Setter`,`@NoArgsConstructor`, `@AllArgsConstructor`, `@Data`, `@Value`, `@ToString`).

This improves code readability and maintainability without altering the runtime logic.

This is part 3 / 3.

### Summary and Changelog

This change introduces the Lombok dependency to the `hudi-utilities` module and refactors several classes to utilize Lombok annotations.

- Added Lombok annotations wherever possible to `hudi-utilities` modules.

### Impact

- **Public API:** None.
- **User Experience:** No visible change for end-users.
- **Performance:** No impact (compile-time code generation).
- **Code Health:** Reduces lines of code and standardizes logging/accessor patterns.

### Risk Level

none

(This is a pure refactoring change involving standard library annotations; no business logic was modified.)

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
