### PR TITLE
fix: sort partitions after filtering for clustering planning

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -144,7 +144,10 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
    * Return list of partition paths to be considered for clustering.
    */
   public Pair<List<String>, List<String>> filterPartitionPaths(HoodieWriteConfig writeConfig, List<String> partitions) {
-    return ClusteringPlanPartitionFilter.filter(partitions, getWriteConfig());
+    Pair<List<String>, List<String>> result = ClusteringPlanPartitionFilter.filter(partitions, getWriteConfig());
+    result.getLeft().sort(String::compareTo);
+    log.debug("Filtered to the following partitions after sorting: {}", result.getLeft());
+    return result;
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestSparkClusteringPlanPartitionFilter.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestSparkClusteringPlanPartitionFilter.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class TestSparkClusteringPlanPartitionFilter {
   @Mock
@@ -70,8 +70,8 @@ public class TestSparkClusteringPlanPartitionFilter {
   @Test
   public void testFilterPartitionRecentDays() {
     HoodieWriteConfig config = hoodieWriteConfigBuilder.withClusteringConfig(HoodieClusteringConfig.newBuilder()
-            .withClusteringSkipPartitionsFromLatest(1)
-            .withClusteringTargetPartitions(1)
+            .withClusteringSkipPartitionsFromLatest(0)
+            .withClusteringTargetPartitions(2)
             .withClusteringPlanPartitionFilterMode(ClusteringPlanPartitionFilterMode.RECENT_DAYS)
             .build())
         .build();
@@ -80,16 +80,16 @@ public class TestSparkClusteringPlanPartitionFilter {
     ArrayList<String> fakeTimeBasedPartitionsPath = new ArrayList<>();
     fakeTimeBasedPartitionsPath.add("20210718");
     fakeTimeBasedPartitionsPath.add("20210716");
-    fakeTimeBasedPartitionsPath.add("20210719");
+    fakeTimeBasedPartitionsPath.add("20210717");
     List list = (List)sg.filterPartitionPaths(null, fakeTimeBasedPartitionsPath).getLeft();
-    assertEquals(1, list.size());
-    assertSame("20210718", list.get(0));
+    assertEquals(2, list.size());
+    assertEquals(Arrays.asList("20210717", "20210718"), list);
   }
 
   @Test
   public void testFilterPartitionSelectedPartitions() {
     HoodieWriteConfig config = hoodieWriteConfigBuilder.withClusteringConfig(HoodieClusteringConfig.newBuilder()
-            .withClusteringPartitionFilterBeginPartition("20211222")
+            .withClusteringPartitionFilterBeginPartition("20211221")
             .withClusteringPartitionFilterEndPartition("20211223")
             .withClusteringPlanPartitionFilterMode(ClusteringPlanPartitionFilterMode.SELECTED_PARTITIONS)
             .build())
@@ -102,8 +102,8 @@ public class TestSparkClusteringPlanPartitionFilter {
     fakeTimeBasedPartitionsPath.add("20211222");
     fakeTimeBasedPartitionsPath.add("20211224");
     List list = (List)sg.filterPartitionPaths(config, fakeTimeBasedPartitionsPath).getLeft();
-    assertEquals(1, list.size());
-    assertSame("20211222", list.get(0));
+    assertEquals(2, list.size());
+    assertEquals(Arrays.asList("20211221", "20211222"), list);
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR addresses HUDI-6912. The clustering plan partition filter does not guarantee a consistent sort order for filtered partitions, which can lead to non-deterministic behavior in clustering operations.

### Summary and Changelog

Sort partitions after filtering in `PartitionAwareClusteringPlanStrategy.filterPartitionPaths()` to ensure consistent ordering.

**Changes:**
- Added `result.getLeft().sort(String::compareTo)` after calling `ClusteringPlanPartitionFilter.filter()` to ensure partitions are always sorted in ascending order
- Updated log message to indicate sorting was applied
- Updated unit tests to verify sorted output

### Impact

No public API changes. Ensures deterministic partition ordering in clustering plan generation.

### Risk Level

low - This is a minor behavioral change that ensures consistent ordering. The sorting is applied after existing filtering logic and does not change what partitions are selected, only their order.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable