### PR TITLE
fix: Fix TestBucketizedBloomCheckPartitioner assertArrayEquals compar…

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/BucketizedBloomCheckPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/BucketizedBloomCheckPartitioner.java
@@ -60,7 +60,7 @@ import scala.Tuple2;
 @Slf4j
 public class BucketizedBloomCheckPartitioner extends Partitioner {
 
-  private int partitions;
+  private final int partitions;
 
   /**
    * Stores the final mapping of a file group to a list of partitions for its keys.
@@ -149,12 +149,16 @@ public class BucketizedBloomCheckPartitioner extends Partitioner {
     }
 
     if (log.isDebugEnabled()) {
-      log.debug("Partitions assigned per file groups :" + fileGroupToPartitions);
+      log.debug("Partitions assigned per file group: {}", fileGroupToPartitions);
       StringBuilder str = new StringBuilder();
       for (int i = 0; i < bucketsFilled.length; i++) {
-        str.append("p" + i + " : " + bucketsFilled[i] + ",");
+        str.append("{p").append(i).append(": ").append(bucketsFilled[i]).append("}, ");
       }
-      log.debug("Num buckets assigned per file group :" + str);
+      // Strip last ", " away
+      if (bucketsFilled.length > 0) {
+        str.setLength(str.length() - 2);
+      }
+      log.debug("Num buckets assigned per partition: {}", str);
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestBucketizedBloomCheckPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/index/bloom/TestBucketizedBloomCheckPartitioner.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBucketizedBloomCheckPartitioner {
+
   private static Stream<Arguments> partitioningTestCases() {
     // Case 1
     Map<HoodieFileGroupId, Long> fileToComparisons = constructFileToComparisons(
@@ -51,7 +52,7 @@ public class TestBucketizedBloomCheckPartitioner {
     // partitioning based on parallelism of 4
     Map<HoodieFileGroupId, List<Integer>> partitioning1 = constructPartitioning(
         Pair.of(new HoodieFileGroupId("p1", "f1"), new Integer[] {0, 0, 3}),
-        Pair.of(new HoodieFileGroupId("p1", "f2"), new Integer[] {2, 2, 3, 1}),
+        Pair.of(new HoodieFileGroupId("p1", "f2"), new Integer[] {1, 2, 2, 1}),
         Pair.of(new HoodieFileGroupId("p1", "f3"), new Integer[] {1, 0})
     );
     List<LookUpKeyAndResult> lookUpKeyAndResults1 = constructLookUpKeyAndResults(
@@ -137,7 +138,7 @@ public class TestBucketizedBloomCheckPartitioner {
     assertEquals(expectedPartitioning.size(), actualPartitioning.size());
     for (HoodieFileGroupId id : actualPartitioning.keySet()) {
       assertTrue(expectedPartitioning.containsKey(id));
-      assertArrayEquals(expectedPartitioning.get(id).toArray(), expectedPartitioning.get(id).toArray());
+      assertArrayEquals(expectedPartitioning.get(id).toArray(), actualPartitioning.get(id).toArray());
     }
     lookUpKeyAndResults.forEach(lookUpKeyAndResult ->
         assertEquals(lookUpKeyAndResult.expectedPartitionId, partitioner.getPartition(


### PR DESCRIPTION
…ison

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

`assertArrayEquals` was comparing the same expected array in `TestBucketizedBloomCheckPartitioner#testPartitioning`. This PR fixes it.

Log messages are also edited, an example is shown below:

```
459  [main] DEBUG org.apache.hudi.index.bloom.BucketizedBloomCheckPartitioner [] - Partitions assigned per file group: {HoodieFileGroupId(partitionPath=p1, fileId=f1)=[0, 3], HoodieFileGroupId(partitionPath=p1, fileId=f3)=[1], HoodieFileGroupId(partitionPath=p1, fileId=f2)=[2, 4]}
459  [main] DEBUG org.apache.hudi.index.bloom.BucketizedBloomCheckPartitioner [] - Num buckets assigned per partition: {p0: 1}, {p1: 1}, {p2: 1}, {p3: 1}, {p4: 1}
```

How to interpret: 

1. `{HoodieFileGroupId(partitionPath=p1, fileId=f1)` has 2 buckets, bucket 0 is assigned to `Spark partition 0`, bucket 1 is assigned to `Spark partition 3`
2. `HoodieFileGroupId(partitionPath=p1, fileId=f3)` has 1 bucket, bucket 0 is assigned to `Spark partition 1`
3. `HoodieFileGroupId(partitionPath=p1, fileId=f2` has 2 buckets, bucket 0 is assigned to `Spark partition 2`, bucket 1 is assigned to `Spark partition 4`

As a result:
1. `Spark Partition 0` has 1 bucket
2. `Spark Partition 1` has 1 bucket
3. `Spark Partition 2` has 1 bucket
4. `Spark Partition 3` has 1 bucket
5. `Spark Partition 4` has 1 bucket

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

1. Edited log messages to make it easier to understand
6. Ensure that `partitionPath` variable is final.
7. Fixed test comparison and test values

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

Test is now correctly comparing correct actual and expected values.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->
None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
