### PR TITLE
fix(spark): Fix TestSparkSchemaUtils failing with Spark 3.3 due to timestamp_ntz

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestSparkSchemaUtils.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestSparkSchemaUtils.java
@@ -26,12 +26,21 @@ import org.apache.hudi.sync.common.util.SparkSchemaUtils;
 import org.apache.spark.sql.execution.SparkSqlParser;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.BinaryType$;
+import org.apache.spark.sql.types.BooleanType$;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DateType$;
+import org.apache.spark.sql.types.DoubleType$;
+import org.apache.spark.sql.types.FloatType$;
 import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampNTZType$;
+import org.apache.spark.sql.types.TimestampType$;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -56,10 +65,29 @@ public class TestSparkSchemaUtils {
 
   @Test
   public void testConvertBasicTypes() {
-    StructType sparkSchema = parser.parseTableSchema(
-            "f0 int NOT NULL, f1 string NOT NULL, f2 bigint NOT NULL, f3 float, f4 double, f5 boolean, f6 binary, f7 binary NOT NULL,"
-                    + " f8 decimal(5,2) NOT NULL, f9 decimal(5,2), f10 timestamp, f11 timestamp NOT NULL, f12 timestamp_ntz NOT NULL, f13 timestamp_ntz,"
-                    + " f14 date NOT NULL, f15 int NOT NULL, f16 bigint NOT NULL, f17 string NOT NULL, f18 string");
+    // Build expected schema programmatically to avoid SQL parser limitations
+    // (timestamp_ntz is not supported by the SQL parser in Spark 3.3)
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("f0", IntegerType$.MODULE$, false, Metadata.empty()),
+        new StructField("f1", StringType$.MODULE$, false, Metadata.empty()),
+        new StructField("f2", LongType$.MODULE$, false, Metadata.empty()),
+        new StructField("f3", FloatType$.MODULE$, true, Metadata.empty()),
+        new StructField("f4", DoubleType$.MODULE$, true, Metadata.empty()),
+        new StructField("f5", BooleanType$.MODULE$, true, Metadata.empty()),
+        new StructField("f6", BinaryType$.MODULE$, true, Metadata.empty()),
+        new StructField("f7", BinaryType$.MODULE$, false, Metadata.empty()),
+        new StructField("f8", DataTypes.createDecimalType(5, 2), false, Metadata.empty()),
+        new StructField("f9", DataTypes.createDecimalType(5, 2), true, Metadata.empty()),
+        new StructField("f10", TimestampType$.MODULE$, true, Metadata.empty()),
+        new StructField("f11", TimestampType$.MODULE$, false, Metadata.empty()),
+        new StructField("f12", TimestampNTZType$.MODULE$, false, Metadata.empty()),
+        new StructField("f13", TimestampNTZType$.MODULE$, true, Metadata.empty()),
+        new StructField("f14", DateType$.MODULE$, false, Metadata.empty()),
+        new StructField("f15", IntegerType$.MODULE$, false, Metadata.empty()),
+        new StructField("f16", LongType$.MODULE$, false, Metadata.empty()),
+        new StructField("f17", StringType$.MODULE$, false, Metadata.empty()),
+        new StructField("f18", StringType$.MODULE$, true, Metadata.empty())
+    });
 
     HoodieSchema schemaWithSupportedTypes =
         HoodieSchema.createRecord("root", null, null, false, Arrays.asList(


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The test `TestSparkSchemaUtils.testConvertBasicTypes()` was using `SparkSqlParser.parseTableSchema()` with a SQL string containing the `timestamp_ntz` data type. However, `timestamp_ntz` is only supported by the SQL parser starting in Spark 3.4, causing the test to fail with "DataType timestamp_ntz is not supported" when running with Spark 3.3.

### Summary and Changelog

Fixed by constructing the expected StructType schema programmatically using Spark's data type API (e.g., `TimestampNTZType$.MODULE$`) instead of parsing SQL strings. This works across all Spark versions since `TimestampNTZType` exists as a class in Spark 3.3 - only the SQL parser syntax was unsupported.

**Changes:**
- Replaced SQL string parsing with programmatic schema construction in `testConvertBasicTypes()` test
- Added necessary imports for Spark data type classes (`BinaryType$`, `BooleanType$`, `DateType$`, `DoubleType$`, `FloatType$`, `LongType$`, `TimestampNTZType$`, `TimestampType$`)

### Impact

Test-only change. No impact on production code or public APIs.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable