### PR TITLE
fix: Adding tests for rolling back on commits older than replacecommit and compaction commits

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -665,7 +665,7 @@ public class TestCleaner extends HoodieCleanerTestBase {
     assertFalse(testTable.baseFileExists(p1, "00000000000001", file1P1C0));
   }
 
-  public static Pair<HoodieRequestedReplaceMetadata, HoodieReplaceCommitMetadata> generateReplaceCommitMetadata(
+  private Pair<HoodieRequestedReplaceMetadata, HoodieReplaceCommitMetadata> generateReplaceCommitMetadata(
       String instantTime, String partition, String replacedFileId, String newFileId) {
     HoodieRequestedReplaceMetadata requestedReplaceMetadata = new HoodieRequestedReplaceMetadata();
     requestedReplaceMetadata.setOperationType(WriteOperationType.CLUSTER.toString());


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

In multi-writer scenarios, rollback operations could fail when attempting to roll back commits that are older than replace commits (clustering) or compaction commits. The system wasn't properly validating the commit sequence and handling these scenarios.

### Summary and Changelog

This PR enables proper rollback of commits that are older than replace and compaction commits.

**Changes:**
- Added support for rolling back commits older than replace and compaction commits
- Added rollback logging for better debugging in rollback scenarios
- Included replacecommit check before isClusteringPlan call during commit sequence validation
- Updated test cases to cover multi-writer rollback scenarios

### Impact

Improves robustness of rollback operations in multi-writer scenarios. No breaking changes to public APIs.

### Risk Level

**Low** - Adds defensive checks and logging for better rollback handling. Includes comprehensive test coverage for the multi-writer scenarios.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable