### PR TITLE
fix: Rename HoodieDataSourceHelpers#listCompletionTimeSince references

### DIFF
--- a/docker/demo/sparksql-incremental.commands
+++ b/docker/demo/sparksql-incremental.commands
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 
 val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
 
-val startCompletionTime = HoodieDataSourceHelpers.listCompletionTimeSince(fs, "/user/hive/warehouse/stock_ticks_cow", "00000").get(0)
+val startCompletionTime = HoodieDataSourceHelpers.streamCompletionTimeSince(fs, "/user/hive/warehouse/stock_ticks_cow", "00000").findFirst().orElseThrow()
 println("Begin completion time for COW incremental query: " + startCompletionTime)
 val hoodieIncQueryDF =  spark.read.format("hudi").
                       option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).
@@ -38,7 +38,7 @@ println("stock_ticks_cow incremental count: " + hoodieIncQueryDF.count)
 hoodieIncQueryDF.registerTempTable("stock_ticks_cow_incr")
 spark.sql("select `_hoodie_commit_time`, symbol, ts, volume, open, close  from stock_ticks_cow_incr where  symbol = 'GOOG'").show(100, false);
 
-val bsStartCompletionTime = HoodieDataSourceHelpers.listCompletionTimeSince(fs, "/user/hive/warehouse/stock_ticks_cow_bs", "00000000000000").get(0)
+val bsStartCompletionTime = HoodieDataSourceHelpers.streamCompletionTimeSince(fs, "/user/hive/warehouse/stock_ticks_cow_bs", "00000000000000").findFirst().orElseThrow()
 println("Begin completion time for bootstrap COW incremental query: " + bsStartCompletionTime)
 val hoodieIncQueryBsDF =  spark.read.format("hudi").
                       option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).
@@ -48,7 +48,7 @@ println("stock_ticks_cow_bs incremental count: " + hoodieIncQueryBsDF.count)
 hoodieIncQueryBsDF.registerTempTable("stock_ticks_cow_bs_incr")
 spark.sql("select `_hoodie_commit_time`, symbol, ts, volume, open, close  from stock_ticks_cow_bs_incr where  symbol = 'GOOG'").show(100, false);
 
-val morStartCompletionTime = HoodieDataSourceHelpers.listCompletionTimeSince(fs, "/user/hive/warehouse/stock_ticks_mor", "00000").get(0)
+val morStartCompletionTime = HoodieDataSourceHelpers.streamCompletionTimeSince(fs, "/user/hive/warehouse/stock_ticks_mor", "00000").findFirst().orElseThrow()
 println("Begin completion time for MOR incremental query: " + morStartCompletionTime)
 val hoodieMorIncQueryDF =  spark.read.format("hudi").
                       option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).
@@ -58,7 +58,7 @@ println("stock_ticks_mor incremental count: " + hoodieMorIncQueryDF.count)
 hoodieMorIncQueryDF.registerTempTable("stock_ticks_mor_incr")
 spark.sql("select `_hoodie_commit_time`, symbol, ts, volume, open, close from stock_ticks_mor_incr where symbol = 'GOOG'").show(100, false);
 
-val bsMorStartCompletionTime = HoodieDataSourceHelpers.listCompletionTimeSince(fs, "/user/hive/warehouse/stock_ticks_mor_bs", "00000000000000").get(0)
+val bsMorStartCompletionTime = HoodieDataSourceHelpers.streamCompletionTimeSince(fs, "/user/hive/warehouse/stock_ticks_mor_bs", "00000000000000").findFirst().orElseThrow()
 println("Begin completion time for bootstrap MOR incremental query: " + bsMorStartCompletionTime)
 val hoodieMorIncQueryBsDF =  spark.read.format("hudi").
                       option(DataSourceReadOptions.QUERY_TYPE.key(), DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL).

--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/HoodieDataSourceHelpers.java
+++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/HoodieDataSourceHelpers.java
@@ -75,6 +75,7 @@ public class HoodieDataSourceHelpers {
         .map(HoodieInstant::requestedTime).collect(Collectors.toList());
   }
 
+  @SuppressWarnings("unused")
   // this is used in the integration test script: docker/demo/sparksql-incremental.commands
   public static Stream<String> streamCompletionTimeSince(FileSystem fs, String basePath,
                                                          String instantTimestamp) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Closes: https://github.com/apache/hudi/issues/17982

Rename `HoodieDataSourceHelpers#listCompletionTimeSince` to `HoodieDataSourceHelpers#streamCompletionTimeSince`

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

1. Rename `HoodieDataSourceHelpers#listCompletionTimeSince` to `HoodieDataSourceHelpers#streamCompletionTimeSince`
2. Update call site to throw `#findFirst` and `#orElseThrow`

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Integration tests using this script correctly references the available methods

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->
None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
