### PR TITLE
fix: too many properties passed to hive table through hoodie hive catalog

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -568,7 +568,15 @@ public class HoodieHiveCatalog extends AbstractCatalog {
       properties.put(HoodieIndexConfig.INDEX_TYPE.key(), properties.get(FlinkOptions.INDEX_TYPE.key()));
     }
     properties.remove(FlinkOptions.INDEX_TYPE.key());
-    hiveConf.getAllProperties().forEach((k, v) -> properties.put("hadoop." + k, String.valueOf(v)));
+    if (hiveConf.get("hive.metastore.uris") != null) {
+      properties.put("hadoop.hive.metastore.uris", hiveConf.get("hive.metastore.uris"));
+    }
+    if (hiveConf.get("hive.metastore.sasl.enabled") != null) {
+      properties.put("hadoop.hive.metastore.sasl.enabled", hiveConf.get("hive.metastore.sasl.enabled"));
+    }
+    if (hiveConf.get("hive.metastore.kerberos.principle") != null) {
+      properties.put("hadoop.hive.metastore.kerberos.principle", hiveConf.get("hive.metastore.kerberos.principle"));
+    }
 
     if (external) {
       hiveTable.setTableType(TableType.EXTERNAL_TABLE.toString());

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
@@ -489,7 +489,7 @@ public class TestHoodieHiveCatalog extends BaseTestHoodieCatalog {
     catalog.createTable(tablePath, table, false);
 
     Table hiveTable = hoodieCatalog.getHiveTable(tablePath);
-    assertEquals("false", hiveTable.getParameters().get("hadoop.hive.metastore.schema.verification"));
+    assertEquals("false", hiveTable.getParameters().get("hadoop.hive.metastore.sasl.enabled"));
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
Current logic of HoodieHiveCatalog passes all the properites from hive-conf.xml to hive table. This was done to address the [this issue](https://github.com/apache/hudi/issues/9269). However, only 3 properties are really needed, according to @nylqd.
Too many properties will significantly increase the size of the metadata of the table and bring big pressure to hive metastore if there are large amount of tables. 
In my case tables had 2700+ properties which is unreasonable .


### Summary and Changelog

Only 3 properties mentioned in https://github.com/apache/hudi/issues/9269 left to pass from hive conf.

### Impact

fix performance issues on hive

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
