### PR TITLE
chore: Add .claude and .codex directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,9 @@ package-lock.json
 # Spark Binaries used for testing
 hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/spark-versions/
 
+#######################################
+# AI Tools
+#######################################
 CLAUDE.md
+.claude
+.codex


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Developers are using AI tools; need to ignore the context files

### Summary and Changelog

Added entries to `.gitignore` 

### Impact

none 

### Risk Level

none 

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
