### PR TITLE
fix: Add missing indexOf guard in HoodieVersion.getSubVersion()

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/HoodieVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/HoodieVersion.java
@@ -81,11 +81,14 @@ public final class HoodieVersion {
   }
 
   private static String getSubVersion(String version, int allowedDotCount) {
+    int index = version.indexOf('.');
     if (allowedDotCount == 1) {
-      int index = version.indexOf('.');
       return index == -1 ? version : version.substring(0, index);
     }
-    return getSubVersion(version.substring(version.indexOf('.') + 1), allowedDotCount - 1);
+    if (index == -1) {
+      return version;
+    }
+    return getSubVersion(version.substring(index + 1), allowedDotCount - 1);
   }
 
   protected static void setVersionOverride(String version) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`HoodieVersion.getSubVersion()` calls `version.indexOf('.')` without checking for `-1` in the recursive branch, which could produce unexpected results if the version string has fewer dots than expected.

### Summary and Changelog

**Summary:**
Add a guard for `indexOf()` returning `-1` in the recursive call of `HoodieVersion.getSubVersion()` to handle version strings with fewer dots than expected.

**Changelog:**
- Extract `indexOf('.')` into a local variable shared by both branches
- Add early return when no dot is found (`index == -1`) in the recursive branch, returning the version string as-is instead of calling `substring(0)` implicitly

**Before:**
```java
private static String getSubVersion(String version, int allowedDotCount) {
    if (allowedDotCount == 1) {
      int index = version.indexOf('.');
      return index == -1 ? version : version.substring(0, index);
    }
    return getSubVersion(version.substring(version.indexOf('.') + 1), allowedDotCount - 1);
}
```

**After:**
```java
private static String getSubVersion(String version, int allowedDotCount) {
    int index = version.indexOf('.');
    if (allowedDotCount == 1) {
      return index == -1 ? version : version.substring(0, index);
    }
    if (index == -1) {
      return version;
    }
    return getSubVersion(version.substring(index + 1), allowedDotCount - 1);
}
```

### Impact

**Public API Changes:**
None.

**User-Facing Changes:**
None. This is a defensive fix for an edge case in internal version parsing.

**Performance Impact:**
None.

### Risk Level

**Risk Level: low**

**Justification:**
- Small defensive change in version string parsing
- Only affects edge case where version string has fewer dots than expected
- No change to normal code path behavior

### Documentation Update

No documentation changes needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] Commits are signed and follow [conventions](https://www.conventionalcommits.org/)