### PR TITLE
fix: Fix typos across codebase

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/KeyGenUtils.java
@@ -93,10 +93,10 @@ public class KeyGenUtils {
   // When auto record key gen is enabled, our inference will be based on partition path only.
   static KeyGeneratorType inferKeyGeneratorTypeFromPartitionFields(String partitionFields) {
     if (!StringUtils.isNullOrEmpty(partitionFields)) {
-      String[] partitonFields = partitionFields.split(",");
-      if (partitonFields[0].contains(BaseKeyGenerator.CUSTOM_KEY_GENERATOR_SPLIT_REGEX)) {
+      String[] partitionFieldsArray = partitionFields.split(",");
+      if (partitionFieldsArray[0].contains(BaseKeyGenerator.CUSTOM_KEY_GENERATOR_SPLIT_REGEX)) {
         return KeyGeneratorType.CUSTOM;
-      } else if (partitonFields.length == 1) {
+      } else if (partitionFieldsArray.length == 1) {
         return KeyGeneratorType.SIMPLE;
       } else {
         return KeyGeneratorType.COMPLEX;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -553,7 +553,7 @@ public class TestHoodieWriteConfig {
       }
     });
 
-    // validate the the configured lock provider is honored by the TimeGeneratorConfig as well.
+    // validate the configured lock provider is honored by the TimeGeneratorConfig as well.
     assertEquals(NoopLockProvider.class.getName(), writeConfig.getTimeGeneratorConfig().getLockConfiguration().getConfig().getProperty(HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key()));
 
     // if auto adjust lock config is enabled, for a single writer w/ all inline table services, InProcessLockProvider is overriden

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieCreateHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieCreateHandle.java
@@ -131,12 +131,12 @@ public class TestHoodieCreateHandle extends HoodieCommonTestHarness {
 
   @Test
   public void testConstructorWithOverriddenSchema() {
-    HoodieSchema overridenSchema = HoodieSchema.parse(TRIP_FLATTENED_SCHEMA);
+    HoodieSchema overriddenSchema = HoodieSchema.parse(TRIP_FLATTENED_SCHEMA);
 
     HoodieCreateHandle handleWithOverridenSchema = new HoodieCreateHandle<>(
         writeConfig, TEST_INSTANT_TIME, hoodieTable, TEST_PARTITION_PATH,
-        TEST_FILE_ID, Option.of(overridenSchema), taskContextSupplier);
-    assertEquals(overridenSchema, handleWithOverridenSchema.writeSchema);
+        TEST_FILE_ID, Option.of(overriddenSchema), taskContextSupplier);
+    assertEquals(overriddenSchema, handleWithOverridenSchema.writeSchema);
   }
 
   @Test

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -666,7 +666,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
           fileIndex = Integer.parseInt(fileId.substring(index + 1));
         }
       } catch (Exception e) {
-        throw new HoodieMetadataException(String.format("Invalid UUID or index: fileID=%s, partition=%s, instantTIme=%s",
+        throw new HoodieMetadataException(String.format("Invalid UUID or index: fileID=%s, partition=%s, instantTime=%s",
             fileId, partition, instantTime), e);
       }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -183,7 +183,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
     updatedProps.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "new_field2");
     Set<String> propsToDelete = new HashSet<>();
     propsToDelete.add(HoodieTableConfig.PARTITION_FIELDS.key());
-    // delete a non existant property as well
+    // delete a non-existent property as well
     propsToDelete.add(HoodieTableConfig.RECORDKEY_FIELDS.key());
     HoodieTableConfig.updateAndDeleteProps(storage, metaPath, updatedProps, propsToDelete);
     config = new HoodieTableConfig(storage, metaPath);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/QueryRunner.java
@@ -46,7 +46,7 @@ import static org.apache.hudi.hadoop.fs.HadoopFSUtils.getStorageConf;
 
 /**
  * This class is currently used only by s3 and gcs incr sources that supports size based batching
- * This class will fetch comitted files from the current commit to support size based batching.
+ * This class will fetch committed files from the current commit to support size based batching.
  */
 @Slf4j
 public class QueryRunner {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BaseErrorTableWriter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BaseErrorTableWriter.java
@@ -78,17 +78,17 @@ public abstract class BaseErrorTableWriter<T extends ErrorEvent> implements Seri
    */
   @VisibleForTesting
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public abstract Option<JavaRDD<HoodieAvroIndexedRecord>> getErrorEvents(String baseTableInstantTime, Option<String> commitedInstantTime);
+  public abstract Option<JavaRDD<HoodieAvroIndexedRecord>> getErrorEvents(String baseTableInstantTime, Option<String> committedInstantTime);
 
   /**
    * This API is called to commit the error events (failed Hoodie Records) processed by the writer so far.
    * These records are committed to a error table.
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public abstract boolean upsertAndCommit(String baseTableInstantTime, Option<String> commitedInstantTime);
+  public abstract boolean upsertAndCommit(String baseTableInstantTime, Option<String> committedInstantTime);
 
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
-  public abstract JavaRDD<WriteStatus> upsert(String baseTableInstantTime, Option<String> commitedInstantTime);
+  public abstract JavaRDD<WriteStatus> upsert(String baseTableInstantTime, Option<String> committedInstantTime);
 
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
   public abstract boolean commit(JavaRDD<WriteStatus> writeStatuses);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerSchemaEvolutionBase.java
@@ -387,7 +387,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
     }
 
     @Override
-    public JavaRDD<WriteStatus> upsert(String baseTableInstantTime, Option commitedInstantTime) {
+    public JavaRDD<WriteStatus> upsert(String baseTableInstantTime, Option committedInstantTime) {
       if (errorEvents.size() > 0) {
         if (errorTableInstantTime.isPresent()) {
           throw new IllegalStateException("Error table instant time should be empty before calling upsert");
@@ -419,7 +419,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
     }
 
     @Override
-    public boolean upsertAndCommit(String baseTableInstantTime, Option commitedInstantTime) {
+    public boolean upsertAndCommit(String baseTableInstantTime, Option committedInstantTime) {
       if (errorEvents.size() > 0) {
         JavaRDD errorsCombined = errorEvents.get(0);
         for (int i = 1; i < errorEvents.size(); i++) {
@@ -435,7 +435,7 @@ public class TestHoodieDeltaStreamerSchemaEvolutionBase extends HoodieDeltaStrea
     }
 
     @Override
-    public Option<JavaRDD<HoodieAvroIndexedRecord>> getErrorEvents(String baseTableInstantTime, Option commitedInstantTime) {
+    public Option<JavaRDD<HoodieAvroIndexedRecord>> getErrorEvents(String baseTableInstantTime, Option committedInstantTime) {
       return Option.empty();
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
@@ -434,7 +434,7 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
     return new BaseErrorTableWriter<ErrorEvent<String>>(new HoodieDeltaStreamer.Config(),
         spark(), props, new HoodieSparkEngineContext(jsc()), fs()) {
       @Override
-      public JavaRDD<WriteStatus> upsert(String baseTableInstantTime, Option<String> commitedInstantTime) {
+      public JavaRDD<WriteStatus> upsert(String baseTableInstantTime, Option<String> committedInstantTime) {
         return null;
       }
 
@@ -451,12 +451,12 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
       }
 
       @Override
-      public Option<JavaRDD<HoodieRecord>> getErrorEvents(String baseTableInstantTime, Option commitedInstantTime) {
+      public Option<JavaRDD<HoodieRecord>> getErrorEvents(String baseTableInstantTime, Option committedInstantTime) {
         return Option.of(errorEvents.stream().reduce((rdd1, rdd2) -> rdd1.union(rdd2)).get());
       }
 
       @Override
-      public boolean upsertAndCommit(String baseTableInstantTime, Option commitedInstantTime) {
+      public boolean upsertAndCommit(String baseTableInstantTime, Option committedInstantTime) {
         return false;
       }
     };


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes various typos in code, comments, Javadoc, and error messages across multiple modules.

### Summary and Changelog

**Summary:**
Fixes typos in variable names, comments, and string literals across hudi-common, hudi-client, hudi-utilities, and hudi-hadoop-common.

**Changelog:**
- Fix "the the" double word in `TestHoodieWriteConfig` comment
- Fix `partitonFields` variable name to `partitionFieldsArray` in `KeyGenUtils`
- Fix `commitedInstantTime` to `committedInstantTime` in `BaseErrorTableWriter` and related test files
- Fix `overridenSchema` to `overriddenSchema` in `TestHoodieCreateHandle`
- Fix "comitted" to "committed" in `QueryRunner` Javadoc
- Fix "existant" to "existent" in `TestHoodieTableConfig` comment
- Fix "instantTIme" to "instantTime" in `HoodieMetadataPayload` error message

### Impact

**Public API Changes:**
- `BaseErrorTableWriter`: Parameter name `commitedInstantTime` renamed to `committedInstantTime` in `getErrorEvents()`, `upsertAndCommit()`, and `upsert()` methods. This is a parameter name change only and does not affect binary compatibility.

**User-Facing Changes:**
None.

**Performance Impact:**
None.

### Risk Level

**Risk Level: low**

**Justification:**
- Typo-only changes in comments, variable names, and error messages
- No logic changes
- Parameter name renames do not affect binary compatibility

### Documentation Update

No documentation changes needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] Commits are signed and follow [conventions](https://www.conventionalcommits.org/)