### PR TITLE
fix(flink): Handle Non-Null Complex Types with Nullable Elements in ParquetSchemaConverter

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/parquet/ParquetSchemaConverter.java
@@ -294,13 +294,14 @@ public class ParquetSchemaConverter {
                 Types
                     .repeatedGroup()
                     .addField(convertToParquetType("key", keyType, Type.Repetition.REQUIRED))
-                    .addField(convertToParquetType("value", valueType, repetition))
+                    .addField(convertToParquetType("value", valueType, valueType.isNullable() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED))
                     .named("key_value"))
             .named(name);
       case ROW:
         RowType rowType = (RowType) type;
         Types.GroupBuilder<GroupType> builder = Types.buildGroup(repetition);
-        rowType.getFields().forEach(field -> builder.addField(convertToParquetType(field.getName(), field.getType(), repetition)));
+        rowType.getFields().forEach(field -> builder
+            .addField(convertToParquetType(field.getName(), field.getType(), field.getType().isNullable() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED)));
         return builder.named(name);
       default:
         throw new UnsupportedOperationException("Unsupported type: " + type);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR fixes an issue in `ParquetSchemaConverter` where complex types (MAP and ROW) with non-null containers but nullable elements were not correctly setting the repetition type for nested elements. 

For example, `Array<Row<int a, string b> NOT NULL> NOT NULL` should create a repeated **required** group with optional elements `a` and `b` (nullable), but the previous implementation was passing the parent's repetition to nested elements instead of checking each element's nullability.

### Summary and Changelog

**Summary:** Fix ParquetSchemaConverter to correctly handle nullability for nested elements in MAP and ROW types.

**Changelog:**
- Fix MAP case: Use `valueType.isNullable()` to determine value repetition instead of inheriting parent's repetition
- Fix ROW case: Use `field.getType().isNullable()` to determine field repetition instead of inheriting parent's repetition  
- Add `testConvertNestedComplexTypes()` test to verify nested complex type handling with mixed nullability
- Update `testConvertComplexTypes()` to test non-null array elements

### Impact

This change affects Parquet schema generation for Flink tables with complex nested types. Tables with non-null complex types containing nullable elements will now generate correct Parquet schemas with proper required/optional annotations.

### Risk Level

Low - This is a targeted fix to the Parquet schema converter for Flink. The change only affects how nullability is propagated for nested types in MAP and ROW. The ARRAY case was already fixed previously in the codebase.

### Documentation Update

None - This is a bug fix with no new configs or user-facing feature changes.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable