### PR TITLE
[HUDI-8371] Fix Column Stats Record Key using full partition path

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -712,12 +712,13 @@ public abstract class HoodieBackedTableMetadataWriter<I> implements HoodieTableM
    * @return List consisting of {@code DirectoryInfo} for each partition found.
    */
   private List<DirectoryInfo> listAllPartitionsFromMDT(String initializationTime) throws IOException {
-    List<DirectoryInfo> dirinfoList = new LinkedList<>();
     List<String> allPartitionPaths = metadata.getAllPartitionPaths().stream()
         .map(partitionPath -> dataWriteConfig.getBasePath() + StoragePath.SEPARATOR_CHAR + partitionPath).collect(Collectors.toList());
     Map<String, List<StoragePathInfo>> partitionFileMap = metadata.getAllFilesInPartitions(allPartitionPaths);
+    List<DirectoryInfo> dirinfoList = new ArrayList<>(partitionFileMap.size());
     for (Map.Entry<String, List<StoragePathInfo>> entry : partitionFileMap.entrySet()) {
-      dirinfoList.add(new DirectoryInfo(entry.getKey(), entry.getValue(), initializationTime));
+      String relativeDirPath = FSUtils.getRelativePartitionPath(new StoragePath(dataWriteConfig.getBasePath()), new StoragePath(entry.getKey()));
+      dirinfoList.add(new DirectoryInfo(relativeDirPath, entry.getValue(), initializationTime));
     }
     return dirinfoList;
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -385,6 +385,109 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
     }
   }
 
+  /**
+   * Validates that when column stats index is initialized from an already-existing FILES partition
+   * (i.e. listAllPartitionsFromMDT is called), partition paths are stored as relative paths rather
+   * than absolute paths. Before the fix, absolute paths were passed to DirectoryInfo causing the
+   * column stats index to be keyed incorrectly, resulting in empty/missing stats.
+   */
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testColumnStatsIndexInitFromMDTUsesRelativePaths(tableType: HoodieTableType): Unit = {
+    // Step 1: Write data with metadata enabled but WITHOUT column stats.
+    // This initializes the FILES partition in MDT.
+    val metadataOnlyOpts = Map(
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false"
+    )
+
+    val commonOpts = Map(
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4",
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> tableType.toString,
+      RECORDKEY_FIELD.key -> "c1",
+      PRECOMBINE_FIELD.key -> "c1",
+      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+    ) ++ metadataOnlyOpts
+
+    val sourceJSONTablePath = getClass.getClassLoader.getResource("index/colstats/input-table-json").toString
+    val inputDF = spark.read.schema(sourceTableSchema).json(sourceJSONTablePath)
+
+    inputDF
+      .sort("c1")
+      .repartition(4, new Column("c1"))
+      .write
+      .format("hudi")
+      .options(commonOpts)
+      .option(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE.key, 10 * 1024)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+
+    // Step 2: Enable column stats and do another write. This triggers listAllPartitionsFromMDT
+    // (since FILES partition is already present) to bootstrap the column stats partition.
+    val metadataWithColStatsOpts = Map(
+      HoodieMetadataConfig.ENABLE.key -> "true",
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true"
+    )
+
+    val commonOptsWithColStats = Map(
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4",
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> tableType.toString,
+      RECORDKEY_FIELD.key -> "c1",
+      PRECOMBINE_FIELD.key -> "c1",
+      HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+    ) ++ metadataWithColStatsOpts
+
+    val updateJSONTablePath = getClass.getClassLoader.getResource("index/colstats/another-input-table-json").toString
+    val updateDF = spark.read.schema(sourceTableSchema).json(updateJSONTablePath)
+
+    updateDF
+      .sort("c1")
+      .repartition(4, new Column("c1"))
+      .write
+      .format("hudi")
+      .options(commonOptsWithColStats)
+      .option(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE.key, 10 * 1024)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+
+    // Step 3: Validate that the column stats index was properly populated.
+    // If listAllPartitionsFromMDT used absolute paths, the column stats would be empty or
+    // would reference wrong keys, causing the transposed DF to be empty.
+    val metadataConfig = HoodieMetadataConfig.newBuilder()
+      .fromProperties(toProperties(metadataWithColStatsOpts))
+      .build()
+
+    val columnStatsIndex = new ColumnStatsIndexSupport(spark, sourceTableSchema, metadataConfig, metaClient)
+
+    columnStatsIndex.loadTransposed(sourceTableSchema.fieldNames.toSeq, shouldReadInMemory = true) { transposedDF =>
+      val rows = transposedDF.collect()
+      // Column stats index must be non-empty: if listAllPartitionsFromMDT used absolute paths,
+      // the DirectoryInfo would have a wrong relative path and column stats would not be
+      // properly indexed, resulting in an empty or corrupted index.
+      assertTrue(rows.length > 0,
+        "Column stats index must be non-empty after initialization via listAllPartitionsFromMDT. " +
+        "An empty result indicates that absolute partition paths were used instead of relative paths.")
+
+      // Verify that the file names in the index do NOT contain the base path (i.e., they are relative)
+      val fileNames = transposedDF.select("fileName").collect().map(_.getString(0))
+      fileNames.foreach { fileName =>
+        assertTrue(!fileName.startsWith(basePath),
+          s"fileName '$fileName' should be a relative path, not absolute. " +
+          s"This indicates the listAllPartitionsFromMDT bug where absolute paths were used.")
+      }
+    }
+  }
+
   @Test
   def testParquetMetadataRangeExtraction(): Unit = {
     val df = generateRandomDataFrame(spark)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When column stats index is enabled on a table that already has the FILES metadata partition initialized listAllPartitionsFromMDT is used to bootstrap the column stats partition. The method was passing the absolute partition path (e.g., hdfs://host/table/partition1) as the first argument to DirectoryInfo instead of the relative path (e.g., partition1). This caused the column stats index to be keyed on wrong paths, resulting in empty or incorrect column stats lookups during data skipping.
  
### Summary and Changelog

Fix: In HoodieBackedTableMetadataWriter.listAllPartitionsFromMDT, compute the relative partition path using FSUtils.getRelativePartitionPath(basePath, absolutePath) before constructing each DirectoryInfo, instead of passing the absolute map key directly.

Changes:
  - HoodieBackedTableMetadataWriter.java: Fixed listAllPartitionsFromMDT to use relative partition paths when constructing DirectoryInfo entries.

### Impact

No public API or config changes. Users who enable column stats on an existing table (i.e., FILES partition already initialized but column stats was not) will now get a correctly populated column stats index, enabling data skipping to work as expected instead of silently returning no stats.

### Risk Level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
