### PR TITLE
fix: Improve config docs of enabling column stats in metadata table

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -203,7 +203,9 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.11.0")
       .withDocumentation("Enable indexing column ranges of user data files under metadata table key lookups. When "
           + "enabled, metadata table will have a partition to store the column ranges and will be "
-          + "used for pruning files during the index lookups.");
+          + "used for pruning files during the index lookups. "
+          + "For the Spark engine, this config defaults to true (enabled), overriding the base default of false. "
+          + "For Flink and Java engines, this remains false by default.");
 
   public static final ConfigProperty<Integer> METADATA_INDEX_COLUMN_STATS_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.file.group.count")


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The config docs of enabling column stats in metadata table is confusing as column stats in metadata table are enabled by default on Spark, though config docs mention `false` as default.

### Summary and Changelog

This PR updates the config docs of enabling column stats in metadata table so it's clear.

### Impact

Docs clarify

### Risk Level

none

### Documentation Update

as above

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
