### PR TITLE
test: add unit test for multiple partition filters on same column

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodiePruneFileSourcePartitions.scala
@@ -237,8 +237,11 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
   }
 
   @ParameterizedTest
-  @CsvSource(value = Array("cow", "mor"))
-  def testMultiplePartitionFiltersPushDown(tableType: String): Unit = {
+  @CsvSource(value = Array(
+    "cow,6", "cow,9",
+    "mor,6", "mor,9"
+  ))
+  def testMultiplePartitionFiltersPushDown(tableType: String, tableVersion: String): Unit = {
     spark.sql(
       s"""
          |CREATE TABLE $tableName (
@@ -252,7 +255,8 @@ class TestHoodiePruneFileSourcePartitions extends HoodieClientTestBase with Scal
          |TBLPROPERTIES (
          |  type = '$tableType',
          |  primaryKey = 'id',
-         |  orderingFields = 'ts'
+         |  orderingFields = 'ts',
+         |  hoodie.write.table.version = '$tableVersion'
          |)
          |LOCATION '$basePath/$tableName'
          """.stripMargin)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Initially, we observed partition filters being dropped in our production systems when multiple conditions were applied to the same partition column (e.g., `datestr > '2016-01-01' AND datestr < '2016-12-31'`). However, when creating a unit test to reproduce the issue, the filters were correctly preserved without any code changes. Since we could not reliably reproduce the issue in the test environment, this PR adds test coverage to prevent potential regressions.

### Summary and Changelog

Adds `testMultiplePartitionFiltersPushDown` test in `TestHoodiePruneFileSourcePartitions` to validate that multiple partition filters (IsNotNull, GreaterThan, LessThan) on the same column are preserved during query optimization. Test covers both COW and MOR table types with range queries.

### Impact

Adds test coverage to ensure partition filter correctness, helping prevent potential filter loss issues in the future. No user-facing changes.

### Risk Level

**none** - Test-only change, no production code modifications.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable