### PR TITLE
[MINOR] Add database name to the metadata table config

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -939,7 +939,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   }
 
   private HoodieTableMetaClient initializeMetaClient() throws IOException {
-    HoodieTableMetaClient.newTableBuilder()
+    HoodieTableMetaClient.TableBuilder builder = HoodieTableMetaClient.newTableBuilder()
         .setTableType(HoodieTableType.MERGE_ON_READ)
         .setTableName(dataWriteConfig.getTableName() + METADATA_TABLE_NAME_SUFFIX)
         // MT version should match DT, such that same readers can read both.
@@ -949,8 +949,16 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         .setBaseFileFormat(HoodieFileFormat.HFILE.toString())
         .setRecordKeyFields(RECORD_KEY_FIELD_NAME)
         .setPopulateMetaFields(DEFAULT_METADATA_POPULATE_META_FIELDS)
-        .setKeyGeneratorClassProp(HoodieTableMetadataKeyGenerator.class.getCanonicalName())
-        .initTable(storageConf.newInstance(), metadataWriteConfig.getBasePath());
+        .setKeyGeneratorClassProp(HoodieTableMetadataKeyGenerator.class.getCanonicalName());
+
+    // Get the database name from dataTable config
+    String databaseName = dataMetaClient.getTableConfig().getDatabaseName();
+
+    if (!StringUtils.isNullOrEmpty(databaseName)) {
+      builder.setDatabaseName(databaseName);
+    }
+
+    builder.initTable(storageConf.newInstance(), metadataWriteConfig.getBasePath());
 
     // reconcile the meta client with time generator config.
     return HoodieTableMetaClient.builder()


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

- This PR is adding the `hoodie.database.name` to the metadata table if main table writer config has been configured with db name.

### Summary and Changelog

- Modified the `HoodieBackedTableMetadataWriter` class to keep the database name in the metadata properties if it is present actual data table properties.
- While initializing the metadata client using `initializeMetaClient()` method, we will look into actual table config if this property is being present and adding it to metadata table config if it's present.

### Impact

- Able to keep the table naming format synced across both data table and metadata table.

### Risk Level

- none

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->
- none
### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
