### PR TITLE
fix: (table-services) When using multiwriter do not delete pending roll…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -938,7 +938,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       try {
         rollbackPlan = RollbackUtils.getRollbackPlan(metaClient, rollbackInstant);
       } catch (Exception e) {
-        if (rollbackInstant.isRequested()) {
+        if (!config.getWriteConcurrencyMode().supportsMultiWriter() && rollbackInstant.isRequested()) {
           log.warn("Fetching rollback plan failed for {}, deleting the plan since it's in REQUESTED state", rollbackInstant, e);
           try {
             metaClient.getActiveTimeline().deletePending(rollbackInstant);


### PR DESCRIPTION
…back plan if exception is thrown while reading it

### Describe the issue this Pull Request addresses

When using multi-writer mode, if an exception is thrown while reading a pending rollback plan, the corrupted rollback plan should NOT be deleted.  
https://github.com/apache/hudi/issues/17922 

### Summary and Changelog

**Summary:** In multi-writer mode, corrupted rollback plans are now preserved (skipped rather than deleted) when an exception occurs while reading them. Single-writer mode continues to delete corrupted rollback plans.

**Changelog:**
- Modified `BaseHoodieTableServiceClient.getPendingRollbackInfos()` to only delete corrupted rollback plans (if an exception was encountered when trying to read it) when NOT using multi-writer mode

### Impact

- **Behavioral change:** In multi-writer mode, corrupted pending rollback plans will remain on the timeline instead of being deleted
- **No public API changes**
- **Improved multi-writer safety:** Prevents one writer from deleting a rollback plan that another concurrent writer may depend on

### Risk Level

**Low** - The change  only affects error handling behavior for multi-writer mode. Single-writer behavior is unchanged
### Documentation Update

None - This is an internal behavioral fix with no new configs or user-facing feature changes.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
