### PR TITLE
feat(schema): Add variant shredding configs

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -83,6 +83,9 @@ import scala.Enumeration;
 import scala.Function1;
 
 import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_FIELD_ID_WRITE_ENABLED;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_ALLOW_READING_SHREDDED;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_WRITE_SHREDDING_ENABLED;
 import static org.apache.hudi.config.HoodieWriteConfig.ALLOW_OPERATION_METADATA_FIELD;
 import static org.apache.hudi.config.HoodieWriteConfig.AVRO_SCHEMA_STRING;
 import static org.apache.hudi.config.HoodieWriteConfig.INTERNAL_SCHEMA_STRING;
@@ -115,6 +118,8 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   private static final String MAP_REPEATED_NAME = "key_value";
   private static final String MAP_KEY_NAME = "key";
   private static final String MAP_VALUE_NAME = "value";
+  private static final String SPARK_VARIANT_WRITE_SHREDDING_ENABLED = "spark.sql.variant.writeShredding.enabled";
+  private static final String SPARK_VARIANT_ALLOW_READING_SHREDDED = "spark.sql.variant.allowReadingShredded";
 
   @Getter
   private final Configuration hadoopConf;
@@ -133,6 +138,8 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
    * For non-shredded cases, this is identical to structType.
    */
   private final StructType shreddedSchema;
+  private final boolean variantWriteShreddingEnabled;
+  private final String variantForceShreddingSchemaForTest;
   private RecordConsumer recordConsumer;
 
   public HoodieRowParquetWriteSupport(Configuration conf, StructType structType, Option<BloomFilter> bloomFilterOpt, HoodieConfig config) {
@@ -141,6 +148,16 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     hadoopConf.set("spark.sql.parquet.writeLegacyFormat", writeLegacyFormatEnabled);
     hadoopConf.set("spark.sql.parquet.outputTimestampType", config.getStringOrDefault(HoodieStorageConfig.PARQUET_OUTPUT_TIMESTAMP_TYPE));
     hadoopConf.set("spark.sql.parquet.fieldId.write.enabled", config.getStringOrDefault(PARQUET_FIELD_ID_WRITE_ENABLED));
+
+    // Variant shredding configs
+    this.variantWriteShreddingEnabled = config.getBooleanOrDefault(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED);
+    this.variantForceShreddingSchemaForTest = config.getString(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST);
+    hadoopConf.setBoolean(SPARK_VARIANT_WRITE_SHREDDING_ENABLED, variantWriteShreddingEnabled);
+    hadoopConf.setBoolean(SPARK_VARIANT_ALLOW_READING_SHREDDED, config.getBooleanOrDefault(PARQUET_VARIANT_ALLOW_READING_SHREDDED));
+    if (variantForceShreddingSchemaForTest != null && !variantForceShreddingSchemaForTest.isEmpty()) {
+      hadoopConf.set("spark.sql.variant.forceShreddingSchemaForTest", variantForceShreddingSchemaForTest);
+    }
+
     this.writeLegacyListFormat = Boolean.parseBoolean(writeLegacyFormatEnabled)
         || Boolean.parseBoolean(config.getStringOrDefault(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, "false"));
     this.structType = structType;
@@ -164,15 +181,34 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   /**
    * Generates a shredded schema from the given structType and hoodieSchema.
    * <p>
-   * For Variant fields that are configured for shredding (based on HoodieSchema.Variant.isShredded()),
-   * the VariantType is replaced with a shredded struct schema. This method recursively processes
-   * nested struct fields to handle Variant fields at any depth.
+   * For Variant fields that are configured for shredding (based on HoodieSchema.Variant.isShredded()), the VariantType is replaced with a shredded struct schema.
+   * <p>
+   * Shredding behavior is controlled by:
+   * <ul>
+   *   <li>{@code hoodie.parquet.variant.write.shredding.enabled} - Master switch for shredding (default: true).
+   *       When false, no shredding happens regardless of schema configuration.</li>
+   *   <li>{@code hoodie.parquet.variant.force.shredding.schema.for.test} - When set, forces this DDL schema
+   *       as the typed_value schema for ALL variant columns, overriding schema-driven shredding.</li>
+   * </ul>
+   *
+   * This method recursively processes nested struct fields to handle Variant fields at any depth.
    *
    * @param structType The original Spark StructType
    * @param hoodieSchema The HoodieSchema containing shredding information
    * @return A StructType with shredded Variant fields replaced by their shredded schemas
    */
   private StructType generateShreddedSchema(StructType structType, HoodieSchema hoodieSchema) {
+    // If write shredding is disabled, skip shredding entirely
+    if (!variantWriteShreddingEnabled) {
+      return structType;
+    }
+
+    // Parse forced shredding schema if configured
+    StructType forcedShreddingSchema = null;
+    if (variantForceShreddingSchemaForTest != null && !variantForceShreddingSchemaForTest.isEmpty()) {
+      forcedShreddingSchema = StructType.fromDDL(variantForceShreddingSchemaForTest);
+    }
+
     StructField[] fields = structType.fields();
     StructField[] shreddedFields = new StructField[fields.length];
     boolean hasShredding = false;
@@ -180,6 +216,16 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     for (int i = 0; i < fields.length; i++) {
       StructField field = fields[i];
       DataType dataType = field.dataType();
+
+      // If a forced shredding schema is configured, use it for all variant columns
+      if (forcedShreddingSchema != null
+          && SparkAdapterSupport$.MODULE$.sparkAdapter().isVariantType(dataType)) {
+        StructType markedShreddedStruct = SparkAdapterSupport$.MODULE$.sparkAdapter()
+            .generateVariantWriteShreddingSchema(forcedShreddingSchema, true, false);
+        shreddedFields[i] = new StructField(field.name(), markedShreddedStruct, field.nullable(), field.metadata());
+        hasShredding = true;
+        continue;
+      }
 
       // Get the HoodieSchema for this field (if available)
       // Use getNonNullType() to unwrap nullable unions (e.g., ["null", "string"] -> "string")
@@ -189,7 +235,6 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
           .map(HoodieSchemaField::schema)
           .orElse(null);
 
-      // Check if this is a Variant field that should be shredded
       if (SparkAdapterSupport$.MODULE$.sparkAdapter().isVariantType(dataType)) {
         if (fieldHoodieSchema != null && fieldHoodieSchema.getType() == HoodieSchemaType.VARIANT) {
           HoodieSchema.Variant variantSchema = (HoodieSchema.Variant) fieldHoodieSchema;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -174,6 +174,36 @@ public class HoodieStorageConfig extends HoodieConfig {
       .withDocumentation("Control whether to write bloom filter or not. Default true. "
           + "We can set to false in non bloom index cases for CPU resource saving.");
 
+  public static final ConfigProperty<Boolean> PARQUET_VARIANT_WRITE_SHREDDING_ENABLED = ConfigProperty
+      .key("hoodie.parquet.variant.write.shredding.enabled")
+      .defaultValue(true)
+      .sinceVersion("1.1.0")
+      .withDocumentation("Controls whether variant columns are written in shredded format. "
+          + "When enabled (default), variant columns with shredding information in the schema will be written "
+          + "in shredded format with typed_value columns. When disabled, variant columns are always written "
+          + "in unshredded format regardless of the schema. "
+          + "Equivalent to Spark's spark.sql.variant.writeShredding.enabled.");
+
+  public static final ConfigProperty<String> PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST = ConfigProperty
+      .key("hoodie.parquet.variant.force.shredding.schema.for.test")
+      .noDefaultValue()
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Forces a specific shredding schema for all variant columns, intended for testing. "
+          + "The value should be a DDL-format schema string (e.g., 'a int, b string, c decimal(15, 1)'). "
+          + "When set and write shredding is enabled, this schema overrides the schema-driven shredding "
+          + "configuration for all variant columns. "
+          + "Equivalent to Spark's spark.sql.variant.forceShreddingSchemaForTest.");
+
+  public static final ConfigProperty<Boolean> PARQUET_VARIANT_ALLOW_READING_SHREDDED = ConfigProperty
+      .key("hoodie.parquet.variant.allow.reading.shredded")
+      .defaultValue(true)
+      .sinceVersion("1.1.0")
+      .withDocumentation("Controls whether shredded variant data can be read. "
+          + "When enabled (default), the reader will reconstruct variant values from shredded components. "
+          + "When disabled, only unshredded variant data can be read. "
+          + "Equivalent to Spark's spark.sql.variant.allowReadingShredded.");
+
   public static final ConfigProperty<Boolean> WRITE_UTC_TIMEZONE = ConfigProperty
       .key("hoodie.parquet.write.utc-timezone.enabled")
       .defaultValue(true)
@@ -495,6 +525,21 @@ public class HoodieStorageConfig extends HoodieConfig {
 
     public Builder parquetBloomFilterEnable(boolean parquetBloomFilterEnable) {
       storageConfig.setValue(PARQUET_WITH_BLOOM_FILTER_ENABLED, String.valueOf(parquetBloomFilterEnable));
+      return this;
+    }
+
+    public Builder parquetVariantWriteShreddingEnabled(boolean enabled) {
+      storageConfig.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED, String.valueOf(enabled));
+      return this;
+    }
+
+    public Builder parquetVariantForceShreddingSchemaForTest(String schemaString) {
+      storageConfig.setValue(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST, schemaString);
+      return this;
+    }
+
+    public Builder parquetVariantAllowReadingShredded(boolean allowed) {
+      storageConfig.setValue(PARQUET_VARIANT_ALLOW_READING_SHREDDED, String.valueOf(allowed));
       return this;
     }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes: [#18037](https://github.com/apache/hudi/issues/18037)

This PR implements the configuration plumbing required to support **Shredded Variant** types in the **Spark Record (HoodieRow)** write path.

While Hudi supports both Avro-based and Spark Row-based writing, proper support for Spark 4.0 `Variant` shredding requires configuring the underlying Parquet writer correctly. This PR ensures that user-facing Hudi configurations for shredding are correctly propagated to the Hadoop configuration used by `HoodieRowParquetWriteSupport` and that the schema is correctly marked for shredding during Spark Row writes.

### Summary and Changelog

This PR introduces new configuration properties to `HoodieStorageConfig` and wires them into `HoodieRowParquetWriteSupport`. It ensures that when users enable shredding (or force a specific shredding schema for testing), these preferences are respected during the Spark Row-based write process.

**Key Changes:**

1.  **Configuration (`HoodieStorageConfig`)**:
    * Added `hoodie.parquet.variant.write.shredding.enabled` (default: `true`): Master switch to enable/disable writing shredded variants.
    * Added `hoodie.parquet.variant.force.shredding.schema.for.test`: Advanced config to force a specific DDL schema for shredding (overriding the natural schema), primarily for testing purposes.
    * Added `hoodie.parquet.variant.allow.reading.shredded` (default: `true`): Controls whether the reader is allowed to reconstruct shredded variants.

2.  **Write Support (`HoodieRowParquetWriteSupport`)**:
    * **Config Propagation**: In the constructor, the Hudi configurations listed above are read and set into the `hadoopConf` using the corresponding internal Spark keys (e.g., `spark.sql.variant.writeShredding.enabled`).
    * **Schema Transformation**: Updated `generateShreddedSchema` to:
        * Respect the "write shredding enabled" flag (returns the original schema if disabled).
        * Handle the "forced shredding schema" logic: if set, it calls `generateVariantWriteShreddingSchema` on the Spark adapter to apply the forced schema to all variant fields.
        * Handle standard schema-driven shredding: Checks the `HoodieSchema` for `isShredded()` metadata and correctly maps the fields.

### Impact

* **Feature Parity:** Brings the Spark Row write path in parity with the Avro write path regarding Variant shredding support.
* **User Control:** Gives users explicit control over whether to write shredded variants and how to handle reading them via Hudi-native configurations.
* **Performance:** Enables the performance benefits of shredded variants (column pruning, compression) for users employing the Bulk Insert / Row writing path in Spark.

### Risk Level

**Low**

* **Config Controlled:** The changes are guarded by feature flags. The default behavior (shredding enabled) aligns with Spark 4.0 defaults, but can be disabled via config.
* **Isolation:** Changes are localized to the Parquet write support initialization and schema generation logic.

### Documentation Update

* [ ] The new configurations in `HoodieStorageConfig` need to be documented:
    * `hoodie.parquet.variant.write.shredding.enabled`
    * `hoodie.parquet.variant.allow.reading.shredded`
    * `hoodie.parquet.variant.force.shredding.schema.for.test` (Advanced)

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable