### PR TITLE
feat(flink): collect event time in HoodieRowDataCreateHandle for min/max event time metrics

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
@@ -84,7 +84,7 @@ public class HoodieRowDataCreateHandle implements Serializable {
   private final HoodieTimer currTimer;
 
   // Event time tracking for min/max event time metrics (when hoodie.payload.event.time.field is set)
-  private final int eventTimeFieldIndex;
+  private final RowData.FieldGetter eventTimeFieldGetter;
 
   public HoodieRowDataCreateHandle(HoodieTable table, HoodieWriteConfig writeConfig, String partitionPath, String fileId,
                                    String instantTime, int taskPartitionId, long taskId, long taskEpochId,
@@ -103,7 +103,7 @@ public class HoodieRowDataCreateHandle implements Serializable {
     this.currTimer = HoodieTimer.start();
     this.storage = table.getStorage();
     this.path = makeNewPath(partitionPath);
-    this.eventTimeFieldIndex = initEventTimeFieldIndex(writeConfig, rowType);
+    this.eventTimeFieldGetter = initEventTimeFieldGetter(writeConfig, rowType);
 
     this.writeStatus = new WriteStatus(table.shouldTrackSuccessRecords(),
         writeConfig.getWriteStatusFailureFraction());
@@ -155,9 +155,9 @@ public class HoodieRowDataCreateHandle implements Serializable {
         rowData = record;
       }
       // Extract event time metadata when metadata is written (rowData matches rowType with event time field)
-      Option<Map<String, String>> recordMetadata = skipMetadataWrite
-          ? Option.empty()
-          : extractEventTimeMetadata(rowData);
+      Option<Map<String, String>> recordMetadata = !skipMetadataWrite
+          ? extractEventTimeMetadata(rowData)
+          : Option.empty();
       try {
         fileWriter.writeRow(recordKey, rowData);
         HoodieRecordDelegate recordDelegate = writeStatus.isTrackingSuccessfulWrites()
@@ -177,50 +177,49 @@ public class HoodieRowDataCreateHandle implements Serializable {
   }
 
   /**
-   * Initializes the event time field index from config (hoodie.payload.event.time.field).
-   * Only DOUBLE type is supported (epoch seconds). Returns -1 if not configured, not found, or wrong type.
+   * Initializes event time field getter from config (hoodie.payload.event.time.field).
+   * Supports DOUBLE and BIGINT only. Returns null if not configured, not found, or unsupported type.
    */
-  private static int initEventTimeFieldIndex(HoodieWriteConfig writeConfig, RowType rowType) {
+  private static RowData.FieldGetter initEventTimeFieldGetter(HoodieWriteConfig writeConfig, RowType rowType) {
     String eventTimeField = writeConfig.getPayloadConfig().getProps().getProperty(
         HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY);
     if (eventTimeField == null || eventTimeField.isEmpty()) {
-      return -1;
+      return null;
     }
     for (int i = 0; i < rowType.getFieldCount(); i++) {
       if (rowType.getFieldNames().get(i).equals(eventTimeField)) {
         RowType.RowField field = rowType.getFields().get(i);
-        if (field.getType().getTypeRoot() == LogicalTypeRoot.DOUBLE) {
-          return i;
+        LogicalTypeRoot root = field.getType().getTypeRoot();
+        if (root == LogicalTypeRoot.DOUBLE || root == LogicalTypeRoot.BIGINT) {
+          return RowData.createFieldGetter(field.getType(), i);
         }
-        log.warn("Event time field '{}' has unsupported type {}. Only DOUBLE (epoch seconds) is supported. "
-            + "Event time metrics will be unavailable.", eventTimeField, field.getType().getTypeRoot());
-        return -1;
+        log.warn("Event time field '{}' has unsupported type {}. Only DOUBLE and BIGINT are supported. "
+            + "Event time metrics will be unavailable.", eventTimeField, root);
+        return null;
       }
     }
     log.warn("Event time field '{}' configured but not found in schema. Event time metrics will be unavailable.",
         eventTimeField);
-    return -1;
+    return null;
   }
 
   /**
-   * Extracts event time from rowData at eventTimeFieldIndex (DOUBLE epoch seconds -> millis).
-   * Returns metadata map for WriteStatus.markSuccess, or empty if unavailable.
+   * Extracts event time from rowData using the event time field getter.
+   * Value is converted to long then string (no unit interpretation); WriteStatus infers unit by string length.
    */
   private Option<Map<String, String>> extractEventTimeMetadata(RowData rowData) {
-    if (eventTimeFieldIndex < 0) {
+    if (eventTimeFieldGetter == null) {
       return Option.empty();
     }
     try {
-      if (rowData.isNullAt(eventTimeFieldIndex)) {
-        return Option.empty();
+      Object val = eventTimeFieldGetter.getFieldOrNull(rowData);
+      if (val instanceof Number) {
+        return Option.of(Collections.singletonMap(METADATA_EVENT_TIME_KEY, String.valueOf(((Number) val).longValue())));
       }
-      double eventTimeSeconds = rowData.getDouble(eventTimeFieldIndex);
-      long eventTimeMillis = (long) (eventTimeSeconds * 1000);
-      return Option.of(Collections.singletonMap(METADATA_EVENT_TIME_KEY, String.valueOf(eventTimeMillis)));
     } catch (Exception e) {
-      log.debug("Failed to extract event time at index {}", eventTimeFieldIndex, e);
-      return Option.empty();
+      log.debug("Failed to extract event time", e);
     }
+    return Option.empty();
   }
 
   /**

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowDataCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowDataCreateHandle.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -61,6 +62,11 @@ public class TestHoodieRowDataCreateHandle extends HoodieFlinkClientTestHarness 
     initPath();
     initFileSystem();
     initMetaClient();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    cleanupResources();
   }
 
   /**
@@ -274,6 +280,63 @@ public class TestHoodieRowDataCreateHandle extends HoodieFlinkClientTestHarness 
 
     // Verify min <= max
     assertTrue(minEventTime <= maxEventTime, "Min event time should be <= max event time");
+  }
+
+  @Test
+  public void testEventTimeExtractionWithBigintMillis() throws Exception {
+    // Schema with BIGINT event_time field (millis)
+    DataType dataType = DataTypes.ROW(
+        DataTypes.FIELD("uuid", DataTypes.VARCHAR(20)),
+        DataTypes.FIELD("name", DataTypes.VARCHAR(20)),
+        DataTypes.FIELD("age", DataTypes.INT()),
+        DataTypes.FIELD("event_time", DataTypes.BIGINT()),
+        DataTypes.FIELD("partition", DataTypes.VARCHAR(20))
+    ).notNull();
+    RowType baseRowType = (RowType) dataType.getLogicalType();
+    RowType rowTypeWithMetadata = addMetadataFields(baseRowType, false);
+
+    Properties props = new Properties();
+    props.setProperty(HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY, "event_time");
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withProperties(props)
+        .withEmbeddedTimelineServerEnabled(false)
+        .build();
+
+    HoodieFlinkTable<?> table = HoodieFlinkTable.create(config, context, metaClient);
+
+    HoodieRowDataCreateHandle handle = new HoodieRowDataCreateHandle(
+        table, config, PARTITION_PATH, FILE_ID, INSTANT_TIME,
+        TASK_PARTITION_ID, TASK_ID, TASK_EPOCH_ID, rowTypeWithMetadata, false, false);
+
+    long eventTimeMillis1 = 1729512000000L;
+    long eventTimeMillis2 = 1729515600000L;
+
+    GenericRowData row1 = new GenericRowData(5);
+    row1.setField(0, StringData.fromString("id1"));
+    row1.setField(1, StringData.fromString("Alice"));
+    row1.setField(2, 25);
+    row1.setField(3, eventTimeMillis1);
+    row1.setField(4, StringData.fromString(PARTITION_PATH));
+
+    GenericRowData row2 = new GenericRowData(5);
+    row2.setField(0, StringData.fromString("id2"));
+    row2.setField(1, StringData.fromString("Bob"));
+    row2.setField(2, 30);
+    row2.setField(3, eventTimeMillis2);
+    row2.setField(4, StringData.fromString(PARTITION_PATH));
+
+    handle.write("id1", PARTITION_PATH, row1);
+    handle.write("id2", PARTITION_PATH, row2);
+
+    WriteStatus writeStatus = handle.close();
+    assertNotNull(writeStatus);
+    Long minEventTime = writeStatus.getStat().getMinEventTime();
+    Long maxEventTime = writeStatus.getStat().getMaxEventTime();
+    assertNotNull(minEventTime);
+    assertNotNull(maxEventTime);
+    assertEquals(eventTimeMillis1, minEventTime.longValue());
+    assertEquals(eventTimeMillis2, maxEventTime.longValue());
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink bulk insert does not populate min/max event time in WriteStatus. Use cases (e.g. metrics) that rely on event time stats do not work. This PR adds event time collection in `HoodieRowDataCreateHandle` when `hoodie.payload.event.time.field` is discovered, so Flink WriteStatus can report min/max event time.

### Summary and Changelog

- **Summary:** When `hoodie.payload.event.time.field` is configured, `HoodieRowDataCreateHandle` reads the event time from each record and passes it to `WriteStatus.markSuccess` as record metadata. WriteStatus then updates min/max event time for the file. No time unit is interpreted in the handle; the value is converted to long then string. WriteStatus infers unit by string length (e.g. 10 digits vs 13) as today.
- **Changelog:**
  - Support **DOUBLE** and **BIGINT** for the event time field (unsupported types are skipped with a warning).
  - Use `RowData.FieldGetter` (Flink API) to read the field by name/type; getter is null when the field is not configured, not found, or unsupported.
  - Extract value as long then string; no unit conversion in the handle.

### Impact

- **User-facing:** Existing config `hoodie.payload.event.time.field` (field name only) is used. When set and the field is DOUBLE or BIGINT, Flink bulk insert will populate min/max event time in WriteStatus. No new config; no change when the config is unset or the field is missing/unsupported.
- **Performance:** One field read per record when event time is enabled; negligible.

### Risk Level

Low. Change is scoped to Flink `HoodieRowDataCreateHandle` and its tests. Event time is optional and only applied when the configured field exists and is DOUBLE or BIGINT. Defensive try-catch avoids failing the write on read errors.

### Documentation Update

None. The config key is existing; behavior is an extension of its use for Flink (min/max event time in WriteStatus). No new configs or defaults.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable