### PR TITLE
fix(core): Check for presence of data files before including in marker based rollback plan

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestMarkerBasedRollbackStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestMarkerBasedRollbackStrategy.java
@@ -176,7 +176,7 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "001"),
         rollbackRequests);
 
-    // then: ensure files are deleted correctly, non-existent files reported as failed deletes
+    // then: ensure files are deleted correctly, non-existent files are filtered and excluded from the plan
     assertEquals(2, stats.size());
 
     FileStatus[] partAFiles = testTable.listAllFilesInPartition("partA");
@@ -184,7 +184,7 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
 
     assertEquals(0, partBFiles.length);
     assertEquals(1, partAFiles.length);
-    assertEquals(3, stats.stream().mapToInt(r -> r.getSuccessDeleteFiles().size()).sum());
+    assertEquals(2, stats.stream().mapToInt(r -> r.getSuccessDeleteFiles().size()).sum());
     assertEquals(0, stats.stream().mapToInt(r -> r.getFailedDeleteFiles().size()).sum());
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When building a rollback plan using markers, data files that were deleted during `finalizeWrite()` can get included in the rollback requests. This results in the metadata table receiving delete operations for non-existent files.

### Summary and Changelog

This PR adds a filter to check if data files actually exist before including them in the marker-based rollback plan.

**Changes:**
- Added file existence check in `MarkerBasedRollbackStrategy.getRollbackRequests()` after collecting rollback requests from markers
- Requests with empty `filesToBeDeleted` (e.g., APPEND operations) are passed through without the check
- Only requests where the file actually exists are included in the final rollback plan
- Updated test expectations in `TestMarkerBasedRollbackStrategy` to reflect the new filtering behavior

### Impact

- No public API changes
- Improves correctness of rollback operations by preventing metadata table from receiving deletes for non-existent files
- Minor performance impact due to additional file existence checks, but this ensures data consistency

### Risk Level

low - The change adds a defensive check that filters out invalid rollback requests. Existing tests validate the behavior.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable