### PR TITLE
perf: Bloom filter improvements for memory usage (address feedback)

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomFilterProbingFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieMetadataBloomFilterProbingFunction.java
@@ -39,11 +39,11 @@ import org.apache.spark.broadcast.Broadcast;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import scala.Tuple2;
@@ -140,7 +140,7 @@ public class HoodieMetadataBloomFilterProbingFunction implements
             }
             final BloomFilter fileBloomFilter = fileToBloomFilterMap.get(partitionPathFileNamePair);
 
-            Set<String> candidateRecordKeys = new HashSet<>();
+            Set<String> candidateRecordKeys = new TreeSet<>();
             hoodieKeyList.forEach(hoodieKey -> {
               if (fileBloomFilter.mightContain(hoodieKey.getRecordKey())) {
                 candidateRecordKeys.add(hoodieKey.getRecordKey());

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -135,7 +135,8 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
     try (HFileReader reader = readerFactory.createHFileReader()) {
       reader.seekTo();
       // candidateRowKeys must be sorted
-      return new TreeSet<>(candidateRowKeys).stream()
+      return (candidateRowKeys instanceof TreeSet ? candidateRowKeys : new TreeSet<>(candidateRowKeys))
+          .stream()
           .filter(k -> {
             try {
               return reader.seekTo(new UTF8StringKey(k)) == HFileReader.SEEK_TO_FOUND;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
Addresses feedback added to https://github.com/apache/hudi/pull/18015 and adds small optimization no HFile lookups

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
- Simplify the HoodieFileProbingFunction.java‎ and make more of the evaluation lazy
- Check if input keyset is already sorted for HFile lookups.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Improves memory usage during index lookup

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
