### PR TITLE
fix: Propagate cfg.sourceOrderingFields in HoodieStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -204,6 +204,9 @@ public class HoodieStreamer implements Serializable {
         && !StringUtils.isNullOrEmpty(cfg.recordMergeImplClasses)) {
       hoodieConfig.setValue(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key(), cfg.recordMergeImplClasses);
     }
+    if (!StringUtils.isNullOrEmpty(cfg.sourceOrderingFields)) {
+      hoodieConfig.setValue(HoodieTableConfig.ORDERING_FIELDS.key(), cfg.sourceOrderingFields);
+    }
 
     return hoodieConfig.getProps(true);
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Closes: https://github.com/apache/hudi/issues/17978

Please refer to the issue for detailed rootcause analysis.

Our change here will trigger an earlier validation in `HoodieWriterUtils`, which is why we are modifying the tests.

#### Before Our Fix                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
1. `combineProperties()` -> properties WITHOUT `sourceOrderingFields`
2. `HoodieStreamer` constructor
3. `StreamSyncService` constructor
    - H`oodieWriterUtils.validateTableConfig()` -> NO conflict (ordering fields not in props)
4. `StreamSync.getHoodieClientConfig()` runs
    - Validates `cfg.sourceOrderingFields` vs `tableConfig`
    - Throws `HoodieValidationException`

#### After Our Fix

1. `combineProperties()` -> properties WITH `sourceOrderingFields`
2. `HoodieStreamer` constructor
3. `StreamSyncService` constructor
    - `HoodieWriterUtils.validateTableConfig()` -> CONFLICT detected
    - Throws `HoodieException` (earlier, different type)
4. `StreamSync.getHoodieClientConfig()` -> NEVER REACHED

TLDR: Tables that are being bootstrapped will be created without `sourceOrderingFields` although one is provided. When performing upserts, a ClassCastException will be thrown if the `sourceOrderingFields` are meant to be string. 

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

1. Ensure that `sourceOrderingFields` are propagated into TypedProperties in `HoodieStreamer#combineProperties`

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Bootstrapped tables will now have the correct orderingFields propagated into their tableConfigs (and also hoodie.properties).

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
