### PR TITLE
fix: flink source v2 serializability

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordEmitter.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordEmitter.java
@@ -22,11 +22,13 @@ import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 
+import java.io.Serializable;
+
 /**
  * Default Hoodie record emitter.
  * @param <T>
  */
-public class HoodieRecordEmitter<T> implements RecordEmitter<HoodieRecordWithPosition<T>, T, HoodieSourceSplit> {
+public class HoodieRecordEmitter<T> implements RecordEmitter<HoodieRecordWithPosition<T>, T, HoodieSourceSplit>, Serializable {
 
   @Override
   public void emitRecord(HoodieRecordWithPosition<T> record, SourceOutput<T> output, HoodieSourceSplit split) throws Exception {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -21,7 +21,6 @@ package org.apache.hudi.table;
 import org.apache.hudi.adapter.DataStreamScanProviderAdapter;
 import org.apache.hudi.adapter.InputFormatSourceFunctionAdapter;
 import org.apache.hudi.adapter.TableFunctionProviderAdapter;
-import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -34,7 +33,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsInference;
@@ -66,7 +64,6 @@ import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.table.format.FilePathUtils;
-import org.apache.hudi.table.format.FlinkReaderContextFactory;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.cdc.CdcInputFormat;
 import org.apache.hudi.table.format.cow.CopyOnWriteInputFormat;
@@ -78,7 +75,6 @@ import org.apache.hudi.table.lookup.HoodieLookupTableReader;
 import org.apache.hudi.util.DataTypeUtils;
 import org.apache.hudi.util.ExpressionUtils;
 import org.apache.hudi.util.ChangelogModes;
-import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.InputFormats;
 import org.apache.hudi.util.FileIndexReader;
@@ -301,13 +297,8 @@ public class HoodieTableSource extends FileIndexReader implements
     final RowType requiredRowType = (RowType) getProducedDataType().notNull().getLogicalType();
 
     HoodieScanContext context = createHoodieScanContext(rowType);
-    HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
-    HoodieFlinkEngineContext flinkEngineContext = new HoodieFlinkEngineContext(hadoopConf.unwrap());
-    HoodieFlinkTable<RowData> flinkTable = HoodieFlinkTable.create(writeConfig, flinkEngineContext);
-    FlinkReaderContextFactory readerContextFactory = new FlinkReaderContextFactory(metaClient);
     HoodieSplitReaderFunction splitReaderFunction = new HoodieSplitReaderFunction(
-        flinkTable,
-        readerContextFactory.getContext(),
+        metaClient,
         conf,
         tableSchema,
         HoodieSchemaConverter.convertToSchema(requiredRowType),

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/function/TestHoodieSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/function/TestHoodieSplitReaderFunction.java
@@ -19,15 +19,12 @@
 package org.apache.hudi.source.reader.function;
 
 import org.apache.hudi.common.config.HoodieReaderConfig;
-import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.internal.schema.InternalSchema;
-import org.apache.hudi.table.HoodieFlinkTable;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.table.data.RowData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,20 +37,13 @@ import static org.mockito.Mockito.when;
  * Test cases for {@link HoodieSplitReaderFunction}.
  */
 public class TestHoodieSplitReaderFunction {
-
-  private HoodieFlinkTable<RowData> mockTable;
-  private HoodieReaderContext<RowData> mockReaderContext;
   private HoodieSchema tableSchema;
   private HoodieSchema requiredSchema;
   private HoodieTableMetaClient mockMetaClient;
 
   @BeforeEach
   public void setUp() {
-    mockTable = mock(HoodieFlinkTable.class);
-    mockReaderContext = mock(HoodieReaderContext.class);
     mockMetaClient = mock(HoodieTableMetaClient.class);
-
-    when(mockTable.getMetaClient()).thenReturn(mockMetaClient);
     when(mockMetaClient.getTableType()).thenReturn(HoodieTableType.MERGE_ON_READ);
 
     // Create mock schemas
@@ -66,8 +56,7 @@ public class TestHoodieSplitReaderFunction {
     // Test that constructor requires non-null tableSchema
     assertThrows(IllegalArgumentException.class, () -> {
       new HoodieSplitReaderFunction(
-          mockTable,
-          mockReaderContext,
+          mockMetaClient,
           new Configuration(),
           null,  // null tableSchema should throw
           requiredSchema,
@@ -82,8 +71,7 @@ public class TestHoodieSplitReaderFunction {
     // Test that constructor requires non-null requiredSchema
     assertThrows(IllegalArgumentException.class, () -> {
       new HoodieSplitReaderFunction(
-          mockTable,
-          mockReaderContext,
+          mockMetaClient,
           new Configuration(),
           tableSchema,
           null,  // null requiredSchema should throw
@@ -98,8 +86,7 @@ public class TestHoodieSplitReaderFunction {
     // Should not throw exception with valid parameters
     HoodieSplitReaderFunction function =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             tableSchema,
             requiredSchema,
@@ -116,8 +103,7 @@ public class TestHoodieSplitReaderFunction {
 
     HoodieSplitReaderFunction function =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             tableSchema,
             requiredSchema,
@@ -132,8 +118,7 @@ public class TestHoodieSplitReaderFunction {
   public void testClosedReaderIsNull() throws Exception {
     HoodieSplitReaderFunction function =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             tableSchema,
             requiredSchema,
@@ -157,8 +142,7 @@ public class TestHoodieSplitReaderFunction {
     for (String mergeType : mergeTypes) {
       HoodieSplitReaderFunction function =
           new HoodieSplitReaderFunction(
-              mockTable,
-              mockReaderContext,
+              mockMetaClient,
               new Configuration(),
               tableSchema,
               requiredSchema,
@@ -174,8 +158,7 @@ public class TestHoodieSplitReaderFunction {
   public void testMultipleCloseCalls() throws Exception {
     HoodieSplitReaderFunction function =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             tableSchema,
             requiredSchema,
@@ -196,8 +179,7 @@ public class TestHoodieSplitReaderFunction {
 
     HoodieSplitReaderFunction function =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             customTableSchema,
             customRequiredSchema,
@@ -216,8 +198,7 @@ public class TestHoodieSplitReaderFunction {
     // Test with present internal schema
     HoodieSplitReaderFunction function1 =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             tableSchema,
             requiredSchema,
@@ -229,8 +210,7 @@ public class TestHoodieSplitReaderFunction {
     // Test with different internal schema
     HoodieSplitReaderFunction function2 =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             tableSchema,
             requiredSchema,
@@ -242,8 +222,7 @@ public class TestHoodieSplitReaderFunction {
     // Test with empty internal schema
     HoodieSplitReaderFunction function3 =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             tableSchema,
             requiredSchema,
@@ -254,55 +233,13 @@ public class TestHoodieSplitReaderFunction {
   }
 
   @Test
-  public void testHoodieTableIntegration() {
-    // Verify that the function properly interacts with HoodieTable
-    HoodieFlinkTable<RowData> customTable = mock(HoodieFlinkTable.class);
-    HoodieTableMetaClient customMetaClient = mock(HoodieTableMetaClient.class);
-
-    when(customTable.getMetaClient()).thenReturn(customMetaClient);
-
-    HoodieSplitReaderFunction function =
-        new HoodieSplitReaderFunction(
-            customTable,
-            mockReaderContext,
-            new Configuration(),
-            tableSchema,
-            requiredSchema,
-            "AVRO_PAYLOAD",
-            Option.empty()
-        );
-
-    assertNotNull(function);
-  }
-
-  @Test
-  public void testReaderContextIntegration() {
-    // Test with different reader contexts
-    HoodieReaderContext<RowData> customContext = mock(HoodieReaderContext.class);
-
-    HoodieSplitReaderFunction function =
-        new HoodieSplitReaderFunction(
-            mockTable,
-            customContext,
-            new Configuration(),
-            tableSchema,
-            requiredSchema,
-            "AVRO_PAYLOAD",
-            Option.empty()
-        );
-
-    assertNotNull(function);
-  }
-
-  @Test
   public void testConfigurationIsStored() {
     Configuration config = new Configuration();
     config.setString("test.key", "test.value");
 
     HoodieSplitReaderFunction function =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             config,
             tableSchema,
             requiredSchema,
@@ -318,8 +255,7 @@ public class TestHoodieSplitReaderFunction {
     // Verify that the read method returns CloseableIterator
     HoodieSplitReaderFunction function =
         new HoodieSplitReaderFunction(
-            mockTable,
-            mockReaderContext,
+            mockMetaClient,
             new Configuration(),
             tableSchema,
             requiredSchema,


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fix classes serializability in flink source v2.

### Summary and Changelog

1. Make HoodieRecordEmitter implements Serializable
2. Remove unserializable inner objects from HoodieSplitReaderFunction
3. Revise test cases

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
