### PR TITLE
fix: correct unsigned int conversion in TestProtoConversionUtil

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
@@ -301,7 +301,7 @@ public class TestProtoConversionUtil {
       wrappedStringOutput = getWrappedRecord(schema, "wrapped_string", wrappedString);
       wrappedIntOutput = getWrappedRecord(schema, "wrapped_int", wrappedInt);
       wrappedLongOutput = getWrappedRecord(schema, "wrapped_long", wrappedLong);
-      wrappedUIntOutput = getWrappedRecord(schema, "wrapped_unsigned_int", (long) wrappedUnsignedInt);
+      wrappedUIntOutput = getWrappedRecord(schema, "wrapped_unsigned_int", Integer.toUnsignedLong(wrappedUnsignedInt));
       wrappedULongOutput = getWrappedRecord(schema, "wrapped_unsigned_long", unsignedLongAsGenericFixed(wrappedUnsignedLong, unsignedLongSchema));
       wrappedDoubleOutput = getWrappedRecord(schema, "wrapped_double", wrappedDouble);
       wrappedFloatOutput = getWrappedRecord(schema, "wrapped_float", wrappedFloat);
@@ -312,7 +312,7 @@ public class TestProtoConversionUtil {
       wrappedStringOutput = wrappedString;
       wrappedIntOutput = wrappedInt;
       wrappedLongOutput = wrappedLong;
-      wrappedUIntOutput = (long) wrappedUnsignedInt;
+      wrappedUIntOutput = Integer.toUnsignedLong(wrappedUnsignedInt);
       wrappedULongOutput = unsignedLongAsGenericFixed(wrappedUnsignedLong, unsignedLongSchema);
       wrappedDoubleOutput = wrappedDouble;
       wrappedFloatOutput = wrappedFloat;
@@ -326,7 +326,7 @@ public class TestProtoConversionUtil {
     expectedRecord.put("primitive_float", primitiveFloat);
     expectedRecord.put("primitive_int", primitiveInt);
     expectedRecord.put("primitive_long", primitiveLong);
-    expectedRecord.put("primitive_unsigned_int", (long) primitiveUnsignedInt);
+    expectedRecord.put("primitive_unsigned_int", Integer.toUnsignedLong(primitiveUnsignedInt));
     expectedRecord.put("primitive_unsigned_long", unsignedLongAsGenericFixed(primitiveUnsignedLong, unsignedLongSchema));
     expectedRecord.put("primitive_signed_int", primitiveSignedInt);
     expectedRecord.put("primitive_signed_long", primitiveSignedLong);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The `TestProtoConversionUtil` class had two failing test methods:
- `allFieldsSet_wellKnownTypesAndTimestampsAsRecords`
- `allFieldsSet_defaultOptions`

The tests were failing because they used simple casting `(long)` to convert unsigned integers to long values. This doesn't properly handle unsigned conversion when the int value is negative in its signed representation (i.e., when the high bit is set).

### Summary and Changelog

Fixed test failures by using `Integer.toUnsignedLong()` instead of casting for unsigned integer conversion, matching the behavior in `ProtoConversionUtil.java:446`.

**Changes:**
- Line 329: Changed `(long) primitiveUnsignedInt` to `Integer.toUnsignedLong(primitiveUnsignedInt)`
- Line 304: Changed `(long) wrappedUnsignedInt` to `Integer.toUnsignedLong(wrappedUnsignedInt)` for wrapped records
- Line 315: Changed `(long) wrappedUnsignedInt` to `Integer.toUnsignedLong(wrappedUnsignedInt)` for default options

All 9 tests in TestProtoConversionUtil now pass.

### Impact

No public API or user-facing changes. This is a test-only fix.

### Risk Level

**none**

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable