### PR TITLE
fix: Remove noisy logging when table partition is empty

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -323,7 +323,6 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
   Stream<HoodieFileGroup> fetchAllStoredFileGroups(String partition) {
     List<HoodieFileGroup> fileGroups = partitionToFileGroupsMap.get(partition);
     if (fileGroups == null || fileGroups.isEmpty()) {
-      LOG.warn("Partition: {} is not available in store", partition);
       return Stream.empty();
     }
     return new ArrayList<>(partitionToFileGroupsMap.get(partition)).stream();


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

#11161 introduces a logic to check if the partition is empty in the file system view.  The logging is noisy.

### Summary and Changelog

This PR removes the noisy logging.

### Impact

Better logging experience.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
