### PR TITLE
docs: rename cleaning related configurations

### DIFF
--- a/website/docs/cleaning.md
+++ b/website/docs/cleaning.md
@@ -23,7 +23,7 @@ For spark based:
 
 | Config Name                                        | Default                        | Description                                                                                                                 |
 |----------------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| hoodie.cleaner.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
+| hoodie.clean.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
 
 The corresponding config for Flink based engine is [`clean.policy`](https://hudi.apache.org/docs/configurations/#cleanpolicy).
 
@@ -35,19 +35,19 @@ Hudi cleaner currently supports the below cleaning policies to keep a certain nu
   retain atleast the last 10 commits. With such a configuration, we ensure that the oldest version of a file is kept on
   disk for at least 5 hours, thereby preventing the longest running query from failing at any point in time. Incremental
   cleaning is also possible using this policy.
-  Number of commits to retain can be configured by [`hoodie.cleaner.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
+  Number of commits to retain can be configured by [`hoodie.clean.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
   The corresponding Flink related config is [`clean.retain_commits`](https://hudi.apache.org/docs/configurations/#cleanretain_commits). 
 
 - **KEEP_LATEST_FILE_VERSIONS**: This policy has the effect of keeping N number of file versions irrespective of time.
   This policy is useful when it is known how many MAX versions of the file does one want to keep at any given time.
   To achieve the same behaviour as before of preventing long running queries from failing, one should do their calculations
   based on data patterns. Alternatively, this policy is also useful if a user just wants to maintain 1 latest version of the file.
-  Number of file versions to retain can be configured by [`hoodie.cleaner.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
+  Number of file versions to retain can be configured by [`hoodie.clean.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
   The corresponding Flink related config is [`clean.retain_file_versions`](https://hudi.apache.org/docs/configurations/#cleanretain_file_versions).
 
 - **KEEP_LATEST_BY_HOURS**: This policy clean up based on hours.It is simple and useful when knowing that you want to 
   keep files at any given time. Corresponding to commits with commit times older than the configured number of hours to 
-  be retained are cleaned. Currently you can configure by parameter [`hoodie.cleaner.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
+  be retained are cleaned. Currently you can configure by parameter [`hoodie.clean.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
   The corresponding Flink related config is [`clean.retain_hours`](https://hudi.apache.org/docs/configurations/#cleanretain_hours).
 
 ### Configs
@@ -64,7 +64,7 @@ to keep this enabled, to ensure metadata and data storage growth is bounded. To 
 | Config Name                      | Default          | Description                                                                                                                                                                                                                                                                            |
 |----------------------------------| -----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | hoodie.clean.automatic           | true (Optional)  | When enabled, the cleaner table service is invoked immediately after each commit, to delete older file slices. It's recommended to enable this, to ensure metadata and data storage growth is bounded.<br /><br />`Config Param: AUTO_CLEAN`                                           |
-| hoodie.cleaner.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
+| hoodie.clean.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
 
 
 #### Async
@@ -107,18 +107,18 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_COMMITS \
-  --hoodie-conf hoodie.cleaner.commits.retained=10 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_COMMITS \
+  --hoodie-conf hoodie.clean.commits.retained=10 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Keep the latest 3 file versions
 ```
 spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_FILE_VERSIONS \
-  --hoodie-conf hoodie.cleaner.fileversions.retained=3 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_FILE_VERSIONS \
+  --hoodie-conf hoodie.clean.fileversions.retained=3 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Clean commits older than 24 hours
 ```
@@ -126,11 +126,11 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_BY_HOURS \
-  --hoodie-conf hoodie.cleaner.hours.retained=24 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_BY_HOURS \
+  --hoodie-conf hoodie.clean.hours.retained=24 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
-Note: The parallelism takes the min value of number of partitions to clean and `hoodie.cleaner.parallelism`.
+Note: The parallelism takes the min value of number of partitions to clean and `hoodie.clean.parallelism`.
 
 #### CLI
 You can also use [Hudi CLI](cli.md) to run Hoodie Cleaner.
@@ -142,7 +142,7 @@ CLI provides the below commands for cleaner service:
 
 Example of cleaner keeping the latest 10 commits
 ```
-cleans run --sparkMaster local --hoodieConfigs hoodie.cleaner.policy=KEEP_LATEST_COMMITS hoodie.cleaner.commits.retained=10 hoodie.cleaner.parallelism=200
+cleans run --sparkMaster local --hoodieConfigs hoodie.clean.policy=KEEP_LATEST_COMMITS hoodie.clean.commits.retained=10 hoodie.clean.parallelism=200
 ```
 
 You can find more details and the relevant code for these commands in [`org.apache.hudi.cli.commands.CleansCommand`](https://github.com/apache/hudi/blob/master/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CleansCommand.java) class. 

--- a/website/versioned_docs/version-1.0.0/cleaning.md
+++ b/website/versioned_docs/version-1.0.0/cleaning.md
@@ -23,7 +23,7 @@ For spark based:
 
 | Config Name                                        | Default                        | Description                                                                                                                 |
 |----------------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| hoodie.cleaner.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
+| hoodie.clean.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
 
 The corresponding config for Flink based engine is [`clean.policy`](https://hudi.apache.org/docs/configurations/#cleanpolicy).
 
@@ -35,19 +35,19 @@ Hudi cleaner currently supports the below cleaning policies to keep a certain nu
   retain atleast the last 10 commits. With such a configuration, we ensure that the oldest version of a file is kept on
   disk for at least 5 hours, thereby preventing the longest running query from failing at any point in time. Incremental
   cleaning is also possible using this policy.
-  Number of commits to retain can be configured by [`hoodie.cleaner.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
+  Number of commits to retain can be configured by [`hoodie.clean.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
   The corresponding Flink related config is [`clean.retain_commits`](https://hudi.apache.org/docs/configurations/#cleanretain_commits). 
 
 - **KEEP_LATEST_FILE_VERSIONS**: This policy has the effect of keeping N number of file versions irrespective of time.
   This policy is useful when it is known how many MAX versions of the file does one want to keep at any given time.
   To achieve the same behaviour as before of preventing long running queries from failing, one should do their calculations
   based on data patterns. Alternatively, this policy is also useful if a user just wants to maintain 1 latest version of the file.
-  Number of file versions to retain can be configured by [`hoodie.cleaner.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
+  Number of file versions to retain can be configured by [`hoodie.clean.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
   The corresponding Flink related config is [`clean.retain_file_versions`](https://hudi.apache.org/docs/configurations/#cleanretain_file_versions).
 
 - **KEEP_LATEST_BY_HOURS**: This policy clean up based on hours.It is simple and useful when knowing that you want to 
   keep files at any given time. Corresponding to commits with commit times older than the configured number of hours to 
-  be retained are cleaned. Currently you can configure by parameter [`hoodie.cleaner.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
+  be retained are cleaned. Currently you can configure by parameter [`hoodie.clean.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
   The corresponding Flink related config is [`clean.retain_hours`](https://hudi.apache.org/docs/configurations/#cleanretain_hours).
 
 ### Configs
@@ -64,7 +64,7 @@ to keep this enabled, to ensure metadata and data storage growth is bounded. To 
 | Config Name                      | Default          | Description                                                                                                                                                                                                                                                                            |
 |----------------------------------| -----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | hoodie.clean.automatic           | true (Optional)  | When enabled, the cleaner table service is invoked immediately after each commit, to delete older file slices. It's recommended to enable this, to ensure metadata and data storage growth is bounded.<br /><br />`Config Param: AUTO_CLEAN`                                           |
-| hoodie.cleaner.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
+| hoodie.clean.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
 
 
 #### Async
@@ -107,18 +107,18 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.0,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.0 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_COMMITS \
-  --hoodie-conf hoodie.cleaner.commits.retained=10 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_COMMITS \
+  --hoodie-conf hoodie.clean.commits.retained=10 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Keep the latest 3 file versions
 ```
 spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.0,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.0 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_FILE_VERSIONS \
-  --hoodie-conf hoodie.cleaner.fileversions.retained=3 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_FILE_VERSIONS \
+  --hoodie-conf hoodie.clean.fileversions.retained=3 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Clean commits older than 24 hours
 ```
@@ -126,11 +126,11 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.0,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.0 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_BY_HOURS \
-  --hoodie-conf hoodie.cleaner.hours.retained=24 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_BY_HOURS \
+  --hoodie-conf hoodie.clean.hours.retained=24 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
-Note: The parallelism takes the min value of number of partitions to clean and `hoodie.cleaner.parallelism`.
+Note: The parallelism takes the min value of number of partitions to clean and `hoodie.clean.parallelism`.
 
 #### CLI
 You can also use [Hudi CLI](cli.md) to run Hoodie Cleaner.
@@ -142,7 +142,7 @@ CLI provides the below commands for cleaner service:
 
 Example of cleaner keeping the latest 10 commits
 ```
-cleans run --sparkMaster local --hoodieConfigs hoodie.cleaner.policy=KEEP_LATEST_COMMITS hoodie.cleaner.commits.retained=3 hoodie.cleaner.parallelism=200
+cleans run --sparkMaster local --hoodieConfigs hoodie.clean.policy=KEEP_LATEST_COMMITS hoodie.clean.commits.retained=3 hoodie.clean.parallelism=200
 ```
 
 You can find more details and the relevant code for these commands in [`org.apache.hudi.cli.commands.CleansCommand`](https://github.com/apache/hudi/blob/master/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CleansCommand.java) class. 

--- a/website/versioned_docs/version-1.0.1/cleaning.md
+++ b/website/versioned_docs/version-1.0.1/cleaning.md
@@ -23,7 +23,7 @@ For spark based:
 
 | Config Name                                        | Default                        | Description                                                                                                                 |
 |----------------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| hoodie.cleaner.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
+| hoodie.clean.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
 
 The corresponding config for Flink based engine is [`clean.policy`](https://hudi.apache.org/docs/configurations/#cleanpolicy).
 
@@ -35,19 +35,19 @@ Hudi cleaner currently supports the below cleaning policies to keep a certain nu
   retain atleast the last 10 commits. With such a configuration, we ensure that the oldest version of a file is kept on
   disk for at least 5 hours, thereby preventing the longest running query from failing at any point in time. Incremental
   cleaning is also possible using this policy.
-  Number of commits to retain can be configured by [`hoodie.cleaner.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
+  Number of commits to retain can be configured by [`hoodie.clean.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
   The corresponding Flink related config is [`clean.retain_commits`](https://hudi.apache.org/docs/configurations/#cleanretain_commits). 
 
 - **KEEP_LATEST_FILE_VERSIONS**: This policy has the effect of keeping N number of file versions irrespective of time.
   This policy is useful when it is known how many MAX versions of the file does one want to keep at any given time.
   To achieve the same behaviour as before of preventing long running queries from failing, one should do their calculations
   based on data patterns. Alternatively, this policy is also useful if a user just wants to maintain 1 latest version of the file.
-  Number of file versions to retain can be configured by [`hoodie.cleaner.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
+  Number of file versions to retain can be configured by [`hoodie.clean.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
   The corresponding Flink related config is [`clean.retain_file_versions`](https://hudi.apache.org/docs/configurations/#cleanretain_file_versions).
 
 - **KEEP_LATEST_BY_HOURS**: This policy clean up based on hours.It is simple and useful when knowing that you want to 
   keep files at any given time. Corresponding to commits with commit times older than the configured number of hours to 
-  be retained are cleaned. Currently you can configure by parameter [`hoodie.cleaner.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
+  be retained are cleaned. Currently you can configure by parameter [`hoodie.clean.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
   The corresponding Flink related config is [`clean.retain_hours`](https://hudi.apache.org/docs/configurations/#cleanretain_hours).
 
 ### Configs
@@ -64,7 +64,7 @@ to keep this enabled, to ensure metadata and data storage growth is bounded. To 
 | Config Name                      | Default          | Description                                                                                                                                                                                                                                                                            |
 |----------------------------------| -----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | hoodie.clean.automatic           | true (Optional)  | When enabled, the cleaner table service is invoked immediately after each commit, to delete older file slices. It's recommended to enable this, to ensure metadata and data storage growth is bounded.<br /><br />`Config Param: AUTO_CLEAN`                                           |
-| hoodie.cleaner.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
+| hoodie.clean.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
 
 
 #### Async
@@ -107,18 +107,18 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.1,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.1 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_COMMITS \
-  --hoodie-conf hoodie.cleaner.commits.retained=10 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_COMMITS \
+  --hoodie-conf hoodie.clean.commits.retained=10 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Keep the latest 3 file versions
 ```
 spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.1,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.1 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_FILE_VERSIONS \
-  --hoodie-conf hoodie.cleaner.fileversions.retained=3 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_FILE_VERSIONS \
+  --hoodie-conf hoodie.clean.fileversions.retained=3 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Clean commits older than 24 hours
 ```
@@ -126,11 +126,11 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.1,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.1 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_BY_HOURS \
-  --hoodie-conf hoodie.cleaner.hours.retained=24 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_BY_HOURS \
+  --hoodie-conf hoodie.clean.hours.retained=24 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
-Note: The parallelism takes the min value of number of partitions to clean and `hoodie.cleaner.parallelism`.
+Note: The parallelism takes the min value of number of partitions to clean and `hoodie.clean.parallelism`.
 
 #### CLI
 You can also use [Hudi CLI](cli.md) to run Hoodie Cleaner.
@@ -142,7 +142,7 @@ CLI provides the below commands for cleaner service:
 
 Example of cleaner keeping the latest 10 commits
 ```
-cleans run --sparkMaster local --hoodieConfigs hoodie.cleaner.policy=KEEP_LATEST_COMMITS hoodie.cleaner.commits.retained=3 hoodie.cleaner.parallelism=200
+cleans run --sparkMaster local --hoodieConfigs hoodie.clean.policy=KEEP_LATEST_COMMITS hoodie.clean.commits.retained=3 hoodie.clean.parallelism=200
 ```
 
 You can find more details and the relevant code for these commands in [`org.apache.hudi.cli.commands.CleansCommand`](https://github.com/apache/hudi/blob/master/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CleansCommand.java) class. 

--- a/website/versioned_docs/version-1.0.2/cleaning.md
+++ b/website/versioned_docs/version-1.0.2/cleaning.md
@@ -23,7 +23,7 @@ For spark based:
 
 | Config Name                                        | Default                        | Description                                                                                                                 |
 |----------------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| hoodie.cleaner.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
+| hoodie.clean.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
 
 The corresponding config for Flink based engine is [`clean.policy`](https://hudi.apache.org/docs/configurations/#cleanpolicy).
 
@@ -35,19 +35,19 @@ Hudi cleaner currently supports the below cleaning policies to keep a certain nu
   retain atleast the last 10 commits. With such a configuration, we ensure that the oldest version of a file is kept on
   disk for at least 5 hours, thereby preventing the longest running query from failing at any point in time. Incremental
   cleaning is also possible using this policy.
-  Number of commits to retain can be configured by [`hoodie.cleaner.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
+  Number of commits to retain can be configured by [`hoodie.clean.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
   The corresponding Flink related config is [`clean.retain_commits`](https://hudi.apache.org/docs/configurations/#cleanretain_commits). 
 
 - **KEEP_LATEST_FILE_VERSIONS**: This policy has the effect of keeping N number of file versions irrespective of time.
   This policy is useful when it is known how many MAX versions of the file does one want to keep at any given time.
   To achieve the same behaviour as before of preventing long running queries from failing, one should do their calculations
   based on data patterns. Alternatively, this policy is also useful if a user just wants to maintain 1 latest version of the file.
-  Number of file versions to retain can be configured by [`hoodie.cleaner.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
+  Number of file versions to retain can be configured by [`hoodie.clean.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
   The corresponding Flink related config is [`clean.retain_file_versions`](https://hudi.apache.org/docs/configurations/#cleanretain_file_versions).
 
 - **KEEP_LATEST_BY_HOURS**: This policy clean up based on hours.It is simple and useful when knowing that you want to 
   keep files at any given time. Corresponding to commits with commit times older than the configured number of hours to 
-  be retained are cleaned. Currently you can configure by parameter [`hoodie.cleaner.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
+  be retained are cleaned. Currently you can configure by parameter [`hoodie.clean.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
   The corresponding Flink related config is [`clean.retain_hours`](https://hudi.apache.org/docs/configurations/#cleanretain_hours).
 
 ### Configs
@@ -64,7 +64,7 @@ to keep this enabled, to ensure metadata and data storage growth is bounded. To 
 | Config Name                      | Default          | Description                                                                                                                                                                                                                                                                            |
 |----------------------------------| -----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | hoodie.clean.automatic           | true (Optional)  | When enabled, the cleaner table service is invoked immediately after each commit, to delete older file slices. It's recommended to enable this, to ensure metadata and data storage growth is bounded.<br /><br />`Config Param: AUTO_CLEAN`                                           |
-| hoodie.cleaner.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
+| hoodie.clean.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
 
 
 #### Async
@@ -107,18 +107,18 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_COMMITS \
-  --hoodie-conf hoodie.cleaner.commits.retained=10 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_COMMITS \
+  --hoodie-conf hoodie.clean.commits.retained=10 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Keep the latest 3 file versions
 ```
 spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_FILE_VERSIONS \
-  --hoodie-conf hoodie.cleaner.fileversions.retained=3 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_FILE_VERSIONS \
+  --hoodie-conf hoodie.clean.fileversions.retained=3 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Clean commits older than 24 hours
 ```
@@ -126,11 +126,11 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_BY_HOURS \
-  --hoodie-conf hoodie.cleaner.hours.retained=24 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_BY_HOURS \
+  --hoodie-conf hoodie.clean.hours.retained=24 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
-Note: The parallelism takes the min value of number of partitions to clean and `hoodie.cleaner.parallelism`.
+Note: The parallelism takes the min value of number of partitions to clean and `hoodie.clean.parallelism`.
 
 #### CLI
 You can also use [Hudi CLI](cli.md) to run Hoodie Cleaner.
@@ -142,7 +142,7 @@ CLI provides the below commands for cleaner service:
 
 Example of cleaner keeping the latest 10 commits
 ```
-cleans run --sparkMaster local --hoodieConfigs hoodie.cleaner.policy=KEEP_LATEST_COMMITS hoodie.cleaner.commits.retained=10 hoodie.cleaner.parallelism=200
+cleans run --sparkMaster local --hoodieConfigs hoodie.clean.policy=KEEP_LATEST_COMMITS hoodie.clean.commits.retained=10 hoodie.clean.parallelism=200
 ```
 
 You can find more details and the relevant code for these commands in [`org.apache.hudi.cli.commands.CleansCommand`](https://github.com/apache/hudi/blob/master/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CleansCommand.java) class. 

--- a/website/versioned_docs/version-1.1.1/cleaning.md
+++ b/website/versioned_docs/version-1.1.1/cleaning.md
@@ -23,7 +23,7 @@ For spark based:
 
 | Config Name                                        | Default                        | Description                                                                                                                 |
 |----------------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| hoodie.cleaner.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
+| hoodie.clean.policy                              | KEEP_LATEST_COMMITS (Optional) | org.apache.hudi.common.model.HoodieCleaningPolicy: Cleaning policy to be used. <br /><br />`Config Param: CLEANER_POLICY`   |
 
 The corresponding config for Flink based engine is [`clean.policy`](https://hudi.apache.org/docs/configurations/#cleanpolicy).
 
@@ -35,19 +35,19 @@ Hudi cleaner currently supports the below cleaning policies to keep a certain nu
   retain atleast the last 10 commits. With such a configuration, we ensure that the oldest version of a file is kept on
   disk for at least 5 hours, thereby preventing the longest running query from failing at any point in time. Incremental
   cleaning is also possible using this policy.
-  Number of commits to retain can be configured by [`hoodie.cleaner.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
+  Number of commits to retain can be configured by [`hoodie.clean.commits.retained`](https://analytics.google.com/analytics/web/#/p300324801/reports/intelligenthome). 
   The corresponding Flink related config is [`clean.retain_commits`](https://hudi.apache.org/docs/configurations/#cleanretain_commits). 
 
 - **KEEP_LATEST_FILE_VERSIONS**: This policy has the effect of keeping N number of file versions irrespective of time.
   This policy is useful when it is known how many MAX versions of the file does one want to keep at any given time.
   To achieve the same behaviour as before of preventing long running queries from failing, one should do their calculations
   based on data patterns. Alternatively, this policy is also useful if a user just wants to maintain 1 latest version of the file.
-  Number of file versions to retain can be configured by [`hoodie.cleaner.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
+  Number of file versions to retain can be configured by [`hoodie.clean.fileversions.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerfileversionsretained).
   The corresponding Flink related config is [`clean.retain_file_versions`](https://hudi.apache.org/docs/configurations/#cleanretain_file_versions).
 
 - **KEEP_LATEST_BY_HOURS**: This policy clean up based on hours.It is simple and useful when knowing that you want to 
   keep files at any given time. Corresponding to commits with commit times older than the configured number of hours to 
-  be retained are cleaned. Currently you can configure by parameter [`hoodie.cleaner.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
+  be retained are cleaned. Currently you can configure by parameter [`hoodie.clean.hours.retained`](https://hudi.apache.org/docs/configurations/#hoodiecleanerhoursretained).
   The corresponding Flink related config is [`clean.retain_hours`](https://hudi.apache.org/docs/configurations/#cleanretain_hours).
 
 ### Configs
@@ -64,7 +64,7 @@ to keep this enabled, to ensure metadata and data storage growth is bounded. To 
 | Config Name                      | Default          | Description                                                                                                                                                                                                                                                                            |
 |----------------------------------| -----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | hoodie.clean.automatic           | true (Optional)  | When enabled, the cleaner table service is invoked immediately after each commit, to delete older file slices. It's recommended to enable this, to ensure metadata and data storage growth is bounded.<br /><br />`Config Param: AUTO_CLEAN`                                           |
-| hoodie.cleaner.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
+| hoodie.clean.commits.retained  | 10 (Optional)    | Number of commits to retain, without cleaning. This will be retained for num_of_commits * time_between_commits (scheduled). This also directly translates into how much data retention the table supports for incremental queries.<br /><br />`Config Param: CLEANER_COMMITS_RETAINED` |
 
 
 #### Async
@@ -107,18 +107,18 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_COMMITS \
-  --hoodie-conf hoodie.cleaner.commits.retained=10 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_COMMITS \
+  --hoodie-conf hoodie.clean.commits.retained=10 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Keep the latest 3 file versions
 ```
 spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_FILE_VERSIONS \
-  --hoodie-conf hoodie.cleaner.fileversions.retained=3 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_FILE_VERSIONS \
+  --hoodie-conf hoodie.clean.fileversions.retained=3 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
 Clean commits older than 24 hours
 ```
@@ -126,11 +126,11 @@ spark-submit --master local \
   --packages org.apache.hudi:hudi-utilities-slim-bundle_2.12:1.0.2,org.apache.hudi:hudi-spark3.5-bundle_2.12:1.0.2 \
   --class org.apache.hudi.utilities.HoodieCleaner `ls packaging/hudi-utilities-slim-bundle/target/hudi-utilities-slim-bundle-*.jar` \
   --target-base-path /path/to/hoodie_table \
-  --hoodie-conf hoodie.cleaner.policy=KEEP_LATEST_BY_HOURS \
-  --hoodie-conf hoodie.cleaner.hours.retained=24 \
-  --hoodie-conf hoodie.cleaner.parallelism=200
+  --hoodie-conf hoodie.clean.policy=KEEP_LATEST_BY_HOURS \
+  --hoodie-conf hoodie.clean.hours.retained=24 \
+  --hoodie-conf hoodie.clean.parallelism=200
 ```
-Note: The parallelism takes the min value of number of partitions to clean and `hoodie.cleaner.parallelism`.
+Note: The parallelism takes the min value of number of partitions to clean and `hoodie.clean.parallelism`.
 
 #### CLI
 You can also use [Hudi CLI](cli.md) to run Hoodie Cleaner.
@@ -142,7 +142,7 @@ CLI provides the below commands for cleaner service:
 
 Example of cleaner keeping the latest 10 commits
 ```
-cleans run --sparkMaster local --hoodieConfigs hoodie.cleaner.policy=KEEP_LATEST_COMMITS hoodie.cleaner.commits.retained=10 hoodie.cleaner.parallelism=200
+cleans run --sparkMaster local --hoodieConfigs hoodie.clean.policy=KEEP_LATEST_COMMITS hoodie.clean.commits.retained=10 hoodie.clean.parallelism=200
 ```
 
 You can find more details and the relevant code for these commands in [`org.apache.hudi.cli.commands.CleansCommand`](https://github.com/apache/hudi/blob/master/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CleansCommand.java) class. 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR updates the documentation for Hudi Cleaner configurations to reflect the naming changes in the 1.x release. Specifically, starting from Hudi 1.x, the configuration prefix hoodie.cleaner.* has been renamed to hoodie.clean.* to align with the new Functional Data Lake architecture.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

Updated the Hudi website documentation to reflect the renaming of Cleaner configuration keys. This ensures users moving to Hudi 1.x use the correct configuration prefixes for automated data cleanup and archival services.

* Updated all instances of hoodie.cleaner to hoodie.clean in the configuration tables.

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

This is a user-facing documentation change. It clarifies the configuration parameters for Hudi 1.x, reducing confusion for users who might attempt to use the legacy hoodie.cleaner prefix in the newer version.

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
Low
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

This PR is explicitly a documentation update for the Hudi website. It ensures that the "Configurations" page is accurate for the 1.x release. No new configurations were added; only existing ones were renamed.

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
