### PR TITLE
fix: Improve error message for conflict resolution

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -207,25 +207,26 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
    * Builds a detailed error message for write conflicts based on the operation types involved.
    */
   private String buildConflictErrorMessage(ConcurrentOperation thisOperation, ConcurrentOperation otherOperation) {
-    boolean otherIsTableService = isTableService(otherOperation.getOperationType());
-
-    String thisOpDesc = formatOperationDescription(thisOperation);
-    String otherOpDesc = formatOperationDescription(otherOperation);
-
-    // If other operation is a table service, provide specific retry guidance
-    if (otherIsTableService) {
-      String serviceType = getTableServiceDisplayName(otherOperation.getOperationType());
+    boolean thisIsTableService = WriteOperationType.isTableService(thisOperation.getOperationType());
+    boolean otherIsTableService = WriteOperationType.isTableService(otherOperation.getOperationType());
+    String thisOperationDescription = formatOperationDescription(thisOperation);
+    String otherOperationDescription = formatOperationDescription(otherOperation);
+    // If either operation is a table service, provide specific retry guidance
+    if (thisIsTableService || otherIsTableService) {
+      ConcurrentOperation tableServiceOperation = thisIsTableService ? thisOperation : otherOperation;
+      String tableServiceDescription = thisIsTableService ? thisOperationDescription : otherOperationDescription;
+      String regularOperationDescription = thisIsTableService ? otherOperationDescription : thisOperationDescription;
+      String serviceType = getTableServiceDisplayName(tableServiceOperation.getOperationType());
       return String.format(
           "Cannot resolve conflicts for overlapping writes. %s is currently running and has overlapping file groups with %s. "
               + "Please retry the write operation after the %s completes.",
-          otherOpDesc, thisOpDesc, serviceType.toLowerCase()
+          tableServiceDescription, regularOperationDescription, serviceType.toLowerCase()
       );
     }
-
-    // For all other cases (this is table service or both are regular operations)
+    // For regular write operations conflicting with each other
     return String.format(
         "Cannot resolve conflicts for overlapping writes. %s has overlapping file groups with %s.",
-        thisOpDesc, otherOpDesc
+        thisOperationDescription, otherOperationDescription
     );
   }
 
@@ -233,7 +234,7 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
    * Formats a description of an operation including its type, instant, and state.
    */
   private String formatOperationDescription(ConcurrentOperation operation) {
-    String operationName = isTableService(operation.getOperationType())
+    String operationName = WriteOperationType.isTableService(operation.getOperationType())
         ? "Table " + getTableServiceDisplayName(operation.getOperationType())
         : operation.getOperationType().value() + " operation";
 
@@ -241,16 +242,6 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
         operationName,
         operation.getInstantTimestamp(),
         operation.getInstantActionState());
-  }
-
-  /**
-   * Checks if the given operation type is a table service operation.
-   */
-  private boolean isTableService(WriteOperationType operationType) {
-    return operationType == WriteOperationType.COMPACT
-        || operationType == WriteOperationType.CLUSTER
-        || operationType == WriteOperationType.LOG_COMPACT
-        || operationType == WriteOperationType.INDEX;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -200,8 +200,75 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
       return thisOperation.getCommitMetadataOption();
     }
     // just abort the current write if conflicts are found (failed for rollback conflicts).
-    throw new HoodieWriteConflictException(new ConcurrentModificationException("Cannot resolve conflicts for overlapping writes between first operation = " + thisOperation
-        + ", second operation = " + otherOperation));
+    throw new HoodieWriteConflictException(new ConcurrentModificationException(buildConflictErrorMessage(thisOperation, otherOperation)));
+  }
+
+  /**
+   * Builds a detailed error message for write conflicts based on the operation types involved.
+   */
+  private String buildConflictErrorMessage(ConcurrentOperation thisOperation, ConcurrentOperation otherOperation) {
+    boolean otherIsTableService = isTableService(otherOperation.getOperationType());
+
+    String thisOpDesc = formatOperationDescription(thisOperation);
+    String otherOpDesc = formatOperationDescription(otherOperation);
+
+    // If other operation is a table service, provide specific retry guidance
+    if (otherIsTableService) {
+      String serviceType = getTableServiceDisplayName(otherOperation.getOperationType());
+      return String.format(
+          "Cannot resolve conflicts for overlapping writes. %s is currently running and has overlapping file groups with %s. "
+              + "Please retry the write operation after the %s completes.",
+          otherOpDesc, thisOpDesc, serviceType.toLowerCase()
+      );
+    }
+
+    // For all other cases (this is table service or both are regular operations)
+    return String.format(
+        "Cannot resolve conflicts for overlapping writes. %s has overlapping file groups with %s.",
+        thisOpDesc, otherOpDesc
+    );
+  }
+
+  /**
+   * Formats a description of an operation including its type, instant, and state.
+   */
+  private String formatOperationDescription(ConcurrentOperation operation) {
+    String operationName = isTableService(operation.getOperationType())
+        ? "Table " + getTableServiceDisplayName(operation.getOperationType())
+        : operation.getOperationType().value() + " operation";
+
+    return String.format("%s (instant: %s, state: %s)",
+        operationName,
+        operation.getInstantTimestamp(),
+        operation.getInstantActionState());
+  }
+
+  /**
+   * Checks if the given operation type is a table service operation.
+   */
+  private boolean isTableService(WriteOperationType operationType) {
+    return operationType == WriteOperationType.COMPACT
+        || operationType == WriteOperationType.CLUSTER
+        || operationType == WriteOperationType.LOG_COMPACT
+        || operationType == WriteOperationType.INDEX;
+  }
+
+  /**
+   * Returns a user-friendly display name for table service operations.
+   */
+  private String getTableServiceDisplayName(WriteOperationType operationType) {
+    switch (operationType) {
+      case COMPACT:
+        return "Compaction";
+      case CLUSTER:
+        return "Clustering";
+      case LOG_COMPACT:
+        return "Log Compaction";
+      case INDEX:
+        return "Indexing";
+      default:
+        return operationType.value();
+    }
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -518,16 +518,16 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testErrorMessageForConflictWithCompaction() throws Exception {
     initMetaClient();
-    createCommit(HoodieActiveTimeline.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
 
     // writer 1 starts
-    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
 
     // compaction gets scheduled and runs
-    String compactionInstant = HoodieActiveTimeline.createNewInstantTime();
+    String compactionInstant = WriteClientTestUtils.createNewInstantTime();
     createCompactionRequested(compactionInstant, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -560,16 +560,16 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testErrorMessageForConflictWithClustering() throws Exception {
     initMetaClient();
-    createCommit(HoodieActiveTimeline.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
 
     // writer 1 starts
-    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
 
     // clustering gets scheduled
-    String clusteringInstant = HoodieActiveTimeline.createNewInstantTime();
+    String clusteringInstant = WriteClientTestUtils.createNewInstantTime();
     createClusterRequested(clusteringInstant, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -602,16 +602,16 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testErrorMessageForConflictBetweenRegularWrites() throws Exception {
     initMetaClient();
-    createCommit(HoodieActiveTimeline.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
 
     // writer 1 starts
-    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
 
     // writer 2 starts and finishes
-    String writer2Instant = HoodieActiveTimeline.createNewInstantTime();
+    String writer2Instant = WriteClientTestUtils.createNewInstantTime();
     createCommit(writer2Instant, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
@@ -649,17 +649,17 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
   @Test
   public void testErrorMessageForConflictWithCompletedClustering() throws Exception {
     initMetaClient();
-    createCommit(HoodieActiveTimeline.createNewInstantTime(), metaClient);
+    createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
 
     // writer 1 starts
-    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    String currentWriterInstant = WriteClientTestUtils.createNewInstantTime();
     createInflightCommit(currentWriterInstant, metaClient);
 
     // clustering completes
-    String clusteringInstant = HoodieActiveTimeline.createNewInstantTime();
-    createCluster(clusteringInstant, metaClient);
+    String clusteringInstant = WriteClientTestUtils.createNewInstantTime();
+    createCluster(clusteringInstant, WriteOperationType.CLUSTER, metaClient);
 
     Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
     SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -517,7 +517,7 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
 
   @Test
   public void testErrorMessageForConflictWithCompaction() throws Exception {
-    initMetaClient();
+    initMetaClient(true, HoodieTableType.MERGE_ON_READ);
     createCommit(WriteClientTestUtils.createNewInstantTime(), metaClient);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
     Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -514,4 +514,175 @@ public class TestSimpleConcurrentFileWritesConflictResolutionStrategy extends Ho
       }
     }
   }
+
+  @Test
+  public void testErrorMessageForConflictWithCompaction() throws Exception {
+    initMetaClient();
+    createCommit(HoodieActiveTimeline.createNewInstantTime(), metaClient);
+    HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
+    Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
+
+    // writer 1 starts
+    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    createInflightCommit(currentWriterInstant, metaClient);
+
+    // compaction gets scheduled and runs
+    String compactionInstant = HoodieActiveTimeline.createNewInstantTime();
+    createCompactionRequested(compactionInstant, metaClient);
+
+    Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
+    SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
+    HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant);
+    metaClient.reloadActiveTimeline();
+
+    List<HoodieInstant> candidateInstants = strategy.getCandidateInstants(metaClient, currentInstant.get(), lastSuccessfulInstant)
+        .collect(Collectors.toList());
+    Assertions.assertEquals(1, candidateInstants.size());
+
+    ConcurrentOperation thatCompactionOperation = new ConcurrentOperation(candidateInstants.get(0), metaClient);
+    ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
+    Assertions.assertTrue(strategy.hasConflict(thisCommitOperation, thatCompactionOperation));
+
+    HoodieWriteConflictException exception = Assertions.assertThrows(HoodieWriteConflictException.class,
+        () -> strategy.resolveConflict(null, thisCommitOperation, thatCompactionOperation));
+
+    String errorMessage = exception.getMessage();
+    Assertions.assertTrue(errorMessage.contains("Table Compaction"),
+        "Error message should mention 'Table Compaction', but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains("is currently running"),
+        "Error message should contain 'is currently running', but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains("Please retry the write operation after the compaction completes"),
+        "Error message should contain retry guidance, but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains(compactionInstant),
+        "Error message should contain compaction instant time, but was: " + errorMessage);
+  }
+
+  @Test
+  public void testErrorMessageForConflictWithClustering() throws Exception {
+    initMetaClient();
+    createCommit(HoodieActiveTimeline.createNewInstantTime(), metaClient);
+    HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
+    Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
+
+    // writer 1 starts
+    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    createInflightCommit(currentWriterInstant, metaClient);
+
+    // clustering gets scheduled
+    String clusteringInstant = HoodieActiveTimeline.createNewInstantTime();
+    createClusterRequested(clusteringInstant, metaClient);
+
+    Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
+    SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
+    HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant);
+    metaClient.reloadActiveTimeline();
+
+    List<HoodieInstant> candidateInstants = strategy.getCandidateInstants(metaClient, currentInstant.get(), lastSuccessfulInstant)
+        .collect(Collectors.toList());
+    Assertions.assertEquals(1, candidateInstants.size());
+
+    ConcurrentOperation thatClusteringOperation = new ConcurrentOperation(candidateInstants.get(0), metaClient);
+    ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
+    Assertions.assertTrue(strategy.hasConflict(thisCommitOperation, thatClusteringOperation));
+
+    HoodieWriteConflictException exception = Assertions.assertThrows(HoodieWriteConflictException.class,
+        () -> strategy.resolveConflict(null, thisCommitOperation, thatClusteringOperation));
+
+    String errorMessage = exception.getMessage();
+    Assertions.assertTrue(errorMessage.contains("Table Clustering"),
+        "Error message should mention 'Table Clustering', but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains("is currently running"),
+        "Error message should contain 'is currently running', but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains("Please retry the write operation after the clustering completes"),
+        "Error message should contain retry guidance, but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains(clusteringInstant),
+        "Error message should contain clustering instant time, but was: " + errorMessage);
+  }
+
+  @Test
+  public void testErrorMessageForConflictBetweenRegularWrites() throws Exception {
+    initMetaClient();
+    createCommit(HoodieActiveTimeline.createNewInstantTime(), metaClient);
+    HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
+    Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
+
+    // writer 1 starts
+    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    createInflightCommit(currentWriterInstant, metaClient);
+
+    // writer 2 starts and finishes
+    String writer2Instant = HoodieActiveTimeline.createNewInstantTime();
+    createCommit(writer2Instant, metaClient);
+
+    Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
+    SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
+    HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant);
+    metaClient.reloadActiveTimeline();
+
+    List<HoodieInstant> candidateInstants = strategy.getCandidateInstants(metaClient, currentInstant.get(), lastSuccessfulInstant)
+        .collect(Collectors.toList());
+    Assertions.assertEquals(1, candidateInstants.size());
+
+    ConcurrentOperation thatCommitOperation = new ConcurrentOperation(candidateInstants.get(0), metaClient);
+    ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
+    Assertions.assertTrue(strategy.hasConflict(thisCommitOperation, thatCommitOperation));
+
+    HoodieWriteConflictException exception = Assertions.assertThrows(HoodieWriteConflictException.class,
+        () -> strategy.resolveConflict(null, thisCommitOperation, thatCommitOperation));
+
+    String errorMessage = exception.getMessage();
+    Assertions.assertTrue(errorMessage.contains("Cannot resolve conflicts for overlapping writes"),
+        "Error message should mention overlapping writes, but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains("has overlapping file groups"),
+        "Error message should contain 'has overlapping file groups', but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains(currentWriterInstant),
+        "Error message should contain current writer instant time, but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains(writer2Instant),
+        "Error message should contain other writer instant time, but was: " + errorMessage);
+    // Should NOT contain table service specific messaging
+    Assertions.assertFalse(errorMessage.contains("Table Compaction"),
+        "Error message should not mention table services for regular writes, but was: " + errorMessage);
+    Assertions.assertFalse(errorMessage.contains("Please retry"),
+        "Error message should not contain retry guidance for regular writes, but was: " + errorMessage);
+  }
+
+  @Test
+  public void testErrorMessageForConflictWithCompletedClustering() throws Exception {
+    initMetaClient();
+    createCommit(HoodieActiveTimeline.createNewInstantTime(), metaClient);
+    HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
+    Option<HoodieInstant> lastSuccessfulInstant = timeline.getCommitsTimeline().filterCompletedInstants().lastInstant();
+
+    // writer 1 starts
+    String currentWriterInstant = HoodieActiveTimeline.createNewInstantTime();
+    createInflightCommit(currentWriterInstant, metaClient);
+
+    // clustering completes
+    String clusteringInstant = HoodieActiveTimeline.createNewInstantTime();
+    createCluster(clusteringInstant, metaClient);
+
+    Option<HoodieInstant> currentInstant = Option.of(INSTANT_GENERATOR.createNewInstant(State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, currentWriterInstant));
+    SimpleConcurrentFileWritesConflictResolutionStrategy strategy = new SimpleConcurrentFileWritesConflictResolutionStrategy();
+    HoodieCommitMetadata currentMetadata = createCommitMetadata(currentWriterInstant);
+    metaClient.reloadActiveTimeline();
+
+    List<HoodieInstant> candidateInstants = strategy.getCandidateInstants(metaClient, currentInstant.get(), lastSuccessfulInstant)
+        .collect(Collectors.toList());
+    Assertions.assertEquals(1, candidateInstants.size());
+
+    ConcurrentOperation thatClusteringOperation = new ConcurrentOperation(candidateInstants.get(0), metaClient);
+    ConcurrentOperation thisCommitOperation = new ConcurrentOperation(currentInstant.get(), currentMetadata);
+    Assertions.assertTrue(strategy.hasConflict(thisCommitOperation, thatClusteringOperation));
+
+    HoodieWriteConflictException exception = Assertions.assertThrows(HoodieWriteConflictException.class,
+        () -> strategy.resolveConflict(null, thisCommitOperation, thatClusteringOperation));
+
+    String errorMessage = exception.getMessage();
+    Assertions.assertTrue(errorMessage.contains("Table Clustering"),
+        "Error message should mention 'Table Clustering', but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains(clusteringInstant),
+        "Error message should contain clustering instant time, but was: " + errorMessage);
+    Assertions.assertTrue(errorMessage.contains("COMPLETED"),
+        "Error message should indicate the state of the clustering operation, but was: " + errorMessage);
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -189,6 +189,17 @@ public enum WriteOperationType {
   }
 
   /**
+   * Checks if the given operation type is a table service operation.
+   * Table service operations include compaction, clustering, log compaction, and indexing.
+   */
+  public static boolean isTableService(WriteOperationType operationType) {
+    return operationType == COMPACT
+        || operationType == CLUSTER
+        || operationType == LOG_COMPACT
+        || operationType == INDEX;
+  }
+
+  /**
    * @return true if streaming writes to metadata table is supported for a given {@link WriteOperationType}. false otherwise.
    */
   public static boolean streamingWritesToMetadataSupported(WriteOperationType writeOperationType) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

From a user perspective, the error message "Cannot resolve conflicts for overlapping writes" is often hit when table services are running in an async manner. It's not super clear from the message that it's an exception that wouldn't be thrown when the write is retried after the table service operation is complete. Adjusting the error message to be more clear.

### Summary and Changelog

Improve error message for conflict resolution. 

### Impact

Better visibility for hudi users writing via SQL or spark jobs. 

### Risk Level

Low. 

### Documentation Update

None. 

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
