### PR TITLE
docs: Update the build instructions by mentioning profiles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Prerequisites for building Apache Hudi:
 ```
 # Checkout code and build
 git clone https://github.com/apache/hudi.git && cd hudi
-mvn clean package -DskipTests -Dspark3.5 -Dflink2.1
+mvn clean package -DskipTests -Dspark3.5 -Dflink1.20
 
 # Start command
 spark-3.5.0-bin-hadoop3/bin/spark-shell \


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The current build instructions do not clearly mention the Maven profiles required when building the project. This can lead to confusion for developers who are trying to build the project locally or customize the build for different environments. This PR updates the documentation to explicitly mention the relevant Maven profiles used during the build process.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

This PR improves the build documentation by adding details about the Maven profiles required when building the project.

**Changes included:**

* Updated the build instructions to mention the relevant Maven profiles.
* Clarified how developers should use these profiles when running the build commands.
* Improved documentation clarity to help new contributors successfully build the project locally.
<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

This change only affects documentation. The update helps developers better understand the build process and reduces potential confusion when building the project.
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

none

This change only updates documentation and does not affect code execution or system behavior.
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

The build instructions have been updated to clearly mention the Maven profiles required during the build process. No additional configuration or feature documentation changes are required.

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable