### PR TITLE
Fast bootstrap rfc

### DIFF
--- a/rfc/rfc-102/rfc-102.md
+++ b/rfc/rfc-102/rfc-102.md
@@ -40,19 +40,19 @@ REGISTER_ONLY entries are stored in a **dedicated** HFile index alongside the ex
 └── .register_only_fileids/         # REGISTER_ONLY (new)
 ```
 
-**Why not a shared index?** HFiles are immutable — any mutation requires a full rewrite. With a shared index, even a single-partition promotion forces a complete rebuild of all METADATA_ONLY + REGISTER_ONLY entries. A separate index scopes mutation cost to REGISTER_ONLY entries only:
+**Why not a shared index?** 
+A shared index between METDATA_ONLY and REGISTER_ONLY makes future operations like rollback, partition promotion complicated. By having 2 seperate indexes, we can simplify the logic for above operations. 
 
 | Operation | Shared index | Separate index |
 |---|---|---|
 | Rollback all REGISTER_ONLY | Rewrite entire HFile | Delete dedicated index + commit |
 | Promote a partition | Rewrite entire HFile | Rewrite only REGISTER_ONLY HFile |
-| Audit REGISTER_ONLY partitions | Scan entire index | Read dedicated index directly |
 
 `HFileBootstrapIndexReader` (in `o.a.h.common.bootstrap.index.hfile`) is extended to transparently union results from both indexes, so the file system view sees all mappings without any changes.
 
 ### Rollback Safety
 
-Anchor files are tracked in commit write stats — standard Hudi rollback deletes them. `dropBootstrapIndexIfNeeded` (in `BaseRollbackActionExecutor`) is made instant-aware:
+Skelton files are tracked in commit write stats — standard Hudi rollback deletes them. `dropBootstrapIndexIfNeeded` (in `BaseRollbackActionExecutor`) should be made instant-aware:
 - Rolling back `00000000000001` → drops METADATA_ONLY index only
 - Rolling back `00000000000003` → drops REGISTER_ONLY index only
 
@@ -66,7 +66,7 @@ SparkBootstrapCommitActionExecutor.execute()
   ├─ fullBootstrap()            @ 00000000000002
   │   └─ bulk-insert rewrite
   └─ registerOnlyBootstrap()    @ 00000000000003   [new]
-      ├─ empty anchor files
+      ├─ empty skelton files
       ├─ writes dedicated register-only index (HFileBootstrapIndexWriter)
       ├─ updates Hudi Metadata Table (partitions + files)
       └─ commits with HoodieWriteStat per file
@@ -94,8 +94,13 @@ A new `rejectWritesToRegisterOnlyPartitions()` check is added to `BaseSparkCommi
 5. Hudi cleaner removes old anchor files
 ```
 
+### Data consistency
+If the table has to be copied into a replicated region, they must copy the skelton files along with bootstrap index generated under .aux directory. 
+
 ## Limitations
 
 - REGISTER_ONLY partitions have NULL meta columns — no incremental queries or record-level ops without promotion
 - Per-partition promotion rewrites the REGISTER_ONLY index HFile
 - COW only in initial implementation
+
+


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This RFC describes implementation details for the feature proposed in https://github.com/apache/hudi/issues/18135  

### Impact

Reduces Hudi onboarding time and avoids storage costs for historical partitions. 

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
