### PR TITLE
fix: correct deleted keys computation in computeRevivedAndDeletedKeys

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1112,9 +1112,9 @@ public class HoodieTableMetadataUtil {
     Set<String> revivedKeys = new HashSet<>(deletedKeysForPreviousLogs);
     revivedKeys.retainAll(validKeysForAllLogs); // Intersection of previously deleted and now valid
 
-    // Compute deleted keys: previously valid but now deleted
-    Set<String> deletedKeys = new HashSet<>(validKeysForPreviousLogs);
-    deletedKeys.retainAll(deletedKeysForAllLogs); // Intersection of previously valid and now deleted
+    // Compute deleted keys: newly deleted keys that weren't deleted before
+    Set<String> deletedKeys = new HashSet<>(deletedKeysForAllLogs);
+    deletedKeys.removeAll(deletedKeysForPreviousLogs); // Remove previously deleted keys
 
     return Pair.of(revivedKeys, deletedKeys);
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -691,7 +691,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
 
     // Expected Results
     Set<String> expectedRevivedKeys = new HashSet<>(Collections.singletonList("K4")); // Revived: Deleted in previous but now valid
-    Set<String> expectedDeletedKeys = new HashSet<>(Collections.singletonList("K1")); // Deleted: Valid in previous but now deleted
+    Set<String> expectedDeletedKeys = new HashSet<>(Arrays.asList("K1", "K7")); // Deleted: Valid in previous but now deleted
 
     // Compute Revived and Deleted Keys
     Pair<Set<String>, Set<String>> result = computeRevivedAndDeletedKeys(validKeysForPreviousLogs, deletedKeysForPreviousLogs, validKeysForAllLogs, deletedKeysForAllLogs);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The previous logic computed deleted keys as the intersection of validKeysForPreviousLogs and deletedKeysForAllLogs, which missed newly deleted keys that weren't in the previous valid set.                                                     

The fix changes the logic to compute deleted keys as deletedKeysForAllLogs minus deletedKeysForPreviousLogs, which correctly captures all newly deleted keys.

### Summary and Changelog

- Fixed `computeRevivedAndDeletedKeys` to compute deleted keys as `deletedKeysForAllLogs - deletedKeysForPreviousLogs` instead of `validKeysForPreviousLogs ∩ deletedKeysForAllLogs`
- Updated test expectations to include K7 in expected deleted keys

### Impact

Prevents potential data inconsistency in metadata table where deleted records might not be properly tracked

### Risk Level

LOW

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
