### PR TITLE
fix(flink): Don't perform table service during mdt initialization if …

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -194,7 +194,11 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
             if (metadataWriter.hasPartitionsStateChanged()) {
               table.getMetaClient().reloadTableConfig();
             }
-            metadataWriter.performTableServices(Option.empty());
+            // Do not perform table service for mdt when streaming write is enabled, since the compaction/clean
+            // will be performed asynchronously in the dedicated compaction pipeline.
+            if (!this.config.getMetadataConfig().isStreamingWriteEnabled()) {
+              metadataWriter.performTableServices(Option.empty());
+            }
           }
         }
       } catch (Exception e) {

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieFlinkTableServiceClient.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
+import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.FlinkHoodieBackedTableMetadataWriter;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.table.HoodieFlinkTable;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.testutils.HoodieFlinkClientTestHarness;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarness {
+
+  @BeforeEach
+  void setUp() throws IOException {
+    initPath();
+    initFileSystem();
+    initMetaClient();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testInitMetadataTableRespectsStreamingWriteFlag(boolean metadataStreamingWriteEnabled) {
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(metaClient.getBasePath())
+        .withLockConfig(HoodieLockConfig.newBuilder()
+            .withLockProvider(InProcessLockProvider.class)
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withStreamingWriteEnabled(metadataStreamingWriteEnabled)
+            .build())
+        .build();
+
+    HoodieFlinkTable<?> table = mock(HoodieFlinkTable.class);
+    HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class);
+    HoodieTimeline inflightAndRequestedTimeline = mock(HoodieTimeline.class);
+    when(table.getActiveTimeline()).thenReturn(activeTimeline);
+    when(activeTimeline.filterInflightsAndRequested()).thenReturn(inflightAndRequestedTimeline);
+    when(inflightAndRequestedTimeline.lastInstant()).thenReturn(Option.empty());
+
+    FlinkHoodieBackedTableMetadataWriter metadataWriter = mock(FlinkHoodieBackedTableMetadataWriter.class);
+    when(metadataWriter.isInitialized()).thenReturn(true);
+
+    TestableHoodieFlinkTableServiceClient tableServiceClient =
+        new TestableHoodieFlinkTableServiceClient(context, writeConfig, Option.empty(), table);
+    try (MockedStatic<FlinkHoodieBackedTableMetadataWriter> writerFactory =
+             Mockito.mockStatic(FlinkHoodieBackedTableMetadataWriter.class)) {
+      writerFactory.when(() -> FlinkHoodieBackedTableMetadataWriter.create(any(), any(), any(), any()))
+          .thenReturn(metadataWriter);
+
+      tableServiceClient.initMetadataTable();
+    } finally {
+      tableServiceClient.close();
+    }
+
+    verify(metadataWriter, times(metadataStreamingWriteEnabled ? 0 : 1)).performTableServices(any());
+    verify(table).deleteMetadataIndexIfNecessary();
+    verify(table, never()).maybeDeleteMetadataTable();
+  }
+
+  private static class TestableHoodieFlinkTableServiceClient extends HoodieFlinkTableServiceClient<Object> {
+    private final HoodieTable mockedTable;
+
+    protected TestableHoodieFlinkTableServiceClient(HoodieFlinkEngineContext context,
+                                                    HoodieWriteConfig clientConfig,
+                                                    Option<EmbeddedTimelineService> timelineService,
+                                                    HoodieTable mockedTable) {
+      super(context, clientConfig, timelineService);
+      this.mockedTable = mockedTable;
+    }
+
+    @Override
+    protected HoodieTable createTable(HoodieWriteConfig config, StorageConfiguration<?> storageConf, boolean skipValidation) {
+      return mockedTable;
+    }
+  }
+}


### PR DESCRIPTION
…streaming write is enabled

### Describe the issue this Pull Request addresses

`HoodieFlinkTableServiceClient#initMetadataTable()` always ran `performTableServices`, even when metadata streaming write was enabled. In streaming mode, this should be skipped. fixes #18284 

### Summary and Changelog

- Added a guard in `initMetadataTable()`:
  - Run `metadataWriter.performTableServices(...)` only when `hoodie.metadata.streaming.write.enabled=false`.
- Added a parameterized test to cover both streaming modes and verify invocation behavior.

### Impact

- Fixes incorrect metadata table service triggering in Flink streaming metadata mode.

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
