### PR TITLE
feat(metadata-table): Add count validation for record index bootstrap

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -624,14 +624,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .withDocumentation("when set to true, it fails the job on metadata table's "
           + "table services operation failure");
 
-  public static final ConfigProperty<Boolean> RECORD_INDEX_BOOTSTRAP_VALIDATION_ENABLE = ConfigProperty
-      .key(METADATA_PREFIX + ".record.index.bootstrap.validation.enable")
+  public static final ConfigProperty<Boolean> RECORD_INDEX_INITIALIZATION_VALIDATION_ENABLE = ConfigProperty
+      .key(METADATA_PREFIX + ".record.index.enable.validation.on.initialization")
       .defaultValue(false)
       .markAdvanced()
       .sinceVersion("1.1.0")
-      .withDocumentation("Enable validation of record index after bootstrap by comparing the expected record count "
+      .withDocumentation("Enable validation of record index after initialization by comparing the expected record count "
           + "with the actual record count stored in the metadata table. This validation runs in a distributed manner "
-          + "using the compute engine. Disabled by default as it adds overhead to the bootstrap process.");
+          + "using the compute engine. Disabled by default as it adds overhead to the initialization process.");
 
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
@@ -777,8 +777,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getInt(RECORD_INDEX_MAX_PARALLELISM);
   }
 
-  public boolean isRecordIndexBootstrapValidationEnabled() {
-    return getBooleanOrDefault(RECORD_INDEX_BOOTSTRAP_VALIDATION_ENABLE);
+  public boolean isRecordIndexInitializationValidationEnabled() {
+    return getBooleanOrDefault(RECORD_INDEX_INITIALIZATION_VALIDATION_ENABLE);
   }
 
   public boolean shouldAutoInitialize() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -624,6 +624,15 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .withDocumentation("when set to true, it fails the job on metadata table's "
           + "table services operation failure");
 
+  public static final ConfigProperty<Boolean> RECORD_INDEX_BOOTSTRAP_VALIDATION_ENABLE = ConfigProperty
+      .key(METADATA_PREFIX + ".record.index.bootstrap.validation.enable")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Enable validation of record index after bootstrap by comparing the expected record count "
+          + "with the actual record count stored in the metadata table. This validation runs in a distributed manner "
+          + "using the compute engine. Disabled by default as it adds overhead to the bootstrap process.");
+
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
@@ -766,6 +775,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public int getRecordIndexMaxParallelism() {
     return getInt(RECORD_INDEX_MAX_PARALLELISM);
+  }
+
+  public boolean isRecordIndexBootstrapValidationEnabled() {
+    return getBooleanOrDefault(RECORD_INDEX_BOOTSTRAP_VALIDATION_ENABLE);
   }
 
   public boolean shouldAutoInitialize() {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -717,33 +717,6 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     return isMetadataTableInitialized;
   }
 
-  /**
-   * Gets the total number of records in the base file of the given file slice.
-   *
-   * @param partitionName the partition name (e.g., record_index)
-   * @param fileSlice the file slice containing the base file
-   * @return the total number of records in the base file
-   */
-  public long getTotalRecordIndexRecords(String partitionName, FileSlice fileSlice) {
-    if (!fileSlice.getBaseFile().isPresent()) {
-      return 0L;
-    }
-    try {
-      HoodieConfig readerConfig = new HoodieConfig();
-      HoodieAvroFileReader reader = (HoodieAvroFileReader) HoodieIOFactory.getIOFactory(getStorage())
-          .getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
-          .getFileReader(readerConfig, fileSlice.getBaseFile().get().getStoragePath(),
-              metadataMetaClient.getTableConfig().getBaseFileFormat(), Option.empty());
-      try {
-        return reader.getTotalRecords();
-      } finally {
-        reader.close();
-      }
-    } catch (IOException e) {
-      throw new HoodieIOException("Error reading total records from file slice " + fileSlice.getFileId(), e);
-    }
-  }
-
   public HoodieTableFileSystemView getMetadataFileSystemView() {
     if (metadataFileSystemView == null) {
       metadataFileSystemView = getFileSystemViewForMetadataTable(metadataMetaClient);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -717,6 +717,33 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     return isMetadataTableInitialized;
   }
 
+  /**
+   * Gets the total number of records in the base file of the given file slice.
+   *
+   * @param partitionName the partition name (e.g., record_index)
+   * @param fileSlice the file slice containing the base file
+   * @return the total number of records in the base file
+   */
+  public long getTotalRecordIndexRecords(String partitionName, FileSlice fileSlice) {
+    if (!fileSlice.getBaseFile().isPresent()) {
+      return 0L;
+    }
+    try {
+      HoodieConfig readerConfig = new HoodieConfig();
+      HoodieAvroFileReader reader = (HoodieAvroFileReader) HoodieIOFactory.getIOFactory(getStorage())
+          .getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
+          .getFileReader(readerConfig, fileSlice.getBaseFile().get().getStoragePath(),
+              metadataMetaClient.getTableConfig().getBaseFileFormat(), Option.empty());
+      try {
+        return reader.getTotalRecords();
+      } finally {
+        reader.close();
+      }
+    } catch (IOException e) {
+      throw new HoodieIOException("Error reading total records from file slice " + fileSlice.getFileId(), e);
+    }
+  }
+
   public HoodieTableFileSystemView getMetadataFileSystemView() {
     if (metadataFileSystemView == null) {
       metadataFileSystemView = getFileSystemViewForMetadataTable(metadataMetaClient);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -2916,6 +2916,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     Properties props = new Properties();
     props.setProperty(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key(), "true");
     props.setProperty(HoodieIndexConfig.INDEX_TYPE.key(), "RECORD_INDEX");
+    // Enable validation of record index on initialization
+    props.setProperty(HoodieMetadataConfig.RECORD_INDEX_INITIALIZATION_VALIDATION_ENABLE.key(), "true");
     HoodieWriteConfig cfg = getWriteConfigBuilder(true, true, false)
         .withProps(props).build();
     // Initialize write client.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18028

When bootstrapping the record index, there is currently no validation to ensure that the expected number of records matches the actual number of records written to the metadata table. This can lead to silent data integrity issues.

### Summary and Changelog

This PR adds validation for record index bootstrap by comparing the expected record count with the actual record count stored in the metadata table.

**Changes:**
- Added `validateRecordIndex` method in `HoodieBackedTableMetadataWriter` to validate record counts after bootstrap completes
- Added `getTotalRecordIndexRecords` method in `HoodieBackedTableMetadata` to get total records from file slice base files
- Updated `initializeFilegroupsAndCommitToRecordIndexPartition` to call validation after commit when duplicates are not allowed (controlled by `hoodie.hfile.writes.allow.duplicates` config)
- Updated `initializeFilegroupsAndCommitToPartitionedRecordIndexPartition` to return file group count for validation

### Impact

- Improves data integrity for record index bootstrap
- Validation is enabled by default (when `hoodie.hfile.writes.allow.duplicates=false`)
- If validation fails, the bootstrap will throw an exception with details about the mismatch

### Risk Level

low - This adds validation logic that runs after the existing bootstrap completes. It does not change the bootstrap behavior itself, only adds a post-commit verification step.

### Documentation Update

none - No new configs are added. The validation uses the existing `hoodie.hfile.writes.allow.duplicates` config.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable