### PR TITLE
(WIP) benchmark: [RFC-98] COW table read performance comparison

### DIFF
--- a/benchmarks/.env-example
+++ b/benchmarks/.env-example
@@ -1,0 +1,43 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export SPARK_CLUSTER=spark://<spark-ip>:7077
+
+export HUDI_JAR=<hudi-project-path>/packaging/hudi-spark-bundle/target/hudi-spark3.5-bundle_2.12-1.2.0-SNAPSHOT.jar
+
+# for instance, if there are 800 parquet files named as part-00[01234567]*.parquet,
+# then the dataset could be configured by mask configuration.
+export HUDI_BENCHMARK_DATA_PATH=hdfs://<hdfs-ip>:9000/<user>/data300_100g/part-00*.parquet
+export HUDI_BENCHMARK_RECORD_KEY="primary_key"
+export HUDI_BENCHMARK_PRECOMBINE_FIELD="primary_key"
+
+export HUDI_BENCHMARK_ITERATIONS=1
+export HUDI_BENCHMARK_PROJECTED_COLS="primary_key,uuid_key,col0,col1,col10,p"
+export HUDI_BENCHMARK_LIMIT_VALUE=1000
+# filter column should be a one with high cardinality and good data distribution
+export HUDI_BENCHMARK_FILTER_COL=col0
+
+export SPARK_HOME=<some-path-to-spark>/spark-3.5.7-bin-hadoop3-os/
+export SPARK_WAREHOUSE=<some-path-to-spark>/spark-warehouse/
+export SPARK_LOCAL_DIR=<some-path-to-spark>/spark-local-dir/
+
+# Hudi doesn't allow to skip instantiation of some Hive related classes even if Hive is not used
+# For Spark 3.5.7 we need to add:
+#   spark-hive_2.12-3.5.7.jar,
+#   hive-exec-2.3.4-core.jar, hive-serde-2.3.4.jar, hive-exec-3.1.3.jar, hive-standalone-metastore-3.1.3.jar
+export HIVE_JARS=<some-path-to-spark>/spark-3.5.7-extra-jars/hive-*.jar

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,205 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Hudi Benchmark — DSv1 vs DSv2 Read Comparison (COW)
+
+## Overview
+
+Read-focused benchmark comparing Hudi **DSv1 vs DSv2** read paths on **COW** tables.
+Measures full scan, column projection, filter pushdown, limit pushdown, and aggregate pushdown.
+Targets real-world Parquet data on HDFS.
+Currently, the benchmark expects run on local machine.
+
+## Test Data
+
+| Property      | Value               |
+|---------------|---------------------|
+| Source format | Parquet             |
+| Files         | ~800                |
+| Columns       | 300 (all primitive) |
+| Total size    | ~100GB              |
+| Storage       | HDFS                |
+
+The source path supports globs for quick smoke tests:
+- `part-0000*.parquet` — ~10 files, ~1.25 GB (small)
+- `part-000*.parquet` — ~100 files, ~12.5 GB (medium)
+- `part-00*.parquet` — ~800 files, ~100 GB (full)
+
+## Benchmark Scenarios
+
+| Scenario             | Modes            | Description                                               |
+|----------------------|------------------|-----------------------------------------------------------|
+| Full scan            | DSv1, DSv2       | `SELECT * FROM table` via noop sink                       |
+| Projected read       | DSv1, DSv2       | `SELECT col_subset FROM table` via noop sink              |
+| Filter pushdown      | DSv1, DSv2       | `SELECT cols FROM table WHERE expr` via noop sink         |
+| Limit pushdown       | DSv1, DSv2       | `SELECT * FROM table LIMIT N` via noop sink               |
+| Aggregate pushdown   | DSv1, DSv2       | `COUNT(*)` and `MIN/MAX` on COW with column stats         |
+
+## Environment Variables
+
+| Variable                         | Required | Default | Description                                                                                      |
+|----------------------------------|----------|---------|--------------------------------------------------------------------------------------------------|
+| `HUDI_BENCHMARK_DATA_PATH`       | Yes      | —       | HDFS path to source Parquet files (supports globs)                                               |
+| `HUDI_BENCHMARK_RECORD_KEY`      | Yes      | —       | Primary key column name                                                                          |
+| `HUDI_BENCHMARK_PRECOMBINE_FIELD`| Yes      | —       | Ordering/precombine field name                                                                   |
+| `HUDI_BENCHMARK_PARTITION_FIELD` | No       | (empty) | Partition field; empty = non-partitioned                                                         |
+| `HUDI_BENCHMARK_ITERATIONS`      | No       | `1`     | Timed iterations per benchmark case                                                              |
+| `HUDI_BENCHMARK_PROJECTED_COLS`  | No       | (auto)  | Comma-separated column subset for projected reads; auto-detects first 6 non-key columns if unset |
+| `HUDI_BENCHMARK_LIMIT_VALUE`     | No       | `1000`  | LIMIT value for limit pushdown benchmark                                                         |
+| `HUDI_BENCHMARK_FILTER_COL`      | No       | (auto)  | Column for filter benchmark; auto-detects first projected column if unset                        |
+
+## Prerequisites
+
+### Build the Hudi Spark bundle
+
+```bash
+mvn clean package -DskipTests -Dspark3.5 -pl packaging/hudi-spark-bundle -am
+```
+
+The resulting JAR is at `packaging/hudi-spark-bundle/target/hudi-spark3.5-bundle_2.12-*.jar`.
+
+## Running the Benchmark
+
+### Environment setup
+
+Create a `.env` file or export variables:
+
+```bash
+export HUDI_BENCHMARK_DATA_PATH="hdfs:///data/benchmark/part-000*.parquet"
+export HUDI_BENCHMARK_RECORD_KEY="uuid_key"
+export HUDI_BENCHMARK_PRECOMBINE_FIELD="primary_key"
+# Optional:
+export HUDI_BENCHMARK_PARTITION_FIELD=""
+export HUDI_BENCHMARK_ITERATIONS=1
+export HUDI_BENCHMARK_PROJECTED_COLS=""
+export HUDI_BENCHMARK_LIMIT_VALUE=1000
+export HUDI_BENCHMARK_FILTER_COL=""
+```
+
+### Via spark-shell
+
+```bash
+source ./benchmarks/.env && \
+$SPARK_HOME/bin/spark-shell \
+    --master $SPARK_CLUSTER \
+    --deploy-mode client \
+    --driver-memory 1g \
+    --executor-memory 6g \
+    --total-executor-cores 9 \
+    --jars $HUDI_JAR,$HIVE_JARS \
+    --conf spark.local.dir=$SPARK_LOCAL_DIR \
+    --conf spark.sql.catalog.spark_catalog.warehouse=$SPARK_WAREHOUSE \
+    --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
+    --conf spark.kryo.registrator=org.apache.spark.HoodieSparkKryoRegistrar \
+    --conf spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension \
+    --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog \
+    --conf spark.sql.catalog.spark_catalog.type=hadoop \
+    --conf spark.sql.catalogImplementation=in-memory \
+    -i ./benchmarks/hudi_benchmark.scala
+```
+
+Where `$HUDI_JAR` points to the Hudi Spark bundle JAR.
+
+## Scenarios Configuration
+
+### Setup
+
+Before running read benchmarks, the script creates a single COW table via `bulk_insert`.
+This is untimed (logged for informational purposes only) and provides the table used by
+all subsequent read benchmarks.
+
+```
+hoodie.datasource.write.operation = bulk_insert
+hoodie.bulkinsert.shuffle.parallelism = 200
+hoodie.compact.inline = false
+hoodie.clustering.inline = false
+```
+
+### Read (DSv1)
+Standard Hudi read path:
+```
+hoodie.datasource.read.use.v2 = false
+```
+
+### Read (DSv2)
+V2 read path with pushdown support:
+```
+hoodie.datasource.read.use.v2 = true
+```
+
+### Read (filter pushdown)
+Filter expression is auto-detected from the first projected column. For numeric columns, uses
+`col >= median_value`. For non-numeric columns, falls back to `col IS NOT NULL`. Override with
+`HUDI_BENCHMARK_FILTER_COL`.
+
+### Read (limit pushdown)
+Uses `SELECT * FROM table LIMIT N` where N defaults to 1000. DSv2 stops reading after collecting
+enough rows, while DSv1 reads all data first. This is the primary scenario where DSv2 should be
+significantly faster.
+
+### Aggregate pushdown
+Creates a dedicated COW table with `hoodie.metadata.index.column.stats.enable = true`.
+Benchmarks `COUNT(*)` and `MIN/MAX` (if numeric column detected). DSv2 resolves aggregates from
+column stats metadata (near-instant), while DSv1 scans all files.
+
+## Log Output
+
+The benchmark script duplicates all stdout to a timestamped log file
+(`hudi_benchmark_YYYYMMDD_HHmmss.log`) in the current working directory.
+This preserves the full output for later analysis even if the terminal buffer is lost.
+
+## Error Handling
+
+The benchmark wraps all timed iterations in a `try`/`finally` block.
+On completion (or failure), the `finally` block drops all benchmark tables created during the run,
+drops the benchmark database, unpersists cached source data, and closes the log file.
+
+## Expected Output
+
+```
+============================================================
+BENCHMARK COMPLETE
+============================================================
+
+Read full (COW, DSv1)        : 277.7s, 279.4s, 275.8s  (min: 275.8s, max: 279.4s, avg: 277.7s)
+Read full (COW, DSv2)        : 279.0s, 279.6s, 278.9s  (min: 278.9s, max: 279.6s, avg: 279.2s)
+Read projected (COW, DSv1)   : 7.8s, 7.2s, 7.3s  (min: 7.2s, max: 7.8s, avg: 7.4s)
+Read projected (COW, DSv2)   : 6.0s, 5.9s, 6.0s  (min: 5.9s, max: 6.0s, avg: 6.0s)
+Read filter (COW, DSv1)      : 7.3s, 7.2s, 7.1s  (min: 7.1s, max: 7.3s, avg: 7.2s)
+Read filter (COW, DSv2)      : 6.0s, 6.1s, 6.1s  (min: 6.0s, max: 6.1s, avg: 6.1s)
+Read limit (COW, DSv1)       : 54.5s, 54.6s, 57.7s  (min: 54.5s, max: 57.7s, avg: 55.6s)
+Read limit (COW, DSv2)       : 59.3s, 59.1s, 58.9s  (min: 58.9s, max: 59.3s, avg: 59.1s)
+Aggregate COUNT(*) (DSv1)    : 3.5s, 3.6s, 3.5s  (min: 3.5s, max: 3.6s, avg: 3.5s)
+Aggregate COUNT(*) (DSv2)    : 0.2s, 0.2s, 0.3s  (min: 0.2s, max: 0.3s, avg: 0.2s)
+Aggregate MIN/MAX (DSv1)     : 3.9s, 3.7s, 3.7s  (min: 3.7s, max: 3.9s, avg: 3.8s)
+Aggregate MIN/MAX (DSv2)     : 0.2s, 0.2s, 0.2s  (min: 0.2s, max: 0.2s, avg: 0.2s)
+
+============================================================
+DSv2 vs DSv1 PERFORMANCE COMPARISON
+============================================================
+
+Full scan (COW)                    : DSv1 avg 277.7s, DSv2 avg 279.2s, speedup 0.99x (DSv1 FASTER)
+Projected (COW)                    : DSv1 avg 7.4s, DSv2 avg 6.0s, speedup 1.25x (DSv2 FASTER)
+Filter (COW)                       : DSv1 avg 7.2s, DSv2 avg 6.1s, speedup 1.19x (DSv2 FASTER)
+Limit (COW)                        : DSv1 avg 55.6s, DSv2 avg 59.1s, speedup 0.94x (DSv1 FASTER)
+Aggregate COUNT(*)                 : DSv1 avg 3.5s, DSv2 avg 0.2s, speedup 14.98x (DSv2 FASTER)
+Aggregate MIN/MAX                  : DSv1 avg 3.8s, DSv2 avg 0.2s, speedup 19.55x (DSv2 FASTER)
+
+PASS: DSv2 is faster than DSv1 in 4 of 6 scenarios
+```
+
+(Numbers are illustrative — actual results depend on hardware and cluster config.)

--- a/benchmarks/hudi_benchmark.scala
+++ b/benchmarks/hudi_benchmark.scala
@@ -1,0 +1,533 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Hudi Benchmark — DSv1 vs DSv2 Read Comparison (COW)
+
+// ---------------------------------------------------------------------------
+//  Configuration
+// ---------------------------------------------------------------------------
+
+require(sys.env.getOrElse("HUDI_BENCHMARK_DATA_PATH", "").nonEmpty,
+  "HUDI_BENCHMARK_DATA_PATH environment variable must be set and non-empty")
+require(sys.env.getOrElse("HUDI_BENCHMARK_RECORD_KEY", "").nonEmpty,
+  "HUDI_BENCHMARK_RECORD_KEY environment variable must be set and non-empty")
+require(sys.env.getOrElse("HUDI_BENCHMARK_PRECOMBINE_FIELD", "").nonEmpty,
+  "HUDI_BENCHMARK_PRECOMBINE_FIELD environment variable must be set and non-empty")
+
+val dataPath = sys.env("HUDI_BENCHMARK_DATA_PATH")
+val recordKey = sys.env("HUDI_BENCHMARK_RECORD_KEY")
+val precombineField = sys.env("HUDI_BENCHMARK_PRECOMBINE_FIELD")
+val partitionField = sys.env.getOrElse("HUDI_BENCHMARK_PARTITION_FIELD", "")
+val iterations = sys.env.getOrElse("HUDI_BENCHMARK_ITERATIONS", "1").toInt
+val projectedColsEnv = sys.env.getOrElse("HUDI_BENCHMARK_PROJECTED_COLS", "")
+val limitValue = sys.env.getOrElse("HUDI_BENCHMARK_LIMIT_VALUE", "1000").toInt
+val filterColEnv = sys.env.getOrElse("HUDI_BENCHMARK_FILTER_COL", "")
+
+val partitionClause = if (partitionField.nonEmpty) s"partitionedBy '$partitionField'" else ""
+val partitionTblProp = if (partitionField.nonEmpty) s"'hoodie.datasource.write.partitionpath.field' = '$partitionField'," else ""
+
+// Table name constant
+val cowBulkInsert = "cow_bulk_insert"
+
+// ---------------------------------------------------------------------------
+//  Logging Setup
+// ---------------------------------------------------------------------------
+
+import java.io.{File, FileOutputStream, OutputStream, PrintStream}
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class TeeOutputStream(primary: OutputStream, secondary: OutputStream) extends OutputStream {
+  override def write(b: Int): Unit = { primary.write(b); secondary.write(b) }
+  override def write(b: Array[Byte]): Unit = { primary.write(b); secondary.write(b) }
+  override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+    primary.write(b, off, len); secondary.write(b, off, len)
+  }
+  override def flush(): Unit = { primary.flush(); secondary.flush() }
+  override def close(): Unit = { secondary.close() }
+}
+
+val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))
+val benchmarkDb = s"hudi_benchmark_$timestamp"
+val logFileName = s"hudi_benchmark_${timestamp}.log"
+val logFile = new FileOutputStream(new File(logFileName))
+val origOut = System.out
+val teeOut = new PrintStream(new TeeOutputStream(origOut, logFile), true)
+System.setOut(teeOut)
+Console.setOut(teeOut)
+
+println(s"Benchmark log file: $logFileName")
+println(s"Configuration:")
+println(s"  Data path:        $dataPath")
+println(s"  Record key:       $recordKey")
+println(s"  Precombine field: $precombineField")
+println(s"  Partition field:  ${if (partitionField.nonEmpty) partitionField else "(none)"}")
+println(s"  Iterations:       $iterations")
+println(s"  Limit value:      $limitValue")
+println(s"  Filter column:    ${if (filterColEnv.nonEmpty) filterColEnv else "(auto-detect)"}")
+
+// ---------------------------------------------------------------------------
+//  Helper Functions
+// ---------------------------------------------------------------------------
+
+def timed(label: String)(block: => Unit): Double = {
+  System.gc()
+  val start = System.nanoTime()
+  block
+  val elapsed = (System.nanoTime() - start) / 1e9
+  println(f"  $label: $elapsed%.1fs")
+  elapsed
+}
+
+def stats(times: Seq[Double]): (Double, Double, Double) = {
+  (times.min, times.max, times.sum / times.size)
+}
+
+def printStats(label: String, times: Seq[Double]): Unit = {
+  val (mn, mx, avg) = stats(times)
+  val timesStr = times.map(t => f"$t%.1fs").mkString(", ")
+  println(f"$label: $timesStr  (min: $mn%.1fs, max: $mx%.1fs, avg: $avg%.1fs)")
+}
+
+// ---------------------------------------------------------------------------
+//  Source Data Loading
+// ---------------------------------------------------------------------------
+
+spark.sql(s"CREATE DATABASE IF NOT EXISTS $benchmarkDb")
+spark.sql(s"USE $benchmarkDb")
+println(s"\nUsing database: $benchmarkDb")
+
+println("\n=== Loading source data ===")
+timed("Load source data") {
+  val df = spark.read.parquet(dataPath)
+  df.createOrReplaceTempView("source_data")
+  val rowCount = df.count()
+  println(s"  Loaded $rowCount rows")
+}
+
+// Auto-detect projected columns if not specified
+val projectedCols = if (projectedColsEnv.nonEmpty) {
+  projectedColsEnv
+} else {
+  val allCols = spark.sql("SELECT * FROM source_data LIMIT 0").columns
+  val keyFields = Set(recordKey, precombineField, partitionField).filter(_.nonEmpty)
+  val nonKeyCols = allCols.filterNot(keyFields.contains)
+  val selected = nonKeyCols.take(6)
+  println(s"  Auto-detected projected columns: ${selected.mkString(", ")}")
+  selected.mkString(",")
+}
+
+// Print schema summary
+println("\n--- Schema Summary ---")
+val schemaFields = spark.sql("SELECT * FROM source_data LIMIT 0").schema.fields
+println(s"  Total columns: ${schemaFields.length}")
+println(s"  First 10: ${schemaFields.take(10).map(f => s"${f.name}:${f.dataType.simpleString}").mkString(", ")}")
+
+// Auto-detect filter column and value for filter pushdown benchmark
+val filterCol = if (filterColEnv.nonEmpty) filterColEnv else projectedCols.split(",").head.trim
+val (filterExpr, filterIsNumeric) = {
+  try {
+    val midRow = spark.sql(
+      s"SELECT percentile_approx(CAST($filterCol AS DOUBLE), 0.5) FROM source_data"
+    ).collect()
+    val filterValue = midRow(0).get(0)
+    (s"$filterCol >= $filterValue", true)
+  } catch {
+    case _: Exception =>
+      (s"$filterCol IS NOT NULL", false)
+  }
+}
+println(s"\n--- Filter Configuration ---")
+println(s"  Filter column: $filterCol")
+println(s"  Filter expression: $filterExpr")
+println(s"  Numeric filter: $filterIsNumeric")
+
+// Track tables created during benchmark for cleanup
+val createdTables = scala.collection.mutable.ListBuffer[String]()
+
+// ---------------------------------------------------------------------------
+//  Benchmark Suite
+// ---------------------------------------------------------------------------
+
+// Collectors for final summary
+var readFullCowDsv1Times: Seq[Double] = Seq.empty
+var readFullCowDsv2Times: Seq[Double] = Seq.empty
+var readProjCowDsv1Times: Seq[Double] = Seq.empty
+var readProjCowDsv2Times: Seq[Double] = Seq.empty
+var readFilterCowDsv1Times: Seq[Double] = Seq.empty
+var readFilterCowDsv2Times: Seq[Double] = Seq.empty
+var readLimitCowDsv1Times: Seq[Double] = Seq.empty
+var readLimitCowDsv2Times: Seq[Double] = Seq.empty
+var aggCountDsv1Times: Seq[Double] = Seq.empty
+var aggCountDsv2Times: Seq[Double] = Seq.empty
+var aggMinMaxDsv1Times: Seq[Double] = Seq.empty
+var aggMinMaxDsv2Times: Seq[Double] = Seq.empty
+
+try {
+  // -------------------------------------------------------------------------
+  //  Setup — Create COW table for read benchmarks (untimed)
+  // -------------------------------------------------------------------------
+
+  println("\n=== SETUP: Creating COW table for read benchmarks ===")
+
+  val cowReadTable = s"${cowBulkInsert}_1"
+  spark.sql(s"DROP TABLE IF EXISTS $cowReadTable PURGE")
+  createdTables += cowReadTable
+
+  spark.sql("SET hoodie.datasource.write.operation = bulk_insert")
+  timed("COW bulk_insert (setup)") {
+    spark.sql(
+      s"""CREATE TABLE $cowReadTable USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = '$recordKey',
+         |  preCombineField = '$precombineField',
+         |  $partitionTblProp
+         |  'hoodie.metadata.index.column.stats.enable' = 'true',
+         |  'hoodie.compact.inline' = 'false',
+         |  'hoodie.clustering.inline' = 'false',
+         |  'hoodie.bulkinsert.shuffle.parallelism' = '200'
+         |) $partitionClause AS SELECT * FROM source_data""".stripMargin)
+  }
+
+  // -------------------------------------------------------------------------
+  //  Read Benchmark — full scan
+  // -------------------------------------------------------------------------
+
+  println("\n=== READ BENCHMARK (full scan) ===")
+
+  // Warmup
+  println("--- Warmup ---")
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+  timed("Warmup COW DSv1 read") {
+    spark.sql(s"SELECT * FROM $cowReadTable LIMIT 100000").write.format("noop").mode("overwrite").save()
+  }
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+  timed("Warmup COW DSv2 read") {
+    spark.sql(s"SELECT * FROM $cowReadTable LIMIT 100000").write.format("noop").mode("overwrite").save()
+  }
+
+  println("\n--- Timed iterations ---")
+
+  // DSv1 reads
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+
+  readFullCowDsv1Times = (1 to iterations).map { i =>
+    timed(s"Read full COW DSv1 (iter $i)") {
+      spark.sql(s"SELECT * FROM $cowReadTable").write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  // DSv2 reads
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+
+  readFullCowDsv2Times = (1 to iterations).map { i =>
+    timed(s"Read full COW DSv2 (iter $i)") {
+      spark.sql(s"SELECT * FROM $cowReadTable").write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  println("\n--- Full Scan Summary ---")
+  printStats("Read full (COW, DSv1)", readFullCowDsv1Times)
+  printStats("Read full (COW, DSv2)", readFullCowDsv2Times)
+
+  // -------------------------------------------------------------------------
+  //  Read Benchmark — projected
+  // -------------------------------------------------------------------------
+
+  println(s"\n=== READ BENCHMARK (projected: ${projectedCols.split(",").length} columns) ===")
+
+  println("--- Timed iterations ---")
+
+  // DSv1 projected reads
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+
+  readProjCowDsv1Times = (1 to iterations).map { i =>
+    timed(s"Read projected COW DSv1 (iter $i)") {
+      spark.sql(s"SELECT $projectedCols FROM $cowReadTable").write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  // DSv2 projected reads
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+
+  readProjCowDsv2Times = (1 to iterations).map { i =>
+    timed(s"Read projected COW DSv2 (iter $i)") {
+      spark.sql(s"SELECT $projectedCols FROM $cowReadTable").write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  println("\n--- Projected Read Summary ---")
+  printStats("Read projected (COW, DSv1)", readProjCowDsv1Times)
+  printStats("Read projected (COW, DSv2)", readProjCowDsv2Times)
+
+  // -------------------------------------------------------------------------
+  //  Filter Pushdown Read
+  // -------------------------------------------------------------------------
+
+  println(s"\n=== READ BENCHMARK (filter pushdown: $filterExpr) ===")
+
+  // Warmup
+  println("--- Warmup ---")
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+  timed("Warmup COW filter DSv1") {
+    spark.sql(s"SELECT $projectedCols FROM $cowReadTable WHERE $filterExpr LIMIT 100000")
+      .write.format("noop").mode("overwrite").save()
+  }
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+  timed("Warmup COW filter DSv2") {
+    spark.sql(s"SELECT $projectedCols FROM $cowReadTable WHERE $filterExpr LIMIT 100000")
+      .write.format("noop").mode("overwrite").save()
+  }
+
+  println("\n--- Timed iterations ---")
+
+  // DSv1 filter reads
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+
+  readFilterCowDsv1Times = (1 to iterations).map { i =>
+    timed(s"Read filter COW DSv1 (iter $i)") {
+      spark.sql(s"SELECT $projectedCols FROM $cowReadTable WHERE $filterExpr")
+        .write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  // DSv2 filter reads
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+
+  readFilterCowDsv2Times = (1 to iterations).map { i =>
+    timed(s"Read filter COW DSv2 (iter $i)") {
+      spark.sql(s"SELECT $projectedCols FROM $cowReadTable WHERE $filterExpr")
+        .write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  println("\n--- Filter Read Summary ---")
+  printStats("Read filter (COW, DSv1)", readFilterCowDsv1Times)
+  printStats("Read filter (COW, DSv2)", readFilterCowDsv2Times)
+
+  // -------------------------------------------------------------------------
+  //  Limit Pushdown Read
+  // -------------------------------------------------------------------------
+
+  println(s"\n=== READ BENCHMARK (limit pushdown: LIMIT $limitValue) ===")
+
+  // Warmup
+  println("--- Warmup ---")
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+  timed("Warmup COW limit DSv1") {
+    spark.sql(s"SELECT * FROM $cowReadTable LIMIT 100").write.format("noop").mode("overwrite").save()
+  }
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+  timed("Warmup COW limit DSv2") {
+    spark.sql(s"SELECT * FROM $cowReadTable LIMIT 100").write.format("noop").mode("overwrite").save()
+  }
+
+  println("\n--- Timed iterations ---")
+
+  // DSv1 limit reads
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+
+  readLimitCowDsv1Times = (1 to iterations).map { i =>
+    timed(s"Read limit COW DSv1 (iter $i)") {
+      spark.sql(s"SELECT * FROM $cowReadTable LIMIT $limitValue")
+        .write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  // DSv2 limit reads
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+
+  readLimitCowDsv2Times = (1 to iterations).map { i =>
+    timed(s"Read limit COW DSv2 (iter $i)") {
+      spark.sql(s"SELECT * FROM $cowReadTable LIMIT $limitValue")
+        .write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  println("\n--- Limit Read Summary ---")
+  printStats("Read limit (COW, DSv1)", readLimitCowDsv1Times)
+  printStats("Read limit (COW, DSv2)", readLimitCowDsv2Times)
+
+  // -------------------------------------------------------------------------
+  //  Aggregate Pushdown
+  // -------------------------------------------------------------------------
+
+  println("\n=== READ BENCHMARK (aggregate pushdown) ===")
+
+  // Warmup
+  println("--- Warmup ---")
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+  timed("Warmup COUNT(*) DSv1") {
+    spark.sql(s"SELECT COUNT(*) FROM $cowReadTable").write.format("noop").mode("overwrite").save()
+  }
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+  timed("Warmup COUNT(*) DSv2") {
+    spark.sql(s"SELECT COUNT(*) FROM $cowReadTable").write.format("noop").mode("overwrite").save()
+  }
+
+  println("\n--- Timed iterations (COUNT(*)) ---")
+
+  // DSv1 COUNT(*)
+  spark.conf.set("hoodie.datasource.read.use.v2", "false")
+  aggCountDsv1Times = (1 to iterations).map { i =>
+    timed(s"COUNT(*) DSv1 (iter $i)") {
+      spark.sql(s"SELECT COUNT(*) FROM $cowReadTable").write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  // DSv2 COUNT(*)
+  spark.conf.set("hoodie.datasource.read.use.v2", "true")
+  aggCountDsv2Times = (1 to iterations).map { i =>
+    timed(s"COUNT(*) DSv2 (iter $i)") {
+      spark.sql(s"SELECT COUNT(*) FROM $cowReadTable").write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  println("\n--- Aggregate COUNT(*) Summary ---")
+  printStats("COUNT(*) (DSv1)", aggCountDsv1Times)
+  printStats("COUNT(*) (DSv2)", aggCountDsv2Times)
+
+  // MIN/MAX — only if filter column is numeric
+  if (filterIsNumeric) {
+    println(s"\n--- Timed iterations (MIN/MAX on $filterCol) ---")
+
+    spark.conf.set("hoodie.datasource.read.use.v2", "false")
+    aggMinMaxDsv1Times = (1 to iterations).map { i =>
+      timed(s"MIN/MAX DSv1 (iter $i)") {
+        spark.sql(s"SELECT MIN($filterCol), MAX($filterCol) FROM $cowReadTable")
+          .write.format("noop").mode("overwrite").save()
+      }
+    }
+
+    spark.conf.set("hoodie.datasource.read.use.v2", "true")
+    aggMinMaxDsv2Times = (1 to iterations).map { i =>
+      timed(s"MIN/MAX DSv2 (iter $i)") {
+        spark.sql(s"SELECT MIN($filterCol), MAX($filterCol) FROM $cowReadTable")
+          .write.format("noop").mode("overwrite").save()
+      }
+    }
+
+    println("\n--- Aggregate MIN/MAX Summary ---")
+    printStats("MIN/MAX (DSv1)", aggMinMaxDsv1Times)
+    printStats("MIN/MAX (DSv2)", aggMinMaxDsv2Times)
+  }
+
+  // -------------------------------------------------------------------------
+  //  Final Summary
+  // -------------------------------------------------------------------------
+
+  println("\n" + "=" * 60)
+  println("BENCHMARK COMPLETE")
+  println("=" * 60)
+  println()
+  printStats("Read full (COW, DSv1)        ", readFullCowDsv1Times)
+  printStats("Read full (COW, DSv2)        ", readFullCowDsv2Times)
+  printStats("Read projected (COW, DSv1)   ", readProjCowDsv1Times)
+  printStats("Read projected (COW, DSv2)   ", readProjCowDsv2Times)
+  printStats("Read filter (COW, DSv1)      ", readFilterCowDsv1Times)
+  printStats("Read filter (COW, DSv2)      ", readFilterCowDsv2Times)
+  printStats("Read limit (COW, DSv1)       ", readLimitCowDsv1Times)
+  printStats("Read limit (COW, DSv2)       ", readLimitCowDsv2Times)
+  printStats("Aggregate COUNT(*) (DSv1)    ", aggCountDsv1Times)
+  printStats("Aggregate COUNT(*) (DSv2)    ", aggCountDsv2Times)
+  if (aggMinMaxDsv1Times.nonEmpty) {
+    printStats("Aggregate MIN/MAX (DSv1)     ", aggMinMaxDsv1Times)
+    printStats("Aggregate MIN/MAX (DSv2)     ", aggMinMaxDsv2Times)
+  }
+
+  // -------------------------------------------------------------------------
+  //  Performance Comparison: DSv2 vs DSv1
+  // -------------------------------------------------------------------------
+
+  println("\n" + "=" * 60)
+  println("DSv2 vs DSv1 PERFORMANCE COMPARISON")
+  println("=" * 60)
+
+  def comparePerf(label: String, dsv1Times: Seq[Double], dsv2Times: Seq[Double]): Boolean = {
+    if (dsv1Times.isEmpty || dsv2Times.isEmpty) {
+      println(f"$label%-35s: N/A (no data)")
+      return false
+    }
+    val dsv1Avg = dsv1Times.sum / dsv1Times.size
+    val dsv2Avg = dsv2Times.sum / dsv2Times.size
+    val speedup = dsv1Avg / dsv2Avg
+    val winner = if (speedup >= 1.0) "DSv2 FASTER" else "DSv1 FASTER"
+    println(f"$label%-35s: DSv1 avg ${dsv1Avg}%.1fs, DSv2 avg ${dsv2Avg}%.1fs, speedup ${speedup}%.2fx ($winner)")
+    speedup >= 1.0
+  }
+
+  println()
+  var dsv2Wins = 0
+  var totalComparisons = 0
+
+  val comparisons = Seq(
+    ("Full scan (COW)", readFullCowDsv1Times, readFullCowDsv2Times),
+    ("Projected (COW)", readProjCowDsv1Times, readProjCowDsv2Times),
+    ("Filter (COW)", readFilterCowDsv1Times, readFilterCowDsv2Times),
+    ("Limit (COW)", readLimitCowDsv1Times, readLimitCowDsv2Times),
+    ("Aggregate COUNT(*)", aggCountDsv1Times, aggCountDsv2Times),
+    ("Aggregate MIN/MAX", aggMinMaxDsv1Times, aggMinMaxDsv2Times)
+  )
+
+  comparisons.foreach { case (label, dsv1, dsv2) =>
+    if (dsv1.nonEmpty && dsv2.nonEmpty) {
+      totalComparisons += 1
+      if (comparePerf(label, dsv1, dsv2)) dsv2Wins += 1
+    }
+  }
+
+  println()
+  if (dsv2Wins > 0) {
+    println(s"PASS: DSv2 is faster than DSv1 in $dsv2Wins of $totalComparisons scenarios")
+  } else {
+    println(s"WARNING: DSv2 was not faster than DSv1 in any scenario (0 of $totalComparisons)")
+  }
+
+} finally {
+  // -------------------------------------------------------------------------
+  //  Cleanup
+  // -------------------------------------------------------------------------
+
+  println("\n--- Cleanup ---")
+  createdTables.foreach { table =>
+    try {
+      spark.sql(s"DROP TABLE IF EXISTS $table PURGE")
+      println(s"  Dropped $table")
+    } catch {
+      case e: Exception => println(s"  Warning: failed to drop $table: ${e.getMessage}")
+    }
+  }
+
+  // Drop the benchmark database (CASCADE drops any remaining tables)
+  try {
+    spark.sql(s"DROP DATABASE IF EXISTS $benchmarkDb CASCADE")
+    println(s"  Dropped database $benchmarkDb")
+  } catch {
+    case e: Exception => println(s"  Warning: failed to drop database $benchmarkDb: ${e.getMessage}")
+  }
+
+  // Restore original stdout and close log file
+  System.out.flush()
+  Console.setOut(origOut)
+  System.setOut(origOut)
+  logFile.close()
+  println(s"Benchmark log saved to: $logFileName")
+}
+
+// Exit spark-shell after benchmark
+System.exit(0)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/spark/sql/hudi/v2/PartialLimitPushDown.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/spark/sql/hudi/v2/PartialLimitPushDown.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2;
+
+import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
+
+/**
+ * Extension of {@link SupportsPushDownLimit} that marks limit pushdown as partial.
+ *
+ * Spark 3.4+ added {@code isPartiallyPushed()} as a default method (returning false).
+ * Spark 3.3 does not have this method. By providing the default here in a Java interface,
+ * we avoid the Scala {@code override} keyword issue: Java default methods don't require
+ * {@code @Override}, so this compiles against both Spark 3.3 (new method) and 3.4+ (override).
+ *
+ * When {@code isPartiallyPushed()} returns true, Spark adds a final LocalLimit on top of the
+ * scan, which is necessary because Hudi's limit pushdown is best-effort (per-partition).
+ */
+public interface PartialLimitPushDown extends SupportsPushDownLimit {
+  default boolean isPartiallyPushed() {
+    return true;
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/resources/META-INF/services/org.apache.spark.sql.connector.catalog.TableProvider
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/resources/META-INF/services/org.apache.spark.sql.connector.catalog.TableProvider
@@ -16,6 +16,4 @@
 # limitations under the License.
 
 
-org.apache.hudi.BaseDefaultSource
-org.apache.spark.sql.execution.datasources.parquet.LegacyHoodieParquetFileFormat
 org.apache.spark.sql.hudi.v2.HoodieDataSourceV2

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -311,6 +311,14 @@ object DataSourceReadOptions {
       " for parsing partition values from partition path. When this config is enabled, it uses" +
       " PartitionValueExtractor class value stored in the hoodie.properties file.")
 
+  val USE_V2_READ: ConfigProperty[String] = ConfigProperty
+    .key("hoodie.datasource.read.use.v2")
+    .defaultValue("false")
+    .markAdvanced()
+    .sinceVersion("1.3.0")
+    .withDocumentation("When enabled, SQL/catalog queries use the DSv2 read path (HoodieSparkV2Table) " +
+      "instead of the default DSv1 path. The DataFrame API can also use format(\"hudi_v2\") directly.")
+
   /** @deprecated Use {@link QUERY_TYPE} and its methods instead */
   @Deprecated
   val QUERY_TYPE_OPT_KEY = QUERY_TYPE.key()

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -161,7 +161,10 @@ class DefaultSource extends RelationProvider
                               df: DataFrame): BaseRelation = {
     try {
       if (optParams.get(OPERATION.key).contains(BOOTSTRAP_OPERATION_OPT_VAL)) {
-        HoodieSparkSqlWriter.bootstrap(sqlContext, mode, optParams, df)
+        val success = HoodieSparkSqlWriter.bootstrap(sqlContext, mode, optParams, df)
+        if (!success) {
+          throw new HoodieException("Failed to bootstrap Hudi table")
+        }
       } else {
         val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sqlContext, mode, optParams, df)
         if (!success) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.hudi.analysis.HoodieSparkBaseAnalysis.{HoodieV1OrV2T
 import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
 import org.apache.spark.sql.hudi.command.{AlterHoodieTableDropPartitionCommand, ShowHoodieTablePartitionsCommand, TruncateHoodieTableCommand}
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
+import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.types.{ArrayType, DecimalType, DoubleType, FloatType, IntegerType, LongType}
 
 /**
@@ -431,6 +432,7 @@ object HoodieSparkBaseAnalysis extends SparkAdapterSupport {
     def unapply(table: Table): Option[CatalogTable] = table match {
       case V1Table(catalogTable) if sparkAdapter.isHoodieTable(catalogTable) => Some(catalogTable)
       case v2: HoodieInternalV2Table => v2.catalogTable
+      case v2: HoodieSparkV2Table => v2.catalogTable
       case _ => None
     }
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
@@ -43,16 +43,6 @@ import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.types.{ArrayType, DecimalType, DoubleType, FloatType, IntegerType, LongType}
 
 /**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
-
-/**
  * Rule for resolve hoodie's extended syntax or rewrite some logical plan.
  */
 case class ResolveReferences(spark: SparkSession) extends Rule[LogicalPlan]

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
@@ -143,13 +143,6 @@ class HoodieCatalog extends DelegatingCatalogExtension
           DataSourceReadOptions.USE_V2_READ.defaultValue).toBoolean
         val schemaEvolutionEnabled = ProvidesHoodieConfig.isSchemaEvolutionEnabled(spark)
 
-        // NOTE: PLEASE READ CAREFULLY
-        //
-        // Since Hudi relations don't currently implement DS V2 Read API, we by default fallback to V1 here.
-        // Such fallback will have considerable performance impact, therefore it's only performed in cases
-        // where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
-        //
-        // Check out HUDI-4178 for more details
         if (v2ReadEnabled) {
           HoodieSparkV2Table(
             spark = spark,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
@@ -19,7 +19,7 @@
 
 package org.apache.spark.sql.hudi.catalog
 
-import org.apache.hudi.{DataSourceWriteOptions, SparkAdapterSupport}
+import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, SparkAdapterSupport}
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.table.HoodieTableMetaClient
@@ -47,6 +47,7 @@ import org.apache.spark.sql.hudi.analysis.HoodieSparkBaseAnalysis.HoodieV1OrV2Ta
 import org.apache.spark.sql.hudi.catalog.HoodieCatalog.{buildPartitionTransforms, isTablePartitioned}
 import org.apache.spark.sql.hudi.command._
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
+import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.types.{StructField, StructType}
 
 import java.net.URI
@@ -137,6 +138,9 @@ class HoodieCatalog extends DelegatingCatalogExtension
           catalogTable = Some(catalogTable),
           tableIdentifier = Some(ident.toString))
 
+        val v2ReadEnabled = spark.sessionState.conf.getConfString(
+          DataSourceReadOptions.USE_V2_READ.key,
+          DataSourceReadOptions.USE_V2_READ.defaultValue).toBoolean
         val schemaEvolutionEnabled = ProvidesHoodieConfig.isSchemaEvolutionEnabled(spark)
 
         // NOTE: PLEASE READ CAREFULLY
@@ -146,7 +150,12 @@ class HoodieCatalog extends DelegatingCatalogExtension
         // where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
         //
         // Check out HUDI-4178 for more details
-        if (schemaEvolutionEnabled) {
+        if (v2ReadEnabled) {
+          HoodieSparkV2Table(
+            spark = spark,
+            path = catalogTable.location.toString,
+            catalogTable = Some(catalogTable))
+        } else if (schemaEvolutionEnabled) {
           v2Table
         } else {
           v2Table.v1TableWrapper

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.hudi.analysis.HoodieSparkBaseAnalysis.HoodieV1OrV2Ta
 import org.apache.spark.sql.hudi.catalog.HoodieCatalog.{buildPartitionTransforms, isTablePartitioned}
 import org.apache.spark.sql.hudi.command._
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
-import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
+import org.apache.spark.sql.hudi.v2.{HoodieSparkV2Table, HoodieV2ReadSupport}
 import org.apache.spark.sql.types.{StructField, StructType}
 
 import java.net.URI
@@ -143,7 +143,15 @@ class HoodieCatalog extends DelegatingCatalogExtension
           DataSourceReadOptions.USE_V2_READ.defaultValue).toBoolean
         val schemaEvolutionEnabled = ProvidesHoodieConfig.isSchemaEvolutionEnabled(spark)
 
-        if (v2ReadEnabled) {
+        val dsv2Supported = v2ReadEnabled && {
+          val metaClient = HoodieTableMetaClient.builder()
+            .setBasePath(catalogTable.location.toString)
+            .setConf(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf))
+            .build()
+          HoodieV2ReadSupport.isSupportedByDSv2(metaClient, Map.empty, spark)
+        }
+
+        if (dsv2Supported) {
           HoodieSparkV2Table(
             spark = spark,
             path = catalogTable.location.toString,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hudi.catalog
 
 import org.apache.hudi.{HoodieSchemaConversionUtils, HoodieSparkSqlWriter}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
@@ -146,8 +147,11 @@ private[hudi] class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
             .convertStructTypeToHoodieSchema(hoodieCatalogTable.tableSchema, structName, namespace)
 
           try {
-            HoodieSparkSqlWriter.write(spark.sqlContext, mode, config, alignedData,
+            val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(spark.sqlContext, mode, config, alignedData,
               schemaFromCatalog = Option(catalogSchema))
+            if (!success) {
+              throw new HoodieException("Failed to write to Hudi")
+            }
           } finally {
             HoodieSparkSqlWriter.cleanup()
           }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieInternalV2Table.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hudi.catalog
 
+import org.apache.hudi.{HoodieSchemaConversionUtils, HoodieSparkSqlWriter}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 
@@ -34,7 +35,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import java.util
 
-import scala.collection.JavaConverters.{mapAsJavaMapConverter, setAsJavaSetConverter}
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter, setAsJavaSetConverter}
 
 case class HoodieInternalV2Table(spark: SparkSession,
                                  path: String,
@@ -87,9 +88,9 @@ case class HoodieInternalV2Table(spark: SparkSession,
 
 }
 
-private class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
-                                   hoodieCatalogTable: HoodieCatalogTable,
-                                   spark: SparkSession)
+private[hudi] class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
+                                         hoodieCatalogTable: HoodieCatalogTable,
+                                         spark: SparkSession)
   extends SupportsTruncate with SupportsOverwrite with ProvidesHoodieConfig {
 
   private var overwriteTable = false
@@ -115,11 +116,41 @@ private class HoodieV1WriteBuilder(writeOptions: CaseInsensitiveStringMap,
             SaveMode.Append
           }
 
-          data.write.format("org.apache.hudi")
-            .mode(mode)
-            .options(buildHoodieConfig(hoodieCatalogTable) ++
-              buildHoodieInsertConfig(hoodieCatalogTable, spark, overwritePartition, overwriteTable, Map.empty, Map.empty))
-            .save()
+          val writeOptsMap = writeOptions.asCaseSensitiveMap().asScala.toMap
+          val config = buildHoodieConfig(hoodieCatalogTable) ++
+            buildHoodieInsertConfig(hoodieCatalogTable, spark,
+              overwritePartition, overwriteTable, Map.empty, writeOptsMap) ++
+            writeOptsMap
+
+          // The V2-to-V1 fallback may receive a DataFrame with generic column names
+          // (e.g., col1, col2 from VALUES clause) and uncast types (e.g., DECIMAL literals
+          // for DOUBLE columns). Rename and cast columns to match the table's user schema.
+          val userSchema = hoodieCatalogTable.tableSchemaWithoutMetaFields
+          val alignedData = if (data.schema == userSchema) {
+            data
+          } else if (data.columns.length == userSchema.length) {
+            val columns = data.schema.fields.zip(userSchema.fields).map {
+              case (srcField, tgtField) =>
+                data.col(srcField.name).cast(tgtField.dataType).as(tgtField.name)
+            }
+            data.select(columns: _*)
+          } else {
+            data
+          }
+
+          // Pass the catalog schema so the V1 writer can properly reconcile the
+          // incoming schema with the full table schema (including meta-fields).
+          val (structName, namespace) =
+            HoodieSchemaConversionUtils.getRecordNameAndNamespace(hoodieCatalogTable.tableName)
+          val catalogSchema = HoodieSchemaConversionUtils
+            .convertStructTypeToHoodieSchema(hoodieCatalogTable.tableSchema, structName, namespace)
+
+          try {
+            HoodieSparkSqlWriter.write(spark.sqlContext, mode, config, alignedData,
+              schemaFromCatalog = Option(catalogSchema))
+          } finally {
+            HoodieSparkSqlWriter.cleanup()
+          }
         }
       }
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -18,14 +18,14 @@
 package org.apache.spark.sql.hudi.v2
 
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
+import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan, Statistics, SupportsReportStatistics}
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Batch scan for CoW snapshot reads via DSv2.
+ * Batch scan for snapshot reads via DSv2 (COW).
  */
 class HoodieBatchScan(readSchema: StructType,
                       inputPartitions: Array[InputPartition],
@@ -33,7 +33,8 @@ class HoodieBatchScan(readSchema: StructType,
                       broadcastConf: Broadcast[SerializableConfiguration],
                       requiredDataSchema: StructType,
                       requiredPartitionSchema: StructType,
-                      pushedFilters: Array[Filter] = Array.empty) extends Scan with Batch {
+                      pushedFilters: Array[Filter] = Array.empty,
+                      pushedLimit: Option[Int] = None) extends Scan with Batch with SupportsReportStatistics {
 
   override def readSchema(): StructType = readSchema
 
@@ -43,7 +44,8 @@ class HoodieBatchScan(readSchema: StructType,
     } else {
       ", PushedFilters: []"
     }
-    s"HoodieBatchScan${readSchema.catalogString}$filtersStr"
+    val limitStr = pushedLimit.map(l => s", PushedLimit: $l").getOrElse("")
+    s"HoodieBatchScan${readSchema.catalogString}$filtersStr$limitStr"
   }
 
   override def toBatch: Batch = this
@@ -56,6 +58,14 @@ class HoodieBatchScan(readSchema: StructType,
       broadcastConf,
       readSchema,
       requiredDataSchema,
-      requiredPartitionSchema)
+      requiredPartitionSchema,
+      pushedLimit)
+  }
+
+  override def estimateStatistics(): Statistics = {
+    val totalSize = inputPartitions.collect {
+      case p: HoodieInputPartition => p.baseFileLength
+    }.sum
+    new HoodieStatistics(totalSize)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Stub batch scan that returns an empty partition list.
+ * The read schema reflects any column pruning applied by the scan builder.
+ */
+class HoodieBatchScan(readSchema: StructType) extends Scan with Batch {
+
+  override def readSchema(): StructType = readSchema
+
+  override def toBatch: Batch = this
+
+  override def planInputPartitions(): Array[InputPartition] = Array.empty
+
+  override def createReaderFactory(): PartitionReaderFactory = new HoodiePartitionReaderFactory
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hudi.v2
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -31,9 +32,19 @@ class HoodieBatchScan(readSchema: StructType,
                       broadcastReader: Broadcast[SparkColumnarFileReader],
                       broadcastConf: Broadcast[SerializableConfiguration],
                       requiredDataSchema: StructType,
-                      requiredPartitionSchema: StructType) extends Scan with Batch {
+                      requiredPartitionSchema: StructType,
+                      pushedFilters: Array[Filter] = Array.empty) extends Scan with Batch {
 
   override def readSchema(): StructType = readSchema
+
+  override def description(): String = {
+    val filtersStr = if (pushedFilters.nonEmpty) {
+      s", PushedFilters: [${pushedFilters.mkString(", ")}]"
+    } else {
+      ", PushedFilters: []"
+    }
+    s"HoodieBatchScan${readSchema.catalogString}$filtersStr"
+  }
 
   override def toBatch: Batch = this
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -17,20 +17,34 @@
 
 package org.apache.spark.sql.hudi.v2
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
+import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Stub batch scan that returns an empty partition list.
- * The read schema reflects any column pruning applied by the scan builder.
+ * Batch scan for CoW snapshot reads via DSv2.
  */
-class HoodieBatchScan(readSchema: StructType) extends Scan with Batch {
+class HoodieBatchScan(readSchema: StructType,
+                      inputPartitions: Array[InputPartition],
+                      broadcastReader: Broadcast[SparkColumnarFileReader],
+                      broadcastConf: Broadcast[SerializableConfiguration],
+                      requiredDataSchema: StructType,
+                      requiredPartitionSchema: StructType) extends Scan with Batch {
 
   override def readSchema(): StructType = readSchema
 
   override def toBatch: Batch = this
 
-  override def planInputPartitions(): Array[InputPartition] = Array.empty
+  override def planInputPartitions(): Array[InputPartition] = inputPartitions
 
-  override def createReaderFactory(): PartitionReaderFactory = new HoodiePartitionReaderFactory
+  override def createReaderFactory(): PartitionReaderFactory = {
+    new HoodiePartitionReaderFactory(
+      broadcastReader,
+      broadcastConf,
+      readSchema,
+      requiredDataSchema,
+      requiredPartitionSchema)
+  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieBatchScan.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.hudi.v2
 
+import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.internal.schema.InternalSchema
+
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan, Statistics, SupportsReportStatistics}
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
@@ -27,25 +30,22 @@ import org.apache.spark.util.SerializableConfiguration
 /**
  * Batch scan for snapshot reads via DSv2 (COW).
  */
-class HoodieBatchScan(readSchema: StructType,
+class HoodieBatchScan(outputSchema: StructType,
                       inputPartitions: Array[InputPartition],
                       broadcastReader: Broadcast[SparkColumnarFileReader],
                       broadcastConf: Broadcast[SerializableConfiguration],
                       requiredDataSchema: StructType,
                       requiredPartitionSchema: StructType,
+                      internalSchemaOpt: HOption[InternalSchema] = HOption.empty(),
                       pushedFilters: Array[Filter] = Array.empty,
                       pushedLimit: Option[Int] = None) extends Scan with Batch with SupportsReportStatistics {
 
-  override def readSchema(): StructType = readSchema
+  override def readSchema(): StructType = outputSchema
 
   override def description(): String = {
-    val filtersStr = if (pushedFilters.nonEmpty) {
-      s", PushedFilters: [${pushedFilters.mkString(", ")}]"
-    } else {
-      ", PushedFilters: []"
-    }
+    val filtersStr = s", PushedFilters: [${pushedFilters.mkString(", ")}]"
     val limitStr = pushedLimit.map(l => s", PushedLimit: $l").getOrElse("")
-    s"HoodieBatchScan${readSchema.catalogString}$filtersStr$limitStr"
+    s"HoodieBatchScan${outputSchema.catalogString}$filtersStr$limitStr"
   }
 
   override def toBatch: Batch = this
@@ -56,9 +56,11 @@ class HoodieBatchScan(readSchema: StructType,
     new HoodiePartitionReaderFactory(
       broadcastReader,
       broadcastConf,
-      readSchema,
+      outputSchema,
       requiredDataSchema,
       requiredPartitionSchema,
+      internalSchemaOpt,
+      pushedFilters,
       pushedLimit)
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
@@ -56,7 +56,7 @@ class HoodieDataSourceV2 extends TableProvider with DataSourceRegister with Crea
       throw new HoodieException("'path' cannot be null, missing 'path' from table properties")
     }
 
-    HoodieSparkV2Table(SparkSession.active, path)
+    HoodieSparkV2Table(SparkSession.active, path, options = options)
   }
 
   override def createRelation(sqlContext: SQLContext,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.hudi.{DataSourceWriteOptions, HoodieEmptyRelation, HoodieSparkSqlWriter}
+import org.apache.hudi.exception.HoodieException
+
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession, SQLContext}
+import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+/**
+ * DSv2 data source for Hudi, registered with short name "hudi_v2".
+ *
+ * Activation via DataFrame API:
+ * - Read: `spark.read.format("hudi_v2").load(path)`
+ * - Write: `df.write.format("hudi_v2").save(path)`
+ *
+ * The SQL/Catalog path is handled by [[org.apache.spark.sql.hudi.catalog.HoodieCatalog.loadTable]].
+ *
+ * Write via DataFrame API is supported through [[CreatableRelationProvider]], which Spark uses
+ * as V1 fallback when the data source implements [[TableProvider]] + [[DataSourceRegister]].
+ */
+class HoodieDataSourceV2 extends TableProvider with DataSourceRegister with CreatableRelationProvider {
+
+  override def shortName(): String = "hudi_v2"
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = new StructType()
+
+  override def getTable(schema: StructType,
+                        partitioning: Array[Transform],
+                        properties: util.Map[String, String]): Table = {
+    val options = new CaseInsensitiveStringMap(properties)
+    val path = options.get("path")
+    if (path == null) {
+      throw new HoodieException("'path' cannot be null, missing 'path' from table properties")
+    }
+
+    HoodieSparkV2Table(SparkSession.active, path)
+  }
+
+  override def createRelation(sqlContext: SQLContext,
+                               mode: SaveMode,
+                               optParams: Map[String, String],
+                               df: DataFrame): BaseRelation = {
+    try {
+      if (optParams.get(DataSourceWriteOptions.OPERATION.key)
+        .contains(DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL)) {
+        HoodieSparkSqlWriter.bootstrap(sqlContext, mode, optParams, df)
+      } else {
+        val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sqlContext, mode, optParams, df)
+        if (!success) {
+          throw new HoodieException("Failed to write to Hudi")
+        }
+      }
+    } finally {
+      HoodieSparkSqlWriter.cleanup()
+    }
+
+    new HoodieEmptyRelation(sqlContext, df.schema)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieDataSourceV2.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.sql.hudi.v2
 
 import org.apache.hudi.{DataSourceWriteOptions, HoodieEmptyRelation, HoodieSparkSqlWriter}
-import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.exception.{HoodieException, TableNotFoundException}
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
 
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession, SQLContext}
 import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
@@ -28,6 +30,8 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import java.util
+
+import scala.collection.JavaConverters._
 
 /**
  * DSv2 data source for Hudi, registered with short name "hudi_v2".
@@ -56,7 +60,29 @@ class HoodieDataSourceV2 extends TableProvider with DataSourceRegister with Crea
       throw new HoodieException("'path' cannot be null, missing 'path' from table properties")
     }
 
-    HoodieSparkV2Table(SparkSession.active, path, options = options)
+    val spark = SparkSession.active
+    // Writes to a new path have no table on disk yet; the gate only applies to reads against
+    // an existing table. Swallowing TableNotFoundException lets the V1-write fallback proceed.
+    val metaClientOpt: Option[HoodieTableMetaClient] = try {
+      Some(HoodieTableMetaClient.builder()
+        .setBasePath(path)
+        .setConf(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf))
+        .build())
+    } catch {
+      case _: TableNotFoundException => None
+    }
+
+    val optsMap = options.asCaseSensitiveMap().asScala.toMap
+    metaClientOpt.foreach { metaClient =>
+      if (!HoodieV2ReadSupport.isSupportedByDSv2(metaClient, optsMap, spark)) {
+        throw new HoodieException(
+          "format(\"hudi_v2\") does not support this query configuration " +
+            "(MOR snapshot, non-Parquet base format, multiple base formats, " +
+            "incremental/CDC, or bootstrap table). Use format(\"hudi\") instead.")
+      }
+    }
+
+    HoodieSparkV2Table(spark, path, options = options)
   }
 
   override def createRelation(sqlContext: SQLContext,
@@ -66,7 +92,10 @@ class HoodieDataSourceV2 extends TableProvider with DataSourceRegister with Crea
     try {
       if (optParams.get(DataSourceWriteOptions.OPERATION.key)
         .contains(DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL)) {
-        HoodieSparkSqlWriter.bootstrap(sqlContext, mode, optParams, df)
+        val success = HoodieSparkSqlWriter.bootstrap(sqlContext, mode, optParams, df)
+        if (!success) {
+          throw new HoodieException("Failed to bootstrap Hudi table")
+        }
       } else {
         val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sqlContext, mode, optParams, df)
         if (!success) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieInputPartition.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieInputPartition.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.connector.read.InputPartition
+
+/**
+ * Placeholder input partition for the DSv2 read path.
+ * Not used in the initial stub (PR1) since the scan returns an empty partition list.
+ */
+case class HoodieInputPartition(index: Int) extends InputPartition

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieInputPartition.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieInputPartition.scala
@@ -20,7 +20,15 @@ package org.apache.spark.sql.hudi.v2
 import org.apache.spark.sql.connector.read.InputPartition
 
 /**
- * Placeholder input partition for the DSv2 read path.
- * Not used in the initial stub (PR1) since the scan returns an empty partition list.
+ * Input partition for the DSv2 read path, representing a single base file to read.
+ *
+ * @param index           partition index
+ * @param baseFilePath    full path to the base (Parquet) file
+ * @param baseFileLength  file size in bytes
+ * @param partitionValues partition column values in Spark internal format (e.g. UTF8String),
+ *                        ordered to match the requiredPartitionSchema
  */
-case class HoodieInputPartition(index: Int) extends InputPartition
+case class HoodieInputPartition(index: Int,
+                                baseFilePath: String,
+                                baseFileLength: Long,
+                                partitionValues: Array[AnyRef]) extends InputPartition

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieLocalScan.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieLocalScan.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.{LocalScan, Scan}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * A scan that returns pre-computed rows without reading any files.
+ * Used for fully pushed-down aggregates (e.g. COUNT(*) from column stats).
+ */
+class HoodieLocalScan(outputSchema: StructType, resultRows: Array[InternalRow])
+  extends Scan with LocalScan {
+
+  override def readSchema(): StructType = outputSchema
+
+  override def rows(): Array[InternalRow] = resultRows
+
+  override def description(): String = s"HoodieLocalScan[${resultRows.length} rows]"
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.SerializableConfiguration
 import java.io.Closeable
 
 /**
- * Partition reader that reads rows from a single CoW base file using [[SparkColumnarFileReader]].
+ * Partition reader that reads rows from a single COW base file using [[SparkColumnarFileReader]].
  */
 class
 
@@ -42,16 +42,20 @@ HoodiePartitionReader(partition: HoodieInputPartition,
                             broadcastConf: Broadcast[SerializableConfiguration],
                             readSchema: StructType,
                             requiredDataSchema: StructType,
-                            requiredPartitionSchema: StructType)
+                            requiredPartitionSchema: StructType,
+                            pushedLimit: Option[Int] = None)
   extends PartitionReader[InternalRow] with SparkAdapterSupport {
 
   private var rawIterator: Iterator[InternalRow] = _
   private val iter: Iterator[InternalRow] = createIterator()
   private var current: InternalRow = _
+  private var rowCount: Int = 0
 
   override def next(): Boolean = {
-    if (iter.hasNext) {
+    val limitReached = pushedLimit.exists(rowCount >= _)
+    if (!limitReached && iter.hasNext) {
       current = iter.next()
+      rowCount += 1
       true
     } else {
       false

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.PartitionReader
+
+/**
+ * Stub partition reader that always returns empty results.
+ * Will be replaced with real record reading in a subsequent PR.
+ */
+class HoodiePartitionReader extends PartitionReader[InternalRow] {
+
+  override def next(): Boolean = false
+
+  override def get(): InternalRow = {
+    throw new NoSuchElementException("HoodiePartitionReader stub has no rows")
+  }
+
+  override def close(): Unit = {}
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
@@ -17,20 +17,73 @@
 
 package org.apache.spark.sql.hudi.v2
 
+import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.storage.StoragePath
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
+import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
+
+import java.io.Closeable
 
 /**
- * Stub partition reader that always returns empty results.
- * Will be replaced with real record reading in a subsequent PR.
+ * Partition reader that reads rows from a single CoW base file using [[SparkColumnarFileReader]].
  */
-class HoodiePartitionReader extends PartitionReader[InternalRow] {
+class
 
-  override def next(): Boolean = false
+HoodiePartitionReader(partition: HoodieInputPartition,
+                            broadcastReader: Broadcast[SparkColumnarFileReader],
+                            broadcastConf: Broadcast[SerializableConfiguration],
+                            readSchema: StructType,
+                            requiredDataSchema: StructType,
+                            requiredPartitionSchema: StructType)
+  extends PartitionReader[InternalRow] with SparkAdapterSupport {
 
-  override def get(): InternalRow = {
-    throw new NoSuchElementException("HoodiePartitionReader stub has no rows")
+  private var rawIterator: Iterator[InternalRow] = _
+  private val iter: Iterator[InternalRow] = createIterator()
+  private var current: InternalRow = _
+
+  override def next(): Boolean = {
+    if (iter.hasNext) {
+      current = iter.next()
+      true
+    } else {
+      false
+    }
   }
 
-  override def close(): Unit = {}
+  override def get(): InternalRow = current
+
+  override def close(): Unit = {
+    rawIterator match {
+      case c: Closeable => c.close()
+      case _ =>
+    }
+  }
+
+  private def createIterator(): Iterator[InternalRow] = {
+    val partValues = InternalRow.fromSeq(partition.partitionValues.toSeq)
+
+    val pFile = sparkAdapter.getSparkPartitionedFileUtils
+      .createPartitionedFile(partValues, new StoragePath(partition.baseFilePath), 0L, partition.baseFileLength)
+
+    val storageConf = new HadoopStorageConfiguration(broadcastConf.value.value)
+    rawIterator = broadcastReader.value.read(
+      pFile, requiredDataSchema, requiredPartitionSchema,
+      HOption.empty(), Seq.empty, storageConf)
+
+    val readerOutputSchema = StructType(requiredDataSchema.fields ++ requiredPartitionSchema.fields)
+    if (readerOutputSchema != readSchema) {
+      val projection = HoodieCatalystExpressionUtils.generateUnsafeProjection(readerOutputSchema, readSchema)
+      rawIterator.map(row => projection(row))
+    } else {
+      rawIterator
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReader.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hudi.v2
 
 import org.apache.hudi.SparkAdapterSupport
 import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.internal.schema.InternalSchema
 import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
 
@@ -27,6 +28,7 @@ import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -35,14 +37,14 @@ import java.io.Closeable
 /**
  * Partition reader that reads rows from a single COW base file using [[SparkColumnarFileReader]].
  */
-class
-
-HoodiePartitionReader(partition: HoodieInputPartition,
+class HoodiePartitionReader(partition: HoodieInputPartition,
                             broadcastReader: Broadcast[SparkColumnarFileReader],
                             broadcastConf: Broadcast[SerializableConfiguration],
                             readSchema: StructType,
                             requiredDataSchema: StructType,
                             requiredPartitionSchema: StructType,
+                            internalSchemaOpt: HOption[InternalSchema] = HOption.empty(),
+                            pushedFilters: Array[Filter] = Array.empty,
                             pushedLimit: Option[Int] = None)
   extends PartitionReader[InternalRow] with SparkAdapterSupport {
 
@@ -80,7 +82,7 @@ HoodiePartitionReader(partition: HoodieInputPartition,
     val storageConf = new HadoopStorageConfiguration(broadcastConf.value.value)
     rawIterator = broadcastReader.value.read(
       pFile, requiredDataSchema, requiredPartitionSchema,
-      HOption.empty(), Seq.empty, storageConf)
+      internalSchemaOpt, pushedFilters.toSeq, storageConf)
 
     val readerOutputSchema = StructType(requiredDataSchema.fields ++ requiredPartitionSchema.fields)
     if (readerOutputSchema != readSchema) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+
+/**
+ * Stub factory that creates [[HoodiePartitionReader]] instances.
+ */
+class HoodiePartitionReaderFactory extends PartitionReaderFactory {
+
+  override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    new HoodiePartitionReader
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
@@ -17,15 +17,29 @@
 
 package org.apache.spark.sql.hudi.v2
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Stub factory that creates [[HoodiePartitionReader]] instances.
+ * Factory that creates [[HoodiePartitionReader]] instances for DSv2 CoW snapshot reads.
  */
-class HoodiePartitionReaderFactory extends PartitionReaderFactory {
+class HoodiePartitionReaderFactory(broadcastReader: Broadcast[SparkColumnarFileReader],
+                                   broadcastConf: Broadcast[SerializableConfiguration],
+                                   readSchema: StructType,
+                                   requiredDataSchema: StructType,
+                                   requiredPartitionSchema: StructType) extends PartitionReaderFactory {
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
-    new HoodiePartitionReader
+    new HoodiePartitionReader(
+      partition.asInstanceOf[HoodieInputPartition],
+      broadcastReader,
+      broadcastConf,
+      readSchema,
+      requiredDataSchema,
+      requiredPartitionSchema)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
@@ -25,21 +25,24 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Factory that creates [[HoodiePartitionReader]] instances for DSv2 CoW snapshot reads.
+ * Factory that creates partition readers for COW snapshot reads.
  */
 class HoodiePartitionReaderFactory(broadcastReader: Broadcast[SparkColumnarFileReader],
                                    broadcastConf: Broadcast[SerializableConfiguration],
                                    readSchema: StructType,
                                    requiredDataSchema: StructType,
-                                   requiredPartitionSchema: StructType) extends PartitionReaderFactory {
+                                   requiredPartitionSchema: StructType,
+                                   pushedLimit: Option[Int] = None) extends PartitionReaderFactory {
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    val hoodiePart = partition.asInstanceOf[HoodieInputPartition]
     new HoodiePartitionReader(
-      partition.asInstanceOf[HoodieInputPartition],
+      hoodiePart,
       broadcastReader,
       broadcastConf,
       readSchema,
       requiredDataSchema,
-      requiredPartitionSchema)
+      requiredPartitionSchema,
+      pushedLimit)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodiePartitionReaderFactory.scala
@@ -17,10 +17,14 @@
 
 package org.apache.spark.sql.hudi.v2
 
+import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.internal.schema.InternalSchema
+
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -32,6 +36,8 @@ class HoodiePartitionReaderFactory(broadcastReader: Broadcast[SparkColumnarFileR
                                    readSchema: StructType,
                                    requiredDataSchema: StructType,
                                    requiredPartitionSchema: StructType,
+                                   internalSchemaOpt: HOption[InternalSchema] = HOption.empty(),
+                                   pushedFilters: Array[Filter] = Array.empty,
                                    pushedLimit: Option[Int] = None) extends PartitionReaderFactory {
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
@@ -43,6 +49,8 @@ class HoodiePartitionReaderFactory(broadcastReader: Broadcast[SparkColumnarFileR
       readSchema,
       requiredDataSchema,
       requiredPartitionSchema,
+      internalSchemaOpt,
+      pushedFilters,
       pushedLimit)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Stub scan builder that accepts column pruning and returns all filters as post-scan.
+ * Filter pushdown will be implemented in a subsequent PR.
+ */
+class HoodieScanBuilder(tableSchema: StructType) extends ScanBuilder
+  with SupportsPushDownFilters
+  with SupportsPushDownRequiredColumns {
+
+  private var requiredSchema: StructType = tableSchema
+  override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+    // Stub: all filters are returned as post-scan (none pushed down)
+    filters
+  }
+
+  override def pushedFilters(): Array[Filter] = Array.empty
+
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    this.requiredSchema = requiredSchema
+  }
+
+  override def build(): Scan = new HoodieBatchScan(requiredSchema)
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -20,7 +20,10 @@ package org.apache.spark.sql.hudi.v2
 import org.apache.hudi.HoodieFileIndex
 import org.apache.hudi.SparkAdapterSupport
 import org.apache.hudi.common.table.HoodieTableMetaClient
+
+import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.Filter
@@ -29,7 +32,7 @@ import org.apache.spark.util.SerializableConfiguration
 
 /**
  * Scan builder for DSv2 CoW snapshot reads.
- * Accepts column pruning; filter pushdown deferred to a later PR.
+ * Accepts column pruning and filter pushdown (partition pruning + data skipping).
  */
 class HoodieScanBuilder(spark: SparkSession,
                         metaClient: HoodieTableMetaClient,
@@ -40,22 +43,44 @@ class HoodieScanBuilder(spark: SparkSession,
   with SparkAdapterSupport {
 
   private var requiredSchema: StructType = tableSchema
+  private var _pushedFilters: Array[Filter] = Array.empty
+  private var partitionFilterExprs: Seq[Expression] = Seq.empty
+  private var dataFilterExprs: Seq[Expression] = Seq.empty
+
+  private lazy val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
+    includeLogFiles = false, shouldEmbedFileSlices = false)
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    // All filters are returned as post-scan (none pushed down)
-    filters
+    val (pushed, postScan) = filters.partition { f =>
+      HoodieCatalystExpressionUtils.convertToCatalystExpression(f, tableSchema).isDefined
+    }
+
+    val expressions = pushed.flatMap(f =>
+      HoodieCatalystExpressionUtils.convertToCatalystExpression(f, tableSchema))
+
+    val (partFilters, datFilters) = HoodieCatalystExpressionUtils
+      .splitPartitionAndDataPredicates(spark, expressions, fileIndex.partitionSchema.fieldNames)
+
+    partitionFilterExprs = partFilters.toSeq
+    dataFilterExprs = datFilters.toSeq
+
+    _pushedFilters = pushed
+
+    // Data filters are only used for file-level skipping (via metadata indices),
+    // not for row-level filtering. Return them as postScan so Spark applies
+    // row-level filtering. Partition filters are fully handled by partition pruning.
+    val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
+    val dataFilterArr = pushed.filterNot(f => f.references.forall(partFieldNames.contains))
+    postScan ++ dataFilterArr
   }
 
-  override def pushedFilters(): Array[Filter] = Array.empty
+  override def pushedFilters(): Array[Filter] = _pushedFilters
 
   override def pruneColumns(requiredSchema: StructType): Unit = {
     this.requiredSchema = requiredSchema
   }
 
   override def build(): Scan = {
-    val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
-      includeLogFiles = false, shouldEmbedFileSlices = false)
-
     val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
     val requiredDataSchema = StructType(requiredSchema.filterNot(f => partFieldNames.contains(f.name)))
     val requiredPartitionSchema = StructType(requiredSchema.filter(f => partFieldNames.contains(f.name)))
@@ -67,7 +92,7 @@ class HoodieScanBuilder(spark: SparkSession,
     val broadcastConf = spark.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
     val fullPartSchema = fileIndex.partitionSchema
-    val fileSlicesPerPartition = fileIndex.filterFileSlices(Seq.empty, Seq.empty)
+    val fileSlicesPerPartition = fileIndex.filterFileSlices(dataFilterExprs, partitionFilterExprs)
 
     val partitions = fileSlicesPerPartition.flatMap { case (partitionOpt, fileSlices) =>
       fileSlices.filter(fs => fs.getBaseFile.isPresent).map { fs =>
@@ -93,6 +118,7 @@ class HoodieScanBuilder(spark: SparkSession,
       broadcastReader,
       broadcastConf,
       requiredDataSchema,
-      requiredPartitionSchema)
+      requiredPartitionSchema,
+      _pushedFilters)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow}
 import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Count, CountStar, Max, Min}
-import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
@@ -50,7 +50,7 @@ class HoodieScanBuilder(spark: SparkSession,
                         options: Map[String, String]) extends ScanBuilder
   with SupportsPushDownFilters
   with SupportsPushDownRequiredColumns
-  with SupportsPushDownLimit
+  with PartialLimitPushDown
   with SupportsPushDownAggregates
   with SparkAdapterSupport {
 
@@ -101,8 +101,6 @@ class HoodieScanBuilder(spark: SparkSession,
     pushedLimit = Some(limit)
     true
   }
-
-  override def isPartiallyPushed(): Boolean = true
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {
     if (aggregation.groupByExpressions().nonEmpty) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -17,22 +17,32 @@
 
 package org.apache.spark.sql.hudi.v2
 
-import org.apache.hudi.HoodieFileIndex
-import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.{HoodieFileIndex, SparkAdapterSupport}
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.engine.HoodieLocalEngineContext
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.util.collection.Pair
+import org.apache.hudi.metadata.{HoodieBackedTableMetadata, MetadataPartitionType}
+import org.apache.hudi.stats.HoodieColumnRangeMetadata
 
 import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow}
+import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Count, CountStar, Max, Min}
+import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SerializableConfiguration
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
 
 /**
  * Scan builder for DSv2 CoW snapshot reads.
- * Accepts column pruning and filter pushdown (partition pruning + data skipping).
  */
 class HoodieScanBuilder(spark: SparkSession,
                         metaClient: HoodieTableMetaClient,
@@ -40,12 +50,21 @@ class HoodieScanBuilder(spark: SparkSession,
                         options: Map[String, String]) extends ScanBuilder
   with SupportsPushDownFilters
   with SupportsPushDownRequiredColumns
+  with SupportsPushDownLimit
+  with SupportsPushDownAggregates
   with SparkAdapterSupport {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   private var requiredSchema: StructType = tableSchema
   private var _pushedFilters: Array[Filter] = Array.empty
   private var partitionFilterExprs: Seq[Expression] = Seq.empty
   private var dataFilterExprs: Seq[Expression] = Seq.empty
+  private var hasPostScanFilters: Boolean = false
+
+  private var pushedLimit: Option[Int] = None
+  private var pushedAggregation: Option[Aggregation] = None
+  private var aggregateResult: Option[Array[InternalRow]] = None
 
   private lazy val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
     includeLogFiles = false, shouldEmbedFileSlices = false)
@@ -65,10 +84,8 @@ class HoodieScanBuilder(spark: SparkSession,
     dataFilterExprs = datFilters.toSeq
 
     _pushedFilters = pushed
+    hasPostScanFilters = postScan.nonEmpty
 
-    // Data filters are only used for file-level skipping (via metadata indices),
-    // not for row-level filtering. Return them as postScan so Spark applies
-    // row-level filtering. Partition filters are fully handled by partition pruning.
     val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
     val dataFilterArr = pushed.filterNot(f => f.references.forall(partFieldNames.contains))
     postScan ++ dataFilterArr
@@ -80,7 +97,56 @@ class HoodieScanBuilder(spark: SparkSession,
     this.requiredSchema = requiredSchema
   }
 
+  override def pushLimit(limit: Int): Boolean = {
+    pushedLimit = Some(limit)
+    true
+  }
+
+  override def isPartiallyPushed(): Boolean = true
+
+  override def pushAggregation(aggregation: Aggregation): Boolean = {
+    if (aggregation.groupByExpressions().nonEmpty) {
+      false
+    } else if (!MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(metaClient)) {
+      false
+    } else {
+      val funcs = aggregation.aggregateExpressions()
+      val allSupported = funcs.forall {
+        case _: CountStar => true
+        case c: Count => !c.isDistinct
+        case _: Min => true
+        case _: Max => true
+        case _ => false
+      }
+      if (!allSupported) {
+        false
+      } else {
+        tryComputeAggregates(aggregation) match {
+          case Some(rows) =>
+            pushedAggregation = Some(aggregation)
+            aggregateResult = Some(rows)
+            true
+          case None => false
+        }
+      }
+    }
+  }
+
+  override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
+    pushedAggregation.contains(aggregation) && dataFilterExprs.isEmpty && !hasPostScanFilters
+  }
+
   override def build(): Scan = {
+    aggregateResult match {
+      case Some(rows) =>
+        val outputSchema = buildAggregateOutputSchema(pushedAggregation.get)
+        new HoodieLocalScan(outputSchema, rows)
+      case None =>
+        buildSnapshotScan()
+    }
+  }
+
+  private def buildSnapshotScan(): Scan = {
     val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
     val requiredDataSchema = StructType(requiredSchema.filterNot(f => partFieldNames.contains(f.name)))
     val requiredPartitionSchema = StructType(requiredSchema.filter(f => partFieldNames.contains(f.name)))
@@ -95,8 +161,9 @@ class HoodieScanBuilder(spark: SparkSession,
     val fileSlicesPerPartition = fileIndex.filterFileSlices(dataFilterExprs, partitionFilterExprs)
 
     val partitions = fileSlicesPerPartition.flatMap { case (partitionOpt, fileSlices) =>
-      fileSlices.filter(fs => fs.getBaseFile.isPresent).map { fs =>
-        val baseFile = fs.getBaseFile.get()
+      fileSlices.filter(_.getBaseFile.isPresent).map { fs =>
+        val baseFilePath = fs.getBaseFile.get().getPath
+        val baseFileLength = fs.getBaseFile.get().getFileSize
         val allPartValues = partitionOpt.map(_.getValues).getOrElse(Array.empty[AnyRef])
 
         val partValues = if (requiredPartitionSchema.isEmpty) {
@@ -108,7 +175,7 @@ class HoodieScanBuilder(spark: SparkSession,
           }
         }
 
-        HoodieInputPartition(0, baseFile.getPath, baseFile.getFileSize, partValues)
+        HoodieInputPartition(0, baseFilePath, baseFileLength, partValues)
       }
     }.zipWithIndex.map { case (p, i) => p.copy(index = i) }.toArray[InputPartition]
 
@@ -119,6 +186,247 @@ class HoodieScanBuilder(spark: SparkSession,
       broadcastConf,
       requiredDataSchema,
       requiredPartitionSchema,
-      _pushedFilters)
+      _pushedFilters,
+      pushedLimit)
+  }
+
+  private def tryComputeAggregates(aggregation: Aggregation): Option[Array[InternalRow]] = {
+    try {
+      val fileSlicesPerPartition = fileIndex.filterFileSlices(dataFilterExprs, partitionFilterExprs)
+
+      if (dataFilterExprs.nonEmpty || hasPostScanFilters) {
+        None
+      } else {
+        // Collect base files as (partitionPath, fileName) pairs
+        val baseFiles = fileSlicesPerPartition.flatMap { case (partOpt, slices) =>
+          slices.filter(_.getBaseFile.isPresent).map { fs =>
+            val partPath = partOpt.map(_.getPath).getOrElse("")
+            val fileName = fs.getBaseFile.get().getFileName
+            (partPath, fileName)
+          }
+        }
+
+        if (baseFiles.isEmpty) {
+          Some(Array(buildEmptyAggregateRow(aggregation)))
+        } else {
+          computeAggregatesFromStats(aggregation, baseFiles)
+        }
+      }
+    } catch {
+      case e: Exception =>
+        log.debug("Aggregate pushdown computation failed, falling back to scan", e)
+        None
+    }
+  }
+
+  private def computeAggregatesFromStats(
+      aggregation: Aggregation,
+      baseFiles: Seq[(String, String)]): Option[Array[InternalRow]] = {
+    val aggFuncs = aggregation.aggregateExpressions()
+
+    // Determine which columns need stats; None if unsupported function found
+    val referencedColumnsOpt = aggFuncs.foldLeft(Option(Seq.empty[String])) { (accOpt, func) =>
+      accOpt.flatMap { acc =>
+        func match {
+          case _: CountStar => Some(acc)
+          case c: Count => extractColumnName(c.column()).map(name => acc :+ name)
+          case m: Min => extractColumnName(m.column()).map(name => acc :+ name)
+          case m: Max => extractColumnName(m.column()).map(name => acc :+ name)
+          case _ => None
+        }
+      }
+    }
+
+    referencedColumnsOpt.flatMap { referencedColumns =>
+      val distinctColumns = referencedColumns.distinct
+
+      // For CountStar, use the first table column to get total row count
+      val countStarColumnOpt: Option[Option[String]] = if (aggFuncs.exists(_.isInstanceOf[CountStar])) {
+        if (tableSchema.nonEmpty) Some(Some(tableSchema.fields.head.name)) else None
+      } else {
+        Some(None)
+      }
+
+      countStarColumnOpt.flatMap { countStarColumn =>
+        val allColumns = (distinctColumns ++ countStarColumn.toSeq).distinct
+        if (allColumns.isEmpty) {
+          None
+        } else {
+          queryAndComputeAggregates(aggFuncs, allColumns, countStarColumn, baseFiles)
+        }
+      }
+    }
+  }
+
+  private def queryAndComputeAggregates(
+      aggFuncs: Array[org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc],
+      allColumns: Seq[String],
+      countStarColumn: Option[String],
+      baseFiles: Seq[(String, String)]): Option[Array[InternalRow]] = {
+    val metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build()
+    val engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf)
+    val tableMetadata = new HoodieBackedTableMetadata(
+      engineContext, metaClient.getStorage, metadataConfig, metaClient.getBasePath.toString)
+
+    try {
+      val filePairs = baseFiles.map { case (part, file) => Pair.of(part, file) }.asJava
+
+      // Query stats for all needed columns; None if any column has incomplete stats
+      val columnStatsOpt = allColumns.foldLeft(
+        Option(Map.empty[String, Seq[HoodieColumnRangeMetadata[Comparable[_]]]])
+      ) { (accOpt, col) =>
+        accOpt.flatMap { acc =>
+          val statsMap = tableMetadata.getColumnStats(filePairs, col)
+          if (statsMap.size() != baseFiles.size) {
+            None
+          } else {
+            val allFileStats = statsMap.values().asScala
+              .map(cs => HoodieColumnRangeMetadata.fromColumnStats(cs)).toSeq
+            Some(acc + (col -> allFileStats))
+          }
+        }
+      }
+
+      columnStatsOpt.flatMap { columnStats =>
+        // Compute each aggregate value as Option; None means unsupported
+        val valuesOpt: Array[Option[Any]] = aggFuncs.map {
+          case _: CountStar =>
+            val stats = columnStats(countStarColumn.get)
+            Some(stats.map(s => s.getValueCount + s.getNullCount).sum: Any)
+
+          case c: Count =>
+            extractColumnName(c.column()).map { colName =>
+              val stats = columnStats(colName)
+              stats.map(_.getValueCount).sum: Any
+            }
+
+          case m: Min =>
+            for {
+              colName <- extractColumnName(m.column())
+              colType <- tableSchema.fields.find(_.name == colName).map(_.dataType)
+              result <- computeMinMax(columnStats(colName), colType, isMin = true)
+            } yield result
+
+          case m: Max =>
+            for {
+              colName <- extractColumnName(m.column())
+              colType <- tableSchema.fields.find(_.name == colName).map(_.dataType)
+              result <- computeMinMax(columnStats(colName), colType, isMin = false)
+            } yield result
+
+          case _ => None
+        }
+
+        if (valuesOpt.forall(_.isDefined)) {
+          Some(Array(new GenericInternalRow(valuesOpt.map(_.get))))
+        } else {
+          None
+        }
+      }
+    } finally {
+      tableMetadata.close()
+    }
+  }
+
+  private def computeMinMax(
+      allFileStats: Seq[HoodieColumnRangeMetadata[Comparable[_]]],
+      colType: DataType,
+      isMin: Boolean): Option[Any] = {
+    val rawValues = allFileStats.map(s => if (isMin) s.getMinValue else s.getMaxValue).filter(_ != null)
+    if (rawValues.isEmpty) {
+      Some(null)
+    } else {
+      val sparkValues = rawValues.flatMap(v => convertToSparkValue(v, colType))
+      if (sparkValues.size != rawValues.size) {
+        None
+      } else {
+        colType match {
+          case ByteType =>
+            val vs = sparkValues.map(_.asInstanceOf[Byte])
+            Some(if (isMin) vs.min else vs.max)
+          case ShortType =>
+            val vs = sparkValues.map(_.asInstanceOf[Short])
+            Some(if (isMin) vs.min else vs.max)
+          case IntegerType =>
+            val vs = sparkValues.map(_.asInstanceOf[Int])
+            Some(if (isMin) vs.min else vs.max)
+          case LongType =>
+            val vs = sparkValues.map(_.asInstanceOf[Long])
+            Some(if (isMin) vs.min else vs.max)
+          case FloatType =>
+            val vs = sparkValues.map(_.asInstanceOf[Float])
+            Some(if (isMin) vs.min else vs.max)
+          case DoubleType =>
+            val vs = sparkValues.map(_.asInstanceOf[Double])
+            Some(if (isMin) vs.min else vs.max)
+          case StringType =>
+            val vs = sparkValues.map(_.asInstanceOf[UTF8String])
+            Some(vs.reduce((a, b) => if ((isMin && a.compareTo(b) <= 0) || (!isMin && a.compareTo(b) >= 0)) a else b))
+          case _ => None
+        }
+      }
+    }
+  }
+
+  private def buildEmptyAggregateRow(aggregation: Aggregation): InternalRow = {
+    val values = aggregation.aggregateExpressions().map {
+      case _: CountStar => 0L: Any
+      case _: Count => 0L: Any
+      case _ => null: Any
+    }
+    new GenericInternalRow(values)
+  }
+
+  private def buildAggregateOutputSchema(aggregation: Aggregation): StructType = {
+    val fields = aggregation.aggregateExpressions().zipWithIndex.map { case (func, i) =>
+      func match {
+        case _: CountStar =>
+          StructField(s"count(*)", LongType, nullable = false)
+        case c: Count =>
+          val colName = extractColumnName(c.column()).getOrElse(s"col$i")
+          StructField(s"count($colName)", LongType, nullable = false)
+        case m: Min =>
+          val colName = extractColumnName(m.column()).getOrElse(s"col$i")
+          val colType = tableSchema.fields.find(_.name == colName).map(_.dataType).getOrElse(LongType)
+          StructField(s"min($colName)", colType, nullable = true)
+        case m: Max =>
+          val colName = extractColumnName(m.column()).getOrElse(s"col$i")
+          val colType = tableSchema.fields.find(_.name == colName).map(_.dataType).getOrElse(LongType)
+          StructField(s"max($colName)", colType, nullable = true)
+        case _ =>
+          StructField(s"agg$i", LongType, nullable = true)
+      }
+    }
+    StructType(fields)
+  }
+
+  private def extractColumnName(
+      expr: org.apache.spark.sql.connector.expressions.Expression): Option[String] = {
+    expr match {
+      case ref: NamedReference =>
+        val names = ref.fieldNames()
+        if (names.length == 1) Some(names.head) else None
+      case _ => None
+    }
+  }
+
+  private def convertToSparkValue(value: Any, dataType: DataType): Option[Any] = {
+    if (value == null) {
+      Some(null)
+    } else try {
+      dataType match {
+        case BooleanType => Some(value.asInstanceOf[Boolean])
+        case ByteType => Some(value.asInstanceOf[Number].byteValue())
+        case ShortType => Some(value.asInstanceOf[Number].shortValue())
+        case IntegerType => Some(value.asInstanceOf[Number].intValue())
+        case LongType => Some(value.asInstanceOf[Number].longValue())
+        case FloatType => Some(value.asInstanceOf[Number].floatValue())
+        case DoubleType => Some(value.asInstanceOf[Number].doubleValue())
+        case StringType => Some(UTF8String.fromString(value.toString))
+        case _ => None
+      }
+    } catch {
+      case _: Exception => None
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -17,21 +17,32 @@
 
 package org.apache.spark.sql.hudi.v2
 
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.hudi.HoodieFileIndex
+import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.read.{InputPartition, Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
 
 /**
- * Stub scan builder that accepts column pruning and returns all filters as post-scan.
- * Filter pushdown will be implemented in a subsequent PR.
+ * Scan builder for DSv2 CoW snapshot reads.
+ * Accepts column pruning; filter pushdown deferred to a later PR.
  */
-class HoodieScanBuilder(tableSchema: StructType) extends ScanBuilder
+class HoodieScanBuilder(spark: SparkSession,
+                        metaClient: HoodieTableMetaClient,
+                        tableSchema: StructType,
+                        options: Map[String, String]) extends ScanBuilder
   with SupportsPushDownFilters
-  with SupportsPushDownRequiredColumns {
+  with SupportsPushDownRequiredColumns
+  with SparkAdapterSupport {
 
   private var requiredSchema: StructType = tableSchema
+
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    // Stub: all filters are returned as post-scan (none pushed down)
+    // All filters are returned as post-scan (none pushed down)
     filters
   }
 
@@ -41,5 +52,47 @@ class HoodieScanBuilder(tableSchema: StructType) extends ScanBuilder
     this.requiredSchema = requiredSchema
   }
 
-  override def build(): Scan = new HoodieBatchScan(requiredSchema)
+  override def build(): Scan = {
+    val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
+      includeLogFiles = false, shouldEmbedFileSlices = false)
+
+    val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
+    val requiredDataSchema = StructType(requiredSchema.filterNot(f => partFieldNames.contains(f.name)))
+    val requiredPartitionSchema = StructType(requiredSchema.filter(f => partFieldNames.contains(f.name)))
+
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    val readerOptions = options + (FileFormat.OPTION_RETURNING_BATCH -> "false")
+    val reader = sparkAdapter.createParquetFileReader(false, spark.sessionState.conf, readerOptions, hadoopConf)
+    val broadcastReader = spark.sparkContext.broadcast(reader)
+    val broadcastConf = spark.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+    val fullPartSchema = fileIndex.partitionSchema
+    val fileSlicesPerPartition = fileIndex.filterFileSlices(Seq.empty, Seq.empty)
+
+    val partitions = fileSlicesPerPartition.flatMap { case (partitionOpt, fileSlices) =>
+      fileSlices.filter(fs => fs.getBaseFile.isPresent).map { fs =>
+        val baseFile = fs.getBaseFile.get()
+        val allPartValues = partitionOpt.map(_.getValues).getOrElse(Array.empty[AnyRef])
+
+        val partValues = if (requiredPartitionSchema.isEmpty) {
+          Array.empty[AnyRef]
+        } else {
+          requiredPartitionSchema.fieldNames.map { name =>
+            val idx = fullPartSchema.fieldIndex(name)
+            allPartValues(idx)
+          }
+        }
+
+        HoodieInputPartition(0, baseFile.getPath, baseFile.getFileSize, partValues)
+      }
+    }.zipWithIndex.map { case (p, i) => p.copy(index = i) }.toArray[InputPartition]
+
+    new HoodieBatchScan(
+      requiredSchema,
+      partitions,
+      broadcastReader,
+      broadcastConf,
+      requiredDataSchema,
+      requiredPartitionSchema)
+  }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala
@@ -17,13 +17,20 @@
 
 package org.apache.spark.sql.hudi.v2
 
-import org.apache.hudi.{HoodieFileIndex, SparkAdapterSupport}
+import org.apache.hudi.{DataSourceReadOptions, HoodieBaseRelation, HoodieFileIndex, SparkAdapterSupport}
+import org.apache.hudi.client.utils.SparkInternalSchemaConverter
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.engine.HoodieLocalEngineContext
-import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE
+import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
+import org.apache.hudi.common.table.timeline.TimelineLayout
+import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.common.util.collection.Pair
+import org.apache.hudi.internal.schema.InternalSchema
+import org.apache.hudi.internal.schema.utils.SerDeHelper
 import org.apache.hudi.metadata.{HoodieBackedTableMetadata, MetadataPartitionType}
 import org.apache.hudi.stats.HoodieColumnRangeMetadata
+import org.apache.hudi.util.SparkConfigUtils
 
 import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.apache.spark.sql.SparkSession
@@ -66,7 +73,7 @@ class HoodieScanBuilder(spark: SparkSession,
   private var pushedAggregation: Option[Aggregation] = None
   private var aggregateResult: Option[Array[InternalRow]] = None
 
-  private lazy val fileIndex = HoodieFileIndex(spark, metaClient, None, options,
+  private lazy val fileIndex = HoodieFileIndex(spark, metaClient, Some(tableSchema), options,
     includeLogFiles = false, shouldEmbedFileSlices = false)
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
@@ -83,12 +90,18 @@ class HoodieScanBuilder(spark: SparkSession,
     partitionFilterExprs = partFilters.toSeq
     dataFilterExprs = datFilters.toSeq
 
-    _pushedFilters = pushed
+    val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
+    // Partition filters are fully handled by partition pruning in filterFileSlices — the
+    // partition column is not in the base file, so forwarding them to the Parquet reader
+    // would filter all rows as null. Only pass data filters to the reader. Return those
+    // data filters to Spark so it re-applies them row-wise (Parquet only does row-group
+    // level pruning via these filters, not precise filtering).
+    val pushedDataFilters = pushed.filterNot(f => f.references.forall(partFieldNames.contains))
+
+    _pushedFilters = pushedDataFilters
     hasPostScanFilters = postScan.nonEmpty
 
-    val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
-    val dataFilterArr = pushed.filterNot(f => f.references.forall(partFieldNames.contains))
-    postScan ++ dataFilterArr
+    postScan ++ pushedDataFilters
   }
 
   override def pushedFilters(): Array[Filter] = _pushedFilters
@@ -112,8 +125,13 @@ class HoodieScanBuilder(spark: SparkSession,
       val allSupported = funcs.forall {
         case _: CountStar => true
         case c: Count => !c.isDistinct
-        case _: Min => true
-        case _: Max => true
+        // Parquet/Hudi column stats exclude NaN from min/max, but Spark SQL
+        // treats NaN as greater than any non-NaN value. Stats can't distinguish
+        // "all NaN" from "all null" (both surface as a null min/max), so skip
+        // MIN/MAX pushdown on float/double columns and let Spark compute from
+        // the scan.
+        case m: Min => !isFloatingPointColumn(m.column())
+        case m: Max => !isFloatingPointColumn(m.column())
         case _ => false
       }
       if (!allSupported) {
@@ -145,11 +163,22 @@ class HoodieScanBuilder(spark: SparkSession,
   }
 
   private def buildSnapshotScan(): Scan = {
+    // Invariant established by HoodieV2ReadSupport.isSupportedByDSv2:
+    // COW snapshot or MOR read_optimized only, Parquet only, single base-file format.
+    val queryType = SparkConfigUtils.getStringWithAltKeys(options, DataSourceReadOptions.QUERY_TYPE)
+    require(metaClient.getTableType == COPY_ON_WRITE ||
+              queryType == DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL,
+            "HoodieScanBuilder supports COW snapshot or read_optimized only; " +
+              s"got tableType=${metaClient.getTableType}, queryType=$queryType")
+
     val partFieldNames = fileIndex.partitionSchema.fieldNames.toSet
     val requiredDataSchema = StructType(requiredSchema.filterNot(f => partFieldNames.contains(f.name)))
     val requiredPartitionSchema = StructType(requiredSchema.filter(f => partFieldNames.contains(f.name)))
 
     val hadoopConf = spark.sessionState.newHadoopConf()
+    val internalSchemaOpt = fetchInternalSchema()
+    embedInternalSchema(hadoopConf, internalSchemaOpt)
+
     val readerOptions = options + (FileFormat.OPTION_RETURNING_BATCH -> "false")
     val reader = sparkAdapter.createParquetFileReader(false, spark.sessionState.conf, readerOptions, hadoopConf)
     val broadcastReader = spark.sparkContext.broadcast(reader)
@@ -184,8 +213,37 @@ class HoodieScanBuilder(spark: SparkSession,
       broadcastConf,
       requiredDataSchema,
       requiredPartitionSchema,
+      internalSchemaOpt,
       _pushedFilters,
       pushedLimit)
+  }
+
+  private def fetchInternalSchema(): HOption[InternalSchema] = {
+    if (!HoodieBaseRelation.isSchemaEvolutionEnabledOnRead(options, spark)) {
+      HOption.empty[InternalSchema]()
+    } else {
+      try {
+        new TableSchemaResolver(metaClient).getTableInternalSchemaFromCommitMetadata
+      } catch {
+        case e: Exception =>
+          log.warn("Failed to fetch internal schema from commit metadata", e)
+          HOption.empty[InternalSchema]()
+      }
+    }
+  }
+
+  private def embedInternalSchema(conf: org.apache.hadoop.conf.Configuration,
+                                  internalSchemaOpt: HOption[InternalSchema]): Unit = {
+    if (internalSchemaOpt.isPresent) {
+      val internalSchema = internalSchemaOpt.get
+      val instantFileNameGenerator = TimelineLayout.fromVersion(metaClient.getTimelineLayoutVersion)
+        .getInstantFileNameGenerator
+      val validCommits = metaClient.getActiveTimeline.getInstants.iterator.asScala
+        .map(instant => instantFileNameGenerator.getFileName(instant)).mkString(",")
+      conf.set(SparkInternalSchemaConverter.HOODIE_QUERY_SCHEMA, SerDeHelper.toJson(internalSchema))
+      conf.set(SparkInternalSchemaConverter.HOODIE_TABLE_PATH, metaClient.getBasePath.toString)
+      conf.set(SparkInternalSchemaConverter.HOODIE_VALID_COMMITS_LIST, validCommits)
+    }
   }
 
   private def tryComputeAggregates(aggregation: Aggregation): Option[Array[InternalRow]] = {
@@ -238,9 +296,16 @@ class HoodieScanBuilder(spark: SparkSession,
     referencedColumnsOpt.flatMap { referencedColumns =>
       val distinctColumns = referencedColumns.distinct
 
-      // For CountStar, use the first table column to get total row count
+      // For CountStar, prefer a user-defined record key field that's present in the
+      // user schema: it's an original column from the table's first commit, so its
+      // column stats are complete even after schema evolution. Fall back to the
+      // first column for keyless tables or when the record key is meta-field-only.
       val countStarColumnOpt: Option[Option[String]] = if (aggFuncs.exists(_.isInstanceOf[CountStar])) {
-        if (tableSchema.nonEmpty) Some(Some(tableSchema.fields.head.name)) else None
+        val schemaNames = tableSchema.fields.map(_.name).toSet
+        val recordKeyFields = metaClient.getTableConfig.getRecordKeyFields.orElse(Array.empty[String])
+        recordKeyFields.find(schemaNames.contains)
+          .orElse(tableSchema.fields.headOption.map(_.name))
+          .map(Some(_))
       } else {
         Some(None)
       }
@@ -290,12 +355,12 @@ class HoodieScanBuilder(spark: SparkSession,
         val valuesOpt: Array[Option[Any]] = aggFuncs.map {
           case _: CountStar =>
             val stats = columnStats(countStarColumn.get)
-            Some(stats.map(s => s.getValueCount + s.getNullCount).sum: Any)
+            Some(stats.map(s => s.getValueCount).sum: Any)
 
           case c: Count =>
             extractColumnName(c.column()).map { colName =>
               val stats = columnStats(colName)
-              stats.map(_.getValueCount).sum: Any
+              stats.map(s => s.getValueCount - s.getNullCount).sum: Any
             }
 
           case m: Min =>
@@ -352,11 +417,11 @@ class HoodieScanBuilder(spark: SparkSession,
             val vs = sparkValues.map(_.asInstanceOf[Long])
             Some(if (isMin) vs.min else vs.max)
           case FloatType =>
-            val vs = sparkValues.map(_.asInstanceOf[Float])
-            Some(if (isMin) vs.min else vs.max)
+            val vs = sparkValues.map(_.asInstanceOf[Float]).filterNot(_.isNaN)
+            if (vs.isEmpty) None else Some(if (isMin) vs.min else vs.max)
           case DoubleType =>
-            val vs = sparkValues.map(_.asInstanceOf[Double])
-            Some(if (isMin) vs.min else vs.max)
+            val vs = sparkValues.map(_.asInstanceOf[Double]).filterNot(_.isNaN)
+            if (vs.isEmpty) None else Some(if (isMin) vs.min else vs.max)
           case StringType =>
             val vs = sparkValues.map(_.asInstanceOf[UTF8String])
             Some(vs.reduce((a, b) => if ((isMin && a.compareTo(b) <= 0) || (!isMin && a.compareTo(b) >= 0)) a else b))
@@ -406,6 +471,16 @@ class HoodieScanBuilder(spark: SparkSession,
         if (names.length == 1) Some(names.head) else None
       case _ => None
     }
+  }
+
+  private def isFloatingPointColumn(
+      expr: org.apache.spark.sql.connector.expressions.Expression): Boolean = {
+    extractColumnName(expr)
+      .flatMap(name => tableSchema.fields.find(_.name == name).map(_.dataType))
+      .exists {
+        case FloatType | DoubleType => true
+        case _ => false
+      }
   }
 
   private def convertToSparkValue(value: Any, dataType: DataType): Option[Any] = {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
@@ -34,12 +34,12 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import java.util
 
-import scala.collection.JavaConverters.{mapAsJavaMapConverter, setAsJavaSetConverter}
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter, setAsJavaSetConverter}
 
 /**
  * DSv2 table implementation for Hudi.
  *
- * Read path: returns a stub [[HoodieScanBuilder]] that produces correct schema but empty results.
+ * Read path: uses [[HoodieScanBuilder]] to build COW snapshot scans via [[HoodieFileIndex]].
  * Write path: falls back to DSv1 via [[V2TableWithV1Fallback]] and [[HoodieV1WriteBuilder]].
  *
  * Schema is resolved via [[HoodieCatalogTable]] (catalog path) or [[HoodieTableMetaClient]] (DataFrame path).
@@ -83,7 +83,10 @@ case class HoodieSparkV2Table(spark: SparkSession,
   }
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-    new HoodieScanBuilder(tableSchema)
+    val tableProps = properties().asScala.toMap
+    val scanOpts = options.asCaseSensitiveMap().asScala.toMap
+    val mergedOpts = tableProps ++ scanOpts
+    new HoodieScanBuilder(spark, metaClient, tableSchema, mergedOpts)
   }
 
   private def requireCatalogTable: HoodieCatalogTable =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, HoodieCatalogTable}
+import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability, V1Table, V2TableWithV1Fallback}
+import org.apache.spark.sql.connector.catalog.TableCapability._
+import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
+import org.apache.spark.sql.hudi.catalog.HoodieV1WriteBuilder
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, setAsJavaSetConverter}
+
+/**
+ * DSv2 table implementation for Hudi.
+ *
+ * Read path: returns a stub [[HoodieScanBuilder]] that produces correct schema but empty results.
+ * Write path: falls back to DSv1 via [[V2TableWithV1Fallback]] and [[HoodieV1WriteBuilder]].
+ *
+ * Schema is resolved via [[HoodieCatalogTable]] (catalog path) or [[HoodieTableMetaClient]] (DataFrame path).
+ */
+case class HoodieSparkV2Table(spark: SparkSession,
+                              path: String,
+                              catalogTable: Option[CatalogTable] = None,
+                              options: CaseInsensitiveStringMap = CaseInsensitiveStringMap.empty())
+  extends Table with SupportsRead with SupportsWrite with V2TableWithV1Fallback {
+
+  lazy val hoodieCatalogTable: Option[HoodieCatalogTable] = catalogTable.map { ct =>
+    HoodieCatalogTable(spark, ct)
+  }
+
+  private lazy val metaClient: HoodieTableMetaClient = HoodieTableMetaClient.builder()
+    .setBasePath(path)
+    .setConf(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf))
+    .build()
+
+  private lazy val tableSchema: StructType = hoodieCatalogTable match {
+    case Some(hct) => hct.tableSchemaWithoutMetaFields
+    case None =>
+      HoodieSqlCommonUtils.getTableSqlSchema(metaClient, includeMetadataFields = false)
+        .getOrElse(new StructType())
+  }
+
+  override def name(): String = hoodieCatalogTable match {
+    case Some(hct) => hct.table.identifier.unquotedString
+    case None => metaClient.getTableConfig.getTableName
+  }
+
+  override def schema(): StructType = tableSchema
+
+  override def capabilities(): util.Set[TableCapability] = Set(
+    BATCH_READ, V1_BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE, ACCEPT_ANY_SCHEMA
+  ).asJava
+
+  override def properties(): util.Map[String, String] = hoodieCatalogTable match {
+    case Some(hct) => hct.catalogProperties.asJava
+    case None => java.util.Collections.emptyMap()
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    new HoodieScanBuilder(tableSchema)
+  }
+
+  private def requireCatalogTable: HoodieCatalogTable =
+    hoodieCatalogTable.getOrElse(
+      throw new IllegalStateException(
+        "Write operations require a catalog table. " +
+          "DataFrame API writes are not supported via hudi_v2; use the SQL/catalog path."))
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    new HoodieV1WriteBuilder(info.options, requireCatalogTable, spark)
+  }
+
+  override def v1Table: CatalogTable = requireCatalogTable.table
+
+  def v1TableWrapper: V1Table = V1Table(v1Table)
+
+  override def partitioning(): Array[Transform] = hoodieCatalogTable match {
+    case Some(hct) =>
+      hct.partitionFields.map { col =>
+        new IdentityTransform(new FieldReference(Seq(col)))
+      }.toArray
+    case None => Array.empty
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieSparkV2Table.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hudi.v2
 
 import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 
 import org.apache.spark.sql.SparkSession
@@ -73,9 +74,15 @@ case class HoodieSparkV2Table(spark: SparkSession,
 
   override def schema(): StructType = tableSchema
 
-  override def capabilities(): util.Set[TableCapability] = Set(
-    BATCH_READ, V1_BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE, ACCEPT_ANY_SCHEMA
-  ).asJava
+  override def capabilities(): util.Set[TableCapability] = {
+    val writeCaps =
+      if (hoodieCatalogTable.isDefined) {
+        Set(V1_BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE, ACCEPT_ANY_SCHEMA)
+      } else {
+        Set.empty[TableCapability]
+      }
+    (Set(BATCH_READ) ++ writeCaps).asJava
+  }
 
   override def properties(): util.Map[String, String] = hoodieCatalogTable match {
     case Some(hct) => hct.catalogProperties.asJava
@@ -85,7 +92,17 @@ case class HoodieSparkV2Table(spark: SparkSession,
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     val tableProps = properties().asScala.toMap
     val scanOpts = options.asCaseSensitiveMap().asScala.toMap
-    val mergedOpts = tableProps ++ scanOpts
+    val classOpts = this.options.asCaseSensitiveMap().asScala.toMap
+    // HoodieFileIndex.getQueryPaths requires "path". On the DataFrame-API path, Spark puts it in
+    // the class-level options map, not the scan-time one — promote it here.
+    val mergedOpts = Map("path" -> path) ++ classOpts ++ tableProps ++ scanOpts
+    if (!HoodieV2ReadSupport.isSupportedByDSv2(metaClient, mergedOpts, spark)) {
+      throw new HoodieException(
+        "DSv2 read path does not support this query configuration " +
+          "(MOR snapshot, non-Parquet base format, multiple base formats, " +
+          "incremental/CDC, or bootstrap table). " +
+          "Disable hoodie.datasource.read.use.v2 or use format(\"hudi\").")
+    }
     new HoodieScanBuilder(spark, metaClient, tableSchema, mergedOpts)
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieStatistics.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieStatistics.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.spark.sql.connector.read.Statistics
+
+import java.util.OptionalLong
+
+/**
+ * Statistics for Spark CBO, reported by [[HoodieBatchScan]].
+ */
+class HoodieStatistics(sizeBytes: Long, rowCount: Option[Long] = None) extends Statistics {
+
+  override def sizeInBytes(): OptionalLong = OptionalLong.of(sizeBytes)
+
+  override def numRows(): OptionalLong =
+    rowCount.map(OptionalLong.of).getOrElse(OptionalLong.empty())
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieV2ReadSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieV2ReadSupport.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.hudi.DataSourceReadOptions
+import org.apache.hudi.common.model.HoodieFileFormat
+import org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.util.SparkConfigUtils
+
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Supportability gate for the DSv2 read path.
+ *
+ * The scan in [[HoodieScanBuilder]] is base-file-only, Parquet-only, single-format, and
+ * does not implement incremental / CDC / bootstrap. Schema evolution is supported by
+ * threading the internal schema from the commit timeline into the columnar reader.
+ */
+object HoodieV2ReadSupport {
+
+  def isSupportedByDSv2(metaClient: HoodieTableMetaClient,
+                        options: Map[String, String],
+                        spark: SparkSession): Boolean = {
+    val tableConfig = metaClient.getTableConfig
+    val queryType = SparkConfigUtils.getStringWithAltKeys(options, DataSourceReadOptions.QUERY_TYPE)
+    val incrementalFormat = options.getOrElse(
+      DataSourceReadOptions.INCREMENTAL_FORMAT.key,
+      DataSourceReadOptions.INCREMENTAL_FORMAT.defaultValue)
+
+    val isReadOptimized = queryType == DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL
+    val isIncremental = queryType == DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
+    val isCdc = incrementalFormat == DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL
+    val isMor = metaClient.getTableType == MERGE_ON_READ
+
+    // Comment #1: MOR snapshot needs log-file merging; only COW or read_optimized are base-file-only.
+    val baseFileOnlySemantics = !isMor || isReadOptimized
+
+    // Comment #2: the scan hard-codes the Parquet reader.
+    val isParquetOnly =
+      !tableConfig.isMultipleBaseFileFormatsEnabled &&
+        tableConfig.getBaseFileFormat == HoodieFileFormat.PARQUET
+
+    val notIncrementalOrCdc = !isIncremental && !isCdc
+    val notBootstrap = !tableConfig.getBootstrapBasePath.isPresent
+
+    baseFileOnlySemantics && isParquetOnly && notIncrementalOrCdc && notBootstrap
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/v2/TestHoodieV2ReadSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/v2/TestHoodieV2ReadSupport.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.v2
+
+import org.apache.hudi.DataSourceReadOptions
+import org.apache.hudi.common.model.{HoodieFileFormat, HoodieTableType}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.common.util.{Option => HOption}
+
+import org.apache.spark.sql.SparkSession
+import org.junit.jupiter.api.Assertions.{assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.{mock, when}
+
+/**
+ * Unit tests for [[HoodieV2ReadSupport.isSupportedByDSv2]] gate conditions.
+ */
+class TestHoodieV2ReadSupport {
+
+  private def mockMetaClient(tableType: HoodieTableType,
+                             baseFileFormat: HoodieFileFormat = HoodieFileFormat.PARQUET,
+                             multipleBaseFileFormats: Boolean = false,
+                             bootstrapBasePath: HOption[String] = HOption.empty[String]()):
+  HoodieTableMetaClient = {
+    val metaClient = mock(classOf[HoodieTableMetaClient])
+    val tableConfig = mock(classOf[HoodieTableConfig])
+    when(metaClient.getTableType).thenReturn(tableType)
+    when(metaClient.getTableConfig).thenReturn(tableConfig)
+    when(tableConfig.getBaseFileFormat).thenReturn(baseFileFormat)
+    when(tableConfig.isMultipleBaseFileFormatsEnabled).thenReturn(multipleBaseFileFormats)
+    when(tableConfig.getBootstrapBasePath).thenReturn(bootstrapBasePath)
+    metaClient
+  }
+
+  private def spark: SparkSession = null // unused by current gate logic
+
+  @Test
+  def testCowWithDefaultsIsSupported(): Unit = {
+    val metaClient = mockMetaClient(HoodieTableType.COPY_ON_WRITE)
+    assertTrue(HoodieV2ReadSupport.isSupportedByDSv2(metaClient, Map.empty, spark))
+  }
+
+  @Test
+  def testMorSnapshotIsNotSupported(): Unit = {
+    val metaClient = mockMetaClient(HoodieTableType.MERGE_ON_READ)
+    assertFalse(HoodieV2ReadSupport.isSupportedByDSv2(metaClient, Map.empty, spark))
+  }
+
+  @Test
+  def testMorReadOptimizedIsSupported(): Unit = {
+    val metaClient = mockMetaClient(HoodieTableType.MERGE_ON_READ)
+    val opts = Map(DataSourceReadOptions.QUERY_TYPE.key ->
+      DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL)
+    assertTrue(HoodieV2ReadSupport.isSupportedByDSv2(metaClient, opts, spark))
+  }
+
+  @Test
+  def testOrcBaseFormatIsNotSupported(): Unit = {
+    val metaClient = mockMetaClient(HoodieTableType.COPY_ON_WRITE, baseFileFormat = HoodieFileFormat.ORC)
+    assertFalse(HoodieV2ReadSupport.isSupportedByDSv2(metaClient, Map.empty, spark))
+  }
+
+  @Test
+  def testMultipleBaseFormatsIsNotSupported(): Unit = {
+    val metaClient = mockMetaClient(HoodieTableType.COPY_ON_WRITE, multipleBaseFileFormats = true)
+    assertFalse(HoodieV2ReadSupport.isSupportedByDSv2(metaClient, Map.empty, spark))
+  }
+
+  @Test
+  def testIncrementalQueryIsNotSupported(): Unit = {
+    val metaClient = mockMetaClient(HoodieTableType.COPY_ON_WRITE)
+    val opts = Map(DataSourceReadOptions.QUERY_TYPE.key ->
+      DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+    assertFalse(HoodieV2ReadSupport.isSupportedByDSv2(metaClient, opts, spark))
+  }
+
+  @Test
+  def testCdcFormatIsNotSupported(): Unit = {
+    val metaClient = mockMetaClient(HoodieTableType.COPY_ON_WRITE)
+    val opts = Map(DataSourceReadOptions.INCREMENTAL_FORMAT.key ->
+      DataSourceReadOptions.INCREMENTAL_FORMAT_CDC_VAL)
+    assertFalse(HoodieV2ReadSupport.isSupportedByDSv2(metaClient, opts, spark))
+  }
+
+  @Test
+  def testBootstrapTableIsNotSupported(): Unit = {
+    val metaClient = mockMetaClient(
+      HoodieTableType.COPY_ON_WRITE,
+      bootstrapBasePath = HOption.of("/tmp/bootstrap"))
+    assertFalse(HoodieV2ReadSupport.isSupportedByDSv2(metaClient, Map.empty, spark))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
@@ -1,0 +1,478 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Functional tests proving DSv2 and DSv1 coexistence.
+ *
+ * DataFrame API tests use `format("hudi_v2")` to activate the DSv2 path.
+ * SQL/Catalog tests use `hoodie.datasource.read.use.v2=true` to route through
+ * [[org.apache.spark.sql.hudi.catalog.HoodieCatalog.loadTable]] -> [[HoodieSparkV2Table]].
+ */
+@Tag("functional")
+class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @BeforeEach
+  def checkSparkVersion(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
+      "DSv2 read tests require Spark 3.5 or later")
+  }
+
+  private def writeTestData(path: String): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    val df = Seq(
+      (1, "Alice", 100.0),
+      (2, "Bob", 200.0),
+      (3, "Charlie", 300.0)
+    ).toDF("id", "name", "amount")
+
+    df.write.format("hudi")
+      .option("hoodie.table.name", "test_table")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  private def containsBatchScan(plan: String): Boolean = plan.contains("BatchScan")
+
+  private def containsFileScan(plan: String): Boolean = plan.contains("FileScan")
+
+  // ---- DataFrame API write tests ----
+
+  @Test
+  def testDSv2WriteViaDataFrameAPI(): Unit = {
+    val path = basePath() + "/v2_write_df_api"
+    val _spark = spark
+    import _spark.implicits._
+    val df = Seq(
+      (1, "Alice", 100.0),
+      (2, "Bob", 200.0),
+      (3, "Charlie", 300.0)
+    ).toDF("id", "name", "amount")
+
+    df.write.format("hudi_v2")
+      .option("hoodie.table.name", "test_v2_write")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Append)
+      .save(path)
+
+    // Read back via DSv1 to verify data was written correctly
+    val result = spark.read.format("hudi").load(path)
+    assertEquals(3, result.count())
+
+    val names = result.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Array("Alice", "Bob", "Charlie").toSeq, names.toSeq)
+  }
+
+  // ---- DataFrame API read tests ----
+
+  @Test
+  def testBaselineDSv1WriteAndRead(): Unit = {
+    val path = basePath() + "/baseline_v1"
+    writeTestData(path)
+
+    val df = spark.read.format("hudi").load(path)
+    assertEquals(3, df.count())
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsFileScan(plan),
+      s"DSv1 read should use FileScan, but plan was:\n$plan")
+  }
+
+  @Test
+  def testDSv1WriteAndDSv2Read(): Unit = {
+    val path = basePath() + "/v1_write_v2_read"
+    writeTestData(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    // DSv2 stub returns empty results
+    assertEquals(0, df.count())
+
+    // Schema should still be correct (contains at least the user columns)
+    val fieldNames = df.schema.fieldNames
+    assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
+    assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
+    assertTrue(fieldNames.contains("amount"), s"Schema should contain 'amount', got: ${fieldNames.mkString(", ")}")
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
+  }
+
+  @Test
+  def testDSv1WriteAndDSv1ReadAfterDSv2Read(): Unit = {
+    val path = basePath() + "/v1_write_both_read"
+    writeTestData(path)
+
+    // DSv2 read returns empty (stub)
+    val v2Df = spark.read.format("hudi_v2").load(path)
+    assertEquals(0, v2Df.count())
+
+    // DSv1 read still works after DSv2 read
+    val df = spark.read.format("hudi").load(path)
+    assertEquals(3, df.count())
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsFileScan(plan),
+      s"DSv1 read should use FileScan, but plan was:\n$plan")
+  }
+
+  @Test
+  def testDSv2ReadSchemaAndPlan(): Unit = {
+    val path = basePath() + "/v2_read_schema"
+    writeTestData(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    // DSv2 stub returns empty results
+    assertEquals(0, df.count())
+
+    // Verify schema is correct
+    val fieldNames = df.schema.fieldNames
+    assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
+    assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
+    assertTrue(fieldNames.contains("amount"), s"Schema should contain 'amount', got: ${fieldNames.mkString(", ")}")
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
+  }
+
+  // ---- SQL/Catalog tests ----
+
+  @Test
+  def testSqlConfigFalseUsesDSv1(): Unit = {
+    val tableName = "sql_v1_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+    try {
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(3, df.count())
+
+      val plan = df.queryExecution.executedPlan.toString()
+      assertTrue(containsFileScan(plan),
+        s"With use.v2=false, should use FileScan, but plan was:\n$plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSqlConfigTrueUsesDSv2Stub(): Unit = {
+    val tableName = "sql_v2_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      // DSv2 stub returns empty
+      assertEquals(0, df.count())
+
+      val fieldNames = df.schema.fieldNames
+      assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
+      assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
+
+      val plan = df.queryExecution.executedPlan.toString()
+      assertTrue(containsBatchScan(plan),
+        s"With use.v2=true, should use BatchScan, but plan was:\n$plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSqlSwitchBetweenV1AndV2Reads(): Unit = {
+    val tableName = "sql_switch_read_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    // Write with v1 (default)
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+    // Read with v2 — stub returns empty
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val v2Df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(0, v2Df.count())
+
+      val v2Plan = v2Df.queryExecution.executedPlan.toString()
+      assertTrue(containsBatchScan(v2Plan),
+        s"V2 read should use BatchScan, but plan was:\n$v2Plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+    }
+
+    // Switch back to v1 — should see real data
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+    try {
+      val v1Df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(3, v1Df.count())
+
+      val v1Plan = v1Df.queryExecution.executedPlan.toString()
+      assertTrue(containsFileScan(v1Plan),
+        s"V1 read should use FileScan, but plan was:\n$v1Plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSqlInsertWithV2ReadEnabled(): Unit = {
+    val tableName = "sql_v2_insert_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    // Enable V2 read BEFORE inserting — write should still work via V1 fallback
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2)")
+
+      // Verify data was written by reading back via V1
+      spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(2, df.count())
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testDdlOperationsWithV2ReadEnabled(): Unit = {
+    val tableName = "sql_v2_ddl_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1)")
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      // ALTER TABLE should work with V2 read enabled
+      spark.sql(s"ALTER TABLE $tableName ADD COLUMNS (extra STRING)")
+
+      // Verify the column was added by checking schema
+      val df = spark.sql(s"DESCRIBE $tableName")
+      val colNames = df.select("col_name").collect().map(_.getString(0))
+      assertTrue(colNames.contains("extra"),
+        s"ALTER TABLE ADD COLUMNS should work with v2 read enabled, columns: ${colNames.mkString(", ")}")
+
+      // DROP TABLE should work with V2 read enabled
+      spark.sql(s"DROP TABLE $tableName")
+
+      // Verify table was dropped
+      val tables = spark.sql("SHOW TABLES").collect().map(_.getString(1))
+      assertTrue(!tables.contains(tableName),
+        s"DROP TABLE should work with v2 read enabled, tables: ${tables.mkString(", ")}")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSchemaEvolutionPathUnaffectedByV2Config(): Unit = {
+    val tableName = "sql_schema_evol_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1)")
+
+    // With schema evolution enabled and v2 read disabled, the loadTable()
+    // should return HoodieInternalV2Table (schema evolution path), not V1Table.
+    // Verify via EXPLAIN that the plan uses BatchScan (V2 path), not FileScan (V1 path).
+    spark.sessionState.conf.setConfString("hoodie.schema.on.read.enable", "true")
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+    try {
+      val explainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
+      val plan = explainRows.map(_.getString(0)).mkString("\n")
+      assertTrue(containsBatchScan(plan),
+        s"Schema evolution path should use BatchScan (V2), but got:\n$plan")
+
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(1, df.count())
+    } finally {
+      spark.sessionState.conf.unsetConf("hoodie.schema.on.read.enable")
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+    }
+
+    // With both schema evolution and v2 read enabled, the loadTable() should
+    // return HoodieSparkV2Table (DSv2 path takes precedence over schema evolution).
+    spark.sessionState.conf.setConfString("hoodie.schema.on.read.enable", "true")
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val explainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
+      val plan = explainRows.map(_.getString(0)).mkString("\n")
+      assertTrue(containsBatchScan(plan),
+        s"V2 read with schema evolution should use BatchScan (V2), but got:\n$plan")
+
+      val df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(1, df.count())
+    } finally {
+      spark.sessionState.conf.unsetConf("hoodie.schema.on.read.enable")
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testExplainShowsDSv2(): Unit = {
+    val tableName = "sql_explain_test"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1)")
+
+    // Verify V1 EXPLAIN shows FileScan
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+    try {
+      val v1ExplainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
+      val v1Plan = v1ExplainRows.map(_.getString(0)).mkString("\n")
+      assertTrue(containsFileScan(v1Plan),
+        s"V1 EXPLAIN should contain FileScan, but got:\n$v1Plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+    }
+
+    // Verify V2 EXPLAIN shows BatchScan
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val v2ExplainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
+      val v2Plan = v2ExplainRows.map(_.getString(0)).mkString("\n")
+      assertTrue(containsBatchScan(v2Plan),
+        s"V2 EXPLAIN should contain BatchScan, but got:\n$v2Plan")
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
@@ -17,15 +17,14 @@
 
 package org.apache.spark.sql.hudi.feature.v2
 
-import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.DataSourceReadOptions
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Functional tests proving DSv2 and DSv1 coexistence.
@@ -38,12 +37,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
-
-  @BeforeEach
-  def checkSparkVersion(): Unit = {
-    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
-      "DSv2 read tests require Spark 3.5 or later")
-  }
 
   private def writeTestData(path: String): Unit = {
     val _spark = spark

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
@@ -115,14 +115,10 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     writeTestData(path)
 
     val df = spark.read.format("hudi_v2").load(path)
-    // DSv2 stub returns empty results
-    assertEquals(0, df.count())
+    assertEquals(3, df.count())
 
-    // Schema should still be correct (contains at least the user columns)
-    val fieldNames = df.schema.fieldNames
-    assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
-    assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
-    assertTrue(fieldNames.contains("amount"), s"Schema should contain 'amount', got: ${fieldNames.mkString(", ")}")
+    val names = df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
 
     val plan = df.queryExecution.executedPlan.toString()
     assertTrue(containsBatchScan(plan),
@@ -134,9 +130,9 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     val path = basePath() + "/v1_write_both_read"
     writeTestData(path)
 
-    // DSv2 read returns empty (stub)
+    // DSv2 read returns real data
     val v2Df = spark.read.format("hudi_v2").load(path)
-    assertEquals(0, v2Df.count())
+    assertEquals(3, v2Df.count())
 
     // DSv1 read still works after DSv2 read
     val df = spark.read.format("hudi").load(path)
@@ -153,14 +149,17 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     writeTestData(path)
 
     val df = spark.read.format("hudi_v2").load(path)
-    // DSv2 stub returns empty results
-    assertEquals(0, df.count())
+    assertEquals(3, df.count())
 
     // Verify schema is correct
     val fieldNames = df.schema.fieldNames
     assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
     assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
     assertTrue(fieldNames.contains("amount"), s"Schema should contain 'amount', got: ${fieldNames.mkString(", ")}")
+
+    // Verify data values
+    val names = df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
 
     val plan = df.queryExecution.executedPlan.toString()
     assertTrue(containsBatchScan(plan),
@@ -205,7 +204,7 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
   }
 
   @Test
-  def testSqlConfigTrueUsesDSv2Stub(): Unit = {
+  def testSqlConfigTrueUsesDSv2(): Unit = {
     val tableName = "sql_v2_test"
     val tablePath = basePath() + "/" + tableName
     spark.sql(
@@ -228,12 +227,10 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
     try {
       val df = spark.sql(s"SELECT * FROM $tableName")
-      // DSv2 stub returns empty
-      assertEquals(0, df.count())
+      assertEquals(3, df.count())
 
-      val fieldNames = df.schema.fieldNames
-      assertTrue(fieldNames.contains("id"), s"Schema should contain 'id', got: ${fieldNames.mkString(", ")}")
-      assertTrue(fieldNames.contains("name"), s"Schema should contain 'name', got: ${fieldNames.mkString(", ")}")
+      val names = df.select("name").collect().map(_.getString(0)).sorted
+      assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
 
       val plan = df.queryExecution.executedPlan.toString()
       assertTrue(containsBatchScan(plan),
@@ -266,11 +263,11 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
     // Write with v1 (default)
     spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
 
-    // Read with v2 — stub returns empty
+    // Read with v2 — returns real data
     spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
     try {
       val v2Df = spark.sql(s"SELECT * FROM $tableName")
-      assertEquals(0, v2Df.count())
+      assertEquals(3, v2Df.count())
 
       val v2Plan = v2Df.queryExecution.executedPlan.toString()
       assertTrue(containsBatchScan(v2Plan),
@@ -279,7 +276,7 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
       spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
     }
 
-    // Switch back to v1 — should see real data
+    // Switch back to v1 — should also see real data
     spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
     try {
       val v1Df = spark.sql(s"SELECT * FROM $tableName")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CoexistenceWithDSv1.scala
@@ -384,16 +384,21 @@ class TestDSv2CoexistenceWithDSv1 extends SparkClientFunctionalTestHarness {
 
     spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1)")
 
-    // With schema evolution enabled and v2 read disabled, the loadTable()
-    // should return HoodieInternalV2Table (schema evolution path), not V1Table.
-    // Verify via EXPLAIN that the plan uses BatchScan (V2 path), not FileScan (V1 path).
+    // With schema evolution enabled and v2 read disabled, loadTable() returns
+    // HoodieInternalV2Table. It does not implement SupportsRead, so reads fall back
+    // to V1 via V2TableWithV1Fallback and use HoodieFileGroupReaderBasedFileFormat —
+    // a Hudi-aware V1 FileScan, NOT DSv2 BatchScan.
     spark.sessionState.conf.setConfString("hoodie.schema.on.read.enable", "true")
     spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
     try {
       val explainRows = spark.sql(s"EXPLAIN SELECT * FROM $tableName").collect()
       val plan = explainRows.map(_.getString(0)).mkString("\n")
-      assertTrue(containsBatchScan(plan),
-        s"Schema evolution path should use BatchScan (V2), but got:\n$plan")
+      assertTrue(containsFileScan(plan),
+        s"HoodieInternalV2Table should use V1 FileScan, but got:\n$plan")
+      assertTrue(plan.contains("HoodieFileGroupReaderBasedFileFormat") || plan.contains("HudiFileGroup"),
+        s"Plan should use Hudi-aware V1 file format, proving HoodieInternalV2Table was used:\n$plan")
+      assertTrue(!containsBatchScan(plan),
+        s"HoodieInternalV2Table should not produce a DSv2 BatchScan, but got:\n$plan")
 
       val df = spark.sql(s"SELECT * FROM $tableName")
       assertEquals(1, df.count())

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Functional tests for COW snapshot reading via the DSv2 path.
+ */
+@Tag("functional")
+class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @BeforeEach
+  def checkSparkVersion(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
+      "DSv2 read tests require Spark 3.5 or later")
+  }
+
+  @Test
+  def testCowReadViaDataFrameApi(): Unit = {
+    val path = basePath() + "/cow_df_read"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_df_read")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(3, df.count())
+
+    val names = df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
+
+    // Verify values match DSv1 read
+    val v1Names = spark.read.format("hudi").load(path)
+      .select("name").collect().map(_.getString(0)).sorted
+    assertEquals(v1Names.toSeq, names.toSeq)
+  }
+
+  @Test
+  def testCowReadViaSqlCatalog(): Unit = {
+    val tableName = "cow_sql_read"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  ts LONG
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val v2Df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(3, v2Df.count())
+
+      spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+      val v1Df = spark.sql(s"SELECT * FROM $tableName")
+      assertEquals(3, v1Df.count())
+
+      // Compare values (exclude meta-fields from V1)
+      val v2Names = v2Df.select("name").collect().map(_.getString(0)).sorted
+      val v1Names = v1Df.select("name").collect().map(_.getString(0)).sorted
+      assertEquals(v1Names.toSeq, v2Names.toSeq)
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testColumnPruning(): Unit = {
+    val path = basePath() + "/cow_col_pruning"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_col_pruning")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path).select("id", "name")
+    assertEquals(2, df.schema.fields.length)
+    assertEquals(3, df.count())
+
+    val rows = df.collect().map(r => (r.getInt(0), r.getString(1))).sortBy(_._1)
+    assertEquals(Seq((1, "Alice"), (2, "Bob"), (3, "Charlie")), rows.toSeq)
+  }
+
+  @Test
+  def testNonPartitionedTable(): Unit = {
+    val path = basePath() + "/cow_non_partitioned"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_non_partitioned")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(2, df.count())
+
+    val ids = df.select("id").collect().map(_.getInt(0)).sorted
+    assertEquals(Seq(1, 2), ids.toSeq)
+  }
+
+  @Test
+  def testPartitionedTable(): Unit = {
+    val path = basePath() + "/cow_partitioned"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", "US"), (2, "Bob", "UK"), (3, "Charlie", "US"))
+      .toDF("id", "name", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_partitioned")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "id")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(3, df.count())
+
+    val countries = df.select("country").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("UK", "US", "US"), countries.toSeq)
+
+    val names = df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
+  }
+
+  @Test
+  def testMultipleCommits(): Unit = {
+    val path = basePath() + "/cow_multi_commit"
+    val _spark = spark
+    import _spark.implicits._
+
+    // Batch 1: insert
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_multi_commit")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    // Batch 2: upsert (update Alice's amount, insert Charlie)
+    Seq((1, "Alice", 150.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_multi_commit")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Append)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(3, df.count())
+
+    val rows = df.select("id", "name", "amount").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
+    assertEquals(Seq((1, "Alice", 150.0), (2, "Bob", 200.0), (3, "Charlie", 300.0)), rows.toSeq)
+  }
+
+  @Test
+  def testDsv1VsDsv2ResultComparison(): Unit = {
+    val path = basePath() + "/cow_v1_v2_compare"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_v1_v2_compare")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val v1Df = spark.read.format("hudi").load(path).select("id", "name", "amount")
+    val v2Df = spark.read.format("hudi_v2").load(path).select("id", "name", "amount")
+
+    val v1Rows = v1Df.collect().map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
+    val v2Rows = v2Df.collect().map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
+    assertEquals(v1Rows.toSeq, v2Rows.toSeq)
+  }
+
+  @Test
+  def testSelectPartitionColumnOnly(): Unit = {
+    val path = basePath() + "/cow_select_part_only"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", "US"), (2, "Bob", "UK"), (3, "Charlie", "US"))
+      .toDF("id", "name", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_select_part_only")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "id")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path).select("country")
+    assertEquals(3, df.count())
+
+    val countries = df.collect().map(_.getString(0)).sorted
+    assertEquals(Seq("UK", "US", "US"), countries.toSeq)
+  }
+
+  @Test
+  def testMultiplePartitions(): Unit = {
+    val path = basePath() + "/cow_multi_partitions"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq(
+      (1, "Alice", "US"),
+      (2, "Bob", "UK"),
+      (3, "Charlie", "DE"),
+      (4, "Diana", "US"),
+      (5, "Eve", "UK")
+    ).toDF("id", "name", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_multi_partitions")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "id")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(5, df.count())
+
+    val distinctCountries = df.select("country").distinct().collect().map(_.getString(0)).sorted
+    assertEquals(Seq("DE", "UK", "US"), distinctCountries.toSeq)
+
+    // Verify counts per partition
+    val countsByCountry = df.groupBy("country").count().collect()
+      .map(r => (r.getString(0), r.getLong(1))).toMap
+    assertEquals(2L, countsByCountry("US"))
+    assertEquals(2L, countsByCountry("UK"))
+    assertEquals(1L, countsByCountry("DE"))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
@@ -17,15 +17,14 @@
 
 package org.apache.spark.sql.hudi.feature.v2
 
-import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.DataSourceReadOptions
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Functional tests for COW snapshot reading via the DSv2 path.
@@ -34,12 +33,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
-
-  @BeforeEach
-  def checkSparkVersion(): Unit = {
-    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
-      "DSv2 read tests require Spark 3.5 or later")
-  }
 
   @Test
   def testCowReadViaDataFrameApi(): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2CowSnapshotRead.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlCon
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
 import org.junit.jupiter.api.{Tag, Test}
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 
 /**
  * Functional tests for COW snapshot reading via the DSv2 path.
@@ -33,6 +33,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
+
+  private def containsBatchScan(plan: String): Boolean = plan.contains("BatchScan")
+
+  private def containsFileScan(plan: String): Boolean = plan.contains("FileScan")
 
   @Test
   def testCowReadViaDataFrameApi(): Unit = {
@@ -59,44 +63,60 @@ class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
     val v1Names = spark.read.format("hudi").load(path)
       .select("name").collect().map(_.getString(0)).sorted
     assertEquals(v1Names.toSeq, names.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
   def testCowReadViaSqlCatalog(): Unit = {
     val tableName = "cow_sql_read"
     val tablePath = basePath() + "/" + tableName
-    spark.sql(
-      s"""CREATE TABLE $tableName (
-         |  id INT,
-         |  name STRING,
-         |  amount DOUBLE,
-         |  ts LONG
-         |) USING hudi
-         |TBLPROPERTIES (
-         |  type = 'cow',
-         |  primaryKey = 'id',
-         |  orderingFields = 'ts'
-         |)
-         |LOCATION '$tablePath'
-         """.stripMargin)
-
-    spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
-
-    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    val confKey = DataSourceReadOptions.USE_V2_READ.key
+    val prev = Option(spark.sessionState.conf.getConfString(confKey, null))
     try {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(
+        s"""CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  amount DOUBLE,
+           |  ts LONG
+           |) USING hudi
+           |TBLPROPERTIES (
+           |  type = 'cow',
+           |  primaryKey = 'id',
+           |  orderingFields = 'ts'
+           |)
+           |LOCATION '$tablePath'
+           """.stripMargin)
+
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2), (3, 'Charlie', 300.0, 3)")
+
+      spark.sessionState.conf.setConfString(confKey, "true")
       val v2Df = spark.sql(s"SELECT * FROM $tableName")
       assertEquals(3, v2Df.count())
+      val v2Plan = v2Df.queryExecution.executedPlan.toString()
+      assertTrue(containsBatchScan(v2Plan),
+        s"With use.v2=true, should use BatchScan, but plan was:\n$v2Plan")
 
-      spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "false")
+      spark.sessionState.conf.setConfString(confKey, "false")
       val v1Df = spark.sql(s"SELECT * FROM $tableName")
       assertEquals(3, v1Df.count())
+      val v1Plan = v1Df.queryExecution.executedPlan.toString()
+      assertTrue(containsFileScan(v1Plan),
+        s"With use.v2=false, should use FileScan, but plan was:\n$v1Plan")
 
       // Compare values (exclude meta-fields from V1)
       val v2Names = v2Df.select("name").collect().map(_.getString(0)).sorted
       val v1Names = v1Df.select("name").collect().map(_.getString(0)).sorted
       assertEquals(v1Names.toSeq, v2Names.toSeq)
     } finally {
-      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      prev match {
+        case Some(v) => spark.sessionState.conf.setConfString(confKey, v)
+        case None => spark.sessionState.conf.unsetConf(confKey)
+      }
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
     }
   }
@@ -122,6 +142,10 @@ class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
 
     val rows = df.collect().map(r => (r.getInt(0), r.getString(1))).sortBy(_._1)
     assertEquals(Seq((1, "Alice"), (2, "Bob"), (3, "Charlie")), rows.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -144,6 +168,10 @@ class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
 
     val ids = df.select("id").collect().map(_.getInt(0)).sorted
     assertEquals(Seq(1, 2), ids.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -170,6 +198,10 @@ class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
 
     val names = df.select("name").collect().map(_.getString(0)).sorted
     assertEquals(Seq("Alice", "Bob", "Charlie"), names.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -204,6 +236,10 @@ class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
     val rows = df.select("id", "name", "amount").collect()
       .map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
     assertEquals(Seq((1, "Alice", 150.0), (2, "Bob", 200.0), (3, "Charlie", 300.0)), rows.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -227,6 +263,13 @@ class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
     val v1Rows = v1Df.collect().map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
     val v2Rows = v2Df.collect().map(r => (r.getInt(0), r.getString(1), r.getDouble(2))).sortBy(_._1)
     assertEquals(v1Rows.toSeq, v2Rows.toSeq)
+
+    val v1Plan = v1Df.queryExecution.executedPlan.toString()
+    assertTrue(containsFileScan(v1Plan),
+      s"DSv1 read should use FileScan, but plan was:\n$v1Plan")
+    val v2Plan = v2Df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(v2Plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$v2Plan")
   }
 
   @Test
@@ -250,6 +293,10 @@ class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
 
     val countries = df.collect().map(_.getString(0)).sorted
     assertEquals(Seq("UK", "US", "US"), countries.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -285,5 +332,40 @@ class TestDSv2CowSnapshotRead extends SparkClientFunctionalTestHarness {
     assertEquals(2L, countsByCountry("US"))
     assertEquals(2L, countsByCountry("UK"))
     assertEquals(1L, countsByCountry("DE"))
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
+  }
+
+  @Test
+  def testDataFrameApiReadDoesNotTriggerV1Table(): Unit = {
+    // Proves that a DataFrame-API read (catalogTable = None) completes end-to-end
+    // through filter + projection analysis without dereferencing v1Table.
+    // Guards against regressions that would surface as IllegalStateException from
+    // HoodieSparkV2Table.requireCatalogTable.
+    val path = basePath() + "/cow_df_read_no_v1"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0), (2, "Bob", 200.0), (3, "Charlie", 300.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_df_read_no_v1")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path)
+      .filter($"amount" > 100.0)
+      .select("id", "name")
+    val rows = df.collect().map(r => (r.getInt(0), r.getString(1))).sortBy(_._1)
+    assertEquals(Seq((2, "Bob"), (3, "Charlie")), rows.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DataFrame-API read should land on BatchScan without v1Table being called, " +
+        s"plan was:\n$plan")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Fallback.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Fallback.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.DataSourceReadOptions
+import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{Tag, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+
+/**
+ * Functional tests for DSv2 supportability gate: out-of-scope scenarios must fall back
+ * to DSv1 (SQL/catalog path) or throw (DataFrame API `format("hudi_v2")` path).
+ */
+@Tag("functional")
+class TestDSv2Fallback extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  private def containsBatchScan(plan: String): Boolean = plan.contains("BatchScan")
+
+  private def containsFileScan(plan: String): Boolean = plan.contains("FileScan")
+
+  private def explainPlan(sql: String): String =
+    spark.sql(s"EXPLAIN $sql").collect().map(_.getString(0)).mkString("\n")
+
+  @Test
+  def testMorSnapshotFallsBackToDsv1UnderSqlWithV2Enabled(): Unit = {
+    val tableName = "mor_snapshot_fallback"
+    val tablePath = basePath() + "/" + tableName
+    val useV2Key = DataSourceReadOptions.USE_V2_READ.key
+    try {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(
+        s"""CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  amount DOUBLE,
+           |  ts LONG
+           |) USING hudi
+           |TBLPROPERTIES (
+           |  type = 'mor',
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           |)
+           |LOCATION '$tablePath'
+           """.stripMargin)
+
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 1)")
+      // UPDATE on MOR writes to log files; a DSv2 path that dropped log files would see stale values.
+      spark.sql(s"UPDATE $tableName SET name = 'Alice2', amount = 150.0, ts = 2 WHERE id = 1")
+      spark.sql(s"INSERT INTO $tableName VALUES (3, 'Charlie', 300.0, 2)")
+
+      spark.sessionState.conf.setConfString(useV2Key, "true")
+      val plan = explainPlan(s"SELECT * FROM $tableName")
+      assertTrue(containsFileScan(plan),
+        s"MOR snapshot should fall back to DSv1 FileScan, got:\n$plan")
+
+      val rows = spark.sql(s"SELECT id, name, amount FROM $tableName ORDER BY id").collect()
+      assertEquals(3, rows.length)
+      assertEquals("Alice2", rows(0).getString(1))
+      assertEquals(150.0, rows(0).getDouble(2))
+      assertEquals("Bob", rows(1).getString(1))
+      assertEquals("Charlie", rows(2).getString(1))
+    } finally {
+      spark.sessionState.conf.unsetConf(useV2Key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testMorSnapshotRejectsHudiV2DataFrameApi(): Unit = {
+    val path = basePath() + "/mor_df_reject"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0, 1L), (2, "Bob", 200.0, 1L))
+      .toDF("id", "name", "amount", "ts")
+      .write.format("hudi")
+      .option("hoodie.table.name", "mor_df_reject")
+      .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "ts")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    assertThrows(classOf[HoodieException],
+      () => spark.read.format("hudi_v2").load(path).collect())
+  }
+
+  @Test
+  def testMorReadOptimizedGoesThroughDsv2(): Unit = {
+    val path = basePath() + "/mor_read_opt"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0, 1L), (2, "Bob", 200.0, 1L), (3, "Charlie", 300.0, 1L))
+      .toDF("id", "name", "amount", "ts")
+      .write.format("hudi")
+      .option("hoodie.table.name", "mor_read_opt")
+      .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "ts")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val v2Df = spark.read.format("hudi_v2")
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL)
+      .load(path)
+    val v2Plan = v2Df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(v2Plan),
+      s"MOR read_optimized via hudi_v2 should use BatchScan, got:\n$v2Plan")
+    assertEquals(3, v2Df.count())
+
+    val v1Names = spark.read.format("hudi")
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_READ_OPTIMIZED_OPT_VAL)
+      .load(path)
+      .select("name").collect().map(_.getString(0)).sorted
+    val v2Names = v2Df.select("name").collect().map(_.getString(0)).sorted
+    assertEquals(v1Names.toSeq, v2Names.toSeq)
+  }
+
+  @Test
+  def testIncrementalQueryRejectsHudiV2DataFrameApi(): Unit = {
+    val path = basePath() + "/cow_incremental_reject"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq((1, "Alice", 100.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "cow_incremental_reject")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    assertThrows(classOf[HoodieException],
+      () => spark.read.format("hudi_v2")
+        .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
+        .load(path).collect())
+  }
+
+  @Test
+  def testCowSnapshotHappyPathUsesDsv2(): Unit = {
+    val tableName = "cow_happy_path"
+    val tablePath = basePath() + "/" + tableName
+    val useV2Key = DataSourceReadOptions.USE_V2_READ.key
+    try {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(
+        s"""CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  amount DOUBLE,
+           |  ts LONG
+           |) USING hudi
+           |TBLPROPERTIES (
+           |  type = 'cow',
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           |)
+           |LOCATION '$tablePath'
+           """.stripMargin)
+
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 2)")
+
+      spark.sessionState.conf.setConfString(useV2Key, "true")
+      val plan = explainPlan(s"SELECT * FROM $tableName")
+      assertTrue(containsBatchScan(plan),
+        s"COW snapshot with use.v2=true should use BatchScan, got:\n$plan")
+      assertEquals(2, spark.sql(s"SELECT * FROM $tableName").count())
+    } finally {
+      spark.sessionState.conf.unsetConf(useV2Key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
@@ -17,15 +17,14 @@
 
 package org.apache.spark.sql.hudi.feature.v2
 
-import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.DataSourceReadOptions
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Functional tests for filter pushdown (partition pruning + data filters) via the DSv2 path.
@@ -34,12 +33,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
-
-  @BeforeEach
-  def checkSparkVersion(): Unit = {
-    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
-      "DSv2 read tests require Spark 3.5 or later")
-  }
 
   private def writePartitionedData(path: String, tableName: String): Unit = {
     val _spark = spark

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Functional tests for filter pushdown (partition pruning + data filters) via the DSv2 path.
+ */
+@Tag("functional")
+class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @BeforeEach
+  def checkSparkVersion(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
+      "DSv2 read tests require Spark 3.5 or later")
+  }
+
+  private def writePartitionedData(path: String, tableName: String): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    Seq(
+      (1, "Alice", 100.0, "US"),
+      (2, "Bob", 200.0, "UK"),
+      (3, "Charlie", 300.0, "US"),
+      (4, "Diana", 150.0, "FR"),
+      (5, "Eve", 250.0, "UK")
+    ).toDF("id", "name", "amount", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", tableName)
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  @Test
+  def testPartitionPruning(): Unit = {
+    val path = basePath() + "/filter_part_prune"
+    writePartitionedData(path, "filter_part_prune")
+
+    val df = spark.read.format("hudi_v2").load(path).filter("country = 'US'")
+    val rows = df.select("id", "name", "country").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getString(2))).sortBy(_._1)
+
+    assertEquals(2, rows.length)
+    assertEquals(Seq((1, "Alice", "US"), (3, "Charlie", "US")), rows.toSeq)
+  }
+
+  @Test
+  def testPartitionPruningViaSql(): Unit = {
+    val tableName = "filter_sql_prune"
+    val tablePath = basePath() + "/" + tableName
+    spark.sql(
+      s"""CREATE TABLE $tableName (
+         |  id INT,
+         |  name STRING,
+         |  amount DOUBLE,
+         |  country STRING
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'amount'
+         |)
+         |PARTITIONED BY (country)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+
+    spark.sql(
+      s"""INSERT INTO $tableName VALUES
+         |(1, 'Alice', 100.0, 'US'),
+         |(2, 'Bob', 200.0, 'UK'),
+         |(3, 'Charlie', 300.0, 'US')
+         """.stripMargin)
+
+    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    try {
+      val df = spark.sql(s"SELECT * FROM $tableName WHERE country = 'US'")
+      assertEquals(2, df.count())
+
+      val names = df.select("name").collect().map(_.getString(0)).sorted
+      assertEquals(Seq("Alice", "Charlie"), names.toSeq)
+    } finally {
+      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testDataFilterPushdown(): Unit = {
+    val path = basePath() + "/filter_data_push"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq(
+      (1, "Alice", 100.0),
+      (2, "Bob", 200.0),
+      (3, "Charlie", 300.0),
+      (4, "Diana", 400.0),
+      (5, "Eve", 500.0)
+    ).toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "filter_data_push")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path).filter("id > 3")
+    val rows = df.select("id", "name").collect()
+      .map(r => (r.getInt(0), r.getString(1))).sortBy(_._1)
+
+    assertEquals(2, rows.length)
+    assertEquals(Seq((4, "Diana"), (5, "Eve")), rows.toSeq)
+  }
+
+  @Test
+  def testMixedPartitionAndDataFilters(): Unit = {
+    val path = basePath() + "/filter_mixed"
+    writePartitionedData(path, "filter_mixed")
+
+    val df = spark.read.format("hudi_v2").load(path)
+      .filter("country = 'US' AND name = 'Alice'")
+    val rows = df.select("id", "name", "country").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getString(2)))
+
+    assertEquals(1, rows.length)
+    assertEquals((1, "Alice", "US"), rows.head)
+  }
+
+  @Test
+  def testExplainShowsPushedFilters(): Unit = {
+    val path = basePath() + "/filter_explain"
+    writePartitionedData(path, "filter_explain")
+
+    val df = spark.read.format("hudi_v2").load(path).filter("country = 'US'")
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(plan.contains("BatchScan"), s"Expected BatchScan in plan:\n$plan")
+    assertTrue(plan.contains("PushedFilters"), s"Expected PushedFilters in plan:\n$plan")
+    assertTrue(plan.contains("country"), s"Expected 'country' in pushed filters:\n$plan")
+  }
+
+  @Test
+  def testDsv1VsDsv2FilterResults(): Unit = {
+    val path = basePath() + "/filter_v1_v2"
+    writePartitionedData(path, "filter_v1_v2")
+
+    val filter = "country = 'UK'"
+    val v1Rows = spark.read.format("hudi").load(path).filter(filter)
+      .select("id", "name", "amount", "country").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getDouble(2), r.getString(3))).sortBy(_._1)
+
+    val v2Rows = spark.read.format("hudi_v2").load(path).filter(filter)
+      .select("id", "name", "amount", "country").collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getDouble(2), r.getString(3))).sortBy(_._1)
+
+    assertEquals(v1Rows.toSeq, v2Rows.toSeq)
+    assertEquals(2, v2Rows.length)
+  }
+
+  @Test
+  def testNoFilterScansAllPartitions(): Unit = {
+    val path = basePath() + "/filter_no_filter"
+    writePartitionedData(path, "filter_no_filter")
+
+    val df = spark.read.format("hudi_v2").load(path)
+    assertEquals(5, df.count())
+
+    val countries = df.select("country").distinct().collect().map(_.getString(0)).sorted
+    assertEquals(Seq("FR", "UK", "US"), countries.toSeq)
+  }
+
+  @Test
+  def testInFilterOnPartitionColumn(): Unit = {
+    val path = basePath() + "/filter_in"
+    writePartitionedData(path, "filter_in")
+
+    val df = spark.read.format("hudi_v2").load(path).filter("country IN ('US', 'UK')")
+    assertEquals(4, df.count())
+
+    val countries = df.select("country").distinct().collect().map(_.getString(0)).sorted
+    assertEquals(Seq("UK", "US"), countries.toSeq)
+  }
+
+  @Test
+  def testIsNullFilter(): Unit = {
+    val path = basePath() + "/filter_null"
+    val _spark = spark
+    import _spark.implicits._
+
+    Seq(
+      (1, "Alice", "US"),
+      (2, "Bob", null: String),
+      (3, "Charlie", "UK"),
+      (4, "Diana", null: String)
+    ).toDF("id", "name", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", "filter_null")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "id")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    val df = spark.read.format("hudi_v2").load(path).filter("country IS NULL")
+    assertEquals(2, df.count())
+
+    val ids = df.select("id").collect().map(_.getInt(0)).sorted
+    assertEquals(Seq(2, 4), ids.toSeq)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2FilterPushdown.scala
@@ -34,6 +34,10 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
 
+  private def containsBatchScan(plan: String): Boolean = plan.contains("BatchScan")
+
+  private def containsFileScan(plan: String): Boolean = plan.contains("FileScan")
+
   private def writePartitionedData(path: String, tableName: String): Unit = {
     val _spark = spark
     import _spark.implicits._
@@ -64,44 +68,58 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
     assertEquals(2, rows.length)
     assertEquals(Seq((1, "Alice", "US"), (3, "Charlie", "US")), rows.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
   def testPartitionPruningViaSql(): Unit = {
     val tableName = "filter_sql_prune"
     val tablePath = basePath() + "/" + tableName
-    spark.sql(
-      s"""CREATE TABLE $tableName (
-         |  id INT,
-         |  name STRING,
-         |  amount DOUBLE,
-         |  country STRING
-         |) USING hudi
-         |TBLPROPERTIES (
-         |  type = 'cow',
-         |  primaryKey = 'id',
-         |  orderingFields = 'amount'
-         |)
-         |PARTITIONED BY (country)
-         |LOCATION '$tablePath'
-         """.stripMargin)
-
-    spark.sql(
-      s"""INSERT INTO $tableName VALUES
-         |(1, 'Alice', 100.0, 'US'),
-         |(2, 'Bob', 200.0, 'UK'),
-         |(3, 'Charlie', 300.0, 'US')
-         """.stripMargin)
-
-    spark.sessionState.conf.setConfString(DataSourceReadOptions.USE_V2_READ.key, "true")
+    val confKey = DataSourceReadOptions.USE_V2_READ.key
+    val prev = Option(spark.sessionState.conf.getConfString(confKey, null))
     try {
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(
+        s"""CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  amount DOUBLE,
+           |  country STRING
+           |) USING hudi
+           |TBLPROPERTIES (
+           |  type = 'cow',
+           |  primaryKey = 'id',
+           |  orderingFields = 'amount'
+           |)
+           |PARTITIONED BY (country)
+           |LOCATION '$tablePath'
+           """.stripMargin)
+
+      spark.sql(
+        s"""INSERT INTO $tableName VALUES
+           |(1, 'Alice', 100.0, 'US'),
+           |(2, 'Bob', 200.0, 'UK'),
+           |(3, 'Charlie', 300.0, 'US')
+           """.stripMargin)
+
+      spark.sessionState.conf.setConfString(confKey, "true")
       val df = spark.sql(s"SELECT * FROM $tableName WHERE country = 'US'")
       assertEquals(2, df.count())
 
       val names = df.select("name").collect().map(_.getString(0)).sorted
       assertEquals(Seq("Alice", "Charlie"), names.toSeq)
+
+      val plan = df.queryExecution.executedPlan.toString()
+      assertTrue(containsBatchScan(plan),
+        s"With use.v2=true, SQL read should use BatchScan, but plan was:\n$plan")
     } finally {
-      spark.sessionState.conf.unsetConf(DataSourceReadOptions.USE_V2_READ.key)
+      prev match {
+        case Some(v) => spark.sessionState.conf.setConfString(confKey, v)
+        case None => spark.sessionState.conf.unsetConf(confKey)
+      }
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
     }
   }
@@ -132,6 +150,10 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
     assertEquals(2, rows.length)
     assertEquals(Seq((4, "Diana"), (5, "Eve")), rows.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -146,6 +168,10 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
     assertEquals(1, rows.length)
     assertEquals((1, "Alice", "US"), rows.head)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -155,7 +181,7 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
     val df = spark.read.format("hudi_v2").load(path).filter("country = 'US'")
     val plan = df.queryExecution.executedPlan.toString()
-    assertTrue(plan.contains("BatchScan"), s"Expected BatchScan in plan:\n$plan")
+    assertTrue(containsBatchScan(plan), s"Expected BatchScan in plan:\n$plan")
     assertTrue(plan.contains("PushedFilters"), s"Expected PushedFilters in plan:\n$plan")
     assertTrue(plan.contains("country"), s"Expected 'country' in pushed filters:\n$plan")
   }
@@ -166,16 +192,25 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
     writePartitionedData(path, "filter_v1_v2")
 
     val filter = "country = 'UK'"
-    val v1Rows = spark.read.format("hudi").load(path).filter(filter)
-      .select("id", "name", "amount", "country").collect()
+    val v1Df = spark.read.format("hudi").load(path).filter(filter)
+      .select("id", "name", "amount", "country")
+    val v1Rows = v1Df.collect()
       .map(r => (r.getInt(0), r.getString(1), r.getDouble(2), r.getString(3))).sortBy(_._1)
 
-    val v2Rows = spark.read.format("hudi_v2").load(path).filter(filter)
-      .select("id", "name", "amount", "country").collect()
+    val v2Df = spark.read.format("hudi_v2").load(path).filter(filter)
+      .select("id", "name", "amount", "country")
+    val v2Rows = v2Df.collect()
       .map(r => (r.getInt(0), r.getString(1), r.getDouble(2), r.getString(3))).sortBy(_._1)
 
     assertEquals(v1Rows.toSeq, v2Rows.toSeq)
     assertEquals(2, v2Rows.length)
+
+    val v1Plan = v1Df.queryExecution.executedPlan.toString()
+    assertTrue(containsFileScan(v1Plan),
+      s"DSv1 read should use FileScan, but plan was:\n$v1Plan")
+    val v2Plan = v2Df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(v2Plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$v2Plan")
   }
 
   @Test
@@ -188,6 +223,10 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
     val countries = df.select("country").distinct().collect().map(_.getString(0)).sorted
     assertEquals(Seq("FR", "UK", "US"), countries.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -200,6 +239,10 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
     val countries = df.select("country").distinct().collect().map(_.getString(0)).sorted
     assertEquals(Seq("UK", "US"), countries.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -226,5 +269,9 @@ class TestDSv2FilterPushdown extends SparkClientFunctionalTestHarness {
 
     val ids = df.select("id").collect().map(_.getInt(0)).sorted
     assertEquals(Seq(2, 4), ids.toSeq)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
@@ -17,15 +17,13 @@
 
 package org.apache.spark.sql.hudi.feature.v2
 
-import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.{Tag, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Functional tests for limit pushdown, statistics reporting, and aggregate pushdown via DSv2.
@@ -34,12 +32,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
-
-  @BeforeEach
-  def checkSparkVersion(): Unit = {
-    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
-      "DSv2 read tests require Spark 3.5 or later")
-  }
 
   private def writeTestData(path: String, tableName: String, numRecords: Int = 10): Unit = {
     val _spark = spark

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.HoodieSparkUtils
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.{BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Functional tests for limit pushdown, statistics reporting, and aggregate pushdown via DSv2.
+ */
+@Tag("functional")
+class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  @BeforeEach
+  def checkSparkVersion(): Unit = {
+    assumeTrue(HoodieSparkUtils.gteqSpark3_5,
+      "DSv2 read tests require Spark 3.5 or later")
+  }
+
+  private def writeTestData(path: String, tableName: String, numRecords: Int = 10): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    (1 to numRecords).map(i => (i, s"name_$i", i * 100.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", tableName)
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  private def writePartitionedTestData(path: String, tableName: String): Unit = {
+    val _spark = spark
+    import _spark.implicits._
+    Seq(
+      (1, "Alice", 100.0, "US"),
+      (2, "Bob", 200.0, "UK"),
+      (3, "Charlie", 300.0, "US"),
+      (4, "Diana", 150.0, "FR"),
+      (5, "Eve", 250.0, "UK"),
+      (6, "Frank", 350.0, "US"),
+      (7, "Grace", 450.0, "FR")
+    ).toDF("id", "name", "amount", "country")
+      .write.format("hudi")
+      .option("hoodie.table.name", tableName)
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .option("hoodie.datasource.write.partitionpath.field", "country")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+  }
+
+  // ==========================================================================
+  // Limit pushdown tests
+  // ==========================================================================
+
+  @Test
+  def testLimitReducesRowCount(): Unit = {
+    val path = basePath() + "/limit_basic"
+    writeTestData(path, "limit_basic")
+
+    val df = spark.read.format("hudi_v2").load(path).limit(3)
+    assertEquals(3, df.count())
+  }
+
+  @Test
+  def testLimitGreaterThanTableSize(): Unit = {
+    val path = basePath() + "/limit_greater"
+    writeTestData(path, "limit_greater", numRecords = 5)
+
+    val df = spark.read.format("hudi_v2").load(path).limit(100)
+    assertEquals(5, df.count())
+  }
+
+  @Test
+  def testLimitWithFilter(): Unit = {
+    val path = basePath() + "/limit_filter"
+    writePartitionedTestData(path, "limit_filter")
+
+    val df = spark.read.format("hudi_v2").load(path)
+      .filter("country = 'US'")
+      .limit(1)
+    assertEquals(1, df.count())
+
+    val country = df.select("country").collect().head.getString(0)
+    assertEquals("US", country)
+  }
+
+  @Test
+  def testLimitDsv1VsDsv2(): Unit = {
+    val path = basePath() + "/limit_v1_v2"
+    writeTestData(path, "limit_v1_v2", numRecords = 10)
+
+    val v1Count = spark.read.format("hudi").load(path).limit(5).count()
+    val v2Count = spark.read.format("hudi_v2").load(path).limit(5).count()
+    assertEquals(v1Count, v2Count)
+    assertEquals(5, v2Count)
+  }
+
+  @Test
+  def testLimitOne(): Unit = {
+    val path = basePath() + "/limit_one"
+    writeTestData(path, "limit_one", numRecords = 10)
+
+    val df = spark.read.format("hudi_v2").load(path).limit(1)
+    assertEquals(1, df.count())
+  }
+
+  @Test
+  def testExplainShowsLimitInfo(): Unit = {
+    val path = basePath() + "/limit_explain"
+    writeTestData(path, "limit_explain", numRecords = 5)
+
+    val df = spark.read.format("hudi_v2").load(path).limit(3)
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(plan.contains("BatchScan"), s"Expected BatchScan in plan:\n$plan")
+    assertTrue(plan.contains("PushedLimit"), s"Expected PushedLimit in plan:\n$plan")
+  }
+
+  // ==========================================================================
+  // Statistics reporting tests
+  // ==========================================================================
+
+  @Test
+  def testStatisticsReportsSizeInBytes(): Unit = {
+    val path = basePath() + "/stats_size"
+    writeTestData(path, "stats_size", numRecords = 10)
+
+    val df = spark.read.format("hudi_v2").load(path)
+    val plan = df.queryExecution.optimizedPlan
+    val stats = plan.stats
+
+    assertTrue(stats.sizeInBytes > 0, s"Expected positive sizeInBytes, got: ${stats.sizeInBytes}")
+  }
+
+  @Test
+  def testStatisticsWithNoMatchFilter(): Unit = {
+    val path = basePath() + "/stats_no_match"
+    val _spark = spark
+    import _spark.implicits._
+
+    // Write one row so the table has metadata and a base file
+    Seq((1, "Alice", 100.0))
+      .toDF("id", "name", "amount")
+      .write.format("hudi")
+      .option("hoodie.table.name", "stats_no_match")
+      .option("hoodie.datasource.write.recordkey.field", "id")
+      .option("hoodie.datasource.write.precombine.field", "amount")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+
+    // Apply a filter that matches nothing; the table still has physical files
+    val df = spark.read.format("hudi_v2").load(path).filter("id < 0")
+    val count = df.count()
+    assertEquals(0L, count, "Expected zero rows for no-match filter")
+
+    // Statistics should still reflect the underlying file sizes
+    val plan = df.queryExecution.optimizedPlan
+    val stats = plan.stats
+    assertTrue(stats.sizeInBytes >= 0,
+      s"Expected non-negative sizeInBytes, got: ${stats.sizeInBytes}")
+  }
+
+  // ==========================================================================
+  // Aggregate pushdown tests (conditional on column stats availability)
+  // ==========================================================================
+
+  @Test
+  def testCountStarWithoutColumnStats(): Unit = {
+    // Without column stats enabled, COUNT(*) should still return correct result
+    // (falls back to scanning all files)
+    val path = basePath() + "/count_no_stats"
+    writeTestData(path, "count_no_stats", numRecords = 5)
+
+    val count = spark.read.format("hudi_v2").load(path)
+      .selectExpr("count(*)").collect().head.getLong(0)
+    assertEquals(5, count)
+  }
+
+  @Test
+  def testCountStarDsv1VsDsv2(): Unit = {
+    val path = basePath() + "/count_v1_v2"
+    writeTestData(path, "count_v1_v2", numRecords = 8)
+
+    val v1Count = spark.read.format("hudi").load(path)
+      .selectExpr("count(*)").collect().head.getLong(0)
+    val v2Count = spark.read.format("hudi_v2").load(path)
+      .selectExpr("count(*)").collect().head.getLong(0)
+    assertEquals(v1Count, v2Count)
+  }
+
+  @Test
+  def testMinMaxWithoutColumnStats(): Unit = {
+    val path = basePath() + "/minmax_no_stats"
+    writeTestData(path, "minmax_no_stats", numRecords = 5)
+
+    val row = spark.read.format("hudi_v2").load(path)
+      .selectExpr("min(amount)", "max(amount)").collect().head
+
+    assertEquals(100.0, row.getDouble(0))
+    assertEquals(500.0, row.getDouble(1))
+  }
+
+  @Test
+  def testAggregateWithGroupByNotPushed(): Unit = {
+    val path = basePath() + "/agg_groupby"
+    writePartitionedTestData(path, "agg_groupby")
+
+    // GROUP BY should prevent aggregate pushdown, but still return correct results
+    val rows = spark.read.format("hudi_v2").load(path)
+      .groupBy("country").count()
+      .collect().map(r => (r.getString(0), r.getLong(1))).sortBy(_._1)
+
+    assertEquals("FR", rows(0)._1)
+    assertEquals(2, rows(0)._2)
+    assertEquals("UK", rows(1)._1)
+    assertEquals(2, rows(1)._2)
+    assertEquals("US", rows(2)._1)
+    assertEquals(3, rows(2)._2)
+  }
+
+  @Test
+  def testCountWithPartitionFilter(): Unit = {
+    val path = basePath() + "/count_part_filter"
+    writePartitionedTestData(path, "count_part_filter")
+
+    val count = spark.read.format("hudi_v2").load(path)
+      .filter("country = 'US'")
+      .selectExpr("count(*)").collect().head.getLong(0)
+    assertEquals(3, count)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala
@@ -33,6 +33,16 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
 
   override def conf: SparkConf = conf(getSparkSqlConf)
 
+  private def containsBatchScan(plan: String): Boolean = plan.contains("BatchScan")
+
+  private def containsFileScan(plan: String): Boolean = plan.contains("FileScan")
+
+  // A fully pushed-down aggregate (e.g. COUNT(*) from column stats) materializes as
+  // Spark's LocalTableScan (via HoodieLocalScan/LocalScan), so accept either form as
+  // a DSv2 indicator in tests that may exercise aggregate pushdown.
+  private def containsDsv2Scan(plan: String): Boolean =
+    plan.contains("BatchScan") || plan.contains("LocalTableScan")
+
   private def writeTestData(path: String, tableName: String, numRecords: Int = 10): Unit = {
     val _spark = spark
     import _spark.implicits._
@@ -78,6 +88,10 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
 
     val df = spark.read.format("hudi_v2").load(path).limit(3)
     assertEquals(3, df.count())
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -87,6 +101,10 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
 
     val df = spark.read.format("hudi_v2").load(path).limit(100)
     assertEquals(5, df.count())
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -101,6 +119,10 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
 
     val country = df.select("country").collect().head.getString(0)
     assertEquals("US", country)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -108,10 +130,19 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     val path = basePath() + "/limit_v1_v2"
     writeTestData(path, "limit_v1_v2", numRecords = 10)
 
-    val v1Count = spark.read.format("hudi").load(path).limit(5).count()
-    val v2Count = spark.read.format("hudi_v2").load(path).limit(5).count()
+    val v1Df = spark.read.format("hudi").load(path).limit(5)
+    val v2Df = spark.read.format("hudi_v2").load(path).limit(5)
+    val v1Count = v1Df.count()
+    val v2Count = v2Df.count()
     assertEquals(v1Count, v2Count)
     assertEquals(5, v2Count)
+
+    val v1Plan = v1Df.queryExecution.executedPlan.toString()
+    assertTrue(containsFileScan(v1Plan),
+      s"DSv1 read should use FileScan, but plan was:\n$v1Plan")
+    val v2Plan = v2Df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(v2Plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$v2Plan")
   }
 
   @Test
@@ -121,6 +152,10 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
 
     val df = spark.read.format("hudi_v2").load(path).limit(1)
     assertEquals(1, df.count())
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -130,7 +165,7 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
 
     val df = spark.read.format("hudi_v2").load(path).limit(3)
     val plan = df.queryExecution.executedPlan.toString()
-    assertTrue(plan.contains("BatchScan"), s"Expected BatchScan in plan:\n$plan")
+    assertTrue(containsBatchScan(plan), s"Expected BatchScan in plan:\n$plan")
     assertTrue(plan.contains("PushedLimit"), s"Expected PushedLimit in plan:\n$plan")
   }
 
@@ -148,6 +183,10 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     val stats = plan.stats
 
     assertTrue(stats.sizeInBytes > 0, s"Expected positive sizeInBytes, got: ${stats.sizeInBytes}")
+
+    val executedPlan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(executedPlan),
+      s"DSv2 read should use BatchScan, but plan was:\n$executedPlan")
   }
 
   @Test
@@ -176,6 +215,10 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     val stats = plan.stats
     assertTrue(stats.sizeInBytes >= 0,
       s"Expected non-negative sizeInBytes, got: ${stats.sizeInBytes}")
+
+    val executedPlan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(executedPlan),
+      s"DSv2 read should use BatchScan, but plan was:\n$executedPlan")
   }
 
   // ==========================================================================
@@ -189,9 +232,15 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     val path = basePath() + "/count_no_stats"
     writeTestData(path, "count_no_stats", numRecords = 5)
 
-    val count = spark.read.format("hudi_v2").load(path)
-      .selectExpr("count(*)").collect().head.getLong(0)
+    val df = spark.read.format("hudi_v2").load(path).selectExpr("count(*)")
+    val count = df.collect().head.getLong(0)
     assertEquals(5, count)
+
+    // count(*) may fully push down via column stats (LocalTableScan) or fall back
+    // to a regular DSv2 scan (BatchScan). DSv1 would surface FileScan instead.
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsDsv2Scan(plan) && !containsFileScan(plan),
+      s"DSv2 read should use BatchScan or LocalTableScan, but plan was:\n$plan")
   }
 
   @Test
@@ -199,11 +248,19 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     val path = basePath() + "/count_v1_v2"
     writeTestData(path, "count_v1_v2", numRecords = 8)
 
-    val v1Count = spark.read.format("hudi").load(path)
-      .selectExpr("count(*)").collect().head.getLong(0)
-    val v2Count = spark.read.format("hudi_v2").load(path)
-      .selectExpr("count(*)").collect().head.getLong(0)
+    val v1Df = spark.read.format("hudi").load(path).selectExpr("count(*)")
+    val v2Df = spark.read.format("hudi_v2").load(path).selectExpr("count(*)")
+    val v1Count = v1Df.collect().head.getLong(0)
+    val v2Count = v2Df.collect().head.getLong(0)
     assertEquals(v1Count, v2Count)
+
+    val v1Plan = v1Df.queryExecution.executedPlan.toString()
+    assertTrue(containsFileScan(v1Plan),
+      s"DSv1 read should use FileScan, but plan was:\n$v1Plan")
+    // DSv2 count(*) may fully push down via stats (LocalTableScan) or fall back to BatchScan.
+    val v2Plan = v2Df.queryExecution.executedPlan.toString()
+    assertTrue(containsDsv2Scan(v2Plan) && !containsFileScan(v2Plan),
+      s"DSv2 read should use BatchScan or LocalTableScan, but plan was:\n$v2Plan")
   }
 
   @Test
@@ -211,11 +268,16 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     val path = basePath() + "/minmax_no_stats"
     writeTestData(path, "minmax_no_stats", numRecords = 5)
 
-    val row = spark.read.format("hudi_v2").load(path)
-      .selectExpr("min(amount)", "max(amount)").collect().head
+    val df = spark.read.format("hudi_v2").load(path)
+      .selectExpr("min(amount)", "max(amount)")
+    val row = df.collect().head
 
     assertEquals(100.0, row.getDouble(0))
     assertEquals(500.0, row.getDouble(1))
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -224,9 +286,8 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     writePartitionedTestData(path, "agg_groupby")
 
     // GROUP BY should prevent aggregate pushdown, but still return correct results
-    val rows = spark.read.format("hudi_v2").load(path)
-      .groupBy("country").count()
-      .collect().map(r => (r.getString(0), r.getLong(1))).sortBy(_._1)
+    val df = spark.read.format("hudi_v2").load(path).groupBy("country").count()
+    val rows = df.collect().map(r => (r.getString(0), r.getLong(1))).sortBy(_._1)
 
     assertEquals("FR", rows(0)._1)
     assertEquals(2, rows(0)._2)
@@ -234,6 +295,10 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     assertEquals(2, rows(1)._2)
     assertEquals("US", rows(2)._1)
     assertEquals(3, rows(2)._2)
+
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsBatchScan(plan),
+      s"DSv2 read should use BatchScan, but plan was:\n$plan")
   }
 
   @Test
@@ -241,9 +306,16 @@ class TestDSv2Pushdowns extends SparkClientFunctionalTestHarness {
     val path = basePath() + "/count_part_filter"
     writePartitionedTestData(path, "count_part_filter")
 
-    val count = spark.read.format("hudi_v2").load(path)
+    val df = spark.read.format("hudi_v2").load(path)
       .filter("country = 'US'")
-      .selectExpr("count(*)").collect().head.getLong(0)
+      .selectExpr("count(*)")
+    val count = df.collect().head.getLong(0)
     assertEquals(3, count)
+
+    // count(*) with partition-only filter may fully push down via stats (LocalTableScan)
+    // or fall back to a regular DSv2 scan (BatchScan). Either is valid DSv2; FileScan isn't.
+    val plan = df.queryExecution.executedPlan.toString()
+    assertTrue(containsDsv2Scan(plan) && !containsFileScan(plan),
+      s"DSv2 read should use BatchScan or LocalTableScan, but plan was:\n$plan")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2SchemaEvolution.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2SchemaEvolution.scala
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.feature.v2
+
+import org.apache.hudi.DataSourceReadOptions
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness.getSparkSqlConf
+
+import org.apache.spark.SparkConf
+import org.junit.jupiter.api.{Tag, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNull, assertTrue}
+
+/**
+ * Functional tests verifying DSv2 reads return correct values on schema-evolved COW
+ * tables. The internal schema is fetched from the commit timeline and threaded into
+ * the columnar file reader (see [[HoodieScanBuilder]] and [[HoodiePartitionReader]]).
+ */
+@Tag("functional")
+class TestDSv2SchemaEvolution extends SparkClientFunctionalTestHarness {
+
+  override def conf: SparkConf = conf(getSparkSqlConf)
+
+  private def containsBatchScan(plan: String): Boolean = plan.contains("BatchScan")
+
+  private def explainPlan(sql: String): String =
+    spark.sql(s"EXPLAIN $sql").collect().map(_.getString(0)).mkString("\n")
+
+  @Test
+  def testSchemaEvolvedColumnAddReadViaDSv2(): Unit = {
+    val tableName = "cow_schema_evol_add_col"
+    val tablePath = basePath() + "/" + tableName
+    val useV2Key = DataSourceReadOptions.USE_V2_READ.key
+    val schemaEvolKey = "hoodie.schema.on.read.enable"
+    try {
+      spark.sessionState.conf.setConfString(schemaEvolKey, "true")
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(
+        s"""CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  amount DOUBLE,
+           |  ts LONG
+           |) USING hudi
+           |TBLPROPERTIES (
+           |  type = 'cow',
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           |)
+           |LOCATION '$tablePath'
+           """.stripMargin)
+
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 1)")
+      spark.sql(s"ALTER TABLE $tableName ADD COLUMNS (category STRING)")
+      spark.sql(s"INSERT INTO $tableName VALUES (3, 'Charlie', 300.0, 2, 'gold')")
+
+      spark.sessionState.conf.setConfString(useV2Key, "true")
+      val plan = explainPlan(s"SELECT * FROM $tableName")
+      assertTrue(containsBatchScan(plan),
+        s"Schema-evolved COW read via DSv2 should use BatchScan, got:\n$plan")
+
+      val rows = spark.sql(s"SELECT id, name, category FROM $tableName ORDER BY id").collect()
+      assertEquals(3, rows.length)
+      assertEquals(1, rows(0).getInt(0))
+      assertNull(rows(0).get(2), "pre-evolution row should have null for added column")
+      assertEquals(2, rows(1).getInt(0))
+      assertNull(rows(1).get(2), "pre-evolution row should have null for added column")
+      assertEquals(3, rows(2).getInt(0))
+      assertEquals("gold", rows(2).getString(2), "post-evolution row should have the added-column value")
+    } finally {
+      spark.sessionState.conf.unsetConf(useV2Key)
+      spark.sessionState.conf.unsetConf(schemaEvolKey)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSchemaEvolvedTypePromotionReadViaDSv2(): Unit = {
+    val tableName = "cow_schema_evol_type_promo"
+    val tablePath = basePath() + "/" + tableName
+    val useV2Key = DataSourceReadOptions.USE_V2_READ.key
+    val schemaEvolKey = "hoodie.schema.on.read.enable"
+    try {
+      spark.sessionState.conf.setConfString(schemaEvolKey, "true")
+      spark.sessionState.conf.setConfString("spark.sql.storeAssignmentPolicy", "legacy")
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(
+        s"""CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  amount INT,
+           |  ts LONG
+           |) USING hudi
+           |TBLPROPERTIES (
+           |  type = 'cow',
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           |)
+           |LOCATION '$tablePath'
+           """.stripMargin)
+
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100, 1), (2, 'Bob', 200, 1)")
+      spark.sql(s"ALTER TABLE $tableName ALTER COLUMN amount TYPE BIGINT")
+      spark.sql(s"INSERT INTO $tableName VALUES (3, 'Charlie', 3000000000, 2)")
+
+      spark.sessionState.conf.setConfString(useV2Key, "true")
+      val plan = explainPlan(s"SELECT * FROM $tableName")
+      assertTrue(containsBatchScan(plan),
+        s"Schema-evolved COW read via DSv2 should use BatchScan, got:\n$plan")
+
+      val rows = spark.sql(s"SELECT id, amount FROM $tableName ORDER BY id").collect()
+      assertEquals(3, rows.length)
+      assertEquals(100L, rows(0).getLong(1))
+      assertEquals(200L, rows(1).getLong(1))
+      assertEquals(3000000000L, rows(2).getLong(1))
+
+      // Cross-check with DSv1
+      spark.sessionState.conf.setConfString(useV2Key, "false")
+      val v1Rows = spark.sql(s"SELECT id, amount FROM $tableName ORDER BY id").collect()
+      assertEquals(rows(0).getLong(1), v1Rows(0).getLong(1))
+      assertEquals(rows(1).getLong(1), v1Rows(1).getLong(1))
+      assertEquals(rows(2).getLong(1), v1Rows(2).getLong(1))
+    } finally {
+      spark.sessionState.conf.unsetConf(useV2Key)
+      spark.sessionState.conf.unsetConf(schemaEvolKey)
+      spark.sessionState.conf.unsetConf("spark.sql.storeAssignmentPolicy")
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+
+  @Test
+  def testSchemaEvolvedReadViaHudiV2DataFrameApi(): Unit = {
+    val tableName = "cow_schema_evol_df_api"
+    val tablePath = basePath() + "/" + tableName
+    val schemaEvolKey = "hoodie.schema.on.read.enable"
+    try {
+      spark.sessionState.conf.setConfString(schemaEvolKey, "true")
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      spark.sql(
+        s"""CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  amount DOUBLE,
+           |  ts LONG
+           |) USING hudi
+           |TBLPROPERTIES (
+           |  type = 'cow',
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           |)
+           |LOCATION '$tablePath'
+           """.stripMargin)
+
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 100.0, 1), (2, 'Bob', 200.0, 1)")
+      spark.sql(s"ALTER TABLE $tableName ADD COLUMNS (region STRING)")
+      spark.sql(s"INSERT INTO $tableName VALUES (3, 'Charlie', 300.0, 2, 'us-west')")
+
+      val v2Df = spark.read.format("hudi_v2")
+        .option(schemaEvolKey, "true")
+        .load(tablePath)
+      val v2Plan = v2Df.queryExecution.executedPlan.toString()
+      assertTrue(containsBatchScan(v2Plan),
+        s"DataFrame API schema-evolved read via hudi_v2 should use BatchScan, got:\n$v2Plan")
+
+      val rows = v2Df.orderBy("id").select("id", "region").collect()
+      assertEquals(3, rows.length)
+      assertNull(rows(0).get(1))
+      assertNull(rows(1).get(1))
+      assertEquals("us-west", rows(2).getString(1))
+    } finally {
+      spark.sessionState.conf.unsetConf(schemaEvolKey)
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
@@ -42,6 +42,8 @@ import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, Pa
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
+import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
+import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark3_3ExtendedSqlParser}
@@ -62,6 +64,8 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
         case plan if !plan.resolved => None
         // NOTE: When resolving Hudi table we allow [[Filter]]s and [[Project]]s be applied
         //       on top of it
+        case PhysicalOperation(_, _, DataSourceV2Relation(v2: HoodieSparkV2Table, _, _, _, _)) =>
+          v2.catalogTable
         case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2) =>
           Some(v2.v1Table)
         case ResolvedTable(_, _, V1Table(v1Table), _) if isHoodieTable(v1Table) =>
@@ -72,8 +76,7 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
   }
 
   def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    val className = v2Table.getClass.getName
-    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
+    v2Table.isInstanceOf[HoodieInternalV2Table] || v2Table.isInstanceOf[HoodieSparkV2Table]
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
@@ -62,13 +62,18 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
         case plan if !plan.resolved => None
         // NOTE: When resolving Hudi table we allow [[Filter]]s and [[Project]]s be applied
         //       on top of it
-        case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2.v1Table) =>
+        case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2) =>
           Some(v2.v1Table)
         case ResolvedTable(_, _, V1Table(v1Table), _) if isHoodieTable(v1Table) =>
           Some(v1Table)
         case _ => None
       }
     }
+  }
+
+  def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
+    val className = v2Table.getClass.getName
+    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark33Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark33Analysis.scala
@@ -27,15 +27,6 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
 
-/**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
 case class HoodieSpark33DataSourceV2ToV1Fallback(sparkSession: SparkSession) extends Rule[LogicalPlan]
   with ProvidesHoodieConfig {
 

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
@@ -43,6 +43,8 @@ import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, Pa
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
+import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
+import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark3_4ExtendedSqlParser}
@@ -63,6 +65,8 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
         case plan if !plan.resolved => None
         // NOTE: When resolving Hudi table we allow [[Filter]]s and [[Project]]s be applied
         //       on top of it
+        case PhysicalOperation(_, _, DataSourceV2Relation(v2: HoodieSparkV2Table, _, _, _, _)) =>
+          v2.catalogTable
         case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2) =>
           Some(v2.v1Table)
         case ResolvedTable(_, _, V1Table(v1Table), _) if isHoodieTable(v1Table) =>
@@ -73,8 +77,7 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
   }
 
   def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    val className = v2Table.getClass.getName
-    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
+    v2Table.isInstanceOf[HoodieInternalV2Table] || v2Table.isInstanceOf[HoodieSparkV2Table]
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
@@ -63,13 +63,18 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
         case plan if !plan.resolved => None
         // NOTE: When resolving Hudi table we allow [[Filter]]s and [[Project]]s be applied
         //       on top of it
-        case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2.v1Table) =>
+        case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2) =>
           Some(v2.v1Table)
         case ResolvedTable(_, _, V1Table(v1Table), _) if isHoodieTable(v1Table) =>
           Some(v1Table)
         case _ => None
       }
     }
+  }
+
+  def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
+    val className = v2Table.getClass.getName
+    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark34Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark34Analysis.scala
@@ -27,15 +27,6 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
 import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
 
-/**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
 case class HoodieSpark34DataSourceV2ToV1Fallback(sparkSession: SparkSession) extends Rule[LogicalPlan]
   with ProvidesHoodieConfig {
 

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -71,7 +71,8 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
   }
 
   def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    v2Table.getClass.getName.contains("HoodieInternalV2Table")
+    val className = v2Table.getClass.getName
+    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -42,6 +42,8 @@ import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, Pa
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
+import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
+import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark3_5ExtendedSqlParser}
 import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructType}
@@ -61,6 +63,8 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
         case plan if !plan.resolved => None
         // NOTE: When resolving Hudi table we allow [[Filter]]s and [[Project]]s be applied
         //       on top of it
+        case PhysicalOperation(_, _, DataSourceV2Relation(v2: HoodieSparkV2Table, _, _, _, _)) =>
+          v2.catalogTable
         case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2) =>
           Some(v2.v1Table)
         case ResolvedTable(_, _, V1Table(v1Table), _) if isHoodieTable(v1Table) =>
@@ -71,8 +75,7 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
   }
 
   def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    val className = v2Table.getClass.getName
-    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
+    v2Table.isInstanceOf[HoodieInternalV2Table] || v2Table.isInstanceOf[HoodieSparkV2Table]
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark35Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark35Analysis.scala
@@ -35,15 +35,6 @@ import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.PartitioningUtils.normalizePartitionSpec
 
-/**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
 case class HoodieSpark35DataSourceV2ToV1Fallback(sparkSession: SparkSession) extends Rule[LogicalPlan]
   with ProvidesHoodieConfig {
 

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -40,6 +40,8 @@ import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, Sp
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
+import org.apache.spark.sql.hudi.catalog.HoodieInternalV2Table
+import org.apache.spark.sql.hudi.v2.HoodieSparkV2Table
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_0ExtendedSqlParser}
 import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructType}
@@ -59,6 +61,8 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
         case plan if !plan.resolved => None
         // NOTE: When resolving Hudi table we allow [[Filter]]s and [[Project]]s be applied
         //       on top of it
+        case PhysicalOperation(_, _, DataSourceV2Relation(v2: HoodieSparkV2Table, _, _, _, _)) =>
+          v2.catalogTable
         case PhysicalOperation(_, _, DataSourceV2Relation(v2: V2TableWithV1Fallback, _, _, _, _)) if isHoodieTable(v2) =>
           Some(v2.v1Table)
         case ResolvedTable(_, _, V1Table(v1Table), _) if isHoodieTable(v1Table) =>
@@ -69,8 +73,7 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
   }
 
   def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    val className = v2Table.getClass.getName
-    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
+    v2Table.isInstanceOf[HoodieInternalV2Table] || v2Table.isInstanceOf[HoodieSparkV2Table]
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -69,7 +69,8 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
   }
 
   def isHoodieTable(v2Table: V2TableWithV1Fallback): Boolean = {
-    v2Table.getClass.getName.contains("HoodieInternalV2Table")
+    val className = v2Table.getClass.getName
+    className.contains("HoodieInternalV2Table") || className.contains("HoodieSparkV2Table")
   }
 
   override def isColumnarBatchRow(r: InternalRow): Boolean = r.isInstanceOf[ColumnarBatchRow]

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark40Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark40Analysis.scala
@@ -36,15 +36,6 @@ import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.PartitioningUtils.normalizePartitionSpec
 
-/**
- * NOTE: PLEASE READ CAREFULLY
- *
- * Since Hudi relations don't currently implement DS V2 Read API, we have to fallback to V1 here.
- * Such fallback will have considerable performance impact, therefore it's only performed in cases
- * where V2 API have to be used. Currently only such use-case is using of Schema Evolution feature
- *
- * Check out HUDI-4178 for more details
- */
 case class HoodieSpark40DataSourceV2ToV1Fallback(sparkSession: SparkSession) extends Rule[LogicalPlan]
   with ProvidesHoodieConfig {
 

--- a/plans/dsv2-aggregate-regression-98af4fe-to-973df90.md
+++ b/plans/dsv2-aggregate-regression-98af4fe-to-973df90.md
@@ -1,0 +1,212 @@
+# DSv2 Aggregate Regression Report Between `98af4fe` and `973df90`
+
+## Summary
+
+The large regression is most likely not a general DSv2 read slowdown. The scan, projection,
+filter, and limit benchmarks stay close to the earlier results. The big drop is isolated to
+aggregate pushdown:
+
+- `COUNT(*)` falls from about `0.2s` to about `3.6s`
+- `MIN/MAX` falls from about `0.2s` to about `3.9s`
+
+That pattern points to DSv2 losing the metadata-only aggregate path and falling back to a normal
+file scan. In the newer tree, `HoodieScanBuilder` still tries to resolve aggregates from column
+stats, but two later changes make that path much easier to miss.
+
+## Main Findings
+
+### 1. `COUNT(*)` most likely regressed because DSv2 changed which column it uses for row-count stats
+
+The original aggregate implementation used the first table column for `COUNT(*)`. In the newer
+tree, `COUNT(*)` now prefers a user-defined record key field:
+
+- Earlier behavior in the initial aggregate pushdown implementation: first table column
+- New behavior in `ee4e497b80f1`: record key if it exists in the user schema, else first column
+
+Current code:
+
+- [HoodieScanBuilder.scala](/home/geserdugarov/git/hudi-open-source/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala:299)
+
+Why this matters in your benchmark:
+
+- The benchmark only enables column stats with
+  `hoodie.metadata.index.column.stats.enable = true`
+- It does not set `hoodie.metadata.index.column.stats.column.list`
+- If no explicit list is set, Hudi indexes only the first `n` supported columns
+- The default `n` is `32`
+
+Relevant defaults and selection logic:
+
+- [HoodieMetadataConfig.java](/home/geserdugarov/git/hudi-open-source/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java:267)
+- [HoodieTableMetadataUtil.java](/home/geserdugarov/git/hudi-open-source/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java:1671)
+
+The aggregate fast path aborts if Hudi cannot fetch column stats for every base file:
+
+- [HoodieScanBuilder.scala](/home/geserdugarov/git/hudi-open-source/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala:324)
+
+So the likely failure mode is:
+
+1. In the earlier commit, `COUNT(*)` asked for stats on the first schema column, which was indexed.
+2. In the newer commit, `COUNT(*)` asks for stats on the configured record key column.
+3. If that record key column is outside the default indexed first-32-column subset, `getColumnStats(...)`
+   is incomplete.
+4. DSv2 drops out of aggregate pushdown and runs a normal scan.
+
+This matches the benchmark very well: `COUNT(*)` becomes DSv1-like while the non-aggregate scan
+benchmarks remain mostly unchanged.
+
+### 2. `MIN/MAX` likely regressed because DSv2 now intentionally disables `MAX` pushdown on floating-point columns
+
+Commit `29623e1b74eb` changed aggregate support so that `MAX` is no longer pushed down for
+`float` and `double` columns:
+
+- [HoodieScanBuilder.scala](/home/geserdugarov/git/hudi-open-source/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala:118)
+
+Reason from the code comment:
+
+- Parquet/Hudi column stats do not preserve Spark SQL NaN semantics for `MAX`
+- Spark treats `NaN` as greater than any non-NaN value
+- Stats alone cannot safely distinguish the required cases
+
+The benchmark runs `MIN/MAX` on `HUDI_BENCHMARK_FILTER_COL`:
+
+- [benchmarks/.env-example at `973df90`](/home/geserdugarov/git/hudi-open-source/benchmarks/.env-example) sets `HUDI_BENCHMARK_FILTER_COL=col0`
+- [benchmarks/hudi_benchmark.scala at `973df90`](/home/geserdugarov/git/hudi-open-source/benchmarks/hudi_benchmark.scala) runs `SELECT MIN($filterCol), MAX($filterCol) FROM $cowReadTable`
+
+If your benchmark column is `float` or `double`, this change alone explains the `MIN/MAX`
+collapse from `~0.2s` to `~3.9s`: DSv2 is intentionally falling back to a normal scan.
+
+### 3. The DSv2 test suite itself was relaxed to allow aggregate fallback
+
+Earlier aggregate tests only validated correctness. Later test updates explicitly accept
+either:
+
+- `LocalTableScan` / `HoodieLocalScan` for fully pushed aggregates
+- `BatchScan` for fallback
+
+Current test file:
+
+- [TestDSv2Pushdowns.scala](/home/geserdugarov/git/hudi-open-source/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/v2/TestDSv2Pushdowns.scala:225)
+
+That is important evidence: by the time of the newer commit, the code and tests no longer treat
+"fully pushed aggregate" as guaranteed behavior.
+
+### 4. Metadata and file-index changes are a secondary suspect, but they do not explain the pattern as well
+
+The range also includes metadata and file-index changes such as:
+
+- `3c53b91d9633` (`perf(metadata): avoid recursive calls for partition listing using catalog`)
+- `9ddf58223922` (extra file-index timing and cache logging)
+
+Those can affect the cost of `fileIndex.filterFileSlices(...)`, which is the first step in DSv2
+aggregate pushdown:
+
+- [HoodieScanBuilder.scala](/home/geserdugarov/git/hudi-open-source/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/v2/HoodieScanBuilder.scala:249)
+
+But they are less likely to be the primary cause because:
+
+- full scan and projection are still close to the earlier numbers
+- the regression is sharply concentrated in `COUNT(*)` and `MIN/MAX`
+- there are direct aggregate-specific logic changes in the same range that match the symptoms
+
+The catalog-backed partition listing path is also off by default:
+
+- `hoodie.datasource.read.file.index.list.partitions.from.catalog = false`
+
+So it only matters if your benchmark environment explicitly enabled it.
+
+## Most Likely Explanation For Your Benchmark
+
+The most likely combined explanation is:
+
+1. `COUNT(*)` lost pushdown because `ee4e497b80f1` switched DSv2 to use record-key stats, while
+   the benchmark table only had the default first-32-column stats coverage.
+2. `MIN/MAX` lost pushdown because `29623e1b74eb` disabled `MAX` pushdown for floating-point
+   columns, and the benchmark column appears to be chosen from a generic primitive dataset where
+   `col0` may be `float` or `double`.
+
+That combination produces exactly the kind of result you observed:
+
+- non-aggregate reads remain similar
+- aggregate queries revert to DSv1-like timings
+
+## How To Validate This Quickly
+
+### Validate `COUNT(*)`
+
+Run on both SHAs:
+
+```sql
+EXPLAIN SELECT COUNT(*) FROM <table>;
+```
+
+Expected outcome:
+
+- fast path: `LocalTableScan` or `HoodieLocalScan`
+- regressed path: `BatchScan`
+
+Then check:
+
+1. Which record key is configured for the benchmark table
+2. Where that field sits in the schema order
+3. Whether it is included in column stats coverage
+
+If the record key is outside the first 32 indexed columns, that strongly confirms the `COUNT(*)`
+root cause.
+
+### Validate `MIN/MAX`
+
+Check the benchmark column type:
+
+```sql
+DESCRIBE TABLE <table>;
+```
+
+or:
+
+```sql
+SELECT typeof(<filterCol>) FROM <table> LIMIT 1;
+```
+
+If the `MIN/MAX` column is `float` or `double`, the new `MAX` pushdown guard explains the
+regression directly.
+
+### Validate actual fallback behavior
+
+Enable explain or inspect the executed plan in the benchmark run:
+
+- older SHA should show the aggregate local path
+- newer SHA should show a scan path for the regressed cases
+
+## Mitigations
+
+### For `COUNT(*)`
+
+Make sure the record key column is indexed by column stats. The two simplest options are:
+
+1. Set `hoodie.metadata.index.column.stats.column.list` explicitly and include the record key.
+2. Increase `hoodie.metadata.index.column.stats.max.columns.to.index` so the record key is still
+   within the indexed prefix.
+
+This should restore the DSv2 `COUNT(*)` fast path if no other pushdown blocker is present.
+
+### For `MIN/MAX`
+
+If the benchmark column is floating-point:
+
+1. Use a non-floating numeric column for the benchmark if the goal is to measure metadata-only
+   pushdown performance.
+2. Or revisit `29623e1b74eb` if you want to trade NaN correctness for speed on `MAX(float/double)`.
+
+The current behavior is intentional, not an accidental slowdown.
+
+## Final Assessment
+
+The strongest root-cause candidates are commit-local and aggregate-specific:
+
+- `ee4e497b80f1` for `COUNT(*)`
+- `29623e1b74eb` for `MIN/MAX`
+
+The `COUNT(*)` explanation is highly likely if the record key is not indexed by default column
+stats. The `MIN/MAX` explanation is close to confirmed if the benchmark column is `float` or
+`double`.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This draft PR shows benchmark, which is used to support design doc https://github.com/apache/hudi/pull/18276 and implementation for COW https://github.com/apache/hudi/pull/18277.
Only the latest commit contains benchmark. All previous commits are copy from https://github.com/apache/hudi/pull/18277, which makes this branch independent and ready for recheck.

**Data: 800 parquet files with column stats, 30 mln rows, 300 column, 100 GB in total.**

**Commit 98af4feac80c63a6a7fd3e561cb5d08de4327382**

The results of reading data locally:
```text
============================================================
DSv2 vs DSv1 PERFORMANCE COMPARISON
============================================================

Full scan (COW)                    : DSv1 avg 277.7s, DSv2 avg 279.2s, speedup 0.99x (DSv1 FASTER)
Projected (COW)                    : DSv1 avg 7.4s, DSv2 avg 6.0s, speedup 1.25x (DSv2 FASTER)
Filter (COW)                       : DSv1 avg 7.2s, DSv2 avg 6.1s, speedup 1.19x (DSv2 FASTER)
Limit (COW)                        : DSv1 avg 55.6s, DSv2 avg 59.1s, speedup 0.94x (DSv1 FASTER)
Aggregate COUNT(*)                 : DSv1 avg 3.5s, DSv2 avg 0.2s, speedup 14.98x (DSv2 FASTER)
Aggregate MIN/MAX                  : DSv1 avg 3.8s, DSv2 avg 0.2s, speedup 19.55x (DSv2 FASTER)

PASS: DSv2 is faster than DSv1 in 4 of 6 scenarios
```

The results of reading data from remote HDFS:

```text
============================================================
DSv2 vs DSv1 PERFORMANCE COMPARISON
============================================================

Full scan (COW)                    : DSv1 avg 273.3s, DSv2 avg 278.0s, speedup 0.98x (DSv1 FASTER)
Projected (COW)                    : DSv1 avg 7.3s, DSv2 avg 5.9s, speedup 1.24x (DSv2 FASTER)
Filter (COW)                       : DSv1 avg 7.2s, DSv2 avg 6.0s, speedup 1.20x (DSv2 FASTER)
Limit (COW)                        : DSv1 avg 56.6s, DSv2 avg 59.5s, speedup 0.95x (DSv1 FASTER)
Aggregate COUNT(*)                 : DSv1 avg 3.6s, DSv2 avg 0.2s, speedup 18.43x (DSv2 FASTER)
Aggregate MIN/MAX                  : DSv1 avg 3.8s, DSv2 avg 0.2s, speedup 20.95x (DSv2 FASTER)

PASS: DSv2 is faster than DSv1 in 4 of 6 scenarios
```

### Summary and Changelog

Scala code for submitting to Spark cluster with description, which will perform DSv2 and DSv1 read comparison.

### Impact

None. Supporting materials.

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
