### PR TITLE
feat(schema): Fix null checks after migrating to HoodieSchema

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
@@ -245,7 +245,7 @@ public class HFileUtils extends FileFormatUtils {
    */
   private void logRecordMetadata(String msg, byte[] bs, HoodieSchema schema) throws IOException {
     GenericRecord record = HoodieAvroUtils.bytesToAvro(bs, schema.toAvroSchema());
-    if (schema.getField(HoodieRecord.RECORD_KEY_METADATA_FIELD) != null) {
+    if (schema.getField(HoodieRecord.RECORD_KEY_METADATA_FIELD).isPresent()) {
       LOG.error("{}: Hudi meta field values -> Record key: {}, Partition Path: {}, FileName: {}, CommitTime: {}, CommitSeqNo: {}", msg,
           record.get(HoodieRecord.RECORD_KEY_METADATA_FIELD), record.get(HoodieRecord.PARTITION_PATH_METADATA_FIELD),
           record.get(HoodieRecord.FILENAME_METADATA_FIELD), record.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD),


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

After migrating to `HoodieSchema#getField` returns an Option instead of null if the field is empty. 

Null checks will hence need to be translated to the `#isPresent` or `#isEmpty` equivalents.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

Fix null checks after migrating to optionals.


### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

None, affected line is for logging, so impact will only be when performing debugging/code tracing.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->
None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
