### PR TITLE
feat(flink): lookup join with retry and async capabilities

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -1301,6 +1301,17 @@ public class FlinkOptions extends HoodieConfig {
           .withDescription(
               "The cache TTL (e.g. 10min) for the build table in lookup join.");
 
+  public static final ConfigOption<Boolean> LOOKUP_ASYNC =
+      key("lookup.async")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to enable async lookup join.");
+
+  public static final ConfigOption<Integer> LOOKUP_ASYNC_THREAD_NUMBER =
+      key("lookup.async-thread-number")
+          .intType()
+          .defaultValue(16)
+          .withDescription("The thread number for lookup async.");
 
   // -------------------------------------------------------------------------
   //  Utilities

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/AsyncLookupFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/AsyncLookupFunctionWrapper.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.lookup;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.AsyncLookupFunction;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.LookupFunction;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/** A {@link AsyncLookupFunction} to wrap sync function. */
+public class AsyncLookupFunctionWrapper extends AsyncLookupFunction {
+
+  private final LookupFunction function;
+  private final int threadNumber;
+
+  private transient ExecutorService lazyExecutor;
+
+  public AsyncLookupFunctionWrapper(LookupFunction function, int threadNumber) {
+    this.function = function;
+    this.threadNumber = threadNumber;
+  }
+
+  @Override
+  public void open(FunctionContext context) throws Exception {
+    function.open(context);
+  }
+
+  private Collection<RowData> lookup(RowData keyRow) {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(AsyncLookupFunctionWrapper.class.getClassLoader());
+    try {
+      synchronized (function) {
+        return function.lookup(keyRow);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } finally {
+      Thread.currentThread().setContextClassLoader(cl);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Collection<RowData>> asyncLookup(RowData keyRow) {
+    return CompletableFuture.supplyAsync(() -> lookup(keyRow), executor());
+  }
+
+  @Override
+  public void close() throws Exception {
+    function.close();
+    if (lazyExecutor != null) {
+      lazyExecutor.shutdownNow();
+      lazyExecutor = null;
+    }
+  }
+
+  private ExecutorService executor() {
+    if (lazyExecutor == null) {
+      lazyExecutor = Executors.newFixedThreadPool(threadNumber,
+          new ExecutorThreadFactory(Thread.currentThread().getName() + "-async"));
+    }
+    return lazyExecutor;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/LookupRuntimeProviderFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/LookupRuntimeProviderFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.lookup;
+
+import org.apache.flink.table.connector.source.LookupTableSource.LookupRuntimeProvider;
+import org.apache.flink.table.connector.source.lookup.AsyncLookupFunctionProvider;
+import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
+
+/** Factory to create {@link LookupRuntimeProvider}. */
+public class LookupRuntimeProviderFactory {
+
+  public static LookupRuntimeProvider create(HoodieLookupFunction function, boolean enableAsync, int asyncThreadNumber) {
+    return enableAsync
+        ? AsyncLookupFunctionProvider.of(new AsyncLookupFunctionWrapper(function, asyncThreadNumber))
+        : LookupFunctionProvider.of(function);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Since Flink 1.16 the LOOKUP hint allows users to suggest the Flink optimizer to:  

- use synchronous(sync) or asynchronous(async) lookup function
- configure the async parameters
- enable delayed retry strategy for lookup

More info about async/retry lookups (usage and available config options): https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/table/sql/queries/hints/#lookup

But Hudi does not support none of these features yet.

### Summary and Changelog

Now HoodieLookupFunction extends Flink's LookupFunction (which supports retry join), also added wrapper  that extends Flink's AsyncLookupFunction.  

### Impact

Flink's async and retry lookup join capabilities can be used with Hudi.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
