### PR TITLE
fix: [HUDI-3055] Fix hardcoded GZIP compression codec in HFileUtils

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
@@ -76,7 +76,8 @@ public class HFileUtils extends FileFormatUtils {
   public static CompressionCodec getHFileCompressionAlgorithm(Map<String, String> paramsMap) {
     String codecName = paramsMap.get(HFILE_COMPRESSION_ALGORITHM_NAME.key());
     if (StringUtils.isNullOrEmpty(codecName)) {
-      return CompressionCodec.GZIP;
+      // Use the default value from config instead of hardcoding GZIP
+      return CompressionCodec.findCodecByName(HFILE_COMPRESSION_ALGORITHM_NAME.defaultValue());
     }
     return CompressionCodec.findCodecByName(codecName);
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fix issue #14963: Ensure that compression codec configuration is respected across the board.

Changes here only affect routes when codec is null or empty, hence default value should be respected.

### Summary and Changelog

- Modified `HFileUtils.getHFileCompressionAlgorithm()` to use `HFILE_COMPRESSION_ALGORITHM_NAME.defaultValue()` instead of hardcoding `CompressionCodec.GZIP`
- This ensures the method respects the configured compression codec default value

## Verify this pull request

This pull request is already covered by existing tests:
- `TestHFileUtils.testGetHFileCompressionAlgorithm()` - tests all compression codecs
- `TestHFileUtils.testGetHFileCompressionAlgorithmWithEmptyString()` - tests empty string case  
- `TestHFileUtils.testGetDefaultHFileCompressionAlgorithm()` - tests default value case

### Impact
Ensure that compression codec configuration is respected across the board, Hfile uses hfile default compression for now.


### Risk Level
None


### Documentation Update
None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable