### PR TITLE
fix: Remove trailing colon from incomplete error message in HoodieTableMetadataUtil

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2256,7 +2256,7 @@ public class HoodieTableMetadataUtil {
       log.debug("Metadata table partition {} not found at path {}", partitionPath, metadataTablePartitionPath);
       return null;
     } catch (Exception e) {
-      throw new HoodieMetadataException(String.format("Failed to check existence of MDT partition %s at path %s: ", partitionPath, metadataTablePartitionPath), e);
+      throw new HoodieMetadataException(String.format("Failed to check existence of MDT partition %s at path %s", partitionPath, metadataTablePartitionPath), e);
     }
 
     if (backup) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The exception message in `HoodieTableMetadataUtil.deleteMetadataTablePartition()` ends with a trailing `: ` which appears incomplete and looks like a formatting artifact.

### Summary and Changelog

**Summary:**
Remove the trailing `: ` from the error message in `HoodieTableMetadataUtil` when failing to check existence of a metadata table partition.

**Changelog:**
- Changed `"Failed to check existence of MDT partition %s at path %s: "` to `"Failed to check existence of MDT partition %s at path %s"` in `HoodieTableMetadataUtil.java:2259`. The cause exception is already passed as the second argument to `HoodieMetadataException`, so the trailing colon adds no value.

### Impact

**Public API Changes:**
None.

**User-Facing Changes:**
Slightly cleaner error message when metadata table partition check fails.

**Performance Impact:**
None.

### Risk Level

**Risk Level: low**

**Justification:**
- Single character removal in an error message string
- No logic changes
- The root cause exception is already chained via the constructor

### Documentation Update

No documentation changes needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] Commits are signed and follow [conventions](https://www.conventionalcommits.org/)