### PR TITLE
refactor(spark): remove redundant SparkAdapter methods

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -36,21 +36,21 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.avro.{HoodieAvroDeserializer, HoodieAvroSerializer}
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, InterpretedPredicate, SpecializedGetters}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, SpecializedGetters}
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Command, DeleteFromTable, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.catalyst.util.DateFormatter
+import org.apache.spark.sql.catalyst.util.{DateFormatter, METADATA_COL_ATTR_KEY}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
-import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{HoodieParquetReadSupport, ParquetFileFormat, ParquetFilters}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.parser.HoodieExtendedParserInterface
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
-import org.apache.spark.sql.types.{DataType, Metadata, StructType}
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.types.{DataType, Metadata, MetadataBuilder, StructType}
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnarBatchRow, ColumnVector}
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.storage.StorageLevel._
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.util.{Locale, TimeZone}
@@ -64,18 +64,21 @@ trait SparkAdapter extends Serializable {
   /**
    * Checks whether provided instance of [[InternalRow]] is actually an instance of [[ColumnarBatchRow]]
    */
-  def isColumnarBatchRow(r: InternalRow): Boolean
+  def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]
 
   /**
    * Creates Catalyst [[Metadata]] for Hudi's meta-fields (designating these w/
    * [[METADATA_COL_ATTR_KEY]] if available (available in Spark >= 3.2)
    */
-  def createCatalystMetadataForMetaField: Metadata
+  def createCatalystMetadataForMetaField: Metadata =
+    new MetadataBuilder()
+      .putBoolean(METADATA_COL_ATTR_KEY, value = true)
+      .build()
 
   /**
    * Inject table-valued functions to SparkSessionExtensions
    */
-  def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {}
+  def injectTableFunctions(extensions: SparkSessionExtensions): Unit
 
   /**
    * Inject scalar functions into Spark SQL function registry.
@@ -169,13 +172,6 @@ trait SparkAdapter extends Serializable {
   def makeColumnarBatch(vectors: Array[ColumnVector], numRows: Int): ColumnarBatch
 
   /**
-   * Create instance of [[InterpretedPredicate]]
-   *
-   * TODO move to HoodieCatalystExpressionUtils
-   */
-  def createInterpretedPredicate(e: Expression): InterpretedPredicate
-
-  /**
    * Create Hoodie relation based on globPaths, otherwise use tablePath if it's empty
    */
   def createRelation(sqlContext: SQLContext,
@@ -197,12 +193,29 @@ trait SparkAdapter extends Serializable {
    * Extract condition in [[DeleteFromTable]]
    * SPARK-38626 condition is no longer Option in Spark 3.3
    */
-  def extractDeleteCondition(deleteFromTable: Command): Expression
+  def extractDeleteCondition(deleteFromTable: Command): Expression = {
+    deleteFromTable.asInstanceOf[DeleteFromTable].condition
+  }
 
   /**
    * Converts instance of [[StorageLevel]] to a corresponding string
    */
-  def convertStorageLevelToString(level: StorageLevel): String
+  def convertStorageLevelToString(level: StorageLevel): String = level match {
+    case NONE => "NONE"
+    case DISK_ONLY => "DISK_ONLY"
+    case DISK_ONLY_2 => "DISK_ONLY_2"
+    case DISK_ONLY_3 => "DISK_ONLY_3"
+    case MEMORY_ONLY => "MEMORY_ONLY"
+    case MEMORY_ONLY_2 => "MEMORY_ONLY_2"
+    case MEMORY_ONLY_SER => "MEMORY_ONLY_SER"
+    case MEMORY_ONLY_SER_2 => "MEMORY_ONLY_SER_2"
+    case MEMORY_AND_DISK => "MEMORY_AND_DISK"
+    case MEMORY_AND_DISK_2 => "MEMORY_AND_DISK_2"
+    case MEMORY_AND_DISK_SER => "MEMORY_AND_DISK_SER"
+    case MEMORY_AND_DISK_SER_2 => "MEMORY_AND_DISK_SER_2"
+    case OFF_HEAP => "OFF_HEAP"
+    case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $level")
+  }
 
   /**
    * Tries to translate a Catalyst Expression into data source Filter
@@ -271,14 +284,6 @@ trait SparkAdapter extends Serializable {
     new HoodieParquetReadSupport(convertTz, enableVectorizedReader, enableTimestampFieldRepair,
       datetimeRebaseSpec, getRebaseSpec("LEGACY"), tableSchemaOpt)
   }
-
-  /**
-   * use new qe execute
-   */
-  def sqlExecutionWithNewExecutionId[T](sparkSession: SparkSession,
-                                        queryExecution: QueryExecution,
-                                        name: Option[String] = None)(body: => T): T
-
 
   /**
    * Stop spark context with exit code

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -26,31 +26,34 @@ import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
 import org.apache.hudi.common.util.JsonUtils
 import org.apache.hudi.spark.internal.ReflectUtil
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.schema.Type
 import org.apache.parquet.schema.Type.Repetition
-import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{AnalysisException, Column, DataFrame, DataFrameUtil, Dataset, Encoder, HoodieUnsafeUtils, HoodieUTF8StringFactory, Spark3DataFrameUtil, Spark3HoodieUnsafeUtils, Spark3HoodieUTF8StringFactory, SparkSession, SQLContext}
+import org.apache.spark.sql.{AnalysisException, Column, DataFrame, DataFrameUtil, Dataset, Encoder, HoodieUnsafeUtils, HoodieUTF8StringFactory, Spark3DataFrameUtil, Spark3HoodieUnsafeUtils, Spark3HoodieUTF8StringFactory, SparkSession, SparkSessionExtensions, SQLContext}
 import org.apache.spark.sql.FileFormatUtilsForFileGroupReader.applyFiltersToPlan
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, InterpretedPredicate, Predicate, SpecializedGetters}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, SpecializedGetters}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.catalyst.util.DateFormatter
-import org.apache.spark.sql.execution.{PartitionedFileUtil, QueryExecution, SQLExecution}
+import org.apache.spark.sql.execution.PartitionedFileUtil
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.parquet.HoodieFormatTrait
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.hudi.{HoodieMemoryStream, SparkAdapter}
+import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
+import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
-import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.time.ZoneId
@@ -97,10 +100,6 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
     }
   }
 
-  override def createInterpretedPredicate(e: Expression): InterpretedPredicate = {
-    Predicate.createInterpreted(e)
-  }
-
   override def createHoodieFileScanRDD(sparkSession: SparkSession,
                                        readFunction: PartitionedFile => Iterator[InternalRow],
                                        filePartitions: Seq[FilePartition],
@@ -117,7 +116,19 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
     DefaultSource.createRelation(sqlContext, metaClient, dataSchema, parameters.asScala.toMap)
   }
 
-  override def convertStorageLevelToString(level: StorageLevel): String
+  override def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {
+    TableValuedFunctions.funcs.foreach(extensions.injectTableFunction)
+  }
+
+  override def injectScalarFunctions(extensions: SparkSessionExtensions): Unit = {
+    ScalarFunctions.funcs.foreach(extensions.injectFunction)
+  }
+
+  override def injectPlannerStrategies(extensions: SparkSessionExtensions): Unit = {
+    extensions.injectPlannerStrategy { session =>
+      BatchedBlobReaderStrategy(session)
+    }
+  }
 
   override def translateFilter(predicate: Expression,
                                supportNestedPredicatePushdown: Boolean = false): Option[Filter] = {
@@ -128,13 +139,12 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
     new ColumnarBatch(vectors, numRows)
   }
 
-  override def sqlExecutionWithNewExecutionId[T](sparkSession: SparkSession,
-                                                 queryExecution: QueryExecution,
-                                                 name: Option[String])(body: => T): T = {
-      SQLExecution.withNewExecutionId(queryExecution, name)(body)
+  override def createLanceFileReader(vectorized: Boolean,
+                                     sqlConf: SQLConf,
+                                     options: Map[String, String],
+                                     hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
+    Some(new SparkLanceReaderBase(vectorized))
   }
-
-  def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit
 
   override def createInternalRow(metaFields: Array[UTF8String],
                                 sourceRow: InternalRow,

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
@@ -30,25 +30,19 @@ import org.apache.spark.sql.avro._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, ResolvedTable}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{Expression}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
+import org.apache.spark.sql.catalyst.util.RebaseDateTime
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.orc.{OrcColumnarBatchReader, SparkOrcReaderBase}
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters, Spark33LegacyHoodieParquetFileFormat, Spark33ParquetReader}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
-import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark3_3ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, Metadata, MetadataBuilder, StructType}
-import org.apache.spark.sql.vectorized.ColumnarBatchRow
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.storage.StorageLevel._
+import org.apache.spark.sql.types.{DataType, StructType}
 
 /**
  * Implementation of [[SparkAdapter]] for Spark 3.3.x branch
@@ -71,13 +65,6 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
     }
   }
 
-  override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]
-
-  def createCatalystMetadataForMetaField: Metadata =
-    new MetadataBuilder()
-      .putBoolean(METADATA_COL_ATTR_KEY, value = true)
-      .build()
-
   override def getCatalystPlanUtils: HoodieCatalystPlansUtils = HoodieSpark33CatalystPlanUtils
 
   override def getCatalystExpressionUtils: HoodieCatalystExpressionUtils = HoodieSpark33CatalystExpressionUtils
@@ -97,44 +84,6 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
 
   override def createLegacyHoodieParquetFileFormat(appendPartitionValues: Boolean): Option[ParquetFileFormat] = {
     Some(new Spark33LegacyHoodieParquetFileFormat(appendPartitionValues))
-  }
-
-  override def extractDeleteCondition(deleteFromTable: Command): Expression = {
-    deleteFromTable.asInstanceOf[DeleteFromTable].condition
-  }
-
-  override def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {
-    TableValuedFunctions.funcs.foreach(extensions.injectTableFunction)
-  }
-
-  override def injectScalarFunctions(extensions: SparkSessionExtensions): Unit = {
-    ScalarFunctions.funcs.foreach(extensions.injectFunction)
-  }
-
-  override def injectPlannerStrategies(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectPlannerStrategy { session =>
-      BatchedBlobReaderStrategy(session)
-    }
-  }
-
-  /**
-   * Converts instance of [[StorageLevel]] to a corresponding string
-   */
-  override def convertStorageLevelToString(level: StorageLevel): String = level match {
-    case NONE => "NONE"
-    case DISK_ONLY => "DISK_ONLY"
-    case DISK_ONLY_2 => "DISK_ONLY_2"
-    case DISK_ONLY_3 => "DISK_ONLY_3"
-    case MEMORY_ONLY => "MEMORY_ONLY"
-    case MEMORY_ONLY_2 => "MEMORY_ONLY_2"
-    case MEMORY_ONLY_SER => "MEMORY_ONLY_SER"
-    case MEMORY_ONLY_SER_2 => "MEMORY_ONLY_SER_2"
-    case MEMORY_AND_DISK => "MEMORY_AND_DISK"
-    case MEMORY_AND_DISK_2 => "MEMORY_AND_DISK_2"
-    case MEMORY_AND_DISK_SER => "MEMORY_AND_DISK_SER"
-    case MEMORY_AND_DISK_SER_2 => "MEMORY_AND_DISK_SER_2"
-    case OFF_HEAP => "OFF_HEAP"
-    case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $level")
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
@@ -30,26 +30,19 @@ import org.apache.spark.sql.avro._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, ResolvedTable}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{Expression}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
+import org.apache.spark.sql.catalyst.util.RebaseDateTime
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.orc.{OrcColumnarBatchReader, SparkOrcReaderBase}
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters, Spark34LegacyHoodieParquetFileFormat, Spark34ParquetReader}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
-import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark3_4ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructType}
-import org.apache.spark.sql.vectorized.ColumnarBatchRow
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.storage.StorageLevel._
+import org.apache.spark.sql.types.{DataType, DataTypes, StructType}
 
 /**
  * Implementation of [[SparkAdapter]] for Spark 3.4.x branch
@@ -72,13 +65,6 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
     }
   }
 
-  override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]
-
-  def createCatalystMetadataForMetaField: Metadata =
-    new MetadataBuilder()
-      .putBoolean(METADATA_COL_ATTR_KEY, value = true)
-      .build()
-
   override def getCatalystExpressionUtils: HoodieCatalystExpressionUtils = HoodieSpark34CatalystExpressionUtils
 
   override def getCatalystPlanUtils: HoodieCatalystPlansUtils = HoodieSpark34CatalystPlanUtils
@@ -100,44 +86,6 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
     Some(new Spark34LegacyHoodieParquetFileFormat(appendPartitionValues))
   }
 
-  override def extractDeleteCondition(deleteFromTable: Command): Expression = {
-    deleteFromTable.asInstanceOf[DeleteFromTable].condition
-  }
-
-  override def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {
-    TableValuedFunctions.funcs.foreach(extensions.injectTableFunction)
-  }
-
-  override def injectScalarFunctions(extensions: SparkSessionExtensions): Unit = {
-    ScalarFunctions.funcs.foreach(extensions.injectFunction)
-  }
-
-  override def injectPlannerStrategies(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectPlannerStrategy { session =>
-      BatchedBlobReaderStrategy(session)
-    }
-  }
-
-  /**
-   * Converts instance of [[StorageLevel]] to a corresponding string
-   */
-  override def convertStorageLevelToString(level: StorageLevel): String = level match {
-    case NONE => "NONE"
-    case DISK_ONLY => "DISK_ONLY"
-    case DISK_ONLY_2 => "DISK_ONLY_2"
-    case DISK_ONLY_3 => "DISK_ONLY_3"
-    case MEMORY_ONLY => "MEMORY_ONLY"
-    case MEMORY_ONLY_2 => "MEMORY_ONLY_2"
-    case MEMORY_ONLY_SER => "MEMORY_ONLY_SER"
-    case MEMORY_ONLY_SER_2 => "MEMORY_ONLY_SER_2"
-    case MEMORY_AND_DISK => "MEMORY_AND_DISK"
-    case MEMORY_AND_DISK_2 => "MEMORY_AND_DISK_2"
-    case MEMORY_AND_DISK_SER => "MEMORY_AND_DISK_SER"
-    case MEMORY_AND_DISK_SER_2 => "MEMORY_AND_DISK_SER_2"
-    case OFF_HEAP => "OFF_HEAP"
-    case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $level")
-  }
-
   /**
    * Get parquet file reader
    *
@@ -157,13 +105,6 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
   override def createOrcFileReader(vectorized: Boolean, sqlConf: SQLConf, options: Map[String, String], hadoopConf: Configuration, dataSchema: StructType): SparkColumnarFileReader = {
     SparkOrcReaderBase.build(vectorized, sqlConf, options, hadoopConf, dataSchema,
       (capacity, memoryMode) => new OrcColumnarBatchReader(capacity, memoryMode))
-  }
-
-  override def createLanceFileReader(vectorized: Boolean,
-                                     sqlConf: SQLConf,
-                                     options: Map[String, String],
-                                     hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
-    Some(new SparkLanceReaderBase(vectorized))
   }
 
   override def createVortexFileReader(vectorized: Boolean,

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -29,25 +29,18 @@ import org.apache.spark.sql.avro._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, ResolvedTable}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{Expression}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
+import org.apache.spark.sql.catalyst.util.RebaseDateTime
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.orc.{OrcColumnarBatchReader, SparkOrcReaderBase}
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters, Spark35LegacyHoodieParquetFileFormat, Spark35ParquetReader}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
-import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark3_5ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructType}
-import org.apache.spark.sql.vectorized.ColumnarBatchRow
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.storage.StorageLevel._
+import org.apache.spark.sql.types.{DataType, DataTypes, StructType}
 
 /**
  * Implementation of [[SparkAdapter]] for Spark 3.5.x branch
@@ -74,13 +67,6 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
     v2Table.getClass.getName.contains("HoodieInternalV2Table")
   }
 
-  override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]
-
-  def createCatalystMetadataForMetaField: Metadata =
-    new MetadataBuilder()
-      .putBoolean(METADATA_COL_ATTR_KEY, value = true)
-      .build()
-
   override def getCatalystExpressionUtils: HoodieCatalystExpressionUtils = HoodieSpark35CatalystExpressionUtils
 
   override def getCatalystPlanUtils: HoodieCatalystPlansUtils = HoodieSpark35CatalystPlanUtils
@@ -100,44 +86,6 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
 
   override def createLegacyHoodieParquetFileFormat(appendPartitionValues: Boolean): Option[ParquetFileFormat] = {
     Some(new Spark35LegacyHoodieParquetFileFormat(appendPartitionValues))
-  }
-
-  override def extractDeleteCondition(deleteFromTable: Command): Expression = {
-    deleteFromTable.asInstanceOf[DeleteFromTable].condition
-  }
-
-  override def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {
-    TableValuedFunctions.funcs.foreach(extensions.injectTableFunction)
-  }
-
-  override def injectScalarFunctions(extensions: SparkSessionExtensions): Unit = {
-    ScalarFunctions.funcs.foreach(extensions.injectFunction)
-  }
-
-  override def injectPlannerStrategies(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectPlannerStrategy { session =>
-      BatchedBlobReaderStrategy(session)
-    }
-  }
-
-  /**
-   * Converts instance of [[StorageLevel]] to a corresponding string
-   */
-  override def convertStorageLevelToString(level: StorageLevel): String = level match {
-    case NONE => "NONE"
-    case DISK_ONLY => "DISK_ONLY"
-    case DISK_ONLY_2 => "DISK_ONLY_2"
-    case DISK_ONLY_3 => "DISK_ONLY_3"
-    case MEMORY_ONLY => "MEMORY_ONLY"
-    case MEMORY_ONLY_2 => "MEMORY_ONLY_2"
-    case MEMORY_ONLY_SER => "MEMORY_ONLY_SER"
-    case MEMORY_ONLY_SER_2 => "MEMORY_ONLY_SER_2"
-    case MEMORY_AND_DISK => "MEMORY_AND_DISK"
-    case MEMORY_AND_DISK_2 => "MEMORY_AND_DISK_2"
-    case MEMORY_AND_DISK_SER => "MEMORY_AND_DISK_SER"
-    case MEMORY_AND_DISK_SER_2 => "MEMORY_AND_DISK_SER_2"
-    case OFF_HEAP => "OFF_HEAP"
-    case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $level")
   }
 
   /**
@@ -172,13 +120,6 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
                                    dataSchema: StructType): SparkColumnarFileReader = {
     SparkOrcReaderBase.build(vectorized, sqlConf, options, hadoopConf, dataSchema,
       (capacity, memoryMode) => new OrcColumnarBatchReader(capacity, memoryMode))
-  }
-
-  override def createLanceFileReader(vectorized: Boolean,
-                                     sqlConf: SQLConf,
-                                     options: Map[String, String],
-                                     hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
-    Some(new SparkLanceReaderBase(vectorized))
   }
 
   override def createVortexFileReader(vectorized: Boolean,

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
@@ -30,27 +30,30 @@ import org.apache.parquet.schema.Type.Repetition
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Column, DataFrame, DataFrameUtil, Dataset, Encoder, ExpressionColumnNodeWrapper, HoodieUnsafeUtils, HoodieUTF8StringFactory, Spark4DataFrameUtil, Spark4HoodieUnsafeUtils, Spark4HoodieUTF8StringFactory, SparkSession, SQLContext}
+import org.apache.spark.sql.{Column, DataFrame, DataFrameUtil, Dataset, Encoder, ExpressionColumnNodeWrapper, HoodieUnsafeUtils, HoodieUTF8StringFactory, Spark4DataFrameUtil, Spark4HoodieUnsafeUtils, Spark4HoodieUTF8StringFactory, SparkSession, SparkSessionExtensions, SQLContext}
 import org.apache.spark.sql.FileFormatUtilsForFileGroupReader.applyFiltersToPlan
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, InterpretedPredicate, Predicate, SpecializedGetters}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, SpecializedGetters}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.util.DateFormatter
+import org.apache.spark.sql.catalyst.util.{DateFormatter, RebaseDateTime}
 import org.apache.spark.sql.classic.ColumnConversions
-import org.apache.spark.sql.execution.{PartitionedFileUtil, QueryExecution, SQLExecution}
+import org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback
+import org.apache.spark.sql.execution.PartitionedFileUtil
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.orc.{OrcColumnarBatchReader, SparkOrcReaderBase}
 import org.apache.spark.sql.execution.datasources.parquet.{HoodieFormatTrait, ParquetFilters, SparkShreddingUtils}
 import org.apache.spark.sql.hudi.SparkAdapter
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
+import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
+import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
-import org.apache.spark.sql.types.{BinaryType, DataType, StructType, VariantType}
+import org.apache.spark.sql.types.{BinaryType, DataType, DataTypes, StructType, VariantType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
-import org.apache.spark.storage.StorageLevel
 import org.apache.spark.types.variant.Variant
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -99,8 +102,8 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
     }
   }
 
-  override def createInterpretedPredicate(e: Expression): InterpretedPredicate = {
-    Predicate.createInterpreted(e)
+  def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
+    v2Table.getClass.getName.contains("HoodieInternalV2Table")
   }
 
   override def createHoodieFileScanRDD(sparkSession: SparkSession,
@@ -128,7 +131,19 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
     DefaultSource.createRelation(sqlContext, metaClient, dataSchema, parameters.asScala.toMap)
   }
 
-  override def convertStorageLevelToString(level: StorageLevel): String
+  override def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {
+    TableValuedFunctions.funcs.foreach(extensions.injectTableFunction)
+  }
+
+  override def injectScalarFunctions(extensions: SparkSessionExtensions): Unit = {
+    ScalarFunctions.funcs.foreach(extensions.injectFunction)
+  }
+
+  override def injectPlannerStrategies(extensions: SparkSessionExtensions): Unit = {
+    extensions.injectPlannerStrategy { session =>
+      BatchedBlobReaderStrategy(session)
+    }
+  }
 
   override def translateFilter(predicate: Expression,
                                supportNestedPredicatePushdown: Boolean = false): Option[Filter] = {
@@ -139,13 +154,16 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
     new ColumnarBatch(vectors, numRows)
   }
 
-  override def sqlExecutionWithNewExecutionId[T](sparkSession: SparkSession,
-                                                 queryExecution: QueryExecution,
-                                                 name: Option[String])(body: => T): T = {
-      SQLExecution.withNewExecutionId(queryExecution, name)(body)
+  override def createLanceFileReader(vectorized: Boolean,
+                                     sqlConf: SQLConf,
+                                     options: Map[String, String],
+                                     hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
+    Some(new SparkLanceReaderBase(vectorized))
   }
 
-  def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit
+  override def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit = {
+    jssc.sc.stop(exitCode)
+  }
 
   override def getUTF8StringFactory: HoodieUTF8StringFactory = Spark4HoodieUTF8StringFactory
 
@@ -180,6 +198,18 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
     org.apache.spark.sql.classic.Dataset.ofRows(sqlContext.sparkSession.asInstanceOf[org.apache.spark.sql.classic.SparkSession],
       applyFiltersToPlan(logicalRelation, requiredSchema, resolvedSchema,
         relation.fileFormat.asInstanceOf[HoodieFormatTrait].getRequiredFilters))
+  }
+
+  override def isLegacyBehaviorPolicy(value: Object): Boolean = {
+    value == LegacyBehaviorPolicy.LEGACY
+  }
+
+  override def isTimestampNTZType(dataType: DataType): Boolean = {
+    dataType == DataTypes.TimestampNTZType
+  }
+
+  override def getRebaseSpec(policy: String): RebaseDateTime.RebaseSpec = {
+    RebaseDateTime.RebaseSpec(LegacyBehaviorPolicy.withName(policy))
   }
 
   override def createParquetFilters(schema: MessageType, storageConf: StorageConfiguration[_], sqlConf: SQLConf): ParquetFilters = {

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -27,35 +27,26 @@ import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.schema.MessageType
 import org.apache.spark.SparkEnv
-import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.avro._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, ResolvedTable}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{Expression}
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.parquet.{HoodieParquetReadSupport, ParquetFileFormat, Spark40HoodieParquetReadSupport, Spark40LegacyHoodieParquetFileFormat, Spark40ParquetReader}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.vortex.SparkVortexReaderBase
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.hudi.HoodieMemoryStream
-import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
-import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_0ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructType}
-import org.apache.spark.sql.vectorized.ColumnarBatchRow
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.storage.StorageLevel._
+import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import scala.jdk.CollectionConverters.MapHasAsScala
@@ -80,17 +71,6 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
       }
     }
   }
-
-  def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    v2Table.getClass.getName.contains("HoodieInternalV2Table")
-  }
-
-  override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]
-
-  def createCatalystMetadataForMetaField: Metadata =
-    new MetadataBuilder()
-      .putBoolean(METADATA_COL_ATTR_KEY, value = true)
-      .build()
 
   override def getCatalystExpressionUtils: HoodieCatalystExpressionUtils = HoodieSpark40CatalystExpressionUtils
 
@@ -134,44 +114,6 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
     new Spark40HoodiePartitionFileSliceMapping(values, slices)
   }
 
-  override def extractDeleteCondition(deleteFromTable: Command): Expression = {
-    deleteFromTable.asInstanceOf[DeleteFromTable].condition
-  }
-
-  override def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {
-    TableValuedFunctions.funcs.foreach(extensions.injectTableFunction)
-  }
-
-  override def injectScalarFunctions(extensions: SparkSessionExtensions): Unit = {
-    ScalarFunctions.funcs.foreach(extensions.injectFunction)
-  }
-
-  override def injectPlannerStrategies(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectPlannerStrategy { session =>
-      BatchedBlobReaderStrategy(session)
-    }
-  }
-
-  /**
-   * Converts instance of [[StorageLevel]] to a corresponding string
-   */
-  override def convertStorageLevelToString(level: StorageLevel): String = level match {
-    case NONE => "NONE"
-    case DISK_ONLY => "DISK_ONLY"
-    case DISK_ONLY_2 => "DISK_ONLY_2"
-    case DISK_ONLY_3 => "DISK_ONLY_3"
-    case MEMORY_ONLY => "MEMORY_ONLY"
-    case MEMORY_ONLY_2 => "MEMORY_ONLY_2"
-    case MEMORY_ONLY_SER => "MEMORY_ONLY_SER"
-    case MEMORY_ONLY_SER_2 => "MEMORY_ONLY_SER_2"
-    case MEMORY_AND_DISK => "MEMORY_AND_DISK"
-    case MEMORY_AND_DISK_2 => "MEMORY_AND_DISK_2"
-    case MEMORY_AND_DISK_SER => "MEMORY_AND_DISK_SER"
-    case MEMORY_AND_DISK_SER_2 => "MEMORY_AND_DISK_SER_2"
-    case OFF_HEAP => "OFF_HEAP"
-    case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $level")
-  }
-
   /**
    * Get parquet file reader
    *
@@ -199,22 +141,11 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
       datetimeRebaseSpec, getRebaseSpec("LEGACY"), tableSchemaOpt)
   }
 
-  override def createLanceFileReader(vectorized: Boolean,
-                                     sqlConf: SQLConf,
-                                     options: Map[String, String],
-                                     hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
-    Some(new SparkLanceReaderBase(vectorized))
-  }
-
   override def createVortexFileReader(vectorized: Boolean,
                                       sqlConf: SQLConf,
                                       options: Map[String, String],
                                       hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
     Some(new SparkVortexReaderBase(vectorized))
-  }
-
-  override def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit = {
-    jssc.sc.stop(exitCode)
   }
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
@@ -225,18 +156,6 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))
-  }
-
-  override def isLegacyBehaviorPolicy(value: Object): Boolean = {
-    value == LegacyBehaviorPolicy.LEGACY
-  }
-
-  override def isTimestampNTZType(dataType: DataType): Boolean = {
-    dataType == DataTypes.TimestampNTZType
-  }
-
-  override def getRebaseSpec(policy: String): RebaseDateTime.RebaseSpec = {
-    RebaseDateTime.RebaseSpec(LegacyBehaviorPolicy.withName(policy))
   }
 
   override def createMemoryStream[T: Encoder](id: Int, sparkSession: SparkSession): HoodieMemoryStream[T] = {

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -26,7 +26,6 @@ import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.schema.{GroupType, LogicalTypeAnnotation, Types}
 import org.apache.spark.SparkEnv
-import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.avro._
 import org.apache.spark.sql.catalyst.InternalRow
@@ -39,23 +38,16 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, Spark41LegacyHoodieParquetFileFormat, Spark41ParquetReader}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.vortex.SparkVortexReaderBase
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.hudi.{HoodieMemoryStream, SparkAdapter}
-import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
-import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_1ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType}
-import org.apache.spark.sql.vectorized.ColumnarBatchRow
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.storage.StorageLevel._
+import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import scala.jdk.CollectionConverters.MapHasAsScala
@@ -80,17 +72,6 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
       }
     }
   }
-
-  def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    v2Table.getClass.getName.contains("HoodieInternalV2Table")
-  }
-
-  override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]
-
-  def createCatalystMetadataForMetaField: Metadata =
-    new MetadataBuilder()
-      .putBoolean(METADATA_COL_ATTR_KEY, value = true)
-      .build()
 
   override def getCatalystExpressionUtils: HoodieCatalystExpressionUtils = HoodieSpark41CatalystExpressionUtils
 
@@ -136,44 +117,6 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
     new Spark41HoodiePartitionFileSliceMapping(values, slices)
   }
 
-  override def extractDeleteCondition(deleteFromTable: Command): Expression = {
-    deleteFromTable.asInstanceOf[DeleteFromTable].condition
-  }
-
-  override def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {
-    TableValuedFunctions.funcs.foreach(extensions.injectTableFunction)
-  }
-
-  override def injectScalarFunctions(extensions: SparkSessionExtensions): Unit = {
-    ScalarFunctions.funcs.foreach(extensions.injectFunction)
-  }
-
-  override def injectPlannerStrategies(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectPlannerStrategy { session =>
-      BatchedBlobReaderStrategy(session)
-    }
-  }
-
-  /**
-   * Converts instance of [[StorageLevel]] to a corresponding string
-   */
-  override def convertStorageLevelToString(level: StorageLevel): String = level match {
-    case NONE => "NONE"
-    case DISK_ONLY => "DISK_ONLY"
-    case DISK_ONLY_2 => "DISK_ONLY_2"
-    case DISK_ONLY_3 => "DISK_ONLY_3"
-    case MEMORY_ONLY => "MEMORY_ONLY"
-    case MEMORY_ONLY_2 => "MEMORY_ONLY_2"
-    case MEMORY_ONLY_SER => "MEMORY_ONLY_SER"
-    case MEMORY_ONLY_SER_2 => "MEMORY_ONLY_SER_2"
-    case MEMORY_AND_DISK => "MEMORY_AND_DISK"
-    case MEMORY_AND_DISK_2 => "MEMORY_AND_DISK_2"
-    case MEMORY_AND_DISK_SER => "MEMORY_AND_DISK_SER"
-    case MEMORY_AND_DISK_SER_2 => "MEMORY_AND_DISK_SER_2"
-    case OFF_HEAP => "OFF_HEAP"
-    case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $level")
-  }
-
   /**
    * Get parquet file reader
    *
@@ -190,22 +133,11 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
     Spark41ParquetReader.build(vectorized, sqlConf, options, hadoopConf)
   }
 
-  override def createLanceFileReader(vectorized: Boolean,
-                                     sqlConf: SQLConf,
-                                     options: Map[String, String],
-                                     hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
-    Some(new SparkLanceReaderBase(vectorized))
-  }
-
   override def createVortexFileReader(vectorized: Boolean,
                                       sqlConf: SQLConf,
                                       options: Map[String, String],
                                       hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
     Some(new SparkVortexReaderBase(vectorized))
-  }
-
-  override def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit = {
-    jssc.sc.stop(exitCode)
   }
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
@@ -218,18 +150,6 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
       .map(LegacyBehaviorPolicy.withName)
     fromSqlConf.orElse(fromSparkConf)
       .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE))
-  }
-
-  override def isLegacyBehaviorPolicy(value: Object): Boolean = {
-    value == LegacyBehaviorPolicy.LEGACY
-  }
-
-  override def isTimestampNTZType(dataType: DataType): Boolean = {
-    dataType == DataTypes.TimestampNTZType
-  }
-
-  override def getRebaseSpec(policy: String): RebaseDateTime.RebaseSpec = {
-    RebaseDateTime.RebaseSpec(LegacyBehaviorPolicy.withName(policy))
   }
 
   override def isVariantProjectionStruct(structType: StructType): Boolean = {

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_2Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_2Adapter.scala
@@ -26,7 +26,6 @@ import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.schema.{GroupType, LogicalTypeAnnotation, Types}
 import org.apache.spark.SparkEnv
-import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.avro._
 import org.apache.spark.sql.catalyst.InternalRow
@@ -39,23 +38,16 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, Spark42LegacyHoodieParquetFileFormat, Spark42ParquetReader}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.vortex.SparkVortexReaderBase
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.hudi.{HoodieMemoryStream, SparkAdapter}
-import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
-import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_2ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType}
-import org.apache.spark.sql.vectorized.ColumnarBatchRow
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.storage.StorageLevel._
+import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import scala.jdk.CollectionConverters.MapHasAsScala
@@ -80,17 +72,6 @@ class Spark4_2Adapter extends BaseSpark4Adapter {
       }
     }
   }
-
-  def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    v2Table.getClass.getName.contains("HoodieInternalV2Table")
-  }
-
-  override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]
-
-  def createCatalystMetadataForMetaField: Metadata =
-    new MetadataBuilder()
-      .putBoolean(METADATA_COL_ATTR_KEY, value = true)
-      .build()
 
   override def getCatalystExpressionUtils: HoodieCatalystExpressionUtils = HoodieSpark42CatalystExpressionUtils
 
@@ -136,44 +117,6 @@ class Spark4_2Adapter extends BaseSpark4Adapter {
     new Spark42HoodiePartitionFileSliceMapping(values, slices)
   }
 
-  override def extractDeleteCondition(deleteFromTable: Command): Expression = {
-    deleteFromTable.asInstanceOf[DeleteFromTable].condition
-  }
-
-  override def injectTableFunctions(extensions: SparkSessionExtensions): Unit = {
-    TableValuedFunctions.funcs.foreach(extensions.injectTableFunction)
-  }
-
-  override def injectScalarFunctions(extensions: SparkSessionExtensions): Unit = {
-    ScalarFunctions.funcs.foreach(extensions.injectFunction)
-  }
-
-  override def injectPlannerStrategies(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectPlannerStrategy { session =>
-      BatchedBlobReaderStrategy(session)
-    }
-  }
-
-  /**
-   * Converts instance of [[StorageLevel]] to a corresponding string
-   */
-  override def convertStorageLevelToString(level: StorageLevel): String = level match {
-    case NONE => "NONE"
-    case DISK_ONLY => "DISK_ONLY"
-    case DISK_ONLY_2 => "DISK_ONLY_2"
-    case DISK_ONLY_3 => "DISK_ONLY_3"
-    case MEMORY_ONLY => "MEMORY_ONLY"
-    case MEMORY_ONLY_2 => "MEMORY_ONLY_2"
-    case MEMORY_ONLY_SER => "MEMORY_ONLY_SER"
-    case MEMORY_ONLY_SER_2 => "MEMORY_ONLY_SER_2"
-    case MEMORY_AND_DISK => "MEMORY_AND_DISK"
-    case MEMORY_AND_DISK_2 => "MEMORY_AND_DISK_2"
-    case MEMORY_AND_DISK_SER => "MEMORY_AND_DISK_SER"
-    case MEMORY_AND_DISK_SER_2 => "MEMORY_AND_DISK_SER_2"
-    case OFF_HEAP => "OFF_HEAP"
-    case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $level")
-  }
-
   /**
    * Get parquet file reader
    *
@@ -190,22 +133,11 @@ class Spark4_2Adapter extends BaseSpark4Adapter {
     Spark42ParquetReader.build(vectorized, sqlConf, options, hadoopConf)
   }
 
-  override def createLanceFileReader(vectorized: Boolean,
-                                     sqlConf: SQLConf,
-                                     options: Map[String, String],
-                                     hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
-    Some(new SparkLanceReaderBase(vectorized))
-  }
-
   override def createVortexFileReader(vectorized: Boolean,
                                       sqlConf: SQLConf,
                                       options: Map[String, String],
                                       hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
     Some(new SparkVortexReaderBase(vectorized))
-  }
-
-  override def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit = {
-    jssc.sc.stop(exitCode)
   }
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
@@ -218,18 +150,6 @@ class Spark4_2Adapter extends BaseSpark4Adapter {
       .map(LegacyBehaviorPolicy.withName)
     fromSqlConf.orElse(fromSparkConf)
       .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE))
-  }
-
-  override def isLegacyBehaviorPolicy(value: Object): Boolean = {
-    value == LegacyBehaviorPolicy.LEGACY
-  }
-
-  override def isTimestampNTZType(dataType: DataType): Boolean = {
-    dataType == DataTypes.TimestampNTZType
-  }
-
-  override def getRebaseSpec(policy: String): RebaseDateTime.RebaseSpec = {
-    RebaseDateTime.RebaseSpec(LegacyBehaviorPolicy.withName(policy))
   }
 
   override def isVariantProjectionStruct(structType: StructType): Boolean = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The `SparkAdapter` trait and its per-version implementations accumulated methods that either have no callers or are implemented with byte-identical bodies in every version adapter, so each change to them is maintained and reviewed up to six times.

### Summary and Changelog

Refreshed against current master; now covers Spark 3.3 through 4.2 (the original revision predated the Spark 4.1/4.2 modules).

- Remove two methods with no callers anywhere in the repository: `createInterpretedPredicate` and `sqlExecutionWithNewExecutionId`.
- Give `SparkAdapter` default implementations for methods whose bodies were byte-identical across all six version adapters: `isColumnarBatchRow`, `createCatalystMetadataForMetaField`, `extractDeleteCondition`, `convertStorageLevelToString`.
- Pull family-identical bodies into the base adapters: `injectTableFunctions`, `injectScalarFunctions`, `injectPlannerStrategies`, `createLanceFileReader` into `BaseSpark3Adapter`/`BaseSpark4Adapter`; additionally `stopSparkContext`, `isLegacyBehaviorPolicy`, `isTimestampNTZType`, `getRebaseSpec`, and `isHoodieTable` into `BaseSpark4Adapter`.
- `Spark3_3Adapter` keeps its `createLanceFileReader` override returning `None` (no Lance support on Spark 3.3); all other removals are pure de-duplication with no behavior change.
- `injectTableFunctions` becomes abstract on the trait: the no-op default was dead since both base adapters override it.

### Impact

No functional change; the adapter surface shrinks and shared bodies are compiled once per family instead of once per version.

### Risk Level

low. Caller absence for the two removed methods verified repo-wide; every pulled-up body verified byte-identical across the copies it replaces; CI compiles all six Spark profiles.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (pure de-duplication; existing tests exercise the adapters on every Spark CI leg)
