### PR TITLE
feat(metadata): Support sub-directory bucketing for MDT partitions

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1138,17 +1138,58 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   }
 
   /**
-   * Initialize file groups for a partition. For file listing, we just have one file group.
-   * <p>
-   * All FileGroups for a given metadata partition has a fixed prefix as per the {@link MetadataPartitionType#getFileIdPrefix()}.
-   * Each file group is suffixed with 4 digits with increments of 1 starting with 0000.
-   * <p>
-   * Let's say we configure 10 file groups for record level index partition, and prefix as "record-index-bucket-"
-   * File groups will be named as :
-   * record-index-bucket-0000, .... -> ..., record-index-bucket-0009
+   * Initialize file groups for a MDT partition.
+   *
+   * All FileGroups for a given metadata partition have a fixed prefix as per the {@link MetadataPartitionType#getFileIdPrefix()}.
+   * Each file group is suffixed with 4 digits with increments of 1 starting with 0000. To limit the number of files that
+   * are created in a single folder, the file groups can be arranged in buckets.
+   *
+   * ==== When file group bucketing is disabled
+   * Let's say we configure 2000 file groups for record index partition. File groups will be created as follows inside the
+   * record_index partition directory:
+   *    record_index/
+   *    record_index/.hoodie_partition_metadata
+   *    record_index/record-index-0000
+   *    record_index/record-index-0001
+   *    ...
+   *    record_index/record-index-1999
+   *
+   *  So 1000 file groups are created in the metadata partition directory.
+   *
+   * ==== When file group bucketing is enabled
+   * Let's say we configure 2000 file groups for record index partition. File groups will be created as follows in 2
+   * buckets (0000 and 0001) in the record_index partition directory.:
+   *    record_index/
+   *    record_index/000/.hoodie_partition_metadata
+   *    record_index/0000/record-index-0000
+   *    record_index/0000/record-index-0001
+   *    ...
+   *    record_index/0000/record-index-0999
+   *    record_index/0001/.hoodie_partition_metadata
+   *    record_index/0001/record-index-1000
+   *    record_index/0001/record-index-1001
+   *    ...
+   *    record_index/0001/record-index-1999
+   *
+   *  So 1000 file groups are created in each bucket within the metadata partition directory.
    */
   private void initializeFileGroups(HoodieTableMetaClient dataMetaClient, MetadataPartitionType metadataPartition, String instantTime,
                                     int fileGroupCount, String relativePartitionPath, Option<String> dataPartitionName) throws IOException {
+    // Capture the storage to avoid lambda capture issues with dataMetaClient reassignment
+    final HoodieStorage storage = dataMetaClient.getStorage();
+
+    // Bucketing is enabled for the entire MDT at the time it is initialized. The bucketing cannot be changed later.
+    boolean bucketingEnabled = false;
+    if (dataMetaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled()) {
+      // already enabled on MDT so we need to ensure that the bucketing is enabled for this partition too
+      bucketingEnabled = true;
+    } else if (dataWriteConfig.getMetadataConfig().isFileGroupBucketingEnabled()) {
+      // Enabled via config. Ensure there are no existing partitions that have been initialized without bucketing
+      bucketingEnabled = !dataMetaClient.getTableConfig().isMetadataTableAvailable();
+      if (!bucketingEnabled) {
+        throw new HoodieMetadataException(String.format("Cannot enable MDT partition %s with bucketing as MDT is already initialized without bucketing", metadataPartition.name()));
+      }
+    }
 
     // Archival of data table has a dependency on compaction(base files) in metadata table.
     // It is assumed that as of time Tx of base instant (/compaction time) in metadata table,
@@ -1159,37 +1200,63 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     // during initial commit, then the fileGroup would still be recognized (as a FileSlice with no baseFiles but a
     // valid logFile). Since these log files being created have no content, it is safe to add them here before
     // the bulkInsert.
-    final String msg = String.format("Creating %d file groups for partition %s with base fileId %s at instant time %s",
-        fileGroupCount, relativePartitionPath, metadataPartition.getFileIdPrefix(), instantTime);
+    final int bucketCount = (int) Math.ceil((float) fileGroupCount / metadataWriteConfig.getMetadataConfig().getFileGroupBucketSize());
+    List<Pair<String, String>> fileGroupIdAndPathPairList;
+    final String msg;
+    if (bucketingEnabled) {
+      msg = String.format("Creating bucketed file groups for MDT partition %s: #buckets=%d, #fileGroups=%d, fileId=%s, instant_time=%s",
+          relativePartitionPath, bucketCount, fileGroupCount, metadataPartition.getFileIdPrefix(), instantTime);
+      fileGroupIdAndPathPairList = IntStream.range(0, fileGroupCount)
+          // Since bucketing is enabled, the filegroups will be located in the bucket directory inside metadata partition directory
+          .mapToObj(i -> {
+            final int bucketIndex = i / metadataWriteConfig.getMetadataConfig().getFileGroupBucketSize();
+            final String bucketPath = HoodieTableMetadataUtil.getBucketRelativePath(relativePartitionPath, bucketIndex);
+            return Pair.of(HoodieTableMetadataUtil.getFileIDForFileGroup(metadataPartition, i, relativePartitionPath, dataPartitionName), bucketPath);
+          })
+          .collect(Collectors.toList());
+    } else {
+      msg = String.format("Creating file groups for MDT partition %s: #fileGroups=%d, fileId=%s, instant_time=%s",
+          relativePartitionPath, fileGroupCount, metadataPartition.getFileIdPrefix(), instantTime);
+      fileGroupIdAndPathPairList = IntStream.range(0, fileGroupCount)
+          // Since bucketing is disabled, the filegroups will be located directly under the metadata partition directory
+          .mapToObj(i -> Pair.of(HoodieTableMetadataUtil.getFileIDForFileGroup(metadataPartition, i, relativePartitionPath, dataPartitionName), relativePartitionPath))
+          .collect(Collectors.toList());
+    }
+
+    ValidationUtils.checkArgument(fileGroupIdAndPathPairList.size() == fileGroupCount);
     LOG.info(msg);
-    final List<String> fileGroupFileIds = IntStream.range(0, fileGroupCount)
-        .mapToObj(i -> HoodieTableMetadataUtil.getFileIDForFileGroup(metadataPartition, i, relativePartitionPath, dataPartitionName))
-        .collect(Collectors.toList());
-    ValidationUtils.checkArgument(fileGroupFileIds.size() == fileGroupCount);
     engineContext.setJobStatus(this.getClass().getSimpleName(), msg);
-    engineContext.foreach(fileGroupFileIds, fileGroupFileId -> {
+    engineContext.foreach(fileGroupIdAndPathPairList, p -> {
+      final String fileGroupFileId = p.getKey();
+      final String relativePath = p.getValue();
+
       try {
         final Map<HeaderMetadataType, String> blockHeader = Collections.singletonMap(HeaderMetadataType.INSTANT_TIME, instantTime);
 
         final HoodieDeleteBlock block = new HoodieDeleteBlock(Collections.emptyList(), blockHeader);
 
         try (HoodieLogFormat.Writer writer = HoodieLogFormat.newWriterBuilder()
-            .onParentPath(FSUtils.constructAbsolutePath(metadataWriteConfig.getBasePath(), relativePartitionPath))
+            .onParentPath(FSUtils.constructAbsolutePath(metadataWriteConfig.getBasePath(), relativePath))
             .withFileId(fileGroupFileId)
             .withInstantTime(instantTime)
             .withLogVersion(HoodieLogFile.LOGFILE_BASE_VERSION)
             .withFileSize(0L)
             .withSizeThreshold(metadataWriteConfig.getLogFileMaxSize())
-            .withStorage(dataMetaClient.getStorage())
+            .withStorage(storage)
             .withLogWriteToken(HoodieLogFormat.DEFAULT_WRITE_TOKEN)
             .withTableVersion(metadataWriteConfig.getWriteVersion())
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build()) {
           writer.appendBlock(block);
         }
       } catch (InterruptedException e) {
-        throw new HoodieException(String.format("Failed to created fileGroup %s for partition %s", fileGroupFileId, relativePartitionPath), e);
+        throw new HoodieException(String.format("Failed to created fileGroup %s for partition %s", fileGroupFileId, relativePath), e);
       }
-    }, fileGroupFileIds.size());
+    }, fileGroupIdAndPathPairList.size());
+
+    if (bucketingEnabled && !dataMetaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled()) {
+      // Bucketing has been enabled so set it in the table config
+      dataMetaClient = HoodieTableMetadataUtil.setMetadataTablePartitionBucketing(dataMetaClient, bucketingEnabled);
+    }
   }
 
   void clearExistingMetadataPartition(String relativePartitionPath) throws IOException {
@@ -2015,6 +2082,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   protected Pair<HoodieData<HoodieRecord>, List<HoodieFileGroupId>> tagRecordsWithLocation(Map<String, HoodieData<HoodieRecord>> partitionRecordsMap, boolean isInitializing) {
     // The result set
     HoodieData<HoodieRecord> allPartitionRecords = engineContext.emptyHoodieData();
+    // Is fileGroup bucketing enabled
+    final boolean bucketingEnabled = dataMetaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled();
     try (HoodieTableFileSystemView fsView = HoodieTableMetadataUtil.getFileSystemViewForMetadataTable(metadataMetaClient)) {
       List<HoodieFileGroupId> hoodieFileGroupIdList = new ArrayList<>();
       for (Map.Entry<String, HoodieData<HoodieRecord>> entry : partitionRecordsMap.entrySet()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1175,9 +1175,6 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    */
   private void initializeFileGroups(HoodieTableMetaClient dataMetaClient, MetadataPartitionType metadataPartition, String instantTime,
                                     int fileGroupCount, String relativePartitionPath, Option<String> dataPartitionName) throws IOException {
-    // Capture the storage to avoid lambda capture issues with dataMetaClient reassignment
-    final HoodieStorage storage = dataMetaClient.getStorage();
-
     // Bucketing is enabled for the entire MDT at the time it is initialized. The bucketing cannot be changed later.
     boolean bucketingEnabled = false;
     if (dataMetaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled()) {
@@ -1246,7 +1243,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
             .withLogVersion(HoodieLogFile.LOGFILE_BASE_VERSION)
             .withFileSize(0L)
             .withSizeThreshold(metadataWriteConfig.getLogFileMaxSize())
-            .withStorage(storage)
+            .withStorage(dataMetaClient.getStorage())
             .withLogWriteToken(HoodieLogFormat.DEFAULT_WRITE_TOKEN)
             .withTableVersion(metadataWriteConfig.getWriteVersion())
             .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1154,13 +1154,13 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    *    ...
    *    record_index/record-index-1999
    *
-   *  So 1000 file groups are created in the metadata partition directory.
+   *  So 2000 file groups are created in the metadata partition directory.
    *
    * ==== When file group bucketing is enabled
    * Let's say we configure 2000 file groups for record index partition. File groups will be created as follows in 2
    * buckets (0000 and 0001) in the record_index partition directory.:
    *    record_index/
-   *    record_index/000/.hoodie_partition_metadata
+   *    record_index/0000/.hoodie_partition_metadata
    *    record_index/0000/record-index-0000
    *    record_index/0000/record-index-0001
    *    ...
@@ -1184,10 +1184,14 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       // already enabled on MDT so we need to ensure that the bucketing is enabled for this partition too
       bucketingEnabled = true;
     } else if (dataWriteConfig.getMetadataConfig().isFileGroupBucketingEnabled()) {
-      // Enabled via config. Ensure there are no existing partitions that have been initialized without bucketing
-      bucketingEnabled = !dataMetaClient.getTableConfig().isMetadataTableAvailable();
-      if (!bucketingEnabled) {
-        throw new HoodieMetadataException(String.format("Cannot enable MDT partition %s with bucketing as MDT is already initialized without bucketing", metadataPartition.name()));
+      // Enabled via config. Bucketing can only be enabled at MDT initialization time. If the MDT is already
+      // initialized without bucketing, we cannot retro-fit bucketing onto it; log a warning and proceed
+      // without bucketing rather than hard-failing the user's pipeline.
+      if (dataMetaClient.getTableConfig().isMetadataTableAvailable()) {
+        LOG.warn("hoodie.metadata.file.group.bucketing.enable=true was requested for MDT partition {} but MDT is already "
+            + "initialized without bucketing. Proceeding without bucketing for this partition.", metadataPartition.name());
+      } else {
+        bucketingEnabled = true;
       }
     }
 
@@ -1254,8 +1258,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }, fileGroupIdAndPathPairList.size());
 
     if (bucketingEnabled && !dataMetaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled()) {
-      // Bucketing has been enabled so set it in the table config
-      dataMetaClient = HoodieTableMetadataUtil.setMetadataTablePartitionBucketing(dataMetaClient, bucketingEnabled);
+      // Bucketing has been enabled. Update the instance field so subsequent partition initializations
+      // in this writer see the refreshed table config. The parameter would otherwise shadow the field,
+      // leaving the writer with a stale view that bucketing is still disabled.
+      this.dataMetaClient = HoodieTableMetadataUtil.setMetadataTablePartitionBucketing(dataMetaClient, metadataMetaClient, bucketingEnabled);
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkClientTestHarness.java
@@ -650,13 +650,15 @@ public abstract class HoodieSparkClientTestHarness extends HoodieWriterClientTes
     // Metadata table has a fixed number of partitions
     // Cannot use FSUtils.getAllFoldersWithPartitionMetaFile for this as that function filters all directory
     // in the .hoodie folder.
-    List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, HoodieTableMetadata.getMetadataTableBasePath(basePath),
-        false, false);
+    List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, metadataMetaClient, false);
 
     List<MetadataPartitionType> enabledPartitionTypes = metadataWriter.getEnabledPartitionTypes();
     if (writeConfig.getMetadataConfig().isFileGroupBucketingEnabled()) {
-      // First bucket should be present
-      assertTrue(metadataTablePartitions.contains(HoodieTableMetadataUtil.getBucketRelativePath(MetadataPartitionType.FILES, 0)));
+      // Each enabled partition should have its first bucket sub-directory present
+      for (MetadataPartitionType partitionType : enabledPartitionTypes) {
+        assertTrue(metadataTablePartitions.contains(HoodieTableMetadataUtil.getBucketRelativePath(partitionType, 0)),
+            "Missing bucket-0 for partition: " + partitionType.getPartitionPath());
+      }
     } else {
       // partition path is the only partition
       assertEquals(enabledPartitionTypes.size(), metadataTablePartitions.size());

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -687,6 +687,16 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
 
+  public static final ConfigProperty<Boolean> FILE_GROUP_BUCKETING_ENABLE = ConfigProperty
+          .key(METADATA_PREFIX + ".file.group.bucketing.enable")
+          .defaultValue(false)
+          .withDocumentation("This flag indicates whether there should be intermediate partitions under partitions such as record index and filelisting");
+
+  public static final ConfigProperty<Integer> FILE_GROUP_BUCKET_SIZE = ConfigProperty
+          .key(METADATA_PREFIX + ".file.group.bucket.size")
+          .defaultValue(1000)
+          .withDocumentation("This is paired with " + FILE_GROUP_BUCKETING_ENABLE.key() + ". This represents number of shards under a single bucket");
+
   private HoodieMetadataConfig() {
     super();
   }
@@ -1018,6 +1028,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     checkArgument(indexName.startsWith(PARTITION_NAME_EXPRESSION_INDEX_PREFIX)
         || indexName.startsWith(PARTITION_NAME_SECONDARY_INDEX_PREFIX), "Unexpected index name to drop: " + indexName);
     return subIndexNameToDrop.contains(indexName);
+  }
+
+  public boolean isFileGroupBucketingEnabled() {
+    return getBoolean(FILE_GROUP_BUCKETING_ENABLE);
+  }
+
+  public int getFileGroupBucketSize() {
+    return getInt(FILE_GROUP_BUCKET_SIZE);
   }
 
   public static class Builder {
@@ -1368,6 +1386,16 @@ public final class HoodieMetadataConfig extends HoodieConfig {
             + " (supported: " + SUPPORTED_TABLE_SERVICE_MANAGER_ACTIONS + ").");
       }
       return metadataConfig;
+    }
+
+    public Builder withFileGroupBucketingEnable(boolean fileGroupBucketingEnable) {
+      metadataConfig.setValue(FILE_GROUP_BUCKETING_ENABLE, String.valueOf(fileGroupBucketingEnable));
+      return this;
+    }
+
+    public Builder withFileGroupBucketSize(int bucketSize) {
+      metadataConfig.setValue(FILE_GROUP_BUCKET_SIZE, String.valueOf(bucketSize));
+      return this;
     }
 
     private boolean getDefaultMetadataEnable(EngineType engineType) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -695,7 +695,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   public static final ConfigProperty<Integer> FILE_GROUP_BUCKET_SIZE = ConfigProperty
           .key(METADATA_PREFIX + ".file.group.bucket.size")
           .defaultValue(1000)
-          .withDocumentation("This is paired with " + FILE_GROUP_BUCKETING_ENABLE.key() + ". This represents number of shards under a single bucket");
+          .withDocumentation("This is paired with " + FILE_GROUP_BUCKETING_ENABLE.key() + ". Maximum number of file groups per bucket sub-directory");
 
   private HoodieMetadataConfig() {
     super();
@@ -1390,7 +1390,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return metadataConfig;
     }
 
-    public Builder withFileGroupBucketingEnable(boolean fileGroupBucketingEnable) {
+    public Builder withFileGroupBucketingEnabled(boolean fileGroupBucketingEnable) {
       metadataConfig.setValue(FILE_GROUP_BUCKETING_ENABLE, String.valueOf(fileGroupBucketingEnable));
       return this;
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -1035,7 +1035,9 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   }
 
   public int getFileGroupBucketSize() {
-    return getInt(FILE_GROUP_BUCKET_SIZE);
+    int bucketSize = getInt(FILE_GROUP_BUCKET_SIZE);
+    checkArgument(bucketSize > 0, FILE_GROUP_BUCKET_SIZE.key() + " must be greater than 0, got " + bucketSize);
+    return bucketSize;
   }
 
   public static class Builder {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -374,6 +374,11 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("1.1.0")
       .withDocumentation("This property when set, will define how two versions of the record will be merged together when records are partially formed");
 
+  public static final ConfigProperty<String> METADATA_TABLE_PARTITION_BUCKETING_ENABLE = ConfigProperty
+          .key("hoodie.metadata.partitions.bucketing.enable")
+          .defaultValue("false")
+          .withDocumentation("This flag indicates whether metadata table file groups should be saved within buckets in each partition such as record index and files.");
+
   public static final ConfigProperty<String> URL_ENCODE_PARTITIONING = KeyGeneratorOptions.URL_ENCODE_PARTITIONING;
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
   public static final ConfigProperty<String> SLASH_SEPARATED_DATE_PARTITIONING = KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING;
@@ -1380,6 +1385,22 @@ public class HoodieTableConfig extends HoodieConfig {
       }
     }
     return configs;
+  }
+
+  /**
+   * Enables or disables the bucketing for file groups within the metadata table partitions.
+   *
+   * @param enable Whether to enable or disable bucketing
+   */
+  public void setMetadataTableBucketing(boolean enable) {
+    setValue(METADATA_TABLE_PARTITION_BUCKETING_ENABLE, String.valueOf(enable));
+  }
+
+  /**
+   * @returns true if metadata table partition bucketing is enabled, else returns false.
+   */
+  public boolean isMetadataTablePartitionBucketingEnabled() {
+    return getBooleanOrDefault(METADATA_TABLE_PARTITION_BUCKETING_ENABLE);
   }
 
   public Map<String, String> propsMap() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -1392,7 +1392,7 @@ public class HoodieTableConfig extends HoodieConfig {
    *
    * @param enable Whether to enable or disable bucketing
    */
-  public void setMetadataTableBucketing(boolean enable) {
+  public void setMetadataTablePartitionBucketing(boolean enable) {
     setValue(METADATA_TABLE_PARTITION_BUCKETING_ENABLE, String.valueOf(enable));
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Metrics for metadata.
@@ -95,19 +94,23 @@ public class HoodieMetadataMetrics implements Serializable {
     try {
       HoodieTableFileSystemView fileSystemView =
           HoodieTableFileSystemView.fileListingBasedFileSystemView(new HoodieLocalEngineContext(metaClient.getStorageConf()), metaClient, metaClient.getActiveTimeline());
-      return getStats(fileSystemView, detailed, metadata, metadataPartitions);
+      return getStats(fileSystemView, metaClient, detailed, metadata, metadataPartitions);
     } catch (IOException ioe) {
       throw new HoodieIOException("Unable to get metadata stats.", ioe);
     }
   }
 
-  private Map<String, String> getStats(HoodieTableFileSystemView fsView, boolean detailed, HoodieTableMetadata tableMetadata, Set<String> metadataPartitions)
+  private Map<String, String> getStats(HoodieTableFileSystemView fsView, HoodieTableMetaClient metaClient, boolean detailed,
+                                       HoodieTableMetadata tableMetadata, Set<String> metadataPartitions)
       throws IOException {
     Map<String, String> stats = new HashMap<>();
 
     // Total size of the metadata and count of base/log files for enabled partitions
     for (String metadataPartition : metadataPartitions) {
-      List<FileSlice> latestSlices = fsView.getLatestFileSlices(metadataPartition).collect(Collectors.toList());
+      // Route through getPartitionLatestFileSlices so the file slices are found whether or not the MDT
+      // partition is bucketed (when bucketing is enabled the file groups live under <partition>/<bucket>/).
+      List<FileSlice> latestSlices =
+          HoodieTableMetadataUtil.getPartitionLatestFileSlices(metaClient, Option.of(fsView), metadataPartition);
 
       // Total size of the metadata and count of base/log files
       long totalBaseFileSizeInBytes = 0;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2375,24 +2375,29 @@ public class HoodieTableMetadataUtil {
    *
    * @param dataMetaClient     MetaClient for the dataset
    * @param metadataMetaClient MetaClient for the MDT (may be null if MDT is not yet initialized)
-   * @param enabled            If true, metadata table is being used for this dataset, false otherwise
+   * @param enabled            If true, enable bucketing for MDT partitions; if false, disable it
    */
   public static HoodieTableMetaClient setMetadataTablePartitionBucketing(HoodieTableMetaClient dataMetaClient,
                                                                          HoodieTableMetaClient metadataMetaClient, boolean enabled) {
     // Only allowed on the main dataset
     ValidationUtils.checkArgument(!isMetadataTable(dataMetaClient.getBasePath().toString()), "Bucketing should only be enabled on the main dataset");
 
-    dataMetaClient.getTableConfig().setMetadataTableBucketing(enabled);
+    // Persist on the MDT first, then on the data table. The data table is the authoritative source for the
+    // retry guard in HoodieBackedTableMetadataWriter#initializeFileGroups
+    // (bucketingEnabled && !dataMetaClient...isMetadataTablePartitionBucketingEnabled()). Updating the data
+    // table last ensures that if the MDT update fails the data table stays un-flipped, so the next retry
+    // naturally re-attempts both updates rather than leaving the two configs permanently desynced.
+    if (metadataMetaClient != null) {
+      // Persist on MDT so reader code can determine bucketing from MDT props alone.
+      metadataMetaClient.getTableConfig().setMetadataTablePartitionBucketing(enabled);
+      HoodieTableConfig.update(metadataMetaClient.getStorage(), metadataMetaClient.getMetaPath(), metadataMetaClient.getTableConfig().getProps());
+    }
+
+    dataMetaClient.getTableConfig().setMetadataTablePartitionBucketing(enabled);
     HoodieTableConfig.update(dataMetaClient.getStorage(), dataMetaClient.getMetaPath(), dataMetaClient.getTableConfig().getProps());
     dataMetaClient = HoodieTableMetaClient.reload(dataMetaClient);
     ValidationUtils.checkState(dataMetaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled() == enabled,
             "Metadata table state change should be persisted");
-
-    if (metadataMetaClient != null) {
-      // Also persist on MDT so reader code can determine bucketing from MDT props alone.
-      metadataMetaClient.getTableConfig().setMetadataTableBucketing(enabled);
-      HoodieTableConfig.update(metadataMetaClient.getStorage(), metadataMetaClient.getMetaPath(), metadataMetaClient.getTableConfig().getProps());
-    }
 
     log.info("Metadata table {} partition bucketing has been {}", dataMetaClient.getBasePath(), enabled ? "enabled" : "disabled");
     return dataMetaClient;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -189,6 +189,7 @@ import static org.apache.hudi.metadata.HoodieMetadataPayload.RECORD_INDEX_MISSIN
 import static org.apache.hudi.metadata.HoodieTableMetadata.EMPTY_PARTITION_NAME;
 import static org.apache.hudi.metadata.HoodieTableMetadata.NON_PARTITIONED_NAME;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
+import static org.apache.hudi.metadata.HoodieTableMetadata.isMetadataTable;
 import static org.apache.hudi.metadata.MetadataPartitionType.fromPartitionPath;
 import static org.apache.hudi.metadata.MetadataPartitionType.isNewExpressionIndexDefinitionRequired;
 import static org.apache.hudi.metadata.MetadataPartitionType.isNewSecondaryIndexDefinitionRequired;
@@ -1514,22 +1515,30 @@ public class HoodieTableMetadataUtil {
     HoodieTableFileSystemView fsView = null;
     try {
       fsView = fileSystemView.orElseGet(() -> getFileSystemViewForMetadataTable(metaClient));
-      Stream<FileSlice> fileSliceStream;
-      if (mergeFileSlices) {
-        if (metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent()) {
-          fileSliceStream = fsView.getLatestMergedFileSlicesBeforeOrOn(
-              // including pending compaction instant as the last instant so that the finished delta commits
-              // that start earlier than the compaction can be queried.
-              partition, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants().lastInstant().get().requestedTime());
+      // Check if bucketing is enabled
+      boolean bucketingEnabled = isBucketingEnabledForMDT(metaClient);
+      List<String> partitionsToList = getPartitionsToList(metaClient, partition, bucketingEnabled);
+
+      List<FileSlice> fileSlices = new ArrayList<>();
+      for (String partitionToList : partitionsToList) {
+        Stream<FileSlice> fileSliceStream;
+        if (mergeFileSlices) {
+          if (metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent()) {
+            fileSliceStream = fsView.getLatestMergedFileSlicesBeforeOrOn(
+                // including pending compaction instant as the last instant so that the finished delta commits
+                // that start earlier than the compaction can be queried.
+                partitionToList, metaClient.getActiveTimeline().filterCompletedAndCompactionInstants().lastInstant().get().requestedTime());
+          } else {
+            fileSliceStream = Stream.empty();
+          }
         } else {
-          return Collections.emptyList();
+          fileSliceStream = fsView.getLatestFileSlices(partitionToList);
         }
-      } else {
-        fileSliceStream = fsView.getLatestFileSlices(partition);
+        fileSliceStream.forEach(fileSlices::add);
       }
-      return fileSliceStream.sorted(Comparator.comparing(FileSlice::getFileId)).collect(Collectors.toList());
+      return fileSlices.stream().sorted(Comparator.comparing(FileSlice::getFileId)).collect(Collectors.toList());
     } finally {
-      if (!fileSystemView.isPresent()) {
+      if (!fileSystemView.isPresent() && fsView != null) {
         fsView.close();
       }
     }
@@ -1549,8 +1558,16 @@ public class HoodieTableMetadataUtil {
     HoodieTableFileSystemView fsView = null;
     try {
       fsView = fileSystemView.orElseGet(() -> getFileSystemViewForMetadataTable(metaClient));
-      Stream<FileSlice> fileSliceStream = fsView.getLatestFileSlicesIncludingInflight(partition);
-      return fileSliceStream
+      // Check if bucketing is enabled
+      boolean bucketingEnabled = isBucketingEnabledForMDT(metaClient);
+      List<String> partitionsToList = getPartitionsToList(metaClient, partition, bucketingEnabled);
+
+      List<FileSlice> fileSlices = new ArrayList<>();
+      for (String partitionToList : partitionsToList) {
+        Stream<FileSlice> fileSliceStream = fsView.getLatestFileSlicesIncludingInflight(partitionToList);
+        fileSliceStream.forEach(fileSlices::add);
+      }
+      return fileSlices.stream()
           .sorted(Comparator.comparing(FileSlice::getFileId))
           .collect(Collectors.toList());
     } finally {
@@ -2295,6 +2312,78 @@ public class HoodieTableMetadataUtil {
   }
 
   /**
+   * Returns true if bucketing is enabled for the metadata table.
+   *
+   * @param metaClient MetaClient for the metadata table
+   * @return true if bucketing is enabled
+   */
+  private static boolean isBucketingEnabledForMDT(HoodieTableMetaClient metaClient) {
+    // Bucketing status is saved within the main dataset's properties.
+    String basePath = HoodieTableMetadata.getDataTableBasePathFromMetadataTable(metaClient.getBasePath().toString());
+    return HoodieTableMetaClient.builder()
+        .setBasePath(basePath)
+        .setConf(metaClient.getStorageConf().newInstance())
+        .setLoadActiveTimelineOnLoad(false)
+        .build()
+        .getTableConfig()
+        .isMetadataTablePartitionBucketingEnabled();
+  }
+
+  /**
+   * Returns the list of partitions to list for file slices.
+   * When bucketing is enabled, returns the bucket sub-directories.
+   * When bucketing is disabled, returns the partition itself.
+   *
+   * @param metaClient MetaClient for the metadata table
+   * @param partition The partition path
+   * @param bucketingEnabled Whether bucketing is enabled
+   * @return List of partition paths to list
+   */
+  private static List<String> getPartitionsToList(HoodieTableMetaClient metaClient, String partition, boolean bucketingEnabled) {
+    List<String> partitionsToList = new ArrayList<>();
+    try {
+      if (bucketingEnabled) {
+        // Find all the buckets in the partition
+        StoragePath partitionPath = new StoragePath(metaClient.getBasePath(), partition);
+        List<StoragePathInfo> statuses = metaClient.getStorage().listDirectEntries(partitionPath);
+        for (StoragePathInfo status : statuses) {
+          if (status.isDirectory()) {
+            partitionsToList.add(partition + StoragePath.SEPARATOR + status.getPath().getName());
+          }
+        }
+        log.info("Listing {} buckets in metadata table partition {}", partitionsToList.size(), partition);
+      } else {
+        // Only list the partition folder as bucketing is not enabled
+        partitionsToList.add(partition);
+        log.info("Listing non-bucketed metadata table partition {}", partition);
+      }
+    } catch (IOException e) {
+      throw new HoodieMetadataException("Failed to check for bucketing in metadata table partition " + partition, e);
+    }
+    return partitionsToList;
+  }
+
+  /**
+   * Set the bucketing of partitions within the metadata table.
+   *
+   * @param dataMetaClient MetaClient for the dataset
+   * @param enabled If true, metadata table is being used for this dataset, false otherwise
+   */
+  public static HoodieTableMetaClient setMetadataTablePartitionBucketing(HoodieTableMetaClient dataMetaClient, boolean enabled) {
+    // Only allowed on the main dataset
+    ValidationUtils.checkArgument(!isMetadataTable(dataMetaClient.getBasePath().toString()), "Bucketing should only be enabled on the main dataset");
+
+    dataMetaClient.getTableConfig().setMetadataTableBucketing(enabled);
+    HoodieTableConfig.update(dataMetaClient.getStorage(), dataMetaClient.getMetaPath(), dataMetaClient.getTableConfig().getProps());
+    dataMetaClient = HoodieTableMetaClient.reload(dataMetaClient);
+    ValidationUtils.checkState(dataMetaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled() == enabled,
+            "Metadata table state change should be persisted");
+
+    log.info("Metadata table {} partition bucketing has been {}", dataMetaClient.getBasePath(), enabled ? "enabled" : "disabled");
+    return dataMetaClient;
+  }
+
+  /**
    * Return the complete fileID for a file group within a MDT partition.
    * <p>
    * MDT fileGroups have the format <fileIDPrefix>-<index>. The fileIDPrefix is hardcoded for each MDT partition and index is an integer.
@@ -2351,6 +2440,22 @@ public class HoodieTableMetadataUtil {
    */
   public static String getFileGroupPrefix(String fileId) {
     return fileId.substring(0, getFileIdLengthWithoutFileIndex(fileId));
+  }
+
+  /**
+   * Returns the relative path of a bucket in an MDT partition.
+   *
+   * Example: For record_index partition and bucket 5, returns record_index/0005
+   *
+   * @param partitionType The MDT partition (e.g. files, record_index)
+   * @param bucketIndex Index of the bucket
+   */
+  public static String getBucketRelativePath(MetadataPartitionType partitionType, int bucketIndex) {
+    return getBucketRelativePath(partitionType.getPartitionPath(), bucketIndex);
+  }
+
+  public static String getBucketRelativePath(String partitionRelativePath, int bucketIndex) {
+    return String.format("%s%s%04d", partitionRelativePath, StoragePath.SEPARATOR, bucketIndex);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2314,25 +2314,28 @@ public class HoodieTableMetadataUtil {
   /**
    * Returns true if bucketing is enabled for the metadata table.
    *
+   * <p>Reads the property from the MDT's own table config so we avoid an extra disk read of the
+   * data table's hoodie.properties on every file-slice lookup. The property is persisted on both
+   * the data table and the MDT during MDT initialization (see
+   * {@link #setMetadataTablePartitionBucketing(HoodieTableMetaClient, HoodieTableMetaClient, boolean)}).
+   *
    * @param metaClient MetaClient for the metadata table
    * @return true if bucketing is enabled
    */
   private static boolean isBucketingEnabledForMDT(HoodieTableMetaClient metaClient) {
-    // Bucketing status is saved within the main dataset's properties.
-    String basePath = HoodieTableMetadata.getDataTableBasePathFromMetadataTable(metaClient.getBasePath().toString());
-    return HoodieTableMetaClient.builder()
-        .setBasePath(basePath)
-        .setConf(metaClient.getStorageConf().newInstance())
-        .setLoadActiveTimelineOnLoad(false)
-        .build()
-        .getTableConfig()
-        .isMetadataTablePartitionBucketingEnabled();
+    return metaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled();
   }
 
   /**
    * Returns the list of partitions to list for file slices.
    * When bucketing is enabled, returns the bucket sub-directories.
    * When bucketing is disabled, returns the partition itself.
+   *
+   * <p>Note: bucketing is fixed at MDT initialization time (see
+   * {@link org.apache.hudi.metadata.HoodieBackedTableMetadataWriter#initializeFileGroups}). A given
+   * MDT is therefore either fully bucketed or fully non-bucketed; mixed-state file groups under
+   * partition/ alongside partition/&lt;bucket&gt;/ cannot occur. We deliberately do not also scan the
+   * partition root when bucketing is enabled.
    *
    * @param metaClient MetaClient for the metadata table
    * @param partition The partition path
@@ -2366,10 +2369,16 @@ public class HoodieTableMetadataUtil {
   /**
    * Set the bucketing of partitions within the metadata table.
    *
-   * @param dataMetaClient MetaClient for the dataset
-   * @param enabled If true, metadata table is being used for this dataset, false otherwise
+   * <p>The property is persisted on both the data table (authoritative source for MDT initialization
+   * decisions) and the MDT (to allow reader code to determine bucketing without loading data table
+   * properties on every call).
+   *
+   * @param dataMetaClient     MetaClient for the dataset
+   * @param metadataMetaClient MetaClient for the MDT (may be null if MDT is not yet initialized)
+   * @param enabled            If true, metadata table is being used for this dataset, false otherwise
    */
-  public static HoodieTableMetaClient setMetadataTablePartitionBucketing(HoodieTableMetaClient dataMetaClient, boolean enabled) {
+  public static HoodieTableMetaClient setMetadataTablePartitionBucketing(HoodieTableMetaClient dataMetaClient,
+                                                                         HoodieTableMetaClient metadataMetaClient, boolean enabled) {
     // Only allowed on the main dataset
     ValidationUtils.checkArgument(!isMetadataTable(dataMetaClient.getBasePath().toString()), "Bucketing should only be enabled on the main dataset");
 
@@ -2378,6 +2387,12 @@ public class HoodieTableMetadataUtil {
     dataMetaClient = HoodieTableMetaClient.reload(dataMetaClient);
     ValidationUtils.checkState(dataMetaClient.getTableConfig().isMetadataTablePartitionBucketingEnabled() == enabled,
             "Metadata table state change should be persisted");
+
+    if (metadataMetaClient != null) {
+      // Also persist on MDT so reader code can determine bucketing from MDT props alone.
+      metadataMetaClient.getTableConfig().setMetadataTableBucketing(enabled);
+      HoodieTableConfig.update(metadataMetaClient.getStorage(), metadataMetaClient.getMetaPath(), metadataMetaClient.getTableConfig().getProps());
+    }
 
     log.info("Metadata table {} partition bucketing has been {}", dataMetaClient.getBasePath(), enabled ? "enabled" : "disabled");
     return dataMetaClient;

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -384,7 +384,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   @Test
   void testDefinedTableConfigs() {
     List<ConfigProperty<?>> configProperties = HoodieTableConfig.definedTableConfigs();
-    assertEquals(44, configProperties.size());
+    assertEquals(45, configProperties.size());
     configProperties.forEach(c -> {
       assertNotNull(c);
       assertFalse(c.doc().isEmpty());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -1010,7 +1010,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     HoodieTable table = HoodieSparkTable.create(metadataTableWriteConfig, context, metadataMetaClient);
     table.getHoodieView().sync();
-    List<FileSlice> fileSlices = table.getSliceView().getLatestFileSlices("files").collect(Collectors.toList());
+    List<FileSlice> fileSlices = HoodieTableMetadataUtil.getPartitionLatestFileSlices(metadataMetaClient, Option.empty(),
+            MetadataPartitionType.FILES.getPartitionPath());
     HoodieBaseFile baseFile = fileSlices.get(0).getBaseFile().get();
     HoodieAvroHFileReaderImplBase hoodieHFileReader = (HoodieAvroHFileReaderImplBase)
         getHoodieSparkIOFactory(storage).getReaderFactory(HoodieRecordType.AVRO).getFileReader(
@@ -1531,7 +1532,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
           enableMetaFields);
     }, "Metadata table should have valid log files!");
 
-    verifyMetadataRecordKeyExcludeFromPayloadBaseFiles(table, enableMetaFields);
+    verifyMetadataRecordKeyExcludeFromPayloadBaseFiles(table, metadataMetaClient, enableMetaFields);
 
     // 2 more commits
     doWriteOperation(testTable, "0000002", UPSERT);
@@ -1546,7 +1547,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
 
     // Verify the base file created by the just completed compaction.
     assertDoesNotThrow(() -> {
-      verifyMetadataRecordKeyExcludeFromPayloadBaseFiles(table, enableMetaFields);
+      verifyMetadataRecordKeyExcludeFromPayloadBaseFiles(table, metadataMetaClient, enableMetaFields);
     }, "Metadata table should have a valid base file!");
 
     // 2 more commits to trigger one more compaction, along with a clean
@@ -1559,7 +1560,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     }, "Metadata table should have valid log files!");
 
     assertDoesNotThrow(() -> {
-      verifyMetadataRecordKeyExcludeFromPayloadBaseFiles(table, enableMetaFields);
+      verifyMetadataRecordKeyExcludeFromPayloadBaseFiles(table, metadataMetaClient, enableMetaFields);
     }, "Metadata table should have a valid base file!");
 
     validateMetadata(testTable);
@@ -1575,15 +1576,16 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * @param latestCommitTimestamp - Latest commit timestamp
    * @param enableMetaFields      - Enable meta fields for the table records
    */
-  private void verifyMetadataRecordKeyExcludeFromPayloadLogFiles(HoodieTable table, HoodieTableMetaClient metadataMetaClient,
+  private void verifyMetadataRecordKeyExcludeFromPayloadLogFiles(HoodieTable table,
+                                                                 HoodieTableMetaClient metadataMetaClient,
                                                                  String latestCommitTimestamp,
                                                                  boolean enableMetaFields) throws IOException {
     table.getHoodieView().sync();
 
     // Compaction should not be triggered yet. Let's verify no base file
     // and few log files available.
-    List<FileSlice> fileSlices = table.getSliceView()
-        .getLatestFileSlices(FILES.getPartitionPath()).collect(Collectors.toList());
+    List<FileSlice> fileSlices = HoodieTableMetadataUtil.getPartitionLatestFileSlices(metadataMetaClient, Option.empty(),
+            MetadataPartitionType.FILES.getPartitionPath());
     if (fileSlices.isEmpty()) {
       throw new IllegalStateException("LogFile slices are not available!");
     }
@@ -1592,7 +1594,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     List<HoodieLogFile> logFiles = fileSlices.get(0).getLogFiles().collect(Collectors.toList());
 
     // Verify the on-disk raw records before they get materialized
-    verifyMetadataRawRecords(table, logFiles, enableMetaFields);
+    verifyMetadataRawRecords(logFiles, enableMetaFields);
 
     // Verify the in-memory materialized and merged records
     verifyMetadataMergedRecords(metadataMetaClient, logFiles, latestCommitTimestamp);
@@ -1603,11 +1605,10 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * these records should have additional meta fields in the payload. When key deduplication
    * is enabled, these records on the disk should have key in the payload as empty string.
    *
-   * @param table
    * @param logFiles         - Metadata table log files to be verified
    * @param enableMetaFields - Enable meta fields for records
    */
-  private static void verifyMetadataRawRecords(HoodieTable table, List<HoodieLogFile> logFiles, boolean enableMetaFields) throws IOException {
+private static void verifyMetadataRawRecords(HoodieTable table, List<HoodieLogFile> logFiles, boolean enableMetaFields) throws IOException {
     HoodieStorage storage = table.getStorage();
     for (HoodieLogFile logFile : logFiles) {
       List<StoragePathInfo> pathInfoList = storage.listDirectEntries(logFile.getPath());
@@ -1691,13 +1692,14 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * the key deduplication is enabled, the records persisted on the disk in the base file
    * should have key field in the payload as empty string.
    *
-   * @param table            - Metadata table
-   * @param enableMetaFields - Enable meta fields
+   * @param table              - Metadata table
+   * @param metadataMetaClient
+   * @param enableMetaFields   - Enable meta fields
    */
-  private void verifyMetadataRecordKeyExcludeFromPayloadBaseFiles(HoodieTable table, boolean enableMetaFields) throws IOException {
+  private void verifyMetadataRecordKeyExcludeFromPayloadBaseFiles(HoodieTable table, HoodieTableMetaClient metadataMetaClient, boolean enableMetaFields) throws IOException {
     table.getHoodieView().sync();
-    List<FileSlice> fileSlices = table.getSliceView()
-        .getLatestFileSlices(FILES.getPartitionPath()).collect(Collectors.toList());
+    List<FileSlice> fileSlices = HoodieTableMetadataUtil.getPartitionLatestFileSlices(metadataMetaClient, Option.empty(),
+            FILES.getPartitionPath());
     if (!fileSlices.get(0).getBaseFile().isPresent()) {
       throw new IllegalStateException("Base file not available!");
     }
@@ -4039,7 +4041,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     }
   }
 
-  private void validateMetadata(SparkRDDWriteClient testClient) throws Exception {
+private void validateMetadata(SparkRDDWriteClient testClient) throws Exception {
     validateMetadata(testClient, Option.empty());
   }
 
@@ -4263,7 +4265,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Metadata table has a fixed number of partitions
       // Cannot use FSUtils.getAllFoldersWithPartitionMetaFile for this as that function filters all directory
       // in the .hoodie folder.
-      List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, metadataMetaClient, false);
+List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, metadataMetaClient, false);
       // check if the last instant is restore, then the metadata table should have only the partitions that are not deleted
       metaClient.reloadActiveTimeline().getReverseOrderedInstants().findFirst().ifPresent(instant -> {
         if (instant.getAction().equals(HoodieActiveTimeline.RESTORE_ACTION)) {
@@ -4282,7 +4284,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         List<HoodieLogFile> logFiles = latestSlices.get(0).getLogFiles().collect(Collectors.toList());
         try {
           if (FILES.getPartitionPath().equals(partition)) {
-            verifyMetadataRawRecords(table, logFiles, false);
+            verifyMetadataRawRecords(logFiles, false);
           }
           if (COLUMN_STATS.getPartitionPath().equals(partition)) {
             verifyMetadataColumnStatsRecords(storage, logFiles);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -1594,7 +1594,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     List<HoodieLogFile> logFiles = fileSlices.get(0).getLogFiles().collect(Collectors.toList());
 
     // Verify the on-disk raw records before they get materialized
-    verifyMetadataRawRecords(logFiles, enableMetaFields);
+    verifyMetadataRawRecords(metadataMetaClient.getStorage(), logFiles, enableMetaFields);
 
     // Verify the in-memory materialized and merged records
     verifyMetadataMergedRecords(metadataMetaClient, logFiles, latestCommitTimestamp);
@@ -1605,11 +1605,11 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
    * these records should have additional meta fields in the payload. When key deduplication
    * is enabled, these records on the disk should have key in the payload as empty string.
    *
+   * @param storage          - HoodieStorage to read the log files from
    * @param logFiles         - Metadata table log files to be verified
    * @param enableMetaFields - Enable meta fields for records
    */
-private static void verifyMetadataRawRecords(HoodieTable table, List<HoodieLogFile> logFiles, boolean enableMetaFields) throws IOException {
-    HoodieStorage storage = table.getStorage();
+  private static void verifyMetadataRawRecords(HoodieStorage storage, List<HoodieLogFile> logFiles, boolean enableMetaFields) throws IOException {
     for (HoodieLogFile logFile : logFiles) {
       List<StoragePathInfo> pathInfoList = storage.listDirectEntries(logFile.getPath());
       HoodieSchema writerSchema  =
@@ -4041,7 +4041,7 @@ private static void verifyMetadataRawRecords(HoodieTable table, List<HoodieLogFi
     }
   }
 
-private void validateMetadata(SparkRDDWriteClient testClient) throws Exception {
+  private void validateMetadata(SparkRDDWriteClient testClient) throws Exception {
     validateMetadata(testClient, Option.empty());
   }
 
@@ -4117,8 +4117,7 @@ private void validateMetadata(SparkRDDWriteClient testClient) throws Exception {
       List<HoodieLogFile> logFiles = latestSlices.get(0).getLogFiles().collect(Collectors.toList());
       try {
         if (FILES.getPartitionPath().equals(partition)) {
-          HoodieTable table = HoodieSparkTable.create(config, engineContext);
-          verifyMetadataRawRecords(table, logFiles, false);
+          verifyMetadataRawRecords(storage, logFiles, false);
         }
         if (COLUMN_STATS.getPartitionPath().equals(partition)) {
           verifyMetadataColumnStatsRecords(storage, logFiles);
@@ -4265,7 +4264,7 @@ private void validateMetadata(SparkRDDWriteClient testClient) throws Exception {
       // Metadata table has a fixed number of partitions
       // Cannot use FSUtils.getAllFoldersWithPartitionMetaFile for this as that function filters all directory
       // in the .hoodie folder.
-List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, metadataMetaClient, false);
+      List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, metadataMetaClient, false);
       // check if the last instant is restore, then the metadata table should have only the partitions that are not deleted
       metaClient.reloadActiveTimeline().getReverseOrderedInstants().findFirst().ifPresent(instant -> {
         if (instant.getAction().equals(HoodieActiveTimeline.RESTORE_ACTION)) {
@@ -4284,7 +4283,7 @@ List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContex
         List<HoodieLogFile> logFiles = latestSlices.get(0).getLogFiles().collect(Collectors.toList());
         try {
           if (FILES.getPartitionPath().equals(partition)) {
-            verifyMetadataRawRecords(logFiles, false);
+            verifyMetadataRawRecords(storage, logFiles, false);
           }
           if (COLUMN_STATS.getPartitionPath().equals(partition)) {
             verifyMetadataColumnStatsRecords(storage, logFiles);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Large-scale Hudi datasets with millions of records require many file groups (shards) in the Metadata Table (MDT), particularly for the Record Index partition. When all these file groups reside in a single directory, filesystems can hit per-directory file count limits. This PR introduces a bucketing strategy that organizes MDT file groups into sub-directories (buckets), enabling Hudi to scale to larger datasets.

### Summary and Changelog

This feature allows file groups within metadata table partitions to be organized into sub-directories (buckets), enabling Hudi to scale to larger datasets without hitting per-directory file count limits.

**Changes:**
- Added new config `hoodie.metadata.file.group.bucketing.enable` (default: false) to enable bucketing for MDT partitions
- Added new config `hoodie.metadata.file.group.bucket.size` (default: 1000) to configure number of file groups per bucket
- Added table property `hoodie.metadata.partitions.bucketing.enable` to persist bucketing state
- Modified `HoodieBackedTableMetadataWriter.initializeFileGroups()` to create file groups in bucket sub-directories when bucketing is enabled
- Modified `HoodieTableMetadataUtil.getPartitionFileSlices()` and `getPartitionLatestFileSlicesIncludingInflight()` to iterate over bucket directories when bucketing is detected
- Added helper methods: `getBucketRelativePath()`, `isBucketingEnabledForMDT()`, `getPartitionsToList()`, `setMetadataTablePartitionBucketing()`

**New bucketed structure:**
```
.hoodie/metadata/
└── record_index/
    ├── 0000/
    │   ├── .hoodie_partition_metadata
    │   ├── record-index-0000_xxx.hfile
    │   └── ...                          # Up to 1000 file groups
    ├── 0001/
    │   ├── record-index-1000_xxx.hfile
    │   └── ...
    └── ...
```

### Impact

- **New configs added**: `hoodie.metadata.file.group.bucketing.enable`, `hoodie.metadata.file.group.bucket.size`
- **New table property**: `hoodie.metadata.partitions.bucketing.enable`
- **Backward compatible**: Reader code auto-detects bucketed vs non-bucketed format without requiring configuration
- **No breaking changes**: Feature is disabled by default

### Risk Level

Low - Feature is disabled by default and only affects new MDT initializations when explicitly enabled. Reader code is backward compatible and auto-detects the format.

### Documentation Update

The config descriptions are included in the code. Website documentation should be updated to describe:
- The new bucketing feature and when to use it (large datasets with many record index shards)
- The two new configuration options

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable