### PR TITLE
fix: address minor compilation issue in getAvroBytes

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -334,7 +334,7 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
     }
     StructType structType = HoodieInternalRowUtils.getCachedSchema(recordSchema);
     GenericRecord avroRecord = AvroConversionUtils
-        .createInternalRowToAvroConverter(structType, recordSchema.toAvroSchema(), false)
+        .createInternalRowToAvroConverter(structType, recordSchema, false)
         .apply(data);
     return HoodieAvroUtils.avroToBytesStream(avroRecord);
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

We recently merged the following change for supporting MOR with lance base file format https://github.com/apache/hudi/commits/master/. While the CI passed at the time, it seems it needed to be rebased on latest master once more since there was a compilation issue thats causing master's build to fail.
```
Error:  /home/runner/work/hudi/hudi/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java:[337,80] incompatible types: org.apache.avro.Schema cannot be converted to org.apache.hudi.common.schema.HoodieSchema

```

### Summary and Changelog

* Address minor compilation issue

### Impact

none

### Risk Level

none

### Documentation Update
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
