### PR TITLE
feat:  Adding Presto to Hudi Notebooks

### DIFF
--- a/hudi-notebooks/Dockerfile.presto
+++ b/hudi-notebooks/Dockerfile.presto
@@ -1,0 +1,20 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG PRESTO_VERSION=${PRESTO_VERSION:-0.296}
+
+FROM prestodb/presto:${PRESTO_VERSION}
+COPY conf/presto/catalog/ $PRESTO_HOME/etc/catalog/

--- a/hudi-notebooks/build.sh
+++ b/hudi-notebooks/build.sh
@@ -24,6 +24,8 @@ export HIVE_VERSION=3.1.3
 export HIVE_VERSION_TAG=${HIVE_VERSION}
 export TRINO_VERSION=477
 export TRINO_VERSION_TAG=${TRINO_VERSION}
+export PRESTO_VERSION=0.296
+export PRESTO_VERSION_TAG=${PRESTO_VERSION}
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
@@ -53,3 +55,11 @@ docker build \
     -t apachehudi/trino:latest \
     -t apachehudi/trino:"$TRINO_VERSION_TAG" \
     -f "$SCRIPT_DIR"/Dockerfile.trino .
+
+echo "Building Presto Docker image using Presto version: $PRESTO_VERSION"
+
+docker build \
+    --build-arg PRESTO_VERSION="$PRESTO_VERSION" \
+    -t apachehudi/presto:latest \
+    -t apachehudi/presto:"$PRESTO_VERSION_TAG" \
+    -f "$SCRIPT_DIR"/Dockerfile.presto .

--- a/hudi-notebooks/conf/presto/catalog/hive.properties
+++ b/hudi-notebooks/conf/presto/catalog/hive.properties
@@ -1,0 +1,23 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+
+connector.name=hive-hadoop2
+hive.metastore.uri=thrift://hive-metastore:9083
+hive.s3.aws-access-key=admin
+hive.s3.aws-secret-key=password
+hive.s3.endpoint=http://minio:9000
+hive.s3.path-style-access=true
+hive.s3.ssl.enabled=false

--- a/hudi-notebooks/conf/presto/catalog/hudi.properties
+++ b/hudi-notebooks/conf/presto/catalog/hudi.properties
@@ -1,0 +1,24 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+
+connector.name=hudi
+hive.metastore.uri=thrift://hive-metastore:9083
+# S3 / MinIO configuration
+hive.s3.aws-access-key=admin
+hive.s3.aws-secret-key=password
+hive.s3.endpoint=http://minio:9000
+hive.s3.path-style-access=true
+hive.s3.ssl.enabled=false

--- a/hudi-notebooks/docker-compose.yml
+++ b/hudi-notebooks/docker-compose.yml
@@ -101,6 +101,17 @@ services:
     networks:
       - hudi-datalake
 
+  presto:
+    image: apachehudi/presto:latest
+    container_name: presto
+    depends_on:
+      - hive-metastore
+      - minio
+    ports:
+      - "8086:8080"   # Trino Web UI
+    networks:
+      - hudi-datalake
+
 networks:
   hudi-datalake:
     name: hudi-datalake


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The existing Hudi notebooks demo supports querying data using engines like Spark/Trino, but Presto is not included. This makes it difficult to demonstrate or validate Hudi tables using Presto, which is still widely used in many environments.

This PR adds Presto support to the existing Hudi notebooks demo to ensure feature parity across query engines and to help users validate Hudi bootstrap and table behaviors using Presto.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

**Summary**

This change adds Presto integration to the existing Hudi notebooks demo, enabling users to query Hudi tables directly from Presto and compare behavior with other engines.

**Changelog**

* Added Presto-related configuration and setup steps to existing Hudi demo notebooks
* Updated queries/examples to include Presto compatibility
* Ensured Hudi table metadata and data access work correctly with Presto

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

* User-facing impact: Users can now run demo queries against Hudi tables using Presto.
* API impact: None
* Performance impact: None expected (demo-only changes)
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
Low

This PR is limited to demo notebooks and configuration changes only.
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update
None
<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable