### PR TITLE
feat: add graceful handling for post-commit failures with metrics

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -290,8 +290,8 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       runTableServicesInline(table, metadata, extraMetadata);
     } catch (Exception e) {
       postCommitStatus = false;
-      if (config.postCommitFailuresIngnored()) {
-        LOG.error("Ignoring exception in perform post commit processing", e);
+      if (config.canIgnorePostCommitFailures()) {
+        LOG.error("Ignoring exception during post-commit or inline table service processing", e);
       } else {
         throw e;
       }
@@ -638,8 +638,8 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
         mayBeCleanAndArchive(hoodieTable);
       } catch (Exception e) {
         postCommitStatus = false;
-        if (config.postCommitFailuresIngnored()) {
-          LOG.error("Ignoring exception in perform post commit processing", e);
+        if (config.canIgnorePostCommitFailures()) {
+          LOG.error("Ignoring exception during post-commit or inline table service processing", e);
         } else {
           throw e;
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -731,11 +731,12 @@ public class HoodieWriteConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("");
 
-  public static final ConfigProperty<String> POST_COMMIT_FAILURES_IGNORED = ConfigProperty
-      .key("hoodie.post.commit.failures.ignored")
-      .defaultValue("false")
-      .withDocumentation("When this config is true, any failures in the post commit operations will be"
-          + " ignored and does not kill the application.");
+  public static final ConfigProperty<Boolean> CAN_IGNORE_POST_COMMIT_FAILURES = ConfigProperty
+      .key("hoodie.write.can.ignore.post.commit.failures")
+      .defaultValue(false)
+      .withAlternatives("hoodie.post.commit.failures.ignored")
+      .withDocumentation("When this config is true, any failures in post-commit operations are"
+          + " ignored and do not kill the application.");
 
   public static final ConfigProperty<String> AVRO_EXTERNAL_SCHEMA_TRANSFORMATION_ENABLE = ConfigProperty
       .key(AVRO_SCHEMA_STRING.key() + ".external.transformation")
@@ -2810,8 +2811,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(BLOCK_WRITES_ON_SPECULATIVE_EXECUTION);
   }
 
-  public Boolean postCommitFailuresIngnored() {
-    return getBoolean(POST_COMMIT_FAILURES_IGNORED);
+  public boolean canIgnorePostCommitFailures() {
+    return getBoolean(CAN_IGNORE_POST_COMMIT_FAILURES);
   }
 
   /**
@@ -3493,8 +3494,8 @@ public class HoodieWriteConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withIgnorePostCommitFailure(boolean postCommitFailureIgnored) {
-      writeConfig.setValue(POST_COMMIT_FAILURES_IGNORED, Boolean.toString(postCommitFailureIgnored));
+    public Builder withCanIgnorePostCommitFailures(boolean canIgnorePostCommitFailures) {
+      writeConfig.setValue(CAN_IGNORE_POST_COMMIT_FAILURES, String.valueOf(canIgnorePostCommitFailures));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metrics/HoodieMetrics.java
@@ -148,6 +148,10 @@ public class HoodieMetrics {
   private Counter compactionRequestedCounter = null;
   private Counter compactionCompletedCounter = null;
   private Counter rollbackFailureCounter = null;
+  private Counter postCommitSuccessCounter = null;
+  private Counter postCommitFailureCounter = null;
+  private String postCommitSuccessCounterName = null;
+  private String postCommitFailureCounterName = null;
 
   public HoodieMetrics(HoodieWriteConfig config, HoodieStorage storage) {
     this.config = config;
@@ -175,6 +179,8 @@ public class HoodieMetrics {
       this.compactionRequestedCounterName = getMetricsName(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.REQUESTED_COMPACTION_SUFFIX + COUNTER_METRIC_EXTENSION);
       this.compactionCompletedCounterName = getMetricsName(HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.COMPLETED_COMPACTION_SUFFIX + COUNTER_METRIC_EXTENSION);
       this.rollbackFailureCounterName = getMetricsName("rollback", FAILURE_COUNTER);
+      this.postCommitSuccessCounterName = getMetricsName(POST_COMMIT_STR, SUCCESS_COUNTER);
+      this.postCommitFailureCounterName = getMetricsName(POST_COMMIT_STR, FAILURE_COUNTER);
     }
   }
 
@@ -361,7 +367,13 @@ public class HoodieMetrics {
 
   public void updatePostCommitMetrics(boolean status, long durationInMs) {
     if (config.isMetricsOn()) {
-      metrics.registerGauge(getMetricsName(POST_COMMIT_STR, status ? SUCCESS_COUNTER : FAILURE_COUNTER), 1);
+      if (status) {
+        postCommitSuccessCounter = getCounter(postCommitSuccessCounter, postCommitSuccessCounterName);
+        postCommitSuccessCounter.inc();
+      } else {
+        postCommitFailureCounter = getCounter(postCommitFailureCounter, postCommitFailureCounterName);
+        postCommitFailureCounter.inc();
+      }
       metrics.registerGauge(getMetricsName(POST_COMMIT_STR, DURATION_STR), durationInMs);
     }
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSparkRDDWriteClient.java
@@ -39,6 +39,7 @@ import org.apache.hudi.metrics.Metrics;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import org.apache.avro.generic.GenericRecord;
@@ -349,7 +350,7 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
     // Test with post commit failures ignored
     HoodieWriteConfig configWithIgnore = getConfigBuilder(true)
         .withPath(metaClient.getBasePath())
-        .withIgnorePostCommitFailure(true)
+        .withCanIgnorePostCommitFailures(true)
         .withMetricsConfig(org.apache.hudi.config.metrics.HoodieMetricsConfig.newBuilder()
             .on(true)
             .withReporterType("INMEMORY")
@@ -382,20 +383,21 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
     String failureMetricName = clientWithIgnore.getMetrics().getMetricsName(POST_COMMIT_STR, FAILURE_COUNTER);
     String durationMetricName = clientWithIgnore.getMetrics().getMetricsName(POST_COMMIT_STR, DURATION_STR);
 
-    Gauge<Long> failureGauge = (Gauge<Long>) registry.getGauges().get(failureMetricName);
+    Counter failureCounter = registry.getCounters().get(failureMetricName);
     Gauge<Long> durationGauge = (Gauge<Long>) registry.getGauges().get(durationMetricName);
 
-    assertNotNull(failureGauge, "Failure metric should be registered");
-    assertEquals(1L, failureGauge.getValue(), "Failure count should be 1");
+    assertNotNull(failureCounter, "Failure metric should be registered");
+    assertEquals(1L, failureCounter.getCount(), "Failure count should be 1");
     assertNotNull(durationGauge, "Duration metric should be registered");
     assertTrue(durationGauge.getValue() >= 0, "Duration should be non-negative");
 
     clientWithIgnore.close();
+    metrics.shutdown();
 
     // Test with post commit failures NOT ignored (should throw exception)
     HoodieWriteConfig configWithoutIgnore = getConfigBuilder(true)
         .withPath(metaClient.getBasePath())
-        .withIgnorePostCommitFailure(false)
+        .withCanIgnorePostCommitFailures(false)
         .withMetricsConfig(org.apache.hudi.config.metrics.HoodieMetricsConfig.newBuilder()
             .on(true)
             .withReporterType("INMEMORY")
@@ -429,14 +431,15 @@ class TestSparkRDDWriteClient extends SparkClientFunctionalTestHarness {
     String failureMetricName2 = clientWithoutIgnore.getMetrics().getMetricsName(POST_COMMIT_STR, FAILURE_COUNTER);
     String durationMetricName2 = clientWithoutIgnore.getMetrics().getMetricsName(POST_COMMIT_STR, DURATION_STR);
 
-    Gauge<Long> failureGauge2 = (Gauge<Long>) registry2.getGauges().get(failureMetricName2);
+    Counter failureCounter2 = registry2.getCounters().get(failureMetricName2);
     Gauge<Long> durationGauge2 = (Gauge<Long>) registry2.getGauges().get(durationMetricName2);
 
-    assertNotNull(failureGauge2, "Failure metric should be registered for second test");
-    assertEquals(1L, failureGauge2.getValue(), "Failure count should be 1");
+    assertNotNull(failureCounter2, "Failure metric should be registered for second test");
+    assertEquals(1L, failureCounter2.getCount(), "Failure count should be 1");
     assertNotNull(durationGauge2, "Duration metric should be registered for second test");
     assertTrue(durationGauge2.getValue() >= 0, "Duration should be non-negative");
 
     clientWithoutIgnore.close();
+    metrics2.shutdown();
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

During parallel ingestion where cell and row level commits happen concurrently, if a row's clean commit fails during post-commit processing, it causes the cell commit to fail as well, wasting the entire run. This PR adds graceful handling of post-commit failures to allow ingestion to complete without failure, along with metrics to track duration and failures.

### Summary and Changelog

Users can now configure Hudi to ignore post-commit operation failures (cleaning, archival, and table services) through a new configuration flag. When enabled, post-commit failures are logged but don't kill the application, allowing the main write operation to succeed. Metrics have been added to track post-commit operation status and duration.

**Changes:**
- Added `hoodie.post.commit.failures.ignored` config to control post-commit failure handling
- Wrapped post-commit operations (`postCommit`, `mayBeCleanAndArchive`, `runTableServicesInline`) in try-catch blocks with configurable failure handling
- Added `updatePostCommitMetrics()` method in `HoodieMetrics` to track post-commit success/failure and duration
- Added comprehensive unit test `testPostCommitFailureHandlingWithMetrics()` in `TestSparkRDDWriteClient` to verify both failure handling modes and metrics tracking

### Impact

**Public API Changes:**
- New configuration property: `hoodie.post.commit.failures.ignored` (default: `false`)
- New builder method: `HoodieWriteConfig.Builder.withIgnorePostCommitFailure(boolean)`

**Metrics:**
- New metrics: `postCommit.failure.counter` and `postCommit.duration`

**Behavior Change:**
When `hoodie.post.commit.failures.ignored=true`, post-commit operation failures (cleaning, archival, table services) will be logged as errors but will not cause the write operation to fail.

### Risk Level

**Low**

The change is backward compatible (default behavior unchanged) and only activates when explicitly configured. The try-catch blocks have finally blocks to ensure metrics are always updated. Comprehensive testing has been added to verify both success and failure scenarios.

### Documentation Update

Configuration documentation needs to be updated:
- Add `hoodie.post.commit.failures.ignored` to configuration reference with description: "When this config is true, any failures in the post commit operations will be ignored and does not kill the application."

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
