### PR TITLE
feat: support flink split distribution strategy

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/DefaultHoodieSplitAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/DefaultHoodieSplitAssigner.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+/**
+ * Default implementation of {@link HoodieSplitAssigner} that assigns Hoodie
+ * source splits to task IDs by hashing the file ID.
+ */
+public class DefaultHoodieSplitAssigner implements HoodieSplitAssigner {
+  private final int parallelism;
+  private final int maxParallelism;
+
+  /**
+   * Creates a new DefaultHoodieSplitAssigner.
+   *
+   * @param parallelism the number of parallel tasks (must be positive)
+   * @throws IllegalArgumentException if parallelism is less than or equal to 0
+   */
+  public DefaultHoodieSplitAssigner(int parallelism) {
+    if (parallelism <= 0) {
+      throw new IllegalArgumentException("Parallelism must be positive, but was: " + parallelism);
+    }
+    this.parallelism = parallelism;
+    this.maxParallelism = KeyGroupRangeAssignment.computeDefaultMaxParallelism(parallelism);
+  }
+
+  @Override
+  public int assign(HoodieSourceSplit split) {
+    return KeyGroupRangeAssignment.assignKeyToParallelOperator(split.getFileId(), maxParallelism, parallelism);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/HoodieSplitAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/HoodieSplitAssigner.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+/**
+ * Interface for assigning {@link HoodieSourceSplit} instances to task IDs.
+ */
+public interface HoodieSplitAssigner {
+
+  /**
+   * Assigns a split to a specific task ID.
+   *
+   * @param split the split to assign
+   * @return the task ID that should process this split
+   */
+  int assign(HoodieSourceSplit split);
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/HoodieSplitAssigners.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/HoodieSplitAssigners.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.hudi.configuration.OptionsResolver;
+
+/**
+ * Factory class for creating {@link HoodieSplitAssigner}.
+ */
+public class HoodieSplitAssigners {
+
+  public static HoodieSplitAssigner createHoodieSplitAssigner(
+          Configuration config,
+          int parallelism) {
+
+    if (OptionsResolver.isMorWithBucketIndexUpsert(config)) {
+      return new HoodieSplitBucketAssigner(parallelism);
+    } else if (OptionsResolver.isAppendMode(config)) {
+      return new HoodieSplitNumberAssigner(parallelism);
+    }
+
+    return new DefaultHoodieSplitAssigner(parallelism);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/HoodieSplitBucketAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/HoodieSplitBucketAssigner.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.hudi.index.bucket.BucketIdentifier;
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+/**
+ * Implementation of {@link HoodieSplitAssigner} that assigns Hoodie
+ * source splits to task IDs using bucket index information for co-location.
+ */
+public class HoodieSplitBucketAssigner implements HoodieSplitAssigner {
+  private final int parallelism;
+
+  /**
+   * Creates a new HoodieSplitBucketAssigner.
+   *
+   * @param parallelism the number of parallel tasks (must be positive)
+   * @throws IllegalArgumentException if parallelism is less than or equal to 0
+   */
+  public HoodieSplitBucketAssigner(int parallelism) {
+    if (parallelism <= 0) {
+      throw new IllegalArgumentException("Parallelism must be positive, but was: " + parallelism);
+    }
+    this.parallelism = parallelism;
+  }
+
+  @Override
+  public int assign(HoodieSourceSplit split) {
+    int bucketId = BucketIdentifier.bucketIdFromFileId(split.getFileId());
+    return bucketId % parallelism;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/HoodieSplitNumberAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/assign/HoodieSplitNumberAssigner.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+/**
+ * Implementation of {@link HoodieSplitAssigner} that assigns Hoodie
+ * source splits to task IDs using round-robin distribution based on split number.
+ */
+public class HoodieSplitNumberAssigner implements HoodieSplitAssigner {
+  private final int parallelism;
+
+  /**
+   * Creates a new HoodieSplitNumberAssigner.
+   *
+   * @param parallelism the number of parallel tasks (must be positive)
+   * @throws IllegalArgumentException if parallelism is less than or equal to 0
+   */
+  public HoodieSplitNumberAssigner(int parallelism) {
+    if (parallelism <= 0) {
+      throw new IllegalArgumentException("Parallelism must be positive, but was: " + parallelism);
+    }
+    this.parallelism = parallelism;
+  }
+
+  @Override
+  public int assign(HoodieSourceSplit split) {
+    return split.getSplitNum() % parallelism;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/AbstractHoodieSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/AbstractHoodieSplitEnumerator.java
@@ -143,7 +143,7 @@ abstract class AbstractHoodieSplitEnumerator
 
       int awaitingSubtask = nextAwaiting.getKey();
       String hostname = nextAwaiting.getValue();
-      Option<HoodieSourceSplit> splitOption = splitProvider.getNext(hostname);
+      Option<HoodieSourceSplit> splitOption = splitProvider.getNext(awaitingSubtask, hostname);
       if (splitOption.isPresent()) {
         log.info("Assign split to subtask {}: {}", awaitingSubtask, splitOption.get());
         enumeratorContext.assignSplit(splitOption.get(), awaitingSubtask);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieContinuousSplitBatch.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieContinuousSplitBatch.java
@@ -57,7 +57,7 @@ public class HoodieContinuousSplitBatch {
   public static HoodieContinuousSplitBatch fromResult(IncrementalInputSplits.Result result) {
     List<HoodieSourceSplit> splits = result.getInputSplits().stream().map(split ->
         new HoodieSourceSplit(
-            HoodieSourceSplit.SPLIT_COUNTER.incrementAndGet(),
+            HoodieSourceSplit.SPLIT_ID_GEN.incrementAndGet(),
             split.getBasePath().orElse(null),
             split.getLogPaths(), split.getTablePath(),
             EMPTY_PARTITION_PATH, split.getMergeType(),

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplit.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplit.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @Getter
 public class HoodieSourceSplit implements SourceSplit, Serializable {
-  public static AtomicInteger SPLIT_COUNTER = new AtomicInteger(0);
+  public static AtomicInteger SPLIT_ID_GEN = new AtomicInteger(-1);
   private static final long serialVersionUID = 1L;
   private static final long NUM_NO_CONSUMPTION = 0L;
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSplitProvider.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSplitProvider.java
@@ -65,8 +65,12 @@ public interface HoodieSplitProvider extends Closeable {
    *
    * <p>If enumerator wasn't able to assign the split (e.g., reader disconnected), enumerator should
    * call {@link HoodieSplitProvider#onUnassignedSplits} to return the split.
+   *
+   * @param taskId the ID of the task requesting a split
+   * @param hostname the hostname of the reader requesting a split (can be null)
+   * @return an Optional containing the next split if available, or empty if no split is available
    */
-  Option<HoodieSourceSplit> getNext(@Nullable String hostname);
+  Option<HoodieSourceSplit> getNext(int taskId, @Nullable String hostname);
 
   /** Add new splits discovered by enumerator */
   void onDiscoveredSplits(Collection<HoodieSourceSplit> splits);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/assign/TestDefaultHoodieSplitAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/assign/TestDefaultHoodieSplitAssigner.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link DefaultHoodieSplitAssigner}.
+ */
+public class TestDefaultHoodieSplitAssigner {
+
+  @Test
+  public void testAssignWithSingleParallelism() {
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(1);
+
+    HoodieSourceSplit split1 = createTestSplit(0, "file1");
+    HoodieSourceSplit split2 = createTestSplit(1, "file2");
+    HoodieSourceSplit split3 = createTestSplit(2, "file3");
+
+    assertEquals(0, assigner.assign(split1), "All splits should be assigned to task 0");
+    assertEquals(0, assigner.assign(split2), "All splits should be assigned to task 0");
+    assertEquals(0, assigner.assign(split3), "All splits should be assigned to task 0");
+  }
+
+  @Test
+  public void testAssignWithMultipleParallelism() {
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(3);
+
+    // DefaultHoodieSplitAssigner uses KeyGroupRangeAssignment which uses hash-based assignment
+    // We test that it assigns consistently and all assignments are within range
+    HoodieSourceSplit split0 = createTestSplit(0, "file0");
+    HoodieSourceSplit split1 = createTestSplit(1, "file1");
+    HoodieSourceSplit split2 = createTestSplit(2, "file2");
+
+    // Verify assignments are within valid range [0, parallelism)
+    int task0 = assigner.assign(split0);
+    int task1 = assigner.assign(split1);
+    int task2 = assigner.assign(split2);
+
+    assertTrue(task0 >= 0 && task0 < 3, "Task ID should be in range [0, 3)");
+    assertTrue(task1 >= 0 && task1 < 3, "Task ID should be in range [0, 3)");
+    assertTrue(task2 >= 0 && task2 < 3, "Task ID should be in range [0, 3)");
+  }
+
+  @Test
+  public void testAssignBasedOnFileIdHash() {
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(5);
+
+    // Same file ID should always map to same task
+    HoodieSourceSplit split1a = createTestSplit(0, "sameFileId");
+    HoodieSourceSplit split1b = createTestSplit(1, "sameFileId");
+    HoodieSourceSplit split1c = createTestSplit(2, "sameFileId");
+
+    int taskId = assigner.assign(split1a);
+    assertEquals(taskId, assigner.assign(split1b), "Same file ID should map to same task");
+    assertEquals(taskId, assigner.assign(split1c), "Same file ID should map to same task");
+  }
+
+  @Test
+  public void testAssignWithDifferentFileIds() {
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(3);
+
+    // Different file IDs with same split number should potentially map to different tasks
+    HoodieSourceSplit split1 = createTestSplit(5, "fileA");
+    HoodieSourceSplit split2 = createTestSplit(5, "fileB");
+    HoodieSourceSplit split3 = createTestSplit(5, "fileC");
+
+    // Just verify all are within range - hash distribution may vary
+    int task1 = assigner.assign(split1);
+    int task2 = assigner.assign(split2);
+    int task3 = assigner.assign(split3);
+
+    assertTrue(task1 >= 0 && task1 < 3, "Task ID should be in range");
+    assertTrue(task2 >= 0 && task2 < 3, "Task ID should be in range");
+    assertTrue(task3 >= 0 && task3 < 3, "Task ID should be in range");
+  }
+
+  @Test
+  public void testAssignDistributionAcrossMultipleSplits() {
+    int parallelism = 4;
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(parallelism);
+
+    // Test that assignments are within valid range for many splits
+    int totalSplits = 100;
+
+    for (int i = 0; i < totalSplits; i++) {
+      HoodieSourceSplit split = createTestSplit(i, "file" + i);
+      int taskId = assigner.assign(split);
+
+      // Verify task ID is within valid range
+      assertTrue(taskId >= 0 && taskId < parallelism,
+          "Task ID " + taskId + " should be in range [0, " + parallelism + ")");
+    }
+  }
+
+  @Test
+  public void testAssignWithHighParallelism() {
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(100);
+
+    HoodieSourceSplit split0 = createTestSplit(0, "file0");
+    HoodieSourceSplit split50 = createTestSplit(50, "file50");
+    HoodieSourceSplit split99 = createTestSplit(99, "file99");
+
+    int task0 = assigner.assign(split0);
+    int task50 = assigner.assign(split50);
+    int task99 = assigner.assign(split99);
+
+    assertTrue(task0 >= 0 && task0 < 100, "Task ID should be in range [0, 100)");
+    assertTrue(task50 >= 0 && task50 < 100, "Task ID should be in range [0, 100)");
+    assertTrue(task99 >= 0 && task99 < 100, "Task ID should be in range [0, 100)");
+  }
+
+  @Test
+  public void testAssignSameSplitMultipleTimes() {
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(5);
+
+    HoodieSourceSplit split = createTestSplit(7, "file7");
+
+    // Assigning the same split multiple times should return the same task ID
+    int taskId = assigner.assign(split);
+    assertEquals(taskId, assigner.assign(split), "Same split should always return same task ID");
+    assertEquals(taskId, assigner.assign(split), "Same split should always return same task ID");
+  }
+
+  @Test
+  public void testConstructorWithZeroParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new DefaultHoodieSplitAssigner(0),
+        "Should throw exception for zero parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: 0", exception.getMessage());
+  }
+
+  @Test
+  public void testConstructorWithNegativeParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new DefaultHoodieSplitAssigner(-1),
+        "Should throw exception for negative parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: -1", exception.getMessage());
+  }
+
+  @Test
+  public void testConstructorWithNegativeLargeParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new DefaultHoodieSplitAssigner(-100),
+        "Should throw exception for large negative parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: -100", exception.getMessage());
+  }
+
+  @Test
+  public void testAssignmentConsistency() {
+    DefaultHoodieSplitAssigner assigner1 = new DefaultHoodieSplitAssigner(5);
+    DefaultHoodieSplitAssigner assigner2 = new DefaultHoodieSplitAssigner(5);
+
+    // Two assigners with same parallelism should assign splits identically
+    for (int i = 0; i < 20; i++) {
+      HoodieSourceSplit split = createTestSplit(i, "file" + i);
+      assertEquals(
+          assigner1.assign(split),
+          assigner2.assign(split),
+          "Different assigner instances should assign same split to same task"
+      );
+    }
+  }
+
+  @Test
+  public void testAssignmentCoLocation() {
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(5);
+
+    // Splits with same file ID should be co-located (assigned to same task)
+    // regardless of split number
+    HoodieSourceSplit split1 = createTestSplit(0, "commonFileId");
+    HoodieSourceSplit split2 = createTestSplit(10, "commonFileId");
+    HoodieSourceSplit split3 = createTestSplit(99, "commonFileId");
+
+    int task1 = assigner.assign(split1);
+    int task2 = assigner.assign(split2);
+    int task3 = assigner.assign(split3);
+
+    assertEquals(task1, task2, "Splits with same file ID should be co-located");
+    assertEquals(task1, task3, "Splits with same file ID should be co-located");
+  }
+
+  @Test
+  public void testKeyGroupRangeAssignment() {
+    // Test with a parallelism that is not a power of 2
+    // to ensure KeyGroupRangeAssignment works correctly
+    DefaultHoodieSplitAssigner assigner = new DefaultHoodieSplitAssigner(7);
+
+    int validAssignments = 0;
+    for (int i = 0; i < 50; i++) {
+      HoodieSourceSplit split = createTestSplit(i, "file_" + i);
+      int taskId = assigner.assign(split);
+      if (taskId >= 0 && taskId < 7) {
+        validAssignments++;
+      }
+    }
+
+    assertEquals(50, validAssignments, "All assignments should be within valid range");
+  }
+
+  private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
+    return new HoodieSourceSplit(
+        splitNum,
+        "basePath_" + splitNum,
+        Option.empty(),
+        "/table/path",
+        "/table/path/partition1",
+        "read_optimized",
+        "19700101000000000",
+        fileId
+    );
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/assign/TestHoodieSplitAssigners.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/assign/TestHoodieSplitAssigners.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.configuration.FlinkOptions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link HoodieSplitAssigners}.
+ */
+public class TestHoodieSplitAssigners {
+
+  @Test
+  public void testCreateDefaultAssigner() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+
+    int parallelism = 5;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof DefaultHoodieSplitAssigner,
+        "Should create DefaultHoodieSplitAssigner for standard COW upsert");
+  }
+
+  @Test
+  public void testCreateBucketAssignerForMorWithBucketIndex() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    config.setString(FlinkOptions.INDEX_TYPE.key(), "BUCKET");
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+    config.setString(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), "8");
+
+    int parallelism = 4;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof HoodieSplitBucketAssigner,
+        "Should create HoodieSplitBucketAssigner for MOR with bucket index upsert");
+  }
+
+  @Test
+  public void testCreateNumberAssignerForAppendMode() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
+    config.setString(FlinkOptions.OPERATION.key(), "insert");
+
+    int parallelism = 10;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof HoodieSplitNumberAssigner,
+        "Should create HoodieSplitNumberAssigner for append mode (insert operation)");
+  }
+
+  @Test
+  public void testCreateDefaultAssignerForCowWithBucketIndex() {
+    // COW with bucket index should still use DefaultAssigner (not BucketAssigner)
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
+    config.setString(FlinkOptions.INDEX_TYPE.key(), "BUCKET");
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+    config.setString(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), "8");
+
+    int parallelism = 4;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof DefaultHoodieSplitAssigner,
+        "Should create DefaultHoodieSplitAssigner for COW with bucket index (not MOR)");
+  }
+
+  @Test
+  public void testCreateDefaultAssignerForMorWithoutBucketIndex() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    config.setString(FlinkOptions.INDEX_TYPE.key(), "SIMPLE");
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+
+    int parallelism = 6;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof DefaultHoodieSplitAssigner,
+        "Should create DefaultHoodieSplitAssigner for MOR without bucket index");
+  }
+
+  @Test
+  public void testCreateAssignerWithDifferentParallelism() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+
+    // Test with various parallelism values
+    int[] parallelisms = {1, 5, 10, 50, 100};
+
+    for (int parallelism : parallelisms) {
+      HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+      assertNotNull(assigner, "Assigner should not be null for parallelism " + parallelism);
+      assertTrue(assigner instanceof DefaultHoodieSplitAssigner,
+          "Should create DefaultHoodieSplitAssigner for parallelism " + parallelism);
+    }
+  }
+
+  @Test
+  public void testFactoryReturnsConsistentAssignerType() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    config.setString(FlinkOptions.INDEX_TYPE.key(), "BUCKET");
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+    config.setString(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), "16");
+
+    int parallelism = 8;
+
+    // Create multiple assigners with same config
+    HoodieSplitAssigner assigner1 = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+    HoodieSplitAssigner assigner2 = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner1, "First assigner should not be null");
+    assertNotNull(assigner2, "Second assigner should not be null");
+    assertEquals(assigner1.getClass(), assigner2.getClass(),
+        "Same configuration should produce same assigner type");
+  }
+
+  @Test
+  public void testCreateAssignerForReadOptimizedQuery() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    config.setString(FlinkOptions.QUERY_TYPE.key(), "read_optimized");
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+
+    int parallelism = 4;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof DefaultHoodieSplitAssigner,
+        "Should create DefaultHoodieSplitAssigner for read optimized query");
+  }
+
+  @Test
+  public void testCreateAssignerForSnapshotQuery() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    config.setString(FlinkOptions.QUERY_TYPE.key(), "snapshot");
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+
+    int parallelism = 4;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof DefaultHoodieSplitAssigner,
+        "Should create DefaultHoodieSplitAssigner for snapshot query without bucket index");
+  }
+
+  @Test
+  public void testAppendModeWithMor() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    config.setString(FlinkOptions.OPERATION.key(), "insert");
+
+    int parallelism = 7;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof HoodieSplitNumberAssigner,
+        "Should create HoodieSplitNumberAssigner for MOR in append mode");
+  }
+
+  @Test
+  public void testBucketIndexWithUpsertDelete() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+    config.setString(FlinkOptions.INDEX_TYPE.key(), "BUCKET");
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+    config.setString(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), "32");
+
+    int parallelism = 16;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof HoodieSplitBucketAssigner,
+        "Should create HoodieSplitBucketAssigner for bucket index with upsert");
+  }
+
+  @Test
+  public void testGlobalIndexWithCow() {
+    Configuration config = new Configuration();
+    config.setString(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
+    config.setString(FlinkOptions.INDEX_TYPE.key(), "GLOBAL_SIMPLE");
+    config.setString(FlinkOptions.OPERATION.key(), "upsert");
+
+    int parallelism = 12;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null");
+    assertTrue(assigner instanceof DefaultHoodieSplitAssigner,
+        "Should create DefaultHoodieSplitAssigner for global index with COW");
+  }
+
+  @Test
+  public void testMinimalConfiguration() {
+    // Test with minimal configuration - should use defaults
+    Configuration config = new Configuration();
+
+    int parallelism = 3;
+    HoodieSplitAssigner assigner = HoodieSplitAssigners.createHoodieSplitAssigner(config, parallelism);
+
+    assertNotNull(assigner, "Assigner should not be null even with minimal config");
+    assertTrue(assigner instanceof DefaultHoodieSplitAssigner,
+        "Should create DefaultHoodieSplitAssigner for minimal configuration");
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/assign/TestHoodieSplitBucketAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/assign/TestHoodieSplitBucketAssigner.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test cases for {@link HoodieSplitBucketAssigner}.
+ */
+public class TestHoodieSplitBucketAssigner {
+
+  @Test
+  public void testAssignWithSingleParallelism() {
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(1);
+
+    HoodieSourceSplit split1 = createTestSplitWithBucket(0, 0);
+    HoodieSourceSplit split2 = createTestSplitWithBucket(1, 5);
+    HoodieSourceSplit split3 = createTestSplitWithBucket(2, 10);
+
+    assertEquals(0, assigner.assign(split1), "All splits should be assigned to task 0");
+    assertEquals(0, assigner.assign(split2), "All splits should be assigned to task 0");
+    assertEquals(0, assigner.assign(split3), "All splits should be assigned to task 0");
+  }
+
+  @Test
+  public void testAssignWithMultipleParallelism() {
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(3);
+
+    HoodieSourceSplit split0 = createTestSplitWithBucket(0, 0);
+    HoodieSourceSplit split1 = createTestSplitWithBucket(1, 1);
+    HoodieSourceSplit split2 = createTestSplitWithBucket(2, 2);
+    HoodieSourceSplit split3 = createTestSplitWithBucket(3, 3);
+    HoodieSourceSplit split4 = createTestSplitWithBucket(4, 4);
+    HoodieSourceSplit split5 = createTestSplitWithBucket(5, 5);
+
+    assertEquals(0, assigner.assign(split0), "Bucket 0 should be assigned to task 0");
+    assertEquals(1, assigner.assign(split1), "Bucket 1 should be assigned to task 1");
+    assertEquals(2, assigner.assign(split2), "Bucket 2 should be assigned to task 2");
+    assertEquals(0, assigner.assign(split3), "Bucket 3 should be assigned to task 0 (round-robin)");
+    assertEquals(1, assigner.assign(split4), "Bucket 4 should be assigned to task 1 (round-robin)");
+    assertEquals(2, assigner.assign(split5), "Bucket 5 should be assigned to task 2 (round-robin)");
+  }
+
+  @Test
+  public void testAssignBucketBasedCoLocation() {
+    int parallelism = 4;
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(parallelism);
+
+    // Splits with the same bucket ID should always be assigned to the same task
+    HoodieSourceSplit split1a = createTestSplitWithBucket(0, 5);
+    HoodieSourceSplit split1b = createTestSplitWithBucket(1, 5);
+    HoodieSourceSplit split1c = createTestSplitWithBucket(2, 5);
+
+    int taskId = assigner.assign(split1a);
+    assertEquals(taskId, assigner.assign(split1b),
+        "Splits with same bucket should be co-located on same task");
+    assertEquals(taskId, assigner.assign(split1c),
+        "Splits with same bucket should be co-located on same task");
+    assertEquals(1, taskId, "Bucket 5 % 4 = 1");
+  }
+
+  @Test
+  public void testAssignDifferentBucketsDistributed() {
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(5);
+
+    // Different buckets should be distributed across different tasks
+    HoodieSourceSplit split0 = createTestSplitWithBucket(0, 0);
+    HoodieSourceSplit split1 = createTestSplitWithBucket(1, 1);
+    HoodieSourceSplit split2 = createTestSplitWithBucket(2, 2);
+
+    assertNotEquals(assigner.assign(split0), assigner.assign(split1),
+        "Different buckets should typically be on different tasks");
+    assertNotEquals(assigner.assign(split1), assigner.assign(split2),
+        "Different buckets should typically be on different tasks");
+  }
+
+  @Test
+  public void testAssignWithHighParallelism() {
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(100);
+
+    HoodieSourceSplit split0 = createTestSplitWithBucket(0, 0);
+    HoodieSourceSplit split50 = createTestSplitWithBucket(1, 50);
+    HoodieSourceSplit split99 = createTestSplitWithBucket(2, 99);
+    HoodieSourceSplit split100 = createTestSplitWithBucket(3, 100);
+
+    assertEquals(0, assigner.assign(split0));
+    assertEquals(50, assigner.assign(split50));
+    assertEquals(99, assigner.assign(split99));
+    assertEquals(0, assigner.assign(split100), "Bucket 100 should wrap around to task 0");
+  }
+
+  @Test
+  public void testAssignSameBucketMultipleTimes() {
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(5);
+
+    HoodieSourceSplit split1 = createTestSplitWithBucket(0, 7);
+    HoodieSourceSplit split2 = createTestSplitWithBucket(1, 7);
+
+    // Assigning splits with the same bucket multiple times should return the same task ID
+    int taskId = assigner.assign(split1);
+    assertEquals(2, taskId, "Bucket 7 % 5 = 2");
+    assertEquals(taskId, assigner.assign(split2),
+        "Same bucket should always return same task ID");
+    assertEquals(taskId, assigner.assign(split1),
+        "Same bucket should always return same task ID");
+  }
+
+  @Test
+  public void testConstructorWithZeroParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new HoodieSplitBucketAssigner(0),
+        "Should throw exception for zero parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: 0", exception.getMessage());
+  }
+
+  @Test
+  public void testConstructorWithNegativeParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new HoodieSplitBucketAssigner(-1),
+        "Should throw exception for negative parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: -1", exception.getMessage());
+  }
+
+  @Test
+  public void testConstructorWithNegativeLargeParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new HoodieSplitBucketAssigner(-100),
+        "Should throw exception for large negative parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: -100", exception.getMessage());
+  }
+
+  @Test
+  public void testAssignmentConsistency() {
+    HoodieSplitBucketAssigner assigner1 = new HoodieSplitBucketAssigner(5);
+    HoodieSplitBucketAssigner assigner2 = new HoodieSplitBucketAssigner(5);
+
+    // Two assigners with same parallelism should assign splits identically
+    for (int i = 0; i < 20; i++) {
+      HoodieSourceSplit split = createTestSplitWithBucket(i, i);
+      assertEquals(
+          assigner1.assign(split),
+          assigner2.assign(split),
+          "Different assigner instances should assign same bucket to same task"
+      );
+    }
+  }
+
+  @Test
+  public void testBucketCoLocationAcrossMultipleSplits() {
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(8);
+
+    // Create multiple splits for the same bucket
+    int bucketId = 15;
+    HoodieSourceSplit[] splits = new HoodieSourceSplit[10];
+    for (int i = 0; i < 10; i++) {
+      splits[i] = createTestSplitWithBucket(i, bucketId);
+    }
+
+    // All splits with the same bucket should be assigned to the same task
+    int expectedTaskId = bucketId % 8;
+    for (HoodieSourceSplit split : splits) {
+      assertEquals(expectedTaskId, assigner.assign(split),
+          "All splits for bucket " + bucketId + " should be on task " + expectedTaskId);
+    }
+  }
+
+  @Test
+  public void testManyBucketsDistribution() {
+    int parallelism = 4;
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(parallelism);
+
+    // Test distribution of many buckets
+    int[] taskCounts = new int[parallelism];
+    int totalBuckets = 100;
+
+    for (int bucketId = 0; bucketId < totalBuckets; bucketId++) {
+      HoodieSourceSplit split = createTestSplitWithBucket(bucketId, bucketId);
+      int taskId = assigner.assign(split);
+      taskCounts[taskId]++;
+
+      // Verify task ID is within valid range
+      assertEquals(bucketId % parallelism, taskId,
+          "Bucket should be assigned using modulo operation");
+    }
+
+    // Verify even distribution
+    for (int count : taskCounts) {
+      assertEquals(totalBuckets / parallelism, count,
+          "Buckets should be evenly distributed");
+    }
+  }
+
+  @Test
+  public void testFileIdParsing() {
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(10);
+
+    // Test with various file ID formats that have bucket ID in first 8 characters
+    HoodieSourceSplit split1 = createTestSplit(0, "00000005-0000-0000-0000-000000000000");
+    HoodieSourceSplit split2 = createTestSplit(1, "00000012-1234-5678-abcd-ef0123456789");
+    HoodieSourceSplit split3 = createTestSplit(2, "00000099-aaaa-bbbb-cccc-dddddddddddd");
+
+    assertEquals(5, assigner.assign(split1), "Should extract bucket 5 from file ID");
+    assertEquals(2, assigner.assign(split2), "Should extract bucket 12 and assign to task 2 (12 % 10)");
+    assertEquals(9, assigner.assign(split3), "Should extract bucket 99 and assign to task 9 (99 % 10)");
+  }
+
+  @Test
+  public void testDifferentSplitNumbersSameBucket() {
+    HoodieSplitBucketAssigner assigner = new HoodieSplitBucketAssigner(5);
+
+    // Different split numbers but same bucket should go to same task
+    HoodieSourceSplit split1 = createTestSplitWithBucket(0, 8);
+    HoodieSourceSplit split2 = createTestSplitWithBucket(100, 8);
+    HoodieSourceSplit split3 = createTestSplitWithBucket(999, 8);
+
+    int taskId = assigner.assign(split1);
+    assertEquals(taskId, assigner.assign(split2),
+        "Split number should not affect bucket-based assignment");
+    assertEquals(taskId, assigner.assign(split3),
+        "Split number should not affect bucket-based assignment");
+    assertEquals(3, taskId, "Bucket 8 % 5 = 3");
+  }
+
+  @Test
+  public void testComparisonWithDefaultAssigner() {
+    int parallelism = 5;
+    HoodieSplitBucketAssigner bucketAssigner = new HoodieSplitBucketAssigner(parallelism);
+    HoodieSplitNumberAssigner defaultAssigner = new HoodieSplitNumberAssigner(parallelism);
+
+    // Create splits where bucket ID != split number
+    HoodieSourceSplit split1 = createTestSplitWithBucket(0, 3);
+    HoodieSourceSplit split2 = createTestSplitWithBucket(3, 0);
+
+    // Bucket assigner uses bucket ID from file ID
+    assertEquals(3, bucketAssigner.assign(split1), "Should use bucket 3");
+    assertEquals(0, bucketAssigner.assign(split2), "Should use bucket 0");
+
+    // Default assigner uses split number
+    assertEquals(0, defaultAssigner.assign(split1), "Should use split number 0");
+    assertEquals(3, defaultAssigner.assign(split2), "Should use split number 3");
+  }
+
+  /**
+   * Creates a test split with a specific bucket ID encoded in the file ID.
+   * File ID format: "{8-digit bucket ID}-{rest of UUID}"
+   */
+  private HoodieSourceSplit createTestSplitWithBucket(int splitNum, int bucketId) {
+    String fileId = String.format("%08d-0000-0000-0000-000000000000", bucketId);
+    return createTestSplit(splitNum, fileId);
+  }
+
+  private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
+    return new HoodieSourceSplit(
+        splitNum,
+        "basePath_" + splitNum,
+        Option.empty(),
+        "/table/path",
+        "/table/path/partition1",
+        "read_optimized",
+        "19700101000000000",
+        fileId
+    );
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/assign/TestHoodieSplitNumberAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/assign/TestHoodieSplitNumberAssigner.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.assign;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test cases for {@link HoodieSplitNumberAssigner}.
+ */
+public class TestHoodieSplitNumberAssigner {
+
+  @Test
+  public void testAssignWithSingleParallelism() {
+    HoodieSplitNumberAssigner assigner = new HoodieSplitNumberAssigner(1);
+
+    HoodieSourceSplit split1 = createTestSplit(0, "file1");
+    HoodieSourceSplit split2 = createTestSplit(1, "file2");
+    HoodieSourceSplit split3 = createTestSplit(2, "file3");
+
+    assertEquals(0, assigner.assign(split1), "All splits should be assigned to task 0");
+    assertEquals(0, assigner.assign(split2), "All splits should be assigned to task 0");
+    assertEquals(0, assigner.assign(split3), "All splits should be assigned to task 0");
+  }
+
+  @Test
+  public void testAssignWithMultipleParallelism() {
+    HoodieSplitNumberAssigner assigner = new HoodieSplitNumberAssigner(3);
+
+    HoodieSourceSplit split0 = createTestSplit(0, "file0");
+    HoodieSourceSplit split1 = createTestSplit(1, "file1");
+    HoodieSourceSplit split2 = createTestSplit(2, "file2");
+    HoodieSourceSplit split3 = createTestSplit(3, "file3");
+    HoodieSourceSplit split4 = createTestSplit(4, "file4");
+    HoodieSourceSplit split5 = createTestSplit(5, "file5");
+
+    assertEquals(0, assigner.assign(split0), "Split 0 should be assigned to task 0");
+    assertEquals(1, assigner.assign(split1), "Split 1 should be assigned to task 1");
+    assertEquals(2, assigner.assign(split2), "Split 2 should be assigned to task 2");
+    assertEquals(0, assigner.assign(split3), "Split 3 should be assigned to task 0 (round-robin)");
+    assertEquals(1, assigner.assign(split4), "Split 4 should be assigned to task 1 (round-robin)");
+    assertEquals(2, assigner.assign(split5), "Split 5 should be assigned to task 2 (round-robin)");
+  }
+
+  @Test
+  public void testAssignRoundRobinDistribution() {
+    int parallelism = 4;
+    HoodieSplitNumberAssigner assigner = new HoodieSplitNumberAssigner(parallelism);
+
+    // Test that splits are evenly distributed across all tasks
+    int[] taskCounts = new int[parallelism];
+    int totalSplits = 100;
+
+    for (int i = 0; i < totalSplits; i++) {
+      HoodieSourceSplit split = createTestSplit(i, "file" + i);
+      int taskId = assigner.assign(split);
+      taskCounts[taskId]++;
+
+      // Verify task ID is within valid range
+      assertEquals(i % parallelism, taskId, "Split should be assigned using modulo operation");
+    }
+
+    // Verify even distribution
+    for (int count : taskCounts) {
+      assertEquals(totalSplits / parallelism, count, "Splits should be evenly distributed");
+    }
+  }
+
+  @Test
+  public void testAssignWithHighParallelism() {
+    HoodieSplitNumberAssigner assigner = new HoodieSplitNumberAssigner(100);
+
+    HoodieSourceSplit split0 = createTestSplit(0, "file0");
+    HoodieSourceSplit split50 = createTestSplit(50, "file50");
+    HoodieSourceSplit split99 = createTestSplit(99, "file99");
+    HoodieSourceSplit split100 = createTestSplit(100, "file100");
+
+    assertEquals(0, assigner.assign(split0));
+    assertEquals(50, assigner.assign(split50));
+    assertEquals(99, assigner.assign(split99));
+    assertEquals(0, assigner.assign(split100), "Split 100 should wrap around to task 0");
+  }
+
+  @Test
+  public void testAssignSameSplitMultipleTimes() {
+    HoodieSplitNumberAssigner assigner = new HoodieSplitNumberAssigner(5);
+
+    HoodieSourceSplit split = createTestSplit(7, "file7");
+
+    // Assigning the same split multiple times should return the same task ID
+    int taskId = assigner.assign(split);
+    assertEquals(2, taskId, "Split 7 % 5 = 2");
+    assertEquals(taskId, assigner.assign(split), "Same split should always return same task ID");
+    assertEquals(taskId, assigner.assign(split), "Same split should always return same task ID");
+  }
+
+  @Test
+  public void testConstructorWithZeroParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new HoodieSplitNumberAssigner(0),
+        "Should throw exception for zero parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: 0", exception.getMessage());
+  }
+
+  @Test
+  public void testConstructorWithNegativeParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new HoodieSplitNumberAssigner(-1),
+        "Should throw exception for negative parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: -1", exception.getMessage());
+  }
+
+  @Test
+  public void testConstructorWithNegativeLargeParallelism() {
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new HoodieSplitNumberAssigner(-100),
+        "Should throw exception for large negative parallelism"
+    );
+    assertEquals("Parallelism must be positive, but was: -100", exception.getMessage());
+  }
+
+  @Test
+  public void testAssignmentConsistency() {
+    HoodieSplitNumberAssigner assigner1 = new HoodieSplitNumberAssigner(5);
+    HoodieSplitNumberAssigner assigner2 = new HoodieSplitNumberAssigner(5);
+
+    // Two assigners with same parallelism should assign splits identically
+    for (int i = 0; i < 20; i++) {
+      HoodieSourceSplit split = createTestSplit(i, "file" + i);
+      assertEquals(
+          assigner1.assign(split),
+          assigner2.assign(split),
+          "Different assigner instances should assign same split to same task"
+      );
+    }
+  }
+
+  @Test
+  public void testAssignWithDifferentFileIds() {
+    HoodieSplitNumberAssigner assigner = new HoodieSplitNumberAssigner(3);
+
+    // Different file IDs should not affect assignment (only split number matters)
+    HoodieSourceSplit split1 = createTestSplit(5, "fileA");
+    HoodieSourceSplit split2 = createTestSplit(5, "fileB");
+    HoodieSourceSplit split3 = createTestSplit(5, "fileC");
+
+    assertEquals(assigner.assign(split1), assigner.assign(split2),
+        "File ID should not affect assignment");
+    assertEquals(assigner.assign(split1), assigner.assign(split3),
+        "File ID should not affect assignment");
+  }
+
+  private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
+    return new HoodieSourceSplit(
+        splitNum,
+        "basePath_" + splitNum,
+        Option.empty(),
+        "/table/path",
+        "/table/path/partition1",
+        "read_optimized",
+        "19700101000000000",
+        fileId
+    );
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieContinuousSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieContinuousSplitEnumerator.java
@@ -21,6 +21,7 @@ package org.apache.hudi.source.enumerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.source.HoodieScanContext;
+import org.apache.hudi.source.assign.HoodieSplitNumberAssigner;
 import org.apache.hudi.source.split.DefaultHoodieSplitProvider;
 import org.apache.hudi.source.split.HoodieContinuousSplitBatch;
 import org.apache.hudi.source.split.HoodieContinuousSplitDiscover;
@@ -67,7 +68,7 @@ public class TestHoodieContinuousSplitEnumerator {
   @BeforeEach
   public void setUp() {
     context = new MockSplitEnumeratorContext();
-    splitProvider = new DefaultHoodieSplitProvider();
+    splitProvider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(1));
 
     Configuration conf = new Configuration();
     conf.set(FlinkOptions.PATH, "/tmp/test");
@@ -252,7 +253,7 @@ public class TestHoodieContinuousSplitEnumerator {
   private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
     return new HoodieSourceSplit(
         splitNum,
-        "basePath_" + splitNum,
+        "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0" + splitNum + "_20260126034717000.parquet",
         Option.empty(),
         "/table/path",
         "/table/path/partition1",

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieStaticSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieStaticSplitEnumerator.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.source.enumerator;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.source.assign.HoodieSplitNumberAssigner;
 import org.apache.hudi.source.split.DefaultHoodieSplitProvider;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 import org.apache.hudi.source.split.SplitRequestEvent;
@@ -59,7 +60,7 @@ public class TestHoodieStaticSplitEnumerator {
   @BeforeEach
   public void setUp() {
     context = new MockSplitEnumeratorContext();
-    splitProvider = new DefaultHoodieSplitProvider();
+    splitProvider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
     enumerator = new HoodieStaticSplitEnumerator(context, splitProvider);
 
     split1 = createTestSplit(1, "file1");
@@ -126,6 +127,9 @@ public class TestHoodieStaticSplitEnumerator {
 
     context.registerReader(new ReaderInfo(0, "localhost"));
     enumerator.handleSplitRequest(0, "localhost");
+
+    context.registerReader(new ReaderInfo(1, "localhost"));
+    enumerator.handleSplitRequest(1, "localhost");
 
     // Simulate reader failure - add splits back
     enumerator.addSplitsBack(Arrays.asList(split1), 0);
@@ -207,10 +211,10 @@ public class TestHoodieStaticSplitEnumerator {
     splitProvider.onDiscoveredSplits(Arrays.asList(split1));
     enumerator.start();
 
-    context.registerReader(new ReaderInfo(0, "localhost"));
+    context.registerReader(new ReaderInfo(1, "localhost"));
 
     SplitRequestEvent event = new SplitRequestEvent(Collections.emptyList(), "localhost");
-    enumerator.handleSourceEvent(0, 1, event);
+    enumerator.handleSourceEvent(1, 1, event);
 
     assertTrue(context.getAssignedSplits().size() > 0, "Should assign split via attempt-aware method");
   }
@@ -218,7 +222,7 @@ public class TestHoodieStaticSplitEnumerator {
   private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
     return new HoodieSourceSplit(
         splitNum,
-        "basePath_" + splitNum,
+        "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0" + splitNum + "_20260126034717000.parquet",
         Option.empty(),
         "/table/path",
         "/table/path/partition1",

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestDefaultHoodieSplitProvider.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestDefaultHoodieSplitProvider.java
@@ -20,6 +20,7 @@ package org.apache.hudi.source.split;
 
 import org.apache.hudi.common.util.Option;
 
+import org.apache.hudi.source.assign.HoodieSplitNumberAssigner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -45,7 +45,7 @@ public class TestDefaultHoodieSplitProvider {
 
   @BeforeEach
   public void setUp() {
-    provider = new DefaultHoodieSplitProvider();
+    provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
     split1 = createTestSplit(1, "file1");
     split2 = createTestSplit(2, "file2");
     split3 = createTestSplit(3, "file3");
@@ -53,7 +53,7 @@ public class TestDefaultHoodieSplitProvider {
 
   @Test
   public void testGetNextFromEmptyProvider() {
-    Option<HoodieSourceSplit> result = provider.getNext(null);
+    Option<HoodieSourceSplit> result = provider.getNext(1, null);
     assertFalse(result.isPresent(), "Should return empty option when no splits available");
   }
 
@@ -61,28 +61,29 @@ public class TestDefaultHoodieSplitProvider {
   public void testGetNextWithHostname() {
     provider.onDiscoveredSplits(Arrays.asList(split1, split2));
 
-    Option<HoodieSourceSplit> result = provider.getNext("localhost");
+    Option<HoodieSourceSplit> result = provider.getNext(1, "localhost");
     assertTrue(result.isPresent(), "Should return a split");
     assertEquals(split1.splitId(), result.get().splitId(), "Should return first split");
   }
 
   @Test
   public void testGetNextSequentially() {
+    provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(1));
     provider.onDiscoveredSplits(Arrays.asList(split1, split2, split3));
 
-    Option<HoodieSourceSplit> first = provider.getNext(null);
+    Option<HoodieSourceSplit> first = provider.getNext(0, null);
     assertTrue(first.isPresent(), "First split should be present");
     assertEquals(split1.splitId(), first.get().splitId(), "Should return splits in order");
 
-    Option<HoodieSourceSplit> second = provider.getNext(null);
+    Option<HoodieSourceSplit> second = provider.getNext(0, null);
     assertTrue(second.isPresent(), "Second split should be present");
     assertEquals(split2.splitId(), second.get().splitId(), "Should return splits in order");
 
-    Option<HoodieSourceSplit> third = provider.getNext(null);
+    Option<HoodieSourceSplit> third = provider.getNext(0, null);
     assertTrue(third.isPresent(), "Third split should be present");
     assertEquals(split3.splitId(), third.get().splitId(), "Should return splits in order");
 
-    Option<HoodieSourceSplit> empty = provider.getNext(null);
+    Option<HoodieSourceSplit> empty = provider.getNext(0, null);
     assertFalse(empty.isPresent(), "Should return empty when all splits consumed");
   }
 
@@ -93,14 +94,14 @@ public class TestDefaultHoodieSplitProvider {
 
     assertEquals(2, provider.pendingSplitCount(), "Should have 2 pending splits");
 
-    provider.getNext(null);
+    provider.getNext(1, null);
     assertEquals(1, provider.pendingSplitCount(), "Should have 1 pending split after consuming one");
   }
 
   @Test
   public void testOnUnassignedSplits() {
     provider.onDiscoveredSplits(Arrays.asList(split1));
-    provider.getNext(null);
+    provider.getNext(1, null);
 
     assertEquals(0, provider.pendingSplitCount(), "Should have no pending splits");
 
@@ -108,7 +109,7 @@ public class TestDefaultHoodieSplitProvider {
     provider.onUnassignedSplits(Arrays.asList(split1));
     assertEquals(1, provider.pendingSplitCount(), "Should have 1 pending split after re-adding");
 
-    Option<HoodieSourceSplit> result = provider.getNext(null);
+    Option<HoodieSourceSplit> result = provider.getNext(1, null);
     assertTrue(result.isPresent(), "Should be able to get the re-added split");
     assertEquals(split1.splitId(), result.get().splitId(), "Should return the re-added split");
   }
@@ -132,14 +133,14 @@ public class TestDefaultHoodieSplitProvider {
     provider.onDiscoveredSplits(Arrays.asList(split1, split2, split3));
 
     // Consume first two splits
-    provider.getNext(null);
-    provider.getNext(null);
+    provider.getNext(1, null);
+    provider.getNext(1, null);
 
     Collection<HoodieSourceSplitState> states = provider.state();
     assertEquals(1, states.size(), "Should have 1 remaining split state");
 
     HoodieSourceSplitState state = states.iterator().next();
-    assertEquals(split3.splitId(), state.split().splitId(), "Remaining split should be split3");
+    assertEquals(split2.splitId(), state.split().splitId(), "Remaining split should be split2");
     assertEquals(HoodieSourceSplitStatus.UNASSIGNED, state.status(), "Split should be UNASSIGNED");
   }
 
@@ -150,10 +151,10 @@ public class TestDefaultHoodieSplitProvider {
     provider.onDiscoveredSplits(Arrays.asList(split1, split2));
     assertEquals(2, provider.pendingSplitCount(), "Should have 2 pending splits");
 
-    provider.getNext(null);
+    provider.getNext(0, null);
     assertEquals(1, provider.pendingSplitCount(), "Should have 1 pending split");
 
-    provider.getNext(null);
+    provider.getNext(1, null);
     assertEquals(0, provider.pendingSplitCount(), "Should have 0 pending splits");
   }
 
@@ -165,23 +166,8 @@ public class TestDefaultHoodieSplitProvider {
   }
 
   @Test
-  public void testMultipleDiscoveredSplitsCalls() {
-    provider.onDiscoveredSplits(Arrays.asList(split1));
-    assertEquals(1, provider.pendingSplitCount(), "Should have 1 split");
-
-    provider.onDiscoveredSplits(Arrays.asList(split2, split3));
-    assertEquals(3, provider.pendingSplitCount(), "Should have 3 splits total");
-
-    // Verify order is maintained
-    assertEquals(split1.splitId(), provider.getNext(null).get().splitId());
-    assertEquals(split2.splitId(), provider.getNext(null).get().splitId());
-    assertEquals(split3.splitId(), provider.getNext(null).get().splitId());
-  }
-
-  @Test
   public void testWithComparatorOrdersByLatestCommit() {
-    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
-    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(1));
 
     HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
     HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
@@ -190,18 +176,18 @@ public class TestDefaultHoodieSplitProvider {
     providerWithComparator.onDiscoveredSplits(Arrays.asList(split1, split2, split3));
 
     // Should return splits in order of commit time (ascending)
-    assertEquals(split2.splitId(), providerWithComparator.getNext(null).get().splitId(),
+    assertEquals(split2.splitId(), providerWithComparator.getNext(0, null).get().splitId(),
         "Should return split with earliest commit time first");
-    assertEquals(split1.splitId(), providerWithComparator.getNext(null).get().splitId(),
+    assertEquals(split1.splitId(), providerWithComparator.getNext(0, null).get().splitId(),
         "Should return split with middle commit time second");
-    assertEquals(split3.splitId(), providerWithComparator.getNext(null).get().splitId(),
+    assertEquals(split3.splitId(), providerWithComparator.getNext(0, null).get().splitId(),
         "Should return split with latest commit time last");
   }
 
   @Test
   public void testWithComparatorSameLatestCommit() {
     HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
-    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(1));
 
     // All have same latest commit, but different base file commit times
     HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
@@ -211,15 +197,15 @@ public class TestDefaultHoodieSplitProvider {
     providerWithComparator.onDiscoveredSplits(Arrays.asList(split1, split2, split3));
 
     // Should return splits ordered by base file commit time
-    assertEquals(split2.splitId(), providerWithComparator.getNext(null).get().splitId());
-    assertEquals(split1.splitId(), providerWithComparator.getNext(null).get().splitId());
-    assertEquals(split3.splitId(), providerWithComparator.getNext(null).get().splitId());
+    assertEquals(split2.splitId(), providerWithComparator.getNext(0, null).get().splitId());
+    assertEquals(split1.splitId(), providerWithComparator.getNext(0, null).get().splitId());
+    assertEquals(split3.splitId(), providerWithComparator.getNext(0, null).get().splitId());
   }
 
   @Test
   public void testWithComparatorMultipleDiscoveryCalls() {
     HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
-    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
 
     HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
     HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
@@ -228,42 +214,42 @@ public class TestDefaultHoodieSplitProvider {
     providerWithComparator.onDiscoveredSplits(Arrays.asList(split2));
 
     // Should still return in sorted order
-    assertEquals(split2.splitId(), providerWithComparator.getNext(null).get().splitId());
-    assertEquals(split1.splitId(), providerWithComparator.getNext(null).get().splitId());
+    assertEquals(split2.splitId(), providerWithComparator.getNext(0, null).get().splitId());
+    assertEquals(split1.splitId(), providerWithComparator.getNext(1, null).get().splitId());
   }
 
   @Test
   public void testWithComparatorAndUnassignedSplits() {
     HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
-    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
 
-    HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
-    HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
+    HoodieSourceSplit split1 = createSplitWithCommit(0, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
+    HoodieSourceSplit split2 = createSplitWithCommit(1, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
 
     providerWithComparator.onDiscoveredSplits(Arrays.asList(split1, split2));
-    providerWithComparator.getNext(null); // Get split2 (earliest)
+    providerWithComparator.getNext(1, null); // Get split2 (earliest)
 
     // Re-add split2 as unassigned
     providerWithComparator.onUnassignedSplits(Arrays.asList(split2));
 
     // Should still maintain order: split2 comes before split1
-    assertEquals(split2.splitId(), providerWithComparator.getNext(null).get().splitId());
-    assertEquals(split1.splitId(), providerWithComparator.getNext(null).get().splitId());
+    assertEquals(split2.splitId(), providerWithComparator.getNext(1, null).get().splitId());
+    assertEquals(split1.splitId(), providerWithComparator.getNext(0, null).get().splitId());
   }
 
   @Test
   public void testWithComparatorEmptyProvider() {
     HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
-    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(1));
 
-    Option<HoodieSourceSplit> result = providerWithComparator.getNext(null);
+    Option<HoodieSourceSplit> result = providerWithComparator.getNext(1, null);
     assertFalse(result.isPresent(), "Should return empty option when no splits available");
   }
 
   @Test
   public void testWithComparatorStateTracking() {
     HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
-    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
 
     HoodieSourceSplit split1 = createSplitWithCommit(1, "20260126034717000", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034717000.parquet");
     HoodieSourceSplit split2 = createSplitWithCommit(2, "20260126034716930", "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0-1_20260126034716930.parquet");
@@ -274,22 +260,16 @@ public class TestDefaultHoodieSplitProvider {
     assertEquals(2, states.size(), "Should have 2 split states");
 
     // Consume one split
-    providerWithComparator.getNext(null);
+    providerWithComparator.getNext(1, null);
 
     states = providerWithComparator.state();
     assertEquals(1, states.size(), "Should have 1 remaining split state");
   }
 
   @Test
-  public void testWithComparatorNullComparator() {
-    assertThrows(IllegalArgumentException.class, () -> new DefaultHoodieSplitProvider(null),
-        "Should throw exception when comparator is null");
-  }
-
-  @Test
   public void testWithComparatorLargeBatchOrdering() {
     HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
-    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(1));
 
     // Create 50 splits with random commit times
     List<HoodieSourceSplit> splits = new ArrayList<>();
@@ -305,7 +285,7 @@ public class TestDefaultHoodieSplitProvider {
     // Should retrieve them in ascending commit time order
     HoodieSourceSplit previousSplit = null;
     for (int i = 0; i < 50; i++) {
-      HoodieSourceSplit currentSplit = providerWithComparator.getNext(null).get();
+      HoodieSourceSplit currentSplit = providerWithComparator.getNext(0, null).get();
       if (previousSplit != null) {
         assertTrue(comparator.compare(previousSplit, currentSplit) < 0,
             "Splits should be retrieved in ascending commit time order");
@@ -316,8 +296,7 @@ public class TestDefaultHoodieSplitProvider {
 
   @Test
   public void testWithComparatorConcurrentAccess() {
-    HoodieSourceSplitComparator comparator = new HoodieSourceSplitComparator();
-    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(comparator);
+    DefaultHoodieSplitProvider providerWithComparator = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(1));
 
     List<HoodieSourceSplit> splits = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
@@ -329,12 +308,338 @@ public class TestDefaultHoodieSplitProvider {
 
     // Verify that we can retrieve all splits in order
     for (int i = 0; i < 100; i++) {
-      Option<HoodieSourceSplit> split = providerWithComparator.getNext(null);
+      Option<HoodieSourceSplit> split = providerWithComparator.getNext(0, null);
       assertTrue(split.isPresent(), "Should have split available");
     }
 
     // No more splits should be available
-    assertFalse(providerWithComparator.getNext(null).isPresent());
+    assertFalse(providerWithComparator.getNext(0, null).isPresent());
+  }
+
+  @Test
+  public void testGetNextWithMultipleSubtasks() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(3));
+
+    // Create 9 splits that will be distributed across 3 subtasks
+    List<HoodieSourceSplit> splits = new ArrayList<>();
+    for (int i = 0; i < 9; i++) {
+      splits.add(createTestSplit(i, "file" + i));
+    }
+    provider.onDiscoveredSplits(splits);
+
+    // Subtask 0 should get splits 0, 3, 6
+    assertEquals(0, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(3, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(6, provider.getNext(0, null).get().getSplitNum());
+    assertFalse(provider.getNext(0, null).isPresent(), "Subtask 0 should have no more splits");
+
+    // Subtask 1 should get splits 1, 4, 7
+    assertEquals(1, provider.getNext(1, null).get().getSplitNum());
+    assertEquals(4, provider.getNext(1, null).get().getSplitNum());
+    assertEquals(7, provider.getNext(1, null).get().getSplitNum());
+    assertFalse(provider.getNext(1, null).isPresent(), "Subtask 1 should have no more splits");
+
+    // Subtask 2 should get splits 2, 5, 8
+    assertEquals(2, provider.getNext(2, null).get().getSplitNum());
+    assertEquals(5, provider.getNext(2, null).get().getSplitNum());
+    assertEquals(8, provider.getNext(2, null).get().getSplitNum());
+    assertFalse(provider.getNext(2, null).isPresent(), "Subtask 2 should have no more splits");
+  }
+
+  @Test
+  public void testGetNextSubtaskOnlyGetsAssignedSplits() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(4));
+
+    List<HoodieSourceSplit> splits = Arrays.asList(
+        createTestSplit(0, "file0"),  // assigned to subtask 0
+        createTestSplit(1, "file1"),  // assigned to subtask 1
+        createTestSplit(2, "file2"),  // assigned to subtask 2
+        createTestSplit(3, "file3")   // assigned to subtask 3
+    );
+    provider.onDiscoveredSplits(splits);
+
+    // Subtask 0 should only get split 0
+    Option<HoodieSourceSplit> split = provider.getNext(0, null);
+    assertTrue(split.isPresent());
+    assertEquals(0, split.get().getSplitNum());
+
+    // Subtask 0 should have no more splits
+    assertFalse(provider.getNext(0, null).isPresent());
+
+    // Other subtasks should still have their splits available
+    assertEquals(1, provider.getNext(1, null).get().getSplitNum());
+    assertEquals(2, provider.getNext(2, null).get().getSplitNum());
+    assertEquals(3, provider.getNext(3, null).get().getSplitNum());
+  }
+
+  @Test
+  public void testGetNextReturnsNonAssignedSplitsToQueue() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
+
+    List<HoodieSourceSplit> splits = Arrays.asList(
+        createTestSplit(0, "file0"),  // assigned to subtask 0
+        createTestSplit(1, "file1"),  // assigned to subtask 1
+        createTestSplit(2, "file2")   // assigned to subtask 0
+    );
+    provider.onDiscoveredSplits(splits);
+
+    // Subtask 1 requests a split - should skip split 0 and split 2, return split 1
+    Option<HoodieSourceSplit> split = provider.getNext(1, null);
+    assertTrue(split.isPresent());
+    assertEquals(1, split.get().getSplitNum());
+
+    // Verify splits 0 and 2 are still available for subtask 0
+    assertEquals(2, provider.pendingSplitCount(), "Skipped splits should be returned to queue");
+    assertEquals(0, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(2, provider.getNext(0, null).get().getSplitNum());
+  }
+
+  @Test
+  public void testGetNextWithUnevenDistribution() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(3));
+
+    // Create 10 splits for 3 subtasks (uneven distribution)
+    List<HoodieSourceSplit> splits = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      splits.add(createTestSplit(i, "file" + i));
+    }
+    provider.onDiscoveredSplits(splits);
+
+    // Subtask 0 should get splits 0, 3, 6, 9 (4 splits)
+    assertEquals(0, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(3, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(6, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(9, provider.getNext(0, null).get().getSplitNum());
+    assertFalse(provider.getNext(0, null).isPresent());
+
+    // Subtask 1 should get splits 1, 4, 7 (3 splits)
+    assertEquals(1, provider.getNext(1, null).get().getSplitNum());
+    assertEquals(4, provider.getNext(1, null).get().getSplitNum());
+    assertEquals(7, provider.getNext(1, null).get().getSplitNum());
+    assertFalse(provider.getNext(1, null).isPresent());
+
+    // Subtask 2 should get splits 2, 5, 8 (3 splits)
+    assertEquals(2, provider.getNext(2, null).get().getSplitNum());
+    assertEquals(5, provider.getNext(2, null).get().getSplitNum());
+    assertEquals(8, provider.getNext(2, null).get().getSplitNum());
+    assertFalse(provider.getNext(2, null).isPresent());
+  }
+
+  @Test
+  public void testGetNextWithInterleavedRequests() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
+
+    List<HoodieSourceSplit> splits = Arrays.asList(
+        createTestSplit(0, "file0"),  // subtask 0
+        createTestSplit(1, "file1"),  // subtask 1
+        createTestSplit(2, "file2"),  // subtask 0
+        createTestSplit(3, "file3")   // subtask 1
+    );
+    provider.onDiscoveredSplits(splits);
+
+    // Interleaved requests from different subtasks
+    assertEquals(0, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(1, provider.getNext(1, null).get().getSplitNum());
+    assertEquals(2, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(3, provider.getNext(1, null).get().getSplitNum());
+
+    // All splits consumed
+    assertFalse(provider.getNext(0, null).isPresent());
+    assertFalse(provider.getNext(1, null).isPresent());
+  }
+
+  @Test
+  public void testGetNextWithUnassignedSplitsMultipleSubtasks() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
+
+    List<HoodieSourceSplit> splits = Arrays.asList(
+        createTestSplit(0, "file0"),  // subtask 0
+        createTestSplit(1, "file1")   // subtask 1
+    );
+    provider.onDiscoveredSplits(splits);
+
+    // Consume both splits
+    HoodieSourceSplit split0 = provider.getNext(0, null).get();
+    HoodieSourceSplit split1 = provider.getNext(1, null).get();
+
+    // Return split1 as unassigned
+    provider.onUnassignedSplits(Arrays.asList(split1));
+
+    // Subtask 1 should get split1 back
+    Option<HoodieSourceSplit> result = provider.getNext(1, null);
+    assertTrue(result.isPresent());
+    assertEquals(1, result.get().getSplitNum());
+
+    // Subtask 0 should not get split1
+    assertFalse(provider.getNext(0, null).isPresent());
+  }
+
+  @Test
+  public void testGetNextPendingSplitCountWithMultipleSubtasks() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(3));
+
+    List<HoodieSourceSplit> splits = new ArrayList<>();
+    for (int i = 0; i < 6; i++) {
+      splits.add(createTestSplit(i, "file" + i));
+    }
+    provider.onDiscoveredSplits(splits);
+
+    assertEquals(6, provider.pendingSplitCount());
+
+    // Subtask 0 gets split 0
+    provider.getNext(0, null);
+    assertEquals(5, provider.pendingSplitCount());
+
+    // Subtask 1 gets split 1 (skips and re-adds split 0)
+    provider.getNext(1, null);
+    assertEquals(4, provider.pendingSplitCount());
+
+    // Subtask 2 gets split 2
+    provider.getNext(2, null);
+    assertEquals(3, provider.pendingSplitCount());
+  }
+
+  @Test
+  public void testIsAvailableCompletesWhenSplitsAdded() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
+
+    // Get the future before any splits are added
+    assertFalse(provider.isAvailable().isDone(), "Future should not be completed initially");
+
+    // Add splits - this should complete the future
+    provider.onDiscoveredSplits(Arrays.asList(split1));
+
+    // Get a new future after splits were added
+    assertFalse(provider.isAvailable().isDone(), "New future should not be completed");
+  }
+
+  @Test
+  public void testStateAcrossMultipleSubtasks() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
+
+    List<HoodieSourceSplit> splits = Arrays.asList(
+        createTestSplit(0, "file0"),  // subtask 0
+        createTestSplit(1, "file1"),  // subtask 1
+        createTestSplit(2, "file2"),  // subtask 0
+        createTestSplit(3, "file3")   // subtask 1
+    );
+    provider.onDiscoveredSplits(splits);
+
+    // State should include all splits across all subtasks
+    Collection<HoodieSourceSplitState> states = provider.state();
+    assertEquals(4, states.size(), "Should have all splits in state");
+
+    // Consume splits from subtask 0
+    provider.getNext(0, null);
+    provider.getNext(0, null);
+
+    states = provider.state();
+    assertEquals(2, states.size(), "Should have remaining splits from both subtasks");
+  }
+
+  @Test
+  public void testGetNextWithDefaultAssigner() {
+    // Test with DefaultHoodieSplitAssigner instead of NumberAssigner
+    org.apache.hudi.source.assign.DefaultHoodieSplitAssigner assigner =
+        new org.apache.hudi.source.assign.DefaultHoodieSplitAssigner(3);
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(assigner);
+
+    List<HoodieSourceSplit> splits = new ArrayList<>();
+    for (int i = 0; i < 9; i++) {
+      splits.add(createTestSplit(i, "file" + i));
+    }
+    provider.onDiscoveredSplits(splits);
+
+    // Splits should be distributed according to DefaultHoodieSplitAssigner's hash-based logic
+    int count = 0;
+    while (provider.getNext(0, null).isPresent()) {
+      count++;
+    }
+    assertTrue(count >= 0, "Should get some splits for subtask 0");
+  }
+
+  @Test
+  public void testGetNextWithBucketAssigner() {
+    // Test with HoodieSplitBucketAssigner
+    org.apache.hudi.source.assign.HoodieSplitBucketAssigner assigner =
+        new org.apache.hudi.source.assign.HoodieSplitBucketAssigner(4);
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(assigner);
+
+    // Create splits with bucket-encoded file IDs
+    List<HoodieSourceSplit> splits = Arrays.asList(
+        createSplitWithBucketFileId(0, "00000000-0000-0000-0000-000000000000"),  // bucket 0 -> task 0
+        createSplitWithBucketFileId(1, "00000001-0000-0000-0000-000000000000"),  // bucket 1 -> task 1
+        createSplitWithBucketFileId(2, "00000002-0000-0000-0000-000000000000"),  // bucket 2 -> task 2
+        createSplitWithBucketFileId(3, "00000003-0000-0000-0000-000000000000")   // bucket 3 -> task 3
+    );
+    provider.onDiscoveredSplits(splits);
+
+    // Each subtask should get its assigned split
+    Option<HoodieSourceSplit> split0 = provider.getNext(0, null);
+    assertTrue(split0.isPresent());
+    assertEquals(0, split0.get().getSplitNum());
+
+    Option<HoodieSourceSplit> split1 = provider.getNext(1, null);
+    assertTrue(split1.isPresent());
+    assertEquals(1, split1.get().getSplitNum());
+
+    Option<HoodieSourceSplit> split2 = provider.getNext(2, null);
+    assertTrue(split2.isPresent());
+    assertEquals(2, split2.get().getSplitNum());
+
+    Option<HoodieSourceSplit> split3 = provider.getNext(3, null);
+    assertTrue(split3.isPresent());
+    assertEquals(3, split3.get().getSplitNum());
+  }
+
+  @Test
+  public void testEmptyDiscoveredSplits() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
+
+    // Add empty list of splits
+    provider.onDiscoveredSplits(Collections.emptyList());
+
+    assertEquals(0, provider.pendingSplitCount(), "Should have 0 pending splits");
+    assertFalse(provider.getNext(0, null).isPresent(), "Should return empty");
+  }
+
+  @Test
+  public void testMultipleDiscoveryCallsAcrossSubtasks() {
+    DefaultHoodieSplitProvider provider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
+
+    // First discovery
+    provider.onDiscoveredSplits(Arrays.asList(createTestSplit(0, "file0")));
+    assertEquals(1, provider.pendingSplitCount());
+
+    // Second discovery
+    provider.onDiscoveredSplits(Arrays.asList(createTestSplit(1, "file1")));
+    assertEquals(2, provider.pendingSplitCount());
+
+    // Third discovery
+    provider.onDiscoveredSplits(Arrays.asList(
+        createTestSplit(2, "file2"),
+        createTestSplit(3, "file3")
+    ));
+    assertEquals(4, provider.pendingSplitCount());
+
+    // Verify splits are distributed correctly
+    assertEquals(0, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(1, provider.getNext(1, null).get().getSplitNum());
+    assertEquals(2, provider.getNext(0, null).get().getSplitNum());
+    assertEquals(3, provider.getNext(1, null).get().getSplitNum());
+  }
+
+  private HoodieSourceSplit createSplitWithBucketFileId(int splitNum, String fileId) {
+    return new HoodieSourceSplit(
+        splitNum,
+        "basePath_" + splitNum,
+        Option.empty(),
+        "/table/path",
+        "/table/path/partition1",
+        "read_optimized",
+        "20260126034717000",
+        fileId
+    );
   }
 
   private HoodieSourceSplit createSplitWithCommit(int splitNum, String latestCommit, String basePath) {
@@ -353,12 +658,12 @@ public class TestDefaultHoodieSplitProvider {
   private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
     return new HoodieSourceSplit(
         splitNum,
-        "basePath_" + splitNum,
+        "40e603a8-3cc1-4d09-b0a5-1432992b4bf7_1-0" + splitNum + "_20260126034717000.parquet",
         Option.empty(),
         "/table/path",
         "/table/path/partition1",
         "read_optimized",
-        "19700101000000000",
+        "2026012603471700" + splitNum,
         fileId
     );
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
Support flink split distribution strategy

### Summary and Changelog

1. Add default split assigner and bucket based assigner
2. Update the split provider to provide split according to the assigner algorithm
3. Add test cases for new classes.

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
