### PR TITLE
fix: Fixing repeated clean attempts using same instant times in mdt when data table has out of order commits

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -243,6 +243,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     return MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
   }
 
+  protected HoodieTableMetaClient getMetadataMetaClient() {
+    return metadataMetaClient;
+  }
+
   private void mayBeReinitMetadataReader() {
     if (metadata == null || metadataMetaClient == null || metadata.getMetadataFileSystemView() == null) {
       initMetadataReader();
@@ -2276,10 +2280,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   }
 
   protected void cleanIfNecessary(BaseHoodieWriteClient writeClient, String instantTime) {
-    Option<HoodieInstant> lastCompletedCompactionInstant = metadataMetaClient.getActiveTimeline()
+    Option<HoodieInstant> lastCompletedCompactionInstant = getMetadataMetaClient().getActiveTimeline()
         .getCommitAndReplaceTimeline().filterCompletedInstants().lastInstant();
     if (lastCompletedCompactionInstant.isPresent()
-        && metadataMetaClient.getActiveTimeline().filterCompletedInstants()
+        && getMetadataMetaClient().getActiveTimeline().filterCompletedInstants()
         .findInstantsAfter(lastCompletedCompactionInstant.get().requestedTime()).countInstants() < 3) {
       // do not clean the log files immediately after compaction to give some buffer time for metadata table reader,
       // because there is case that the reader has prepared for the log file readers already before the compaction completes

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
@@ -318,7 +318,7 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
   protected void executeClean(BaseHoodieWriteClient writeClient, String instantTime) {
     String cleanInstant = createCleanTimestamp(instantTime);
     if (getMetadataMetaClient().getActiveTimeline().getCleanerTimeline().filterCompletedInstants().containsInstant(cleanInstant)) {
-      LOG.info(String.format("Clean with same %s time is already present in the timeline, hence skipping to clean", cleanInstant));
+      LOG.info("Clean with same {} time is already present in the timeline, hence skipping to clean", cleanInstant);
     } else {
       writeClient.clean(cleanInstant);
     }
@@ -349,12 +349,14 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
 
   @VisibleForTesting
   static String createCleanTimestamp(String timestamp) {
-    return timestamp + "002";
+    return timestamp + CLEAN_OPERATION_SUFFIX;
   }
 
   private String createRestoreTimestamp(String timestamp) {
     return timestamp + getRestoreOperationSuffix();
   }
+
+  private static final String CLEAN_OPERATION_SUFFIX = "002";
 
   private String getCompactionOperationSuffix() {
     return "001";
@@ -369,7 +371,7 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
   }
 
   private String getCleanOperationSuffix() {
-    return "002";
+    return CLEAN_OPERATION_SUFFIX;
   }
 
   private String getRestoreOperationSuffix() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantComparatorV1;
 import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieMetadataException;
@@ -315,7 +316,12 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
 
   @Override
   protected void executeClean(BaseHoodieWriteClient writeClient, String instantTime) {
-    writeClient.clean(createCleanTimestamp(instantTime));
+    String cleanInstant = createCleanTimestamp(instantTime);
+    if (getMetadataMetaClient().getActiveTimeline().getCleanerTimeline().filterCompletedInstants().containsInstant(cleanInstant)) {
+      LOG.info(String.format("Clean with same %s time is already present in the timeline, hence skipping to clean", cleanInstant));
+    } else {
+      writeClient.clean(cleanInstant);
+    }
   }
 
   @Override
@@ -341,8 +347,9 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
     return timestamp + getRollbackOperationSuffix();
   }
 
-  private String createCleanTimestamp(String timestamp) {
-    return timestamp + getCleanOperationSuffix();
+  @VisibleForTesting
+  static String createCleanTimestamp(String timestamp) {
+    return timestamp + "002";
   }
 
   private String createRestoreTimestamp(String timestamp) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -551,4 +551,81 @@ class TestHoodieBackedTableMetadataWriter {
     // Verify metrics are incremented when there's a failure
     verify(metrics, times(1)).incrementMetric(HoodieMetadataMetrics.PENDING_COMPACTIONS_FAILURES, 1);
   }
+
+  @Test
+  void testExecuteCleanWhenCleanInstantDoesNotExist() throws Exception {
+    // Create mocks
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class, RETURNS_DEEP_STUBS);
+
+    // Set up timeline to indicate clean instant doesn't exist
+    String instantTime = "20250101120000000";
+    String expectedCleanInstant = HoodieBackedTableMetadataWriterTableVersionSix.createCleanTimestamp(instantTime);
+    when(metadataMetaClient.getActiveTimeline()).thenReturn(activeTimeline);
+    when(activeTimeline.getCleanerTimeline().filterCompletedInstants().containsInstant(expectedCleanInstant)).thenReturn(false);
+
+    // Create a partial mock of HoodieBackedTableMetadataWriterTableVersionSix
+    HoodieBackedTableMetadataWriterTableVersionSix writer = mock(HoodieBackedTableMetadataWriterTableVersionSix.class);
+    when(writer.getMetadataMetaClient()).thenReturn(metadataMetaClient);
+
+    // Call the real executeClean method
+    doCallRealMethod().when(writer).executeClean(any(), any());
+
+    // Execute the clean
+    writer.executeClean(writeClient, instantTime);
+
+    // Verify that writeClient.clean() was called with the correct timestamp
+    verify(writeClient, times(1)).clean(expectedCleanInstant);
+  }
+
+  @Test
+  void testExecuteCleanWhenCleanInstantAlreadyExists() throws Exception {
+    // Create mocks
+    BaseHoodieWriteClient writeClient = mock(BaseHoodieWriteClient.class);
+    HoodieTableMetaClient metadataMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class, RETURNS_DEEP_STUBS);
+
+    // Set up timeline to indicate clean instant already exists
+    String instantTime = "20250101120000000";
+    String expectedCleanInstant = HoodieBackedTableMetadataWriterTableVersionSix.createCleanTimestamp(instantTime);
+    when(metadataMetaClient.getActiveTimeline()).thenReturn(activeTimeline);
+    when(activeTimeline.getCleanerTimeline().filterCompletedInstants().containsInstant(expectedCleanInstant)).thenReturn(true);
+
+    // Create a partial mock of HoodieBackedTableMetadataWriterTableVersionSix
+    HoodieBackedTableMetadataWriterTableVersionSix writer = mock(HoodieBackedTableMetadataWriterTableVersionSix.class);
+    when(writer.getMetadataMetaClient()).thenReturn(metadataMetaClient);
+
+    // Call the real executeClean method
+    doCallRealMethod().when(writer).executeClean(any(), any());
+
+    // Execute the clean
+    writer.executeClean(writeClient, instantTime);
+
+    // Verify that writeClient.clean() was NOT called since the instant already exists
+    verify(writeClient, times(0)).clean(any());
+  }
+
+  @Test
+  void testCreateCleanTimestamp() {
+    // Test that createCleanTimestamp appends the correct suffix
+    String baseTimestamp = "20250101120000000";
+    String cleanTimestamp = HoodieBackedTableMetadataWriterTableVersionSix.createCleanTimestamp(baseTimestamp);
+
+    // The clean operation suffix should be "002"
+    String expectedTimestamp = baseTimestamp + "002";
+    assertEquals(expectedTimestamp, cleanTimestamp, "Clean timestamp should have the correct suffix appended");
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "20250101120000000,20250101120000000002",
+      "20240615100530456,20240615100530456002",
+      "20231231235959999,20231231235959999002"
+  })
+  void testCreateCleanTimestampWithMultipleValues(String input, String expected) {
+    String result = HoodieBackedTableMetadataWriterTableVersionSix.createCleanTimestamp(input);
+    assertEquals(expected, result, "Clean timestamp should match expected format");
+  }
+
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Prevent duplicate clean operations in metadata table when data table commits complete out of order. When commits are out of order, the metadata table may attempt to execute the same clean operation multiple times with the same instant time, leading to failures or inconsistent state. This is applicable only to version6, since in version 8 and above, we always generate a new instant time for cleans in mdt. 

### Summary and Changelog

- Added getMetadataMetaClient() protected method in HoodieBackedTableMetadataWriter to allow subclasses to access the metadata meta
  client
  - Modified executeClean() in HoodieBackedTableMetadataWriterTableVersionSix to check if a clean instant already exists in the completed
  cleaner timeline before executing clean operation
  - When a clean instant already exists, the operation is skipped with a log message instead of attempting to execute it again
  - Refactored timestamp creation methods (createCleanTimestamp, createRestoreTimestamp, etc.) to be static in
  HoodieBackedTableMetadataWriterTableVersionSix
  - Made createCleanTimestamp visible for testing with @VisibleForTesting annotation
  - Updated cleanIfNecessary() to use the new getMetadataMetaClient() getter method for consistency

- Scenario
  When data table commits complete out of order:
  1. Commit C3 completes first and MDT syncs, creating clean instant C3002
  2. Commit C2 (started before C3) completes later
  3. MDT re-attempts sync and may try to execute clean with the same instant time C3002
  4. Without this check, duplicate clean execution causes failures

  This fix ensures idempotency by checking the timeline before executing clean operations, similar to the existing checks for compaction and log compaction operations in the same class.

Verification: 
 Added comprehensive unit tests in TestHoodieBackedTableMetadataWriter:
  - testExecuteCleanWhenCleanInstantDoesNotExist() - Verifies clean operation proceeds when instant doesn't exist
  - testExecuteCleanWhenCleanInstantAlreadyExists() - Verifies clean operation is skipped when instant already exists (prevents duplicate
  in out-of-order scenarios)
  - testCreateCleanTimestamp() - Tests the clean timestamp creation helper method
  - testCreateCleanTimestampWithMultipleValues() - Parameterized test for timestamp formatting

### Impact

No failures when performing clean in mdt. 

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
