### PR TITLE
fix: throw correct exception when reading hoodie.properties file without access

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -681,7 +681,12 @@ public class ConfigUtils {
           }
           return props;
         } catch (IOException e) {
-          log.warn("Could not read properties from {}: {}", path, e);
+          if (HoodieExceptionUtil.isPermissionDeniedException(e)) {
+            log.error("Permission denied for " + path.toString() + " file.", e);
+            throw new HoodieIOException("Permission denied for " + path + " file path. User does not have read access on the dataset.", e);
+          } else {
+            log.warn("Could not read properties from {}: {}", path, e);
+          }
         } catch (IllegalArgumentException e) {
           log.warn("Invalid properties file {}: {}", path, props);
         }

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/HoodieExceptionUtil.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/HoodieExceptionUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import java.io.IOException;
+
+/**
+ * Utility class for exception handling and analysis.
+ */
+public class HoodieExceptionUtil {
+
+  /**
+   * Checks if the given IOException is a permission denied error.
+   * This works across different storage implementations (Hadoop, S3, GCS, etc.)
+   * by checking both the exception class name and message.
+   *
+   * @param e the IOException to check
+   * @return true if the exception indicates permission denied, false otherwise
+   */
+  public static boolean isPermissionDeniedException(IOException e) {
+    return e.getClass().getSimpleName().contains("AccessControl")
+        || (e.getMessage() != null && (e.getMessage().contains("Permission denied")
+        || e.getMessage().contains("Access denied")));
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When users do not have read access on the `hoodie.properties` file, the error bubbles up as `FileNotFoundException` instead of showing the actual access control issue. 

The job looks for `hoodie.properties` file and `hoodie.properties.backup` file in a loop alternatively. Since `AccessControlException` is a subclass of `IOException`, the final error seen by the user is `FileNotFoundException`, which is misleading.

This PR fixes the issue by properly detecting and throwing access control exceptions with a clear error message.

### Summary and Changelog

- **What changed**: Modified `ConfigUtils.fetchConfigs()` to detect permission denied errors by checking exception class name and message
- **Why**: Users now see accurate error messages when they don't have read access to hoodie.properties instead of misleading FileNotFoundException
- **How**: The fix checks if an IOException contains "AccessControl" in its class name or "Permission denied"/"Access denied" in its message, then throws a descriptive HoodieIOException

The original fix applied the check in Hadoop's FileSystem layer. In the current codebase, the code has been refactored with the `fetchConfigs` method moved from `HoodieTableConfig` to `ConfigUtils` and using the storage abstraction layer. The fix has been adapted to work across different storage implementations (Hadoop, S3, GCS, etc.) without requiring direct Hadoop dependencies.

### Impact

Users will now receive clear error messages when they encounter permission issues reading hoodie.properties files, making debugging easier.

### Risk Level

**Low** - The change only affects error handling in the properties file reading logic. It does not modify the core functionality, only improves error reporting.

### Documentation Update

None - This is an internal error handling improvement with no user-facing configuration or feature changes.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Build verification completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)