### PR TITLE
docs: document wildcardSuites workaround for single Java test runs

### DIFF
--- a/website/contribute/developer-setup.md
+++ b/website/contribute/developer-setup.md
@@ -65,12 +65,13 @@ with multi-threaded, could get your compilation in 1.5 to 2 mins.
 
 If you wish to run any single test class in java.
 ```shell
-mvn test -Punit-tests -pl hudi-spark-datasource/hudi-spark/ -am -B -DfailIfNoTests=false -Dtest=TestCleaner -Dspark3.5
+mvn test -Punit-tests -pl hudi-spark-datasource/hudi-spark/ -am -B -DfailIfNoTests=false -Dtest=TestCleaner -DwildcardSuites="abc" -Dspark3.5
 ```
+-DwildcardSuites="abc" will assist in skipping all scala tests.
 
 If you wish to run a single test method in java.
 ```shell
-mvn test -Punit-tests -pl hudi-spark-datasource/hudi-spark/ -am -B -DfailIfNoTests=false -Dtest=TestCleaner#testKeepLatestCommitsMOR -Dspark3.5
+mvn test -Punit-tests -pl hudi-spark-datasource/hudi-spark/ -am -B -DfailIfNoTests=false -Dtest=TestCleaner#testKeepLatestCommitsMOR -DwildcardSuites="abc" -Dspark3.5
 ```
 
 To filter particular scala test:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16438.

The developer setup docs suggest using `-Dtest=...` to run a single Java test, but following it can still run ScalaTest discovery. This makes the command unexpectedly slow and confusing for first-time contributors.

### Summary and Changelog

**Summary**
- Improve developer documentation for running a single Java test while preventing Scala tests from being selected/executed.

**Changelog**
- Add `-DwildcardSuites="abc"` as a workaround to the documented Maven commands for running:
  - a single Java test class
  - a single Java test method
- Add a short note for the option.

### Impact

Documentation-only change.

### Risk Level

none

### Documentation Update

Updated the developer setup documentation by adding `-DwildcardSuites="abc"` to the Java single-test examples and documenting why it is needed.

### Contributor's checklist

- [x] Read through contributor's guide
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable