### PR TITLE
fix(flink): include exception stacktrace in error logs

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -644,14 +644,14 @@ public class StreamWriteOperatorCoordinator
       log.error("The first 10 files with write errors:");
       dataWriteResults.stream().filter(WriteStatus::hasErrors).limit(10).forEach(ws -> {
         if (ws.getGlobalError() != null) {
-          log.error("Global error for partition path {} and fileID {}:",
+          log.error("Global error for partition path {} and fileID {}: ",
               ws.getPartitionPath(), ws.getFileId(), ws.getGlobalError());
         }
         if (!ws.getErrors().isEmpty()) {
           log.error("The first 100 records-level errors for partition path {} and fileID {}:",
               ws.getPartitionPath(), ws.getFileId());
           ws.getErrors().entrySet().stream().limit(100).forEach(entry ->
-              log.error("Error for key {}:", entry.getKey(), entry.getValue()));
+              log.error("Error for key {}: ", entry.getKey(), entry.getValue()));
         }
       });
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When write errors occur in the Flink StreamWriteOperatorCoordinator, the error logs only include the exception message but not the full stacktrace. This makes debugging write failures difficult as the root cause information is lost.

### Summary and Changelog

Fix error logging in `StreamWriteOperatorCoordinator` to include exception stacktraces by passing the `Throwable` as the last parameter to the log call.

**Changes:**
- For global errors: Pass the exception as the last parameter (without a `{}` placeholder) so SLF4J prints the full stacktrace
- For record-level errors: Pass the full `Throwable` (`entry.getValue()`) instead of just the message (`entry.getValue().getMessage()`)

### Impact

No public API or user-facing feature change. This only improves error logging to include exception stacktraces for better debugging.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable