### PR TITLE
fix: Guard against missing scheme separator in ListingBasedRollbackStrategy.formatDeletePath()

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -289,7 +289,8 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
 
   private static String formatDeletePath(String path) {
     // strip scheme E.g: file:/var/folders
-    return path.substring(path.indexOf(":") + 1);
+    int colonIndex = path.indexOf(":");
+    return colonIndex == -1 ? path : path.substring(colonIndex + 1);
   }
 
   private List<StoragePath> listBaseFilesToBeDeleted(String commit,


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`ListingBasedRollbackStrategy.formatDeletePath()` assumes the path always contains a `:` for the scheme separator. If a path without a scheme is passed, `indexOf(":")` returns `-1`, and `substring(0)` returns the full string by coincidence rather than by explicit intent.

### Summary and Changelog

**Summary:**
Add an explicit guard for `indexOf()` returning `-1` in `formatDeletePath()` to handle paths without a URI scheme.

**Changelog:**
- Check `indexOf(":")` result before calling `substring()` in `ListingBasedRollbackStrategy.formatDeletePath()`
- Return path as-is when no scheme separator is found

**Before:**
```java
private static String formatDeletePath(String path) {
    // strip scheme E.g: file:/var/folders
    return path.substring(path.indexOf(":") + 1);
}
```

**After:**
```java
private static String formatDeletePath(String path) {
    // strip scheme E.g: file:/var/folders
    int colonIndex = path.indexOf(":");
    return colonIndex == -1 ? path : path.substring(colonIndex + 1);
}
```

### Impact

**Public API Changes:**
None. This is a private method.

**User-Facing Changes:**
None.

**Performance Impact:**
None.

### Risk Level

**Risk Level: low**

**Justification:**
- Small defensive change in a private utility method
- Current behavior accidentally works for the no-colon case (`substring(0)` returns the full string), so this change makes the intent explicit without changing observable behavior
- No change to normal code path where scheme is present

### Documentation Update

No documentation changes needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] Commits are signed and follow [conventions](https://www.conventionalcommits.org/)