### PR TITLE
fix: handle ArrayIndexOutOfBoundsException for non-partitioned datasets during upgrade

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FourToFiveUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FourToFiveUpgradeHandler.java
@@ -82,7 +82,9 @@ public class FourToFiveUpgradeHandler implements UpgradeHandler {
     // dt=default/ht=default, only need check dt=default
     if (hiveStylePartitioningEnable) {
       String[] partitions = tableConfig.getPartitionFields().get();
-      checkPartitionPath = partitions[0] + "=" + DEPRECATED_DEFAULT_PARTITION_PATH;
+      if (partitions.length > 0) {
+        checkPartitionPath = partitions[0] + "=" + DEPRECATED_DEFAULT_PARTITION_PATH;
+      }
     }
 
     return table.getStorage().exists(new StoragePath(config.getBasePath() + "/" + checkPartitionPath));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When upgrading datasets from table version 3 to 6, non-partitioned datasets encounter an ArrayIndexOutOfBoundsException during the FourToFiveUpgrade process. Starting from Hudi 0.12, support for default partitionPath was removed. During the upgrade, a check for the default partitionPath existence is performed, but the code attempts to access `partitions[0]` without first verifying that the partitions array is non-empty.

### Summary and Changelog

This PR adds a defensive check to prevent ArrayIndexOutOfBoundsException for non-partitioned datasets during table version upgrades.

**Changes:**
- Added array length check before accessing partition fields in FourToFiveUpgradeHandler
- Ensures `partitions.length > 0` before attempting to access `partitions[0]`
- Prevents crash during upgrade for non-partitioned datasets with hive-style partitioning enabled

### Impact

Fixes table version upgrade failures for non-partitioned datasets. No impact to public APIs or user-facing features beyond the bug fix.

### Risk Level

**Low** - Defensive fix that adds a bounds check before array access. Prevents a crash condition for non-partitioned datasets during upgrade.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable