### PR TITLE
feat: add storage LP implementation for azure

### DIFF
--- a/hudi-azure/pom.xml
+++ b/hudi-azure/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>hudi</artifactId>
+        <groupId>org.apache.hudi</groupId>
+        <version>1.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hudi-azure</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+
+    <name>hudi-azure</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <azure.storage.blob.version>12.25.1</azure.storage.blob.version>
+        <azure.identity.version>1.11.1</azure.identity.version>
+        <azurite.version>3.29.0</azurite.version>
+    </properties>
+
+    <dependencies>
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+
+        <!-- Hoodie -->
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-client-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Azure Storage SDK -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+            <version>${azure.storage.blob.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>${azure.identity.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-tests-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-client-common</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo-shaded</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+            </plugin>
+        </plugins>
+
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/hudi-azure/src/main/java/org/apache/hudi/azure/transaction/lock/AzureStorageLockClient.java
+++ b/hudi-azure/src/main/java/org/apache/hudi/azure/transaction/lock/AzureStorageLockClient.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.
+ * See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.apache.hudi.azure.transaction.lock;
+
+import org.apache.hudi.azure.utils.AzureStorageUtils;
+import org.apache.hudi.azure.utils.AzureStorageUtils.AzureStorageUriComponents;
+import org.apache.hudi.client.transaction.lock.StorageLockClient;
+import org.apache.hudi.client.transaction.lock.models.LockGetResult;
+import org.apache.hudi.client.transaction.lock.models.LockUpsertResult;
+import org.apache.hudi.client.transaction.lock.models.StorageLockData;
+import org.apache.hudi.client.transaction.lock.models.StorageLockFile;
+import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.common.util.collection.Pair;
+
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
+import com.azure.core.util.HttpClientOptions;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.BlockBlobItem;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+import com.azure.core.http.policy.ExponentialBackoffOptions;
+import com.azure.core.http.policy.RetryOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.apache.hudi.config.StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS;
+
+/**
+ * Azure Blob Storage-based distributed lock client using ETag checks.
+ * Supports both WASB(S) and ABFS(S) URI schemes for Azure Data Lake Storage Gen2.
+ *
+ * <p>Authentication is handled automatically via DefaultAzureCredential which supports:
+ * <ul>
+ *   <li>Managed Identity (Azure VMs, App Service, Container Instances, AKS)</li>
+ *   <li>Workload Identity (Kubernetes service accounts)</li>
+ *   <li>Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)</li>
+ *   <li>Azure CLI credentials (for local development)</li>
+ *   <li>VS Code, IntelliJ, and Azure PowerShell credentials</li>
+ * </ul>
+ *
+ * <p>No configuration is required when running on Azure infrastructure.
+ * See RFC: <a href="https://github.com/apache/hudi/blob/master/rfc/rfc-91/rfc-91.md">RFC-91</a>
+ */
+@Slf4j
+@ThreadSafe
+public class AzureStorageLockClient implements StorageLockClient {
+  private static final int PRECONDITION_FAILURE_ERROR_CODE = 412;
+  private static final int NOT_FOUND_ERROR_CODE = 404;
+  private static final int CONFLICT_ERROR_CODE = 409;
+  private static final int RATE_LIMIT_ERROR_CODE = 429;
+  private static final int INTERNAL_SERVER_ERROR_CODE_MIN = 500;
+
+  private final Logger logger;
+  private final BlobClient blobClient;
+  private final String containerName;
+  private final String blobPath;
+  private final String ownerId;
+
+  /**
+   * Constructor that is used by reflection to instantiate an Azure-based storage locking client.
+   *
+   * @param ownerId     The owner id.
+   * @param lockFileUri The full table base path where the lock will be written.
+   * @param props       The properties for the lock config, can be used to customize client.
+   */
+  public AzureStorageLockClient(String ownerId, String lockFileUri, Properties props) {
+    this(ownerId, lockFileUri, props, createDefaultBlobClient(), log);
+  }
+
+  @VisibleForTesting
+  AzureStorageLockClient(String ownerId, String lockFileUri, Properties props,
+                         Functions.Function2<String, Properties, BlobClient> blobClientSupplier,
+                         Logger logger) {
+    AzureStorageUriComponents uriComponents = AzureStorageUtils.parseAzureUri(lockFileUri);
+    this.containerName = uriComponents.containerName;
+    this.blobPath = uriComponents.blobPath;
+
+    this.blobClient = blobClientSupplier.apply(lockFileUri, props);
+    this.ownerId = ownerId;
+    this.logger = logger;
+  }
+
+  @Override
+  public Pair<LockGetResult, Option<StorageLockFile>> readCurrentLockFile() {
+    try {
+      BlobProperties properties = blobClient.getProperties();
+      String eTag = properties.getETag();
+
+      byte[] content = blobClient.downloadContent().toBytes();
+      ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
+
+      return Pair.of(LockGetResult.SUCCESS,
+          Option.of(StorageLockFile.createFromStream(inputStream, eTag)));
+    } catch (BlobStorageException e) {
+      int status = e.getStatusCode();
+      LockGetResult result = LockGetResult.UNKNOWN_ERROR;
+
+      if (status == NOT_FOUND_ERROR_CODE || e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+        logger.info("OwnerId: {}, Blob not found: {}", ownerId, blobPath);
+        result = LockGetResult.NOT_EXISTS;
+      } else if (status == CONFLICT_ERROR_CODE) {
+        logger.info("OwnerId: {}, Conflicting operation has occurred: {}", ownerId, blobPath);
+      } else if (status == RATE_LIMIT_ERROR_CODE) {
+        logger.warn("OwnerId: {}, Rate limit exceeded: {}", ownerId, blobPath);
+      } else if (status >= INTERNAL_SERVER_ERROR_CODE_MIN) {
+        logger.warn("OwnerId: {}, Azure internal server error: {}", ownerId, blobPath, e);
+      } else {
+        throw e;
+      }
+      return Pair.of(result, Option.empty());
+    }
+  }
+
+  @Override
+  public Pair<LockUpsertResult, Option<StorageLockFile>> tryUpsertLockFile(
+      StorageLockData newLockData, Option<StorageLockFile> previousLockFile) {
+    boolean isLockRenewal = previousLockFile.isPresent();
+    String currentEtag = isLockRenewal ? previousLockFile.get().getVersionId() : null;
+
+    try {
+      StorageLockFile updated = createOrUpdateLockFileInternal(newLockData, currentEtag);
+      return Pair.of(LockUpsertResult.SUCCESS, Option.of(updated));
+    } catch (BlobStorageException e) {
+      LockUpsertResult result = handleUpsertBlobStorageException(e);
+      return Pair.of(result, Option.empty());
+    } catch (HttpResponseException e) {
+      logger.error("OwnerId: {}, Unexpected Azure SDK error while writing lock file: {}",
+          ownerId, blobPath, e);
+      if (!isLockRenewal) {
+        // We should always throw errors early when we are creating the lock file.
+        // This is likely indicative of a larger issue that should bubble up sooner.
+        throw e;
+      }
+      return Pair.of(LockUpsertResult.UNKNOWN_ERROR, Option.empty());
+    }
+  }
+
+  /**
+   * Internal helper to create or update the lock file with optional ETag precondition.
+   */
+  private StorageLockFile createOrUpdateLockFileInternal(StorageLockData lockData, String expectedEtag) {
+    byte[] bytes = StorageLockFile.toByteArray(lockData);
+    BinaryData binaryData = BinaryData.fromBytes(bytes);
+    BlobRequestConditions requestConditions = new BlobRequestConditions();
+
+    // ETag-based constraints:
+    // - If expectedEtag is not null:
+    //    We assume that the blob already exists with the ETag "expectedEtag".
+    //    The update operation will include an ifMatch(expectedEtag) condition, meaning the update will only
+    //    succeed if the current blob's ETag exactly matches expectedEtag.
+    //    If the actual ETag of the blob differs from expectedEtag, the update attempt will fail.
+    // - If expectedEtag is null:
+    //    We assume that the blob does not currently exist.
+    //    The operation will use ifNoneMatch("*"), which instructs Azure to create the blob only if it doesn't already exist.
+    //    If a blob with the same name is present (i.e., there is an existing ETag), the creation attempt will fail.
+    if (expectedEtag == null) {
+      requestConditions.setIfNoneMatch("*");
+    } else {
+      requestConditions.setIfMatch(expectedEtag);
+    }
+
+    BlobParallelUploadOptions options = new BlobParallelUploadOptions(binaryData)
+        .setRequestConditions(requestConditions);
+
+    Response<BlockBlobItem> response = blobClient.uploadWithResponse(options, null, Context.NONE);
+    String newEtag = response.getValue().getETag();
+
+    return new StorageLockFile(lockData, newEtag);
+  }
+
+  private LockUpsertResult handleUpsertBlobStorageException(BlobStorageException e) {
+    int status = e.getStatusCode();
+
+    if (status == PRECONDITION_FAILURE_ERROR_CODE
+        || e.getErrorCode() == BlobErrorCode.CONDITION_NOT_MET) {
+      logger.info("OwnerId: {}, Lock file modified by another process: {}", ownerId, blobPath);
+      return LockUpsertResult.ACQUIRED_BY_OTHERS;
+    } else if (status == CONFLICT_ERROR_CODE) {
+      logger.info("OwnerId: {}, Retriable conditional request conflict error: {}", ownerId, blobPath);
+    } else if (status == RATE_LIMIT_ERROR_CODE) {
+      logger.warn("OwnerId: {}, Rate limit exceeded for: {}", ownerId, blobPath);
+    } else if (status >= INTERNAL_SERVER_ERROR_CODE_MIN) {
+      logger.warn("OwnerId: {}, Internal server error for: {}", ownerId, blobPath, e);
+    } else {
+      logger.warn("OwnerId: {}, Error writing lock file: {}", ownerId, blobPath, e);
+    }
+
+    return LockUpsertResult.UNKNOWN_ERROR;
+  }
+
+  private static Functions.Function2<String, Properties, BlobClient> createDefaultBlobClient() {
+    return (lockFileUri, props) -> {
+      AzureStorageUriComponents uriComponents = AzureStorageUtils.parseAzureUri(lockFileUri);
+
+      URI uri = URI.create(lockFileUri);
+      String scheme = uri.getScheme();
+
+      // Determine the appropriate endpoint based on scheme
+      // ABFS uses DFS endpoint for ADLS Gen2, WASB uses Blob endpoint
+      String endpoint;
+      if (scheme.startsWith("abfs")) {
+        endpoint = String.format("https://%s.dfs.core.windows.net", uriComponents.accountName);
+      } else {
+        endpoint = String.format("https://%s.blob.core.windows.net", uriComponents.accountName);
+      }
+
+      // Set all request timeouts to be 1/5 of the default validity.
+      // Each call to acquire a lock requires 2 requests.
+      // Each renewal requires 1 request.
+      long validityTimeoutSecs = ((Number) props.getOrDefault(
+          VALIDITY_TIMEOUT_SECONDS.key(),
+          VALIDITY_TIMEOUT_SECONDS.defaultValue()
+      )).longValue();
+      long azureCallTimeoutSecs = validityTimeoutSecs / 5;
+
+      // Disable automatic retries in the Azure SDK to let Hudi's StorageBasedLockProvider
+      // handle retries with proper backoff and timeout logic
+      ExponentialBackoffOptions exponentialOptions = new ExponentialBackoffOptions()
+          .setMaxRetries(0);
+      RetryOptions retryOptions = new RetryOptions(exponentialOptions);
+
+      // Configure HTTP client timeouts
+      HttpClientOptions clientOptions = new HttpClientOptions()
+          .setResponseTimeout(Duration.ofSeconds(azureCallTimeoutSecs))
+          .setReadTimeout(Duration.ofSeconds(azureCallTimeoutSecs));
+
+      // Use DefaultAzureCredential for automatic authentication
+      // This supports: Managed Identity, Workload Identity, Environment Variables,
+      // Azure CLI, VS Code, IntelliJ, and Azure PowerShell credentials
+      BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+          .endpoint(endpoint)
+          .credential(new DefaultAzureCredentialBuilder().build())
+          .retryOptions(retryOptions)
+          .clientOptions(clientOptions)
+          .buildClient();
+
+      BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(uriComponents.containerName);
+      return containerClient.getBlobClient(uriComponents.blobPath);
+    };
+  }
+
+  @Override
+  public Option<String> readObject(String filePath, boolean checkExistsFirst) {
+    try {
+      AzureStorageUriComponents uriComponents = AzureStorageUtils.parseAzureUri(filePath);
+      BlobClient client = blobClient.getContainerClient()
+          .getBlobClient(uriComponents.blobPath);
+
+      if (checkExistsFirst) {
+        if (!client.exists()) {
+          logger.debug("JSON config file not found: {}", filePath);
+          return Option.empty();
+        }
+      }
+
+      String content = client.downloadContent().toString();
+      return Option.of(content);
+    } catch (BlobStorageException e) {
+      if (e.getStatusCode() == NOT_FOUND_ERROR_CODE
+          || e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+        logger.debug("JSON config file not found: {}", filePath);
+      } else {
+        logger.error("Error reading JSON config file: {}", filePath, e);
+      }
+      return Option.empty();
+    } catch (Exception e) {
+      logger.error("Error reading JSON config file: {}", filePath, e);
+      return Option.empty();
+    }
+  }
+
+  @Override
+  public boolean writeObject(String filePath, String content) {
+    try {
+      AzureStorageUriComponents uriComponents = AzureStorageUtils.parseAzureUri(filePath);
+      BlobClient client = blobClient.getContainerClient()
+          .getBlobClient(uriComponents.blobPath);
+
+      client.upload(BinaryData.fromString(content), true);
+
+      logger.debug("Successfully wrote object to: {}", filePath);
+      return true;
+    } catch (Exception e) {
+      logger.error("Error writing object to: {}", filePath, e);
+      return false;
+    }
+  }
+
+  @Override
+  public void close() {
+    // BlobClient doesn't require explicit cleanup
+  }
+}

--- a/hudi-azure/src/main/java/org/apache/hudi/azure/utils/AzureStorageUtils.java
+++ b/hudi-azure/src/main/java/org/apache/hudi/azure/utils/AzureStorageUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.azure.utils;
+
+import org.apache.hudi.common.util.StringUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Utility class for Azure Blob Storage operations.
+ */
+public class AzureStorageUtils {
+
+  /**
+   * Parses Azure storage URI and extracts components.
+   * Supports WASB(S): wasbs://container@account.blob.core.windows.net/path
+   * Supports ABFS(S): abfss://container@account.dfs.core.windows.net/path
+   *
+   * @param uriString The Azure storage URI to parse
+   * @return Parsed URI components containing container name, account name, and blob path
+   * @throws IllegalArgumentException if the URI format is invalid
+   */
+  public static AzureStorageUriComponents parseAzureUri(String uriString) {
+    try {
+      URI uri = new URI(uriString);
+      String scheme = uri.getScheme();
+
+      if (scheme == null) {
+        throw new IllegalArgumentException("URI does not contain a scheme: " + uriString);
+      }
+
+      String authority = uri.getAuthority();
+      if (StringUtils.isNullOrEmpty(authority)) {
+        throw new IllegalArgumentException("URI does not contain authority: " + uriString);
+      }
+
+      String containerName;
+      String accountName;
+
+      // Parse based on scheme
+      if (scheme.startsWith("wasb")) {
+        // WASB format: wasbs://container@account.blob.core.windows.net/path
+        String[] parts = authority.split("@");
+        if (parts.length != 2) {
+          throw new IllegalArgumentException("Invalid WASB URI format: " + uriString);
+        }
+        containerName = parts[0];
+        accountName = parts[1].split("\\.")[0];
+      } else if (scheme.startsWith("abfs")) {
+        // ABFS format: abfss://container@account.dfs.core.windows.net/path
+        String[] parts = authority.split("@");
+        if (parts.length != 2) {
+          throw new IllegalArgumentException("Invalid ABFS URI format: " + uriString);
+        }
+        containerName = parts[0];
+        accountName = parts[1].split("\\.")[0];
+      } else {
+        throw new IllegalArgumentException("Unsupported Azure URI scheme: " + scheme);
+      }
+
+      String path = uri.getPath();
+      if (StringUtils.isNullOrEmpty(path) || path.equals("/")) {
+        throw new IllegalArgumentException("URI does not contain a valid path: " + uriString);
+      }
+
+      // Remove leading slash
+      String blobPath = path.startsWith("/") ? path.substring(1) : path;
+
+      return new AzureStorageUriComponents(containerName, accountName, blobPath);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Failed to parse Azure URI: " + uriString, e);
+    }
+  }
+
+  /**
+   * Helper class to hold parsed Azure URI components.
+   */
+  public static class AzureStorageUriComponents {
+    public final String containerName;
+    public final String accountName;
+    public final String blobPath;
+
+    public AzureStorageUriComponents(String containerName, String accountName, String blobPath) {
+      this.containerName = containerName;
+      this.accountName = accountName;
+      this.blobPath = blobPath;
+    }
+  }
+}

--- a/hudi-azure/src/test/java/org/apache/hudi/azure/transaction/lock/TestAzureStorageBasedLockProvider.java
+++ b/hudi-azure/src/test/java/org/apache/hudi/azure/transaction/lock/TestAzureStorageBasedLockProvider.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.azure.transaction.lock;
+
+import org.apache.hudi.client.transaction.lock.StorageBasedLockProvider;
+import org.apache.hudi.client.transaction.lock.StorageBasedLockProviderTestBase;
+import org.apache.hudi.common.config.LockConfiguration;
+
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.apache.hudi.common.config.HoodieCommonConfig.BASE_PATH;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests Azure Blob Storage-based StorageBasedLockProvider using Azurite container
+ * to emulate Azure Blob Storage.
+ */
+@Disabled("Integration test requiring Docker - enable for manual testing")
+public class TestAzureStorageBasedLockProvider extends StorageBasedLockProviderTestBase {
+
+  private static final DockerImageName AZURITE_IMAGE =
+      DockerImageName.parse("mcr.microsoft.com/azure-storage/azurite:latest");
+
+  private static GenericContainer<?> AZURITE_CONTAINER;
+
+  private static final String TEST_CONTAINER = "test-container";
+  private static final String AZURITE_ACCOUNT_NAME = "devstoreaccount1";
+  private static final String AZURITE_ACCOUNT_KEY =
+      "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+  private static BlobServiceClient blobServiceClient;
+  private static String connectionString;
+
+  @BeforeAll
+  static void initContainer() {
+    // Spin up Azurite container with Blob service
+    AZURITE_CONTAINER = new GenericContainer<>(AZURITE_IMAGE)
+        .withExposedPorts(10000)  // Blob service port
+        .withCommand("azurite-blob", "--blobHost", "0.0.0.0");
+    AZURITE_CONTAINER.start();
+
+    String blobEndpoint = String.format("http://%s:%d/%s",
+        AZURITE_CONTAINER.getHost(),
+        AZURITE_CONTAINER.getMappedPort(10000),
+        AZURITE_ACCOUNT_NAME);
+
+    connectionString = String.format(
+        "DefaultEndpointsProtocol=http;AccountName=%s;AccountKey=%s;BlobEndpoint=%s;",
+        AZURITE_ACCOUNT_NAME,
+        AZURITE_ACCOUNT_KEY,
+        blobEndpoint);
+
+    blobServiceClient = new BlobServiceClientBuilder()
+        .connectionString(connectionString)
+        .buildClient();
+
+    BlobContainerClient containerClient = blobServiceClient.createBlobContainer(TEST_CONTAINER);
+    assertNotNull(containerClient);
+  }
+
+  @AfterAll
+  static void stopContainer() {
+    if (AZURITE_CONTAINER != null) {
+      AZURITE_CONTAINER.stop();
+    }
+  }
+
+  /**
+   * Creates a real Azure-based StorageBasedLockProvider for testing.
+   */
+  @Override
+  protected StorageBasedLockProvider createLockProvider() {
+    LockConfiguration lockConf = new LockConfiguration(providerProperties);
+    return new StorageBasedLockProvider(lockConf, null);
+  }
+
+  @BeforeEach
+  void setupLockProvider() {
+    // Provide base path for the test using WASB format
+    String basePath = String.format("wasbs://%s@%s.blob.core.windows.net/lake/db/tbl-default",
+        TEST_CONTAINER, AZURITE_ACCOUNT_NAME);
+    providerProperties.put(BASE_PATH.key(), basePath);
+    // Note: The lock client will use DefaultAzureCredential which will work with
+    // the Azurite endpoint. For real Azure environments, no configuration is needed.
+    lockProvider = createLockProvider();
+  }
+
+  @Test
+  void testAzurePreconditions() {
+    String blobName = "test-preconditions-blob";
+    BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(TEST_CONTAINER);
+
+    BlobParallelUploadOptions options1 = new BlobParallelUploadOptions(BinaryData.fromString("Content1"))
+        .setRequestConditions(new BlobRequestConditions().setIfNoneMatch("*"));
+    var response1 = containerClient.getBlobClient(blobName)
+        .uploadWithResponse(options1, null, null);
+    assertNotNull(response1.getValue().getETag());
+    String etag1 = response1.getValue().getETag();
+
+    BlobParallelUploadOptions options2 = new BlobParallelUploadOptions(BinaryData.fromString("Content2"))
+        .setRequestConditions(new BlobRequestConditions().setIfMatch(etag1));
+    var response2 = containerClient.getBlobClient(blobName)
+        .uploadWithResponse(options2, null, null);
+    assertNotNull(response2.getValue().getETag());
+    String etag2 = response2.getValue().getETag();
+
+    assertNotEquals(etag1, etag2);
+  }
+}

--- a/hudi-azure/src/test/java/org/apache/hudi/azure/transaction/lock/TestAzureStorageLockClient.java
+++ b/hudi-azure/src/test/java/org/apache/hudi/azure/transaction/lock/TestAzureStorageLockClient.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.
+ * See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.apache.hudi.azure.transaction.lock;
+
+import org.apache.hudi.client.transaction.lock.models.LockGetResult;
+import org.apache.hudi.client.transaction.lock.models.LockUpsertResult;
+import org.apache.hudi.client.transaction.lock.models.StorageLockData;
+import org.apache.hudi.client.transaction.lock.models.StorageLockFile;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.BlockBlobItem;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import java.util.Properties;
+
+import static org.apache.hudi.client.transaction.lock.models.LockUpsertResult.UNKNOWN_ERROR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestAzureStorageLockClient {
+
+  private static final String OWNER_ID = "ownerId";
+  private static final String LOCK_FILE_URI_WASB = "wasbs://container@account.blob.core.windows.net/lockFilePath";
+  private static final String LOCK_FILE_URI_ABFS = "abfss://container@account.dfs.core.windows.net/lockFilePath";
+  private static final String LOCK_FILE_PATH = "lockFilePath";
+
+  @Mock
+  private BlobClient mockBlobClient;
+
+  @Mock
+  private BlobContainerClient mockContainerClient;
+
+  @Mock
+  private Logger mockLogger;
+
+  private AzureStorageLockClient lockService;
+
+  @BeforeEach
+  void setUp() {
+    lockService = new AzureStorageLockClient(
+        OWNER_ID,
+        LOCK_FILE_URI_WASB,
+        new Properties(),
+        (uri, props) -> mockBlobClient,
+        mockLogger
+    );
+  }
+
+  @Test
+  void testTryCreateOrUpdateLockFile_noPreviousLock_success() {
+    StorageLockData lockData = new StorageLockData(false, System.currentTimeMillis(), "myTxOwner");
+    BlockBlobItem mockItem = mock(BlockBlobItem.class);
+    when(mockItem.getETag()).thenReturn("new-etag-123");
+    @SuppressWarnings("unchecked")
+    Response<BlockBlobItem> mockResponse = mock(Response.class);
+    when(mockResponse.getValue()).thenReturn(mockItem);
+    when(mockBlobClient.uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any())).thenReturn(mockResponse);
+
+    Pair<LockUpsertResult, Option<StorageLockFile>> result = lockService.tryUpsertLockFile(lockData, Option.empty());
+
+    assertEquals(LockUpsertResult.SUCCESS, result.getLeft());
+    assertTrue(result.getRight().isPresent());
+    assertEquals("new-etag-123", result.getRight().get().getVersionId());
+    verify(mockBlobClient, times(1)).uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any());
+    verifyNoMoreInteractions(mockLogger);
+  }
+
+  @Test
+  void testInitializeWithInvalidUri() {
+    assertThrows(IllegalArgumentException.class, () -> new AzureStorageLockClient(
+        OWNER_ID,
+        "\\",
+        new Properties(),
+        (uri, props) -> mockBlobClient,
+        mockLogger
+    ));
+  }
+
+  @Test
+  void testInitializeWithNoLockFilePath() {
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new AzureStorageLockClient(
+        OWNER_ID,
+        "wasbs://container@account.blob.core.windows.net/",
+        new Properties(),
+        (uri, props) -> mockBlobClient,
+        mockLogger
+    ));
+    assertTrue(ex.getMessage().contains("path"));
+  }
+
+  @Test
+  void testInitializeWithNoContainerName() {
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new AzureStorageLockClient(
+        OWNER_ID,
+        "wasbs:///path",
+        new Properties(),
+        (uri, props) -> mockBlobClient,
+        mockLogger
+    ));
+    assertTrue(ex.getMessage().contains("authority"));
+  }
+
+  @Test
+  void testInitializeWithInvalidWasbFormat() {
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new AzureStorageLockClient(
+        OWNER_ID,
+        "wasbs://container/path",
+        new Properties(),
+        (uri, props) -> mockBlobClient,
+        mockLogger
+    ));
+    assertTrue(ex.getMessage().contains("WASB"));
+  }
+
+  @Test
+  void testInitializeWithAbfsUri() {
+    // Should not throw
+    AzureStorageLockClient client = new AzureStorageLockClient(
+        OWNER_ID,
+        LOCK_FILE_URI_ABFS,
+        new Properties(),
+        (uri, props) -> mockBlobClient,
+        mockLogger
+    );
+    assertTrue(client != null);
+  }
+
+  @Test
+  void testTryCreateOrUpdateLockFile_withPreviousLock_success() {
+    StorageLockData lockData = new StorageLockData(false, 1000L, "myTxOwner");
+    StorageLockFile prevLockFile = new StorageLockFile(lockData, "old-etag-999");
+    BlockBlobItem mockItem = mock(BlockBlobItem.class);
+    when(mockItem.getETag()).thenReturn("new-etag-456");
+    @SuppressWarnings("unchecked")
+    Response<BlockBlobItem> mockResponse = mock(Response.class);
+    when(mockResponse.getValue()).thenReturn(mockItem);
+    when(mockBlobClient.uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any())).thenReturn(mockResponse);
+
+    Pair<LockUpsertResult, Option<StorageLockFile>> result =
+        lockService.tryUpsertLockFile(lockData, Option.of(prevLockFile));
+
+    assertEquals(LockUpsertResult.SUCCESS, result.getLeft());
+    assertTrue(result.getRight().isPresent());
+    assertEquals("new-etag-456", result.getRight().get().getVersionId());
+    verify(mockBlobClient, times(1)).uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any());
+  }
+
+  @Test
+  void testTryCreateOrUpdateLockFile_preconditionFailed() {
+    StorageLockData lockData = new StorageLockData(false, 2000L, "txOwner");
+    StorageLockFile prevLockFile = new StorageLockFile(lockData, "some-etag");
+
+    BlobStorageException ex412 = mockBlobStorageException(412, BlobErrorCode.CONDITION_NOT_MET);
+    when(mockBlobClient.uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any())).thenThrow(ex412);
+
+    Pair<LockUpsertResult, Option<StorageLockFile>> result =
+        lockService.tryUpsertLockFile(lockData, Option.of(prevLockFile));
+
+    assertEquals(LockUpsertResult.ACQUIRED_BY_OTHERS, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).info(contains("Lock file modified by another process"), eq(OWNER_ID), eq(LOCK_FILE_PATH));
+  }
+
+  @Test
+  void testTryCreateOrUpdateLockFile_conflict409() {
+    StorageLockData lockData = new StorageLockData(false, 3000L, "myTxOwner");
+    StorageLockFile prevLockFile = new StorageLockFile(lockData, "some-etag-409");
+
+    BlobStorageException ex409 = mockBlobStorageException(409, null);
+    when(mockBlobClient.uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any())).thenThrow(ex409);
+
+    Pair<LockUpsertResult, Option<StorageLockFile>> result =
+        lockService.tryUpsertLockFile(lockData, Option.of(prevLockFile));
+
+    assertEquals(UNKNOWN_ERROR, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).info(contains("Retriable conditional request conflict error"), eq(OWNER_ID), eq(LOCK_FILE_PATH));
+  }
+
+  @Test
+  void testTryCreateOrUpdateLockFile_rateLimitExceeded() {
+    StorageLockData lockData = new StorageLockData(false, 4000L, "myTxOwner");
+    BlobStorageException ex429 = mockBlobStorageException(429, null);
+    when(mockBlobClient.uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any())).thenThrow(ex429);
+
+    Pair<LockUpsertResult, Option<StorageLockFile>> result =
+        lockService.tryUpsertLockFile(lockData, Option.empty());
+
+    assertEquals(UNKNOWN_ERROR, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).warn(contains("Rate limit exceeded"), eq(OWNER_ID), eq(LOCK_FILE_PATH));
+  }
+
+  @Test
+  void testTryCreateOrUpdateLockFile_serverError() {
+    StorageLockData lockData = new StorageLockData(false, 5000L, "myTxOwner");
+    BlobStorageException ex503 = mockBlobStorageException(503, null);
+    when(mockBlobClient.uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any())).thenThrow(ex503);
+
+    Pair<LockUpsertResult, Option<StorageLockFile>> result =
+        lockService.tryUpsertLockFile(lockData, Option.empty());
+
+    assertEquals(UNKNOWN_ERROR, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).warn(contains("Internal server error"), eq(OWNER_ID), eq(LOCK_FILE_PATH), eq(ex503));
+  }
+
+  @Test
+  void testTryCreateLockFile_unexpectedError() {
+    StorageLockData lockData = new StorageLockData(false, 8000L, "myTxOwner");
+    BlobStorageException ex400 = mockBlobStorageException(400, null);
+    when(mockBlobClient.uploadWithResponse(any(BlobParallelUploadOptions.class),
+        any(), any())).thenThrow(ex400);
+
+    Pair<LockUpsertResult, Option<StorageLockFile>> result = lockService.tryUpsertLockFile(lockData, Option.empty());
+
+    assertEquals(UNKNOWN_ERROR, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).warn(contains("Error writing lock file"), eq(OWNER_ID), eq(LOCK_FILE_PATH), eq(ex400));
+  }
+
+  @Test
+  void testGetCurrentLockFile_404Error() {
+    BlobStorageException ex404 = mockBlobStorageException(404, BlobErrorCode.BLOB_NOT_FOUND);
+    when(mockBlobClient.getProperties()).thenThrow(ex404);
+
+    Pair<LockGetResult, Option<StorageLockFile>> result = lockService.readCurrentLockFile();
+    assertEquals(LockGetResult.NOT_EXISTS, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).info(contains("Blob not found"), eq(OWNER_ID), eq(LOCK_FILE_PATH));
+  }
+
+  @Test
+  void testGetCurrentLockFile_409Error() {
+    BlobStorageException ex409 = mockBlobStorageException(409, null);
+    when(mockBlobClient.getProperties()).thenThrow(ex409);
+
+    Pair<LockGetResult, Option<StorageLockFile>> result = lockService.readCurrentLockFile();
+    assertEquals(LockGetResult.UNKNOWN_ERROR, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).info(contains("Conflicting operation has occurred"), eq(OWNER_ID), eq(LOCK_FILE_PATH));
+  }
+
+  @Test
+  void testGetCurrentLockFile_objectFound() {
+    StorageLockData lockData = new StorageLockData(false, 9999L, "myTxOwner");
+    byte[] bytes = StorageLockFile.toByteArray(lockData);
+
+    BlobProperties mockProps = mock(BlobProperties.class);
+    when(mockProps.getETag()).thenReturn("abc-etag");
+    when(mockBlobClient.getProperties()).thenReturn(mockProps);
+    when(mockBlobClient.downloadContent()).thenReturn(BinaryData.fromBytes(bytes));
+
+    Pair<LockGetResult, Option<StorageLockFile>> result = lockService.readCurrentLockFile();
+    assertEquals(LockGetResult.SUCCESS, result.getLeft());
+    assertTrue(result.getRight().isPresent());
+    assertEquals("abc-etag", result.getRight().get().getVersionId());
+    assertEquals("myTxOwner", result.getRight().get().getOwner());
+  }
+
+  @Test
+  void testGetCurrentLockFile_rateLimit() {
+    BlobStorageException ex429 = mockBlobStorageException(429, null);
+    when(mockBlobClient.getProperties()).thenThrow(ex429);
+
+    Pair<LockGetResult, Option<StorageLockFile>> result = lockService.readCurrentLockFile();
+    assertEquals(LockGetResult.UNKNOWN_ERROR, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).warn(contains("Rate limit exceeded"), eq(OWNER_ID), eq(LOCK_FILE_PATH));
+  }
+
+  @Test
+  void testGetCurrentLockFile_serverError() {
+    BlobStorageException ex500 = mockBlobStorageException(500, null);
+    when(mockBlobClient.getProperties()).thenThrow(ex500);
+
+    Pair<LockGetResult, Option<StorageLockFile>> result = lockService.readCurrentLockFile();
+    assertEquals(LockGetResult.UNKNOWN_ERROR, result.getLeft());
+    assertTrue(result.getRight().isEmpty());
+    verify(mockLogger).warn(contains("Azure internal server error"), eq(OWNER_ID), eq(LOCK_FILE_PATH), eq(ex500));
+  }
+
+  @Test
+  void testGetCurrentLockFile_unexpectedError() {
+    BlobStorageException ex400 = mockBlobStorageException(400, null);
+    when(mockBlobClient.getProperties()).thenThrow(ex400);
+
+    assertThrows(BlobStorageException.class, () -> lockService.readCurrentLockFile());
+  }
+
+  @Test
+  void testReadObject_found() {
+    when(mockBlobClient.getContainerClient()).thenReturn(mockContainerClient);
+    when(mockContainerClient.getBlobClient(any())).thenReturn(mockBlobClient);
+    String testContent = "{\"test\":\"data\"}";
+    when(mockBlobClient.exists()).thenReturn(true);
+    when(mockBlobClient.downloadContent()).thenReturn(BinaryData.fromString(testContent));
+
+    Option<String> result = lockService.readObject(LOCK_FILE_URI_WASB, true);
+    assertTrue(result.isPresent());
+    assertEquals(testContent, result.get());
+  }
+
+  @Test
+  void testReadObject_notFound() {
+    when(mockBlobClient.getContainerClient()).thenReturn(mockContainerClient);
+    when(mockContainerClient.getBlobClient(any())).thenReturn(mockBlobClient);
+    when(mockBlobClient.exists()).thenReturn(false);
+
+    Option<String> result = lockService.readObject(LOCK_FILE_URI_WASB, true);
+    assertTrue(result.isEmpty());
+    verify(mockLogger).debug(contains("JSON config file not found"), eq(LOCK_FILE_URI_WASB));
+  }
+
+  @Test
+  void testWriteObject_success() {
+    when(mockBlobClient.getContainerClient()).thenReturn(mockContainerClient);
+    when(mockContainerClient.getBlobClient(any())).thenReturn(mockBlobClient);
+    doNothing().when(mockBlobClient).upload(any(BinaryData.class), anyBoolean());
+
+    boolean result = lockService.writeObject(LOCK_FILE_URI_WASB, "test content");
+    assertTrue(result);
+    verify(mockBlobClient).upload(any(BinaryData.class), eq(true));
+    verify(mockLogger).debug(contains("Successfully wrote object"), eq(LOCK_FILE_URI_WASB));
+  }
+
+  @Test
+  void testWriteObject_failure() {
+    when(mockBlobClient.getContainerClient()).thenReturn(mockContainerClient);
+    when(mockContainerClient.getBlobClient(any())).thenReturn(mockBlobClient);
+    doThrow(new RuntimeException("Upload failed"))
+        .when(mockBlobClient).upload(any(BinaryData.class), anyBoolean());
+
+    boolean result = lockService.writeObject(LOCK_FILE_URI_WASB, "test content");
+    assertTrue(!result);
+    verify(mockLogger).error(contains("Error writing object"), eq(LOCK_FILE_URI_WASB), any(RuntimeException.class));
+  }
+
+  @Test
+  void testClose() {
+    lockService.close();
+    // BlobClient doesn't require explicit close, so nothing to verify
+  }
+
+  private BlobStorageException mockBlobStorageException(int statusCode, BlobErrorCode errorCode) {
+    BlobStorageException ex = mock(BlobStorageException.class);
+    when(ex.getStatusCode()).thenReturn(statusCode);
+    if (errorCode != null) {
+      org.mockito.Mockito.lenient().when(ex.getErrorCode()).thenReturn(errorCode);
+    }
+    return ex;
+  }
+}

--- a/hudi-azure/src/test/java/org/apache/hudi/azure/transaction/lock/TestAzureStorageLockClientAuditOperations.java
+++ b/hudi-azure/src/test/java/org/apache/hudi/azure/transaction/lock/TestAzureStorageLockClientAuditOperations.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.azure.transaction.lock;
+
+import org.apache.hudi.common.util.Option;
+
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for AzureStorageLockClient audit operations (readObject and writeObject methods)
+ */
+public class TestAzureStorageLockClientAuditOperations {
+
+  private BlobClient mockBlobClient;
+  private BlobClient mockConfigBlobClient;
+  private BlobContainerClient mockContainerClient;
+  private Logger mockLogger;
+  private AzureStorageLockClient lockClient;
+
+  @BeforeEach
+  void setUp() {
+    mockBlobClient = mock(BlobClient.class);
+    mockConfigBlobClient = mock(BlobClient.class);
+    mockContainerClient = mock(BlobContainerClient.class);
+    mockLogger = mock(Logger.class);
+
+    when(mockBlobClient.getContainerClient()).thenReturn(mockContainerClient);
+    when(mockContainerClient.getBlobClient(any())).thenReturn(mockConfigBlobClient);
+
+    String ownerId = "test-owner";
+    String lockFileUri = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/table_lock.json";
+    lockClient = new AzureStorageLockClient(
+        ownerId,
+        lockFileUri,
+        new Properties(),
+        (uri, props) -> mockBlobClient,
+        mockLogger);
+  }
+
+  @Test
+  void testReadConfigWithCheckExistsFirstFileNotFound() {
+    String configPath = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/audit_enabled.json";
+
+    // exists() returns false
+    when(mockConfigBlobClient.exists()).thenReturn(false);
+
+    Option<String> result = lockClient.readObject(configPath, true);
+
+    assertTrue(result.isEmpty());
+    // Should only call exists(), not downloadContent()
+    verify(mockConfigBlobClient, times(1)).exists();
+    verify(mockConfigBlobClient, never()).downloadContent();
+  }
+
+  @Test
+  void testReadConfigWithCheckExistsFirstFileExists() {
+    String configPath = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/audit_enabled.json";
+    String expectedContent = "{\"STORAGE_LP_AUDIT_SERVICE_ENABLED\": true}";
+
+    // exists() returns true
+    when(mockConfigBlobClient.exists()).thenReturn(true);
+
+    // downloadContent() returns content
+    when(mockConfigBlobClient.downloadContent()).thenReturn(BinaryData.fromString(expectedContent));
+
+    Option<String> result = lockClient.readObject(configPath, true);
+
+    assertTrue(result.isPresent());
+    assertEquals(expectedContent, result.get());
+    // Should call both exists() and downloadContent()
+    verify(mockConfigBlobClient, times(1)).exists();
+    verify(mockConfigBlobClient, times(1)).downloadContent();
+  }
+
+  @Test
+  void testReadConfigWithoutCheckExistsFirstFileNotFound() {
+    String configPath = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/audit_enabled.json";
+
+    // Direct downloadContent() throws BlobNotFound
+    BlobStorageException notFoundException = mockBlobStorageException(404, BlobErrorCode.BLOB_NOT_FOUND);
+    when(mockConfigBlobClient.downloadContent()).thenThrow(notFoundException);
+
+    Option<String> result = lockClient.readObject(configPath, false);
+
+    assertTrue(result.isEmpty());
+    // Should not call exists(), only downloadContent()
+    verify(mockConfigBlobClient, never()).exists();
+    verify(mockConfigBlobClient, times(1)).downloadContent();
+  }
+
+  @Test
+  void testReadConfigWithoutCheckExistsFirstFileExists() {
+    String configPath = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/audit_enabled.json";
+    String expectedContent = "{\"STORAGE_LP_AUDIT_SERVICE_ENABLED\": false}";
+
+    // Direct downloadContent() returns content
+    when(mockConfigBlobClient.downloadContent()).thenReturn(BinaryData.fromString(expectedContent));
+
+    Option<String> result = lockClient.readObject(configPath, false);
+
+    assertTrue(result.isPresent());
+    assertEquals(expectedContent, result.get());
+    // Should not call exists(), only downloadContent()
+    verify(mockConfigBlobClient, never()).exists();
+    verify(mockConfigBlobClient, times(1)).downloadContent();
+  }
+
+  @Test
+  void testReadConfigWithCheckExistsFirstOtherError() {
+    String configPath = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/audit_enabled.json";
+
+    // exists() throws non-404 error
+    BlobStorageException serverError = mockBlobStorageException(500, null);
+    when(mockConfigBlobClient.exists()).thenThrow(serverError);
+
+    Option<String> result = lockClient.readObject(configPath, true);
+
+    assertTrue(result.isEmpty());
+    verify(mockConfigBlobClient, times(1)).exists();
+    verify(mockConfigBlobClient, never()).downloadContent();
+  }
+
+  @Test
+  void testReadConfigWithInvalidUri() {
+    String invalidPath = "not-a-valid-uri";
+
+    Option<String> result = lockClient.readObject(invalidPath, false);
+
+    assertTrue(result.isEmpty());
+    // Should not make any blob calls due to URI parsing error
+    verify(mockConfigBlobClient, never()).exists();
+  }
+
+  @Test
+  void testReadConfigWithRateLimitError() {
+    String configPath = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/audit_enabled.json";
+
+    // downloadContent() returns rate limit error
+    BlobStorageException rateLimitException = mockBlobStorageException(429, null);
+    when(mockConfigBlobClient.downloadContent()).thenThrow(rateLimitException);
+
+    Option<String> result = lockClient.readObject(configPath, false);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testWriteConfigSuccess() {
+    String configPath = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/audit_log.json";
+    String content = "{\"operation\":\"START\",\"timestamp\":123456789}";
+
+    doNothing().when(mockConfigBlobClient).upload(any(BinaryData.class), anyBoolean());
+
+    boolean result = lockClient.writeObject(configPath, content);
+
+    assertTrue(result);
+    verify(mockConfigBlobClient, times(1)).upload(any(BinaryData.class), eq(true));
+  }
+
+  @Test
+  void testWriteConfigFailure() {
+    String configPath = "wasbs://container@account.blob.core.windows.net/table/.hoodie/.locks/audit_log.json";
+    String content = "{\"operation\":\"START\",\"timestamp\":123456789}";
+
+    BlobStorageException uploadException = mockBlobStorageException(500, null);
+    doThrow(uploadException).when(mockConfigBlobClient).upload(any(BinaryData.class), anyBoolean());
+
+    boolean result = lockClient.writeObject(configPath, content);
+
+    assertFalse(result);
+    verify(mockConfigBlobClient, times(1)).upload(any(BinaryData.class), eq(true));
+  }
+
+  @Test
+  void testWriteConfigInvalidUri() {
+    String invalidPath = "not-a-valid-uri";
+    String content = "some content";
+
+    boolean result = lockClient.writeObject(invalidPath, content);
+
+    assertFalse(result);
+    // Should not make any blob calls due to URI parsing error
+    verify(mockConfigBlobClient, never()).upload(any(BinaryData.class), anyBoolean());
+  }
+
+  private BlobStorageException mockBlobStorageException(int statusCode, BlobErrorCode errorCode) {
+    BlobStorageException ex = mock(BlobStorageException.class);
+    when(ex.getStatusCode()).thenReturn(statusCode);
+    if (errorCode != null) {
+      when(ex.getErrorCode()).thenReturn(errorCode);
+    }
+    return ex;
+  }
+}

--- a/hudi-azure/src/test/java/org/apache/hudi/azure/utils/TestAzureStorageUtils.java
+++ b/hudi-azure/src/test/java/org/apache/hudi/azure/utils/TestAzureStorageUtils.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.azure.utils;
+
+import org.apache.hudi.azure.utils.AzureStorageUtils.AzureStorageUriComponents;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link AzureStorageUtils}.
+ */
+public class TestAzureStorageUtils {
+
+  @Test
+  public void testParseWasbUri() {
+    String uri = "wasb://container@account.blob.core.windows.net/path/to/file";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertNotNull(components);
+    assertEquals("container", components.containerName);
+    assertEquals("account", components.accountName);
+    assertEquals("path/to/file", components.blobPath);
+  }
+
+  @Test
+  public void testParseWasbsUri() {
+    String uri = "wasbs://mycontainer@mystorageaccount.blob.core.windows.net/data/lake/table";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertNotNull(components);
+    assertEquals("mycontainer", components.containerName);
+    assertEquals("mystorageaccount", components.accountName);
+    assertEquals("data/lake/table", components.blobPath);
+  }
+
+  @Test
+  public void testParseAbfsUri() {
+    String uri = "abfs://container@account.dfs.core.windows.net/path/to/file";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertNotNull(components);
+    assertEquals("container", components.containerName);
+    assertEquals("account", components.accountName);
+    assertEquals("path/to/file", components.blobPath);
+  }
+
+  @Test
+  public void testParseAbfssUri() {
+    String uri = "abfss://filesystem@datalake.dfs.core.windows.net/folder/subfolder/file.parquet";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertNotNull(components);
+    assertEquals("filesystem", components.containerName);
+    assertEquals("datalake", components.accountName);
+    assertEquals("folder/subfolder/file.parquet", components.blobPath);
+  }
+
+  @Test
+  public void testParseUriWithSinglePathSegment() {
+    String uri = "wasbs://container@account.blob.core.windows.net/file";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertNotNull(components);
+    assertEquals("container", components.containerName);
+    assertEquals("account", components.accountName);
+    assertEquals("file", components.blobPath);
+  }
+
+  @Test
+  public void testParseUriWithDeepPath() {
+    String uri = "abfss://container@account.dfs.core.windows.net/a/b/c/d/e/f/g.txt";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertNotNull(components);
+    assertEquals("container", components.containerName);
+    assertEquals("account", components.accountName);
+    assertEquals("a/b/c/d/e/f/g.txt", components.blobPath);
+  }
+
+  @Test
+  public void testParseUriMissingScheme() {
+    String uri = "//container@account.blob.core.windows.net/path";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("scheme"));
+  }
+
+  @Test
+  public void testParseUriMissingAuthority() {
+    String uri = "wasbs:///path/to/file";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("authority"));
+  }
+
+  @Test
+  public void testParseUriMissingPath() {
+    String uri = "wasbs://container@account.blob.core.windows.net/";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("path"));
+  }
+
+  @Test
+  public void testParseUriMissingPathNoSlash() {
+    String uri = "wasbs://container@account.blob.core.windows.net";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("path"));
+  }
+
+  @Test
+  public void testParseUriInvalidWasbFormat() {
+    // Missing @ separator
+    String uri = "wasbs://containeraccount.blob.core.windows.net/path";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("WASB"));
+  }
+
+  @Test
+  public void testParseUriInvalidAbfsFormat() {
+    // Missing @ separator
+    String uri = "abfss://containeraccount.dfs.core.windows.net/path";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("ABFS"));
+  }
+
+  @Test
+  public void testParseUriUnsupportedScheme() {
+    String uri = "s3://bucket/path";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("Unsupported Azure URI scheme"));
+  }
+
+  @Test
+  public void testParseUriInvalidUriSyntax() {
+    String uri = "wasbs://container@account^invalid.blob.core.windows.net/path";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("Failed to parse Azure URI"));
+  }
+
+  @Test
+  public void testParseUriMultipleAtSymbols() {
+    String uri = "wasbs://container@account@extra.blob.core.windows.net/path";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AzureStorageUtils.parseAzureUri(uri));
+    assertTrue(ex.getMessage().contains("WASB"));
+  }
+
+  @Test
+  public void testParseUriWithSpecialCharactersInPath() {
+    String uri = "wasbs://container@account.blob.core.windows.net/path/with-dash_underscore.file";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertNotNull(components);
+    assertEquals("container", components.containerName);
+    assertEquals("account", components.accountName);
+    assertEquals("path/with-dash_underscore.file", components.blobPath);
+  }
+
+  @Test
+  public void testParseUriAccountNameExtraction() {
+    // Test that we correctly extract just the account name, not the full domain
+    String uri = "wasbs://container@myaccount.blob.core.windows.net/path";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertEquals("myaccount", components.accountName);
+  }
+
+  @Test
+  public void testParseUriContainerNameWithSpecialCharacters() {
+    // Container names can contain hyphens
+    String uri = "wasbs://my-container-123@account.blob.core.windows.net/path";
+    AzureStorageUriComponents components = AzureStorageUtils.parseAzureUri(uri);
+
+    assertEquals("my-container-123", components.containerName);
+    assertEquals("account", components.accountName);
+    assertEquals("path", components.blobPath);
+  }
+}

--- a/hudi-azure/style/import-control.xml
+++ b/hudi-azure/style/import-control.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE import-control PUBLIC
+    "-//Checkstyle//DTD ImportControl Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/import_control_1_4.dtd">
+<import-control pkg="org.apache.hudi.azure">
+    <allow pkg="org.apache.hudi"/>
+    <allow pkg="com.azure"/>
+    <allow pkg="org.slf4j"/>
+    <allow pkg="lombok"/>
+    <subpackage name="utils">
+        <allow pkg="org.apache.hudi.common.util"/>
+    </subpackage>
+    <subpackage name="transaction.lock">
+        <allow pkg="org.apache.hudi.azure.utils"/>
+    </subpackage>
+</import-control>

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestStorageSchemes.java
@@ -41,7 +41,10 @@ public class TestStorageSchemes {
 
     for (StorageSchemes scheme : StorageSchemes.values()) {
       String schemeName = scheme.getScheme();
-      if (scheme.getScheme().startsWith("s3") || scheme.getScheme().startsWith("gs")) {
+      if (scheme.getScheme().startsWith("s3")
+          || scheme.getScheme().startsWith("gs")
+          || scheme.getScheme().startsWith("wasb")
+          || scheme.getScheme().startsWith("abfs")) {
         assertTrue(StorageSchemes.getStorageLockImplementationIfExists(schemeName).isPresent());
       } else {
         assertFalse(StorageSchemes.getStorageLockImplementationIfExists(schemeName).isPresent());

--- a/hudi-io/src/main/java/org/apache/hudi/storage/StorageSchemes.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/StorageSchemes.java
@@ -48,13 +48,13 @@ public enum StorageSchemes {
   // Google Cloud Storage
   GCS("gs", true, null, "org.apache.hudi.gcp.transaction.lock.GCSStorageLockClient"),
   // Azure WASB
-  WASB("wasb", null, null, null),
-  WASBS("wasbs", null, null, null),
+  WASB("wasb", null, null, "org.apache.hudi.azure.transaction.lock.AzureStorageLockClient"),
+  WASBS("wasbs", null, null, "org.apache.hudi.azure.transaction.lock.AzureStorageLockClient"),
   // Azure ADLS
   ADL("adl", null, null, null),
   // Azure ADLS Gen2
-  ABFS("abfs", null, null, null),
-  ABFSS("abfss", null, null, null),
+  ABFS("abfs", null, null, "org.apache.hudi.azure.transaction.lock.AzureStorageLockClient"),
+  ABFSS("abfss", null, null, "org.apache.hudi.azure.transaction.lock.AzureStorageLockClient"),
   // Aliyun OSS
   OSS("oss", null, null, null),
   // View FS for federated setups. If federating across cloud stores, then append

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <module>hudi-cli</module>
     <module>hudi-client</module>
     <module>hudi-aws</module>
+    <module>hudi-azure</module>
     <module>hudi-gcp</module>
     <module>hudi-hadoop-common</module>
     <module>hudi-hadoop-mr</module>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/17905
https://github.com/apache/hudi/issues/17708

### Summary and Changelog

Adds hudi-azure module and implements storage LP for various azure blob types

### Impact

Allows for using Storage LP in Azure

### Risk Level

Low

### Documentation Update

N/A, no extra configs needed.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
