### PR TITLE
feat: introduce the raw active timeline to provide all instants

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineFactory.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.table.timeline;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.stream.Stream;
 
 public abstract class TimelineFactory implements Serializable {
@@ -42,4 +43,6 @@ public abstract class TimelineFactory implements Serializable {
   public abstract HoodieActiveTimeline createActiveTimeline(HoodieTableMetaClient metaClient, boolean applyLayoutFilter);
 
   public abstract CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient);
+
+  public abstract HoodieActiveTimeline createActiveTimeline(HoodieTableMetaClient metaClient, List<HoodieInstant> instants);
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -56,6 +56,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -89,6 +90,12 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
     this.metaClient = metaClient;
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
+    LOG.debug("Loaded instants upto : " + lastInstant());
+  }
+
+  public ActiveTimelineV1(HoodieTableMetaClient metaClient, List<HoodieInstant> instants) {
+    this.setInstants(instants);
+    this.metaClient = metaClient;
     LOG.debug("Loaded instants upto : " + lastInstant());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/TimelineV1Factory.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 public class TimelineV1Factory extends TimelineFactory {
@@ -82,5 +83,10 @@ public class TimelineV1Factory extends TimelineFactory {
   @Override
   public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient) {
     return new CompletionTimeQueryViewV1(metaClient);
+  }
+
+  @Override
+  public HoodieActiveTimeline createActiveTimeline(HoodieTableMetaClient metaClient, List<HoodieInstant> instants) {
+    return new ActiveTimelineV1(metaClient, instants);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -95,6 +96,12 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
     this.metaClient = metaClient;
     // multiple casts will make this lambda serializable -
     // http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.16
+    LOG.debug("Loaded instants upto : {}", lastInstant());
+  }
+
+  public ActiveTimelineV2(HoodieTableMetaClient metaClient, List<HoodieInstant> instants) {
+    this.setInstants(instants);
+    this.metaClient = metaClient;
     LOG.debug("Loaded instants upto : {}", lastInstant());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/TimelineV2Factory.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 public class TimelineV2Factory extends TimelineFactory {
@@ -82,5 +83,10 @@ public class TimelineV2Factory extends TimelineFactory {
   @Override
   public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient) {
     return new CompletionTimeQueryViewV2(metaClient);
+  }
+
+  @Override
+  public HoodieActiveTimeline createActiveTimeline(HoodieTableMetaClient metaClient, List<HoodieInstant> instants) {
+    return new ActiveTimelineV2(metaClient, instants);
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/tableformat/TestActiveTimeline.java
+++ b/hudi-common/src/test/java/org/apache/hudi/tableformat/TestActiveTimeline.java
@@ -47,6 +47,11 @@ public class TestActiveTimeline extends ActiveTimelineV2 {
     this.metaClient = metaClient;
   }
 
+  public TestActiveTimeline(HoodieTableMetaClient metaClient, List<HoodieInstant> instants) {
+    this.setInstants(instants);
+    this.metaClient = metaClient;
+  }
+
   public TestActiveTimeline(HoodieTableMetaClient metaClient) {
     this(metaClient, Collections.unmodifiableSet(VALID_EXTENSIONS_IN_ACTIVE_TIMELINE), true);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/tableformat/TestTimelineFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/tableformat/TestTimelineFactory.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.table.timeline.versioning.v2.ArchivedTimelineV2;
 import org.apache.hudi.common.table.timeline.versioning.v2.BaseTimelineV2;
 import org.apache.hudi.common.table.timeline.versioning.v2.CompletionTimeQueryViewV2;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -87,5 +88,10 @@ public class TestTimelineFactory extends TimelineFactory {
   @Override
   public CompletionTimeQueryView createCompletionTimeQueryView(HoodieTableMetaClient metaClient) {
     return new CompletionTimeQueryViewV2(metaClient);
+  }
+
+  @Override
+  public HoodieActiveTimeline createActiveTimeline(HoodieTableMetaClient metaClient, List<HoodieInstant> instants) {
+    return new TestActiveTimeline(metaClient, instants);
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.io.util.FileIOUtils;
@@ -377,5 +378,32 @@ class TestHoodieTableMetaClient extends HoodieCommonTestHarness {
         throw new RuntimeException(e);
       }
     }, "Should throw HoodieIOException for invalid JSON");
+  }
+
+  @Test
+  void testGetRawActiveTimeline() {
+    // With V2 layout
+    HoodieTableMetaClient freshMetaClient = HoodieTableMetaClient.builder()
+            .setConf(metaClient.getStorageConf())
+            .setBasePath(basePath)
+            .setLayoutVersion(Option.of(TimelineLayoutVersion.LAYOUT_VERSION_2))
+            .setLoadActiveTimelineOnLoad(false)
+            .build();
+
+    HoodieActiveTimeline activeTimeline = freshMetaClient.getActiveTimeline();
+
+    assertNotNull(activeTimeline);
+    assertNotNull(freshMetaClient.getRawActiveTimeline());
+
+    // Load while initialization of client itself
+    freshMetaClient = HoodieTableMetaClient.builder()
+            .setConf(metaClient.getStorageConf())
+            .setBasePath(basePath)
+            .setLayoutVersion(Option.of(TimelineLayoutVersion.LAYOUT_VERSION_2))
+            .setLoadActiveTimelineOnLoad(true)
+            .build();
+
+    assertNotNull(freshMetaClient.getActiveTimeline());
+    assertNotNull(freshMetaClient.getRawActiveTimeline());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
This PR introduces a new member variable which helps us to cache the timeline by keeping whole instants.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

- Introducing `rawActiveTimeline` which will store all the instants in the current timeline.
- Keeping the existing `activeTimeline` and loading both with single scan over all instants in the .hoodie folder
- This will be useful when someone working on retrieving all the hoodie instants instead of scanning again and again. 


### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

- No impact as it will keep two timelines with the single scan over timeline filesystem

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
- none

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->
- none

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
