### PR TITLE
feat(metadata): Defer RLI initialization for fresh tables to optimize file group allocation

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -24,7 +24,6 @@ import org.apache.hudi.avro.model.HoodieIndexPlan;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
-import org.apache.hudi.io.storage.HoodieAvroFileReader;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieConfig;
@@ -81,8 +80,9 @@ import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.index.record.HoodieRecordIndex;
 import org.apache.hudi.internal.schema.InternalSchema;
-import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.internal.schema.utils.SerDeHelper;
+import org.apache.hudi.io.storage.HoodieAvroFileReader;
+import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil.DirectoryInfo;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
@@ -450,7 +450,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       }
     }
 
-    // for a fresh table, lets defer RLI initialization
+    // For a fresh table, defer RLI initialization
     if (dataWriteConfig.getMetadataConfig().shouldDeferRliInitForFreshTable() && this.enabledPartitionTypes.contains(RECORD_INDEX)
         && dataMetaClient.getActiveTimeline().filterCompletedInstants().countInstants() == 0) {
       this.enabledPartitionTypes.remove(RECORD_INDEX);

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -377,7 +377,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .markAdvanced()
       .sinceVersion("1.2.0")
       .withDocumentation("When enabled, defers RLI initialization to 2nd commit for a fresh table. This should help with determining the file group "
-          + "count dynamically for Record Index (global and partitioned RLI)");
+          + "count dynamically for Record Index (global and non-global RLI)");
 
   public static final ConfigProperty<Integer> RECORD_INDEX_MAX_PARALLELISM = ConfigProperty
       .key(METADATA_PREFIX + ".max.init.parallelism")

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -1944,7 +1944,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
   /**
    * Test that partitioned RLI initialization is deferred for fresh tables.
    * Partitioned RLI should NOT be initialized on the first commit but should be initialized
-   * on the second commit with programmatically determined file group count (should be 1 for small tables).
+   * on the second commit with programmatically determined file group count.
    */
   @ParameterizedTest
   @EnumSource(HoodieTableType.class)
@@ -1955,12 +1955,12 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // Config with partitioned record index enabled (not global)
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
         .withIndexConfig(HoodieIndexConfig.newBuilder()
-            .withIndexType(HoodieIndex.IndexType.RECORD_INDEX)
+            .withIndexType(HoodieIndex.IndexType.RECORD_LEVEL_INDEX)
             .build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(true)
-            .withEnableRecordLevelIndex(true)  // Partitioned RLI
-            .withPartitionedRecordIndexFileGroupCount(2,2)
+            .withEnableRecordLevelIndex(true)
+            .withPartitionedRecordIndexFileGroupCount(1, 10)
             .withDeferRliInitializationForFreshTable(true)
             .build())
         .build();
@@ -1997,15 +1997,15 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       assertTrue(metaClient.getTableConfig().isMetadataPartitionAvailable(RECORD_INDEX),
           "Partitioned RLI should be initialized after second commit");
 
-      // Verify file group count is 6 (2 for each data table partition and we have 3 partitions)
+      // Verify file group count is 3 (1 for each data table partition and we have 3 partitions)
       HoodieBackedTableMetadata metadataReader = (HoodieBackedTableMetadata) metadata(client, storage);
       int fileGroupCount = HoodieTableMetadataUtil.getPartitionLatestFileSlices(
           metadataReader.getMetadataMetaClient(), Option.empty(),
           RECORD_INDEX.getPartitionPath()).size();
 
-      // For partitioned RLI with small data, file group count should be 6 (2 as default for 3 partitions)
-      assertEquals(6, fileGroupCount,
-          "File group count should be 6 for partitioned RLI table, but got: " + fileGroupCount);
+      // For partitioned RLI with small data, file group count should be 3 (1 as default for 3 partitions)
+      assertEquals(3, fileGroupCount,
+          "File group count should be 3 for partitioned RLI table (1 per partition x 3 partitions), but got: " + fileGroupCount);
 
       // Validate metadata integrity
       validateMetadata(client);
@@ -2013,7 +2013,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
   }
 
   /**
-   * Test that partitioned RLI with larger data results in appropriate file group count.
+   * Test that global RLI with larger data results in appropriate file group count.
    * This validates that the file group count is determined programmatically based on data size,
    * not using a hardcoded default.
    */
@@ -2022,20 +2022,20 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     init(HoodieTableType.COPY_ON_WRITE);
     HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
 
-    // Config with partitioned record index enabled
+    // Config with global record index enabled
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
         .withIndexConfig(HoodieIndexConfig.newBuilder()
             .withIndexType(HoodieIndex.IndexType.RECORD_INDEX)
             .build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(true)
-            .withEnableGlobalRecordLevelIndex(true)  // Partitioned RLI
+            .withEnableGlobalRecordLevelIndex(true)
             .withDeferRliInitializationForFreshTable(true)
             .build())
         .build();
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
-      // First commit with moderate data size (5000 records)
+      // First commit with moderate data size (4000 records)
       String firstCommitTime = client.startCommit();
       List<HoodieRecord> records = dataGen.generateInserts(firstCommitTime, 4000);
       List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 5), firstCommitTime).collect();
@@ -2045,7 +2045,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // Verify RLI is NOT initialized after first commit
       metaClient = HoodieTableMetaClient.reload(metaClient);
       assertFalse(metaClient.getTableConfig().isMetadataPartitionAvailable(RECORD_INDEX),
-          "Partitioned RLI should NOT be initialized on first commit");
+          "Global RLI should NOT be initialized on first commit");
 
       // Second commit to trigger RLI initialization
       String secondCommitTime = client.startCommit();
@@ -2054,7 +2054,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       assertNoWriteErrors(writeStatuses);
       client.commit(secondCommitTime, jsc.parallelize(writeStatuses));
 
-      // Verify partitioned RLI is now initialized
+      // Verify global RLI is now initialized
       metaClient = HoodieTableMetaClient.reload(metaClient);
       assertTrue(metaClient.getTableConfig().isMetadataPartitionAvailable(RECORD_INDEX));
 
@@ -2064,10 +2064,10 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
           metadataReader.getMetadataMetaClient(), Option.empty(),
           RECORD_INDEX.getPartitionPath()).size();
 
-      // For 4000 records with partitioned RLI, file group count should be between min (1) and max (10)
-      // It should be > 1 for this data size based on estimation logic
-      assertTrue(fileGroupCount > 1 && fileGroupCount < writeConfig.getMetadataConfig().getGlobalRecordLevelIndexMaxFileGroupCount(),
-          "File group count should be at least the configured minimum (1), but got: " + fileGroupCount);
+      // For 4000 records with global RLI, file group count should be within configured bounds
+      int maxFileGroupCount = writeConfig.getMetadataConfig().getGlobalRecordLevelIndexMaxFileGroupCount();
+      assertTrue(fileGroupCount > 1 && fileGroupCount <= maxFileGroupCount,
+          "File group count should be between 1 and " + maxFileGroupCount + ", but got: " + fileGroupCount);
       // Validate metadata integrity
       validateMetadata(client);
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR optimizes Record Level Index (RLI) initialization for fresh Hudi tables by deferring RLI bootstrapping to the second commit. This enhancement allows for dynamic file group count determination based on actual data characteristics, improving both performance and resource utilization.

 Key Benefits:
  - Reduces initial metadata table setup overhead for fresh tables
  - Enables data-driven file group count estimation for RLI partitions
  - Improves scalability for tables with varying data volumes
  - Works for both global and partitioned RLI configurations
  
### Summary and Changelog

  Core Implementation (HoodieBackedTableMetadataWriter.java)

  - Added logic to defer RLI partition initialization when metadata table is first created (data table has 0 completed instants)
  - Deferred initialization applies to both RECORD_INDEX (partitioned RLI) and global RLI when enabled via config
  - RLI partition is automatically initialized on subsequent commits with programmatically determined file group count

  Configuration (HoodieMetadataConfig.java)

  - New Config: hoodie.metadata.record.level.index.defer.for.fresh.table
    - Type: Boolean (default: false)
    - Category: Advanced config for power users
    - Purpose: Controls whether RLI initialization is deferred to 2nd commit
    - Impact: When enabled, allows file group count to be estimated based on initial data patterns rather than using defaults

Testing

  - Added comprehensive tests validating deferred RLI initialization behavior:
    - testPartitionedRecordIndexDeferredInitializationForFreshTable(): Validates partitioned RLI is NOT initialized on first commit but is initialized on second commit with correct file group count
    - testGlobalRecordIndexDeferredInitialization(): Validates global RLI deferred initialization with programmatic file group determination
  - Updated existing tests to account for the new RLI initialization timing:
    - TestMetadataWriterCommit.testCreateHandleRLIStats(): Added data table timeline commit to properly test deferred initialization
    - TestSparkRDDMetadataWriteClient: Tests remain unchanged as config is disabled by default

  Breaking Changes

  None - This is a backward-compatible change controlled by an opt-in configuration flag.

### Impact

 **User-facing changes:**
  - **Behavioral change (non-breaking)**: For new tables with RLI enabled with the new config enabled (`hoodie.metadata.record.level.index.defer.for.fresh.table`), the RLI partition will not be available after the first commit, but will be available starting from the second commit
  - **Performance improvement**: Reduced overhead for small tables, better scaling for large bootstrap scenarios
  - **Config changes needed**: Existing configurations continue to work; the optimization is opt in.

  **Performance impact:**
  - Small tables (< 1000 records): Expected reduction from 10 file groups to 1-2 file groups, reducing metadata table overhead
  - Large bootstrap tables (> 100K records): Better distribution across more file groups within max bounds


### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
