### PR TITLE
chore: Allow versions to be specified in build_docker_images.sh

### DIFF
--- a/docker/build_docker_images.sh
+++ b/docker/build_docker_images.sh
@@ -14,9 +14,40 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
+
 # This script builds all required Hudi Docker images for Hadoop, Spark, and Hive components.
 # It detects the system architecture, sets up Docker build platform, and loops through image configs.
-# Usage: ./build_docker_images.sh
+# Usage: ./build_docker_images.sh [--hadoop-version <version>] [--spark-version <version>] [--hive-version <version>] [--version-tag <tag>]
+
+# Default versions for Hadoop, Spark, and Hive
+HADOOP_VERSION="2.8.4"
+SPARK_VERSION="3.5.3"
+HIVE_VERSION="2.3.10"
+VERSION_TAG_ARG="" # Initialize to empty, will be set by command-line arg if provided
+
+# Function to get Maven project version
+get_hudi_project_version() {
+  local pom_path="$1"
+  if [ -f "$pom_path" ]; then
+    mvn -f "$pom_path" help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null
+  else
+    echo "Error: pom.xml not found at $pom_path" >&2
+    exit 1
+  fi
+}
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --hadoop-version) HADOOP_VERSION="$2"; shift ;;
+        --spark-version) SPARK_VERSION="$2"; shift ;;
+        --hive-version) HIVE_VERSION="$2"; shift ;;
+        --version-tag) VERSION_TAG_ARG="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
 # Detect system architecture and set Docker platform accordingly
 ARCHITECTURE=$(uname -m)
 case "$ARCHITECTURE" in
@@ -35,18 +66,27 @@ export DOCKER_DEFAULT_PLATFORM="$DOCKER_PLATFORM"
 export BUILDX_EXPERIMENTAL=1
 # Get the directory of this script for relative paths
 SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
-# Versions for Hadoop, Spark, and Hive
-HADOOP_VERSION="3.3.4"
-SPARK_VERSION="3.5.3"
-HIVE_VERSION="3.1.3"
+
+# Determine VERSION_TAG (command line arg or Maven project version)
+if [ -n "$VERSION_TAG_ARG" ]; then
+  VERSION_TAG="$VERSION_TAG_ARG"
+else
+  # Path to the root pom.xml relative to SCRIPT_DIR
+  ROOT_POM_PATH="$SCRIPT_DIR/../pom.xml"
+  VERSION_TAG=$(get_hudi_project_version "$ROOT_POM_PATH")
+  if [ -z "$VERSION_TAG" ]; then
+    echo "Error: Could not determine Maven project version. Please ensure Maven is installed and a valid pom.xml exists, or specify --version-tag manually." >&2
+    exit 1
+  fi
+fi
+
 # Docker image tags
-VERSION_TAG="1.1.0"
 LATEST_TAG="latest"
 DOCKER_CONTEXT_DIR="hoodie/hadoop"
 # List of images to build: "subdir|image_base_name"
 # Each entry: <subdir>|<image_base_name>
 DOCKER_IMAGES=(
-  "base|apachehudi/hudi-hadoop_${HADOOP_VERSION}-base"
+  "base_java11|apachehudi/hudi-hadoop_${HADOOP_VERSION}-base"
   "datanode|apachehudi/hudi-hadoop_${HADOOP_VERSION}-datanode"
   "historyserver|apachehudi/hudi-hadoop_${HADOOP_VERSION}-history"
   "hive_base|apachehudi/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}"
@@ -65,7 +105,11 @@ for IMAGE_CONFIG in "${DOCKER_IMAGES[@]}"; do
   TAG_VERSIONED="$IMAGE_BASE:$VERSION_TAG"
   echo "Building $IMAGE_CONTEXT as $TAG_LATEST and $TAG_VERSIONED"
   # Build the Docker image with both latest and versioned tags
-  if ! docker build "$IMAGE_CONTEXT" -t "$TAG_LATEST" -t "$TAG_VERSIONED"; then
+  if ! docker build \
+    --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
+    --build-arg SPARK_VERSION=${SPARK_VERSION} \
+    --build-arg HIVE_VERSION=${HIVE_VERSION} \
+    "$IMAGE_CONTEXT" -t "$TAG_LATEST" -t "$TAG_VERSIONED"; then
     echo "Error: Failed to build docker image for $IMAGE_CONTEXT"
     exit 1
   fi


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Building docker images is quite painful where we have to modify each of the versions within the docker files previously for all image.

Since we have `build_docker_images.sh` that is the common entrypoint for helping build these images, we should also allow the versions specified in these scripts to be pushed down to the docker files.

On top of that, they shouldn't be hardcoded in files too. We can make the hardcoded versions defaults, but the script should be able to allow command line arguments to be passed into it.

On top of that, we have changed the base version of java to java11 since we have moved to java11. 

We can now use the script as such:

```shell
./build_docker_images.sh \ 
    [--hadoop-version <version>] \
    [--spark-version <version>] \
    [--hive-version <version>] \
    [--version-tag <tag>]
```

Note: Lowered hive version to `2.3.10` (verified to play well with java11) manually, however, the docker will have some build issues as calcite jar that is copied in spark adhoc is not longer available if hive version `2.3.10` is used. Will address this separately in another PR.

Closes: https://github.com/apache/hudi/issues/17962

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

1. Bumped base java version to 11
2. Allow versions specified `build_docker_images.sh` to be pushed down to docker files
3. Allow auto resolving of hudi project version via main pom file as image tag version
4. Allow users to specify image tag version explicitly
5. Allow users to specify HADOOP, SPARK, HIVE version via CLI
6. Lowered hive version to `2.3.10` (verified to play well with java11) manually

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

Better developer experience for building docker images without having to trudge through dockerfiles.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None, no code changes, everything done here is tooling related

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

We will address usage of this script's documentation later.

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
