### PR TITLE
feat(spark): Add guardrail to prevent writes when Spark speculative execution is enabled

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -779,6 +779,18 @@ public class HoodieWriteConfig extends HoodieConfig {
       .withDocumentation("When table is upgraded from pre 0.12 to 0.12, we check for \"default\" partition and fail if found one. "
           + "Users are expected to rewrite the data in those partitions. Enabling this config will bypass this validation");
 
+  /**
+   * Config that determines whether to block writes when Spark speculative execution is enabled.
+   */
+  public static final ConfigProperty<Boolean> BLOCK_WRITES_ON_SPECULATIVE_EXECUTION = ConfigProperty
+      .key("hoodie.block.writes.on.speculative.execution")
+      .defaultValue(true)
+      .sinceVersion("0.14.0")
+      .withDocumentation("When enabled (default), throws an exception if Spark speculative execution is enabled "
+          + "during the client creation. This prevents potential data corruption "
+          + "due to duplicate writes by speculative executors. Set to false only if you understand the risks "
+          + "of running with Spark speculative execution enabled.");
+
   public static final ConfigProperty<String> EARLY_CONFLICT_DETECTION_STRATEGY_CLASS_NAME = ConfigProperty
       .key(CONCURRENCY_PREFIX + "early.conflict.detection.strategy")
       .noDefaultValue()
@@ -2735,6 +2747,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(SKIP_DEFAULT_PARTITION_VALIDATION);
   }
 
+  public boolean shouldBlockWritesOnSpeculativeExecution() {
+    return getBoolean(BLOCK_WRITES_ON_SPECULATIVE_EXECUTION);
+  }
+
   /**
    * Are any table services configured to run inline for both scheduling and execution?
    *
@@ -3442,6 +3458,11 @@ public class HoodieWriteConfig extends HoodieConfig {
 
     public Builder doSkipDefaultPartitionValidation(boolean skipDefaultPartitionValidation) {
       writeConfig.setValue(SKIP_DEFAULT_PARTITION_VALIDATION, String.valueOf(skipDefaultPartitionValidation));
+      return this;
+    }
+
+    public Builder withBlockWritesOnSpeculativeExecution(boolean blockWritesOnSpeculativeExecution) {
+      writeConfig.setValue(BLOCK_WRITES_ON_SPECULATIVE_EXECUTION, String.valueOf(blockWritesOnSpeculativeExecution));
       return this;
     }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/SparkRDDWriteClient.java
@@ -57,6 +57,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
@@ -81,6 +82,7 @@ public class SparkRDDWriteClient<T> extends
                              Option<EmbeddedTimelineService> timelineService) {
     super(context, writeConfig, timelineService, SparkUpgradeDowngradeHelper.getInstance());
     this.tableServiceClient = new SparkRDDTableServiceClient<T>(context, writeConfig, getTimelineServer());
+    checkSpeculativeExecution();
   }
 
   @Override
@@ -420,6 +422,27 @@ public class SparkRDDWriteClient<T> extends
   public void releaseResources(String instantTime) {
     super.releaseResources(instantTime);
     SparkReleaseResources.releaseCachedData(context, config, basePath, instantTime);
+  }
+
+  /**
+   * Check if Spark speculative execution is enabled and block writes if the guardrail is enabled.
+   * Speculative execution can lead to duplicate writes and data corruption.
+   */
+  private void checkSpeculativeExecution() {
+    if (config.shouldBlockWritesOnSpeculativeExecution() && context != null) {
+      // Get Spark context from the HoodieSparkEngineContext
+      SparkContext sparkContext = ((HoodieSparkEngineContext) context).getJavaSparkContext().sc();
+      boolean speculationEnabled = sparkContext.conf().getBoolean("spark.speculation", false);
+
+      if (speculationEnabled) {
+        String errorMsg = "Spark speculative execution is enabled (spark.speculation=true). "
+            + "This can lead to duplicate writes and data corruption. "
+            + "Disable spark.speculation to fix this issue, or set hoodie.block.writes.on.speculative.execution=false "
+            + "to bypass this guardrail at your own risk.";
+        LOG.error(errorMsg);
+        throw new HoodieException(errorMsg);
+      }
+    }
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/callback/TestHoodieClientInitCallback.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/callback/TestHoodieClientInitCallback.java
@@ -30,6 +30,9 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.execution.bulkinsert.NonSortPartitionerWithRows;
 import org.apache.hudi.storage.StorageConfiguration;
 
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -69,6 +72,17 @@ public class TestHoodieClientInitCallback {
 
   @BeforeAll
   public static void setup() {
+    // Mock JavaSparkContext and SparkContext for speculative execution check
+    JavaSparkContext mockJavaSparkContext = Mockito.mock(JavaSparkContext.class);
+    SparkContext mockSparkContext = Mockito.mock(SparkContext.class);
+    SparkConf mockSparkConf = Mockito.mock(SparkConf.class);
+
+    // Setup the mock chain
+    when(engineContext.getJavaSparkContext()).thenReturn(mockJavaSparkContext);
+    when(mockJavaSparkContext.sc()).thenReturn(mockSparkContext);
+    when(mockSparkContext.conf()).thenReturn(mockSparkConf);
+    when(mockSparkConf.getBoolean("spark.speculation", false)).thenReturn(false);
+
     StorageConfiguration storageConfToReturn = getDefaultStorageConf();
     when(engineContext.getStorageConf()).thenReturn(storageConfToReturn);
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
@@ -55,6 +56,7 @@ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.getCommit
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
@@ -69,6 +71,16 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
         Arguments.of(HoodieTableType.COPY_ON_WRITE, false, false),
         Arguments.of(HoodieTableType.MERGE_ON_READ, false, true),
         Arguments.of(HoodieTableType.MERGE_ON_READ, false, false)
+    );
+  }
+
+  static Stream<Arguments> testSpeculativeExecutionGuardrail() {
+    return Stream.of(
+        // blockOnSpeculativeExecution, speculationEnabled
+        Arguments.of(true, true),    // Guardrail enabled (default), speculation enabled -> should throw
+        Arguments.of(true, false),   // Guardrail enabled (default), speculation disabled -> should not throw
+        Arguments.of(false, true),   // Guardrail disabled, speculation enabled -> should not throw
+        Arguments.of(false, false)   // Guardrail disabled, speculation disabled -> should not throw
     );
   }
 
@@ -266,5 +278,37 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
         org.mockito.Mockito.verify(spyMetaClient, org.mockito.Mockito.atLeastOnce()).reloadTableConfig();
       }
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource("testSpeculativeExecutionGuardrail")
+  public void testSpeculativeExecutionGuardrail(boolean blockOnSpeculativeExecution, boolean speculationEnabled) throws IOException {
+    // Set spark.speculation based on the test parameter
+    jsc().sc().conf().set("spark.speculation", String.valueOf(speculationEnabled));
+
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(storageConf(), URI.create(basePath()).getPath(), new Properties());
+    HoodieWriteConfig writeConfig = getConfigBuilder(true)
+        .withPath(metaClient.getBasePath().toString())
+        .withBlockWritesOnSpeculativeExecution(blockOnSpeculativeExecution)
+        .build();
+
+    if (blockOnSpeculativeExecution && speculationEnabled) {
+      // When speculative execution is enabled and the guardrail is enabled,
+      // creating a SparkRDDWriteClient should throw an exception
+      HoodieException exception = assertThrows(HoodieException.class, () -> {
+        new SparkRDDWriteClient(context(), writeConfig);
+      });
+
+      // Verify the exception message
+      assertTrue(exception.getMessage().contains("Spark speculative execution is enabled"));
+      assertTrue(exception.getMessage().contains("can lead to duplicate writes and data corruption"));
+    } else {
+      // In all other cases, creating a SparkRDDWriteClient should not throw an exception
+      SparkRDDWriteClient writeClient = new SparkRDDWriteClient(context(), writeConfig);
+      writeClient.close();
+    }
+
+    // Reset speculation config after test
+    jsc().sc().conf().set("spark.speculation", "false");
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18044

When Spark speculative execution is enabled (`spark.speculation=true`), it can lead to data corruption and duplicate records in Hudi tables. This happens because speculative execution launches duplicate task attempts, which can result in multiple write attempts to the same file slices, broken/partial parquet files, and duplicate records.

This is also related to issue #9615, which reports broken parquet files after compaction with speculative execution enabled.

### Summary and Changelog

Adds a configuration-controlled guardrail that prevents `SparkRDDWriteClient` creation when Spark speculative execution is detected:

- Added new config `hoodie.block.writes.on.speculative.execution` (default: `true`) in `HoodieWriteConfig`
- Added `checkSpeculativeExecution()` method in `SparkRDDWriteClient` that is called during client initialization
- Throws `HoodieException` with a clear error message if speculative execution is enabled and the guardrail is active
- Added comprehensive tests for the guardrail behavior

### Impact

- **New Config**: `hoodie.block.writes.on.speculative.execution` - When enabled (default), throws an exception if Spark speculative execution is enabled during client creation. Users who understand the risks can set this to `false` to bypass the guardrail.
- **User-facing Change**: Users with `spark.speculation=true` will now get a clear error message instead of potential data corruption.

### Risk Level

low - This is an additive change that provides a safety guardrail. The default behavior (blocking writes with speculative execution) is intentionally conservative to prevent data corruption. Users who need speculative execution can explicitly opt-out.

### Documentation Update

The config description is self-documenting. The new configuration property includes detailed documentation explaining:
- What the guardrail does
- Why speculative execution is problematic for Hudi
- How to bypass it if needed

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable