### PR TITLE
fix(flink): Use timestamp based partitioning in AutoRowDataKeyGen

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestRowDataKeyGens.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestRowDataKeyGens.java
@@ -246,6 +246,26 @@ public class TestRowDataKeyGens {
   }
 
   @Test
+  void testTimestampBasedKeyGeneratorForKeylessWrite() {
+    final String partitionFormat = "yyyy/MM/dd";
+    final int taskId = 3;
+    final String instantTime = "000001";
+
+    Configuration conf = TestConfigurations.getDefaultConf("path1");
+    conf.set(FlinkOptions.RECORD_KEY_FIELD, "");
+    conf.set(FlinkOptions.PARTITION_PATH_FIELD, "ts");
+    conf.set(FlinkOptions.PARTITION_FORMAT, partitionFormat);
+    HoodieTableFactory.setupTimestampKeygenOptions(conf, DataTypes.TIMESTAMP(3));
+
+    final RowData rowData = insertRow(StringData.fromString("id1"), StringData.fromString("Danny"), 23,
+            TimestampData.fromEpochMillis(7200000), StringData.fromString("par1"));
+
+    final RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, TestConfigurations.ROW_TYPE, taskId, instantTime);
+    assertThat(keyGen.getRecordKey(rowData), is(instantTime + "_" + taskId + "_0"));
+    assertThat(keyGen.getPartitionPath(rowData), is("1970/01/01"));
+  }
+
+  @Test
   void testRecordKeyContainsTimestamp() {
     Configuration conf = TestConfigurations.getDefaultConf("path1");
     conf.set(FlinkOptions.RECORD_KEY_FIELD, "uuid,ts");


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When `FlinkOptions.RECORD_KEY_FIELD` is set to empty, Flink Hudi allows auto-generation of `hoodie_record_key` without specifying a primary key UUID (which is nullified in the ingestion job). However, the partition format was incorrectly set in this scenario.

### Summary and Changelog

Use `TimestampBasedAvroKeyGenerator` to format partitions in the `AutoRowDataKeyGen` class, consistent with the behavior in `RowDataKeyGen`.

**Changes:**
- Updated `AutoRowDataKeyGen` constructor to accept an optional `TimestampBasedAvroKeyGenerator`
- Modified `instance()` method to detect when `TimestampBasedAvroKeyGenerator` is configured and instantiate it appropriately
- Added unit test `testTimestampBasedKeyGeneratorForKeylessWrite` to verify correct partition path formatting

### Impact

This fix ensures that when using keyless writes with timestamp-based partitioning, the partition path is formatted correctly according to the configured partition format.

### Risk Level

low - The change only affects the `AutoRowDataKeyGen` class used for keyless writes with timestamp-based partitioning. Existing behavior for other key generation scenarios is unchanged.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable