### PR TITLE
perf: Allow all processed commits to be cached in the CompletionTimeQueryViewV2

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/timeline/TestCompletionTimeQueryView.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/timeline/TestCompletionTimeQueryView.java
@@ -191,7 +191,8 @@ public class TestCompletionTimeQueryView {
       assertEquals(instantRequestedAndCompletionTime.get(6).getLeft(), view.getCursorInstant());
       // fetch completion time for the first archived instant should update the cursor instant to it.
       assertEquals(instantRequestedAndCompletionTime.get(5).getRight(), view.getCompletionTime(instantRequestedAndCompletionTime.get(5).getLeft()).get());
-      assertEquals(instantRequestedAndCompletionTime.get(5).getLeft(), view.getCursorInstant());
+      // cursor will be updated to the earliest instant present in the files read from the archived timeline (not simply the oldest instant)
+      assertEquals(instantRequestedAndCompletionTime.get(4).getLeft(), view.getCursorInstant());
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/ArchivedTimelineLoader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/ArchivedTimelineLoader.java
@@ -19,10 +19,9 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.generic.GenericRecord;
-
-import org.apache.hudi.common.util.Option;
 
 import javax.annotation.Nullable;
 
@@ -68,4 +67,20 @@ public interface ArchivedTimelineLoader extends Serializable {
     // Default implementation calls the method without limit for backward compatibility
     loadInstants(metaClient, filter, loadMode, commitsFilter, recordConsumer);
   }
+
+  /**
+   * Loads all the instants from the files in the timeline that match the given range filter
+   *
+   * @param metaClient     The meta client.
+   * @param fileFilter     The time range filter for limiting the files to be loaded.
+   * @param loadMode       The load mode.
+   * @param recordConsumer Consumer of the instant record payload.
+   * @return the last instant time loaded or empty if no instant is loaded.
+   */
+  Option<String>  loadAllInstantsFromFilesInRange(
+        HoodieTableMetaClient metaClient,
+        HoodieArchivedTimeline.TimeRangeFilter fileFilter,
+        HoodieArchivedTimeline.LoadMode loadMode,
+        BiConsumer<String, GenericRecord> recordConsumer
+  );
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineLoaderV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ArchivedTimelineLoaderV1.java
@@ -88,6 +88,12 @@ public class ArchivedTimelineLoaderV1 implements ArchivedTimelineLoader {
     loadInstants(metaClient, filter, Option.empty(), loadMode, commitsFilter, recordConsumer, limit);
   }
 
+  @Override
+  public Option<String> loadAllInstantsFromFilesInRange(HoodieTableMetaClient metaClient, HoodieArchivedTimeline.TimeRangeFilter fileFilter, HoodieArchivedTimeline.LoadMode loadMode,
+                                                        BiConsumer<String, GenericRecord> recordConsumer) {
+    throw new UnsupportedOperationException("Not implemented in V1 loader");
+  }
+
   public void loadInstants(HoodieTableMetaClient metaClient,
                            @Nullable HoodieArchivedTimeline.TimeRangeFilter filter,
                            Option<ArchivedTimelineV1.LogFileFilter> logFileFilter,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineLoaderV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineLoaderV2.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.ArchivedTimelineLoader;
 import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
+import org.apache.hudi.common.table.timeline.InstantComparison;
 import org.apache.hudi.common.table.timeline.LSMTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
@@ -39,12 +40,14 @@ import org.apache.avro.generic.IndexedRecord;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.util.ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER;
 
@@ -69,29 +72,18 @@ public class ArchivedTimelineLoaderV2 implements ArchivedTimelineLoader {
                            BiConsumer<String, GenericRecord> recordConsumer,
                            Option<Integer> limit) {
     try {
-      // List all files
-      List<String> fileNames = LSMTimeline.latestSnapshotManifest(metaClient, metaClient.getArchivePath()).getFileNames();
-
       boolean hasLimit = limit.isPresent() && limit.get() > 0;
       AtomicInteger loadedCount = new AtomicInteger(0);
-      
-      List<String> filteredFiles = new ArrayList<>();
-      for (String fileName : fileNames) {
-        if (filter == null || LSMTimeline.isFileInRange(filter, fileName)) {
-          filteredFiles.add(fileName);
-        }
-      }
+      List<String> filteredFiles = getFilteredFiles(metaClient, filter);
 
       // Sort files in reverse chronological order if limit is specified (newest first for limit queries)
       if (hasLimit) {
-        filteredFiles.sort(Comparator.comparing((String fileName) -> {
-          return LSMTimeline.getMaxInstantTime(fileName);
-        }).reversed());
+        filteredFiles.sort(Comparator.comparing(LSMTimeline::getMaxInstantTime).reversed());
       }
 
       Schema readSchema = LSMTimeline.getReadSchema(loadMode);
       // Use serial stream when limit is involved to guarantee order
-      java.util.stream.Stream<String> fileStream = hasLimit
+      Stream<String> fileStream = hasLimit
           ? filteredFiles.stream()
           : filteredFiles.parallelStream();
       fileStream.forEach(fileName -> {
@@ -99,21 +91,15 @@ public class ArchivedTimelineLoaderV2 implements ArchivedTimelineLoader {
           return;
         }
         // Read the archived file
-        try (HoodieAvroFileReader reader = (HoodieAvroFileReader) HoodieIOFactory.getIOFactory(metaClient.getStorage())
-            .getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
-            .getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, new StoragePath(metaClient.getArchivePath(), fileName))) {
-          //TODO boundary to revisit in later pr to use HoodieSchema directly
-          try (ClosableIterator<IndexedRecord> iterator = reader.getIndexedRecordIterator(HoodieSchema.fromAvroSchema(HoodieLSMTimelineInstant.getClassSchema()),
-                  HoodieSchema.fromAvroSchema(readSchema))) {            
-            while (iterator.hasNext() && (!hasLimit || loadedCount.get() < limit.get())) {
-              GenericRecord record = (GenericRecord) iterator.next();
-              String instantTime = record.get(INSTANT_TIME_ARCHIVED_META_FIELD).toString();
-              if ((filter == null || filter.isInRange(instantTime))
-                  && commitsFilter.apply(record)) {
-                recordConsumer.accept(instantTime, record);
-                if (hasLimit) {
-                  loadedCount.incrementAndGet();
-                }
+        try (ClosableIterator<IndexedRecord> iterator = getArchivedInstantIterator(metaClient, fileName, readSchema)) {
+          while (iterator.hasNext() && (!hasLimit || loadedCount.get() < limit.get())) {
+            GenericRecord record = (GenericRecord) iterator.next();
+            String instantTime = record.get(INSTANT_TIME_ARCHIVED_META_FIELD).toString();
+            if ((filter == null || filter.isInRange(instantTime))
+                && commitsFilter.apply(record)) {
+              recordConsumer.accept(instantTime, record);
+              if (hasLimit) {
+                loadedCount.incrementAndGet();
               }
             }
           }
@@ -126,5 +112,46 @@ public class ArchivedTimelineLoaderV2 implements ArchivedTimelineLoader {
       throw new HoodieIOException(
           "Could not load archived commit timeline from path " + metaClient.getArchivePath(), e);
     }
+  }
+
+  @Override
+  public Option<String> loadAllInstantsFromFilesInRange(HoodieTableMetaClient metaClient, HoodieArchivedTimeline.TimeRangeFilter fileFilter, HoodieArchivedTimeline.LoadMode loadMode,
+                                              BiConsumer<String, GenericRecord> recordConsumer) {
+    try {
+      List<String> filteredFiles = getFilteredFiles(metaClient, fileFilter);
+      Schema readSchema = LSMTimeline.getReadSchema(loadMode);
+      return Option.fromJavaOptional(filteredFiles.parallelStream().map(fileName -> {
+        // Read the archived file
+        try (ClosableIterator<IndexedRecord> iterator = getArchivedInstantIterator(metaClient, fileName, readSchema)) {
+          while (iterator.hasNext()) {
+            GenericRecord record = (GenericRecord) iterator.next();
+            String instantTime = record.get(INSTANT_TIME_ARCHIVED_META_FIELD).toString();
+            recordConsumer.accept(instantTime, record);
+          }
+        } catch (IOException ioException) {
+          throw new HoodieIOException("Error open file reader for path: "
+              + new StoragePath(metaClient.getArchivePath(), fileName));
+        }
+        return LSMTimeline.getMinInstantTime(fileName);
+      }).filter(Objects::nonNull).reduce(InstantComparison::minTimestamp));
+    } catch (IOException e) {
+      throw new HoodieIOException(
+          "Could not load archived commit timeline from path " + metaClient.getArchivePath(), e);
+    }
+  }
+
+  private List<String> getFilteredFiles(HoodieTableMetaClient metaClient, HoodieArchivedTimeline.TimeRangeFilter fileFilter) throws IOException {
+    // List all files
+    List<String> fileNames = LSMTimeline.latestSnapshotManifest(metaClient, metaClient.getArchivePath()).getFileNames();
+    return fileNames.stream().filter(fileName -> fileFilter == null || LSMTimeline.isFileInRange(fileFilter, fileName)).collect(Collectors.toList());
+  }
+
+  private ClosableIterator<IndexedRecord> getArchivedInstantIterator(HoodieTableMetaClient metaClient, String fileName, Schema readSchema) throws IOException {
+    HoodieAvroFileReader reader = (HoodieAvroFileReader) HoodieIOFactory.getIOFactory(metaClient.getStorage())
+        .getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
+        .getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, new StoragePath(metaClient.getArchivePath(), fileName));
+    //TODO boundary to revisit in later pr to use HoodieSchema directly
+    return reader.getIndexedRecordIterator(HoodieSchema.fromAvroSchema(HoodieLSMTimelineInstant.getClassSchema()),
+        HoodieSchema.fromAvroSchema(readSchema));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CompletionTimeQueryViewV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/CompletionTimeQueryViewV2.java
@@ -280,14 +280,13 @@ public class CompletionTimeQueryViewV2 implements CompletionTimeQueryView, Seria
     // This operation is resource costly.
     synchronized (this) {
       if (InstantComparison.compareTimestamps(startTime, LESSER_THAN, this.cursorInstant)) {
-        metaClient.getTableFormat().getTimelineFactory().createArchivedTimelineLoader().loadInstants(metaClient,
+        Option<String> oldestStartTime = metaClient.getTableFormat().getTimelineFactory().createArchivedTimelineLoader().loadAllInstantsFromFilesInRange(metaClient,
             new HoodieArchivedTimeline.ClosedOpenTimeRangeFilter(startTime, this.cursorInstant),
             HoodieArchivedTimeline.LoadMode.TIME,
-            r -> true,
             this::readCompletionTime);
+        // refresh the start instant
+        this.cursorInstant = oldestStartTime.map(time -> InstantComparison.minTimestamp(startTime, time)).orElse(startTime);
       }
-      // refresh the start instant
-      this.cursorInstant = startTime;
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
The CompletionTimeQueryViewV2 will load the completion times incrementally and focus on loading the minimal set of files from the archived timeline. The issue is that it will potentially load the same file multiple times since it reads all entries from the file but only processes the instants in the provided range. 

The inefficiency is seen when loading the view for instant at time T2 then at time T1. The LSMTimeline is read up to time T1 but only instants up to T2 are processed. The next request for T1 will re-read the file.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
- Update the filtering to only apply at the file level
- Update the ArchivedTimelineLoader interface to return the earliest instant time processed.
- Update the cursor to use the returned instant time

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Makes loading the FileSystemView significantly more performant when there are archived instants

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
