### PR TITLE
docs: Update build steps using profiles in Developer Setup

### DIFF
--- a/website/contribute/developer-setup.md
+++ b/website/contribute/developer-setup.md
@@ -36,7 +36,7 @@ Listing out some of the maven commands that could be useful for developers.
 - Compile/build entire project
 
 ```shell
-mvn clean package -DskipTests
+mvn clean package -DskipTests -Dspark3.5 -Dflink1.20
 ```
 Default profile is Spark 3.5 and Scala 2.12
 
@@ -196,7 +196,7 @@ We have embraced the code style largely based on [google format](https://google.
 When submitting a PR please make sure to NOT commit the changes mentioned in these steps, instead once testing is done make sure to revert the changes and then submit a pr.
 :::
 
-0. Build the project with the intended profiles via the `mvn` cli, for example for spark 3.5 use `mvn clean package -Dspark3.5 -Dscala-2.12 -DskipTests`.
+0. Build the project with the intended profiles via the `mvn` cli, for example for spark 3.5 use `mvn clean package -Dspark3.5 -Dscala-2.12 -Dflink1.20 -DskipTests`.
 1. Install the "Maven Helper" plugin from the Intellij IDE.
 2. Make sure IDEA uses Maven to build/run tests:
    * You need to select the intended Maven profiles (using Maven tool pane in IDEA): select profiles you are targeting for example `spark3.5`, `scala-2.12` etc.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The current Developer Setup documentation does not clearly mention the Maven profiles required when building the project locally. This can lead to confusion for new contributors when trying to compile the project or run tests. This PR updates the documentation to explicitly mention the relevant build profiles and how they should be used during the build process.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

This PR improves the developer documentation by clarifying the build instructions and including the Maven profiles required during the build process.

Changes included:

* Updated the Developer Setup build instructions to include the relevant Maven profiles.
* Improved clarity around the build commands used by contributors.
* Ensured that the documentation reflects the recommended way to build the project locally.

These changes make it easier for developers to successfully build the project without confusion.

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact
None
<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
None
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

The Developer Setup documentation has been updated to clearly mention the Maven build profiles used during the build process.
<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
