### PR TITLE
perf: Skip reading file slice only containing an initial log file whe…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -618,6 +618,10 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
     if (sortedKeys.isEmpty()) {
       return new EmptyIterator<>();
     }
+    // if the file slice is an initial file slice, return empty directly, since the initial log is empty.
+    if (HoodieTableMetadataUtil.isInitialFileSlice(fileSlice)) {
+      return new EmptyIterator<>();
+    }
     try {
       Predicate predicate = buildPredicate(partitionName, sortedKeys, isFullKey);
       ClosableIterator<IndexedRecord> rawIterator = readSliceWithFilter(predicate, fileSlice);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -3042,6 +3042,13 @@ public class HoodieTableMetadataUtil {
     return indexName;
   }
 
+  /**
+   * Returns whether the given file slice contains only an initialized log file for the metadata index partition.
+   */
+  public static boolean isInitialFileSlice(FileSlice fileSlice) {
+    return fileSlice.getBaseFile().isEmpty() && fileSlice.getBaseInstantTime().startsWith(SOLO_COMMIT_TIMESTAMP) && fileSlice.getLogFiles().count() == 1;
+  }
+
   private static Set<String> getIndexPartitionsToInitBasedOnIndexDefinition(MetadataPartitionType partitionType, HoodieTableMetaClient dataMetaClient) {
     if (dataMetaClient.getIndexMetadata().isEmpty()) {
       return Collections.emptySet();


### PR DESCRIPTION
…n looking up records by key for metadata table

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
