### PR TITLE
fix: Use explicit Throwable type in AvroConversionUtils catch clause

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/AvroConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/AvroConversionUtils.scala
@@ -67,7 +67,7 @@ object AvroConversionUtils {
             .asInstanceOf[GenericRecord]
         } catch {
           case e: HoodieSchemaException => throw e
-          case e => throw new SchemaCompatibilityException("Failed to convert spark record into avro record", e)
+          case e: Throwable => throw new SchemaCompatibilityException("Failed to convert spark record into avro record", e)
         }
       }
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The bare `case e =>` in `AvroConversionUtils.scala:70` catches all Throwables implicitly, triggering a Scala compiler warning.

### Summary and Changelog

This PR makes the intent explicit with `case e: Throwable =>` to silence the warning without changing behavior

### Impact

Addressed build warning

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
