### PR TITLE
Add helper functions to parse Kafka offset differences between commits

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
@@ -111,6 +112,9 @@ public class StreamerUtil {
 
   public static final String FLINK_CHECKPOINT_ID = "flink_checkpoint_id";
   public static final String EMPTY_PARTITION_PATH = "";
+  public static final String HOODIE_METADATA_KEY = "HoodieMetadataKey";
+  private static final String URL_ENCODED_COLON = "%3A";
+  private static final String PARTITION_SEPARATOR = ";";
 
   public static TypedProperties appendKafkaProps(FlinkStreamerConfig config) {
     TypedProperties properties = getProps(config);
@@ -727,6 +731,155 @@ public class StreamerUtil {
         Map.Entry<HoodieKey, Throwable> entry = writeStatus.getErrors().entrySet().iterator().next();
         throw new HoodieException(String.format("Write failure occurs with hoodie key %s at Instant [%s] in append write function", entry.getKey(), currentInstant), entry.getValue());
       });
+    }
+  }
+
+  /**
+   * Extracts Kafka offset metadata from a Hudi commit.
+   *
+   * @param commitInstant The commit instant to extract metadata from
+   * @param timeline The timeline to read commit details from
+   * @return The Kafka offset metadata string, or null if not found
+   * @throws IOException if error reading commit metadata
+   */
+  public static String extractKafkaOffsetMetadata(final HoodieInstant commitInstant,
+                                                  final HoodieTimeline timeline) throws IOException {
+    HoodieCommitMetadata commitMetadata = TimelineUtils.getCommitMetadata(commitInstant, timeline);
+    return commitMetadata.getExtraMetadata().get(HOODIE_METADATA_KEY);
+  }
+
+  /**
+   * Parses Kafka offset string and restores partition offsets as Map.
+   *
+   * @param kafkaOffsetString URL-encoded Kafka offset string in format:
+   *        "kafka_metadata%3Atopic%3Apartition:offset;kafka_metadata%3Atopic%3Apartition:offset"
+   * @return Map of partition ID to offset, or empty map if parsing fails
+   */
+  public static Map<Integer, Long> parseKafkaOffsets(final String kafkaOffsetString) {
+    Map<Integer, Long> partitionOffsets = new HashMap<>();
+
+    if (kafkaOffsetString == null || kafkaOffsetString.isEmpty()) {
+      return partitionOffsets;
+    }
+
+    try {
+      // Split by semicolon to get individual partition entries
+      String[] partitionEntries = kafkaOffsetString.split(PARTITION_SEPARATOR);
+
+      for (String entry : partitionEntries) {
+        entry = entry.trim();
+
+        // Skip cluster metadata entries (they don't contain partition:offset format)
+        if (!entry.contains(":") || entry.contains("kafka_cluster")) {
+          continue;
+        }
+
+        // Entry format: kafka_metadata%3Atopic%3Apartition:offset
+        // Find the last colon which separates partition and offset
+        int lastColonIndex = entry.lastIndexOf(':');
+        if (lastColonIndex == -1) {
+          continue;
+        }
+
+        String offsetStr = entry.substring(lastColonIndex + 1);
+        String beforeOffset = entry.substring(0, lastColonIndex);
+
+        // Find the partition number (everything after the last %3A before the colon)
+        int lastEncodedColonIndex = beforeOffset.lastIndexOf(URL_ENCODED_COLON);
+        if (lastEncodedColonIndex == -1) {
+          continue;
+        }
+
+        String partitionStr = beforeOffset.substring(lastEncodedColonIndex + URL_ENCODED_COLON.length());
+
+        try {
+          int partitionId = Integer.parseInt(partitionStr);
+          long offset = Long.parseLong(offsetStr);
+          partitionOffsets.put(partitionId, offset);
+        } catch (NumberFormatException e) {
+          log.warn("Failed to parse partition ID or offset from entry: {}", entry, e);
+        }
+      }
+    } catch (Exception e) {
+      log.error("Failed to parse Kafka offset string: {}", kafkaOffsetString, e);
+    }
+
+    return partitionOffsets;
+  }
+
+  /**
+   * Calculates the total difference count between Kafka offsets of two Hudi commits.
+   * The difference is: current commit's kafka offset minus previous commit's kafka offset
+   * for each partition. All partition differences are summed together.
+   *
+   * @param currentCommitInstant The current (newer) commit instant
+   * @param previousCommitInstant The previous (older) commit instant
+   * @param timeline The timeline to read commit details from
+   * @return The total count of offset differences across all partitions, or 0 if calculation fails
+   */
+  public static long calculateKafkaOffsetDifference(
+      final HoodieInstant currentCommitInstant,
+      final HoodieInstant previousCommitInstant,
+      final HoodieTimeline timeline) {
+
+    if (currentCommitInstant == null || previousCommitInstant == null || timeline == null) {
+      log.warn("Invalid input parameters for calculating Kafka offset difference");
+      return 0L;
+    }
+
+    try {
+      // Extract Kafka offset metadata from both commits
+      String currentOffsetString = extractKafkaOffsetMetadata(currentCommitInstant, timeline);
+      String previousOffsetString = extractKafkaOffsetMetadata(previousCommitInstant, timeline);
+
+      if (currentOffsetString == null || previousOffsetString == null) {
+        log.warn("Kafka offset metadata not found in one or both commits: current={}, previous={}",
+            currentCommitInstant.requestedTime(), previousCommitInstant.requestedTime());
+        return 0L;
+      }
+
+      // Parse offset strings into partition -> offset maps
+      Map<Integer, Long> currentOffsets = parseKafkaOffsets(currentOffsetString);
+      Map<Integer, Long> previousOffsets = parseKafkaOffsets(previousOffsetString);
+
+      if (currentOffsets.isEmpty() || previousOffsets.isEmpty()) {
+        log.warn("Failed to parse Kafka offsets from commits: current={}, previous={}",
+            currentCommitInstant.requestedTime(), previousCommitInstant.requestedTime());
+        return 0L;
+      }
+
+      // Calculate total difference across all partitions
+      long totalDifference = 0L;
+
+      for (Map.Entry<Integer, Long> currentEntry : currentOffsets.entrySet()) {
+        Integer partitionId = currentEntry.getKey();
+        Long currentOffset = currentEntry.getValue();
+        Long previousOffset = previousOffsets.get(partitionId);
+
+        // If partition doesn't exist in previous commit (new partition), use 0 as base
+        if (previousOffset == null) {
+          previousOffset = 0L;
+          log.debug("New partition {} detected, using 0 as previous offset baseline",
+              partitionId);
+        }
+
+        long difference = currentOffset - previousOffset;
+        totalDifference += difference;
+
+        log.debug("Partition {} offset difference: {} - {} = {}",
+            partitionId, currentOffset, previousOffset, difference);
+      }
+
+      log.info("Total Kafka offset difference between commits {} and {}: {}",
+          currentCommitInstant.requestedTime(), previousCommitInstant.requestedTime(),
+          totalDifference);
+
+      return totalDifference;
+
+    } catch (Exception e) {
+      log.error("Failed to calculate Kafka offset difference between commits {} and {}",
+          currentCommitInstant.requestedTime(), previousCommitInstant.requestedTime(), e);
+      return 0L;
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestStreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestStreamerUtil.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for StreamerUtil Kafka offset methods.
+ */
+public class TestStreamerUtil {
+
+  @Test
+  public void testExtractKafkaOffsetMetadata() throws Exception {
+    HoodieInstant mockInstant = mock(HoodieInstant.class);
+    HoodieTimeline mockTimeline = mock(HoodieTimeline.class);
+    HoodieCommitMetadata mockCommitMetadata = mock(HoodieCommitMetadata.class);
+
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(StreamerUtil.HOODIE_METADATA_KEY, "kafka_metadata%3Atopic%3A0:100;kafka_metadata%3Atopic%3A1:200");
+
+    when(mockCommitMetadata.getExtraMetadata()).thenReturn(extraMetadata);
+
+    try (MockedStatic<TimelineUtils> mockedTimelineUtils = Mockito.mockStatic(TimelineUtils.class)) {
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(any(HoodieInstant.class), any(HoodieTimeline.class)))
+          .thenReturn(mockCommitMetadata);
+
+      String result = StreamerUtil.extractKafkaOffsetMetadata(mockInstant, mockTimeline);
+      assertEquals("kafka_metadata%3Atopic%3A0:100;kafka_metadata%3Atopic%3A1:200", result);
+    }
+  }
+
+  @Test
+  public void testExtractKafkaOffsetMetadataNotFound() throws Exception {
+    HoodieInstant mockInstant = mock(HoodieInstant.class);
+    HoodieTimeline mockTimeline = mock(HoodieTimeline.class);
+    HoodieCommitMetadata mockCommitMetadata = mock(HoodieCommitMetadata.class);
+
+    Map<String, String> extraMetadata = new HashMap<>();
+
+    when(mockCommitMetadata.getExtraMetadata()).thenReturn(extraMetadata);
+
+    try (MockedStatic<TimelineUtils> mockedTimelineUtils = Mockito.mockStatic(TimelineUtils.class)) {
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(any(HoodieInstant.class), any(HoodieTimeline.class)))
+          .thenReturn(mockCommitMetadata);
+
+      String result = StreamerUtil.extractKafkaOffsetMetadata(mockInstant, mockTimeline);
+      assertNull(result);
+    }
+  }
+
+  @Test
+  public void testParseKafkaOffsetsValidInput() {
+    String kafkaOffsetString = "kafka_metadata%3Atopic%3A0:100;kafka_metadata%3Atopic%3A1:200;kafka_metadata%3Atopic%3A2:300";
+
+    Map<Integer, Long> result = StreamerUtil.parseKafkaOffsets(kafkaOffsetString);
+
+    assertEquals(3, result.size());
+    assertEquals(100L, result.get(0));
+    assertEquals(200L, result.get(1));
+    assertEquals(300L, result.get(2));
+  }
+
+  @Test
+  public void testParseKafkaOffsetsEmptyString() {
+    Map<Integer, Long> result = StreamerUtil.parseKafkaOffsets("");
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testParseKafkaOffsetsNullString() {
+    Map<Integer, Long> result = StreamerUtil.parseKafkaOffsets(null);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testParseKafkaOffsetsWithClusterMetadata() {
+    // Include cluster metadata which should be skipped
+    String kafkaOffsetString = "kafka_metadata%3Atopic%3A0:100;kafka_cluster%3Atopicname%3Aclustername;kafka_metadata%3Atopic%3A1:200";
+
+    Map<Integer, Long> result = StreamerUtil.parseKafkaOffsets(kafkaOffsetString);
+
+    assertEquals(2, result.size());
+    assertEquals(100L, result.get(0));
+    assertEquals(200L, result.get(1));
+  }
+
+  @Test
+  public void testParseKafkaOffsetsMalformedEntry() {
+    // Entry without colon should be skipped
+    String kafkaOffsetString = "kafka_metadata%3Atopic%3A0:100;invalidentry;kafka_metadata%3Atopic%3A1:200";
+
+    Map<Integer, Long> result = StreamerUtil.parseKafkaOffsets(kafkaOffsetString);
+
+    assertEquals(2, result.size());
+    assertEquals(100L, result.get(0));
+    assertEquals(200L, result.get(1));
+  }
+
+  @Test
+  public void testParseKafkaOffsetsInvalidNumber() {
+    // Entry with invalid offset number should be skipped
+    String kafkaOffsetString = "kafka_metadata%3Atopic%3A0:100;kafka_metadata%3Atopic%3A1:notanumber;kafka_metadata%3Atopic%3A2:300";
+
+    Map<Integer, Long> result = StreamerUtil.parseKafkaOffsets(kafkaOffsetString);
+
+    assertEquals(2, result.size());
+    assertEquals(100L, result.get(0));
+    assertEquals(300L, result.get(2));
+  }
+
+  @Test
+  public void testCalculateKafkaOffsetDifference() throws Exception {
+    HoodieInstant currentInstant = mock(HoodieInstant.class);
+    HoodieInstant previousInstant = mock(HoodieInstant.class);
+    HoodieTimeline mockTimeline = mock(HoodieTimeline.class);
+    HoodieCommitMetadata currentMetadata = mock(HoodieCommitMetadata.class);
+    HoodieCommitMetadata previousMetadata = mock(HoodieCommitMetadata.class);
+
+    when(currentInstant.requestedTime()).thenReturn("20250828120000");
+    when(previousInstant.requestedTime()).thenReturn("20250828110000");
+
+    Map<String, String> currentExtraMetadata = new HashMap<>();
+    currentExtraMetadata.put(StreamerUtil.HOODIE_METADATA_KEY, "kafka_metadata%3Atopic%3A0:150;kafka_metadata%3Atopic%3A1:250;kafka_metadata%3Atopic%3A2:350");
+
+    Map<String, String> previousExtraMetadata = new HashMap<>();
+    previousExtraMetadata.put(StreamerUtil.HOODIE_METADATA_KEY, "kafka_metadata%3Atopic%3A0:100;kafka_metadata%3Atopic%3A1:200;kafka_metadata%3Atopic%3A2:300");
+
+    when(currentMetadata.getExtraMetadata()).thenReturn(currentExtraMetadata);
+    when(previousMetadata.getExtraMetadata()).thenReturn(previousExtraMetadata);
+
+    try (MockedStatic<TimelineUtils> mockedTimelineUtils = Mockito.mockStatic(TimelineUtils.class)) {
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(currentInstant, mockTimeline))
+          .thenReturn(currentMetadata);
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(previousInstant, mockTimeline))
+          .thenReturn(previousMetadata);
+
+      long result = StreamerUtil.calculateKafkaOffsetDifference(currentInstant, previousInstant, mockTimeline);
+
+      // (150-100) + (250-200) + (350-300) = 50 + 50 + 50 = 150
+      assertEquals(150L, result);
+    }
+  }
+
+  @Test
+  public void testCalculateKafkaOffsetDifferenceWithNewPartition() throws Exception {
+    HoodieInstant currentInstant = mock(HoodieInstant.class);
+    HoodieInstant previousInstant = mock(HoodieInstant.class);
+    HoodieTimeline mockTimeline = mock(HoodieTimeline.class);
+    HoodieCommitMetadata currentMetadata = mock(HoodieCommitMetadata.class);
+    HoodieCommitMetadata previousMetadata = mock(HoodieCommitMetadata.class);
+
+    when(currentInstant.requestedTime()).thenReturn("20250828120000");
+    when(previousInstant.requestedTime()).thenReturn("20250828110000");
+
+    Map<String, String> currentExtraMetadata = new HashMap<>();
+    // Current has partition 2 which didn't exist in previous
+    currentExtraMetadata.put(StreamerUtil.HOODIE_METADATA_KEY, "kafka_metadata%3Atopic%3A0:150;kafka_metadata%3Atopic%3A1:250;kafka_metadata%3Atopic%3A2:100");
+
+    Map<String, String> previousExtraMetadata = new HashMap<>();
+    // Previous only has partitions 0 and 1
+    previousExtraMetadata.put(StreamerUtil.HOODIE_METADATA_KEY, "kafka_metadata%3Atopic%3A0:100;kafka_metadata%3Atopic%3A1:200");
+
+    when(currentMetadata.getExtraMetadata()).thenReturn(currentExtraMetadata);
+    when(previousMetadata.getExtraMetadata()).thenReturn(previousExtraMetadata);
+
+    try (MockedStatic<TimelineUtils> mockedTimelineUtils = Mockito.mockStatic(TimelineUtils.class)) {
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(currentInstant, mockTimeline))
+          .thenReturn(currentMetadata);
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(previousInstant, mockTimeline))
+          .thenReturn(previousMetadata);
+
+      long result = StreamerUtil.calculateKafkaOffsetDifference(currentInstant, previousInstant, mockTimeline);
+
+      // (150-100) + (250-200) + (100-0) = 50 + 50 + 100 = 200
+      assertEquals(200L, result);
+    }
+  }
+
+  @Test
+  public void testCalculateKafkaOffsetDifferenceNullInstants() {
+    long result = StreamerUtil.calculateKafkaOffsetDifference(null, null, null);
+    assertEquals(0L, result);
+  }
+
+  @Test
+  public void testCalculateKafkaOffsetDifferenceNoMetadata() throws Exception {
+    HoodieInstant currentInstant = mock(HoodieInstant.class);
+    HoodieInstant previousInstant = mock(HoodieInstant.class);
+    HoodieTimeline mockTimeline = mock(HoodieTimeline.class);
+    HoodieCommitMetadata currentMetadata = mock(HoodieCommitMetadata.class);
+    HoodieCommitMetadata previousMetadata = mock(HoodieCommitMetadata.class);
+
+    when(currentInstant.requestedTime()).thenReturn("20250828120000");
+    when(previousInstant.requestedTime()).thenReturn("20250828110000");
+
+    Map<String, String> currentExtraMetadata = new HashMap<>();
+    Map<String, String> previousExtraMetadata = new HashMap<>();
+
+    when(currentMetadata.getExtraMetadata()).thenReturn(currentExtraMetadata);
+    when(previousMetadata.getExtraMetadata()).thenReturn(previousExtraMetadata);
+
+    try (MockedStatic<TimelineUtils> mockedTimelineUtils = Mockito.mockStatic(TimelineUtils.class)) {
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(currentInstant, mockTimeline))
+          .thenReturn(currentMetadata);
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(previousInstant, mockTimeline))
+          .thenReturn(previousMetadata);
+
+      long result = StreamerUtil.calculateKafkaOffsetDifference(currentInstant, previousInstant, mockTimeline);
+
+      assertEquals(0L, result);
+    }
+  }
+
+  @Test
+  public void testCalculateKafkaOffsetDifferenceEmptyOffsets() throws Exception {
+    HoodieInstant currentInstant = mock(HoodieInstant.class);
+    HoodieInstant previousInstant = mock(HoodieInstant.class);
+    HoodieTimeline mockTimeline = mock(HoodieTimeline.class);
+    HoodieCommitMetadata currentMetadata = mock(HoodieCommitMetadata.class);
+    HoodieCommitMetadata previousMetadata = mock(HoodieCommitMetadata.class);
+
+    when(currentInstant.requestedTime()).thenReturn("20250828120000");
+    when(previousInstant.requestedTime()).thenReturn("20250828110000");
+
+    Map<String, String> currentExtraMetadata = new HashMap<>();
+    currentExtraMetadata.put(StreamerUtil.HOODIE_METADATA_KEY, "");
+
+    Map<String, String> previousExtraMetadata = new HashMap<>();
+    previousExtraMetadata.put(StreamerUtil.HOODIE_METADATA_KEY, "");
+
+    when(currentMetadata.getExtraMetadata()).thenReturn(currentExtraMetadata);
+    when(previousMetadata.getExtraMetadata()).thenReturn(previousExtraMetadata);
+
+    try (MockedStatic<TimelineUtils> mockedTimelineUtils = Mockito.mockStatic(TimelineUtils.class)) {
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(currentInstant, mockTimeline))
+          .thenReturn(currentMetadata);
+      mockedTimelineUtils.when(() -> TimelineUtils.getCommitMetadata(previousInstant, mockTimeline))
+          .thenReturn(previousMetadata);
+
+      long result = StreamerUtil.calculateKafkaOffsetDifference(currentInstant, previousInstant, mockTimeline);
+
+      assertEquals(0L, result);
+    }
+  }
+}


### PR DESCRIPTION
This is to port the internal changes from Uber internal build to prepare upgrading Hudi. 

This commit adds utility functions to StreamerUtil for extracting and parsing Kafka offset metadata from Hudi commits, enabling analysis of message processing progress between commits.

Changes:
- Add extractKafkaOffsetMetadata() to extract Kafka offset metadata from commit
- Add parseKafkaOffsets() to parse URL-encoded Kafka offset strings into partition->offset map
- Add calculateKafkaOffsetDifference() to compute total offset delta between two commits
- Add comprehensive unit tests in TestStreamerUtil covering normal cases and edge cases
- Add constants: HOODIE_METADATA_KEY, URL_ENCODED_COLON, PARTITION_SEPARATOR

Use Cases:
- Data loss detection by comparing expected vs actual record counts
- Monitoring Kafka consumption progress across Hudi commits
- Debugging offset tracking issues in Flink-Kafka-Hudi pipelines

Test Coverage:
- Metadata extraction from commits
- Parsing various Kafka offset string formats
- Handling new partitions, malformed entries, missing metadata
- Calculating offset differences with edge cases

Original Internal Commit (for lineage):
bb19ca6cbe - Add helper function to parse the Kafka offsets diff range between two commits Differential: 