### PR TITLE
fix(trino): Fix Docker initialization issue in the Trino plugin

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1272,7 +1272,5 @@ jobs:
           mvn clean install -DskipTests
       - name: Test hudi-trino-plugin with JDK 23
         working-directory: ./hudi-trino-plugin
-        env:
-          DOCKER_API_VERSION: "1.44"
         run:
-          mvn test
+          mvn test -Dapi.version=1.44


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

CI job test-hudi-trino-plugin is failing across all PRs with: IllegalState Previous attempts to find a Docker environment failed. Will not retry. 
UnixSocketClientProviderStrategy: failed with exception BadRequestException                                     
(Status 400: {"message":"client version 1.32 is too old. Minimum supported API version is 1.44"})

Docker Engine 29.0.0 (now shipping on GitHub Actions ubuntu-latest runners) raised the minimum supported Docker API version from 1.24 to 1.44. Testcontainers defaults to probing Docker using API version 1.32, which Docker 29   now rejects, causing TestHudiMinioConnectorSmokeTest to fail at Docker environment detection before any test
logic runs.                                                   
                                                                                                                  
### Summary and Changelog                                                                    
                                                                                                                  
Passes -Dapi.version=1.44 as a JVM system property to the Maven test command for test-hudi-trino-plugin. This
tells docker-java (bundled inside Testcontainers as a shaded dependency) to use Docker API version 1.44 for all requests, satisfying Docker 29's minimum requirement.
                     
### Impact                                                                                                 
                                                                                                              
No user-facing or API impact. CI-only change.
                                                                                                              
### Risk Level                                                                                              

Low                 
                                                                                                              
### Documentation Update                                                                                    
                                                                                                              
None
                                                                                                              
### Contributor's checklist                                                                                 
                                                                                                              
  - [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)              
  - [x] Enough context is provided in the sections above                                                      
  - [x] Adequate tests were added if applicable 