### PR TITLE
feat(table-services): Allow  users to not parallelize each partition with engine context during clustering planning

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieClusteringConfig.java
@@ -347,17 +347,15 @@ public class HoodieClusteringConfig extends HoodieConfig {
           + "Please exercise caution while setting this config, especially when clustering is done very frequently. This could lead to race condition in "
           + "rare scenarios, for example, when the clustering completes after instants are fetched but before rollback completed.");
 
-  public static final ConfigProperty<Boolean> PLAN_PARTITION_PARALLEL = ConfigProperty
-      .key("hoodie.clustering.plan.partition.parallel")
-      .defaultValue(true)
+  public static final ConfigProperty<Boolean> PLAN_GENERATION_USE_LOCAL_ENGINE_CONTEXT = ConfigProperty
+      .key("hoodie.clustering.plan.generation.use.local.engine.context")
+      .defaultValue(false)
       .sinceVersion("1.2.0")
-      .withDocumentation("Compute clustering groups for each partition in parallel using engine context when generating "
-          + "the clustering plan. For example, with Spark engine setting this to true would lead to a separate spark task (computing all clustering "
-          + "groups per dataset partition), whereas setting this to false would lead to all clustering groups for all partitions being locally "
-          + "computed in parallel on the driver. By default this should be enabled, but can be disabled for cases where there are guaranteed to only be "
-          + "a few partitions with many files in clustering plan. And (when using Spark) it would be more resource-efficient to just use local "
-          + "engine context which will allow the spark driver (which has extra memory) to compute it all locally, rather than allocate more memory per executor "
-          + "(which won't anyway be needed later in the spark job).");
+      .withDocumentation("When enabled, uses a local engine context (e.g., driver-side in Spark) instead of the distributed engine context "
+          + "to compute clustering groups for each partition during clustering plan generation. By default this is disabled, meaning the distributed "
+          + "engine context is used (e.g., with Spark, each partition's clustering groups are computed in a separate Spark task). "
+          + "Enable this for cases where there are guaranteed to only be a few partitions with many files in the clustering plan, "
+          + "and it would be more resource-efficient to compute locally on the driver rather than allocate executor resources.");
 
   public static final ConfigProperty<Boolean> FILE_STITCHING_BINARY_COPY_SCHEMA_EVOLUTION_ENABLE = ConfigProperty
       .key(CLUSTERING_STRATEGY_PARAM_PREFIX + "binary.copy.schema.evolution.enable")
@@ -642,8 +640,8 @@ public class HoodieClusteringConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder planPartitionParallel(Boolean isParallel) {
-      clusteringConfig.setValue(PLAN_PARTITION_PARALLEL, String.valueOf(isParallel));
+    public Builder useLocalEngineContextForPlanGeneration(Boolean useLocal) {
+      clusteringConfig.setValue(PLAN_GENERATION_USE_LOCAL_ENGINE_CONTEXT, String.valueOf(useLocal));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1927,8 +1927,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBooleanOrDefault(HoodieClusteringConfig.FILE_STITCHING_BINARY_COPY_SCHEMA_EVOLUTION_ENABLE);
   }
 
-  public boolean isClusteringPlanPartitionParallel() {
-    return getBoolean(HoodieClusteringConfig.PLAN_PARTITION_PARALLEL);
+  public boolean isClusteringPlanGenerationUseLocalEngineContext() {
+    return getBoolean(HoodieClusteringConfig.PLAN_GENERATION_USE_LOCAL_ENGINE_CONTEXT);
   }
 
   public int getInlineClusterMaxCommits() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -120,6 +120,19 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
   }
 
   /**
+   * Resolves the engine context to use for clustering plan generation.
+   * When {@code hoodie.clustering.plan.generation.use.local.engine.context} is enabled,
+   * returns a new {@link HoodieLocalEngineContext} to compute on the driver;
+   * otherwise returns the distributed engine context.
+   */
+  protected HoodieEngineContext resolveEngineContextForPlanGeneration() {
+    if (getWriteConfig().isClusteringPlanGenerationUseLocalEngineContext()) {
+      return new HoodieLocalEngineContext(getEngineContext().getStorageConf());
+    }
+    return getEngineContext();
+  }
+
+  /**
    * Return list of partition paths to be considered for clustering.
    */
   public Pair<List<String>, List<String>> filterPartitionPaths(HoodieWriteConfig writeConfig, List<String> partitions) {
@@ -165,12 +178,7 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
       return Option.empty();
     }
 
-    final HoodieEngineContext engineContext;
-    if (getWriteConfig().isClusteringPlanPartitionParallel()) {
-      engineContext = getEngineContext();
-    } else {
-      engineContext = new HoodieLocalEngineContext(getEngineContext().getStorageConf());
-    }
+    final HoodieEngineContext engineContext = resolveEngineContextForPlanGeneration();
 
     List<Pair<List<HoodieClusteringGroup>, String>> res = engineContext.map(partitionPaths, partitionPath -> {
       List<FileSlice> fileSlicesEligible = getFileSlicesEligibleForClustering(partitionPath).collect(Collectors.toList());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestPartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestPartitionAwareClusteringPlanStrategy.java
@@ -19,8 +19,10 @@
 package org.apache.hudi.table.action.cluster.strategy;
 
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.table.HoodieTable;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +36,9 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestPartitionAwareClusteringPlanStrategy {
@@ -76,6 +81,44 @@ public class TestPartitionAwareClusteringPlanStrategy {
     assertEquals(2, list.size());
     assertTrue(list.contains("20210721"));
     assertTrue(list.contains("20210723"));
+  }
+
+  @Test
+  public void testResolveEngineContextUsesLocalWhenEnabled() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(new HadoopStorageConfiguration(false));
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
+        .withPath("dummy_Table_Path")
+        .withClusteringConfig(HoodieClusteringConfig.newBuilder()
+            .useLocalEngineContextForPlanGeneration(true)
+            .build())
+        .build();
+
+    DummyPartitionAwareClusteringPlanStrategy strategy =
+        new DummyPartitionAwareClusteringPlanStrategy(table, engineContext, config);
+    HoodieEngineContext resolved = strategy.resolveEngineContextForPlanGeneration();
+
+    assertInstanceOf(HoodieLocalEngineContext.class, resolved,
+        "Expected HoodieLocalEngineContext but got " + resolved.getClass().getName());
+    assertNotSame(engineContext, resolved,
+        "Expected a new HoodieLocalEngineContext instance, but got the same instance");
+  }
+
+  @Test
+  public void testResolveEngineContextUsesDistributedWhenDisabled() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(new HadoopStorageConfiguration(false));
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
+        .withPath("dummy_Table_Path")
+        .withClusteringConfig(HoodieClusteringConfig.newBuilder()
+            .useLocalEngineContextForPlanGeneration(false)
+            .build())
+        .build();
+
+    DummyPartitionAwareClusteringPlanStrategy strategy =
+        new DummyPartitionAwareClusteringPlanStrategy(table, engineContext, config);
+    HoodieEngineContext resolved = strategy.resolveEngineContextForPlanGeneration();
+
+    assertSame(engineContext, resolved,
+        "Expected the original engine context to be returned when local engine context is disabled");
   }
 
   class DummyPartitionAwareClusteringPlanStrategy extends PartitionAwareClusteringPlanStrategy {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1034,17 +1034,16 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   }
 
   /**
-   * Tests clustering when {@code hoodie.clustering.plan.partition.parallel} is disabled (non-default).
-   * Ensures the code path that computes clustering groups on the driver serially (HoodieLocalEngineContext) is exercised.
+   * Tests clustering when {@code hoodie.clustering.plan.generation.use.local.engine.context} is enabled.
+   * Ensures the code path that computes clustering groups on the driver using HoodieLocalEngineContext is exercised.
    */
-  @ParameterizedTest
-  @MethodSource("populateMetaFieldsParams")
-  public void testClusteringWithComputePlanPerPartitionParallelDisabled(boolean populateMetaFields) throws Exception {
-    initMetaClient(getPropertiesForKeyGen(populateMetaFields));
+  @Test
+  public void testClusteringWithLocalEngineContextForPlanGeneration() throws Exception {
+    initMetaClient(getPropertiesForKeyGen(true));
     HoodieClusteringConfig clusteringConfig = createClusteringBuilder(true, 1)
-        .planPartitionParallel(false)
+        .useLocalEngineContextForPlanGeneration(true)
         .build();
-    testInsertAndClustering(clusteringConfig, populateMetaFields, true,
+    testInsertAndClustering(clusteringConfig, true, true,
         false, SqlQueryEqualityPreCommitValidator.class.getName(), COUNT_SQL_QUERY_FOR_VALIDATION, "");
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/17902

### Summary and Changelog
- New config `hoodie.clustering.plan.generation.use.local.engine.context` (default `false`). When `true`, clustering groups for all partitions are computed on the driver using `HoodieLocalEngineContext` instead of in parallel via the engine context (with one "engine task" per partition - in the case of spark a spark task).



- **HoodieClusteringConfig:** Added `hoodie.clustering.plan.generation.use.local.engine.context` (default `false`) and `Builder.useLocalEngineContextForPlanGenerationBoolean)`.
- **PartitionAwareClusteringPlanStrategy:** When `useLocalEngineContextForPlanGenerationBoolean()` is true, use `HoodieLocalEngineContext` for plan generation

### Impact

- **Public API:** New configs `hoodie.clustering.plan.generation.use.local.engine.context`, plus builder methods and getters above. No breaking changes.
- **User-facing:** Optional behavior; defaults preserve using engine for parallel partition plan computation.
- **Performance:** Plan generation runs on the driver and can be preferable when there are few partitions with many files. This also allows us to add a future optimization to `SparkStreamCopyClusteringPlanStrategy` to have it use spark engine context to check schema hash of all files in a partition in parallel

### Risk Level

**Low.** New configs are additive and default to current behavior. New plan-computation code path is covered by new test in `TestHoodieClientOnCopyOnWriteStorage`.

### Documentation Update

- **Config:** Can document new configs in the clustering section: 'hoodie.clustering.plan.generation.use.local.engine.context` (default `false`, description and when to set to `true`).

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
