### PR TITLE
feat(common): add a flag for disabling append to log files

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
@@ -113,7 +113,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
       if (this.writer == null) {
         return HoodieLogFormat.newWriterBuilder().onParentPath(archivePath).withInstantTime("")
             .withFileId(archiveFilePath.getName()).withFileExtension(HoodieArchivedLogFile.ARCHIVE_EXTENSION)
-            .withStorage(metaClient.getStorage()).build();
+            .withStorage(metaClient.getStorage()).withAppendDisabled(config.isLogFileAppendDisabled()).build();
       } else {
         return this.writer;
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -931,6 +931,12 @@ public class HoodieWriteConfig extends HoodieConfig {
    */
   public static final String WRITES_FILEID_ENCODING = "_hoodie.writes.fileid.encoding";
 
+  public static final ConfigProperty<String> LOG_FILE_APPEND_DISABLED = ConfigProperty
+      .key("hoodie.log.file.append.disabled")
+      .defaultValue("false")
+      .sinceVersion("0.8.0")
+      .withDocumentation("When enabled, all appends go to a new log file.");
+
   @Setter
   private ConsistencyGuardConfig consistencyGuardConfig;
   private FileSystemRetryConfig fileSystemRetryConfig;
@@ -1693,6 +1699,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public boolean populateMetaFields() {
     return getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS);
+  }
+
+  public boolean isLogFileAppendDisabled() {
+    return getBooleanOrDefault(LOG_FILE_APPEND_DISABLED);
   }
 
   /**
@@ -3502,6 +3512,11 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder withFileGroupReaderMergeHandleClassName(String className) {
       writeConfig.setValue(COMPACT_MERGE_HANDLE_CLASS_NAME, className);
+      return this;
+    }
+
+    public Builder withLogFileAppendDisabled(boolean disabled) {
+      writeConfig.setValue(LOG_FILE_APPEND_DISABLED, Boolean.toString(disabled));
       return this;
     }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR adds a configuration flag `hoodie.log.file.append.disabled` that allows users to disable appending to existing log files. When enabled, all appends go to a new log file instead of appending to an existing one.

### Summary and Changelog

**Summary:** Adds a new configuration option to control log file append behavior, useful for environments where appending to existing files is problematic.

**Changelog:**
- Added `LOG_FILE_APPEND_DISABLED` config property to `HoodieWriteConfig` with default value `false`
- Added `withAppendDisabled(boolean)` method to `HoodieLogFormat.WriterBuilder`
- Modified log file version computation to increment version when appends are disabled
- Updated `TimelineArchiverV1` to use the new append disabled flag from config
- Added unit test `testAppendDisabledFlag` in `TestHoodieLogFormat`

### Impact

New configuration option for users who need to disable log file appending. No breaking changes - default behavior remains unchanged (appends enabled).

### Risk Level

low - This is an additive change with a safe default value (disabled by default). Existing behavior is preserved unless explicitly opted into.

### Documentation Update

The config description is included in the code. The new config is:
- `hoodie.log.file.append.disabled` (default: `false`) - When enabled, all appends go to a new log file.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable