### PR TITLE
fix: Support Databricks Spark runtime

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
+++ b/hudi-common/src/main/java/org/apache/hudi/BaseHoodieTableFileIndex.java
@@ -554,4 +554,21 @@ public abstract class BaseHoodieTableFileIndex implements AutoCloseable {
 
     void invalidate();
   }
+
+  public static class NoopCache implements FileStatusCache {
+    @Override
+    public Option<List<StoragePathInfo>> get(StoragePath path) {
+      return Option.empty();
+    }
+
+    @Override
+    public void put(StoragePath path, List<StoragePathInfo> leafFiles) {
+      // no-op
+    }
+
+    @Override
+    public void invalidate() {
+      // no-op
+    }
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestReflectionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestReflectionUtils.java
@@ -22,9 +22,13 @@ package org.apache.hudi.common.util;
 import org.apache.hudi.common.conflict.detection.DirectMarkerBasedDetectionStrategy;
 import org.apache.hudi.common.conflict.detection.EarlyConflictDetectionStrategy;
 import org.apache.hudi.common.conflict.detection.TimelineServerBasedDetectionStrategy;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathFilter;
 
 import org.junit.jupiter.api.Test;
 
+import static org.apache.hudi.common.util.ReflectionUtils.getMethod;
 import static org.apache.hudi.common.util.ReflectionUtils.isSubClass;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,5 +45,16 @@ public class TestReflectionUtils {
     assertTrue(isSubClass(subClassName2, EarlyConflictDetectionStrategy.class));
     assertTrue(isSubClass(subClassName2, TimelineServerBasedDetectionStrategy.class));
     assertFalse(isSubClass(subClassName2, DirectMarkerBasedDetectionStrategy.class));
+  }
+
+  @Test
+  void testGetMethod() {
+    assertTrue(getMethod(HoodieStorage.class, "getScheme").isPresent());
+    assertTrue(getMethod(HoodieStorage.class, "listFiles", StoragePath.class).isPresent());
+    assertTrue(getMethod(HoodieStorage.class,
+        "listDirectEntries", StoragePath.class, StoragePathFilter.class).isPresent());
+    assertFalse(getMethod(HoodieStorage.class,
+        "listDirectEntries", StoragePathFilter.class).isPresent());
+    assertFalse(getMethod(HoodieStorage.class, "nonExistentMethod").isPresent());
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieTableFileIndex.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieTableFileIndex.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieTableQueryType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.storage.StoragePath;
 
 import org.slf4j.Logger;
@@ -80,22 +79,5 @@ public class HiveHoodieTableFileIndex extends BaseHoodieTableFileIndex {
     //       since Hive does partition pruning in a different way (based on the input-path being
     //       fetched by the query engine)
     return new Object[0];
-  }
-
-  static class NoopCache implements FileStatusCache {
-    @Override
-    public Option<List<StoragePathInfo>> get(StoragePath path) {
-      return Option.empty();
-    }
-
-    @Override
-    public void put(StoragePath path, List<StoragePathInfo> leafFiles) {
-      // no-op
-    }
-
-    @Override
-    public void invalidate() {
-      // no-op
-    }
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -208,6 +208,22 @@ public class ReflectionUtils {
   }
 
   /**
+   * Gets a method based on the method name and type of parameters through reflection.
+   *
+   * @param clazz          {@link Class} object
+   * @param methodName     method name
+   * @param parametersType type of parameters
+   * @return {@link Option} of the method if found; {@code Option.empty()} if not found or error out
+   */
+  public static Option<Method> getMethod(Class<?> clazz, String methodName, Class<?>... parametersType) {
+    try {
+      return Option.of(clazz.getMethod(methodName, parametersType));
+    } catch (Throwable e) {
+      return Option.empty();
+    }
+  }
+
+  /**
    * Checks if the given class with the name is a subclass of another class.
    *
    * @param aClazzName Class name.

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -26,6 +26,7 @@ import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS_WITH_OPERATION
 import org.apache.hudi.common.model.{FileSlice, HoodieTableQueryType}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
+import org.apache.hudi.common.util.ReflectionUtils
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.config.HoodieBootstrapConfig.DATA_QUERIES_ONLY
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
@@ -45,7 +46,9 @@ import org.apache.spark.sql.catalyst.{InternalRow, expressions}
 import org.apache.spark.sql.execution.datasources.{FileStatusCache, NoopCache}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ByteType, DateType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
+import org.slf4j.LoggerFactory
 
+import java.lang.reflect.{Array => JArray}
 import java.util.Collections
 import javax.annotation.concurrent.NotThreadSafe
 
@@ -410,6 +413,8 @@ class SparkHoodieTableFileIndex(spark: SparkSession,
 }
 
 object SparkHoodieTableFileIndex extends SparkAdapterSupport {
+  private val LOG = LoggerFactory.getLogger(classOf[SparkHoodieTableFileIndex])
+  private val PUT_LEAF_FILES_METHOD_NAME = "putLeafFiles"
 
   private def haveProperPartitionValues(partitionPaths: Seq[PartitionPath]) = {
     partitionPaths.forall(_.values.length > 0)
@@ -491,17 +496,27 @@ object SparkHoodieTableFileIndex extends SparkAdapterSupport {
   }
 
   private def adapt(cache: FileStatusCache): BaseHoodieTableFileIndex.FileStatusCache = {
-    new BaseHoodieTableFileIndex.FileStatusCache {
-      override def get(path: StoragePath): org.apache.hudi.common.util.Option[java.util.List[StoragePathInfo]] =
-        toJavaOption(cache.getLeafFiles(new Path(path.toUri)).map(opt => opt.map(
-          e => HadoopFSUtils.convertToStoragePathInfo(e)).toList.asJava
-        ))
+    // Certain Spark runtime like Databricks Spark has changed the FileStatusCache APIs
+    // so we need to check the API to avoid NoSuchMethodError
+    if (ReflectionUtils.getMethod(
+      classOf[FileStatusCache], PUT_LEAF_FILES_METHOD_NAME, classOf[Path],
+      JArray.newInstance(classOf[FileStatus], 0).getClass).isPresent) {
+      new BaseHoodieTableFileIndex.FileStatusCache {
+        override def get(path: StoragePath): org.apache.hudi.common.util.Option[java.util.List[StoragePathInfo]] =
+          toJavaOption(cache.getLeafFiles(new Path(path.toUri)).map(opt => opt.map(
+            e => HadoopFSUtils.convertToStoragePathInfo(e)).toList.asJava
+          ))
 
-      override def put(path: StoragePath, leafFiles: java.util.List[StoragePathInfo]): Unit =
-        cache.putLeafFiles(new Path(path.toUri), leafFiles.asScala.map(e => new FileStatus(
-          e.getLength, e.isDirectory, 0, e.getBlockSize, e.getModificationTime, new Path(e.getPath.toUri))).toArray)
+        override def put(path: StoragePath, leafFiles: java.util.List[StoragePathInfo]): Unit =
+          cache.putLeafFiles(new Path(path.toUri), leafFiles.asScala.map(e => new FileStatus(
+            e.getLength, e.isDirectory, 0, e.getBlockSize, e.getModificationTime, new Path(e.getPath.toUri))).toArray)
 
-      override def invalidate(): Unit = cache.invalidateAll()
+        override def invalidate(): Unit = cache.invalidateAll()
+      }
+    } else {
+      LOG.warn("Use no-op file status cache instead because the FileStatusCache APIs at runtime "
+        + "are different from open-source Spark")
+      new BaseHoodieTableFileIndex.NoopCache
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Cherrypicking #13129 to `branch-0.x`

### Summary and Changelog

This PR makes Hudi tables queryable on Databricks Spark runtime.  With the fix, the datasource reader can read Hudi tables leveraging `SparkHoodieTableFileIndex` without using the metadata table.

The root cause of the issue is that the `FileStatusCache` from Databricks Spark runtime has different APIs compared to OSS Spark, leading to the `NoSuchMethodError` below:
```
java.lang.NoSuchMethodError: org.apache.spark.sql.execution.datasources.FileStatusCache.putLeafFiles(Lorg/apache/hadoop/fs/Path;[Lorg/apache/hadoop/fs/FileStatus;)V
	at org.apache.hudi.SparkHoodieTableFileIndex$$anon$1.put(SparkHoodieTableFileIndex.scala:516)
	at org.apache.hudi.BaseHoodieTableFileIndex.lambda$listPartitionPathFiles$13(BaseHoodieTableFileIndex.java:410)
	at java.util.HashMap.forEach(HashMap.java:1290)
	at org.apache.hudi.BaseHoodieTableFileIndex.listPartitionPathFiles(BaseHoodieTableFileIndex.java:408)
```
`FileStatusCache`'s declared methods on Databricks Spark runtime:
```
classOf[FileStatusCache].getDeclaredMethods
res11: Array[java.lang.reflect.Method] = Array(public abstract java.util.UUID org.apache.spark.sql.execution.datasources.FileStatusCache.clientId(), public static void org.apache.spark.sql.execution.datasources.FileStatusCache.resetForTesting(), public scala.Option org.apache.spark.sql.execution.datasources.FileStatusCache.getLeafFiles(org.apache.hadoop.fs.Path), public abstract void org.apache.spark.sql.execution.datasources.FileStatusCache.putLeafFiles(org.apache.hadoop.fs.Path,org.apache.spark.sql.execution.datasources.SerializableFileStatus[]), public static org.apache.spark.sql.execution.datasources.FileStatusCache org.apache.spark.sql.execution.datasources.FileStatusCache.getOrCreate(org.apache.spark.sql.internal.SQLConf,scala.Option), public static org.apache.spark.sql.execution.datasources.FileStatusCache org.apache.spark.sql.execution.datasources.FileStatusCache.getOrCreate(org.apache.spark.sql.SparkSession), public abstract void org.apache.spark.sql.execution.datasources.FileStatusCache.invalidateAll())
```
As seen, the second parameter of `putLeafFiles` is of type `SerializableFileStatus[]` which is different from `FileStatus[]` in OSS.

Two alternatives are explored:
- Using reflection: to use Java's reflection to invoke the method `putLeafFiles` we have to have the class `SerializableFileStatus` to pass the type safety check (i.e., passing `SerializableFileStatus[]` instead of `Object[]` which is the only possible way; otherwise seeing `IllegalArgumentException: argument type mismatch`).  As the class `SerializableFileStatus` is no longer available in OSS Spark, the reflection route is not possible.
```
IllegalArgumentException: argument type mismatch
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```
- Avoid using the cache: this is the fix in this PR, by not using the file status cache.  Such a fix gets rid of the `NoSuchMethodError`.

COW table generated by [Spark Quick Start](https://hudi.apache.org/docs/quick-start-guide) is validated (using `spark.read.format("org.apache.hudi.Spark3DefaultSource").option("hoodie.metadata.enable", "false").load(tablePath)`).

### Impact

Fixes reading Hudi tables leveraging `SparkHoodieTableFileIndex` without using the metadata table.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
