### PR TITLE
fix(common): Handle null actionState in LegacyArchivedMetaEntryReader

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LegacyArchivedMetaEntryReader.java
@@ -120,9 +120,13 @@ public class LegacyArchivedMetaEntryReader {
       return null;
     });
     InstantGenerator instantGenerator = metaClient.getInstantGenerator();
-    HoodieInstant instant = instantGenerator.createNewInstant(HoodieInstant.State.valueOf(record.get(ACTION_STATE).toString()), action,
+    // Older log files don't have action state set.
+    final HoodieInstant.State state = Option.ofNullable(record.get(ACTION_STATE))
+        .map(s -> HoodieInstant.State.valueOf(s.toString()))
+        .orElse(HoodieInstant.State.COMPLETED);
+    HoodieInstant instant = instantGenerator.createNewInstant(state, action,
         instantTime, stateTransitionTime);
-    return Pair.of(instant,details);
+    return Pair.of(instant, details);
   }
 
   @Nonnull


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes potential NPE in `LegacyArchivedMetaEntryReader` when reading older archived log files that don't have the `actionState` field set.

The `ArchivedTimelineV1.java` already handles this case correctly, but `LegacyArchivedMetaEntryReader.java` (used during 7→8 upgrades via `SevenToEightUpgradeHandler`) does not have this fix.

### Summary and Changelog

When reading archived timeline records, older log files may have `actionState` set to null. The current code calls `record.get(ACTION_STATE).toString()` which throws an NPE when actionState is null.

**Changes:**
- Added null check for `actionState` field in `LegacyArchivedMetaEntryReader.readInstant()`
- Default to `HoodieInstant.State.COMPLETED` when actionState is null, consistent with the fix in `ArchivedTimelineV1.java`

### Impact

No public API changes. This is a defensive fix to prevent NPE during upgrade scenarios when reading legacy archived timeline records.

### Risk Level

low - This is a simple null check that defaults to the same behavior as the existing fix in ArchivedTimelineV1.java. The change only affects upgrade scenarios where old archived logs are being read.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable