### PR TITLE
perf: eliminate unnecessary timeline loading for Flink append only write path

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -1368,7 +1368,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    * </ul>
    */
   public final HoodieTable initTable(WriteOperationType operationType, Option<String> instantTime) {
-    HoodieTableMetaClient metaClient = createMetaClient(true);
+    HoodieTableMetaClient metaClient = createMetaClient(loadActiveTimelineOnTableInit());
     // Setup write schemas for deletes
     if (WriteOperationType.isDelete(operationType)) {
       setWriteSchemaForDeletes(metaClient);
@@ -1400,6 +1400,10 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     }
 
     return table;
+  }
+
+  protected boolean loadActiveTimelineOnTableInit() {
+    return true;
   }
 
   public void validateAgainstTableProperties(HoodieTableConfig tableConfig, HoodieWriteConfig writeConfig) {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkWriteClient.java
@@ -464,6 +464,21 @@ public class HoodieFlinkWriteClient<T>
     // flink performs metadata table bootstrap on the coordinator when it starts up.
   }
 
+  /**
+   * Marks the timeline loading as lazy for table init in write path.
+   *
+   * <p>The write client is local entry per-task and the table is initialized for each write,
+   * always make the timeline loading as lazy because there is no cross-network transmission
+   * so no gains for eager loading.
+   *
+   * <p>For append-only write path like pk-less table and log append for MOR table, the timeline loading is unnecessary
+   * and the metadata file listing cost could be saved.
+   */
+  @Override
+  protected boolean loadActiveTimelineOnTableInit() {
+    return false;
+  }
+
   public void completeTableService(
       TableServiceType tableServiceType,
       HoodieCommitMetadata metadata,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkTable.java
@@ -52,7 +52,7 @@ public abstract class HoodieFlinkTable<T>
   }
 
   public static <T> HoodieFlinkTable<T> create(HoodieWriteConfig config, HoodieEngineContext context) {
-    return create(config, context, true);
+    return create(config, context, false);
   }
 
   public static <T> HoodieFlinkTable<T> create(HoodieWriteConfig config, HoodieEngineContext context, boolean loadActiveTimelineOnLoad) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

For append only write path, there is no need to load the timeline eagerly for most of the cases, different with Spark, the Flink write client is local to write task, there is no network transmission so the eager flush does not have any gains though.

### Summary and Changelog

- change the `HoodieFlinkTable#create` timeline loading as lazy;
- change the genetal write client `#initTable` timeline loading as lazy;

### Impact

less timeline loading.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
