### PR TITLE
[MINOR] Remove redundant local variable from DynamoDBBasedImplicitPartitionKeyLockProvider

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
@@ -56,12 +56,9 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
 
   @Override
   public String getDynamoDBPartitionKey(LockConfiguration lockConfiguration) {
-    // Ensure consistent format for S3 URI.
-    String hudiTableBasePathNormalized = s3aToS3(lockConfiguration.getConfig().getString(
-        HoodieCommonConfig.BASE_PATH.key()));
-    String partitionKey = HashID.generateXXHashAsString(hudiTableBasePathNormalized, HashID.Size.BITS_64);
+    String partitionKey = HashID.generateXXHashAsString(hudiTableBasePath, HashID.Size.BITS_64);
     LOG.info(String.format("The DynamoDB partition key of the lock provider for the base path %s is %s",
-        hudiTableBasePathNormalized, partitionKey));
+        hudiTableBasePath, partitionKey));
     return partitionKey;
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Removes redundant table base path local variable from getPartitionKey method in DynamoDBBasedImplicitPartitionKeyLockProvider since the table base path is a field. Reusing the same.
Refer: https://github.com/apache/hudi/pull/17875#discussion_r2730180684

### Summary and Changelog

Removes redundant table base path local variable from getPartitionKey method in DynamoDBBasedImplicitPartitionKeyLockProvider since the table base path is a field. Reusing the same.

### Impact

NA

### Risk Level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
