### PR TITLE
fix: Allow String ordering fields can work with JSON src with COW

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java
@@ -49,6 +49,7 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -434,7 +435,7 @@ public class MercifulJsonConverter {
     };
   }
 
-  private static JsonFieldProcessor generateStringTypeHandler() {
+  protected JsonFieldProcessor generateStringTypeHandler() {
     return new StringProcessor();
   }
 
@@ -444,10 +445,10 @@ public class MercifulJsonConverter {
     @Override
     public Pair<Boolean, Object> convert(Object value, String name, HoodieSchema schema) {
       if (value instanceof String) {
-        return Pair.of(true, value);
+        return Pair.of(true, new Utf8((String) value));
       } else {
         try {
-          return Pair.of(true, STRING_MAPPER.writeValueAsString(value));
+          return Pair.of(true, new Utf8(STRING_MAPPER.writeValueAsString(value)));
         } catch (IOException ex) {
           return Pair.of(false, null);
         }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes: https://github.com/apache/hudi/issues/17938

For more details, please check the issue above. 

The full E2E test should be covered in `org.apache.hudi.integ.ITTestHoodieDemo#testParquetDemo`, specifically: `org.apache.hudi.integ.ITTestHoodieDemo#ingestSecondBatchAndHiveSync`, which is currently disabled.

However, we have an Azure test that cover this case now and it is the parameterized test with the following arguments:
```java
Arguments.of(false, "rider", HoodieRecordType.AVRO, HoodieTableType.COPY_ON_WRITE)

org.apache.hudi.utilities.deltastreamer.TestHoodieDeltaStreamer#testLogicalTypesWithJsonSource
```

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

Ensure that `StringProcessor` in `MercifulJsonConverter` returns `org.apache.avro.util.Utf8` instead of `java.lang.String`.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

Ordering value comparison will now pass without ClassCastExceptions.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

Medium, this might affect other Dataflows. Will ensure that existing CI succeeds.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
