### PR TITLE
feat(flink): Blocking RLI bootstrap when there is pending instant on job restart

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -423,8 +423,13 @@ public class StreamWriteOperatorCoordinator
   private CompletableFuture<CoordinationResponse> handleAwaitPendingInstantsRequest(Correspondent.AwaitPendingInstantsRequest request) {
     CompletableFuture<CoordinationResponse> response = new CompletableFuture<>();
     instantRequestExecutor.execute(() -> {
-      // wait until receiving any bootstrap event.
-      eventBuffers.awaitPrevInstantsToComplete(request.getCheckpointId());
+      // 1. wait until receiving any bootstrap event when the job is started
+      if (!request.isTaskFailover()) {
+        eventBuffers.awaitWriterBootstrapEventReceived();
+      }
+      // 2. wait until all the previous instant committed successfully
+      // Note: when the case is job restart, the checkpoint id is -1, but we should wait for all pending instants to be committed.
+      eventBuffers.awaitPrevInstantsToComplete(request.isTaskFailover() ? request.getCheckpointId() : Long.MAX_VALUE);
       response.complete(CoordinationResponseSerDe.wrap(Correspondent.AwaitPendingInstantsResponse.getInstance()));
     }, "await pending instants to complete");
     return response;
@@ -555,10 +560,12 @@ public class StreamWriteOperatorCoordinator
   private void handleBootstrapEvent(WriteMetadataEvent event) {
     if (event.getInstantTime().equals(WriteMetadataEvent.BOOTSTRAP_INSTANT)) {
       this.eventBuffers.cleanLegacyEvents(event);
+      this.eventBuffers.notifyWriterBootstrapEventReceived();
       return;
     }
     EventBuffer eventBuffer = this.eventBuffers.getOrCreateBootstrapBuffer(event);
     eventBuffer.addBootstrapEvent(event);
+    this.eventBuffers.notifyWriterBootstrapEventReceived();
     if (eventBuffer.allBootstrapEventsReceived()) {
       // start to recommit the instant.
       recommitInstant(event.getCheckpointId(), event.getInstantTime(), eventBuffer);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
@@ -33,6 +33,7 @@ import org.apache.hudi.sink.utils.OperatorIDGenerator;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.RuntimeContextUtils;
 
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.state.ListState;
@@ -69,6 +70,7 @@ public class RLIBootstrapOperator
 
   private transient HoodieTableMetaClient metaClient;
   private transient HoodieBackedTableMetadata metadataTable;
+  @Setter
   private transient Correspondent correspondent;
   private transient long loadedCnt;
 
@@ -114,7 +116,7 @@ public class RLIBootstrapOperator
     if (context.isRestored()) {
       // Wait for pending instants being committed successfully before loading the record index
       log.info("Waiting for pending instants committed before RLI bootstrap.");
-      correspondent.awaitPendingInstantsCommitted(checkpointId);
+      correspondent.awaitPendingInstantsCommitted(attemptId > 0, checkpointId);
       log.info("All pending instants are completed, continue RLI bootstrap.");
     }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
@@ -23,6 +23,7 @@ import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
 import org.apache.hudi.sink.buffer.MemorySegmentPoolFactory;
 import org.apache.hudi.sink.event.CommitAckEvent;
@@ -234,6 +235,7 @@ public abstract class AbstractStreamWriteFunction<I>
       if (isRestored) {
         HoodieTimeline pendingTimeline = this.metaClient.getActiveTimeline().filterPendingExcludingCompaction();
         // if the task is initially started, resend the pending event.
+        boolean bootstrapEventSent = false;
         for (WriteMetadataEvent event : this.writeMetadataState.get()) {
           // Must filter out the completed instants in case it is a partial failover,
           // the write status should not be accumulated in such case.
@@ -243,8 +245,14 @@ public abstract class AbstractStreamWriteFunction<I>
             // The checkpoint succeed but the meta does not commit,
             // re-commit the inflight instant
             sendWriteMetadataEvent(event);
+            bootstrapEventSent = true;
             log.info("Send uncommitted write metadata event to coordinator, task[{}].", taskID);
           }
+        }
+        // always send a bootstrap event to unblock RLI bootstrap.
+        if (!bootstrapEventSent && OptionsResolver.isRLIWithBootstrap(config)) {
+          sendWriteMetadataEvent(WriteMetadataEvent.emptyBootstrap(taskID, checkpointId, isMetadataTable));
+          log.info("Send empty bootstrap write metadata event to coordinator, task[{}].", taskID);
         }
       }
     } else {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/Correspondent.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/event/Correspondent.java
@@ -103,10 +103,10 @@ public class Correspondent {
   /**
    * Requests coordinator to wait until all pending instants are committed if necessary.
    */
-  public void awaitPendingInstantsCommitted(long checkpointId) {
+  public void awaitPendingInstantsCommitted(boolean isTaskFailover, long checkpointId) {
     try {
       this.gateway.sendRequestToCoordinator(this.operatorID,
-          new SerializedValue<>(AwaitPendingInstantsRequest.getInstance(checkpointId))).get();
+          new SerializedValue<>(AwaitPendingInstantsRequest.getInstance(isTaskFailover, checkpointId))).get();
     } catch (Exception e) {
       throw new HoodieException("Error awaiting pending instants completion from coordinator", e);
     }
@@ -172,11 +172,11 @@ public class Correspondent {
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
   @Getter
   public static class AwaitPendingInstantsRequest implements CoordinationRequest {
-
+    private final boolean isTaskFailover;
     private final long checkpointId;
 
-    public static AwaitPendingInstantsRequest getInstance(long checkpointId) {
-      return new AwaitPendingInstantsRequest(checkpointId);
+    public static AwaitPendingInstantsRequest getInstance(boolean isTaskFailover, long checkpointId) {
+      return new AwaitPendingInstantsRequest(isTaskFailover, checkpointId);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/CommitGuard.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/CommitGuard.java
@@ -91,6 +91,23 @@ public class CommitGuard {
     }
   }
 
+  public void blockUntil(Supplier<Boolean> shouldBlock) {
+    lock.lock();
+    long nanos = TimeUnit.MILLISECONDS.toNanos(commitAckTimeout);
+    try {
+      while (shouldBlock.get()) {
+        if (nanos <= 0L) {
+          throw new HoodieException("Timeout(" + commitAckTimeout + "ms) while waiting for unblock signal.");
+        }
+        nanos = condition.awaitNanos(nanos);
+      }
+    } catch (InterruptedException e) {
+      throw new HoodieException("Blocking is interrupted.", e);
+    } finally {
+      lock.unlock();
+    }
+  }
+
   /**
    * Signals all waited threads which are waiting on the condition.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/EventBuffers.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/EventBuffers.java
@@ -49,14 +49,20 @@ public class EventBuffers implements Serializable {
   // {checkpointId -> (instant, data write events, index write events)}
   private final Map<Long, Pair<String, EventBuffer>> eventBuffers;
   private final Option<CommitGuard> commitGuardOption;
+  // Guard to blocking index bootstrap on job restart until the writer bootstrap event being received by coordinator.
+  private final Option<CommitGuard> writerBootstrapEventGuardOption;
+  // Commit guard to block index bootstrap on job restart until the previous instants being committed.
   private final Option<CommitGuard> indexBootstrapGuardOption;
   private final int dataWriteParallelism;
   private final int indexWriteParallelism;
+  // Whether any bootstrap event is received from any subtask of the writer
+  private volatile boolean writerBootstrapEventReceived;
 
   private EventBuffers(
       Map<Long, Pair<String, EventBuffer>> eventBuffers,
       Option<CommitGuard> commitGuardOption,
       Option<CommitGuard> indexBootstrapGuardOption,
+      Option<CommitGuard> writerBootstrapEventGuardOption,
       int dataWriteParallelism,
       int indexWriteParallelism) {
     this.eventBuffers = eventBuffers;
@@ -64,6 +70,8 @@ public class EventBuffers implements Serializable {
     this.dataWriteParallelism = dataWriteParallelism;
     this.indexWriteParallelism = indexWriteParallelism;
     this.indexBootstrapGuardOption = indexBootstrapGuardOption;
+    this.writerBootstrapEventGuardOption = writerBootstrapEventGuardOption;
+    this.writerBootstrapEventReceived = false;
   }
 
   public static EventBuffers getInstance(Configuration conf, int dataWriteParallelism) {
@@ -71,8 +79,10 @@ public class EventBuffers implements Serializable {
         ? Option.of(CommitGuard.create(conf.get(FlinkOptions.WRITE_COMMIT_ACK_TIMEOUT))) : Option.empty();
     final Option<CommitGuard> indexBootstrapGuardOption = OptionsResolver.isRLIWithBootstrap(conf)
         ? Option.of(CommitGuard.create(conf.get(FlinkOptions.WRITE_COMMIT_ACK_TIMEOUT))) : Option.empty();
+    final Option<CommitGuard> writerBootstrapEventGuardOption = OptionsResolver.isRLIWithBootstrap(conf)
+        ? Option.of(CommitGuard.create(conf.get(FlinkOptions.WRITE_COMMIT_ACK_TIMEOUT))) : Option.empty();
     final int indexWriteParallelism = OptionsResolver.indexWriteParallelism(conf);
-    return new EventBuffers(new ConcurrentSkipListMap<>(), commitGuardOpt, indexBootstrapGuardOption, dataWriteParallelism, indexWriteParallelism);
+    return new EventBuffers(new ConcurrentSkipListMap<>(), commitGuardOpt, indexBootstrapGuardOption, writerBootstrapEventGuardOption, dataWriteParallelism, indexWriteParallelism);
   }
 
   public EventBuffer addEventToBuffer(WriteMetadataEvent event) {
@@ -153,6 +163,17 @@ public class EventBuffers implements Serializable {
     if (!pendingInstants.isEmpty() && this.indexBootstrapGuardOption.isPresent()) {
       this.indexBootstrapGuardOption.get().blockFor(() -> getPendingInstantsBefore(checkpointId));
     }
+  }
+
+  public void awaitWriterBootstrapEventReceived() {
+    if (this.writerBootstrapEventGuardOption.isPresent() && !writerBootstrapEventReceived) {
+      this.writerBootstrapEventGuardOption.get().blockUntil(() -> !writerBootstrapEventReceived);
+    }
+  }
+
+  public void notifyWriterBootstrapEventReceived() {
+    this.writerBootstrapEventReceived = true;
+    this.writerBootstrapEventGuardOption.ifPresent(CommitGuard::unblock);
   }
 
   public void reset(long checkpointId) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -684,7 +684,7 @@ public class TestStreamWriteOperatorCoordinator {
     Thread t = new Thread(() -> {
       try {
         CompletableFuture<CoordinationResponse> responseFuture =
-            coordinator.handleCoordinationRequest(Correspondent.AwaitPendingInstantsRequest.getInstance(1));
+            coordinator.handleCoordinationRequest(Correspondent.AwaitPendingInstantsRequest.getInstance(false, 1));
         Correspondent.AwaitPendingInstantsResponse response =
             CoordinationResponseSerDe.unwrap(responseFuture.get());
         assertNotNull(response);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
@@ -18,9 +18,11 @@
 
 package org.apache.hudi.sink;
 
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -29,6 +31,7 @@ import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestData;
 
@@ -255,6 +258,57 @@ public class TestWriteMergeOnRead extends TestWriteCopyOnWrite {
         // subtask will resend the write metadata event during initialize state
         // and coordinator will recommit data for ckp-2
         .assertNextEvent()
+        // insert another batch of data.
+        .consume(TestData.DATA_SET_PART4)
+        .checkpoint(3)
+        .assertNextEvent(1, "par2")
+        // write metadata will be committed for ckp-3
+        .checkpointComplete(3)
+        // there should be 3 rows and 2 partitions
+        .checkWrittenData(expected, 2)
+        .end();
+  }
+
+  @Test
+  public void testRLIBootstrapBlockingOnPendingInstants() throws Exception {
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX.name());
+    conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key(), "true");
+    conf.setString(HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key(), "true");
+    conf.set(FlinkOptions.WRITE_COMMIT_ACK_TIMEOUT, 10_000L);
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, true);
+
+    Map<String, String> expected = new HashMap<>();
+    expected.put("par1", "[id1,par1,id1,Danny,23,1,par1]");
+    expected.put("par2", "[id3,par2,id3,Julian,53,3,par2, id4,par2,id4,Fabian,31,4,par2]");
+
+    TestHarness testHarness = preparePipeline(conf)
+        .consume(TestData.DATA_SET_PART1)
+        .emptyEventBuffer()
+        .checkpoint(1)
+        .assertNextEvent(1, "par1")
+        .consume(TestData.DATA_SET_PART3)
+        .checkpoint(2)
+        // both ckp-1 and ckp-2 are not committing
+        .assertNextEvent(1, "par2")
+        // then simulating restarting job manually, coordinator will reset to ckp-2
+        // and recommit write metadata for ckp-1
+        .restartCoordinator()
+        .subTaskFails(0, 0)
+        // index bootstrap is blocked now, no records are bootstraped.
+        .checkIndexNotLoaded(
+            new HoodieKey("id1", "par1"),
+            new HoodieKey("id3", "par2"))
+        // subtask will resend the write metadata event during initialize state
+        // and coordinator will recommit data for ckp-2
+        .assertNextEvent();
+
+    // sleep 3 seconds to wait index bootstrap finish
+    Thread.sleep(3_000);
+    // index bootstrap unblocked after pending commit (ckp-2) is committed
+    testHarness
+        .checkIndexLoaded(
+            new HoodieKey("id1", "par1"),
+            new HoodieKey("id3", "par2"))
         // insert another batch of data.
         .consume(TestData.DATA_SET_PART4)
         .checkpoint(3)

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockCorrespondent.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockCorrespondent.java
@@ -58,4 +58,13 @@ public class MockCorrespondent extends Correspondent {
   public void sendWriteMetadataEvent(WriteMetadataEvent writeMetadataEvent) {
     this.coordinator.handleEventFromOperator(0, writeMetadataEvent);
   }
+
+  @Override
+  public void awaitPendingInstantsCommitted(boolean isTaskFailover, long checkpointId) {
+    try {
+      this.coordinator.handleCoordinationRequest(AwaitPendingInstantsRequest.getInstance(isTaskFailover, checkpointId)).get();
+    } catch (Exception e) {
+      throw new HoodieException("Error awaiting pending instants completion from coordinator", e);
+    }
+  }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockStateSnapshotContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/MockStateSnapshotContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils;
+
+import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
+import org.apache.flink.runtime.state.OperatorStateCheckpointOutputStream;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.collect.utils.MockFunctionSnapshotContext;
+
+/** A {@link StateSnapshotContext} for testing purpose. */
+public class MockStateSnapshotContext extends MockFunctionSnapshotContext implements StateSnapshotContext {
+  public MockStateSnapshotContext(long checkpointId) {
+    super(checkpointId);
+  }
+
+  @Override
+  public KeyedStateCheckpointOutputStream getRawKeyedOperatorStateOutput() throws Exception {
+    throw new UnsupportedOperationException("Unsupported now.");
+  }
+
+  @Override
+  public OperatorStateCheckpointOutputStream getRawOperatorStateOutput() throws Exception {
+    throw new UnsupportedOperationException("Unsupported now.");
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
@@ -28,8 +28,10 @@ import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.sink.StreamWriteFunction;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
+import org.apache.hudi.sink.bootstrap.AbstractBootstrapOperator;
 import org.apache.hudi.sink.bootstrap.BootstrapOperator;
 import org.apache.hudi.sink.buffer.MemorySegmentPoolFactory;
+import org.apache.hudi.sink.bootstrap.RLIBootstrapOperator;
 import org.apache.hudi.sink.common.AbstractWriteFunction;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
 import org.apache.hudi.sink.partitioner.BucketAssignFunction;
@@ -59,6 +61,7 @@ import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Collector;
+import org.mockito.Mockito;
 
 import java.util.HashSet;
 import java.util.List;
@@ -66,7 +69,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -91,6 +98,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   private final MockStateInitializationContext indexStateInitializationContext;
   private final TreeMap<Long, byte[]> coordinatorStateStore;
   private final KeyedProcessFunction.Context context;
+  private final ExecutorService bootstrapExecutor;
 
   /**
    * Function that converts row data to HoodieRecord.
@@ -99,7 +107,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   /**
    * Function that load index in state.
    */
-  private BootstrapOperator bootstrapOperator;
+  private AbstractBootstrapOperator bootstrapOperator;
   /**
    * Function that assigns bucket ID.
    */
@@ -117,6 +125,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
    * Index write function for metadata table.
    */
   private IndexWriteFunction indexWriteFunction;
+  private CompletableFuture<Void> bootstrapInitializationFuture;
 
   private CompactFunctionWrapper compactFunctionWrapper;
 
@@ -154,6 +163,8 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
     this.coordinatorStateStore = new TreeMap<>();
     this.asyncCompaction = OptionsResolver.needsAsyncCompaction(conf) || OptionsResolver.needsAsyncMetadataCompaction(conf);
     this.isStreamingWriteIndexEnabled = OptionsResolver.isStreamingIndexWriteEnabled(conf);
+    this.bootstrapExecutor = Executors.newSingleThreadExecutor();
+    this.bootstrapInitializationFuture = CompletableFuture.completedFuture(null);
     this.streamConfig = new StreamConfig(conf);
     streamConfig.setOperatorID(new OperatorID());
     this.streamTask = new MockStreamTaskBuilder(environment)
@@ -179,9 +190,16 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
     bucketAssignerFunction.initializeState(this.stateInitializationContext);
 
     if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
-      bootstrapOperator = new BootstrapOperator(conf);
+      if (isStreamingWriteIndexEnabled) {
+        conf.set(FlinkOptions.WRITE_OPERATOR_UID, "fake_write_op_id");
+      }
+      bootstrapOperator = isStreamingWriteIndexEnabled ? Mockito.spy(new RLIBootstrapOperator(conf)) : new BootstrapOperator(conf);
       CollectOutputAdapter<HoodieFlinkInternalRow> output = new CollectOutputAdapter<>();
       bootstrapOperator.setup(streamTask, streamConfig, output);
+      if (isStreamingWriteIndexEnabled) {
+        ((RLIBootstrapOperator) bootstrapOperator).setCorrespondent(correspondent);
+        doReturn(runtimeContext).when(bootstrapOperator).getRuntimeContext();
+      }
       bootstrapOperator.initializeState(this.stateInitializationContext);
 
       Collector<HoodieFlinkInternalRow> collector = RecordsCollector.getInstance(rowType);
@@ -191,6 +209,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
         bucketAssignerFunction.processElement(bootstrapRecord, context, collector);
         bucketAssignFunctionContext.setCurrentKey(bootstrapRecord.getRecordKey());
       }
+      this.bootstrapInitializationFuture = CompletableFuture.completedFuture(null);
     }
 
     setupWriteFunction();
@@ -204,6 +223,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public void invoke(I record) throws Exception {
+    awaitBootstrapInitializationIfNecessary();
     HoodieFlinkInternalRow hoodieRecord = toHoodieFunction.map((RowData) record);
     stateInitializationContext.getKeyedStateStore().setCurrentKey(hoodieRecord.getRecordKey());
     RecordsCollector<HoodieFlinkInternalRow> collector = RecordsCollector.getInstance(rowType);
@@ -255,10 +275,11 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public void checkpointFunction(long checkpointId) throws Exception {
+    awaitBootstrapInitializationIfNecessary();
     // checkpoint the coordinator first
     checkpointCoordinator(checkpointId);
     if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
-      bootstrapOperator.snapshotState(null);
+      bootstrapOperator.snapshotState(new MockStateSnapshotContext(checkpointId));
     }
     bucketAssignerFunction.snapshotState(new MockFunctionSnapshotContext(checkpointId));
 
@@ -286,6 +307,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public void endInput() {
+    awaitBootstrapInitializationIfNecessary();
     writeFunction.endInput();
     if (isStreamingWriteIndexEnabled) {
       indexWriteFunction.endInput();
@@ -346,14 +368,22 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
     coordinator.subtaskFailed(taskID, new RuntimeException("Dummy exception"));
     // reset the attempt number to simulate the task failover/retries
     this.runtimeContext.setAttemptNumber(attemptNumber);
+    this.bucketAssignFunctionContext.clear();
     setupWriteFunction();
     if (supportStreamingWriteIndex()) {
+      if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
+        setupIndexBootstrapFunction();
+      } else {
+        this.bootstrapInitializationFuture = CompletableFuture.completedFuture(null);
+      }
       setupIndexWriteFunction();
     }
   }
 
   public void close() throws Exception {
+    awaitBootstrapInitializationIfNecessary();
     coordinator.close();
+    bootstrapExecutor.shutdownNow();
     ioManager.close();
     bucketAssignerFunction.close();
     writeFunction.close();
@@ -384,7 +414,10 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public boolean isAlreadyBootstrap() throws Exception {
-    return this.bootstrapOperator.isAlreadyBootstrap();
+    if (this.bootstrapOperator instanceof BootstrapOperator) {
+      return ((BootstrapOperator) this.bootstrapOperator).isAlreadyBootstrap();
+    }
+    return this.bootstrapOperator != null;
   }
 
   // -------------------------------------------------------------------------
@@ -410,6 +443,41 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
     indexWriteFunction.open(conf);
   }
 
+  private void setupIndexBootstrapFunction() {
+    bootstrapOperator = Mockito.spy(new RLIBootstrapOperator(conf));
+    CollectOutputAdapter<HoodieFlinkInternalRow> output = new CollectOutputAdapter<>();
+    bootstrapOperator.setup(streamTask, streamConfig, output);
+    ((RLIBootstrapOperator) bootstrapOperator).setCorrespondent(correspondent);
+    doReturn(runtimeContext).when(bootstrapOperator).getRuntimeContext();
+    this.bootstrapInitializationFuture = CompletableFuture.runAsync(() -> {
+      try {
+        // may be blocked on pending instants committing in coordinator.
+        bootstrapOperator.initializeState(this.stateInitializationContext);
+
+        Collector<HoodieFlinkInternalRow> collector = RecordsCollector.getInstance(rowType);
+        for (HoodieFlinkInternalRow bootstrapRecord : output.getRecords()) {
+          stateInitializationContext.getKeyedStateStore().setCurrentKey(bootstrapRecord.getRecordKey());
+          when(context.getCurrentKey()).thenReturn(bootstrapRecord.getRecordKey());
+          bucketAssignerFunction.processElement(bootstrapRecord, context, collector);
+          bucketAssignFunctionContext.setCurrentKey(bootstrapRecord.getRecordKey());
+        }
+      } catch (Exception e) {
+        throw new CompletionException(e);
+      }
+    }, bootstrapExecutor);
+  }
+
+  private void awaitBootstrapInitializationIfNecessary() {
+    if (bootstrapInitializationFuture == null) {
+      return;
+    }
+    try {
+      bootstrapInitializationFuture.join();
+    } catch (CompletionException e) {
+      throw new HoodieException("Error waiting for bootstrap initialization to finish", e.getCause());
+    }
+  }
+
   // -------------------------------------------------------------------------
   //  Inner Class
   // -------------------------------------------------------------------------
@@ -423,6 +491,10 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
 
     public boolean isKeyInState(String key) {
       return this.updateKeys.contains(key);
+    }
+
+    public void clear() {
+      this.updateKeys.clear();
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestEventBuffers.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestEventBuffers.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -107,6 +108,46 @@ public class TestEventBuffers {
     } finally {
       executor.shutdownNow();
     }
+  }
+
+  @Test
+  void testAwaitWriterBootstrapEventReceivedWaitsUntilNotified() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX.name());
+    conf.set(FlinkOptions.INDEX_BOOTSTRAP_ENABLED, true);
+    conf.set(FlinkOptions.WRITE_COMMIT_ACK_TIMEOUT, 5_000L);
+    conf.set(FlinkOptions.INDEX_WRITE_TASKS, 4);
+    EventBuffers eventBuffers = EventBuffers.getInstance(conf, 1);
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      CompletableFuture<Void> waitingFuture1 = CompletableFuture.runAsync(
+          eventBuffers::awaitWriterBootstrapEventReceived, executor);
+      CompletableFuture<Void> waitingFuture2 = CompletableFuture.runAsync(
+          eventBuffers::awaitWriterBootstrapEventReceived, executor);
+
+      Thread.sleep(100);
+      assertFalse(waitingFuture1.isDone());
+      assertFalse(waitingFuture2.isDone());
+
+      eventBuffers.notifyWriterBootstrapEventReceived();
+
+      waitingFuture1.get(2, TimeUnit.SECONDS);
+      assertTrue(waitingFuture1.isDone());
+      waitingFuture2.get(2, TimeUnit.SECONDS);
+      assertTrue(waitingFuture2.isDone());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void testAwaitWriterBootstrapEventReceivedNoOpWithoutBootstrapGuard() {
+    Configuration conf = new Configuration();
+    conf.set(FlinkOptions.WRITE_COMMIT_ACK_TIMEOUT, 5_000L);
+    EventBuffers eventBuffers = EventBuffers.getInstance(conf, 1);
+
+    assertDoesNotThrow(eventBuffers::awaitWriterBootstrapEventReceived);
   }
 
   private static WriteMetadataEvent newWriteEvent(long checkpointId, String instant) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -616,6 +616,14 @@ public class TestWriteBase {
       return this;
     }
 
+    public TestHarness checkIndexNotLoaded(HoodieKey... keys) {
+      for (HoodieKey key : keys) {
+        assertFalse(this.pipeline.isKeyInState(key),
+            "Key: " + key + " assumes to not in the index state");
+      }
+      return this;
+    }
+
     public TestHarness assertBootstrapped() throws Exception {
       assertTrue(this.pipeline.isAlreadyBootstrap());
       return this;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

On Flink job restart, Record Level Index (RLI) bootstrap could start loading index records before the writer side had resent bootstrap metadata events and before previously pending instants were recommitted. That creates a
  race between index bootstrap and recovery, which can leave the restored job observing incomplete state during bootstrap.

This PR makes RLI bootstrap explicitly block on recovery progress: it waits until the coordinator receives writer bootstrap signals and all pending instants from the previous run are completed before index bootstrap
  proceeds, fixes #18300 

### Summary and Changelog

- Update RLIBootstrapOperator to wait on coordinator-side recovery signals before loading RLI state on restored jobs.
- Make restored write tasks always send a bootstrap event, even when there is no uncommitted write metadata to resend, so RLI bootstrap cannot remain blocked indefinitely.
- Add restart-path test coverage for the pending-instant scenario in Flink MOR write tests, plus focused unit tests for the new event-buffer blocking behavior.

### Impact

This change affects Flink streaming jobs using RLI with bootstrap enabled, specifically the recovery path after job restart or failover.

### Risk Level

low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
