### PR TITLE
feat: support watermark emitter from split info

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordEmitter.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordEmitter.java
@@ -18,19 +18,78 @@
 
 package org.apache.hudi.source.reader;
 
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 
 /**
  * Default Hoodie record emitter.
- * @param <T>
+ *
+ * <p>This emitter handles watermark emission based on split information.
+ *
+ * @param <T> The type of records to emit
  */
 public class HoodieRecordEmitter<T> implements RecordEmitter<HoodieRecordWithPosition<T>, T, HoodieSourceSplit> {
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieRecordEmitter.class);
+  private HoodieSourceSplit lastSplit = null;
+  private long watermark = Long.MIN_VALUE;
 
   @Override
   public void emitRecord(HoodieRecordWithPosition<T> record, SourceOutput<T> output, HoodieSourceSplit split) throws Exception {
+    if (lastSplit == null || !split.splitId().equals(lastSplit.splitId())) {
+      long newWatermark = extractWatermark(split);
+      if (newWatermark < watermark) {
+        LOG.warn(
+            "Received a new split with lower watermark. Previous watermark = {}, current watermark = {}, previous split = {}, current split = {}",
+            watermark,
+            newWatermark,
+            lastSplit,
+            split);
+      } else {
+        // emit the watermark of previous finished split
+        if (watermark != Long.MIN_VALUE) {
+          output.emitWatermark(new Watermark(watermark));
+          LOG.debug("Watermark = {} emitted based on split = {}", watermark, split);
+        }
+        watermark = newWatermark;
+      }
+
+      lastSplit = split;
+    }
+
     output.collect(record.record());
     split.updatePosition(record.fileOffset(), record.recordOffset());
+  }
+
+  private long extractWatermark(HoodieSourceSplit split) {
+    long maxInstantTime = Long.MIN_VALUE;
+
+    if (split.getBasePath().isPresent()) {
+      String basePath = split.getBasePath().get();
+      try {
+        long baseCommitTime = Long.parseLong(FSUtils.getCommitTime(basePath));
+        maxInstantTime = Math.max(baseCommitTime, maxInstantTime);
+      } catch (NumberFormatException e) {
+        LOG.warn("Failed to parse commit time from basePath: {}", basePath, e);
+      }
+    }
+
+    if (split.getLogPaths().isPresent()) {
+      for (String logPath : split.getLogPaths().get()) {
+        try {
+          long logCommitTime = Long.parseLong(FSUtils.getCommitTime(logPath));
+          maxInstantTime = Math.max(logCommitTime, maxInstantTime);
+        } catch (NumberFormatException e) {
+          LOG.warn("Failed to parse commit time from logPath: {}", logPath, e);
+        }
+      }
+    }
+
+    return maxInstantTime;
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
 
support watermark emitter from split info

closes #14424

### Summary and Changelog

1. add the watermark emit by looking up the base file path in HoodieRecordEmitter
2. add test coverage to test logic change

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
