### PR TITLE
feat: Add configurable cleaner policy for metadata table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -159,8 +159,7 @@ public class HoodieMetadataWriteUtils {
 
     final long maxLogFileSizeBytes = writeConfig.getMetadataConfig().getMaxLogFileSize();
     // Borrow the cleaner policy from the main table and adjust the cleaner policy based on the main table's cleaner policy
-    boolean useMainTableCleanPolicy = writeConfig.getMetadataConfig().useMainTableCleanPolicy();
-    HoodieCleaningPolicy dataTableCleaningPolicy = writeConfig.getCleanerPolicy();
+    boolean shouldDeriveFromDataTableCleanPolicy = writeConfig.getMetadataConfig().shouldDeriveFromDataTableCleanPolicy();
     HoodieCleanConfig.Builder cleanConfigBuilder = HoodieCleanConfig.newBuilder()
         .withAsyncClean(DEFAULT_METADATA_ASYNC_CLEAN)
         .withAutoClean(false)
@@ -168,7 +167,8 @@ public class HoodieMetadataWriteUtils {
         .withFailedWritesCleaningPolicy(failedWritesCleaningPolicy)
         .withMaxCommitsBeforeCleaning(writeConfig.getCleaningMaxCommits());
 
-    if (useMainTableCleanPolicy) {
+    if (shouldDeriveFromDataTableCleanPolicy) {
+      HoodieCleaningPolicy dataTableCleaningPolicy = writeConfig.getCleanerPolicy();
       cleanConfigBuilder.withCleanerPolicy(dataTableCleaningPolicy);
       if (HoodieCleaningPolicy.KEEP_LATEST_COMMITS.equals(dataTableCleaningPolicy)) {
         int retainCommits = (int) Math.max(DEFAULT_METADATA_CLEANER_COMMITS_RETAINED, writeConfig.getCleanerCommitsRetained() * 1.2);

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -151,12 +151,12 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.14.0")
       .withDocumentation("Controls the criteria to log compacted files groups in metadata table.");
 
-  public static final ConfigProperty<Boolean> USE_MAIN_TABLE_CLEAN_POLICY = ConfigProperty
-      .key(METADATA_PREFIX + ".use.main.table.clean.policy")
+  public static final ConfigProperty<Boolean> DERIVE_FROM_DATA_TABLE_CLEAN_POLICY = ConfigProperty
+      .key(METADATA_PREFIX + ".derive.from.datatable.clean.policy")
       .defaultValue(true)
       .markAdvanced()
       .sinceVersion("1.2.0")
-      .withDocumentation("This config determines whether the cleaner policy should use main table's cleaner policy.");
+      .withDocumentation("This config determines whether the cleaner policy should use data table's cleaner policy.");
 
   // Regex to filter out matching directories during bootstrap
   public static final ConfigProperty<String> DIR_FILTER_REGEX = ConfigProperty
@@ -894,8 +894,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getIntOrDefault(RECORD_PREPARATION_PARALLELISM);
   }
 
-  public boolean useMainTableCleanPolicy() {
-    return getBooleanOrDefault(USE_MAIN_TABLE_CLEAN_POLICY);
+  public boolean shouldDeriveFromDataTableCleanPolicy() {
+    return getBooleanOrDefault(DERIVE_FROM_DATA_TABLE_CLEAN_POLICY);
   }
 
   /**
@@ -1027,8 +1027,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
-    public HoodieMetadataConfig.Builder withMainTableCleanPolicy(boolean useMainTableCleanPolicy) {
-      metadataConfig.setValue(USE_MAIN_TABLE_CLEAN_POLICY, Boolean.toString(useMainTableCleanPolicy));
+    public HoodieMetadataConfig.Builder deriveFromDataTableCleanPolicy(boolean deriveFromDataTableCleanPolicy) {
+      metadataConfig.setValue(DERIVE_FROM_DATA_TABLE_CLEAN_POLICY, Boolean.toString(deriveFromDataTableCleanPolicy));
       return this;
     }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
@@ -145,34 +145,34 @@ class TestHoodieMetadataConfig {
   void testUseMainTableCleanPolicy() {
     // Test default value
     HoodieMetadataConfig config = HoodieMetadataConfig.newBuilder().build();
-    assertTrue(config.useMainTableCleanPolicy());
+    assertTrue(config.shouldDeriveFromDataTableCleanPolicy());
 
     // Test setting to false using builder method
     HoodieMetadataConfig configWithFalse = HoodieMetadataConfig.newBuilder()
-        .withMainTableCleanPolicy(false)
+        .deriveFromDataTableCleanPolicy(false)
         .build();
-    assertFalse(configWithFalse.useMainTableCleanPolicy());
+    assertFalse(configWithFalse.shouldDeriveFromDataTableCleanPolicy());
 
     // Test setting to true using builder method
     HoodieMetadataConfig configWithTrue = HoodieMetadataConfig.newBuilder()
-        .withMainTableCleanPolicy(true)
+        .deriveFromDataTableCleanPolicy(true)
         .build();
-    assertTrue(configWithTrue.useMainTableCleanPolicy());
+    assertTrue(configWithTrue.shouldDeriveFromDataTableCleanPolicy());
 
     // Test custom value via Properties - false
     Properties propsFalse = new Properties();
-    propsFalse.put(HoodieMetadataConfig.USE_MAIN_TABLE_CLEAN_POLICY.key(), "false");
+    propsFalse.put(HoodieMetadataConfig.DERIVE_FROM_DATA_TABLE_CLEAN_POLICY.key(), "false");
     HoodieMetadataConfig configWithPropertiesFalse = HoodieMetadataConfig.newBuilder()
         .fromProperties(propsFalse)
         .build();
-    assertFalse(configWithPropertiesFalse.useMainTableCleanPolicy());
+    assertFalse(configWithPropertiesFalse.shouldDeriveFromDataTableCleanPolicy());
 
     // Test custom value via Properties - true
     Properties propsTrue = new Properties();
-    propsTrue.put(HoodieMetadataConfig.USE_MAIN_TABLE_CLEAN_POLICY.key(), "true");
+    propsTrue.put(HoodieMetadataConfig.DERIVE_FROM_DATA_TABLE_CLEAN_POLICY.key(), "true");
     HoodieMetadataConfig configWithPropertiesTrue = HoodieMetadataConfig.newBuilder()
         .fromProperties(propsTrue)
         .build();
-    assertTrue(configWithPropertiesTrue.useMainTableCleanPolicy());
+    assertTrue(configWithPropertiesTrue.shouldDeriveFromDataTableCleanPolicy());
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -584,7 +584,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
             .enableMetrics(false)
             .withMetadataIndexColumnStats(false)
             .withMaxNumDeltaCommitsBeforeCompaction(5)
-            .withMainTableCleanPolicy(false)
+            .deriveFromDataTableCleanPolicy(false)
             .build())
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .retainCommits(1)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Metadata table currently inherits the cleaning policy from the data table, which may not always be optimal for metadata table operations. This PR introduces a dedicated configurable cleaning policy for the metadata table that can either use main table's clean or use KEEP_LATEST_FILE_VERSIONS which is recommended strategy for MOR table type.

### Summary and Changelog

This PR adds support for configuring the metadata table's cleaning policy independently from the data table. Users can now set `hoodie.metadata.clean.policy` to control how the metadata table performs cleaning operations.

**Changes:**
- Added new config `hoodie.metadata.use.main.table.clean.policy` in `HoodieMetadataConfig` with default value as `true`
- Modified `HoodieMetadataWriteUtils.createMetadataWriteConfig()` to use either KEEP_LATEST_FILE_VERSIONS stratgy for clean or to inherit clean policy from data table.

### Impact

Users can now independently configure metadata table cleaning behavior. Creating a way for metadata clean policy  to use (`KEEP_LATEST_FILE_VERSIONS`) as it ensures efficient file management regardless of the data table's cleaning strategy.

### Risk Level

**low** - This change is backward compatible. The `hoodie.metadata.use.main.table.clean.policy` config makes sure the original logic is not overridden.

### Documentation Update

**New config:**
- `hoodie.metadata.use.main.table.clean.policy` (advanced): Determines the cleaner policy for metadata table. Default: true.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable