### PR TITLE
fix: add all fields in HoodieSourceSplitSerializer

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/InstantRange.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/InstantRange.java
@@ -19,14 +19,15 @@
 package org.apache.hudi.common.table.log;
 
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
@@ -39,12 +40,12 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.compareTim
 public abstract class InstantRange implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  protected final Option<String> startInstant;
-  protected final Option<String> endInstant;
+  protected final Option<String> startInstantOpt;
+  protected final Option<String> endInstantOpt;
 
   public InstantRange(String startInstant, String endInstant) {
-    this.startInstant = Option.ofNullable(startInstant);
-    this.endInstant = Option.ofNullable(endInstant);
+    this.startInstantOpt = Option.ofNullable(startInstant);
+    this.endInstantOpt = Option.ofNullable(endInstant);
   }
 
   /**
@@ -55,11 +56,11 @@ public abstract class InstantRange implements Serializable {
   }
 
   public Option<String> getStartInstant() {
-    return startInstant;
+    return startInstantOpt;
   }
 
   public Option<String> getEndInstant() {
-    return endInstant;
+    return endInstantOpt;
   }
 
   public abstract boolean isInRange(String instant);
@@ -69,8 +70,8 @@ public abstract class InstantRange implements Serializable {
   @Override
   public String toString() {
     return "InstantRange{"
-        + "startInstant='" + (startInstant.isEmpty() ? "-INF" : startInstant.get()) + '\''
-        + ", endInstant='" + (endInstant.isEmpty() ? "+INF" : endInstant.get()) + '\''
+        + "startInstant='" + (startInstantOpt.isEmpty() ? "-INF" : startInstantOpt.get()) + '\''
+        + ", endInstant='" + (endInstantOpt.isEmpty() ? "+INF" : endInstantOpt.get()) + '\''
         + ", rangeType='" + this.getRangeType().name() + '\''
         + '}';
   }
@@ -101,9 +102,9 @@ public abstract class InstantRange implements Serializable {
 
     @Override
     public boolean isInRange(String instant) {
-      boolean validAgainstStart = compareTimestamps(instant, GREATER_THAN, startInstant.get());
+      boolean validAgainstStart = compareTimestamps(instant, GREATER_THAN, startInstantOpt.get());
       // if there is an end instant, check against it, otherwise assume +INF and its always valid.
-      boolean validAgainstEnd = endInstant
+      boolean validAgainstEnd = endInstantOpt
               .map(e -> compareTimestamps(instant, LESSER_THAN_OR_EQUALS, e))
               .orElse(true);
       return validAgainstStart && validAgainstEnd;
@@ -119,16 +120,16 @@ public abstract class InstantRange implements Serializable {
 
     public OpenClosedRangeNullableBoundary(String startInstant, String endInstant) {
       super(startInstant, endInstant);
-      ValidationUtils.checkArgument(!StringUtils.isNullOrEmpty(startInstant) || !StringUtils.isNullOrEmpty(endInstant),
+      ValidationUtils.checkArgument(!startInstantOpt.isEmpty() || !endInstantOpt.isEmpty(),
           "At least one of start and end instants should be specified.");
     }
 
     @Override
     public boolean isInRange(String instant) {
-      boolean validAgainstStart = startInstant
+      boolean validAgainstStart = startInstantOpt
               .map(s -> compareTimestamps(instant, GREATER_THAN, s))
               .orElse(true);
-      boolean validAgainstEnd = endInstant
+      boolean validAgainstEnd = endInstantOpt
               .map(e -> compareTimestamps(instant, LESSER_THAN_OR_EQUALS, e))
               .orElse(true);
 
@@ -149,8 +150,8 @@ public abstract class InstantRange implements Serializable {
 
     @Override
     public boolean isInRange(String instant) {
-      boolean validAgainstStart = compareTimestamps(instant, GREATER_THAN_OR_EQUALS, startInstant.get());
-      boolean validAgainstEnd = endInstant
+      boolean validAgainstStart = compareTimestamps(instant, GREATER_THAN_OR_EQUALS, startInstantOpt.get());
+      boolean validAgainstEnd = endInstantOpt
               .map(e -> compareTimestamps(instant, LESSER_THAN_OR_EQUALS, e))
               .orElse(true);
       return validAgainstStart && validAgainstEnd;
@@ -166,16 +167,16 @@ public abstract class InstantRange implements Serializable {
 
     public ClosedClosedRangeNullableBoundary(String startInstant, String endInstant) {
       super(startInstant, endInstant);
-      ValidationUtils.checkArgument(!StringUtils.isNullOrEmpty(startInstant) || !StringUtils.isNullOrEmpty(endInstant),
+      ValidationUtils.checkArgument(!startInstantOpt.isEmpty() || !endInstantOpt.isEmpty(),
           "At least one of start and end instants should be specified.");
     }
 
     @Override
     public boolean isInRange(String instant) {
-      boolean validAgainstStart = startInstant
+      boolean validAgainstStart = startInstantOpt
               .map(s -> compareTimestamps(instant, GREATER_THAN_OR_EQUALS, s))
               .orElse(true);
-      boolean validAgainstEnd = endInstant
+      boolean validAgainstEnd = endInstantOpt
               .map(e -> compareTimestamps(instant, LESSER_THAN_OR_EQUALS, e))
               .orElse(true);
       return validAgainstStart && validAgainstEnd;
@@ -210,6 +211,33 @@ public abstract class InstantRange implements Serializable {
 
     public Set<String> getInstants() {
       return instants;
+    }
+  }
+
+  /**
+   * Composition of multiple instant ranges in disjunctive form.
+   */
+  public static class CompositionRange extends InstantRange {
+    List<InstantRange> instantRanges;
+
+    public CompositionRange(List<InstantRange> instantRanges) {
+      super(null, null);
+      this.instantRanges = Objects.requireNonNull(instantRanges, "Instant ranges should not be null");
+    }
+
+    @Override
+    public boolean isInRange(String instant) {
+      for (InstantRange range : instantRanges) {
+        if (range.isInRange(instant)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public RangeType getRangeType() {
+      return RangeType.COMPOSITION;
     }
   }
 
@@ -256,6 +284,11 @@ public abstract class InstantRange implements Serializable {
       return this;
     }
 
+    public Builder instantRanges(InstantRange... instantRanges) {
+      this.instantRanges = Arrays.stream(instantRanges).collect(Collectors.toList());
+      return this;
+    }
+
     public InstantRange build() {
       ValidationUtils.checkState(this.rangeType != null, "Range type is required");
       switch (rangeType) {
@@ -270,7 +303,7 @@ public abstract class InstantRange implements Serializable {
         case EXACT_MATCH:
           return new ExactMatchRange(this.explicitInstants);
         case COMPOSITION:
-          throw new UnsupportedOperationException("COMPOSITION range type is not supported.");
+          return new CompositionRange(this.instantRanges);
         default:
           throw new AssertionError();
       }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplitSerializer.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/HoodieSourceSplitSerializer.java
@@ -91,7 +91,9 @@ public class HoodieSourceSplitSerializer implements SimpleVersionedSerializer<Ho
         InstantRange instantRange = obj.getInstantRange().get();
         out.writeUTF(instantRange.getRangeType().name());
 
-        if (instantRange instanceof InstantRange.ClosedClosedRangeNullableBoundary
+        if (instantRange instanceof InstantRange.CompositionRange) {
+          throw new UnsupportedOperationException("Composition Range is not supported.");
+        } else if (instantRange instanceof InstantRange.ClosedClosedRangeNullableBoundary
                 || instantRange instanceof InstantRange.OpenClosedRangeNullableBoundary) {
           out.writeBoolean(true);
         } else {
@@ -168,6 +170,11 @@ public class HoodieSourceSplitSerializer implements SimpleVersionedSerializer<Ho
       if (in.readBoolean()) {
         InstantRange.Builder builder = InstantRange.builder();
         InstantRange.RangeType rangeType = InstantRange.RangeType.valueOf(in.readUTF());
+
+        if (rangeType.equals(InstantRange.RangeType.COMPOSITION)) {
+          throw new UnsupportedOperationException("Composition Range is not supported.");
+        }
+
         boolean nullableBoundary = in.readBoolean();
         builder.nullableBoundary(nullableBoundary);
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestHoodieSourceSplitSerializer.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/split/TestHoodieSourceSplitSerializer.java
@@ -23,6 +23,8 @@ import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +36,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -1098,6 +1101,78 @@ public class TestHoodieSourceSplitSerializer {
     assertFalse(deserialized4.getInstantRange().get().getStartInstant().isPresent());
     assertTrue(deserialized4.getInstantRange().get().getEndInstant().isPresent());
     assertEquals(InstantRange.RangeType.CLOSED_CLOSED, deserialized4.getInstantRange().get().getRangeType());
+  }
+
+  @Test
+  public void testSerializeThrowsExceptionForCompositionRange() {
+    // Create a composition range
+    InstantRange range1 = InstantRange.builder()
+        .startInstant("20230101000000000")
+        .endInstant("20230115235959999")
+        .rangeType(InstantRange.RangeType.OPEN_CLOSED)
+        .build();
+
+    InstantRange range2 = InstantRange.builder()
+        .startInstant("20230201000000000")
+        .endInstant("20230215235959999")
+        .rangeType(InstantRange.RangeType.OPEN_CLOSED)
+        .build();
+
+    InstantRange compositionRange = new InstantRange.CompositionRange(Arrays.asList(range1, range2));
+
+    HoodieSourceSplit split = new HoodieSourceSplit(
+        1,
+        "base-path",
+        Option.empty(),
+        "/table/path",
+        "/partition/path",
+        "read_optimized",
+        "20240101000000000",
+        "file1",
+        Option.of(compositionRange)
+    );
+
+    UnsupportedOperationException exception = assertThrows(
+        UnsupportedOperationException.class,
+        () -> serializer.serialize(split)
+    );
+
+    assertEquals("Composition Range is not supported.", exception.getMessage());
+  }
+
+  @Test
+  public void testDeserializeThrowsExceptionForCompositionRangeType() throws IOException {
+    // Manually create a byte array with COMPOSITION range type
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(baos);
+
+    // Serialize all fields except instant range
+    out.writeInt(1); // splitNum
+    out.writeBoolean(true); // basePath present
+    out.writeUTF("base-path");
+    out.writeBoolean(false); // logPaths not present
+    out.writeUTF("/table/path"); // tablePath
+    out.writeUTF("/partition/path"); // partitionPath
+    out.writeUTF("read_optimized"); // mergeType
+    out.writeUTF("20240101000000000"); // latestCommit
+    out.writeUTF("file1"); // fileId
+    out.writeLong(0L); // consumed
+    out.writeInt(0); // fileOffset
+
+    // Write instant range with COMPOSITION type
+    out.writeBoolean(true); // instantRange present
+    out.writeUTF("COMPOSITION"); // rangeType - this will trigger the exception
+
+    out.flush();
+    byte[] serialized = baos.toByteArray();
+    out.close();
+
+    UnsupportedOperationException exception = assertThrows(
+        UnsupportedOperationException.class,
+        () -> serializer.deserialize(serializer.getVersion(), serialized)
+    );
+
+    assertEquals("Composition Range is not supported.", exception.getMessage());
   }
 }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

add all fields from different InstantRange into HoodieSourceSplitSerializer.

### Summary and Changelog

1. Revise HoodieSourceSplitSerializer for Exact Match InstantRange type
2. Remove unused InstantRange composite type.
3. Added test coverage for changes.

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable