### PR TITLE
fix cdc compare result

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCFileSplit.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCFileSplit.java
@@ -133,7 +133,15 @@ public class HoodieCDCFileSplit implements Serializable, Comparable<HoodieCDCFil
       // A deterministic ordering between splits from the same file group is required to infer row changes for readers.
       // beforeFileSlice` includes the log files already existed before the write of the log file in this split, which can be used as the
       // tie-breaker to preserve the relative order of multiple log files.
-      return Math.toIntExact(this.beforeFileSlice.get().getLogFiles().count() - o.getBeforeFileSlice().get().getLogFiles().count());
+      int thisLogFilesCount = this.beforeFileSlice
+              .map(fs -> Math.toIntExact(fs.getLogFiles().count()))
+              .orElse(0);
+
+      int otherLogFilesCount = o.getBeforeFileSlice()
+              .map(fs -> Math.toIntExact(fs.getLogFiles().count()))
+              .orElse(0);
+
+      return Integer.compare(thisLogFilesCount, otherLogFilesCount);
     }
     return cmpResult;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCFileSplit.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/cdc/HoodieCDCFileSplit.java
@@ -126,8 +126,7 @@ public class HoodieCDCFileSplit implements Serializable, Comparable<HoodieCDCFil
   @Override
   public int compareTo(HoodieCDCFileSplit o) {
     int cmpResult = this.instant.compareTo(o.instant);
-    if (cmpResult == 0 && this.cdcInferCase == HoodieCDCInferenceCase.LOG_FILE
-        && this.beforeFileSlice.isPresent() && o.getBeforeFileSlice().isPresent()) {
+    if (cmpResult == 0 && this.cdcInferCase == HoodieCDCInferenceCase.LOG_FILE) {
       // For mor table, multiple writes may occur for the same file group for a single instant,
       // producing multiple log files that have monotonically increasing  file version.
       //


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Based on this PR's fix, I conducted tests and found that even with the bucket index, there were still a few duplicate inserts, and they were concentrated in the last data. Therefore, I modified the comparison condition, and after the modification, this problem can be solved.
https://github.com/apache/hudi/pull/18206

### Summary and Changelog

Enhanced HoodieCDCFileSplit.compareTo:
When instants are equal and inference case is LOG_FILE, use beforeFileSlice log-file count as a tie-breaker to preserve deterministic ordering for splits in the same instant.

### Impact

Improves determinism of write/commit ordering for Flink CDC, especially MOR + upsert.

### Risk Level

low

### Documentation Update


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
