### PR TITLE
feat: add flink HoodieSourceSplitComparator

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieSource.java
@@ -33,6 +33,7 @@ import org.apache.hudi.source.split.DefaultHoodieSplitProvider;
 import org.apache.hudi.source.split.HoodieContinuousSplitBatch;
 import org.apache.hudi.source.split.HoodieContinuousSplitDiscover;
 import org.apache.hudi.source.split.HoodieSourceSplit;
+import org.apache.hudi.source.split.HoodieSourceSplitComparator;
 import org.apache.hudi.source.split.HoodieSourceSplitSerializer;
 import org.apache.hudi.source.split.HoodieSourceSplitState;
 import org.apache.hudi.source.split.HoodieSplitProvider;
@@ -121,7 +122,7 @@ public class HoodieSource<T> implements Source<T, HoodieSourceSplit, HoodieSplit
       @Nullable HoodieSplitEnumeratorState enumeratorState) {
     HoodieSplitProvider splitProvider;
     if (enumeratorState == null) {
-      splitProvider = new DefaultHoodieSplitProvider();
+      splitProvider = new DefaultHoodieSplitProvider(new HoodieSourceSplitComparator());
     } else {
       LOG.info(
           "Hoodie source restored {} splits from state for table {}",

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/DefaultHoodieSplitProvider.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/DefaultHoodieSplitProvider.java
@@ -19,22 +19,38 @@
 package org.apache.hudi.source.split;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
 
 import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.stream.Collectors;
 
 /**
  *  Default split provider caches pending splits in queue and return split sequentially.
  */
 public class DefaultHoodieSplitProvider implements HoodieSplitProvider {
+  public static final int DEFAULT_SPLIT_QUEUE_SIZE = 20;
+
   private Queue<HoodieSourceSplit> pendingSplits;
 
   public DefaultHoodieSplitProvider() {
     this.pendingSplits = new ConcurrentLinkedDeque<>();
+  }
+
+  /**
+   * Creates a DefaultHoodieSplitProvider with a custom comparator for ordering splits.
+   *
+   * @param comparator the comparator to use for ordering splits
+   */
+  public DefaultHoodieSplitProvider(SerializableComparator<HoodieSourceSplit> comparator) {
+    ValidationUtils.checkArgument(comparator != null,
+        "The hoodie source split comparator can't be null");
+    this.pendingSplits = new PriorityBlockingQueue<>(DEFAULT_SPLIT_QUEUE_SIZE, comparator);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieContinuousSplitBatch.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieContinuousSplitBatch.java
@@ -61,6 +61,7 @@ public class HoodieContinuousSplitBatch {
             split.getBasePath().orElse(null),
             split.getLogPaths(), split.getTablePath(),
             EMPTY_PARTITION_PATH, split.getMergeType(),
+            split.getLatestCommit(),
             split.getFileId()
         )
     ).collect(Collectors.toList());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplit.java
@@ -52,6 +52,8 @@ public class HoodieSourceSplit implements SourceSplit, Serializable {
   private final String partitionPath;
   // source merge type
   private final String mergeType;
+  // latest commit time
+  private final String latestCommit;
   // file id of file splice
   @Setter
   protected String fileId;
@@ -70,6 +72,7 @@ public class HoodieSourceSplit implements SourceSplit, Serializable {
       String tablePath,
       String partitionPath,
       String mergeType,
+      String latestCommit,
       String fileId) {
     this.splitNum = splitNum;
     this.basePath = Option.ofNullable(basePath);
@@ -77,6 +80,7 @@ public class HoodieSourceSplit implements SourceSplit, Serializable {
     this.tablePath = tablePath;
     this.partitionPath = partitionPath;
     this.mergeType = mergeType;
+    this.latestCommit = latestCommit;
     this.fileId = fileId;
     this.fileOffset = 0;
   }
@@ -111,12 +115,12 @@ public class HoodieSourceSplit implements SourceSplit, Serializable {
     HoodieSourceSplit that = (HoodieSourceSplit) o;
     return splitNum == that.splitNum && consumed == that.consumed && fileOffset == that.fileOffset && Objects.equals(basePath, that.basePath)
         && Objects.equals(logPaths, that.logPaths) && Objects.equals(tablePath, that.tablePath) && Objects.equals(partitionPath, that.partitionPath)
-        && Objects.equals(mergeType, that.mergeType) && Objects.equals(fileId, that.fileId);
+        && Objects.equals(mergeType, that.mergeType) && Objects.equals(latestCommit, that.latestCommit) && Objects.equals(fileId, that.fileId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(splitNum, basePath, logPaths, tablePath, partitionPath, mergeType, fileId, consumed, fileOffset);
+    return Objects.hash(splitNum, basePath, logPaths, tablePath, partitionPath, mergeType, latestCommit, fileId, consumed, fileOffset);
   }
 
   @Override
@@ -128,6 +132,7 @@ public class HoodieSourceSplit implements SourceSplit, Serializable {
         + ", tablePath='" + tablePath + '\''
         + ", partitionPath='" + partitionPath + '\''
         + ", mergeType='" + mergeType + '\''
+        + ", latestCommit='" + latestCommit + '\''
         + '}';
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplitComparator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplitComparator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.split;
+
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.ValidationUtils;
+
+import static org.apache.hudi.common.fs.FSUtils.getCommitTime;
+
+/**
+ * Commit time based Hoodie source split comparator.
+ * <p>
+ * This comparator orders splits by their latest commit time in ascending order.
+ * When two splits have the same latest commit time, they are ordered by the commit
+ * time extracted from their base file path.
+ */
+public class HoodieSourceSplitComparator implements SerializableComparator<HoodieSourceSplit> {
+
+  @Override
+  public int compare(HoodieSourceSplit o1, HoodieSourceSplit o2) {
+    ValidationUtils.checkArgument(
+        !StringUtils.isNullOrEmpty(o1.getLatestCommit()),
+        "The latest commit field of split can't be null or empty: " + o1);
+
+    ValidationUtils.checkArgument(
+        !StringUtils.isNullOrEmpty(o2.getLatestCommit()),
+        "The latest commit field of split can't be null or empty: " + o2);
+
+    int commitComparison = CharSequence.compare(o1.getLatestCommit(), o2.getLatestCommit());
+    if (commitComparison == 0) {
+      String commitTime1 = o1.getBasePath()
+          .map(path -> getCommitTime(path))
+          .orElse("");
+      String commitTime2 = o2.getBasePath()
+          .map(path -> getCommitTime(path))
+          .orElse("");
+      return CharSequence.compare(commitTime1, commitTime2);
+    }
+    return commitComparison;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplitSerializer.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplitSerializer.java
@@ -73,6 +73,8 @@ public class HoodieSourceSplitSerializer implements SimpleVersionedSerializer<Ho
       out.writeUTF(obj.getPartitionPath());
       // Serialize mergeType
       out.writeUTF(obj.getMergeType());
+      // Serialize latest commit
+      out.writeUTF(obj.getLatestCommit());
       // Serialize fileId
       out.writeUTF(obj.getFileId());
       // Serialize consumed
@@ -118,6 +120,8 @@ public class HoodieSourceSplitSerializer implements SimpleVersionedSerializer<Ho
       String partitionPath = in.readUTF();
       // Deserialize mergeType
       String mergeType = in.readUTF();
+      // Deserialize latestCommit
+      String latestCommit = in.readUTF();
       // Deserialize fileId
       String fileId = in.readUTF();
       // Deserialize consumed
@@ -133,6 +137,7 @@ public class HoodieSourceSplitSerializer implements SimpleVersionedSerializer<Ho
           tablePath,
           partitionPath,
           mergeType,
+          latestCommit,
           fileId);
 
       // Update position to restore consumed and fileOffset

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/SerializableComparator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/SerializableComparator.java
@@ -22,6 +22,13 @@ import java.io.Serializable;
 import java.util.Comparator;
 
 /**
- * Comparator interface for HoodieSourceSplit.
+ * A serializable comparator interface for objects that need to be compared
+ * in a distributed environment.
+ *
+ * <p>This interface extends both {@link Comparator} and {@link Serializable},
+ * making it suitable for use in distributed systems where comparators need to be
+ * serialized and sent across network boundaries.
+ *
+ * @param <T> the type of objects that may be compared by this comparator
  */
 public interface SerializableComparator<T> extends Comparator<T>, Serializable {}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestHoodieSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestHoodieSource.java
@@ -516,6 +516,7 @@ public class TestHoodieSource {
         "/test/table",
         partitionPath,
         "read_optimized",
+        "19700101000000000",
         fileId
     );
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieContinuousSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieContinuousSplitEnumerator.java
@@ -257,6 +257,7 @@ public class TestHoodieContinuousSplitEnumerator {
         "/table/path",
         "/table/path/partition1",
         "read_optimized",
+        "19700101000000000",
         fileId
     );
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieEnumeratorStateSerializer.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieEnumeratorStateSerializer.java
@@ -456,7 +456,7 @@ public class TestHoodieEnumeratorStateSerializer {
     splitStates.add(new HoodieSourceSplitState(split1, HoodieSourceSplitStatus.ASSIGNED));
 
     HoodieSourceSplit split2 = new HoodieSourceSplit(2, null,
-        Option.of(Arrays.asList("log1", "log2")), "/table", "/p2", "payload_combine", "file2");
+        Option.of(Arrays.asList("log1", "log2")), "/table", "/p2", "payload_combine", "", "file2");
     splitStates.add(new HoodieSourceSplitState(split2, HoodieSourceSplitStatus.UNASSIGNED));
 
     HoodieSourceSplit split3 = createTestSplit(3, "file3", "/p3");
@@ -490,6 +490,7 @@ public class TestHoodieEnumeratorStateSerializer {
         "/test/table",
         partitionPath,
         "read_optimized",
+        "19700101000000000",
         fileId
     );
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieStaticSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieStaticSplitEnumerator.java
@@ -223,6 +223,7 @@ public class TestHoodieStaticSplitEnumerator {
         "/table/path",
         "/table/path/partition1",
         "read_optimized",
+        "19700101000000000",
         fileId
     );
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestBatchReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestBatchReader.java
@@ -259,6 +259,7 @@ public class TestBatchReader {
         "/test/table",
         "/test/partition",
         "read_optimized",
+        "",
         "file-1"
     );
     for (long i = 0; i < consumed; i++) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestDefaultBatchReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestDefaultBatchReader.java
@@ -435,6 +435,7 @@ public class TestDefaultBatchReader {
         "/test/table",
         "/test/partition",
         "read_optimized",
+        "19700101000000000",
         "file-1"
     );
     // Simulate consumed records

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieRecordEmitter.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieRecordEmitter.java
@@ -207,6 +207,7 @@ public class TestHoodieRecordEmitter {
         "/test/table/path",
         "/test/partition",
         "read_optimized",
+        "19700101000000000",
         "file-1"
     );
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieSourceSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieSourceSplitReader.java
@@ -358,6 +358,7 @@ public class TestHoodieSourceSplitReader {
         "/test/table",
         "/test/partition",
         "read_optimized",
+        "19700101000000000",
         fileId
     );
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestDefaultHoodieSplitProvider.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestDefaultHoodieSplitProvider.java
@@ -23,12 +23,15 @@ import org.apache.hudi.common.util.Option;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -175,6 +178,178 @@ public class TestDefaultHoodieSplitProvider {
     assertEquals(split3.splitId(), provider.getNext(null).get().splitId());
   }
 
+  @Test
+  public void testWithComparatorOrdersByLatestCommit() {
+    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+
+    HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split3 = createSplitWithCommit(3, "20260126034718000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034718000.parquet");
+
+    providerWithComparator.onDiscoveredSplits(Arrays.asList(split1, split2, split3));
+
+    // Should return splits in order of commit time (ascending)
+    assertEquals(split2.splitId(), providerWithComparator.getNext(null).get().splitId(),
+        "Should return split with earliest commit time first");
+    assertEquals(split1.splitId(), providerWithComparator.getNext(null).get().splitId(),
+        "Should return split with middle commit time second");
+    assertEquals(split3.splitId(), providerWithComparator.getNext(null).get().splitId(),
+        "Should return split with latest commit time last");
+  }
+
+  @Test
+  public void testWithComparatorSameLatestCommit() {
+    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+
+    // All have same latest commit, but different base file commit times
+    HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split3 = createSplitWithCommit(3, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034718000.parquet");
+
+    providerWithComparator.onDiscoveredSplits(Arrays.asList(split1, split2, split3));
+
+    // Should return splits ordered by base file commit time
+    assertEquals(split2.splitId(), providerWithComparator.getNext(null).get().splitId());
+    assertEquals(split1.splitId(), providerWithComparator.getNext(null).get().splitId());
+    assertEquals(split3.splitId(), providerWithComparator.getNext(null).get().splitId());
+  }
+
+  @Test
+  public void testWithComparatorMultipleDiscoveryCalls() {
+    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+
+    HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    providerWithComparator.onDiscoveredSplits(Arrays.asList(split1));
+    providerWithComparator.onDiscoveredSplits(Arrays.asList(split2));
+
+    // Should still return in sorted order
+    assertEquals(split2.splitId(), providerWithComparator.getNext(null).get().splitId());
+    assertEquals(split1.splitId(), providerWithComparator.getNext(null).get().splitId());
+  }
+
+  @Test
+  public void testWithComparatorAndUnassignedSplits() {
+    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+
+    HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    providerWithComparator.onDiscoveredSplits(Arrays.asList(split1, split2));
+    providerWithComparator.getNext(null); // Get split2 (earliest)
+
+    // Re-add split2 as unassigned
+    providerWithComparator.onUnassignedSplits(Arrays.asList(split2));
+
+    // Should still maintain order: split2 comes before split1
+    assertEquals(split2.splitId(), providerWithComparator.getNext(null).get().splitId());
+    assertEquals(split1.splitId(), providerWithComparator.getNext(null).get().splitId());
+  }
+
+  @Test
+  public void testWithComparatorEmptyProvider() {
+    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+
+    Option<HoodieSourceSplit> result = providerWithComparator.getNext(null);
+    assertFalse(result.isPresent(), "Should return empty option when no splits available");
+  }
+
+  @Test
+  public void testWithComparatorStateTracking() {
+    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+
+    HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    providerWithComparator.onDiscoveredSplits(Arrays.asList(split1, split2));
+
+    Collection<HoodieSourceSplitState> states = providerWithComparator.state();
+    assertEquals(2, states.size(), "Should have 2 split states");
+
+    // Consume one split
+    providerWithComparator.getNext(null);
+
+    states = providerWithComparator.state();
+    assertEquals(1, states.size(), "Should have 1 remaining split state");
+  }
+
+  @Test
+  public void testWithComparatorNullComparator() {
+    assertThrows(IllegalArgumentException.class, () -> new DefaultHoodieSplitProvider(null),
+        "Should throw exception when comparator is null");
+  }
+
+  @Test
+  public void testWithComparatorLargeBatchOrdering() {
+    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+
+    // Create 50 splits with random commit times
+    List<HoodieSourceSplit> splits = new ArrayList<>();
+    for (int i = 0; i < 50; i++) {
+      String commitTime = String.format("2026012603471%04d0", i * 100);
+      splits.add(createSplitWithCommit(i, commitTime, "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_" + commitTime + ".parquet"));
+    }
+
+    // Add them in reverse order
+    Collections.reverse(splits);
+    providerWithComparator.onDiscoveredSplits(splits);
+
+    // Should retrieve them in ascending commit time order
+    HoodieSourceSplit previousSplit = null;
+    for (int i = 0; i < 50; i++) {
+      HoodieSourceSplit currentSplit = providerWithComparator.getNext(null).get();
+      if (previousSplit != null) {
+        assertTrue(comparator.compare(previousSplit, currentSplit) < 0,
+            "Splits should be retrieved in ascending commit time order");
+      }
+      previousSplit = currentSplit;
+    }
+  }
+
+  @Test
+  public void testWithComparatorConcurrentAccess() {
+    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+
+    List<HoodieSourceSplit> splits = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      String commitTime = String.format("2026012603%010d", i);
+      splits.add(createSplitWithCommit(i, commitTime, "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_" + commitTime + ".parquet"));
+    }
+
+    providerWithComparator.onDiscoveredSplits(splits);
+
+    // Verify that we can retrieve all splits in order
+    for (int i = 0; i < 100; i++) {
+      Option<HoodieSourceSplit> split = providerWithComparator.getNext(null);
+      assertTrue(split.isPresent(), "Should have split available");
+    }
+
+    // No more splits should be available
+    assertFalse(providerWithComparator.getNext(null).isPresent());
+  }
+
+  private HoodieSourceSplit createSplitWithCommit(int splitNum, String latestCommit, String basePath) {
+    return new HoodieSourceSplit(
+        splitNum,
+        basePath,
+        Option.empty(),
+        "/table/path",
+        "/table/path/partition1",
+        "read_optimized",
+        latestCommit,
+        "file" + splitNum
+    );
+  }
+
   private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
     return new HoodieSourceSplit(
         splitNum,
@@ -183,6 +358,7 @@ public class TestDefaultHoodieSplitProvider {
         "/table/path",
         "/table/path/partition1",
         "read_optimized",
+        "19700101000000000",
         fileId
     );
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestHoodieSourceSplit.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestHoodieSourceSplit.java
@@ -95,9 +95,9 @@ public class TestHoodieSourceSplit {
   @Test
   public void testEqualsWithDifferentBasePath() {
     HoodieSourceSplit split1 = new HoodieSourceSplit(
-        1, "base-path-1", Option.empty(), "/table", "/partition1",  "read_optimized", "file1");
+        1, "base-path-1", Option.empty(), "/table", "/partition1",  "read_optimized", "", "file1");
     HoodieSourceSplit split2 = new HoodieSourceSplit(
-        1, "base-path-2", Option.empty(), "/table", "/partition1", "read_optimized", "file1");
+        1, "base-path-2", Option.empty(), "/table", "/partition1", "read_optimized", "", "file1");
 
     assertNotEquals(split1, split2);
   }
@@ -105,9 +105,9 @@ public class TestHoodieSourceSplit {
   @Test
   public void testEqualsWithDifferentLogPaths() {
     HoodieSourceSplit split1 = new HoodieSourceSplit(
-        1, "base-path", Option.of(Arrays.asList("log1", "log2")), "/table", "/partition1", "payload_combine", "file1");
+        1, "base-path", Option.of(Arrays.asList("log1", "log2")), "/table", "/partition1", "payload_combine", "", "file1");
     HoodieSourceSplit split2 = new HoodieSourceSplit(
-        1, "base-path", Option.of(Arrays.asList("log1", "log3")), "/table", "/partition1",  "payload_combine", "file1");
+        1, "base-path", Option.of(Arrays.asList("log1", "log3")), "/table", "/partition1",  "payload_combine", "", "file1");
 
     assertNotEquals(split1, split2);
   }
@@ -115,9 +115,9 @@ public class TestHoodieSourceSplit {
   @Test
   public void testEqualsWithDifferentTablePath() {
     HoodieSourceSplit split1 = new HoodieSourceSplit(
-        1, "base-path", Option.empty(), "/table1", "/partition1",  "read_optimized", "file1");
+        1, "base-path", Option.empty(), "/table1", "/partition1",  "read_optimized", "", "file1");
     HoodieSourceSplit split2 = new HoodieSourceSplit(
-        1, "base-path", Option.empty(), "/table2", "/partition1", "read_optimized", "file1");
+        1, "base-path", Option.empty(), "/table2", "/partition1", "read_optimized", "","file1");
 
     assertNotEquals(split1, split2);
   }
@@ -125,9 +125,9 @@ public class TestHoodieSourceSplit {
   @Test
   public void testEqualsWithDifferentMergeType() {
     HoodieSourceSplit split1 = new HoodieSourceSplit(
-        1, "base-path", Option.empty(), "/table", "/partition1", "read_optimized", "file1");
+        1, "base-path", Option.empty(), "/table", "/partition1", "read_optimized", "","file1");
     HoodieSourceSplit split2 = new HoodieSourceSplit(
-        1, "base-path", Option.empty(), "/table", "/partition1", "payload_combine", "file1");
+        1, "base-path", Option.empty(), "/table", "/partition1", "payload_combine", "", "file1");
 
     assertNotEquals(split1, split2);
   }
@@ -228,7 +228,7 @@ public class TestHoodieSourceSplit {
 
     HoodieSourceSplit split = new HoodieSourceSplit(
         42, basePath, Option.of(Arrays.asList("log1", "log2")),
-        tablePath, partitionPath, mergeType, fileId);
+        tablePath, partitionPath, mergeType, "", fileId);
 
     assertTrue(split.getBasePath().isPresent());
     assertEquals(basePath, split.getBasePath().get());
@@ -267,7 +267,7 @@ public class TestHoodieSourceSplit {
   public void testToString() {
     HoodieSourceSplit split = new HoodieSourceSplit(
         1, "base-path", Option.of(Arrays.asList("log1")),
-        "/table", "/partition", "read_optimized", "file1");
+        "/table", "/partition", "read_optimized", "", "file1");
 
     String result = split.toString();
 
@@ -303,9 +303,9 @@ public class TestHoodieSourceSplit {
   @Test
   public void testEqualsWithNullBasePath() {
     HoodieSourceSplit split1 = new HoodieSourceSplit(
-        1, null, Option.empty(), "/table", "/partition","read_optimized", "file1");
+        1, null, Option.empty(), "/table", "/partition","read_optimized", "", "file1");
     HoodieSourceSplit split2 = new HoodieSourceSplit(
-        1, null, Option.empty(), "/table", "/partition","read_optimized", "file1");
+        1, null, Option.empty(), "/table", "/partition","read_optimized", "", "file1");
 
     assertEquals(split1, split2);
   }
@@ -313,9 +313,9 @@ public class TestHoodieSourceSplit {
   @Test
   public void testEqualsOneNullBasePathOneNot() {
     HoodieSourceSplit split1 = new HoodieSourceSplit(
-        1, null, Option.empty(), "/table", "/partition", "read_optimized", "file1");
+        1, null, Option.empty(), "/table", "/partition", "read_optimized", "", "file1");
     HoodieSourceSplit split2 = new HoodieSourceSplit(
-        1, "base-path", Option.empty(), "/table", "/partition", "read_optimized", "file1");
+        1, "base-path", Option.empty(), "/table", "/partition", "read_optimized", "","file1");
 
     assertNotEquals(split1, split2);
   }
@@ -331,6 +331,7 @@ public class TestHoodieSourceSplit {
         "/test/table",
         partitionPath,
         "read_optimized",
+        "19700101000000000",
         fileId
     );
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestHoodieSourceSplitComparator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestHoodieSourceSplitComparator.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.split;
+
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link HoodieSourceSplitComparator}.
+ */
+public class TestHoodieSourceSplitComparator {
+  private HoodieSourceSplitComparator comparator;
+
+  @BeforeEach
+  public void setUp() {
+    comparator = new HoodieSourceSplitComparator();
+  }
+
+  @Test
+  public void testCompareWithDifferentLatestCommits() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result < 0, "Split with earlier commit time should come first");
+  }
+
+  @Test
+  public void testCompareWithSameLatestCommits() {
+    // Both have same latest commit but different base file commit times
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result < 0, "Split with earlier base file commit time should come first");
+  }
+
+  @Test
+  public void testCompareWithIdenticalCommits() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    int result = comparator.compare(split1, split2);
+    assertEquals(0, result, "Identical splits should return 0");
+  }
+
+  @Test
+  public void testCompareReverseOrder() {
+    HoodieSourceSplit split1 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result > 0, "Split with later commit time should come after");
+  }
+
+  @Test
+  public void testCompareWithNullLatestCommit() {
+    HoodieSourceSplit split1 = createSplit(null, "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    assertThrows(IllegalArgumentException.class, () -> comparator.compare(split1, split2),
+        "Should throw exception when first split has null latest commit");
+  }
+
+  @Test
+  public void testCompareWithEmptyLatestCommit() {
+    HoodieSourceSplit split1 = createSplit("", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    assertThrows(IllegalArgumentException.class, () -> comparator.compare(split1, split2),
+        "Should throw exception when first split has empty latest commit");
+  }
+
+  @Test
+  public void testCompareWithBothNullLatestCommits() {
+    HoodieSourceSplit split1 = createSplit(null, "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit(null, "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    assertThrows(IllegalArgumentException.class, () -> comparator.compare(split1, split2),
+        "Should throw exception when both splits have null latest commit");
+  }
+
+  @Test
+  public void testCompareMultipleSplitsOrdering() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split3 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split4 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034718000.parquet");
+
+    // Verify ordering
+    assertTrue(comparator.compare(split1, split2) < 0);
+    assertTrue(comparator.compare(split1, split3) < 0);
+    assertTrue(comparator.compare(split1, split4) < 0);
+    assertTrue(comparator.compare(split2, split3) < 0);
+    assertTrue(comparator.compare(split2, split4) < 0);
+    assertTrue(comparator.compare(split3, split4) < 0);
+  }
+
+  @Test
+  public void testCompareWithOrcFiles() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.orc");
+    HoodieSourceSplit split2 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.orc");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result < 0, "Should work with ORC file extensions");
+  }
+
+  @Test
+  public void testCompareWithLogFiles() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.log");
+    HoodieSourceSplit split2 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.log");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result < 0, "Should work with log file extensions");
+  }
+
+  @Test
+  public void testCompareWithComplexFilePaths() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930",
+        "/table/path/partition1/09983c46-6160-48e7-a8ec-4e69f742b4ce-0_83-512-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034717000",
+        "/table/path/partition2/09983c46-6160-48e7-a8ec-4e69f742b4ce-0_83-512-1_20260126034717000.parquet");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result < 0, "Should work with complex file paths");
+  }
+
+  @Test
+  public void testCompareWithVeryCloseCommitTimes() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716931", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716931.parquet");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result < 0, "Should correctly order very close commit times");
+  }
+
+  @Test
+  public void testComparatorIsConsistent() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+
+    int result1 = comparator.compare(split1, split2);
+    int result2 = comparator.compare(split1, split2);
+    assertEquals(result1, result2, "Comparator should be consistent");
+  }
+
+  @Test
+  public void testComparatorSymmetry() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+
+    int result1 = comparator.compare(split1, split2);
+    int result2 = comparator.compare(split2, split1);
+    assertEquals(-Integer.signum(result1), Integer.signum(result2),
+        "Comparator should be symmetric");
+  }
+
+  @Test
+  public void testComparatorTransitivity() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split3 = createSplit("20260126034718000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034718000.parquet");
+
+    assertTrue(comparator.compare(split1, split2) < 0);
+    assertTrue(comparator.compare(split2, split3) < 0);
+    assertTrue(comparator.compare(split1, split3) < 0,
+        "Comparator should be transitive");
+  }
+
+  @Test
+  public void testCompareWithNullBasePath() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", null);
+    HoodieSourceSplit split2 = createSplit("20260126034716930", null);
+
+    int result = comparator.compare(split1, split2);
+    assertEquals(0, result, "Splits with same latest commit and null base paths should be equal");
+  }
+
+  @Test
+  public void testCompareWithOneNullBasePath() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", null);
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result < 0, "Split with null base path should come before split with base path");
+  }
+
+  @Test
+  public void testCompareWithDifferentLatestCommitOverridesBasePathOrder() {
+    // Latest commit takes precedence over base path commit time
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034718000.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    int result = comparator.compare(split1, split2);
+    assertTrue(result < 0, "Latest commit should take precedence over base file commit time");
+  }
+
+  @Test
+  public void testCompareWithNonStandardFileNames() {
+    // Test with file names that might not have standard Hudi naming pattern
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-2_20260126034716930.parquet");
+
+    // Should not throw exception and should compare based on latest commit
+    int result = comparator.compare(split1, split2);
+    assertEquals(0, result, "When latest commits are equal and base paths don't contain commit times, should return 0");
+  }
+
+  @Test
+  public void testCompareWithSecondSplitNullLatestCommit() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit(null, "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    assertThrows(IllegalArgumentException.class, () -> comparator.compare(split1, split2),
+        "Should throw exception when second split has null latest commit");
+  }
+
+  @Test
+  public void testCompareWithSecondSplitEmptyLatestCommit() {
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split2 = createSplit("", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+
+    assertThrows(IllegalArgumentException.class, () -> comparator.compare(split1, split2),
+        "Should throw exception when second split has empty latest commit");
+  }
+
+  @Test
+  public void testCompareWithSameLatestCommitDifferentBaseFileCommitTimes() {
+    // Testing secondary sort by base file commit time
+    HoodieSourceSplit split1 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716000.parquet");
+    HoodieSourceSplit split2 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716500.parquet");
+    HoodieSourceSplit split3 = createSplit("20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+
+    assertTrue(comparator.compare(split1, split2) < 0);
+    assertTrue(comparator.compare(split2, split3) < 0);
+    assertTrue(comparator.compare(split1, split3) < 0);
+  }
+
+  private HoodieSourceSplit createSplit(String latestCommit, String basePath) {
+    return new HoodieSourceSplit(
+        1,
+        basePath,
+        Option.empty(),
+        "/table/path",
+        "/partition/path",
+        "read_optimized",
+        latestCommit,
+        "file-1"
+    );
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestHoodieSourceSplitSerializer.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestHoodieSourceSplitSerializer.java
@@ -49,6 +49,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-123"
     );
 
@@ -79,6 +80,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "payload_combine",
+        "19700101000000000",
         "file-456"
     );
 
@@ -100,6 +102,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "payload_combine",
+        "19700101000000000",
         "file-789"
     );
 
@@ -123,6 +126,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-000"
     );
 
@@ -143,6 +147,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-111"
     );
 
@@ -167,6 +172,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-222"
     );
 
@@ -197,6 +203,7 @@ public class TestHoodieSourceSplitSerializer {
         "/very/long/table/path/with/multiple/segments",
         "/partition/year=2024/month=01/day=22",
         "payload_combine",
+        "19700101000000000",
         "complex-file-id-with-uuid-12345678"
     );
 
@@ -231,6 +238,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-333"
     );
 
@@ -250,6 +258,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "payload_combine",
+        "19700101000000000",
         "file-444"
     );
 
@@ -264,9 +273,9 @@ public class TestHoodieSourceSplitSerializer {
 
   @Test
   public void testSerializeMultipleSplitsWithDifferentStates() throws IOException {
-    HoodieSourceSplit split1 = new HoodieSourceSplit(1, "base1", Option.empty(), "/t1", "/p1", "read_optimized", "f1");
-    HoodieSourceSplit split2 = new HoodieSourceSplit(2, "base2", Option.of(Arrays.asList("log1")), "/t2", "/p2", "payload_combine", "f2");
-    HoodieSourceSplit split3 = new HoodieSourceSplit(3, null, Option.of(Arrays.asList("log1", "log2", "log3")), "/t3", "/p3", "read_optimized", "f3");
+    HoodieSourceSplit split1 = new HoodieSourceSplit(1, "base1", Option.empty(), "/t1", "/p1", "read_optimized", "19700101000000000","f1");
+    HoodieSourceSplit split2 = new HoodieSourceSplit(2, "base2", Option.of(Arrays.asList("log1")), "/t2", "/p2", "payload_combine", "19700101000000000","f2");
+    HoodieSourceSplit split3 = new HoodieSourceSplit(3, null, Option.of(Arrays.asList("log1", "log2", "log3")), "/t3", "/p3", "read_optimized", "19700101000000000","f3");
 
     split1.updatePosition(1, 10L);
     split2.consume();
@@ -294,6 +303,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-large"
     );
 
@@ -315,6 +325,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-zero"
     );
 
@@ -337,6 +348,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-negative"
     );
 
@@ -360,6 +372,7 @@ public class TestHoodieSourceSplitSerializer {
         longString.toString(),
         longString.toString(),
         "read_optimized",
+        "19700101000000000",
         longString.toString()
     );
 
@@ -381,6 +394,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path/with/\t/tabs/and/\n/newlines",
         "/partition/with/\r\n/carriage/return",
         "read_optimized",
+        "19700101000000000",
         "file-id-with-unicode-字符-émojis-🎉"
     );
 
@@ -389,27 +403,6 @@ public class TestHoodieSourceSplitSerializer {
 
     assertEquals(original.getBasePath(), deserialized.getBasePath());
     assertEquals(original.getLogPaths(), deserialized.getLogPaths());
-    assertEquals(original.getTablePath(), deserialized.getTablePath());
-    assertEquals(original.getPartitionPath(), deserialized.getPartitionPath());
-    assertEquals(original.getFileId(), deserialized.getFileId());
-  }
-
-  @Test
-  public void testSerializeWithEmptyStrings() throws IOException {
-    HoodieSourceSplit original = new HoodieSourceSplit(
-        1,
-        "",
-        Option.of(Arrays.asList("", "")),
-        "",
-        "",
-        "",
-        ""
-    );
-
-    byte[] serialized = serializer.serialize(original);
-    HoodieSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), serialized);
-
-    assertEquals(original.getBasePath().get(), deserialized.getBasePath().get());
     assertEquals(original.getTablePath(), deserialized.getTablePath());
     assertEquals(original.getPartitionPath(), deserialized.getPartitionPath());
     assertEquals(original.getFileId(), deserialized.getFileId());
@@ -429,6 +422,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "payload_combine",
+        "19700101000000000",
         "file-many-logs"
     );
 
@@ -448,6 +442,7 @@ public class TestHoodieSourceSplitSerializer {
         "/table/path",
         "/partition/path",
         "read_optimized",
+        "19700101000000000",
         "file-roundtrip"
     );
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
Add flink HoodieSourceSplitComparator for better watermark alignment.

closes #18019

### Summary and Changelog
1. add flink HoodieSourceSplitComparator and use it as default split comparator in Hudi Source.

2. The current solution only works for any split with base path, for example COW, MOR splits. The CDC split will be handled in a follow up PR to resolve the issue #18020.

### Impact

 
none

### Risk Level

 
none

### Documentation Update


none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
