### PR TITLE
fix(spark): SparkSQL write queries should correctly infer HUDI write configs from spark.hoodie.* configs in spark conf

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieSqlCommonUtils.scala
@@ -248,6 +248,10 @@ object HoodieSqlCommonUtils extends SparkAdapterSupport {
     opts.filterKeys(isHoodieConfigKey(_,
       opts.getOrElse(COMMIT_METADATA_KEYPREFIX.key, COMMIT_METADATA_KEYPREFIX.defaultValue()))).toMap
 
+  def extractSparkPrefixedHoodieConfigs(opts: Map[String, String]): Map[String, String] =
+    opts.filter { case (k, _) => k.startsWith("spark.hoodie.") }
+      .map { case (k, v) => (k.stripPrefix("spark."), v) }
+
   /**
    * Checks whether Spark is using Hive as Session's Catalog
    */

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, L
 import org.apache.spark.sql.execution.datasources.FileStatusCache
 import org.apache.spark.sql.hive.HiveExternalCatalog
 import org.apache.spark.sql.hudi.HoodieOptionConfig.mapSqlOptionsToDataSourceWriteConfigs
-import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{filterHoodieConfigs, isUsingHiveCatalog}
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{extractSparkPrefixedHoodieConfigs, filterHoodieConfigs, isUsingHiveCatalog}
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig.{buildOverridingOpts, buildOverridingOptsForDelete, combineOptions, getPartitionPathFieldWriteConfig}
 import org.apache.spark.sql.hudi.command.SqlKeyGenerator
 import org.apache.spark.sql.internal.SQLConf
@@ -515,18 +515,21 @@ object ProvidesHoodieConfig {
     // NOTE: Properties are merged in the following order of priority (first has the highest priority, last has the
     //       lowest, which is inverse to the ordering in the code):
     //          1. (Extra) Option overrides
-    //          2. Spark SQL configs
+    //          2. Spark SQL configs (hoodie.* keys)
+    //          2b. Spark SQL configs (spark.hoodie.* keys, normalized to hoodie.*)
     //          3. Persisted Hudi's Table configs
     //          4. Table's properties in Spark Catalog
     //          5. Global DFS properties
     //          6. (Feature-specific) Default values
+    val allConfs = sqlConf.getAllConfs
     filterNullValues(defaultOpts) ++
       DFSPropertiesConfiguration.getGlobalProps.asScala.toMap ++
       // NOTE: Catalog table provided t/h `TBLPROPERTIES` clause might contain Spark SQL specific
       //       properties that need to be mapped into Hudi's conventional ones
       mapSqlOptionsToDataSourceWriteConfigs(catalogTable.catalogProperties) ++
       tableConfig.getProps.asScala.toMap ++
-      filterHoodieConfigs(sqlConf.getAllConfs) ++
+      extractSparkPrefixedHoodieConfigs(allConfs) ++
+      filterHoodieConfigs(allConfs) ++
       filterNullValues(overridingOpts)
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSqlConf.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestSqlConf.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.hudi.common
 
 import org.apache.hudi.DataSourceReadOptions._
-import org.apache.hudi.common.config.DFSPropertiesConfiguration
+import org.apache.hudi.common.config.{DFSPropertiesConfiguration, HoodieMetadataConfig}
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.testutils.HoodieTestUtils
@@ -101,6 +101,39 @@ class TestSqlConf extends HoodieSparkSqlTestBase with BeforeAndAfter {
       // check that schema evolution is enabled (from hudi-defaults.conf),
       // so no exception is thrown on alter table change column type
       spark.sql(s"alter table $tableName change column price price string")
+    }
+  }
+
+  test("Test spark.hoodie.* configs propagate to write path") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath
+
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  price double,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | options (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           | )
+       """.stripMargin)
+
+      val metadataTablePath = s"$tablePath/${HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH}"
+
+      withSQLConf("spark." + HoodieMetadataConfig.ENABLE.key -> "false") {
+        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000)")
+      }
+      assertResult(false)(existsPath(metadataTablePath))
+
+      checkAnswer(s"select id, name, price, ts from $tableName")(
+        Seq(1, "a1", 10.0, 1000)
+      )
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Spark SQL write operations (CREATE TABLE, INSERT INTO, DELETE, etc.) do not
consume configs set with the `spark.hoodie.*` prefix. Users expect that setting
`spark.hoodie.metadata.enable=false` (or any other hoodie config behind the
`spark.` namespace) in their Spark session would be respected by both reads and
writes, but the write path silently ignores these configs because
`combineOptions` only passes through keys that start with `hoodie.`.

The read path already handles this correctly via `DefaultSource` and
`DataSourceOptionsHelper.parametersWithReadDefaults`, but the write path in
`ProvidesHoodieConfig.combineOptions` does not.

### Summary and Changelog

`spark.hoodie.*` SQL configs are now normalized to `hoodie.*` and included in
the write-path option merging, with `hoodie.*` keys still taking precedence when
both forms are set.

- Added `extractSparkPrefixedHoodieConfigs` to `HoodieSqlCommonUtils` that
  filters `spark.hoodie.*` keys and strips the `spark.` prefix.
- Updated `ProvidesHoodieConfig.combineOptions` to include the normalized
  `spark.hoodie.*` configs at a priority level just below `hoodie.*` SQL configs.
- Added a unit test in `TestSqlConf` that sets `spark.hoodie.metadata.enable`
  to `false` via `withSQLConf`, performs a Spark SQL insert, and asserts the
  metadata table is not created.

### Impact

Users can now set Hudi write configs using the `spark.hoodie.*` prefix in their
Spark session and have them respected by Spark SQL DML operations. No public API
changes. No breaking changes — existing `hoodie.*` configs continue to take
precedence.

### Risk Level

Low. The change is additive and follows the same normalization pattern already
used on the read path. Existing config resolution order is preserved;
`hoodie.*` keys still override `spark.hoodie.*` keys when both are present.

### Documentation Update

None. The `spark.hoodie.*` prefix convention is already documented; this change
fixes the write path to honor it consistently.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
