### PR TITLE
fix: NoClassDefFoundError for HiveConf when Hive jars not on classpath

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
@@ -441,23 +441,29 @@ trait ProvidesHoodieConfig extends Logging {
   def buildHiveSyncConfig(sparkSession: SparkSession,
                           hoodieCatalogTable: HoodieCatalogTable,
                           tableConfig: HoodieTableConfig,
-                          extraOptions: Map[String, String] = Map.empty): HiveSyncConfig = {
+                          extraOptions: Map[String, String] = Map.empty): HoodieSyncConfig = {
     val combinedOpts = combineOptions(hoodieCatalogTable, tableConfig, sparkSession.sessionState.conf,
       defaultOpts = Map.empty, overridingOpts = extraOptions)
     val props = toProperties(combinedOpts)
 
     // Enable the hive sync by default if spark have enable the hive metastore.
     val enableHive = isUsingHiveCatalog(sparkSession)
-    val hiveSyncConfig: HiveSyncConfig = new HiveSyncConfig(props)
-    hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_ENABLED.key, enableHive.toString)
-    hiveSyncConfig.setValue(HiveSyncConfigHolder.HIVE_SYNC_ENABLED.key, enableHive.toString)
-    hiveSyncConfig.setValue(HiveSyncConfigHolder.HIVE_SYNC_MODE.key, props.getString(HiveSyncConfigHolder.HIVE_SYNC_MODE.key, HiveSyncMode.HMS.name()))
-    hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_BASE_PATH, hoodieCatalogTable.tableLocation)
-    hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT, props.getString(HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT.key, HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT.defaultValue))
-    hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_DATABASE_NAME, hoodieCatalogTable.table.identifier.database.getOrElse("default"))
-    hiveSyncConfig.setDefaultValue(HoodieSyncConfig.META_SYNC_TABLE_NAME, hoodieCatalogTable.table.identifier.table)
+    // Only instantiate HiveSyncConfig when Hive catalog is enabled, to avoid
+    // NoClassDefFoundError for HiveConf when Hive jars are not on the classpath.
+    val syncConfig: HoodieSyncConfig = if (enableHive) {
+      new HiveSyncConfig(props)
+    } else {
+      new HoodieSyncConfig(props)
+    }
+    syncConfig.setValue(HoodieSyncConfig.META_SYNC_ENABLED.key, enableHive.toString)
+    syncConfig.setValue(HiveSyncConfigHolder.HIVE_SYNC_ENABLED.key, enableHive.toString)
+    syncConfig.setValue(HiveSyncConfigHolder.HIVE_SYNC_MODE.key, props.getString(HiveSyncConfigHolder.HIVE_SYNC_MODE.key, HiveSyncMode.HMS.name()))
+    syncConfig.setValue(HoodieSyncConfig.META_SYNC_BASE_PATH, hoodieCatalogTable.tableLocation)
+    syncConfig.setValue(HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT, props.getString(HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT.key, HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT.defaultValue))
+    syncConfig.setValue(HoodieSyncConfig.META_SYNC_DATABASE_NAME, hoodieCatalogTable.table.identifier.database.getOrElse("default"))
+    syncConfig.setDefaultValue(HoodieSyncConfig.META_SYNC_TABLE_NAME, hoodieCatalogTable.table.identifier.table)
     if (props.get(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key) != null) {
-      hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS, props.getString(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key))
+      syncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS, props.getString(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key))
     }
     // If partition value extractor is present in params Object we can use it.
     // Here as well it checks first for hoodie.datasource.hive_sync.partition_extractor_class and then
@@ -466,29 +472,29 @@ trait ProvidesHoodieConfig extends Logging {
     // Even if that fails, then we can assume it to be a NonPartitionExtractor.
     val inferredPartitionValueExtractorClass = HoodieTableConfigUtils.inferPartitionValueExtractorClass(tableConfig)
     if (props.containsKey(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key())) {
-      hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(),
+      syncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(),
         props.getString(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key()))
     } else if (props.containsKey(DataSourceWriteOptions.PARTITION_EXTRACTOR_CLASS.key())) {
-      hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(),
+      syncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(),
         props.getString(DataSourceWriteOptions.PARTITION_EXTRACTOR_CLASS.key()))
     } else if (inferredPartitionValueExtractorClass.isPresent) {
-      hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(),
+      syncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(),
         inferredPartitionValueExtractorClass.get())
     } else {
-      hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), classOf[NonPartitionedExtractor].getName)
+      syncConfig.setValue(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), classOf[NonPartitionedExtractor].getName)
     }
 
     // This is hardcoded to true to ensure consistency as Spark syncs TIMESTAMP types as TIMESTAMP by default
     // via Spark's externalCatalog API, which is used by AlterHoodieTableCommand.
-    hiveSyncConfig.setDefaultValue(HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE, "true")
-    if (hiveSyncConfig.useBucketSync())
-      hiveSyncConfig.setValue(HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC,
+    syncConfig.setDefaultValue(HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE, "true")
+    if (syncConfig.getBooleanOrDefault(HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC))
+      syncConfig.setValue(HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC,
         HiveSyncConfig.getBucketSpec(props.getString(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key),
           props.getInteger(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key)))
     if (props.containsKey(HiveExternalCatalog.CREATED_SPARK_VERSION))
-      hiveSyncConfig.setValue(HoodieSyncConfig.META_SYNC_SPARK_VERSION,
+      syncConfig.setValue(HoodieSyncConfig.META_SYNC_SPARK_VERSION,
         props.getString(HiveExternalCatalog.CREATED_SPARK_VERSION))
-    hiveSyncConfig
+    syncConfig
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/common/TestProvidesHoodieConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/common/TestProvidesHoodieConfig.scala
@@ -22,8 +22,8 @@ package org.apache.spark.sql.hudi.common
 import org.apache.hudi.DataSourceWriteOptions
 import org.apache.hudi.common.config.TypedProperties
 import org.apache.hudi.common.table.HoodieTableConfig
-import org.apache.hudi.hive.HiveSyncConfig
 import org.apache.hudi.keygen.{ComplexKeyGenerator, CustomKeyGenerator}
+import org.apache.hudi.sync.common.HoodieSyncConfig
 
 import org.apache.spark.sql.{RuntimeConfig, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -125,7 +125,7 @@ class TestProvidesHoodieConfig {
 
     val mockCmd = mock(classOf[ProvidesHoodieConfig])
     when(mockCmd.buildHiveSyncConfig(any(), any(), any(), any()))
-      .thenReturn(new HiveSyncConfig(new TypedProperties()))
+      .thenReturn(new HoodieSyncConfig(new TypedProperties()))
     when(mockCmd.getDropDupsConfig(any(), any())).thenReturn(Map.empty[String, String])
     when(mockCmd.buildHoodieInsertConfig(any(), any(), any(), any(), any(), any(), any()))
       .thenCallRealMethod()


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The call of `ProvidesHoodieConfig::buildHiveSyncConfig` is unconditional in the write path currently, `ProvidesHoodieConfig::buildHoodieInsertConfig` always call it.
Therefore when I run Spark job even with `--conf spark.sql.catalogImplementation=in-memory`, which makes `HoodieSqlCommonUtils::isUsingHiveCatalog` return `false`. But the method is still invoked and `new HiveSyncConfig(props)` was executed before that check mattered.
It leads to 
```text
java.lang.NoClassDefFoundError: org/apache/hadoop/hive/conf/HiveConf
  at org.apache.spark.sql.hudi.ProvidesHoodieConfig.buildHiveSyncConfig(ProvidesHoodieConfig.scala:451)
  at org.apache.spark.sql.hudi.ProvidesHoodieConfig.buildHiveSyncConfig$(ProvidesHoodieConfig.scala:441)
  at org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand$.buildHiveSyncConfig(InsertIntoHoodieTableCommand.scala:81)
  at org.apache.spark.sql.hudi.ProvidesHoodieConfig.buildHoodieInsertConfig(ProvidesHoodieConfig.scala:183)
  at org.apache.spark.sql.hudi.ProvidesHoodieConfig.buildHoodieInsertConfig$(ProvidesHoodieConfig.scala:163)
  at org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand$.buildHoodieInsertConfig(InsertIntoHoodieTableCommand.scala:81)
  at org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand$.run(InsertIntoHoodieTableCommand.scala:112)
  at org.apache.spark.sql.hudi.command.CreateHoodieTableAsSelectCommand.run(CreateHoodieTableAsSelectCommand.scala:114)
```
due to absent Hive JARs in Spark cluster.

The same with `HiveExternalCatalog.CREATED_SPARK_VERSION`, which triggers class loading of `HiveExternalCatalog`.

### Summary and Changelog

`ProvidesHoodieConfig::buildHiveSyncConfig` starts to return `HoodieSyncConfig` (parent type) and only instantiate `HiveSyncConfig` when `HoodieSqlCommonUtils::isUsingHiveCatalog` returns `true`.
When Hive is disabled, it creates a `HoodieSyncConfig` instead.
`HiveExternalCatalog.CREATED_SPARK_VERSION` replaced with the literal string value `spark.sql.create.version`.

### Impact

Spark cluster without Hive jars writes Hudi tables without `NoClassDefFoundError`.

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
