### PR TITLE
feat(hudi-sync): Publish HUDI version to Hive metastore (allowing users to infer which HUDI client jar to use for a given dataset)

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -271,6 +271,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
       if (!config.getBoolean(META_SYNC_CONDITIONAL_SYNC) || meetSyncConditions) {
         syncClient.updateLastCommitTimeSynced(tableName);
       }
+      syncClient.updateHoodieWriterVersion(tableName);
       log.info("Sync complete for {}", tableName);
     } catch (HoodieHiveSyncException ex) {
       if (shouldRecreateAndSyncTable()) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.hive;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hudi.HoodieVersion;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -483,6 +484,18 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
     } else {
       ddlExecutor.updateTableComments(tableName, alterComments);
       return true;
+    }
+  }
+
+  @Override
+  public void updateHoodieWriterVersion(String tableName) {
+    try {
+      Table table = client.getTable(databaseName, tableName);
+      table.putToParameters(HoodieVersion.HOODIE_WRITER_VERSION, HoodieVersion.get());
+      client.alter_table(databaseName, tableName, table);
+    } catch (Exception e) {
+      throw new HoodieHiveSyncException(String.format("Failed to update hudi writer major version %s for %s",
+          HoodieVersion.get(), tableName), e);
     }
   }
 

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.hive;
 
+import org.apache.hudi.HoodieVersion;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -569,6 +570,8 @@ public class TestHiveSyncTool {
     String sparkTableProperties = getSparkTableProperties(syncAsDataSourceTable, useSchemaFromCommitMetadata);
     assertEquals(
         "EXTERNAL\tTRUE\n"
+            + String.format("%s\t%s\n", HoodieVersion.HOODIE_WRITER_VERSION,
+            HoodieVersion.get())
             + "last_commit_completion_time_sync\t" + getLastCommitCompletionTimeSynced() + "\n"
             + "last_commit_time_sync\t100\n"
             + sparkTableProperties
@@ -607,8 +610,10 @@ public class TestHiveSyncTool {
     hiveDriver.getResults(results);
 
     assertEquals(
-        String.format("%slast_commit_completion_time_sync\t%s\nlast_commit_time_sync\t%s\n%s",
+        String.format("%s%s\t%s\nlast_commit_completion_time_sync\t%s\nlast_commit_time_sync\t%s\n%s",
             createManagedTable ? StringUtils.EMPTY_STRING : "EXTERNAL\tTRUE\n",
+            HoodieVersion.HOODIE_WRITER_VERSION,
+            HoodieVersion.get(),
             getLastCommitCompletionTimeSynced(),
             instantTime,
             getSparkTableProperties(true, true)),
@@ -702,6 +707,8 @@ public class TestHiveSyncTool {
           results.subList(0, results.size() - 1));
       assertEquals(
           "EXTERNAL\tTRUE\n"
+              + String.format("%s\t%s\n", HoodieVersion.HOODIE_WRITER_VERSION,
+              HoodieVersion.get())
               + "last_commit_completion_time_sync\t" + getLastCommitCompletionTimeSynced() + "\n"
               + "last_commit_time_sync\t101\n"
               + sparkTableProperties

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieMetaSyncOperations.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieMetaSyncOperations.java
@@ -279,4 +279,11 @@ public interface HoodieMetaSyncOperations {
   default String generatePushDownFilter(List<String> writtenPartitions, List<FieldSchema> partitionFields) {
     throw new UnsupportedOperationException();
   }
+
+  /**
+   * Publish version of HUDI client library used
+   */
+  default void updateHoodieWriterVersion(String tableName) {
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

During hive sync, the Hudi writer version is not published to the Hive Metastore (HMS) table properties. This makes it difficult for downstream consumers and platform tooling to determine which version of the Hudi writer library produced the data for a given table.

Publishing this version info allows users to infer which HUDI jar versions to use when writing to the dataset. This is helpful for cases when a user is performing a rolling HUDI verison upgrade of all their datasets, and has a table service platform for invoking table services (that needs to infer which HUDI jar to use before running a table service against a dataset)

https://github.com/apache/hudi/issues/17954 

### Summary and Changelog

Publish the Hudi writer version as a table property (`hudi_writer_version`) in HMS during hive sync.

- Add `updateHoodieWriterVersion(String tableName)` default method to `HoodieMetaSyncOperations` interface
- Implement `updateHoodieWriterVersion` in `HoodieHiveSyncClient`, which reads the current Hudi version via `HoodieVersion.get()` and sets it as a table parameter in HMS
- Call `updateHoodieWriterVersion` in `HiveSyncTool.syncHoodieTable` after updating the last commit time synced
- Update unit test assertions in `TestHiveSyncTool` to validate the new table property is present

### Impact

A new table property `hudi_writer_version` will be set on HMS tables during every hive sync. This is a metadata-only change with no impact on the storage format or read/write path. Existing tables will get the property populated on their next sync.

### Risk Level

low — The change only adds a single HMS `alter_table` call per sync to set a table-level property. No existing behavior is modified. If the call fails, it throws a clear exception consistent with existing error handling in the sync client.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
