### PR TITLE
fix: Fix flaky test TestProtoConversionUtil#allFieldsSet_wellKnownTyp…

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
@@ -218,7 +218,7 @@ public class TestProtoConversionUtil {
     float primitiveFloat = RANDOM.nextFloat();
     int primitiveInt = RANDOM.nextInt();
     long primitiveLong = RANDOM.nextLong();
-    int primitiveUnsignedInt = RANDOM.nextInt();
+    int primitiveUnsignedInt = Math.abs(RANDOM.nextInt());
     long primitiveUnsignedLong = RANDOM.nextLong();
     int primitiveSignedInt = RANDOM.nextInt();
     long primitiveSignedLong = RANDOM.nextLong();


### PR DESCRIPTION
…esAndTimestampsAsRecords

### Describe the issue this Pull Request addresses

`TestProtoConversionUtil#allFieldsSet_wellKnownTypesAndTimestampsAsRecords` can fail nondeterministically due to random unsigned test data generation.

A concrete failure example:
- Expected record had `"primitive_unsigned_int": 3514477690`
- Actual record had `"primitive_unsigned_int": -780489606`

These two values represent the same 32-bit pattern, but one is interpreted as unsigned (`3514477690`) and the other as signed (`-780489606`). Because the test compares full records, this mismatch causes assertion failure.

Root cause in test input generation: `primitiveUnsignedInt` was generated via `RANDOM.nextInt()` (can be negative).


<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

Updated unsigned random data generation in `TestProtoConversionUtil`:

- `primitiveUnsignedInt`
  - from: `RANDOM.nextInt()`
  - to: `Math.abs(RANDOM.nextInt())`

### Impact

Improved determinism and reduced flaky failures.

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

low.
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
