### PR TITLE
fix: Fix string handling on bloom index Metadata Payload

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -144,8 +144,8 @@ public enum MetadataPartitionType {
             String.format("Valid %s record expected for type: %s", SCHEMA_FIELD_ID_BLOOM_FILTER, MetadataPartitionType.BLOOM_FILTERS.getRecordType()));
       } else {
         payload.bloomFilterMetadata = new HoodieMetadataBloomFilter(
-            (String) bloomFilterRecord.get(BLOOM_FILTER_FIELD_TYPE),
-            (String) bloomFilterRecord.get(BLOOM_FILTER_FIELD_TIMESTAMP),
+            bloomFilterRecord.get(BLOOM_FILTER_FIELD_TYPE).toString(),
+            bloomFilterRecord.get(BLOOM_FILTER_FIELD_TIMESTAMP).toString(),
             (ByteBuffer) bloomFilterRecord.get(BLOOM_FILTER_FIELD_BLOOM_FILTER),
             (Boolean) bloomFilterRecord.get(BLOOM_FILTER_FIELD_IS_DELETED)
         );


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
Fixes a potential issue where strings can be UTF8 String in GenericRecord. This was handled for other payloads but not the bloom filter payload.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
Uses `toString` instead of casting

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Fixes potential runtime issue

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
