### PR TITLE
test(common): add JVM memory reporting test for environment diagnostics

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/TestReportJvmConfiguration.java
+++ b/hudi-common/src/test/java/org/apache/hudi/TestReportJvmConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+
+public class TestReportJvmConfiguration {
+  private static final Logger LOG = LoggerFactory.getLogger(TestReportJvmConfiguration.class);
+
+  @Test
+  public void testReportMemoryUsage() {
+    reportMemoryUsageWithMXBean();
+    reportMemoryUsageWithRuntime();
+  }
+
+  private void reportMemoryUsageWithMXBean() {
+    MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+
+    MemoryUsage heapMemoryUsage = memoryBean.getHeapMemoryUsage();
+    MemoryUsage nonHeapMemoryUsage = memoryBean.getNonHeapMemoryUsage();
+
+    LOG.warn("Heap Memory Usage (MemoryMXBean):");
+    LOG.warn("  Used: " + heapMemoryUsage.getUsed() + " bytes");
+    LOG.warn("  Committed: " + heapMemoryUsage.getCommitted() + " bytes");
+    LOG.warn("  Max: " + heapMemoryUsage.getMax() + " bytes");
+
+    LOG.warn("Non-Heap Memory Usage (MemoryMXBean):");
+    LOG.warn("  Used: " + nonHeapMemoryUsage.getUsed() + " bytes");
+    LOG.warn("  Committed: " + nonHeapMemoryUsage.getCommitted() + " bytes");
+    LOG.warn("  Max: " + nonHeapMemoryUsage.getMax() + " bytes");
+  }
+
+  private void reportMemoryUsageWithRuntime() {
+    Runtime runtime = Runtime.getRuntime();
+
+    long totalMemory = runtime.totalMemory();
+    long freeMemory = runtime.freeMemory();
+    long usedMemory = totalMemory - freeMemory;
+
+    LOG.warn("Memory Usage (Runtime):");
+    LOG.warn("  Total Memory: " + totalMemory + " bytes");
+    LOG.warn("  Free Memory: " + freeMemory + " bytes");
+    LOG.warn("  Used Memory: " + usedMemory + " bytes");
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flaky memory regressions are often triggered by environment/runtime changes (JVM, CI container limits, or test runner behavior), not only by code changes. Diagnosing these regressions is difficult when test logs do not include runtime memory context.

This PR adds a lightweight unit test that reports JVM memory statistics during test execution to improve observability when investigating memory-related regressions.

### Summary and Changelog

- Added `TestReportJvmConfiguration` under `hudi-common` tests.
- The test logs heap and non-heap memory metrics using `MemoryMXBean`.
- The test also logs runtime memory metrics (`total`, `free`, `used`) via `Runtime` APIs.
- The goal is diagnostic visibility in CI/local logs for environment comparison during flaky memory investigations.

### Impact

- Improves debugging signal for memory regressions by providing consistent JVM memory snapshot in test logs.
- No functional behavior change in production code paths.
- Minimal runtime overhead since this is a single lightweight test utility.

### Risk Level

low

This is test-only, additive, and non-invasive.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable