### PR TITLE
chore(ci): Add test jobs and Codecov integration in GitHub Actions

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -181,9 +181,9 @@ jobs:
             flinkProfile: "flink1.18"
 
     env:
-      JOB10_UT_MODULES: >-
+      UT_MODULES: >-
         !hudi-hadoop-common,!hudi-hadoop-mr,!hudi-client/hudi-java-client,!hudi-client/hudi-spark-client,!hudi-cli,!hudi-examples,!hudi-examples/hudi-examples-common,!hudi-examples/hudi-examples-flink,!hudi-examples/hudi-examples-java,!hudi-examples/hudi-examples-spark,!hudi-spark-datasource,!hudi-spark-datasource/hudi-spark,!hudi-spark-datasource/hudi-spark3.5.x,!hudi-spark-datasource/hudi-spark3-common,!hudi-spark-datasource/hudi-spark-common,!hudi-utilities
-      JOB10_FT_MODULES: >-
+      FT_MODULES: >-
         !hudi-client/hudi-spark-client,!hudi-cli,!hudi-examples,!hudi-examples/hudi-examples-common,!hudi-examples/hudi-examples-flink,!hudi-examples/hudi-examples-java,!hudi-examples/hudi-examples-spark,!hudi-spark-datasource/hudi-spark,!hudi-utilities
 
     steps:
@@ -222,7 +222,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -w /hudi \
             hudi-ci \
-            /bin/bash -c "MAVEN_OPTS='-Xmx4g' mvn test -Punit-tests -D$SCALA_PROFILE -D$SPARK_PROFILE -D$FLINK_PROFILE -fae -pl $JOB10_UT_MODULES -Dcheckstyle.skip=true -Drat.skip=true $MVN_ARGS -Djacoco.skip=false"
+            /bin/bash -c "MAVEN_OPTS='-Xmx4g' mvn test -Punit-tests -D$SCALA_PROFILE -D$SPARK_PROFILE -D$FLINK_PROFILE -fae -pl $UT_MODULES -Dcheckstyle.skip=true -Drat.skip=true $MVN_ARGS -Djacoco.skip=false"
       - name: UT - hudi-utilities (non-TestHoodie)
         env:
           SCALA_PROFILE: ${{ matrix.scalaProfile }}
@@ -248,7 +248,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -w /hudi \
             hudi-ci \
-            /bin/bash -c "MAVEN_OPTS='-Xmx4g' mvn test -Pfunctional-tests -D$SCALA_PROFILE -D$SPARK_PROFILE -D$FLINK_PROFILE -fae -pl $JOB10_FT_MODULES -Dcheckstyle.skip=true -Drat.skip=true $MVN_ARGS -Djacoco.skip=false"
+            /bin/bash -c "MAVEN_OPTS='-Xmx4g' mvn test -Pfunctional-tests -D$SCALA_PROFILE -D$SPARK_PROFILE -D$FLINK_PROFILE -fae -pl $FT_MODULES -Dcheckstyle.skip=true -Drat.skip=true $MVN_ARGS -Djacoco.skip=false"
       - name: Generate merged coverage report
         if: always()
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

GitHub Actions (bot.yml) skips several test suites for Spark 3.5 + Scala 2.12, deferring them to Azure CI. Three Azure jobs have no GitHub Actions equivalent:
- UT_FT_1 (hudi-hadoop-common & hudi-spark-client)
- UT_FT_7 (hudi-utilities)
- UT_FT_10 (common & other modules).

This PR aims to ensure GitHub Actions has full test coverage so we can migrate away from Azure CI.

### Summary and Changelog

 Add 3 missing test jobs to GitHub Actions and integrate Codecov for code coverage reporting.

- Add `test-spark-client-and-hadoop-common` job (Azure UT_FT_1): hudi-hadoop-common UT, hudi-spark-client UT & FT
- Add `test-utilities` job (Azure UT_FT_7): hudi-utilities UT (TestHoodie*) & FT
- Add `test-common-and-other-modules` job (Azure UT_FT_10): remaining modules UT & FT using exclusion lists from Azure config
- All new jobs run on Spark 3.5 / Scala 2.12 / Flink 1.18 / JDK 11 to match Azure CI
- Enable JaCoCo in jobs via `-Djacoco.skip=false` and upload coverage with `codecov/codecov-action@v5`

### Impact

CI-only change that adds test jobs and enables coverage reporting.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
