### PR TITLE
fix: Set credentials for Hive metastore based lock provider

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TransactionManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TransactionManager.java
@@ -42,12 +42,17 @@ public class TransactionManager implements Serializable {
   private Option<HoodieInstant> lastCompletedTxnOwnerInstant = Option.empty();
 
   public TransactionManager(HoodieWriteConfig config, FileSystem fs) {
-    this(new LockManager(config, fs), config.isLockRequired());
+    this(createLockManager(config, fs), config.isLockRequired());
   }
 
   protected TransactionManager(LockManager lockManager, boolean isLockRequired) {
     this.lockManager = lockManager;
     this.isLockRequired = isLockRequired;
+  }
+
+  private static LockManager createLockManager(HoodieWriteConfig config, FileSystem fs) {
+    fs.getConf().addResource(fs.getConf());
+    return new LockManager(config, fs);
   }
 
   public void beginTransaction(Option<HoodieInstant> newTxnOwnerInstant,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TransactionManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/TransactionManager.java
@@ -42,17 +42,12 @@ public class TransactionManager implements Serializable {
   private Option<HoodieInstant> lastCompletedTxnOwnerInstant = Option.empty();
 
   public TransactionManager(HoodieWriteConfig config, FileSystem fs) {
-    this(createLockManager(config, fs), config.isLockRequired());
+    this(new LockManager(config, fs), config.isLockRequired());
   }
 
   protected TransactionManager(LockManager lockManager, boolean isLockRequired) {
     this.lockManager = lockManager;
     this.isLockRequired = isLockRequired;
-  }
-
-  private static LockManager createLockManager(HoodieWriteConfig config, FileSystem fs) {
-    fs.getConf().addResource(fs.getConf());
-    return new LockManager(config, fs);
   }
 
   public void beginTransaction(Option<HoodieInstant> newTxnOwnerInstant,

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
@@ -88,9 +88,9 @@ public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse
   public HiveMetastoreBasedLockProvider(final LockConfiguration lockConfiguration, final Configuration conf) {
     this(lockConfiguration);
     try {
-      if (!StringUtils.isNullOrEmpty(conf.getString(CommonConfigurationKeysPublic.HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH, null))
-          && StringUtils.isNullOrEmpty(conf.getString(HiveConf.ConfVars.METASTOREPWD.varname, null))) {
-        String passwd = ShimLoader.getHadoopShims().getPassword((Configuration) conf.unwrap(), HiveConf.ConfVars.METASTOREPWD.varname);
+      if (!StringUtils.isNullOrEmpty(conf.get(CommonConfigurationKeysPublic.HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH, null))
+          && StringUtils.isNullOrEmpty(conf.get(HiveConf.ConfVars.METASTOREPWD.varname, null))) {
+        String passwd = ShimLoader.getHadoopShims().getPassword(conf, HiveConf.ConfVars.METASTOREPWD.varname);
         if (!StringUtils.isNullOrEmpty(passwd)) {
           conf.set(HiveConf.ConfVars.METASTOREPWD.varname, passwd);
         }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
@@ -27,6 +27,7 @@ import org.apache.hudi.exception.HoodieLockException;
 import org.apache.hudi.hive.util.IMetaStoreClientUtil;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.LockRequestBuilder;
@@ -39,6 +40,7 @@ import org.apache.hadoop.hive.metastore.api.LockType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,6 +87,17 @@ public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse
 
   public HiveMetastoreBasedLockProvider(final LockConfiguration lockConfiguration, final Configuration conf) {
     this(lockConfiguration);
+    try {
+      if (!StringUtils.isNullOrEmpty(conf.getString(CommonConfigurationKeysPublic.HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH, null))
+          && StringUtils.isNullOrEmpty(conf.getString(HiveConf.ConfVars.METASTOREPWD.varname, null))) {
+        String passwd = ShimLoader.getHadoopShims().getPassword((Configuration) conf.unwrap(), HiveConf.ConfVars.METASTOREPWD.varname);
+        if (!StringUtils.isNullOrEmpty(passwd)) {
+          conf.set(HiveConf.ConfVars.METASTOREPWD.varname, passwd);
+        }
+      }
+    } catch (Exception e) {
+      LOG.info("Exception while trying to get Hive password from hadoop credential store", e);
+    }
     try {
       HiveConf hiveConf = new HiveConf();
       setHiveLockConfs(hiveConf);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Add credentials to hive metastore based lock provider.

### Summary and Changelog

Add the extra configurations, e.g., credentials, to the storage conf before the lock provider creation.

### Impact

In this case, the extra configurations could take effect.

### Risk Level

Low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
