### PR TITLE
feat(flink): Off-heap lookup join cache backed by RocksDB

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -1306,6 +1306,25 @@ public class FlinkOptions extends HoodieConfig {
           .defaultValue(16)
           .withDescription("The thread number for lookup async.");
 
+  public static final ConfigOption<String> LOOKUP_JOIN_CACHE_TYPE =
+      key("lookup.join.cache.type")
+          .stringType()
+          .defaultValue("heap")
+          .withDescription("The storage backend for the lookup join cache. "
+              + "Possible values: 'heap' (default) stores all dimension-table rows in JVM heap memory "
+              + "(may cause OutOfMemoryError for large tables); "
+              + "'rocksdb' stores rows off-heap in an embedded RocksDB instance on local disk, "
+              + "which avoids OOM at the cost of additional serialization overhead.");
+
+  public static final ConfigOption<String> LOOKUP_JOIN_ROCKSDB_PATH =
+      key("lookup.join.rocksdb.path")
+          .stringType()
+          .defaultValue(System.getProperty("java.io.tmpdir") + "/hudi-lookup-rocksdb")
+          .withDescription("Local directory path for storing RocksDB data when "
+              + "'lookup.join.cache.type' is set to 'rocksdb'. "
+              + "Each task manager will create a unique subdirectory under this path. "
+              + "The directory is cleaned up when the lookup function is closed.");
+
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/HeapLookupCache.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/HeapLookupCache.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.lookup;
+
+import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Heap-based {@link LookupCache} backed by a {@link HashMap}.
+ *
+ * <p>Suitable for small-to-medium dimension tables. For large tables, use
+ * {@link RocksDBLookupCache} to avoid JVM OutOfMemoryError.
+ */
+public class HeapLookupCache implements LookupCache {
+
+  private final Map<RowData, List<RowData>> store = new HashMap<>();
+
+  @Override
+  public void addRow(RowData key, RowData row) {
+    store.computeIfAbsent(key, k -> new ArrayList<>()).add(row);
+  }
+
+  @Override
+  @Nullable
+  public List<RowData> getRows(RowData key) {
+    return store.get(key);
+  }
+
+  @Override
+  public void clear() {
+    store.clear();
+  }
+
+  @Override
+  public void close() {
+    store.clear();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/LookupCache.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/LookupCache.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.lookup;
+
+import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Cache abstraction for lookup join dimension table data.
+ *
+ * <p>Implementations may store data on-heap (e.g. {@link HeapLookupCache}) or off-heap
+ * (e.g. {@link RocksDBLookupCache}) to avoid JVM OutOfMemoryError on large tables.
+ */
+public interface LookupCache extends Closeable {
+
+  /**
+   * Adds a single row to the cache under the given lookup key.
+   * Multiple rows may be associated with the same key.
+   *
+   * @param key   the lookup key row (contains only the join key fields)
+   * @param row   the full dimension table row
+   * @throws IOException if the write fails
+   */
+  void addRow(RowData key, RowData row) throws IOException;
+
+  /**
+   * Returns all rows matching the given lookup key, or {@code null} / empty list if none exist.
+   *
+   * @param key the lookup key row
+   * @return matching rows, or {@code null} if not found
+   */
+  @Nullable
+  List<RowData> getRows(RowData key) throws IOException;
+
+  /**
+   * Clears all entries from the cache so it can be reloaded.
+   */
+  void clear() throws IOException;
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/RocksDBLookupCache.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/lookup/RocksDBLookupCache.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.lookup;
+
+import org.apache.hudi.common.serialization.CustomSerializer;
+import org.apache.hudi.common.util.collection.RocksDBDAO;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Off-heap {@link LookupCache} backed by RocksDB.
+ *
+ * <p>Data is stored on disk / in the OS page cache, keeping JVM heap usage minimal. Each lookup
+ * key maps to one or more full dimension-table rows. The compound RocksDB key encodes the lookup
+ * key bytes in hexadecimal plus a monotonic counter so that multiple rows sharing the same lookup
+ * key can coexist in the store without overwriting each other. Retrieval is a prefix scan on the
+ * hex-encoded lookup key.
+ *
+ * <p>Keys are serialized with Flink's {@link TypeSerializer} for the key {@link
+ * org.apache.flink.table.types.logical.RowType}, and values (full rows) are serialized with the
+ * row-level {@link TypeSerializer}. The raw bytes are stored as-is in RocksDB via a
+ * pass-through {@link CustomSerializer} — no additional Java-serialization overhead.
+ */
+@Slf4j
+public class RocksDBLookupCache implements LookupCache {
+
+  private static final String COLUMN_FAMILY = "lookup_cache";
+
+  /** Separator between the hex-encoded key and the row counter in the compound RocksDB key. */
+  private static final String KEY_SEPARATOR = "_";
+
+  private final TypeSerializer<RowData> keySerializer;
+  private final TypeSerializer<RowData> rowSerializer;
+  private final String rocksDbBasePath;
+
+  /** Reusable serialization buffer — single-threaded use only. */
+  private final DataOutputSerializer keyOutputBuffer = new DataOutputSerializer(64);
+  private final DataOutputSerializer rowOutputBuffer = new DataOutputSerializer(256);
+  private final DataInputDeserializer rowInputBuffer = new DataInputDeserializer();
+
+  private RocksDBDAO rocksDBDAO;
+  private long rowCounter;
+
+  public RocksDBLookupCache(
+      TypeSerializer<RowData> keySerializer,
+      TypeSerializer<RowData> rowSerializer,
+      String rocksDbBasePath) {
+    this.keySerializer = keySerializer;
+    this.rowSerializer = rowSerializer;
+    this.rocksDbBasePath = rocksDbBasePath;
+    this.rocksDBDAO = createDAO();
+    this.rowCounter = 0L;
+  }
+
+  @Override
+  public void addRow(RowData key, RowData row) throws IOException {
+    String keyHex = serializeKeyToHex(key);
+    String compoundKey = keyHex + KEY_SEPARATOR + rowCounter++;
+    byte[] valueBytes = serializeRow(row);
+    rocksDBDAO.put(COLUMN_FAMILY, compoundKey, valueBytes);
+  }
+
+  @Override
+  @Nullable
+  public List<RowData> getRows(RowData key) throws IOException {
+    String prefix = serializeKeyToHex(key) + KEY_SEPARATOR;
+    List<byte[]> rawValues = rocksDBDAO.<byte[]>prefixSearch(COLUMN_FAMILY, prefix)
+        .map(pair -> pair.getValue())
+        .collect(Collectors.toList());
+    if (rawValues.isEmpty()) {
+      return null;
+    }
+    List<RowData> result = new ArrayList<>(rawValues.size());
+    for (byte[] bytes : rawValues) {
+      result.add(deserializeRow(bytes));
+    }
+    return result;
+  }
+
+  @Override
+  public void clear() {
+    if (rocksDBDAO != null) {
+      rocksDBDAO.close();
+    }
+    rocksDBDAO = createDAO();
+    rowCounter = 0L;
+    log.debug("RocksDB lookup cache cleared and reinitialized at {}", rocksDbBasePath);
+  }
+
+  @Override
+  public void close() {
+    if (rocksDBDAO != null) {
+      rocksDBDAO.close();
+      rocksDBDAO = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  //  Internals
+  // -------------------------------------------------------------------------
+
+  private RocksDBDAO createDAO() {
+    ConcurrentHashMap<String, CustomSerializer<?>> serializers = new ConcurrentHashMap<>();
+    serializers.put(COLUMN_FAMILY, new PassThroughSerializer());
+    RocksDBDAO dao = new RocksDBDAO("hudi-lookup", rocksDbBasePath, serializers);
+    dao.addColumnFamily(COLUMN_FAMILY);
+    return dao;
+  }
+
+  private String serializeKeyToHex(RowData key) throws IOException {
+    keyOutputBuffer.clear();
+    keySerializer.serialize(key, keyOutputBuffer);
+    return bytesToHex(keyOutputBuffer.getCopyOfBuffer());
+  }
+
+  private byte[] serializeRow(RowData row) throws IOException {
+    rowOutputBuffer.clear();
+    rowSerializer.serialize(row, rowOutputBuffer);
+    return rowOutputBuffer.getCopyOfBuffer();
+  }
+
+  private RowData deserializeRow(byte[] bytes) throws IOException {
+    rowInputBuffer.setBuffer(bytes);
+    return rowSerializer.deserialize(rowInputBuffer);
+  }
+
+  private static String bytesToHex(byte[] bytes) {
+    StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+
+  /**
+   * A {@link CustomSerializer} that treats the serialized form as the raw byte array itself,
+   * bypassing Java object serialization overhead. Used to store pre-serialized Flink
+   * {@link RowData} bytes directly in RocksDB.
+   */
+  private static class PassThroughSerializer implements CustomSerializer<byte[]> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public byte[] serialize(byte[] input) {
+      return input;
+    }
+
+    @Override
+    public byte[] deserialize(byte[] bytes) {
+      return bytes;
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When using Hudi as a lookup join dimension table in Flink, the entire table is loaded into the cache on each reload. If dimension table is large - we got OOM.

### Summary and Changelog

Introduced `LookupCache` — a minimal interface (addRow, getRows, clear, close) that abstracts the cache backend from the lookup function.  
`HeapLookupCache` — wraps the original HashMap behavior; default, backward-compatible.  
`RocksDBLookupCache` — off-heap implementation.

Rows are written to RocksDB one-by-one during reload (no intermediate HashMap) so heap never spikes to O(n)
Each row gets its own RocksDB entry with a compound key <keyHex>_<counter>, enabling efficient prefix-scan lookup
Flink's TypeSerializer<RowData> handles binary serialization; a PassThroughSerializer stores the raw bytes without extra Java-serialization overhead
clear() tears down and re-creates the RocksDBDAO (cleaning up the old temp directory automatically)

Added two new config options to `FlinkOptions`:  
`lookup.join.cache.type` = `heap` (default) | `rocksdb`  
`lookup.join.rocksdb.path` = local directory path, default `${java.io.tmpdir}/hudi-lookup-rocksdb`  

`HoodieLookupFunction` refactored to use `LookupCache` interface.

Also fixes a pre-existing bug where currentCommit was never set after a successful load, causing redundant full reloads on every TTL expiry

### Impact

Solved OutOfMemoryError on lookup joins with large Hudi tables.

### Risk Level

none

### Documentation Update

Need to add two new config options to documentation: `lookup.join.cache.type` and `lookup.join.rocksdb.path`.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
