### PR TITLE
feat: add flink stream read metrics for hudi source v2

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamReadMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkStreamReadMetrics.java
@@ -59,8 +59,8 @@ public class FlinkStreamReadMetrics extends HoodieFlinkMetrics {
    */
   private long splitLatestCommitDelay;
 
-  public FlinkStreamReadMetrics(MetricGroup metricGroup) {
-    super(metricGroup);
+  public FlinkStreamReadMetrics(MetricGroup metricGroup, String tableName) {
+    super(metricGroup.addGroup("table", tableName));
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadMonitoringFunction.java
@@ -88,6 +88,11 @@ public class StreamReadMonitoringFunction
   private final long interval;
 
   /**
+   * Table to read from
+   */
+  private final String tableName;
+
+  /**
    * Flag saying whether the change log capture is enabled.
    */
   private final boolean cdcEnabled;
@@ -123,11 +128,13 @@ public class StreamReadMonitoringFunction
   private transient FlinkStreamReadMetrics readMetrics;
 
   public StreamReadMonitoringFunction(
+      String tableName,
       Configuration conf,
       Path path,
       RowType rowType,
       long maxCompactionMemoryInBytes,
       @Nullable PartitionPruners.PartitionPruner partitionPruner) {
+    this.tableName = tableName;
     this.conf = conf;
     this.path = path;
     this.interval = conf.get(FlinkOptions.READ_STREAMING_CHECK_INTERVAL);
@@ -326,7 +333,7 @@ public class StreamReadMonitoringFunction
 
   private void registerMetrics() {
     MetricGroup metrics = getRuntimeContext().getMetricGroup();
-    readMetrics = new FlinkStreamReadMetrics(metrics);
+    readMetrics = new FlinkStreamReadMetrics(metrics, tableName);
     readMetrics.registerMetrics();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/StreamReadOperator.java
@@ -234,7 +234,7 @@ public class StreamReadOperator extends AbstractStreamOperator<RowData>
 
   private void registerMetrics() {
     MetricGroup metrics = getRuntimeContext().getMetricGroup();
-    readMetrics = new FlinkStreamReadMetrics(metrics);
+    readMetrics = new FlinkStreamReadMetrics(metrics, format.getTableName());
     readMetrics.registerMetrics();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/HoodieContinuousSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/HoodieContinuousSplitEnumerator.java
@@ -49,12 +49,13 @@ public class HoodieContinuousSplitEnumerator extends AbstractHoodieSplitEnumerat
   private final AtomicReference<HoodieEnumeratorPosition> position;
 
   public HoodieContinuousSplitEnumerator(
+      String tableName,
       SplitEnumeratorContext<HoodieSourceSplit> enumeratorContext,
       HoodieSplitProvider splitProvider,
       HoodieContinuousSplitDiscover splitDiscover,
       HoodieScanContext scanContext,
       Option<HoodieSplitEnumeratorState> enumStateOpt) {
-    super(enumeratorContext, splitProvider);
+    super(tableName, enumeratorContext, splitProvider);
     this.enumeratorContext = enumeratorContext;
     this.splitProvider = splitProvider;
     this.splitDiscover = splitDiscover;
@@ -108,6 +109,7 @@ public class HoodieContinuousSplitEnumerator extends AbstractHoodieSplitEnumerat
 
     if (!result.getSplits().isEmpty()) {
       splitProvider.onDiscoveredSplits(result.getSplits());
+      position.get().getIssuedInstant().ifPresent(enumeratorMetrics::setIssuedInstant);
       LOG.debug(
           "Added {} splits discovered between ({}, {}] to the assigner",
           result.getSplits().size(),

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/HoodieStaticSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/HoodieStaticSplitEnumerator.java
@@ -29,8 +29,8 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 public class HoodieStaticSplitEnumerator extends AbstractHoodieSplitEnumerator {
 
   public HoodieStaticSplitEnumerator(
-      SplitEnumeratorContext<HoodieSourceSplit> enumeratorContext, HoodieSplitProvider provider) {
-    super(enumeratorContext, provider);
+      String tableName, SplitEnumeratorContext<HoodieSourceSplit> enumeratorContext, HoodieSplitProvider provider) {
+    super(tableName, enumeratorContext, provider);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieSourceReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieSourceReader.java
@@ -39,14 +39,14 @@ import java.util.Map;
  */
 public class HoodieSourceReader<T> extends
         SingleThreadMultiplexSourceReaderBase<HoodieRecordWithPosition<T>, T, HoodieSourceSplit, HoodieSourceSplit> {
-
   public HoodieSourceReader(
+          String tableName,
           RecordEmitter<HoodieRecordWithPosition<T>, T, HoodieSourceSplit> recordEmitter,
           Configuration config,
           SourceReaderContext context,
           SplitReaderFunction<T> readerFunction,
           SerializableComparator<HoodieSourceSplit> splitComparator) {
-    super(() -> new HoodieSourceSplitReader<>(context, readerFunction, splitComparator), recordEmitter, config, context);
+    super(() -> new HoodieSourceSplitReader<>(tableName, context, readerFunction, splitComparator), recordEmitter, config, context);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -260,6 +260,7 @@ public class HoodieTableSource extends FileIndexReader implements
       TypeInformation<RowData> typeInfo) {
     if (conf.get(FlinkOptions.READ_AS_STREAMING)) {
       StreamReadMonitoringFunction monitoringFunction = new StreamReadMonitoringFunction(
+              metaClient == null ? "" : metaClient.getTableConfig().getTableName(),
           conf, FilePathUtils.toFlinkPath(path), tableRowType, maxCompactionMemoryInBytes, partitionPruner);
       InputFormat<RowData, ?> inputFormat = getInputFormat(true);
       OneInputStreamOperatorFactory<MergeOnReadInputSplit, RowData> factory = StreamReadOperator.factory((MergeOnReadInputFormat) inputFormat);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -115,6 +115,12 @@ public class MergeOnReadInputFormat
   protected boolean emitDelete;
 
   /**
+   * Table name
+   */
+  @Getter
+  private String tableName;
+
+  /**
    * Flag saying whether the input format has been closed.
    */
   @Getter
@@ -168,6 +174,7 @@ public class MergeOnReadInputFormat
     this.metaClient = StreamerUtil.metaClientForReader(this.conf, hadoopConf);
     this.writeConfig = FlinkWriteClients.getHoodieClientConfig(this.conf);
     this.iterator = initIterator(split);
+    this.tableName = metaClient.getTableConfig().getTableName();
     mayShiftInputSplit(split);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieStaticSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieStaticSplitEnumerator.java
@@ -61,7 +61,7 @@ public class TestHoodieStaticSplitEnumerator {
   public void setUp() {
     context = new MockSplitEnumeratorContext();
     splitProvider = new DefaultHoodieSplitProvider(new HoodieSplitNumberAssigner(2));
-    enumerator = new HoodieStaticSplitEnumerator(context, splitProvider);
+    enumerator = new HoodieStaticSplitEnumerator("test-table", context, splitProvider);
 
     split1 = createTestSplit(1, "file1");
     split2 = createTestSplit(2, "file2");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
@@ -140,7 +140,8 @@ public class TestUtils {
 
   public static StreamReadMonitoringFunction getMonitorFunc(Configuration conf) {
     final String basePath = conf.get(FlinkOptions.PATH);
-    return new StreamReadMonitoringFunction(conf, new Path(basePath), TestConfigurations.ROW_TYPE, 1024 * 1024L, null);
+    return new StreamReadMonitoringFunction(
+            conf.get(FlinkOptions.TABLE_NAME), conf, new Path(basePath), TestConfigurations.ROW_TYPE, 1024 * 1024L, null);
   }
 
   public static MockStreamingRuntimeContext getMockRuntimeContext() {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Integrate FlinkStreamReadMetrics into Hudi Flink Source V2 

Closes   #18129

### Summary and Changelog

1. Table name as parameter for FlinkStreamReadMetrics to track reading from multiple tables.
2. Integrate FlinkStreamReadMetrics in HoodieSourceSplitReader to track split latest commit
3. Integrate FlinkStreamReadMetrics in HoodieContinuousSplitEnumerator to track issued instant

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
