### PR TITLE
perf(metadata table) Metadata table archival should proceed until earliest commit to retain on data table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
@@ -318,7 +318,8 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
           .build();
       Option<HoodieInstant> qualifiedEarliestInstant =
           TimelineUtils.getEarliestInstantForMetadataArchival(
-              dataMetaClient.getActiveTimeline(), config.shouldArchiveBeyondSavepoint());
+              dataMetaClient.getActiveTimeline(), config.shouldArchiveBeyondSavepoint(),
+              TimelineUtils.getEarliestRetainedCommitFromLastClean(dataMetaClient));
 
       // Do not archive the instants after the earliest commit (COMMIT, DELTA_COMMIT, and
       // REPLACE_COMMIT only, considering non-savepoint commit only if enabling archive

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/TimelineArchiverV2.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/TimelineArchiverV2.java
@@ -241,7 +241,8 @@ public class TimelineArchiverV2<T extends HoodieAvroPayload, I, K, O> implements
           .build();
       Option<HoodieInstant> qualifiedEarliestInstant =
           TimelineUtils.getEarliestInstantForMetadataArchival(
-              dataMetaClient.getActiveTimeline(), config.shouldArchiveBeyondSavepoint());
+              dataMetaClient.getActiveTimeline(), config.shouldArchiveBeyondSavepoint(),
+              TimelineUtils.getEarliestRetainedCommitFromLastClean(dataMetaClient));
 
       // Do not archive the instants after the earliest commit (COMMIT, DELTA_COMMIT, and
       // REPLACE_COMMIT only, considering non-savepoint commit only if enabling archive

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -1971,7 +1971,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
         .getCommitsTimeline().filterCompletedInstants().getInstants();
     // Archival on MDT is now blocked by the ECTR of data table instead of earliest instant,
     // allowing more instants in MDT to be archived
-    assertEquals(6, metadataTableInstants.size());
+    assertEquals(7, metadataTableInstants.size());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/BaseHoodieTimeline.java
@@ -549,6 +549,18 @@ public abstract class BaseHoodieTimeline implements HoodieTimeline {
     return this.firstNonSavepointCommit;
   }
 
+  @Override
+  public Option<HoodieInstant> findFirstSavepointedWrite() {
+    Option<HoodieInstant> firstSavePointInstantOption = getSavePointTimeline().firstInstant();
+    if (!firstSavePointInstantOption.isPresent()) {
+      return Option.empty();
+    }
+    HoodieInstant firstSavePoint = firstSavePointInstantOption.get();
+    return getWriteTimeline()
+        .filter(instant -> instant.requestedTime().equals(firstSavePoint.requestedTime()))
+        .firstInstant();
+  }
+
   public Option<HoodieInstant> getFirstNonSavepointCommitByCompletionTime() {
     if (this.firstNonSavepointCommitByCompletionTime == null) {
       synchronized (this) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -642,6 +642,11 @@ public interface HoodieTimeline extends HoodieInstantReader, Serializable {
   Option<HoodieInstant> getFirstNonSavepointCommit();
 
   /**
+   * Returns the first write commit that has been savepoint-ed.
+   */
+  Option<HoodieInstant> findFirstSavepointedWrite();
+
+  /**
    * get the most recent cluster commit if present
    */
   Option<HoodieInstant> getLastClusteringInstant();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -409,8 +409,7 @@ public class TimelineUtils {
       }
       return Option.of(ectr);
     } catch (IOException e) {
-      LOG.warn("Failed to read clean metadata for " + lastClean.get(), e);
-      return Option.empty();
+      throw new HoodieIOException("Failed to read clean metadata for " + lastClean.get(), e);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.CleanerUtils;
 import org.apache.hudi.common.util.ClusteringUtils;
-import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -66,7 +65,6 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_AC
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.LOG_COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
-import static org.apache.hudi.common.table.timeline.HoodieTimeline.SAVEPOINT_ACTION;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
@@ -355,42 +353,90 @@ public class TimelineUtils {
    * for the archival in metadata table.
    * <p>
    * the qualified earliest instant is chosen as the earlier one between the earliest
-   * commit (COMMIT, DELTA_COMMIT, and REPLACE_COMMIT only, considering non-savepoint
+   * commit that dataset can be potentially restored to
+   * (COMMIT, DELTA_COMMIT, and REPLACE_COMMIT only, considering non-savepoint
    * commit only if enabling archive beyond savepoint) and the earliest inflight
    * instant (all actions).
    *
    * @param dataTableActiveTimeline      the active timeline of the data table.
    * @param shouldArchiveBeyondSavepoint whether to archive beyond savepoint.
+   * @param earliestUncleanedDataTableInstantTimeOption ECTR from latest clean on data table, if present.
    * @return the instant meeting the requirement.
    */
   public static Option<HoodieInstant> getEarliestInstantForMetadataArchival(
-      HoodieActiveTimeline dataTableActiveTimeline, boolean shouldArchiveBeyondSavepoint) {
+      HoodieActiveTimeline dataTableActiveTimeline, boolean shouldArchiveBeyondSavepoint,
+      Option<String> earliestUncleanedDataTableInstantTimeOption) {
     // This is for commits only, not including CLEAN, ROLLBACK, etc.
-    // When archive beyond savepoint is enabled, there are chances that there could be holes
-    // in the timeline due to archival and savepoint interplay.  So, the first non-savepoint
-    // commit in the data timeline is considered as beginning of the active timeline.
-    Option<HoodieInstant> earliestCommit = shouldArchiveBeyondSavepoint
-        ? dataTableActiveTimeline.getTimelineOfActions(
-            CollectionUtils.createSet(
-                COMMIT_ACTION, DELTA_COMMIT_ACTION, REPLACE_COMMIT_ACTION, CLUSTERING_ACTION, SAVEPOINT_ACTION))
-        .getFirstNonSavepointCommit()
-        : dataTableActiveTimeline.getCommitsTimeline().firstInstant();
-    // This is for all instants which are in-flight
+
+    // If it exists and is still in active timeline of data table, find
+    // the ECTR of latest clean in data table. Otherwise, default to the earliest commit
+    // in timeline, as depending on the user's ingestion workload and clean policy
+    // they may still be able and wish to restore to that instant for recovery purposes
+    Option<HoodieInstant> earliestPossibleRestoreCommit = getEarliestPossibleRestoreCommit(dataTableActiveTimeline,
+        earliestUncleanedDataTableInstantTimeOption);
+
+    // If there are any inflight instants, then get the earlier instant (between inflight and the completed
+    // restore-able commit)
     Option<HoodieInstant> earliestInflight =
         dataTableActiveTimeline.filterInflightsAndRequested().firstInstant();
 
-    if (earliestCommit.isPresent() && earliestInflight.isPresent()) {
-      if (earliestCommit.get().compareTo(earliestInflight.get()) < 0) {
-        return earliestCommit;
-      }
-      return earliestInflight;
-    } else if (earliestCommit.isPresent()) {
-      return earliestCommit;
-    } else if (earliestInflight.isPresent()) {
-      return earliestInflight;
-    } else {
+    if (shouldArchiveBeyondSavepoint) {
+      return findSmallestInstant(earliestInflight, earliestPossibleRestoreCommit);
+    }
+
+    // If we are blocking on earliest savepoint, then check and return the earliest write instant among
+    // - First save-pointed write
+    // - Earliest inflight
+    // - Earliest commit that dataset can potentially be restored to
+    return findSmallestInstant(dataTableActiveTimeline.findFirstSavepointedWrite(),
+        findSmallestInstant(earliestInflight, earliestPossibleRestoreCommit));
+  }
+
+  /**
+   * Returns the earliest commit to retain from the latest completed clean on the given table, if present.
+   */
+  public static Option<String> getEarliestRetainedCommitFromLastClean(HoodieTableMetaClient metaClient) {
+    Option<HoodieInstant> lastClean = metaClient.getActiveTimeline().getCleanerTimeline().filterCompletedInstants()
+        .lastInstant();
+    if (!lastClean.isPresent()) {
       return Option.empty();
     }
+    try {
+      HoodieCleanMetadata cleanMetadata = CleanerUtils.getCleanerMetadata(metaClient, lastClean.get());
+      String ectr = cleanMetadata.getEarliestCommitToRetain();
+      if (StringUtils.isNullOrEmpty(ectr)) {
+        return Option.empty();
+      }
+      return Option.of(ectr);
+    } catch (IOException e) {
+      LOG.warn("Failed to read clean metadata for " + lastClean.get(), e);
+      return Option.empty();
+    }
+  }
+
+  public static Option<HoodieInstant> findSmallestInstant(Option<HoodieInstant> left,
+      Option<HoodieInstant> right) {
+    if (left.isPresent() && right.isPresent()) {
+      return left.get().compareTo(right.get()) <= 0 ? left : right;
+    } else if (left.isPresent()) {
+      return left;
+    } else {
+      return right;
+    }
+  }
+
+  public static Option<HoodieInstant> getEarliestPossibleRestoreCommit(
+      HoodieActiveTimeline dataTableActiveTimeline, Option<String> earliestUncleanedDataTableInstantTimeOption) {
+    if (earliestUncleanedDataTableInstantTimeOption.isPresent()) {
+      String earliestUncleanedDataTableInstantTime = earliestUncleanedDataTableInstantTimeOption.get();
+      Option<HoodieInstant> earliestUncleanedDataTableInstant = dataTableActiveTimeline
+          .filter(instant -> instant.requestedTime().equals(earliestUncleanedDataTableInstantTime))
+          .firstInstant();
+      if (earliestUncleanedDataTableInstant.isPresent()) {
+        return earliestUncleanedDataTableInstant;
+      }
+    }
+    return dataTableActiveTimeline.getCommitsTimeline().firstInstant();
   }
 
   /**

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -418,7 +418,7 @@ class TestTimelineUtils extends HoodieCommonTestHarness {
     assertEquals(
         Option.empty(),
         TimelineUtils.getEarliestInstantForMetadataArchival(
-            prepareActiveTimeline(new ArrayList<>()), false));
+            prepareActiveTimeline(new ArrayList<>()), false, Option.empty()));
 
     // Earlier request clean action before commits
     assertEquals(
@@ -431,9 +431,9 @@ class TestTimelineUtils extends HoodieCommonTestHarness {
                     new HoodieInstant(REQUESTED, CLEAN_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
                     new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
                     new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "011", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
-                    new HoodieInstant(REQUESTED, CLUSTERING_ACTION, "012", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false));
+                    new HoodieInstant(REQUESTED, CLUSTERING_ACTION, "012", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false, Option.empty()));
 
-    // No inflight instants
+    // No inflight instants and no ECTR
     assertEquals(
         Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
         TimelineUtils.getEarliestInstantForMetadataArchival(
@@ -444,7 +444,31 @@ class TestTimelineUtils extends HoodieCommonTestHarness {
                     new HoodieInstant(COMPLETED, CLEAN_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
                     new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
                     new HoodieInstant(COMPLETED, REPLACE_COMMIT_ACTION, "011", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
-                    new HoodieInstant(REQUESTED, CLUSTERING_ACTION, "012", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false));
+                    new HoodieInstant(REQUESTED, CLUSTERING_ACTION, "012", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false, Option.empty()));
+
+    // No inflight instants and ECTR present
+    assertEquals(
+        Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
+        TimelineUtils.getEarliestInstantForMetadataArchival(
+            prepareActiveTimeline(
+                Arrays.asList(
+                    new HoodieInstant(COMPLETED, COMMIT_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                    new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                    new HoodieInstant(COMPLETED, CLEAN_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                    new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false,
+            Option.of("002")));
+
+    // No inflight instants and ECTR present but earlier than / not in the active timeline
+    assertEquals(
+        Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
+        TimelineUtils.getEarliestInstantForMetadataArchival(
+            prepareActiveTimeline(
+                Arrays.asList(
+                    new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                    new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                    new HoodieInstant(COMPLETED, CLEAN_ACTION, "004", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+                    new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false,
+            Option.of("001")));
 
     // Rollbacks only
     assertEquals(
@@ -454,7 +478,7 @@ class TestTimelineUtils extends HoodieCommonTestHarness {
                 Arrays.asList(
                     new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
                     new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
-                    new HoodieInstant(INFLIGHT, ROLLBACK_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false));
+                    new HoodieInstant(INFLIGHT, ROLLBACK_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false, Option.empty()));
 
     assertEquals(
         Option.empty(),
@@ -463,9 +487,9 @@ class TestTimelineUtils extends HoodieCommonTestHarness {
                 Arrays.asList(
                     new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
                     new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
-                    new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false));
+                    new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR))), false, Option.empty()));
 
-    // With savepoints
+    // With savepoints but no ECTR from clean
     HoodieActiveTimeline timeline = prepareActiveTimeline(
         Arrays.asList(
             new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
@@ -475,10 +499,46 @@ class TestTimelineUtils extends HoodieCommonTestHarness {
             new HoodieInstant(COMPLETED, COMMIT_ACTION, "011", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
     assertEquals(
         Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
-        TimelineUtils.getEarliestInstantForMetadataArchival(timeline, false));
+        TimelineUtils.getEarliestInstantForMetadataArchival(timeline, false, Option.empty()));
     assertEquals(
-        Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
-        TimelineUtils.getEarliestInstantForMetadataArchival(timeline, true));
+        Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
+        TimelineUtils.getEarliestInstantForMetadataArchival(timeline, true, Option.empty()));
+
+    // With savepoints and clean's ECTR is earlier than all savepoints
+    // Expect that it should block on ECTR regardless of if archival beyond savepoint allowed
+    timeline = prepareActiveTimeline(
+        Arrays.asList(
+            new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, SAVEPOINT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    assertEquals(
+        Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
+        TimelineUtils.getEarliestInstantForMetadataArchival(timeline, false, Option.of("002")));
+    assertEquals(
+        Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "002", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
+        TimelineUtils.getEarliestInstantForMetadataArchival(timeline, true, Option.of("002")));
+
+    // With savepoints and clean's ECTR is in between savepoints
+    // Then it should block on first savepoint or ECTR depending on if archival beyond savepoint is set
+    timeline = prepareActiveTimeline(
+        Arrays.asList(
+            new HoodieInstant(COMPLETED, ROLLBACK_ACTION, "001", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, SAVEPOINT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "004", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "005", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, SAVEPOINT_ACTION, "005", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "010", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR),
+            new HoodieInstant(COMPLETED, COMMIT_ACTION, "011", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)));
+    assertEquals(
+        Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "003", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
+        TimelineUtils.getEarliestInstantForMetadataArchival(timeline, false, Option.of("004")));
+    assertEquals(
+        Option.of(new HoodieInstant(COMPLETED, COMMIT_ACTION, "004", InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR)),
+        TimelineUtils.getEarliestInstantForMetadataArchival(timeline, true, Option.of("004")));
   }
 
   private HoodieActiveTimeline prepareActiveTimeline(

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestTable.java
@@ -428,6 +428,21 @@ public class HoodieTestTable implements AutoCloseable {
     return addClean(instantTime, Option.empty(), cleanerPlan, metadata, false, false);
   }
 
+  public HoodieTestTable addIncrementalClean(String instantTime, String earliestCommitToRetain) throws IOException {
+    HoodieCleanerPlan cleanerPlan = new HoodieCleanerPlan(new HoodieActionInstant(EMPTY_STRING, EMPTY_STRING, EMPTY_STRING),
+        EMPTY_STRING, EMPTY_STRING, new HashMap<>(), CleanPlanV2MigrationHandler.VERSION, new HashMap<>(), new ArrayList<>(), Collections.EMPTY_MAP);
+    HoodieCleanStat cleanStats = new HoodieCleanStat(
+        HoodieCleaningPolicy.KEEP_LATEST_COMMITS,
+        HoodieTestUtils.DEFAULT_PARTITION_PATHS[RANDOM.nextInt(HoodieTestUtils.DEFAULT_PARTITION_PATHS.length)],
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        earliestCommitToRetain,
+        "");
+    HoodieCleanMetadata cleanMetadata = convertCleanMetadata(instantTime, Option.of(0L), Collections.singletonList(cleanStats), Collections.EMPTY_MAP);
+    return HoodieTestTable.of(metaClient).addClean(instantTime, cleanerPlan, cleanMetadata);
+  }
+
   public HoodieTestTable addClean(String instantTime, Option<String> completeTime, HoodieCleanerPlan cleanerPlan, HoodieCleanMetadata metadata) throws IOException {
     return addClean(instantTime, completeTime, cleanerPlan, metadata, false, false);
   }


### PR DESCRIPTION
### Summary and Changelog

**Summary:** Metadata table (MDT) archival should be able to archive instants that are before the earliest commit to retain (in latest clean) on the data table, provided that there are no savepoints. This is since 
- the metadata table anyway cannot be safely restored to a point before the earliest commit to retain (ECTR) on the data table
- For datasets with infrequent ingestion writes and duration based compaction scheduling on MDT, there can be 1.5-2x the number of instant files in MDT active timeline compared to data table timeline. This is since each write to the data table will not only create a deltacommit on MDT, but most likely compaction commit as well. 

**Changelog:**

- **TimelineUtils**
  - `getEarliestInstantForMetadataArchival` now takes a third parameter: `Option<String> earliestUncleanedDataTableInstantTimeOption` (ECTR from the latest clean).
  - Logic uses “earliest possible restore commit” (ECTR if present and on timeline, else first commit), “smallest” of that and inflight, and when not archiving beyond savepoint, the minimum of first savepointed write, earliest inflight, and earliest possible restore commit.
  - Added `getEarliestRetainedCommitFromLastClean(HoodieTableMetaClient)` to read ECTR from the latest completed clean; throws `HoodieIOException` on read failure.
  - Added `findSmallestInstant(Option<HoodieInstant>, Option<HoodieInstant>)` and `getEarliestPossibleRestoreCommit(HoodieActiveTimeline, Option<String>)`.
- **HoodieTimeline / BaseHoodieTimeline**
  - New method `findFirstSavepointedWrite()`: returns the first write commit that has been savepointed (used when blocking MDT archival on savepoints).
- **TimelineArchiverV1 and TimelineArchiverV2**
  - When computing the earliest instant to retain for the metadata table, both archivers now pass the data table ECTR: `TimelineUtils.getEarliestRetainedCommitFromLastClean(dataMetaClient)` is supplied as the third argument to `getEarliestInstantForMetadataArchival`.
- **Tests**
  - **TestTimelineUtils:** All `getEarliestInstantForMetadataArchival` call sites updated to the 3-arg signature; added cases for ECTR present, ECTR not on timeline, and savepoints + ECTR (earlier than savepoints and between savepoints).
  - **HoodieTestTable:** Added `addIncrementalClean(String instantTime, String earliestCommitToRetain)` for tests that need a clean with a given ECTR.
  - **TestHoodieTimelineArchiver:** Added `testArchivalInMetadataTableCanProceedUntilECTR` to assert MDT archival proceeds up to the data table ECTR.

### Impact

- **User-facing / API:** No new public APIs. MDT archival may retain fewer instants (archive more)
- **Performance:** Slightly less MDT timeline to scan when ECTR is present, due to more aggressive archival.

### Risk Level

**Low.** It should be safe if instants on the data table before the ECTR don't have a corresponding deltacommit on MDT. This is since those instants must already have been committed, and cannot anyway be rolled back.

### Documentation Update

None.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
