### PR TITLE
fix: Fixed the issue of incorrect opName values in Flink bulk insert writing

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -176,10 +176,11 @@ public class Pipelines {
     }
 
     // main write operator with following dummy sink in the end
+    String opName = isBucketIndexType ? "bucket_bulk_insert" : "hoodie_bulk_insert_write";
     return dataStream
-        .transform(opName(isBucketIndexType ? "bucket_bulk_insert" : "hoodie_bulk_insert_write", conf),
+        .transform(opName(opName, conf),
             TypeInformation.of(RowData.class), BulkInsertWriteOperator.getFactory(conf, rowType))
-        .uid(opUID("bucket_bulk_insert", conf))
+        .uid(opUID(opName, conf))
         .setParallelism(PARALLELISM_VALUE);
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
Incorrect operator name used when specifying UID for bulk insert operator.

### Summary and Changelog
Adjust the operator name in the UID method to the correct one


### Impact
None

### Risk Level
none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
