### PR TITLE
feat(blob): Supplementing RFC-100 with blob cleaner design

### DIFF
--- a/rfc/rfc-100/rfc-100-blob-cleaner-design-v2.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design-v2.md
@@ -1,0 +1,790 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# RFC-100 Part 2 (Design v2): File-Granularity Blob Reference Registry
+
+**Status: DRAFT for internal review, revision 2 (2026-07-02) -- incorporates adversarial review
+findings: defaults coherence, two-step drain locking, tombstone lifecycle ownership,
+defer-vs-annul semantics, completed-instant fencing, queue atomicity, observability. Supersedes
+[rfc-100-blob-cleaner-design.md](rfc-100-blob-cleaner-design.md) (the "SI design"), which is now
+marked ABANDONED. Problem statement, constraints (C1-C11), and requirements (R1-R9) are unchanged
+and live in [rfc-100-blob-cleaner-problem.md](rfc-100-blob-cleaner-problem.md).**
+
+---
+
+## Abstract
+
+This design replaces the SI design's cross-file-group verification mechanism (MDT secondary index
+on `reference.external_path` + record index two-hop lookup) with two components:
+
+1. A **blob reference registry**: a new MDT partition that records, per physical data file, which
+   external blob paths that file contains. Entries are born when a file is committed and die when
+   the file is cleaned -- the same lifecycle the MDT column stats partition already implements.
+2. **Two-phase deletion**: no blob is hard-deleted in the clean cycle that discovers it. Verified
+   candidates enter a durable pending-deletes queue; a later cycle re-verifies them against the
+   registry under the transaction lock and deletes only entries older than a grace window.
+
+The change of indexing granularity -- from *records* (SI) to *files* (registry) -- is the core of
+the proposal. The cleaner's liveness question is physical ("does any retained file still contain a
+reference to this path?"), and a file-granular index answers it exactly. A record-granular index
+answers a different question ("does any record reference this path in the latest snapshot?"),
+which is provably insufficient for R1 (Motivation, below).
+
+---
+
+## Motivation: verified defects in the SI design
+
+Fact-checking the SI design against the codebase (2026-07-02) found three P0-level problems. All
+three are structural consequences of record-granular, snapshot-semantics indexing; none is fixable
+by patching the SI design without changing the question the index answers.
+
+### M1. The secondary index is incompatible with insert_overwrite / delete_partition
+
+`HoodieBackedTableMetadataWriter.updateSecondaryIndexIfPresent` (line 1648) **throws**
+`HoodieIndexException` for any `isInsertOverwriteOrDeletePartition()` operation when a secondary
+index exists. Enabling the index the SI design requires therefore breaks `insert_overwrite`,
+`insert_overwrite_table`, and `delete_partition` table-wide -- operations the SI design's own
+preCommit coverage table claims to support (C7, R7). In addition:
+
+- SI creation hard-requires the record index (`HoodieIndexUtils`, lines 708-721), so the SI
+  design's primary path needs two MDT index partitions maintained on every commit.
+- SI maintenance re-reads the **previous merged file slice** of every touched file group on every
+  commit to compute old-value tombstones
+  (`SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords`, lines 142-147).
+  This is a permanent write-path tax on all writers, absent from the SI design's cost model.
+
+### M2. Snapshot liveness is the wrong liveness
+
+SI reads merge base and log records and filter tombstones, returning only the latest-snapshot
+mapping; the payload stores only `isDeleted`, so the instant at which a mapping was superseded is
+not recoverable. But the liveness rule in the problem statement is slice-level: "if any
+**retained** reference to the same `external_path` exists (regardless of the `managed` flag), the
+blob must not be deleted." And Hudi's retention contract is explicit that retained slices are
+queryable history (`hoodie.clean.commits.retained`: "This also directly translates into how much
+data retention the table supports for incremental queries").
+
+Concrete failure:
+
+```
+FG-Z (NOT cleaned this cycle):
+    slice@t1: row1 -> P     (base file, retained -- within retention)
+    slice@t2: row1 -> Q     (update; SI tombstones (P, row1))
+FG-Y (cleaned): expired slice references P -> P becomes a candidate.
+Stage 2: SI shows zero live refs for P -> DELETE P.
+Result: FG-Z's t1 slice is retained and readable (time travel, incremental
+    pull) -> dangling blob reference INSIDE the retention window. R1 violation.
+```
+
+The SI design is internally inconsistent about this: its Stage 1 computes liveness over retained
+*slices* within cleaned FGs, while its Stage 2 computes liveness over the latest *snapshot*
+globally. No SI-side fix exists: per-key instants are not stored, and `earliestInstantToRetain`
+does not exist under `KEEP_LATEST_FILE_VERSIONS` (`CleanerUtils.getEarliestCommitToRetain` has no
+versions branch), so an instant-fence workaround has nothing to fence against.
+
+### M3. The cleaned_fg_ids discount deletes live blobs in partially-cleaned file groups
+
+Partial cleans are the norm: every policy method spares the latest slice(s); full file-group
+removal happens only for replaced FGs. The SI design's Stage 2 treats `location.fileId in
+cleaned_fg_ids` as dead. If FG-X is partially cleaned and its retained latest slice references P,
+while candidate P came from FG-Y, the record index resolves the referencing record to FG-X, the
+discount fires, and P is deleted while a retained slice references it -- an R1 violation with no
+concurrency involved. (The discount's intended target -- stale locations in fully-removed FGs --
+is nearly dead code: the record index is properly maintained for replace operations via anti-join
+deletes and relocation upserts, `HoodieBackedTableMetadataWriter.getRecordIndexAdditionalUpserts`,
+lines 2328-2354.)
+
+### Why file granularity fixes all three at once
+
+| Defect | Cause in SI design                                                                                   | Registry behavior                                                                                     |
+|--------|------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| M1     | SI record generation cannot handle replace ops; throws                                               | Entries key on files; replace commits need NO registry action (old files stay retained until cleaned) |
+| M2     | Record mappings are tombstoned on update, even though the old file still physically contains the ref | Entries are immutable for the file's lifetime; they die only when the file dies                       |
+| M3     | Record->location resolution forces a heuristic about which FGs "count"                               | The liveness check is against concrete files; no FG-level heuristic exists                            |
+
+RFC-77's rationale for mapping secondary keys to record keys (not file groups) is correct *for
+queries*, which care about a record's current logical state and location. The cleaner asks a
+physical question, and file granularity is that question's native granularity.
+
+---
+
+## Design Overview
+
+### Components
+
+| Component               | What it is                                                                                                       | Lifecycle                                                               |
+|-------------------------|------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| Per-file blob manifest  | Distinct `OUT_OF_LINE` path set (+ managed bits) embedded in each data file                                      | Written with the file; immutable                                        |
+| Blob reference registry | MDT partition: `(external_path, file) -> entry`                                                                  | Entry born at commit, tombstoned by the clean that deletes the file     |
+| Pending-deletes queue   | Durable candidate list under `.hoodie/.aux/clean/`                                                               | Appended at plan time; drained (age-gated, re-verified) by later cleans |
+| Drain protocol          | Snapshot pre-verification (unlocked) + bounded locked delta re-check atomic with the clean's timeline transition | Per clean cycle                                                         |
+| Writer preCommit veto   | Existing check, reduced role: only against an actively-draining clean                                            | Per commit                                                              |
+
+### The correctness kernel
+
+Everything reduces to one invariant pair and one delete rule.
+
+- **I1 (completeness):** for every retained data file F that contains an `OUT_OF_LINE` reference
+  to path P, the registry contains a live entry (P, F). (Guaranteed by write-path maintenance +
+  the MDT consistency mechanisms; gated during bootstrap, see Fallback.)
+- **I2 (hygiene):** an entry (P, F) is tombstoned only by the clean that deletes F (or by MDT
+  rollback of the commit that created F).
+
+**Delete rule D:** hard-delete P only when ALL of the following hold:
+(a) P was durably enqueued at plan time of an earlier clean (before any slice deletion);
+(b) P's queue entry is older than the grace window;
+(c) under the transaction lock, atomic with the draining clean's REQUESTED->INFLIGHT
+transition: the registry has **no live entry** for P;
+(d) the drain intent (sidecar listing P) is visible on the timeline before the physical delete.
+
+R1 follows from I1 + D(c): any retained file referencing P implies a live entry, which fails
+D(c). R2 follows from D(a) + queue draining at a bounded rate: candidates are durable before the
+slices that produced them are deleted; a candidate found alive at drain is deferred (kept) or --
+only when the live reference sits in a stable file -- annulled with an audit record, re-entering
+the pipeline when that file eventually expires (see the drain classification).
+
+Rule D has two standing prerequisites, enforced rather than assumed. **(i)** D(c) is defined
+against the registry, so blob cleanup hard-requires the `blob_refs` partition -- auto-enabled
+when MDT is present, fail-fast when it is not (see Fallback and Bootstrap). **(ii)** D(c)'s
+atomicity needs real mutual exclusion or strict sequentiality; the deployment modes and the
+fail-fast rule are in "Lock prerequisite and deployment modes". Everything else in this document
+is mechanism to establish I1/I2 cheaply and to execute D at low cost.
+
+### Flow
+
+```mermaid
+flowchart LR
+    subgraph Write["Every commit (blob tables)"]
+        WF["Write data files with<br/>footer/header manifests"]
+        WR["Emit registry records<br/>(path, file) in same<br/>MDT delta commit"]
+        WF --> WR
+    end
+
+    subgraph Plan["Clean planning"]
+        EX["Read expired files' manifests<br/>(inline, or column projection<br/>when truncated)"]
+        CAND["Candidates = managed paths<br/>in expired files"]
+        ENQ["Append to durable<br/>pending-deletes queue"]
+        HYG["Write hygiene sidecar<br/>(all paths per expired file)"]
+        EX --> CAND --> ENQ
+        EX --> HYG
+    end
+
+    subgraph Exec["Clean execution + MDT commit"]
+        DEL["Delete file slices (existing)"]
+        TOMB["Registry tombstones for<br/>deleted files (from sidecar)"]
+        DEL --> TOMB
+    end
+
+    subgraph Drain["Later clean: drain phase"]
+        AGE["Select queue entries<br/>age >= grace, up to rate limit"]
+        PRE["Step A (unlocked):<br/>registry scan per path<br/>at snapshot T0"]
+        LOCK["Step B (under txn lock, atomic<br/>with REQUESTED->INFLIGHT):<br/>delta re-check of commits<br/>after T0 only"]
+        DELB["No entry -> delete blob<br/>Live ref -> defer or annul"]
+        AGE --> PRE --> LOCK --> DELB
+    end
+
+    Write --> Plan --> Exec
+    Exec -.-> Drain
+```
+
+---
+
+## Data Model
+
+### Per-file blob manifest
+
+Each base file written for a table with blob columns carries a manifest entry in its Parquet
+footer key-value metadata; log files carry the same per log block via a new `HeaderMetadataType`
+entry (the enum is version-gated and append-only, so this is a compatible log-format addition). A
+file slice's manifest is the union of its base and log manifests. The entry has three parts:
+
+```
+key:   hudi.blob.manifest.v1
+value: { distinct_count : long,
+         inline         : optional [(external_path, managed)],  // iff within size caps
+         bloom          : optional fixed-size bloom over ALL OUT_OF_LINE paths }
+```
+
+**Size discipline.** Footers and log-block headers are read by every reader (schema discovery,
+stats collection), not just the cleaner, so the inline list is capped by *encoded size*, not only
+count: paths are sorted, front-coded (shared-prefix compressed), and block-compressed, inlined
+only if the result fits `hoodie.blob.manifest.inline.max.bytes` (default 256KB for footers, 64KB
+for log-block headers -- roughly 2-8K paths after prefix compression on typical URL-shaped
+paths). The bloom is a fixed-size digest (default 128KB, ~100K paths at ~1% false-positive rate;
+beyond that the FPR degrades but correctness never does -- see the table below). Above the caps
+the manifest is `{distinct_count, bloom}` only: **truncated**.
+
+**Consumers and degradation.** Every consumer has defined truncated-mode behavior, and every
+degradation moves toward more I/O or more retention -- never toward a wrong delete:
+
+| Consumer                                                                                 | Inline present   | Truncated                                                                                                                                                     |
+|------------------------------------------------------------------------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Candidate derivation + hygiene sidecar (enumerate an expired file's paths, at plan time) | Read inline list | Single-column projection read of the file's blob-ref column -- once, at the file's end of life. Identical to the read the SI design's Stage 1 always performs |
+| Fallback liveness scan (membership: might retained file F contain P?)                    | Exact check      | Bloom check; false positive -> retain (safe). Degraded FPR at extreme counts means more over-retention, reclaimed later once the registry is available        |
+| Registry backfill / repair (ground truth per file)                                       | Inline list      | Column projection read                                                                                                                                        |
+
+The bloom is built over ALL `OUT_OF_LINE` paths regardless of `managed`, because its consumer is
+the liveness check, which must be managed-agnostic (R1). The inline list carries per-path managed
+bits because its consumers include the eligibility gate.
+
+**Registry completeness does not depend on the manifest.** The writer collects the distinct path
+set in memory while writing the file (it must, to build the manifest at all) and emits the
+registry records from that set at commit time, carried as an *optional* field on the write stat:
+present-and-empty means "no blob refs", absent means "not tracked on this engine path". Where an
+engine path cannot carry it reliably (bulk-insert row writers, Flink recovery from checkpoint),
+the MDT writer detects the absent field and derives the records from the just-written file itself
+(inline manifest, else column projection) -- bounded by the files written in that commit. So
+truncation never weakens I1, and a dropped in-memory set degrades to extra commit-path reads,
+not to silent index gaps (the failure mode the SI design's transient-only `externalBlobPaths`
+could not detect).
+
+**Expected, not pathological.** Row-level-distinct blob references (every record pointing to its
+own image or video) are RFC-100's *primary* workload, so large distinct counts are the common
+case, not a tail. Such files routinely carry digest-only manifests, and the plan-time column
+projection is the designed path for them -- priced identically to the SI design's Stage 1 read.
+The footer-only fast path is an optimization that pays on sharing-heavy or sparse-ref tables; it
+is not a load-bearing assumption anywhere in the design.
+
+Files written before this feature lack manifests entirely; all consumers treat that as truncated
+mode without a bloom (column projection; the fallback scan reads the column too).
+
+Implementation note: the column-projection fallback can read Parquet **dictionary pages** instead
+of data pages when the path column chunk is fully dictionary-encoded (verify via
+`encoding_stats`; a chunk that fell back to plain encoding mid-write has an incomplete dictionary
+and MUST NOT be trusted for enumeration -- missing paths break R2 silently). This mainly helps
+backfill over pre-feature base files; it never applies to log blocks (no dictionaries) and
+typically not to high-cardinality path columns (dictionary-size fallback).
+
+### Registry: MDT partition `blob_refs`
+
+A new `MetadataPartitionType.BLOB_REFS`, modeled on `COLUMN_STATS`' commit/clean lifecycle
+(per-file keyed records created from write stats at commit, deleted per cleaned file at clean).
+The parity claim is lifecycle-scoped, not total -- three surfaces are genuinely new and carry
+their own compatibility testing: a new MDT payload schema plus record-type int; restore behavior
+*opposite* to col-stats (col-stats is excluded from delete-on-restore, the registry opts IN to
+delete-and-rebuild initially); and the log-block header addition is a versioned on-disk format
+change, a different compatibility story than an MDT partition addition.
+
+This is a **system partition, not a user index**: it is the cleaner's deletion authority,
+auto-enabled with blob cleanup, and never exposed to the `CREATE INDEX`/`DROP INDEX` surface --
+dropping a query accelerator costs performance, dropping the registry would cost correctness.
+Expression-index infrastructure is therefore not reused (record shapes, key orientation, and
+clean-time behavior all diverge; see Open Questions, item 5); the async index builder is reused,
+since it operates on `MetadataPartitionType` generally.
+
+**Key** (escaped-string concatenation, SI convention, path-first so prefix scans by path are a
+single seek):
+
+```
+key = escape(external_path) $ escape(partition) $ escape(fileName)
+```
+
+Escaped strings are chosen over hashed components deliberately: they are collision-free by
+construction, so retain/delete verdicts are exact with no probabilistic argument, and the
+escaping + prefix-scan machinery has direct precedent in the secondary index
+(`SecondaryIndexKeyUtils`). The cost is variable key width; HFile prefix compression absorbs
+most of it, since adjacent keys share the path.
+
+**Payload** `HoodieBlobRefInfo`:
+
+```
+{ isDeleted: boolean }     // path, partition, file are recovered by unescaping the key
+```
+
+This matches the SI payload precedent (`HoodieSecondaryIndexInfo` carries only `isDeleted`).
+
+Merge semantics: newer-wins (the default `combineMetadataPayloads`). Entries are written
+`isDeleted=false` at commit and `isDeleted=true` at clean. Because a file is immutable, an entry
+is never *updated* -- only born and killed.
+
+**Why hashed keys are rejected as the default (a subtle R1 inversion).** A fixed-width hash key
+(col-stats style, e.g. `hash128(path) + hash64(partition) + hash128(file)`) shrinks keys, but its
+collision handling is a trap: if two colliding paths are referenced by the SAME file, their
+records share one key, and the newer-wins merge keeps only one payload. Read-time payload
+filtering ("does the stored `externalPath` equal the path I asked about?") would then silently
+drop the other path's liveness and authorize a wrong delete -- the "verification" intended to
+prevent over-retention becomes the R1 hazard. A hashed variant is admissible only as a future
+size optimization and only under the rule: **liveness reads never filter by payload -- any prefix
+hit retains** (collisions then cause only over-retention, surfaced by a collision metric). 64-bit
+path hashes are ruled out entirely: at billions of distinct paths, birthday collisions are
+expected, not exotic.
+
+**Path identity is the exact string.** `s3://bucket/k` and `s3a://bucket/k` are different paths
+to the registry. Referencing one object through multiple spellings defeats liveness tracking and
+is a documented user contract violation (same stance as the SI design and problem-statement Q1).
+
+**Registry size:** one entry per distinct (path, file) pair across live files. For sharing-heavy
+tables this is column-stats scale; for row-level-distinct workloads (the primary use case) it is
+**record-index scale** -- one entry per blob-ref row -- which is already Hudi's accepted operating
+regime (the RLI ships at billions of entries), and strictly less than the SI design's bill for the
+same workload (SI entry per row, carrying the same path string, PLUS the mandatory RLI entry per
+row). Path-first sorted keys make URL-shaped data near-ideal for HFile prefix + block compression
+(typically 3-10x); entries cover live files only (clean tombstones + MDT compaction reclaim dead
+ones), so steady-state size is on the order of one compressed string column of the table. If
+size pressure ever demands it, hashed fixed-width keys remain a shrink knob -- but only under the
+retain-on-any-prefix-hit rule; payload-filtered liveness reads on hashed keys are forbidden (see
+the R1 inversion note under Key).
+
+### Pending-deletes queue
+
+Durable artifact(s) under `.hoodie/.aux/clean/pending_blob_deletes/`, Parquet rows:
+
+```
+{ externalPath: string,
+  enqueueInstant: string,     // clean instant that discovered the candidate
+  sourceCleanInstant: string }
+```
+
+Written at **plan time**, before any slice deletion (the R2 durability argument from the SI
+design's deferred-queue fix carries over unchanged).
+
+**Atomicity (R2/R8).** Queue updates are copy-on-write, never in-place: a drain writes a complete
+new snapshot file named by the draining clean instant, and readers select the newest snapshot
+whose instant completed; superseded snapshots are removed only after the drain completes. A crash
+mid-write leaves the previous snapshot authoritative (entries may be re-verified twice --
+idempotent). In-place rewrite is forbidden: it is not atomic on object stores and a crash could
+silently lose live candidates.
+
+**Orphan-sweep carve-out.** The per-instant aux orphan sweep ("delete artifacts whose instant is
+not on the active timeline") must NOT apply to `pending_blob_deletes/` -- the queue is a
+cross-instant artifact, and the per-instant heuristic would delete the running queue. Queue
+snapshots are lifecycle-managed by the drain itself (newest completed snapshot always retained).
+
+**Restore.** The queue survives restore: entries re-verify against the rebuilt registry at drain
+time, and drains defer while the rebuild is inflight (the partition-availability gate), so a
+pre-restore candidate can be deleted only if the *restored* state also shows no references. The
+unrecoverable case is a drain that hard-deleted P before a restore to a state referencing P --
+the grace window is the only mitigation, so operators should size grace against their
+savepoint/restore SLA (Q9; same residual risk class as the SI design).
+
+### Hygiene sidecar
+
+Per clean instant, `.hoodie/.aux/clean/<instant>.blob_refs.parquet`, rows
+`(externalPath, partitionPath, fileName)` for **every** `OUT_OF_LINE` path in **every** expired
+file (not only candidates). Purpose: the clean's MDT conversion cannot derive registry tombstone
+keys from file names alone (the key leads with the escaped path), and by MDT-update time the files are
+already deleted -- so the path list must be durable at plan time. The MDT clean conversion reads
+this sidecar and emits the registry tombstones (I2) -- with direct precedent: the bloom-filter
+and column-stats conversions already open and read files from storage inside the conversion
+(`HoodieTableMetadataUtil:586-590`, `:1766-1770`). Written before the plan is persisted, same
+atomicity argument as the SI design's sidecar. It also serves as the drain-phase delete-intent
+artifact the writer veto checks (see Concurrency).
+
+**Ownership: I2 is a partition property, not a feature flag.** The hygiene sidecar and its
+tombstones are emitted by EVERY clean on a table whose MDT has a live `blob_refs` partition,
+regardless of `hoodie.cleaner.blob.enabled`. Pausing blob cleanup stops enqueueing and draining;
+it must not stop hygiene -- otherwise every file deleted during the pause leaves permanently-live
+stale entries (I2 broken, unbounded over-retention, no reconciliation path back). Turning the
+registry off means DROPPING the partition (re-enable = rebuild), exactly like other MDT index
+partitions.
+
+---
+
+## Registry Maintenance
+
+| Event                                                         | Registry action                                                                                                                                                              | Source of truth                                                                                                        |
+|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| Commit / delta commit                                         | Insert (P, F) for each distinct path P in each written file F, in the same MDT delta commit                                                                                  | Write stats fast path; the written file itself (inline manifest, else column projection) when the stat field is absent |
+| Clean                                                         | Tombstone (P, F) for each path P of each deleted file F, in the clean's MDT update -- emitted whenever the partition exists, independent of the blob-cleanup flag            | Hygiene sidecar                                                                                                        |
+| insert_overwrite / delete_partition / clustering / compaction | **Nothing special.** New files get entries via the commit path; replaced/compacted old files keep their entries until physically cleaned                                     | --                                                                                                                     |
+| Rollback of a data commit                                     | The MDT rollback removes the commit's registry records in lockstep; the reader watermark hides uncommitted entries meanwhile                                                 | Existing MDT rollback machinery                                                                                        |
+| Restore                                                       | Registry partition is delete-and-rebuilt (`shouldDeletePartitionOnRestore`), matching how newer partitions are handled; incremental restore handling is a later optimization | Backfill job                                                                                                           |
+| Savepoint                                                     | Nothing: savepointed files are never cleaned, so their entries persist and their blobs are retained (C8 holds structurally)                                                  | --                                                                                                                     |
+| Archival                                                      | Nothing: the registry is MDT data, not commit metadata (C10 holds structurally)                                                                                              | --                                                                                                                     |
+
+Consistency inheritance: registry records ride the same MDT delta commit as the data commit, so
+the three mechanisms already proven for the SI design apply verbatim -- same-instant maintenance,
+hard failure coupling (MDT commits before `saveAsComplete`), and the reader consistency watermark.
+A completed data commit implies its registry entries are visible; a failed commit's entries are
+hidden and rolled back.
+
+The `managed` flag: the registry indexes **all** `OUT_OF_LINE` references regardless of `managed`
+(liveness is managed-agnostic, per the problem statement's rule). The flag is applied only as the
+eligibility gate when deriving candidates from expired manifests. Manifests carry the per-path
+managed bit to make that gate footer-only.
+
+**Reconciliation sweep (staleness backstop).** Hygiene can leak: an enumeration failure at clean
+time (flagged loudly -- see Cleanup Algorithm) or a bug can leave live entries whose file is gone,
+each one a permanently-alive path (silent over-retention, an R2 leak). A rate-limited sweep runs
+with the clean: it walks a bounded budget of registry entries per cycle, checks each entry's file
+against the MDT files partition, and tombstones entries whose file no longer exists. The sweep
+only removes stale RETAIN votes -- the safe direction; it never authorizes a delete -- and it
+guarantees staleness is eventually repaired rather than accumulating forever.
+
+---
+
+## Cleanup Algorithm
+
+### Candidate derivation (at clean planning)
+
+```
+Input:  expired file slices per FG (from the existing policy methods)
+Output: queue appends + hygiene sidecar
+
+expired_paths   = union of manifests of all expired files        // inline manifest, or blob-column
+                                                                  // projection when truncated
+candidates      = { p in expired_paths where p.managed == true }  // eligibility gate
+retained_local  = union of manifests of retained files in the SAME cleaned FGs   // optional prefilter
+candidates      = candidates - retained_local                     // skip obviously-alive paths
+
+write hygiene sidecar (ALL expired paths x files, managed-agnostic)
+append candidates to pending-deletes queue (durable BEFORE any slice deletion)
+```
+
+Notes:
+
+- The per-FG set difference is now only a **prefilter** to keep the queue small; it is not load
+  bearing for correctness. The authoritative check is delete rule D(c).
+- MOR: an expired slice's manifest is base union logs, so log-chain-only refs are captured (the SI
+  design's "expired side reads logs" requirement, now footer-cost). The retained-side prefilter
+  may read base manifests only; missing a log-added ref merely fails to prefilter -- the registry
+  check catches it.
+- Replaced FGs: all slices are expired; identical handling.
+- **Completed-instant fencing (R1).** All manifest enumeration that feeds *candidacy* -- footer
+  fast path and log-block header scans alike -- is fenced on the exact completed-instant set:
+  log-block reads go through the instant-validating scanner (`HoodieLogBlockMetadataScanner` with
+  an `InstantRange` over completed instants), never a raw header walk, and a `maxInstantTime`
+  high-water mark is NOT sufficient (a failed-but-not-yet-rolled-back block sits inside it). A
+  failed commit's block may list paths that were never committed; letting them into candidacy
+  hard-deletes a user blob on uncommitted intent. Hygiene tombstones tolerate over-enumeration
+  (tombstoning a nonexistent entry is a no-op), but candidacy must be fenced.
+- **Enumeration failure is loud, not silent.** If a file's paths cannot be enumerated at its
+  clean time (corrupt/absent manifest AND failed column read), the clean proceeds but flags the
+  file -- metric plus warning -- and its registry entries are left stale for the reconciliation
+  sweep to reclaim. Never silently skipped: a silent skip converts directly into invisible
+  permanent over-retention.
+
+### Liveness verification (at drain): snapshot pre-check + bounded locked delta re-check
+
+Two forces pull in opposite directions here and the protocol must satisfy both: correctness
+requires the verdict that authorizes a delete to be atomic with the drain becoming visible, while
+R4/C6 forbid holding the table lock across up to `max.candidates` MDT scans (seconds to minutes
+during which no writer could commit -- a global serialization point). The drain therefore splits
+the check:
+
+**Step A -- bulk pre-verification (UNLOCKED).** Record the latest completed instant T0.
+Prefix-scan the registry as of T0 for every batch entry and classify:
+
+```
+for path in queue entries with age >= grace, up to rate limit:
+    entries = registry.prefixScan(path)           // 1 hop; exact match by escaped-key prefix
+    entries = entries where file NOT in this clean's own expired-file set
+    if entries is empty:                 survivors.add(path)   // tentatively deletable
+    else if every entry's file is in a PENDING clean's delete set:
+                                         defer(path)           // dying refs; re-check next cycle
+    else:                                annul(path, audit)    // stable live ref
+```
+
+**Step B -- delta re-check (LOCKED, atomic with REQUESTED->INFLIGHT + drain-sidecar persist).**
+Under the transaction lock: list the data commits completed in (T0, now]; read ONLY those
+commits' `blob_refs` additions (their MDT log records, addressable per instant); defer any
+survivor whose path appears. The locked work is proportional to the volume of commits concurrent
+with Step A -- typically zero commits, zero reads -- never to the candidate count. This is the
+same shape as OCC's own "did anyone commit since my snapshot" check.
+
+**Defer vs annul.** Deferring keeps the durable queue entry (with a re-check deadline); annulment
+drops it, and is permitted ONLY on a live reference from a *stable* file -- one not in any
+pending clean's delete set -- because then re-derivation at that file's eventual expiry is the
+recovery path. The distinction closes two R2 holes. First, a drain concurrent with a
+still-INFLIGHT earlier clean must not annul on that clean's dying entries: its files are deleted
+but its tombstones not yet committed, so annulling would lose the path from both the queue and,
+moments later, the registry -- a permanent orphan. Second, every annulment is audited (metric
+plus log) so a downstream re-derivation failure is detectable rather than silent.
+
+Cost: O(queue batch) unlocked prefix scans + O(concurrent commits) locked reads (R5, R4).
+
+Hardening, ON by default (`hoodie.cleaner.blob.drain.include.inflight.refs`): Step A relaxes the
+completed-instant watermark, with a strictly one-sided rule: **apply inflight INSERTS, ignore
+inflight TOMBSTONES**. Counting an uncommitted add as a
+retain vote can only cause deferral (over-retention -- safe: if the commit completes the deferral
+was correct, if it fails the blob waits one extra cycle). Naively dropping the watermark filter
+entirely would be WRONG: it would also apply an inflight clean's uncommitted tombstones, removing
+retain votes and erring in the delete direction. Over-approximate the live set; never
+under-approximate it.
+
+---
+
+## Two-Phase Deletion and Concurrency
+
+### Drain protocol
+
+```mermaid
+sequenceDiagram
+    participant CL as Cleaner
+    participant TL as Timeline
+    participant REG as MDT blob_refs
+    participant Q as Pending queue
+    participant S as Storage
+
+    Note over CL: Later clean cycle begins
+    CL->>Q: Load entries with age >= grace (rate-limited)
+    Note over CL: Step A (UNLOCKED)
+    CL->>REG: Prefix scan each path at snapshot T0
+    CL->>CL: Classify: survivors / defer / annul
+    CL->>TL: BEGIN txn lock
+    Note over CL: Step B (LOCKED, bounded)
+    CL->>TL: List commits completed after T0
+    CL->>REG: Read only those commits' blob_refs additions
+    CL->>CL: Defer survivors they reference
+    CL->>TL: Persist drain sidecar + transition REQUESTED->INFLIGHT (atomic)
+    CL->>TL: END txn lock
+    par outside lock
+        CL->>S: Delete confirmed blobs (FileNotFound = success)
+    end
+    CL->>Q: Write NEW queue snapshot (copy-on-write)
+    CL->>TL: Transition to COMPLETED
+```
+
+**This is new locking, stated plainly.** Today the clean's REQUESTED->INFLIGHT transition is
+UNLOCKED (`CleanActionExecutor.runClean`, lines 209-210), and the existing lock wraps only
+completion (`writeTableMetadata` + INFLIGHT->COMPLETED, lines 227-237). Step B introduces a new
+locked block around the transition -- a localized but real restructuring of the clean executor,
+not a ride on existing machinery. The in-tree pattern to follow is `scheduleCleaning`'s
+REQUESTED-creation-under-lock (`BaseHoodieTableServiceClient`, lines 898-914).
+
+### Lock prerequisite and deployment modes
+
+`TransactionManager.beginStateChange` is a NO-OP when `isLockRequired()` is false
+(`HoodieWriteConfig:2873` -- true only when a lock provider is set or the concurrency mode is
+multi-writer). The ordering argument below holds only where real mutual exclusion exists, so the
+design states its assumption per deployment mode instead of asserting it universally:
+
+| Deployment                                                                           | Lock reality                                                                                                           | Blob-drain stance                                                            |
+|--------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| Multi-writer                                                                         | External lock provider (already required by Hudi OCC)                                                                  | Supported                                                                    |
+| Single-writer + async table services + MDT                                           | Auto `InProcessLockProvider` (`HoodieWriteConfig:3659-3691`); the registry requires MDT anyway                         | Supported -- the standard blob configuration                                 |
+| Single-writer, all services inline                                                   | No lock; safe by strict sequentiality -- the clean runs in the writer's own thread, so no interleaving exists to order | Supported; the proof is sequentiality, not the lock                          |
+| Single-writer + async services, `hoodie.auto.adjust.lock.configs=false`, no provider | `isLockRequired()` false with REAL concurrency: no mutual exclusion at all                                             | **Fail fast** -- blob drains refuse to run and surface a configuration error |
+
+### Ordering argument (closes the SI design's open planning-snapshot window)
+
+The verified commit path holds ONE lock across `preCommit()` -> `writeToMetadataTable()` ->
+`saveAsComplete()` (`BaseHoodieWriteClient.commitStats`, lines 266-281). Step B holds the same
+lock. For any writer W and drain D, where mutual exclusion exists (table above):
+
+- If W's commit completes before D's Step B: W's commit instant lands in (T0, now], so the delta
+  re-check reads W's registry additions -> any survivor W references is deferred, not deleted.
+- If W's `preCommit` runs after D's transition: W sees the INFLIGHT clean and its drain sidecar
+  on the timeline -> overlap raises `HoodieWriteConflictException` (the existing veto).
+
+There is no third interleaving. The SI design's t0-t3 hole (liveness snapshotted unlocked at plan
+time, never re-validated) cannot occur: under rule D, **no liveness decision made outside the
+lock ever authorizes a delete** -- Step A is advisory; only Step B authorizes.
+
+### Writer interplay (improved semantics)
+
+| Writer references path P while...                             | SI design                              | This design                                                                                                                                                                  |
+|---------------------------------------------------------------|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| P sits in the pending queue (not draining)                    | Abort + retry (REQUESTED plan overlap) | **Proceed.** Blob still exists; writer's commit adds a registry entry; the next drain's re-check defers or annuls P. C2 delete-and-re-add within grace is safe, not an error |
+| P is in an actively-draining clean (INFLIGHT)                 | Abort + retry                          | Abort + retry (unchanged; delete is imminent/underway)                                                                                                                       |
+| P was deleted by a clean completed inside the writer's window | Abort (bounded COMPLETED-window check) | Same bounded check, unchanged                                                                                                                                                |
+
+The veto therefore fires only against actual drains -- rarer, and with the same bounded
+sidecar-read cost as the SI design (typically zero to two reads per commit, zero for non-blob
+writers, R6).
+
+### Crash recovery
+
+Same idempotency skeleton as the SI design (sidecar re-read, FileNotFound = success), with two
+additions:
+
+| Crash point                                                | Recovery                                                                                                                                                                                                                                                                                                                        |
+|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| After queue/hygiene sidecar written, before plan persisted | Orphan sweep at startup deletes per-instant artifacts whose instant is not on the active timeline (the `pending_blob_deletes/` queue directory is exempt -- see Data Model)                                                                                                                                                     |
+| After slices deleted, before clean's MDT update            | The clean instant is INFLIGHT; re-execution re-reads the hygiene sidecar and re-runs the MDT update. The guarantee is MDT commit atomicity: a partially-written MDT delta commit at the clean instant is removed by MDT inflight-deltacommit rollback and rewritten whole (tombstones are additionally idempotent keyed writes) |
+| During drain physical deletes                              | Re-execution re-reads the drain sidecar; deletes are idempotent (FileNotFound = success); the queue snapshot write is copy-on-write, so a crash leaves the prior snapshot authoritative                                                                                                                                         |
+
+### Q6 (premature deletion) -- answered by default
+
+Prevention is rule D. Detection is unchanged from the SI design (dangling-ref error surfacing +
+audit trail in clean metadata and sidecars). Recovery improves: because nothing is hard-deleted
+before the grace window elapses, a wrong verdict detected within the window is repaired by
+annulling the queue entry -- **zero data movement**, no copy-based quarantine, on by default.
+Operators who need immediate reclamation set grace to 0 and accept the SI-design-equivalent
+recovery posture.
+
+---
+
+## Fallback and Bootstrap
+
+**Blob cleanup hard-requires the registry.** Rule D(c) is defined against the registry: with no
+partition there is no deletion authority, and a permanent fallback scan is an R5 violation by
+construction. Enabling `hoodie.cleaner.blob.enabled` on a table without the partition
+auto-schedules the registry build (MDT present) or fails fast with a configuration error (MDT
+disabled). The fallback below is a **bounded transition mode** -- it keeps the cleaner correct
+while the partition is being built or rebuilt (initial enable, restore, re-enable), never a
+permanent operating mode; remaining in fallback is surfaced as a warning plus a metric.
+
+The registry is authoritative only when its partition is **available and not inflight** -- the
+identical gate the SI design uses. During the transition window (and for pre-feature files):
+
+- **Bootstrap/backfill:** an async indexer job builds the registry by reading retained files'
+  manifests (footer-only); files without manifests get a one-time blob-column read. Standard
+  index-build lifecycle; the partition is inflight until reconciled.
+- **Fallback verification:** a scan over **all retained files' manifests** (footer-only,
+  metadata-scale I/O -- not the SI design's data scan), rate-limited by
+  `max.candidates` with overflow staying in the durable queue. Note the fallback is
+  multi-version-correct by construction (it enumerates retained files, not a merged snapshot),
+  which the SI design's fallback was not as specified.
+- One-sided trust carries over: uncertainty resolves to retain or defer, never to delete.
+
+---
+
+## Performance
+
+| Path                            | SI design                                                                                 | This design                                                                                                                                                            |
+|---------------------------------|-------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Write path, per commit          | SI records per touched record + previous-slice diff read per touched FG + RLI maintenance | One registry record per distinct (path, written file); no diffing; no RLI. Strictly <= SI record count                                                                 |
+| Candidate derivation (Stage 1)  | Columnar read of base blob columns + full log record reads, ~6 files/FG                   | Inline manifest reads (sharing-heavy tables); blob-column projection for truncated files (no worse than the SI design's read)                                          |
+| Cross-FG verification           | 2 hops (SI prefix scan -> record keys -> RLI scan) + in-memory FG resolution              | 1 hop (registry prefix scan), short-circuit on first live entry                                                                                                        |
+| Fallback (transition mode only) | O(candidates x table) data scan                                                           | O(retained files) footer scan, bounded to the registry build/rebuild window                                                                                            |
+| Reclamation latency             | Same cycle                                                                                | + grace window (config; 0 = same cycle)                                                                                                                                |
+| MDT storage                     | SI partition (per record) + RLI (per record)                                              | Registry (per distinct path x file): col-stats scale when sharing-heavy, RLI scale when row-level-distinct -- strictly less than SI+RLI either way (see Registry size) |
+
+R6 (non-blob tables): `hasBlobColumns()` gates manifests, registry maintenance, candidate
+derivation, and the veto -- zero cost, unchanged.
+
+---
+
+## Observability and Clean Metadata (R9)
+
+`HoodieCleanMetadata` gains a nullable `blobCleanStats`:
+
+- `totalBlobPathsEnqueued`, `totalBlobFilesDeleted`, `totalBlobStorageReclaimed`
+- `totalDeferred`, `totalAnnulled` -- the drain classification counts; annulments are the audited
+  events a re-derivation failure would surface against
+- `failedBlobFilePaths` and `manifestEnumerationFailures` -- the loud-failure counter that feeds
+  the reconciliation sweep
+- `hygieneSidecarPath` / `drainSidecarPath` -- the durable audit trail Q6's detection story
+  depends on (matching a missing-blob error against delete history)
+
+Metrics: pending-queue depth and oldest-entry age (draining vs stuck), drain and defer/annul
+rates, hygiene-failure and sweep-reclaim counters, and a persistent-fallback warning (blob
+cleanup enabled while the registry partition is absent or inflight). The bar: an operator must be
+able to distinguish "backlog draining slowly" from "registry silently stopped tombstoning" from
+metrics alone.
+
+---
+
+## Configuration
+
+| Property                                          | Default                | Description                                                                                                                                                                                                              |
+|---------------------------------------------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `hoodie.cleaner.blob.enabled`                     | `true`                 | Enable blob cleanup during clean. Hard-requires the registry: auto-enables the `blob_refs` partition when MDT is present; fails fast with a config error when MDT is disabled                                            |
+| `hoodie.cleaner.blob.pending.delete.grace`        | `24h`                  | Minimum age of a queue entry before it may be drained. `0` = drain in the discovering cycle. Size against the savepoint/restore SLA: a drain older than grace is unrecoverable by restore                                |
+| `hoodie.cleaner.blob.drain.max.candidates`        | `1000`                 | Per-cycle drain rate limit (queue is durable; overflow waits)                                                                                                                                                            |
+| `hoodie.cleaner.blob.drain.include.inflight.refs` | `true`                 | Step A counts inflight commits' registry INSERTS as retain votes (one-sided rule; inflight tombstones are always ignored). Disabling narrows deferrals but leaves mid-flight writers solely to the locked delta re-check |
+| `hoodie.cleaner.blob.dry.run`                     | `false`                | Skip physical blob deletes and log drain decisions. Candidates ARE still enqueued -- the file slices are deleted regardless, so skipping enqueue would permanently lose them (R2)                                        |
+| `hoodie.cleaner.blob.sweep.max.entries`           | `10000`                | Per-cycle budget for the reconciliation sweep (staleness backstop)                                                                                                                                                       |
+| `hoodie.metadata.index.blob.refs.enable`          | auto with blob cleanup | Build and maintain the `blob_refs` MDT partition. Disabling means DROPPING the partition (re-enable = rebuild); hygiene tombstones follow partition existence, not the cleaner flag                                      |
+
+---
+
+## Rollout
+
+1. **Manifests** (independent value): footer/header manifest write + read utilities. Enables
+   footer-only candidate derivation and the fallback scan even before the registry exists.
+   Each engine write path is an explicit line item -- Spark record-level handles, Spark
+   row-writer bulk_insert, Flink, Java, and the log-block writers -- because the fallback for a
+   missing write-stat set re-reads the just-written files, and `writeToMetadataTable` runs inside
+   the commit lock, so on bulk loads the fallback is a real commit-latency tax. Mitigation:
+   derive the path set at file-close time on the executor (the data is still in memory there),
+   not at commit time on the driver.
+2. **Registry partition**: `MetadataPartitionType.BLOB_REFS` + payload + commit/clean conversion
+    + writer wiring + async backfill. Touchpoint list matches the PARTITION_STATS precedent
+      (commit `f553ba25fe30`); no table-version bump was required for that addition.
+3. **Queue + drain protocol**: pending-deletes queue, hygiene sidecar, locked drain, annulment.
+4. **Writer veto** (reduced scope): reuse the SI design's preCommit machinery against the drain
+   sidecar only.
+
+Backward compatibility: all new metadata is additive (new MDT partition, nullable clean-metadata
+stats, aux artifacts); non-blob tables are unaffected; pre-feature files are handled by the
+manifest fallback.
+
+---
+
+## Comparison with the SI design
+
+| Dimension                   | SI design                                                  | This design                                                           |
+|-----------------------------|------------------------------------------------------------|-----------------------------------------------------------------------|
+| Liveness question answered  | "referenced in latest snapshot?" (record-granular)         | "referenced by any retained file?" (file-granular) -- the R1 question |
+| M1 insert_overwrite ban     | Inherited from SI; must be fixed upstream or ops banned    | Not applicable (no SI)                                                |
+| M2 snapshot hole            | Present; unfixable without SI payload/read changes         | Absent by construction                                                |
+| M3 cleaned_fg_ids heuristic | Required, and wrong for partial cleans                     | No FG heuristic exists                                                |
+| Planning-snapshot window    | Open (option (a)/(b) unresolved)                           | Closed structurally: only the locked drain check authorizes deletes   |
+| Index prerequisites         | SI + RLI, per-record maintenance, per-commit slice diffing | One partition, per-file records, no diffing                           |
+| Writer race handling        | Abort on any overlap with REQUESTED/INFLIGHT/COMPLETED     | Defer/annul (proceed) during queue phase; abort only during drains    |
+| Recovery from wrong verdict | Opt-in copy-based quarantine                               | Default grace window, zero data movement                              |
+| New infra                   | Nested-SI index definition (exists), sidecar convention    | New MDT partition type, manifests, queue (sidecar convention shared)  |
+| Reclamation latency         | Same cycle                                                 | Grace window (default 24h; 0 opt-out)                                 |
+
+## Constraint and Requirement Coverage
+
+Traceability against the problem statement (C1-C11, R1-R9):
+
+| ID  | Summary                                            | Where addressed / mechanism                                                                                                                                                                                                            |
+|-----|----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| C1  | Blob immutability                                  | Assumed and exploited: registry entries are immutable for a file's lifetime (born at commit, killed at clean, never updated); the cleaner only ever deletes whole blobs, never mutates them                                            |
+| C2  | Delete-and-re-add same path                        | Safe within grace (writer proceeds; the re-adding commit's registry entry defers the drain); post-delete re-add caught by the bounded completed-window veto -- Writer interplay                                                        |
+| C3  | Cross-FG blob sharing                              | The registry IS the cross-FG liveness index: any file's entry, in any FG, retains the path -- Abstract, Motivation                                                                                                                     |
+| C4  | MOR log updates shadow base refs                   | Expired side enumerates base union logs; a shadowed base ref stays alive until its base file is physically cleaned (over-retention only) -- Candidate derivation, MOR note                                                             |
+| C5  | Cleaner is per-FG scoped                           | Candidate derivation consumes the existing policy methods' per-FG expired/retained output unchanged -- Cleanup Algorithm input                                                                                                         |
+| C6  | OCC per-FG, no global contention                   | Two-step drain: locked work is O(concurrent commits), never O(candidates); no new global serialization -- Liveness verification, Lock prerequisite                                                                                     |
+| C7  | Replace commits move refs between FGs              | No special handling needed: old FG's files stay retained (entries live) until cleaned; new files carry their own entries -- Registry Maintenance table                                                                                 |
+| C8  | Savepoints freeze slices and refs                  | Savepointed files are never cleaned, so their entries persist and their blobs are retained structurally -- Registry Maintenance table                                                                                                  |
+| C9  | Rollback / restore invalidate or resurrect         | MDT-lockstep rollback removes a failed commit's entries; restore delete-and-rebuilds the partition, the queue survives and defers during rebuild, grace sized against restore SLA -- Registry Maintenance, Pending-deletes queue       |
+| C10 | Archival removes commit metadata                   | The registry is MDT data, not commit metadata; per-instant sidecars live until archival with the existing sweep -- Registry Maintenance table                                                                                          |
+| C11 | Cross-FG verification at scale                     | O(candidates) targeted prefix scans with first-hit short-circuit -- Liveness verification, Performance                                                                                                                                 |
+| R1  | No premature deletion                              | Kernel I1 + rule D(c); completed-instant fencing; one-sided rules (no payload-filtered hashed reads, no inflight tombstones); writer veto + ordering argument                                                                          |
+| R2  | No permanent orphans                               | Plan-time durable enqueue before slice deletion; defer-vs-annul classification; audited annulments; reconciliation sweep; dry-run still enqueues; copy-on-write queue                                                                  |
+| R3  | MOR correctness (over-retain OK, under-retain not) | All MOR degradations point toward retention: shadowed refs live until their file dies; rollback resurrection is safe because entries outlive snapshot supersession (file granularity)                                                  |
+| R4  | Concurrency safety, no global serialization        | Two-step drain (bounded lock hold); per-mode lock grounding with fail-fast -- Lock prerequisite and deployment modes                                                                                                                   |
+| R5  | Cost proportional to work                          | Registry lookups O(candidates); fallback bounded to the build/rebuild transition window; drain and sweep rate-limited                                                                                                                  |
+| R6  | Zero cost for non-blob tables                      | `hasBlobColumns()` gates manifests, registry maintenance, candidate derivation, and the veto -- Performance                                                                                                                            |
+| R7  | All cleaning policies                              | Candidate derivation is policy-agnostic (consumes expired/retained slices from the existing policy methods); notably the design has NO dependency on `earliestInstantToRetain`, which does not exist under `KEEP_LATEST_FILE_VERSIONS` |
+| R8  | Crash safety and idempotency                       | Crash-recovery table: MDT commit atomicity for tombstones, idempotent physical deletes, copy-on-write queue snapshots, orphan sweep with queue carve-out                                                                               |
+| R9  | Observability                                      | Observability and Clean Metadata section: `blobCleanStats`, queue/drain/sweep metrics, persistent-fallback warning                                                                                                                     |
+
+## Open Questions
+
+All questions initially left open by this draft have been resolved (decisions recorded in place
+below); what remains are implementation-time tunables noted inside items 2 and 6.
+
+1. (Resolved.) Registry key encoding: escaped-string concatenation -- collision-free by
+   construction, SI-precedent escaping. Hashed fixed-width keys survive only as a future size
+   optimization under the retain-on-any-prefix-hit rule; payload-filtered liveness reads on
+   hashed keys are an R1 inversion (see Data Model, Key).
+2. (Resolved -- see "Pending-deletes queue", Atomicity.) Queue storage is copy-on-write
+   snapshots named by the draining instant; remaining tunable: snapshot compaction cadence.
+3. (Resolved.) Grace default: **24h**, per-table configurable
+   (`hoodie.cleaner.blob.pending.delete.grace`, `0` allowed). No automatic floor -- instead,
+   config documentation directs operators to size it against the clean retention window and
+   their savepoint/restore SLA (see queue Restore note).
+4. (Resolved.) Unwatermarked drain read: **ON by default**
+   (`hoodie.cleaner.blob.drain.include.inflight.refs`), under the one-sided rule -- apply
+   inflight inserts, never inflight tombstones (see the drain hardening note).
+5. (Resolved.) First-class `MetadataPartitionType.BLOB_REFS`, NOT expression-index reuse. The
+   registry is a SYSTEM partition -- the cleaner's deletion authority, auto-enabled, hygiene tied
+   to its existence -- and must not be droppable via the user-facing `DROP INDEX` surface; its
+   record shape (existence entry, path-first key) and clean-time tombstone path (hygiene
+   sidecar) match neither expression-index record type anyway. The async builder is reused
+   regardless (it works against `MetadataPartitionType` generally, as RLI shows). Precedent:
+   PARTITION_STATS is col-stats-shaped -- the best candidate for expression-index reuse -- and
+   still shipped first-class.
+6. (Resolved -- see "Per-file blob manifest".) Manifest size: capped inline tier + fixed-size
+   bloom digest + column-projection fallback; truncation degrades only to more I/O or safe
+   over-retention. Remaining tunables: inline cap defaults (256KB footer / 64KB log header) and
+   bloom sizing policy (fixed 128KB vs scaled-to-count).

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -1,0 +1,749 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# RFC-100 Part 2: Blob Cleanup for Unstructured Data
+
+## Proposers
+
+- @voon
+
+## Approvers
+
+- (TBD)
+
+## Status
+
+Issue: <Link to GH feature issue>
+
+> Please keep the status updated in `rfc/README.md`.
+
+---
+
+## Abstract
+
+When Hudi cleans expired file slices, out-of-line blob files they reference may become orphaned --
+still consuming storage but unreachable by any query. This RFC extends the existing file slice
+cleaner to identify and delete these orphaned blob files safely and efficiently. The design uses a
+three-stage pipeline: (1) per-file-group set-difference to find locally-orphaned blobs, (2) an MDT
+secondary index lookup for cross-file-group verification of externally-referenced blobs, and (3)
+container file lifecycle resolution. For Hudi-created blobs, cleanup is essentially free -- structural
+path uniqueness eliminates cross-file-group concerns entirely. For user-provided external blobs,
+targeted index lookups scale with the number of candidates, not the table size. Tables without blob
+columns pay zero cost.
+
+---
+
+## Background
+
+### Why Blob Cleanup Is Needed
+
+RFC-100 introduces out-of-line blob storage for unstructured data (images, video, documents). A
+record's `BlobReference` field points to an external blob file by `(path, offset, length)`. When
+the cleaner expires old file slices, the blob files they reference may no longer be needed -- but the
+existing cleaner has no concept of transitive references. It deletes file slices without considering
+the blob files they point to. Without blob cleanup, orphaned blobs accumulate indefinitely.
+
+### Two Blob Flows
+
+Blob cleanup must support two distinct entry flows with fundamentally different properties:
+
+**Flow 1 -- Hudi-created blobs.** Blobs created by Hudi's write path, stored at
+`{table}/.hoodie/blobs/{partition}/{col}/{instant}/{blob_id}`. The commit instant in the path
+guarantees uniqueness (C11), and blobs are scoped to a single file group (P3). Cross-file-group
+sharing does not occur. This is the expected majority flow for Phase 3 workloads.
+
+**Flow 2 -- User-provided external blobs.** Users have existing blob files in external storage
+(e.g., `s3://media-bucket/videos/`). Records reference these blobs directly by path. Hudi manages
+the *references*, not the *storage layout*. Cross-file-group sharing is common -- multiple records
+across different file groups can point to the same blob. This is the expected primary flow for
+Phase 1 workloads.
+
+| Property                  | Flow 1 (Hudi-created)             | Flow 2 (External)                    |
+|---------------------------|-----------------------------------|--------------------------------------|
+| Path uniqueness           | Guaranteed (instant in path, C11) | Not guaranteed (user controls)       |
+| Cross-FG sharing          | Does not occur (FG-scoped)        | Common (multiple records, same blob) |
+| Writer/cleaner race       | Cannot occur (D2)                 | Can occur (D3)                       |
+| Per-FG cleanup sufficient | Yes                               | No -- cross-FG verification needed   |
+
+### Constraints and Requirements Reference
+
+Full descriptions and failure modes in [Appendix B](rfc-100-blob-cleaner-problem.md).
+
+| ID  | Constraint                                      | Flow 1 | Flow 2 | Remarks                      |
+|-----|-------------------------------------------------|--------|--------|------------------------------|
+| C1  | Blob immutability (append-once, read-many)      | Y      | Y      |                              |
+| C2  | Delete-and-re-add same path                     | --     | Y      | Eliminated for Flow 1 by C11 |
+| C3  | Cross-file-group blob sharing                   | --     | Y      | Common for external blobs    |
+| C4  | Container files (`(offset, length)` ranges)     | Y      | Y      |                              |
+| C5  | MOR log updates shadow base file blob refs      | Y      | Y      |                              |
+| C6  | Existing cleaner is per-file-group scoped       | Y      | Y      |                              |
+| C7  | OCC is per-file-group                           | Y      | Y      | No global contention allowed |
+| C8  | Clustering moves blob refs between file groups  | Y      | Y      |                              |
+| C9  | Savepoints freeze file slices and blob refs     | Y      | Y      |                              |
+| C10 | Rollback can invalidate or resurrect references | Y      | Y      |                              |
+| C11 | Blob paths include commit instant               | Y      | --     | Eliminates C2, C3, C13       |
+| C12 | Archival removes commit metadata                | Y      | Y      |                              |
+| C13 | Cross-FG verification needed at scale           | --     | Y      |                              |
+
+| ID  | Requirement                                                      |
+|-----|------------------------------------------------------------------|
+| R1  | No premature deletion (hard invariant)                           |
+| R2  | No permanent orphans (bounded cleanup)                           |
+| R3  | Container awareness (range-level liveness)                       |
+| R4  | MOR correctness (over-retention acceptable, under-retention not) |
+| R5  | Concurrency safety (no global serialization)                     |
+| R6  | Scale proportional to work, not table size                       |
+| R7  | No cost for non-blob tables                                      |
+| R8  | All cleaning policies supported                                  |
+| R9  | Crash safety and idempotency                                     |
+| R10 | Observability (metrics for deleted, retained, reclaimed)         |
+
+---
+
+## Design Overview
+
+### Design Philosophy
+
+Blob cleanup extends the existing `CleanPlanner` / `CleanActionExecutor` pipeline -- same timeline
+instant, same plan-execute-complete lifecycle, same crash recovery and OCC integration. A
+`hasBlobColumns()` check gates all blob logic so non-blob tables pay zero cost.
+
+The two flows have different cost structures, and the design keeps them separate. Flow 1
+(Hudi-created blobs) gets per-FG cleanup with no cross-FG overhead. Flow 2 (external blobs) gets
+targeted cross-FG verification via MDT secondary index. Dispatch is a string prefix check on the
+blob path.
+
+### Three-Stage Pipeline
+
+| Stage       | Scope                | Purpose                                                                          | When it runs                           |
+|-------------|----------------------|----------------------------------------------------------------------------------|----------------------------------------|
+| **Stage 1** | Per-file-group       | Collect expired/retained blob refs, compute set difference, dispatch by category | Always (for blob tables)               |
+| **Stage 2** | Cross-file-group     | Verify external blob candidates against MDT secondary index or fallback scan     | Only when external candidates exist    |
+| **Stage 3** | Container resolution | Determine delete vs. flag-for-compaction at the container level                  | Only when container blobs are involved |
+
+### Independent Implementability
+
+The three stages have clean input/output interfaces and can be implemented, tested, and shipped
+independently:
+
+| Stage   | Input                                                   | Output                                              |
+|---------|---------------------------------------------------------|-----------------------------------------------------|
+| Stage 1 | `FileGroupCleanResult` (expired + retained slices)      | `hudi_blob_deletes`, `external_candidates`          |
+| Stage 2 | `external_candidates`, `cleaned_fg_ids`                 | `external_deletes`                                  |
+| Stage 3 | `hudi_blob_deletes` + `external_deletes`, retained refs | `blob_files_to_delete`, `containers_for_compaction` |
+
+A shared foundation layer must land first (see [Rollout / Adoption Plan](#rollout--adoption-plan)), after which stages
+can proceed in any order.
+
+### Key Decisions
+
+| Decision            | Choice                                                  | Rationale                                                          |
+|---------------------|---------------------------------------------------------|--------------------------------------------------------------------|
+| Blob identity       | `(path, offset, length)` tuple                          | Handles containers (C4) and path reuse (C2) correctly              |
+| Cleanup scope       | Per-FG (Hudi blobs) + MDT index lookup (external blobs) | Aligns with OCC (C7) and existing cleaner (C6); scales for C13     |
+| Dispatch mechanism  | Path prefix check on blob path                          | Zero-cost classification; Hudi blobs match `.hoodie/blobs/` prefix |
+| Cross-FG mechanism  | MDT secondary index on `reference.external_path`        | Short-circuits on first non-cleaned FG ref; first-class for Flow 2 |
+| Write-path overhead | None (Flow 1); MDT index maintenance (Flow 2)           | Index maintained by existing MDT pipeline, not a new write cost    |
+| MOR strategy        | Over-retain (union of base + log refs)                  | Safe (C5, R4); cleaned after compaction                            |
+| Container strategy  | Tuple-level tracking; delete only when all ranges dead  | Correct (C4, R3); partial containers flagged for blob compaction   |
+
+```mermaid
+flowchart LR
+    subgraph Planning["CleanPlanActionExecutor.requestClean()"]
+        direction TB
+        Gate{"hasBlobColumns()?"}
+        Gate -- No --> Skip["Skip blob cleanup<br/>(zero cost)"]
+        Gate -- Yes --> CP
+
+        subgraph CP["CleanPlanner (per-partition, per-FG)"]
+            direction TB
+            Policy["Policy method<br/>→ FileGroupCleanResult<br/>(expired + retained slices)"]
+            S1["<b>Stage 1</b><br/>Per-FG blob ref<br/>set difference + dispatch"]
+            Policy --> S1
+        end
+
+        S1 --> S2["<b>Stage 2</b><br/>Cross-FG verification<br/>(MDT secondary index)"]
+        S1 -->|hudi_blob_deletes| S3
+        S2 -->|external_deletes| S3["<b>Stage 3</b><br/>Container lifecycle<br/>resolution"]
+    end
+
+    subgraph Plan["HoodieCleanerPlan"]
+        FP["filePathsToBeDeleted<br/>(existing)"]
+        BP["blobFilesToDelete<br/>(new)"]
+        CC["containersToCompact<br/>(new)"]
+    end
+
+    S3 --> BP
+    S3 --> CC
+    CP --> FP
+
+    subgraph Execution["CleanActionExecutor.runClean()"]
+        direction TB
+        DF["Delete file slices<br/>(existing, parallel)"]
+        DB["Delete blob files<br/>(new, parallel)"]
+        RC["Record containers<br/>for blob compaction"]
+    end
+
+    FP --> DF
+    BP --> DB
+    CC --> RC
+```
+
+---
+
+## Algorithm
+
+### Stage 1: Per-File-Group Local Cleanup
+
+Stage 1 runs after the existing policy logic determines which file slices are expired and retained
+for a given file group. It collects blob refs from both sets and computes locally-orphaned blobs by
+set difference.
+
+```
+Input:  A file group FG with expired_slices and retained_slices (from policy)
+Output: hudi_blob_deletes     -- blobs safe to delete immediately
+        external_candidates   -- external blobs needing cross-FG verification
+
+for each file_group being cleaned:
+
+    // Collect expired blob refs (base files + log files)
+    // Must read log files: blob refs introduced and superseded within the log
+    // chain before compaction would otherwise become permanent orphans.
+    expired_refs = Set<(path, offset, length)>()
+    for slice in expired_slices:
+        for ref in extractBlobRefs(slice.baseFile):   // columnar projection
+            if ref.type == OUT_OF_LINE and ref.managed == true:
+                expired_refs.add((ref.path, ref.offset, ref.length))
+        for ref in extractBlobRefs(slice.logFiles):   // full record read
+            if ref.type == OUT_OF_LINE and ref.managed == true:
+                expired_refs.add((ref.path, ref.offset, ref.length))
+
+    if expired_refs is empty:
+        continue                                       // no blob work for this FG
+
+    // Collect retained blob refs (base files only)
+    // Cleaning is fenced on compaction: retained base files contain the merged
+    // state. Log reads are unnecessary -- any shadowed base ref causes safe
+    // over-retention, cleaned after the next compaction cycle.
+    retained_refs = Set<(path, offset, length)>()
+    for slice in retained_slices:
+        for ref in extractBlobRefs(slice.baseFile):   // columnar projection only
+            if ref.type == OUT_OF_LINE and ref.managed == true:
+                retained_refs.add((ref.path, ref.offset, ref.length))
+
+    // Compute local orphans by set difference
+    local_orphans = expired_refs - retained_refs
+
+    // Dispatch by blob category
+    for ref in local_orphans:
+        if ref.path starts with TABLE_PATH + "/.hoodie/blobs/":
+            hudi_blob_deletes.add(ref)             // P3: no cross-FG refs possible
+        else:
+            external_candidates.add(ref)           // C13: cross-FG refs are common
+```
+
+**Correctness notes:**
+
+- **Hudi-created blobs:** If a blob ref appears in expired but not retained slices of the same FG,
+  it is globally orphaned -- Hudi blobs are FG-scoped (C11), so no cross-FG check is needed.
+- **MOR -- expired side reads base + logs:** Blob refs can be introduced and superseded entirely
+  within the log chain (e.g., `log@t2: row1→blob_B`, then `log@t3: row1→blob_C`). After
+  compaction, `blob_B` exists only in the expired log. Skipping logs would orphan it permanently.
+- **MOR -- retained side reads base only:** Cleaning is fenced on compaction, so retained base
+  files contain the merged state. Shadowed base refs cause over-retention (safe), cleaned after
+  the next compaction.
+- **Savepoints:** Inherited from existing cleaner -- savepointed slices stay in the retained set.
+- **Replaced FGs (clustering):** `retained_slices` is empty, so all blob refs become candidates.
+  Hudi blobs are safe to delete (clustering creates new blobs in the target FG). External blobs
+  flow to Stage 2 (clustering copies the pointer, so Stage 2 finds it in the target FG).
+
+### Stage 2: Cross-FG Verification (External Blobs)
+
+Stage 2 executes only when `external_candidates` is non-empty. For Flow 1 workloads (Hudi-created
+blobs only), this stage is skipped entirely.
+
+#### Primary path: MDT secondary index
+
+When the MDT secondary index on `reference.external_path` is available and fully built:
+
+```
+Input:  external_candidates, cleaned_fg_ids
+Output: external_deletes (confirmed globally orphaned)
+
+candidate_paths = external_candidates.map(ref -> ref.path).distinct()
+
+// Step 1: Batched prefix scan on secondary index
+// Key format: escaped(external_path)$escaped(record_key)
+// Returns ALL record keys that reference each candidate path
+path_to_record_keys = mdtMetadata.readSecondaryIndexDataTableRecordKeysWithKeys(
+    HoodieListData.eager(candidate_paths), indexPartitionName)
+    .groupBy(pair -> pair.getKey())
+
+// Step 2: Batch record index lookup -- ONE call for ALL record keys
+// Sorts keys internally, single sequential forward-scan through HFile.
+all_record_keys = path_to_record_keys.values().flatMap()
+all_locations = mdtMetadata.readRecordIndexLocations(
+    HoodieListData.eager(all_record_keys))             // -> Map<recordKey, (partition, fileId)>
+
+// Step 3: In-memory resolution with short-circuit per candidate
+for path in candidate_paths:
+    record_keys = path_to_record_keys.getOrDefault(path, [])
+
+    if record_keys is empty:
+        external_deletes.addAll(candidates for this path)  // globally orphaned
+        continue
+
+    found_live_reference = false
+    for rk in record_keys:
+        location = all_locations.get(rk)
+        if location != null and location.fileId NOT in cleaned_fg_ids:
+            found_live_reference = true
+            break                                           // short-circuit (in-memory)
+
+    if not found_live_reference:
+        external_deletes.addAll(candidates for this path)   // all refs in cleaned FGs
+```
+
+**Cost model.** Three steps: (1) batched prefix scan on secondary index, (2) batched record index
+lookup in a single sorted HFile scan, (3) in-memory resolution with short-circuit. Steps 1 and 2
+are each a single I/O pass; step 3 is pure hash set lookups.
+
+| Step                      | I/O                                           | Estimated cost (2K candidates) |
+|---------------------------|-----------------------------------------------|--------------------------------|
+| 1. Prefix scan (batched)  | 1 HFile open + forward scan of N prefix keys  | ~2-5s                          |
+| 2. Record index (batched) | 1 HFile open + forward scan of 6K sorted keys | ~1-2s                          |
+| 3. In-memory resolution   | Hash set checks (cleaned_fg_ids)              | ~0ms                           |
+
+*Estimates assume cloud object storage (S3/GCS/ADLS), ~10-100ms per-read latency, ~50-200 MB/s
+sequential throughput, 64-256KB HFile blocks. Step 1: a 250K-entry secondary index is ~50MB; a
+sorted scan for 2K prefixes reads ~200-500 blocks, dominated by HFile open (~100-200ms) plus
+sequential block reads with cold-cache latency overhead. Step 2: similar profile, fewer blocks
+hit relative to index size. Pending benchmarking.*
+
+**Index definition.** Uses the existing `HoodieIndexDefinition` mechanism with
+`sourceFields = ["<blob_col>", "reference", "external_path"]`. The nested field path is supported
+by `HoodieSchemaUtils.projectSchema()` and `SecondaryIndexRecordGenerationUtils`. No new index
+infrastructure is needed.
+
+**Safety check.** The cleaner verifies the index is fully built before using it via
+`getMetadataPartitions()` and `getMetadataPartitionsInflight()`. A partially-built index falls
+back to the table scan path.
+
+#### Fallback path: table scan with circuit breaker
+
+When the MDT secondary index is unavailable, Stage 2 falls back to a parallelized table scan
+across all partitions. A circuit breaker (`hoodie.cleaner.blob.external.scan.max.candidates`,
+default 1000) defers cleanup if candidates exceed the threshold, preventing the scan from becoming
+a bottleneck on large tables. The operator is warned to enable the MDT secondary index.
+
+#### Decision matrix
+
+| Condition                   | Path used     | Cost                  | Suitable for                   |
+|-----------------------------|---------------|-----------------------|--------------------------------|
+| No external candidates      | Skip Stage 2  | Zero                  | Flow 1 workloads               |
+| MDT secondary index enabled | Index lookup  | O(candidates)         | Flow 2 at any scale            |
+| No index, few candidates    | Table scan    | O(candidates * table) | Small tables, few shared blobs |
+| No index, many candidates   | Circuit break | Zero (deferred)       | Large tables -- index required |
+
+```mermaid
+sequenceDiagram
+    participant C as Cleaner (Stage 2)
+    participant SI as MDT Secondary Index
+    participant RI as MDT Record Index
+
+    Note over C: Step 1: Batch prefix scan
+    C->>SI: All candidate paths (N paths, single call)
+    SI-->>C: Map<path, List<recordKey>>
+
+    Note over C: Step 2: Batch record index lookup
+    C->>C: Collect all record keys from all candidates
+    C->>RI: readRecordIndexLocations(all record keys)
+    Note over RI: Sort keys → single sequential<br/>forward-scan through HFile
+    RI-->>C: Map<recordKey, (partition, fileId)>
+
+    Note over C: Step 3: In-memory resolution
+    loop For each candidate path
+        alt No record keys for this path
+            Note right of C: Globally orphaned → DELETE
+        else Has record keys
+            C->>C: Check each location.fileId<br/>against cleaned_fg_ids (in-memory)
+            alt Any fileId NOT in cleaned_fg_ids
+                Note right of C: Live reference → RETAIN
+            else All in cleaned FGs
+                Note right of C: Globally orphaned → DELETE
+            end
+        end
+    end
+```
+
+### Stage 3: Container File Lifecycle
+
+Container files pack multiple blobs at different `(offset, length)` ranges. A container can only be
+deleted when *all* ranges within it are unreferenced.
+
+```
+all_deletes = hudi_blob_deletes + external_deletes
+
+// Non-container blobs: each occupies an entire file -> delete directly
+for ref in all_deletes where ref.offset is null:
+    blob_files_to_delete.add(ref.path)
+
+// Container blobs: group by path, check for remaining live ranges
+for each container_path in container_range_deletes grouped by path:
+    dead_ranges = ranges being deleted for this container
+    live_ranges = retained refs (from Stage 1) + referenced refs (from Stage 2)
+
+    if live_ranges is empty:
+        blob_files_to_delete.add(container_path)           // entire container dead
+    else:
+        containers_for_compaction.add(container_path, dead_ranges)  // partial -> repack
+```
+
+For Hudi-created containers, all ranges belong to the same FG (instant in path scopes it to a
+single write), so retained refs from Stage 1 are sufficient -- no cross-FG check needed.
+
+### Execution Flow
+
+```
+1. CleanPlanActionExecutor.requestClean()
+   ├── hasBlobColumns(table)?                         // R7: zero-cost gate
+   ├── CleanPlanner: for each partition, for each file group:
+   │     ├── Refactored policy method -> FileGroupCleanResult
+   │     └── If hasBlobColumns: Stage 1 per FG
+   ├── CleanPlanner: replaced file groups -> Stage 1
+   ├── If external_candidates non-empty: Stage 2
+   ├── Stage 3: container lifecycle resolution
+   ├── Build HoodieCleanerPlan (+ blobFilesToDelete, containersToCompact)
+   └── Persist plan to timeline (REQUESTED state)
+
+2. CleanActionExecutor.runClean()
+   ├── Transition to INFLIGHT
+   ├── Delete file slices (existing, parallelized)
+   ├── Delete blob files (new, same parallelized pattern)
+   ├── Record containers for blob compaction (metadata only)
+   ├── Build HoodieCleanMetadata with blobCleanStats
+   └── Transition to COMPLETED
+```
+
+```mermaid
+sequenceDiagram
+    participant P as CleanPlanActionExecutor
+    participant TL as Timeline
+    participant E as CleanActionExecutor
+    participant S as Storage
+
+    Note over P: requestClean()
+
+    P->>P: Stage 1: per-FG blob ref set difference
+    P->>P: Stage 2: MDT index lookup (if external candidates)
+    P->>P: Stage 3: container lifecycle resolution
+    P->>TL: Persist HoodieCleanerPlan
+
+    Note over TL: REQUESTED
+
+    rect rgb(255, 245, 230)
+        Note right of TL: Crash here → restart fresh<br/>(no plan persisted yet)
+    end
+
+    E->>TL: Transition plan state
+    Note over TL: INFLIGHT
+
+    rect rgb(255, 245, 230)
+        Note right of TL: Crash here → re-execute plan<br/>(idempotent: FileNotFound = success)
+    end
+
+    par Parallel deletion
+        E->>S: Delete file slices (existing)
+    and
+        E->>S: Delete blob files (new)
+    end
+
+    E->>E: Build HoodieCleanMetadata<br/>(+ blobCleanStats)
+    E->>TL: Transition plan state
+
+    rect rgb(255, 245, 230)
+        Note right of TL: Crash here → re-execute<br/>(all deletes are no-ops)
+    end
+
+    Note over TL: COMPLETED
+```
+
+---
+
+## Integration with Existing Cleaner
+
+### CleanPlanner Refactoring
+
+The existing `CleanPlanner` policy methods produce `CleanFileInfo` objects (file paths to delete)
+without exposing the expired/retained slice partition that blob cleanup needs. We introduce a new
+return type:
+
+```java
+public class FileGroupCleanResult {
+  private final List<CleanFileInfo> filePathsToDelete;
+  private final List<FileSlice> expiredSlices;
+  private final List<FileSlice> retainedSlices;
+}
+```
+
+The three policy methods (`getFilesToCleanKeepingLatestVersions`,
+`getFilesToCleanKeepingLatestCommits`, `getFilesToCleanKeepingLatestHours`) are refactored to
+collect both expired and retained slices alongside the existing `CleanFileInfo` production. The
+existing behavior is unchanged -- the refactoring adds output without modifying the
+expired/retained classification logic.
+
+### Replaced File Group Handling
+
+Replaced file groups (from clustering) are cleaned via `getReplacedFilesEligibleToClean()`. A
+parallel method `getReplacedFileGroupBlobCleanResults()` produces `FileGroupCleanResult` objects
+with `retainedSlices = empty` and `expiredSlices = all slices`. This feeds into Stage 1 identically
+to normal file groups.
+
+### Schema Changes: HoodieCleanerPlan
+
+Two new nullable fields with null defaults (backward compatible):
+
+- **`blobFilesToDelete`**: `List<HoodieCleanBlobFileInfo>` -- blob files where all ranges are dead.
+  The executor deletes these.
+- **`containersToCompact`**: `List<HoodieCleanContainerInfo>` -- containers with mixed live/dead
+  ranges, including the dead `(offset, length)` ranges. Handed to the blob compaction service.
+
+### Schema Changes: HoodieCleanMetadata
+
+A new nullable field `blobCleanStats` of type `HoodieBlobCleanStats`:
+
+- `totalBlobFilesDeleted`, `totalBlobFilesRetained`, `totalContainersFlaggedForCompaction`
+- `totalBlobStorageReclaimed`
+- `deletedBlobFilePaths`, `failedBlobFilePaths`
+
+### hasBlobColumns() Gate
+
+An in-memory schema check (`TableSchemaResolver.getTableSchema().containsBlobType()`) gates all
+blob cleanup logic. Requires making `containsBlobType()` public (one-line visibility change).
+
+---
+
+## Concurrency & Safety
+
+### Writer-Cleaner Race: Two-Sided Guard
+
+**Hudi-created blobs (Flow 1): structurally impossible.** A new write creates new blob files with a
+new instant in the path (C11). An UPSERT carries forward blob refs from retained slices (already
+live). There is no mechanism for a writer to reference a Hudi-created blob that exists only in
+expired slices. No writer-side check is needed for Flow 1.
+
+**External blobs (Flow 2): writer-side conflict check in `preCommit()`.** The gap between the
+cleaner's planning-time snapshot and its actual file deletion is closed by a commit-time conflict
+check:
+
+1. Writers track external managed blob paths in `HoodieWriteStat.externalBlobPaths` (in-memory
+   collection, no additional I/O).
+2. At commit time (in `preCommit()`, under the existing transaction lock), the writer checks all
+   three clean states -- COMPLETED, INFLIGHT, and REQUESTED -- because a REQUESTED plan can begin
+   executing at any moment (the REQUESTED→INFLIGHT transition doesn't acquire the transaction
+   lock). It checks `deletedBlobFilePaths` (COMPLETED) and `blobFilesToDelete` (INFLIGHT/REQUESTED).
+3. If any overlap is found, the commit is rejected with `HoodieWriteConflictException` and the
+   writer retries.
+
+Cost is zero for non-blob tables and Flow 1. For Flow 2: one timeline scan + 1-3 metadata reads.
+
+```mermaid
+sequenceDiagram
+    participant W as Writer
+    participant TL as Timeline
+    participant CL as Cleaner
+
+    Note over W,CL: Scenario A: Writer commits BEFORE cleaner plans
+
+    W->>TL: Commit (references blob_X)
+    CL->>TL: Plan cleanup
+    Note right of CL: Sees blob_X in retained slice → not deleted
+    Note over W,CL: ✓ Safe
+
+    Note over W,CL: Scenario B: Writer commits AFTER cleaner plans, BEFORE delete
+
+    CL->>TL: Plan cleanup (blob_X in blobFilesToDelete)
+    Note over TL: REQUESTED / INFLIGHT
+    W->>TL: preCommit() -- reads clean plan
+    Note left of W: Intersection found!<br/>HoodieWriteConflictException<br/>→ Writer retries
+    Note over W,CL: ✓ Safe -- conflict detected
+
+    Note over W,CL: Scenario C: Writer commits AFTER cleaner deletes, BEFORE COMPLETED
+
+    CL->>CL: Delete blob_X from storage
+    Note over TL: Still INFLIGHT
+    W->>TL: preCommit() -- reads INFLIGHT plan
+    Note left of W: blob_X in blobFilesToDelete<br/>→ Rejection
+    Note over W,CL: ✓ Safe -- same as B
+
+    Note over W,CL: Scenario D: Cleaner completes, THEN writer acquires lock
+
+    CL->>TL: Transition to COMPLETED
+    W->>TL: preCommit() -- reads COMPLETED metadata
+    Note left of W: blob_X in deletedBlobFilePaths<br/>→ Rejection
+    Note over W,CL: ✓ Safe
+```
+
+### Concurrency Matrix
+
+| Operation                      | Concurrent with Blob Cleaner | Safety Mechanism                                          |
+|--------------------------------|------------------------------|-----------------------------------------------------------|
+| Regular write (INSERT/UPSERT)  | Safe                         | C11 path uniqueness (Flow 1); writer-side check (Flow 2)  |
+| Compaction                     | Safe                         | `isFileSliceNeededForPendingMajorOrMinorCompaction`       |
+| Clustering                     | Safe                         | Replaced FG lifecycle; Stage 2 for external blobs         |
+| Rollback                       | Safe                         | MOR over-retention; clean operates on post-rollback state |
+| Savepoint create/delete        | Safe                         | `isFileSliceExistInSavepointedFiles`                      |
+| Archival                       | No interaction               | Blob cleaner reads file slices, not commit metadata       |
+| Another cleaner instance       | Safe                         | `TransactionManager`; `checkIfOtherWriterCommitted`       |
+| Blob compaction                | Safe                         | Independent lifecycle                                     |
+| MDT writes (index maintenance) | Safe                         | MDT commit atomicity                                      |
+
+### Crash Recovery
+
+Crash recovery is idempotent by construction, using the same mechanisms as existing file slice
+cleaning:
+
+| Crash point                             | Recovery                                                                                               |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------------|
+| During planning (before plan persisted) | No REQUESTED instant on timeline. Cleaner starts fresh.                                                |
+| After plan persisted, before execution  | REQUESTED instant found; plan re-read and executed.                                                    |
+| During execution (partial deletes)      | INFLIGHT instant re-executed. Already-deleted files return FileNotFoundException → treated as success. |
+| After execution, before COMPLETED       | INFLIGHT re-executed. All deletes are no-ops. Metadata written, instant transitions to COMPLETED.      |
+
+---
+
+## Performance
+
+### Cost Summary
+
+| Workload                 | Stage 1 cost                    | Stage 2 cost               | Total per cleanup cycle        |
+|--------------------------|---------------------------------|----------------------------|--------------------------------|
+| Non-blob table           | Zero (`hasBlobColumns` gate)    | N/A                        | **Zero**                       |
+| Flow 1 (Hudi-created)    | ~6 Parquet reads per cleaned FG | Skipped                    | O(cleaned_FGs * slices_per_FG) |
+| Flow 2 (external, index) | ~6 Parquet reads per cleaned FG | O(candidates) amortized    | O(cleaned_FGs + candidates)    |
+| Flow 2 (external, scan)  | ~6 Parquet reads per cleaned FG | O(candidates * table_size) | Circuit breaker limits this    |
+
+### Back-of-Envelope: Example 7 (50K FGs, 2K External Candidates)
+
+| Parameter                           | Value     | Notes                                                |
+|-------------------------------------|-----------|------------------------------------------------------|
+| FGs cleaned this cycle              | 500       | 1% of table                                          |
+| Stage 1: reads per FG               | ~6        | 3 retained + 3 expired slices                        |
+| Stage 1: total reads                | 3,000     | Parallelized across executors, ~20s                  |
+| External blob candidates            | 2,000     | Locally orphaned in cleaned FGs                      |
+| Avg refs per candidate              | 3         | Random assumption                                    |
+| Total record keys                   | 6,000     | 2,000 * 3                                            |
+| **Stage 2 cost (estimated)**        |           |                                                      |
+| Step 1: batched prefix scan         | 1 call    | Returns 6K record keys, ~2-5s estimated              |
+| Step 2: batched record index lookup | 1 call    | 6K keys sorted, single HFile scan, ~1-2s estimated   |
+| Step 3: in-memory resolution        | 6K checks | Hash set lookups against cleaned_fg_ids, ~0ms        |
+| **Total Stage 2**                   | **~3-7s** | Estimated; see I/O assumptions in Stage 2 cost model |
+| Comparison: naive full-table scan   | 12.5TB    | 50K FGs * 5 slices * 50MB = prohibitive              |
+
+### Memory Budget
+
+Per-FG blob ref sets: ~100MB peak (500K records * 100 bytes/ref for expired + retained). FGs are
+processed sequentially within each partition batch -- per-FG sets are computed and discarded, not
+accumulated. Only the output lists (`hudi_blob_deletes`, `external_candidates`) grow, containing
+only orphaned refs (much smaller). Peak heap: ~100MB * `cleanerParallelism` = 400MB-1.6GB.
+
+---
+
+## Configuration
+
+| Property                                           | Default | Description                                                                       |
+|----------------------------------------------------|---------|-----------------------------------------------------------------------------------|
+| `hoodie.cleaner.blob.enabled`                      | `true`  | Enable blob cleanup during clean action                                           |
+| `hoodie.cleaner.blob.dry.run`                      | `false` | Compute blob cleanup plan and log results but do not execute                      |
+| `hoodie.cleaner.blob.external.scan.parallelism`    | `10`    | Parallelism for Stage 2 fallback table scan                                       |
+| `hoodie.cleaner.blob.external.scan.max.candidates` | `1000`  | Circuit breaker for Stage 2 fallback scan; exceeding defers external blob cleanup |
+| `hoodie.metadata.index.secondary.column`           | (none)  | Set to `<blob_col>.reference.external_path` for Flow 2 cross-FG verification      |
+
+---
+
+## Rollout / Adoption Plan
+
+Each stage can be implemented, tested, and shipped independently once the foundation layer is in
+place (see [Independent Implementability](#independent-implementability)).
+
+**Foundation (shared prerequisite).** `CleanPlanner` refactoring (policy methods return
+`FileGroupCleanResult`), `BlobRef` type, schema changes (nullable `blobFilesToDelete` and
+`containersToCompact` fields), and the `hasBlobColumns` zero-cost gate.
+
+**Stage 1 (per-FG cleanup).** Set-difference logic and dispatch by blob category. Produces
+`hudi_blob_deletes` (immediate) and `external_candidates` (for Stage 2).
+
+**Stage 2 (cross-FG verification) -- priority.** Flow 2 (external blobs) is the primary initial
+use case -- cross-FG verification prevents premature deletion of shared blobs. Requires MDT +
+record index + secondary index on `reference.external_path` (P6). Includes fallback table scan
+with circuit breaker.
+
+**Stage 3 (container lifecycle).** Delete-entire-file vs. flag-for-compaction at the container
+level. Needed only when container files are used.
+
+**Writer-side conflict check.** `preCommit()` conflict check for Flow 2 concurrency safety.
+Closes the writer-cleaner race window. Independent of the three stages.
+
+### Backward Compatibility
+
+- All schema changes use nullable fields with null defaults. Existing clean plans and metadata
+  are unaffected.
+- `hasBlobColumns()` gate ensures zero behavioral change for non-blob tables.
+- One prerequisite code change: `HoodieSchema.containsBlobType()` visibility from package-private
+  to public (one-line change, no behavioral impact).
+
+---
+
+## Test Plan
+
+### Unit Tests
+
+- **Stage 1 set-difference:** Verify correct orphan identification for COW and MOR file groups,
+  including MOR over-retention (shadowed base refs kept until post-compaction).
+- **Stage 1 dispatch:** Verify Hudi-created blobs route to `hudi_blob_deletes` and external blobs
+  route to `external_candidates`.
+- **Stage 2 index lookup:** Verify short-circuit behavior (stop after first live reference), empty
+  results (globally orphaned), and batched prefix scans.
+- **Stage 2 fallback:** Verify table scan correctness and circuit breaker activation.
+- **Stage 3 container lifecycle:** Verify delete-all-dead vs. flag-for-compaction decisions.
+- **Writer-side conflict check:** Verify detection of conflicts with COMPLETED, INFLIGHT, and
+  REQUESTED clean actions.
+
+### Integration Tests
+
+- End-to-end clean cycle with Hudi-created blob table (COW and MOR).
+- End-to-end clean cycle with external blob table and MDT secondary index.
+- Clean cycle with replaced file groups (post-clustering).
+
+### Concurrency Tests
+
+- Writer-cleaner race scenarios A-D (from concurrency analysis) with external blobs.
+- Concurrent clean + compaction with blob tables.
+
+### Backward Compatibility
+
+- Non-blob table clean cycle produces identical behavior (no `blobFilesToDelete`, no
+  `blobCleanStats`).
+- Clean plan deserialization with and without blob fields (nullable field compatibility).
+
+---
+
+## Appendix
+
+- **[Problem Statement, Constraints & Requirements](rfc-100-blob-cleaner-problem.md)**
+  -- Complete problem scope, all 13 constraints (C1-C13), all 10 requirements (R1-R10), 8
+  illustrative failure mode examples, and open questions.

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -634,7 +634,7 @@ cleaning:
 |--------------------------|---------------------------------|----------------------------|--------------------------------|
 | Non-blob table           | Zero (`hasBlobColumns` gate)    | N/A                        | **Zero**                       |
 | Flow 1 (Hudi-created)    | ~6 Parquet reads per cleaned FG | Skipped                    | O(cleaned_FGs * slices_per_FG) |
-| Flow 2 (external, index) | ~6 Parquet reads per cleaned FG | O(candidates) amortized    | O(cleaned_FGs + candidates)    |
+| Flow 2 (external, index) | ~6 Parquet reads per cleaned FG | O(C * R_avg)               | O(cleaned_FGs + C * R_avg)     |
 | Flow 2 (external, scan)  | ~6 Parquet reads per cleaned FG | O(candidates * table_size) | Circuit breaker limits this    |
 
 ### Back-of-Envelope: Example 7 (50K FGs, 2K External Candidates)

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 
-# RFC-100 Part 2: Blob Cleanup for Unstructured Data
+# RFC-100 Part 2: External Blob Cleanup for Unstructured Data
 
 ## Proposers
 
@@ -23,7 +23,9 @@
 
 ## Approvers
 
-- (TBD)
+- @rahil-c
+- @vinothchandar
+- @yihua
 
 ## Status
 
@@ -35,15 +37,16 @@ Issue: <Link to GH feature issue>
 
 ## Abstract
 
-When Hudi cleans expired file slices, out-of-line blob files they reference may become orphaned --
-still consuming storage but unreachable by any query. This RFC extends the existing file slice
-cleaner to identify and delete these orphaned blob files safely and efficiently. The design uses a
-three-stage pipeline: (1) per-file-group set-difference to find locally-orphaned blobs, (2) an MDT
-secondary index lookup for cross-file-group verification of externally-referenced blobs, and (3)
-container file lifecycle resolution. For Hudi-created blobs, cleanup is essentially free -- structural
-path uniqueness eliminates cross-file-group concerns entirely. For user-provided external blobs,
-targeted index lookups scale with the number of candidates, not the table size. Tables without blob
-columns pay zero cost.
+When Hudi cleans expired file slices, external out-of-line blob files they reference may become
+orphaned -- still consuming storage but unreachable by any query. This RFC extends the existing file
+slice cleaner to identify and delete these orphaned blob files safely and efficiently. The design
+uses a two-stage pipeline: (1) per-file-group set-difference to find locally-orphaned blobs, and
+(2) cross-file-group verification via MDT secondary index lookup. Targeted index lookups scale with
+the number of candidates, not the table size. Tables without blob columns pay zero cost.
+
+This design focuses on **external blobs** -- the Phase 1 use case of RFC-100 where users have
+existing blob files in external storage (e.g., `s3://media-bucket/videos/`) and Hudi manages the
+*references* via the `BlobReference` schema, not the *storage layout*.
 
 ---
 
@@ -52,65 +55,54 @@ columns pay zero cost.
 ### Why Blob Cleanup Is Needed
 
 RFC-100 introduces out-of-line blob storage for unstructured data (images, video, documents). A
-record's `BlobReference` field points to an external blob file by `(path, offset, length)`. When
+record's `BlobReference` field points to an external blob file by `reference.external_path`. When
 the cleaner expires old file slices, the blob files they reference may no longer be needed -- but the
 existing cleaner has no concept of transitive references. It deletes file slices without considering
 the blob files they point to. Without blob cleanup, orphaned blobs accumulate indefinitely.
 
-### Two Blob Flows
+### External Blobs
 
-Blob cleanup must support two distinct entry flows with fundamentally different properties:
+Users have existing blob files in external storage (e.g., `s3://media-bucket/videos/`). Records
+reference these blobs directly by path. Hudi manages the *references*, not the *storage layout*.
+Cross-file-group sharing is common -- multiple records across different file groups can point to the
+same blob. Key properties:
 
-**Flow 1 -- Hudi-created blobs.** Blobs created by Hudi's write path, stored at
-`{table}/.hoodie/blobs/{partition}/{col}/{instant}/{blob_id}`. The commit instant in the path
-guarantees uniqueness (C11), and blobs are scoped to a single file group (P3). Cross-file-group
-sharing does not occur. This is the expected majority flow for Phase 3 workloads.
-
-**Flow 2 -- User-provided external blobs.** Users have existing blob files in external storage
-(e.g., `s3://media-bucket/videos/`). Records reference these blobs directly by path. Hudi manages
-the *references*, not the *storage layout*. Cross-file-group sharing is common -- multiple records
-across different file groups can point to the same blob. This is the expected primary flow for
-Phase 1 workloads.
-
-| Property                  | Flow 1 (Hudi-created)             | Flow 2 (External)                    |
-|---------------------------|-----------------------------------|--------------------------------------|
-| Path uniqueness           | Guaranteed (instant in path, C11) | Not guaranteed (user controls)       |
-| Cross-FG sharing          | Does not occur (FG-scoped)        | Common (multiple records, same blob) |
-| Writer/cleaner race       | Cannot occur (D2)                 | Can occur (D3)                       |
-| Per-FG cleanup sufficient | Yes                               | No -- cross-FG verification needed   |
+| Property                  | External blobs                               |
+|---------------------------|----------------------------------------------|
+| Path uniqueness           | Not guaranteed (user controls)               |
+| Cross-FG sharing          | Common (multiple records, same blob)         |
+| Writer/cleaner race       | Can occur (external paths outside MVCC)      |
+| Per-FG cleanup sufficient | No -- cross-FG verification needed           |
 
 ### Constraints and Requirements Reference
 
-Full descriptions and failure modes in [Appendix B](rfc-100-blob-cleaner-problem.md).
+Full descriptions and failure modes in [Problem Statement](rfc-100-blob-cleaner-problem.md).
 
-| ID  | Constraint                                      | Flow 1 | Flow 2 | Remarks                      |
-|-----|-------------------------------------------------|--------|--------|------------------------------|
-| C1  | Blob immutability (append-once, read-many)      | Y      | Y      |                              |
-| C2  | Delete-and-re-add same path                     | --     | Y      | Eliminated for Flow 1 by C11 |
-| C3  | Cross-file-group blob sharing                   | --     | Y      | Common for external blobs    |
-| C4  | Container files (`(offset, length)` ranges)     | Y      | Y      |                              |
-| C5  | MOR log updates shadow base file blob refs      | Y      | Y      |                              |
-| C6  | Existing cleaner is per-file-group scoped       | Y      | Y      |                              |
-| C7  | OCC is per-file-group                           | Y      | Y      | No global contention allowed |
-| C8  | Clustering moves blob refs between file groups  | Y      | Y      |                              |
-| C9  | Savepoints freeze file slices and blob refs     | Y      | Y      |                              |
-| C10 | Rollback can invalidate or resurrect references | Y      | Y      |                              |
-| C11 | Blob paths include commit instant               | Y      | --     | Eliminates C2, C3, C13       |
-| C12 | Archival removes commit metadata                | Y      | Y      |                              |
-| C13 | Cross-FG verification needed at scale           | --     | Y      |                              |
+| ID  | Constraint                                          | Remarks                          |
+|-----|-----------------------------------------------------|----------------------------------|
+| C1  | Blob immutability (append-once, read-many)          |                                  |
+| C2  | Delete-and-re-add same path                         | Real concern for external blobs  |
+| C3  | Cross-file-group blob sharing                       | Common for external blobs        |
+| C4  | MOR log updates shadow base file blob refs          |                                  |
+| C5  | Existing cleaner is per-file-group scoped           |                                  |
+| C6  | OCC is per-file-group                               | No global contention allowed     |
+| C7  | Replace commits move blob refs between file groups  | Clustering, insert_overwrite     |
+| C8  | Savepoints freeze file slices and blob refs         |                                  |
+| C9  | Rollback and restore can invalidate or resurrect    |                                  |
+| C10 | Archival removes commit metadata                    |                                  |
+| C11 | Cross-FG verification needed at scale               |                                  |
 
 | ID  | Requirement                                                      |
 |-----|------------------------------------------------------------------|
 | R1  | No premature deletion (hard invariant)                           |
 | R2  | No permanent orphans (bounded cleanup)                           |
-| R3  | Container awareness (range-level liveness)                       |
-| R4  | MOR correctness (over-retention acceptable, under-retention not) |
-| R5  | Concurrency safety (no global serialization)                     |
-| R6  | Scale proportional to work, not table size                       |
-| R7  | No cost for non-blob tables                                      |
-| R8  | All cleaning policies supported                                  |
-| R9  | Crash safety and idempotency                                     |
-| R10 | Observability (metrics for deleted, retained, reclaimed)         |
+| R3  | MOR correctness (over-retention acceptable, under-retention not) |
+| R4  | Concurrency safety (no global serialization)                     |
+| R5  | Scale proportional to work, not table size                       |
+| R6  | No cost for non-blob tables                                      |
+| R7  | All cleaning policies supported                                  |
+| R8  | Crash safety and idempotency                                     |
+| R9  | Observability (metrics for deleted, retained, reclaimed)         |
 
 ---
 
@@ -120,46 +112,28 @@ Full descriptions and failure modes in [Appendix B](rfc-100-blob-cleaner-problem
 
 Blob cleanup extends the existing `CleanPlanner` / `CleanActionExecutor` pipeline -- same timeline
 instant, same plan-execute-complete lifecycle, same crash recovery and OCC integration. A
-`hasBlobColumns()` check gates all blob logic so non-blob tables pay zero cost.
+`hasBlobColumns()` check gates all blob logic so non-blob tables pay near zero cost (schema scan 
+cost).
 
-The two flows have different cost structures, and the design keeps them separate. Flow 1
-(Hudi-created blobs) gets per-FG cleanup with no cross-FG overhead. Flow 2 (external blobs) gets
-targeted cross-FG verification via MDT secondary index. Dispatch is a string prefix check on the
-blob path.
+External blobs require cross-file-group verification because the same blob can be referenced from
+multiple file groups (C3, C11). The design uses targeted MDT secondary index lookups that scale
+with the number of candidates, not the table size.
 
-### Three-Stage Pipeline
+### Two-Stage Pipeline
 
-| Stage       | Scope                | Purpose                                                                          | When it runs                           |
-|-------------|----------------------|----------------------------------------------------------------------------------|----------------------------------------|
-| **Stage 1** | Per-file-group       | Collect expired/retained blob refs, compute set difference, dispatch by category | Always (for blob tables)               |
-| **Stage 2** | Cross-file-group     | Verify external blob candidates against MDT secondary index or fallback scan     | Only when external candidates exist    |
-| **Stage 3** | Container resolution | Determine delete vs. flag-for-compaction at the container level                  | Only when container blobs are involved |
-
-### Independent Implementability
-
-The three stages have clean input/output interfaces and can be implemented, tested, and shipped
-independently:
-
-| Stage   | Input                                                   | Output                                              |
-|---------|---------------------------------------------------------|-----------------------------------------------------|
-| Stage 1 | `FileGroupCleanResult` (expired + retained slices)      | `hudi_blob_deletes`, `external_candidates`          |
-| Stage 2 | `external_candidates`, `cleaned_fg_ids`                 | `external_deletes`                                  |
-| Stage 3 | `hudi_blob_deletes` + `external_deletes`, retained refs | `blob_files_to_delete`, `containers_for_compaction` |
-
-A shared foundation layer must land first (see [Rollout / Adoption Plan](#rollout--adoption-plan)), after which stages
-can proceed in any order.
+| Stage       | Scope            | Purpose                                                              | When it runs                 |
+|-------------|------------------|----------------------------------------------------------------------|------------------------------|
+| **Stage 1** | Per-file-group   | Collect expired/retained blob refs, compute set difference           | Always (for blob tables)     |
+| **Stage 2** | Cross-file-group | Verify candidates against MDT secondary index or fallback scan       | When local orphans exist     |
 
 ### Key Decisions
 
-| Decision            | Choice                                                  | Rationale                                                          |
-|---------------------|---------------------------------------------------------|--------------------------------------------------------------------|
-| Blob identity       | `(path, offset, length)` tuple                          | Handles containers (C4) and path reuse (C2) correctly              |
-| Cleanup scope       | Per-FG (Hudi blobs) + MDT index lookup (external blobs) | Aligns with OCC (C7) and existing cleaner (C6); scales for C13     |
-| Dispatch mechanism  | Path prefix check on blob path                          | Zero-cost classification; Hudi blobs match `.hoodie/blobs/` prefix |
-| Cross-FG mechanism  | MDT secondary index on `reference.external_path`        | Short-circuits on first non-cleaned FG ref; first-class for Flow 2 |
-| Write-path overhead | None (Flow 1); MDT index maintenance (Flow 2)           | Index maintained by existing MDT pipeline, not a new write cost    |
-| MOR strategy        | Over-retain (union of base + log refs)                  | Safe (C5, R4); cleaned after compaction                            |
-| Container strategy  | Tuple-level tracking; delete only when all ranges dead  | Correct (C4, R3); partial containers flagged for blob compaction   |
+| Decision            | Choice                                                  | Rationale                                                      |
+|---------------------|---------------------------------------------------------|----------------------------------------------------------------|
+| Blob identity       | `reference.external_path`                               | Path-based identity for external blobs                         |
+| Cleanup scope       | Per-FG candidate identification + cross-FG verification | Aligns with OCC (C6) and existing cleaner (C5); scales for C11 |
+| Cross-FG mechanism  | MDT secondary index on `reference.external_path`        | Short-circuits on first non-cleaned FG ref                     |
+| MOR strategy        | Over-retain (union of base + log refs)                  | Safe (C4, R3); cleaned after compaction                        |
 
 ```mermaid
 flowchart LR
@@ -172,35 +146,29 @@ flowchart LR
         subgraph CP["CleanPlanner (per-partition, per-FG)"]
             direction TB
             Policy["Policy method<br/>→ FileGroupCleanResult<br/>(expired + retained slices)"]
-            S1["<b>Stage 1</b><br/>Per-FG blob ref<br/>set difference + dispatch"]
+            S1["<b>Stage 1</b><br/>Per-FG blob ref<br/>set difference"]
             Policy --> S1
         end
 
         S1 --> S2["<b>Stage 2</b><br/>Cross-FG verification<br/>(MDT secondary index)"]
-        S1 -->|hudi_blob_deletes| S3
-        S2 -->|external_deletes| S3["<b>Stage 3</b><br/>Container lifecycle<br/>resolution"]
     end
 
     subgraph Plan["HoodieCleanerPlan"]
         FP["filePathsToBeDeleted<br/>(existing)"]
         BP["blobFilesToDelete<br/>(new)"]
-        CC["containersToCompact<br/>(new)"]
     end
 
-    S3 --> BP
-    S3 --> CC
+    S2 --> BP
     CP --> FP
 
     subgraph Execution["CleanActionExecutor.runClean()"]
         direction TB
         DF["Delete file slices<br/>(existing, parallel)"]
         DB["Delete blob files<br/>(new, parallel)"]
-        RC["Record containers<br/>for blob compaction"]
     end
 
     FP --> DF
     BP --> DB
-    CC --> RC
 ```
 
 ---
@@ -211,26 +179,25 @@ flowchart LR
 
 Stage 1 runs after the existing policy logic determines which file slices are expired and retained
 for a given file group. It collects blob refs from both sets and computes locally-orphaned blobs by
-set difference.
+set difference. All local orphans proceed to Stage 2 for cross-FG verification.
 
 ```
 Input:  A file group FG with expired_slices and retained_slices (from policy)
-Output: hudi_blob_deletes     -- blobs safe to delete immediately
-        external_candidates   -- external blobs needing cross-FG verification
+Output: local_orphan_candidates -- external blobs needing cross-FG verification
 
 for each file_group being cleaned:
 
     // Collect expired blob refs (base files + log files)
     // Must read log files: blob refs introduced and superseded within the log
     // chain before compaction would otherwise become permanent orphans.
-    expired_refs = Set<(path, offset, length)>()
+    expired_refs = Set<external_path>()
     for slice in expired_slices:
         for ref in extractBlobRefs(slice.baseFile):   // columnar projection
             if ref.type == OUT_OF_LINE and ref.managed == true:
-                expired_refs.add((ref.path, ref.offset, ref.length))
+                expired_refs.add(ref.external_path)
         for ref in extractBlobRefs(slice.logFiles):   // full record read
             if ref.type == OUT_OF_LINE and ref.managed == true:
-                expired_refs.add((ref.path, ref.offset, ref.length))
+                expired_refs.add(ref.external_path)
 
     if expired_refs is empty:
         continue                                       // no blob work for this FG
@@ -239,52 +206,47 @@ for each file_group being cleaned:
     // Cleaning is fenced on compaction: retained base files contain the merged
     // state. Log reads are unnecessary -- any shadowed base ref causes safe
     // over-retention, cleaned after the next compaction cycle.
-    retained_refs = Set<(path, offset, length)>()
+    retained_refs = Set<external_path>()
     for slice in retained_slices:
         for ref in extractBlobRefs(slice.baseFile):   // columnar projection only
             if ref.type == OUT_OF_LINE and ref.managed == true:
-                retained_refs.add((ref.path, ref.offset, ref.length))
+                retained_refs.add(ref.external_path)
 
     // Compute local orphans by set difference
     local_orphans = expired_refs - retained_refs
 
-    // Dispatch by blob category
-    for ref in local_orphans:
-        if ref.path starts with TABLE_PATH + "/.hoodie/blobs/":
-            hudi_blob_deletes.add(ref)             // P3: no cross-FG refs possible
-        else:
-            external_candidates.add(ref)           // C13: cross-FG refs are common
+    // All local orphans proceed to Stage 2 for cross-FG verification
+    all_local_orphans.addAll(local_orphans)
 ```
 
 **Correctness notes:**
 
-- **Hudi-created blobs:** If a blob ref appears in expired but not retained slices of the same FG,
-  it is globally orphaned -- Hudi blobs are FG-scoped (C11), so no cross-FG check is needed.
 - **MOR -- expired side reads base + logs:** Blob refs can be introduced and superseded entirely
-  within the log chain (e.g., `log@t2: row1→blob_B`, then `log@t3: row1→blob_C`). After
+  within the log chain (e.g., `log@t2: row1->blob_B`, then `log@t3: row1->blob_C`). After
   compaction, `blob_B` exists only in the expired log. Skipping logs would orphan it permanently.
 - **MOR -- retained side reads base only:** Cleaning is fenced on compaction, so retained base
   files contain the merged state. Shadowed base refs cause over-retention (safe), cleaned after
   the next compaction.
 - **Savepoints:** Inherited from existing cleaner -- savepointed slices stay in the retained set.
-- **Replaced FGs (clustering):** `retained_slices` is empty, so all blob refs become candidates.
-  Hudi blobs are safe to delete (clustering creates new blobs in the target FG). External blobs
-  flow to Stage 2 (clustering copies the pointer, so Stage 2 finds it in the target FG).
+- **Replaced FGs (replace commits):** `retained_slices` is empty, so all blob refs become
+  candidates. For external blobs, clustering copies the pointer to the target FG, so Stage 2
+  finds the reference in the target FG and retains the blob.
 
-### Stage 2: Cross-FG Verification (External Blobs)
+### Stage 2: Cross-File-Group Verification
 
-Stage 2 executes only when `external_candidates` is non-empty. For Flow 1 workloads (Hudi-created
-blobs only), this stage is skipped entirely.
+Stage 2 verifies each local orphan candidate against the global state to determine if the blob is
+still referenced by any active file slice outside the cleaned file groups. This is necessary because
+external blobs can be shared across file groups (C3, C11).
 
 #### Primary path: MDT secondary index
 
 When the MDT secondary index on `reference.external_path` is available and fully built:
 
 ```
-Input:  external_candidates, cleaned_fg_ids
-Output: external_deletes (confirmed globally orphaned)
+Input:  all_local_orphans, cleaned_fg_ids
+Output: blob_files_to_delete (confirmed globally orphaned)
 
-candidate_paths = external_candidates.map(ref -> ref.path).distinct()
+candidate_paths = all_local_orphans.distinct()
 
 // Step 1: Batched prefix scan on secondary index
 // Key format: escaped(external_path)$escaped(record_key)
@@ -307,7 +269,7 @@ for path in candidate_paths:
     record_keys = path_to_record_keys.getOrDefault(path, [])
 
     if record_keys is empty:
-        external_deletes.addAll(candidates for this path)  // globally orphaned
+        blob_files_to_delete.add(path)                  // globally orphaned
         continue
 
     found_live_reference = false
@@ -315,10 +277,10 @@ for path in candidate_paths:
         location = all_locations.get(rk)
         if location != null and location.fileId NOT in cleaned_fg_ids:
             found_live_reference = true
-            break                                           // short-circuit (in-memory)
+            break                                       // short-circuit (in-memory)
 
     if not found_live_reference:
-        external_deletes.addAll(candidates for this path)   // all refs in cleaned FGs
+        blob_files_to_delete.add(path)                  // all refs in cleaned FGs
 ```
 
 **Cost model.** Three steps: (1) batched prefix scan on secondary index, (2) batched record index
@@ -332,10 +294,7 @@ are each a single I/O pass; step 3 is pure hash set lookups.
 | 3. In-memory resolution   | Hash set checks (cleaned_fg_ids)              | ~0ms                           |
 
 *Estimates assume cloud object storage (S3/GCS/ADLS), ~10-100ms per-read latency, ~50-200 MB/s
-sequential throughput, 64-256KB HFile blocks. Step 1: a 250K-entry secondary index is ~50MB; a
-sorted scan for 2K prefixes reads ~200-500 blocks, dominated by HFile open (~100-200ms) plus
-sequential block reads with cold-cache latency overhead. Step 2: similar profile, fewer blocks
-hit relative to index size. Pending benchmarking.*
+sequential throughput, 64-256KB HFile blocks. Pending benchmarking.*
 
 **Index definition.** Uses the existing `HoodieIndexDefinition` mechanism with
 `sourceFields = ["<blob_col>", "reference", "external_path"]`. The nested field path is supported
@@ -355,12 +314,12 @@ a bottleneck on large tables. The operator is warned to enable the MDT secondary
 
 #### Decision matrix
 
-| Condition                   | Path used     | Cost                  | Suitable for                   |
-|-----------------------------|---------------|-----------------------|--------------------------------|
-| No external candidates      | Skip Stage 2  | Zero                  | Flow 1 workloads               |
-| MDT secondary index enabled | Index lookup  | O(candidates)         | Flow 2 at any scale            |
-| No index, few candidates    | Table scan    | O(candidates * table) | Small tables, few shared blobs |
-| No index, many candidates   | Circuit break | Zero (deferred)       | Large tables -- index required |
+| Condition                   | Path used     | Cost                  | Suitable for              |
+|-----------------------------|---------------|-----------------------|---------------------------|
+| No local orphan candidates  | Skip Stage 2  | Zero                  | No blob work this cycle   |
+| MDT secondary index enabled | Index lookup  | O(candidates)         | Any scale                 |
+| No index, few candidates    | Table scan    | O(candidates * table) | Small tables              |
+| No index, many candidates   | Circuit break | Zero (deferred)       | Large tables need index   |
 
 ```mermaid
 sequenceDiagram
@@ -393,51 +352,23 @@ sequenceDiagram
     end
 ```
 
-### Stage 3: Container File Lifecycle
-
-Container files pack multiple blobs at different `(offset, length)` ranges. A container can only be
-deleted when *all* ranges within it are unreferenced.
-
-```
-all_deletes = hudi_blob_deletes + external_deletes
-
-// Non-container blobs: each occupies an entire file -> delete directly
-for ref in all_deletes where ref.offset is null:
-    blob_files_to_delete.add(ref.path)
-
-// Container blobs: group by path, check for remaining live ranges
-for each container_path in container_range_deletes grouped by path:
-    dead_ranges = ranges being deleted for this container
-    live_ranges = retained refs (from Stage 1) + referenced refs (from Stage 2)
-
-    if live_ranges is empty:
-        blob_files_to_delete.add(container_path)           // entire container dead
-    else:
-        containers_for_compaction.add(container_path, dead_ranges)  // partial -> repack
-```
-
-For Hudi-created containers, all ranges belong to the same FG (instant in path scopes it to a
-single write), so retained refs from Stage 1 are sufficient -- no cross-FG check needed.
-
 ### Execution Flow
 
 ```
 1. CleanPlanActionExecutor.requestClean()
-   ├── hasBlobColumns(table)?                         // R7: zero-cost gate
+   ├── hasBlobColumns(table)?                         // R6: zero-cost gate
    ├── CleanPlanner: for each partition, for each file group:
    │     ├── Refactored policy method -> FileGroupCleanResult
    │     └── If hasBlobColumns: Stage 1 per FG
    ├── CleanPlanner: replaced file groups -> Stage 1
-   ├── If external_candidates non-empty: Stage 2
-   ├── Stage 3: container lifecycle resolution
-   ├── Build HoodieCleanerPlan (+ blobFilesToDelete, containersToCompact)
+   ├── If local orphan candidates non-empty: Stage 2
+   ├── Build HoodieCleanerPlan (+ blobFilesToDelete)
    └── Persist plan to timeline (REQUESTED state)
 
 2. CleanActionExecutor.runClean()
    ├── Transition to INFLIGHT
    ├── Delete file slices (existing, parallelized)
    ├── Delete blob files (new, same parallelized pattern)
-   ├── Record containers for blob compaction (metadata only)
    ├── Build HoodieCleanMetadata with blobCleanStats
    └── Transition to COMPLETED
 ```
@@ -452,8 +383,7 @@ sequenceDiagram
     Note over P: requestClean()
 
     P->>P: Stage 1: per-FG blob ref set difference
-    P->>P: Stage 2: MDT index lookup (if external candidates)
-    P->>P: Stage 3: container lifecycle resolution
+    P->>P: Stage 2: MDT index lookup (if candidates exist)
     P->>TL: Persist HoodieCleanerPlan
 
     Note over TL: REQUESTED
@@ -511,25 +441,23 @@ expired/retained classification logic.
 
 ### Replaced File Group Handling
 
-Replaced file groups (from clustering) are cleaned via `getReplacedFilesEligibleToClean()`. A
-parallel method `getReplacedFileGroupBlobCleanResults()` produces `FileGroupCleanResult` objects
-with `retainedSlices = empty` and `expiredSlices = all slices`. This feeds into Stage 1 identically
-to normal file groups.
+Replaced file groups (from clustering, insert_overwrite, insert_overwrite_table) are cleaned via
+`getReplacedFilesEligibleToClean()`. A parallel method `getReplacedFileGroupBlobCleanResults()`
+produces `FileGroupCleanResult` objects with `retainedSlices = empty` and
+`expiredSlices = all slices`. This feeds into Stage 1 identically to normal file groups.
 
 ### Schema Changes: HoodieCleanerPlan
 
-Two new nullable fields with null defaults (backward compatible):
+One new nullable field with null default (backward compatible):
 
-- **`blobFilesToDelete`**: `List<HoodieCleanBlobFileInfo>` -- blob files where all ranges are dead.
-  The executor deletes these.
-- **`containersToCompact`**: `List<HoodieCleanContainerInfo>` -- containers with mixed live/dead
-  ranges, including the dead `(offset, length)` ranges. Handed to the blob compaction service.
+- **`blobFilesToDelete`**: `List<HoodieCleanBlobFileInfo>` -- external blob files confirmed as
+  globally orphaned. The executor deletes these.
 
 ### Schema Changes: HoodieCleanMetadata
 
 A new nullable field `blobCleanStats` of type `HoodieBlobCleanStats`:
 
-- `totalBlobFilesDeleted`, `totalBlobFilesRetained`, `totalContainersFlaggedForCompaction`
+- `totalBlobFilesDeleted`, `totalBlobFilesRetained`
 - `totalBlobStorageReclaimed`
 - `deletedBlobFilePaths`, `failedBlobFilePaths`
 
@@ -542,27 +470,26 @@ blob cleanup logic. Requires making `containsBlobType()` public (one-line visibi
 
 ## Concurrency & Safety
 
-### Writer-Cleaner Race: Two-Sided Guard
+### Writer-Cleaner Race: Conflict Check
 
-**Hudi-created blobs (Flow 1): structurally impossible.** A new write creates new blob files with a
-new instant in the path (C11). An UPSERT carries forward blob refs from retained slices (already
-live). There is no mechanism for a writer to reference a Hudi-created blob that exists only in
-expired slices. No writer-side check is needed for Flow 1.
+Under Hudi's MVCC design, the cleaner and writers operate on non-overlapping file slices -- the
+cleaner never conflicts with writers on file slice operations. However, external blob files are
+**not** covered by MVCC: a writer's new file slice may reference an external blob that the cleaner
+is simultaneously evaluating for deletion.
 
-**External blobs (Flow 2): writer-side conflict check in `preCommit()`.** The gap between the
-cleaner's planning-time snapshot and its actual file deletion is closed by a commit-time conflict
-check:
+**Writer-side conflict check in `preCommit()`.** The gap between the cleaner's planning-time
+snapshot and its actual file deletion is closed by a commit-time conflict check:
 
 1. Writers track external managed blob paths in `HoodieWriteStat.externalBlobPaths` (in-memory
    collection, no additional I/O).
 2. At commit time (in `preCommit()`, under the existing transaction lock), the writer checks all
    three clean states -- COMPLETED, INFLIGHT, and REQUESTED -- because a REQUESTED plan can begin
-   executing at any moment (the REQUESTED→INFLIGHT transition doesn't acquire the transaction
+   executing at any moment (the REQUESTED->INFLIGHT transition doesn't acquire the transaction
    lock). It checks `deletedBlobFilePaths` (COMPLETED) and `blobFilesToDelete` (INFLIGHT/REQUESTED).
 3. If any overlap is found, the commit is rejected with `HoodieWriteConflictException` and the
    writer retries.
 
-Cost is zero for non-blob tables and Flow 1. For Flow 2: one timeline scan + 1-3 metadata reads.
+Cost is zero for non-blob tables. For external blobs: one timeline scan + 1-3 metadata reads.
 
 ```mermaid
 sequenceDiagram
@@ -605,14 +532,14 @@ sequenceDiagram
 
 | Operation                      | Concurrent with Blob Cleaner | Safety Mechanism                                          |
 |--------------------------------|------------------------------|-----------------------------------------------------------|
-| Regular write (INSERT/UPSERT)  | Safe                         | C11 path uniqueness (Flow 1); writer-side check (Flow 2)  |
+| Regular write (INSERT/UPSERT)  | Safe                         | Writer-side conflict check in preCommit()                 |
 | Compaction                     | Safe                         | `isFileSliceNeededForPendingMajorOrMinorCompaction`       |
-| Clustering                     | Safe                         | Replaced FG lifecycle; Stage 2 for external blobs         |
+| Clustering / insert_overwrite  | Safe                         | Replaced FG lifecycle; Stage 2 finds refs in target FG    |
 | Rollback                       | Safe                         | MOR over-retention; clean operates on post-rollback state |
-| Savepoint create/delete        | Safe                         | `isFileSliceExistInSavepointedFiles`                      |
+| Restore                        | Safe                         | Clean operates on post-restore state                      |
+| Savepoint create/delete        | Safe                         | Savepointed slices excluded from cleaning                 |
 | Archival                       | No interaction               | Blob cleaner reads file slices, not commit metadata       |
 | Another cleaner instance       | Safe                         | `TransactionManager`; `checkIfOtherWriterCommitted`       |
-| Blob compaction                | Safe                         | Independent lifecycle                                     |
 | MDT writes (index maintenance) | Safe                         | MDT commit atomicity                                      |
 
 ### Crash Recovery
@@ -624,7 +551,7 @@ cleaning:
 |-----------------------------------------|--------------------------------------------------------------------------------------------------------|
 | During planning (before plan persisted) | No REQUESTED instant on timeline. Cleaner starts fresh.                                                |
 | After plan persisted, before execution  | REQUESTED instant found; plan re-read and executed.                                                    |
-| During execution (partial deletes)      | INFLIGHT instant re-executed. Already-deleted files return FileNotFoundException → treated as success. |
+| During execution (partial deletes)      | INFLIGHT instant re-executed. Already-deleted files return FileNotFoundException -> treated as success. |
 | After execution, before COMPLETED       | INFLIGHT re-executed. All deletes are no-ops. Metadata written, instant transitions to COMPLETED.      |
 
 ---
@@ -633,14 +560,13 @@ cleaning:
 
 ### Cost Summary
 
-| Workload                 | Stage 1 cost                    | Stage 2 cost               | Total per cleanup cycle        |
-|--------------------------|---------------------------------|----------------------------|--------------------------------|
-| Non-blob table           | Zero (`hasBlobColumns` gate)    | N/A                        | **Zero**                       |
-| Flow 1 (Hudi-created)    | ~6 Parquet reads per cleaned FG | Skipped                    | O(cleaned_FGs * slices_per_FG) |
-| Flow 2 (external, index) | ~6 Parquet reads per cleaned FG | O(C * R_avg)               | O(cleaned_FGs + C * R_avg)     |
-| Flow 2 (external, scan)  | ~6 Parquet reads per cleaned FG | O(candidates * table_size) | Circuit breaker limits this    |
+| Workload                     | Stage 1 cost                    | Stage 2 cost               | Total per cleanup cycle        |
+|------------------------------|---------------------------------|----------------------------|--------------------------------|
+| Non-blob table               | Zero (`hasBlobColumns` gate)    | N/A                        | **Zero**                       |
+| External blobs (index)       | ~6 Parquet reads per cleaned FG | O(C * R_avg)               | O(cleaned_FGs + C * R_avg)     |
+| External blobs (scan)        | ~6 Parquet reads per cleaned FG | O(candidates * table_size) | Circuit breaker limits this    |
 
-### Back-of-Envelope: Example 7 (50K FGs, 2K External Candidates)
+### Back-of-Envelope: Example 6 (50K FGs, 2K External Candidates)
 
 | Parameter                           | Value     | Notes                                                |
 |-------------------------------------|-----------|------------------------------------------------------|
@@ -677,33 +603,25 @@ contribute row-level blob refs as candidates. These are backed by engine-context
 | `hoodie.cleaner.blob.enabled`                      | `true`  | Enable blob cleanup during clean action                                           |
 | `hoodie.cleaner.blob.dry.run`                      | `false` | Compute blob cleanup plan and log results but do not execute                      |
 | `hoodie.cleaner.blob.external.scan.parallelism`    | `10`    | Parallelism for Stage 2 fallback table scan                                       |
-| `hoodie.cleaner.blob.external.scan.max.candidates` | `1000`  | Circuit breaker for Stage 2 fallback scan; exceeding defers external blob cleanup |
-| `hoodie.metadata.index.secondary.column`           | (none)  | Set to `<blob_col>.reference.external_path` for Flow 2 cross-FG verification      |
+| `hoodie.cleaner.blob.external.scan.max.candidates` | `1000`  | Circuit breaker for Stage 2 fallback scan; exceeding defers blob cleanup          |
+| `hoodie.metadata.index.secondary.column`           | (none)  | Set to `<blob_col>.reference.external_path` for cross-FG verification             |
 
 ---
 
 ## Rollout / Adoption Plan
 
-Each stage can be implemented, tested, and shipped independently once the foundation layer is in
-place (see [Independent Implementability](#independent-implementability)).
-
 **Foundation (shared prerequisite).** `CleanPlanner` refactoring (policy methods return
-`FileGroupCleanResult`), `BlobRef` type, schema changes (nullable `blobFilesToDelete` and
-`containersToCompact` fields), and the `hasBlobColumns` zero-cost gate.
+`FileGroupCleanResult`), schema changes (nullable `blobFilesToDelete` field), and the
+`hasBlobColumns` zero-cost gate.
 
-**Stage 1 (per-FG cleanup).** Set-difference logic and dispatch by blob category. Produces
-`hudi_blob_deletes` (immediate) and `external_candidates` (for Stage 2).
+**Stage 1 (per-FG cleanup).** Set-difference logic. Produces local orphan candidates for Stage 2.
 
-**Stage 2 (cross-FG verification) -- priority.** Flow 2 (external blobs) is the primary initial
-use case -- cross-FG verification prevents premature deletion of shared blobs. Requires MDT +
-record index + secondary index on `reference.external_path` (P6). Includes fallback table scan
-with circuit breaker.
+**Stage 2 (cross-FG verification) -- priority.** External blobs are the primary initial use case --
+cross-FG verification prevents premature deletion of shared blobs. Requires MDT + record index +
+secondary index on `reference.external_path`. Includes fallback table scan with circuit breaker.
 
-**Stage 3 (container lifecycle).** Delete-entire-file vs. flag-for-compaction at the container
-level. Needed only when container files are used.
-
-**Writer-side conflict check.** `preCommit()` conflict check for Flow 2 concurrency safety.
-Closes the writer-cleaner race window. Independent of the three stages.
+**Writer-side conflict check.** `preCommit()` conflict check for concurrency safety. Closes the
+writer-cleaner race window. Independent of the two stages.
 
 ### Backward Compatibility
 
@@ -721,20 +639,16 @@ Closes the writer-cleaner race window. Independent of the three stages.
 
 - **Stage 1 set-difference:** Verify correct orphan identification for COW and MOR file groups,
   including MOR over-retention (shadowed base refs kept until post-compaction).
-- **Stage 1 dispatch:** Verify Hudi-created blobs route to `hudi_blob_deletes` and external blobs
-  route to `external_candidates`.
 - **Stage 2 index lookup:** Verify short-circuit behavior (stop after first live reference), empty
   results (globally orphaned), and batched prefix scans.
 - **Stage 2 fallback:** Verify table scan correctness and circuit breaker activation.
-- **Stage 3 container lifecycle:** Verify delete-all-dead vs. flag-for-compaction decisions.
 - **Writer-side conflict check:** Verify detection of conflicts with COMPLETED, INFLIGHT, and
   REQUESTED clean actions.
 
 ### Integration Tests
 
-- End-to-end clean cycle with Hudi-created blob table (COW and MOR).
-- End-to-end clean cycle with external blob table and MDT secondary index.
-- Clean cycle with replaced file groups (post-clustering).
+- End-to-end clean cycle with external blob table and MDT secondary index (COW and MOR).
+- Clean cycle with replaced file groups (post-clustering, post-insert_overwrite).
 
 ### Concurrency Tests
 
@@ -752,7 +666,7 @@ Closes the writer-cleaner race window. Independent of the three stages.
 ## Appendix
 
 - **[Problem Statement, Constraints & Requirements](rfc-100-blob-cleaner-problem.md)**
-  -- Complete problem scope, all 13 constraints (C1-C13), all 10 requirements (R1-R10), 8
+  -- Complete problem scope, all 11 constraints (C1-C11), all 9 requirements (R1-R9), 7
   illustrative failure mode examples, and open questions.
 
 ### Why the MDT Secondary Index Maps to Record Keys (Not File Groups)

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -289,15 +289,18 @@ candidate_paths = external_candidates.map(ref -> ref.path).distinct()
 // Step 1: Batched prefix scan on secondary index
 // Key format: escaped(external_path)$escaped(record_key)
 // Returns ALL record keys that reference each candidate path
+// Uses engine-context HoodieData (e.g., RDD on Spark) to distribute work
+// across executors -- candidate sets can be large (row-level blob refs).
+candidate_paths_data = engineContext.parallelize(candidate_paths)
 path_to_record_keys = mdtMetadata.readSecondaryIndexDataTableRecordKeysWithKeys(
-    HoodieListData.eager(candidate_paths), indexPartitionName)
+    candidate_paths_data, indexPartitionName)
     .groupBy(pair -> pair.getKey())
 
 // Step 2: Batch record index lookup -- ONE call for ALL record keys
 // Sorts keys internally, single sequential forward-scan through HFile.
 all_record_keys = path_to_record_keys.values().flatMap()
 all_locations = mdtMetadata.readRecordIndexLocations(
-    HoodieListData.eager(all_record_keys))             // -> Map<recordKey, (partition, fileId)>
+    all_record_keys)                                    // -> Map<recordKey, (partition, fileId)>
 
 // Step 3: In-memory resolution with short-circuit per candidate
 for path in candidate_paths:
@@ -659,7 +662,11 @@ cleaning:
 Per-FG blob ref sets: ~100MB peak (500K records * 100 bytes/ref for expired + retained). FGs are
 processed sequentially within each partition batch -- per-FG sets are computed and discarded, not
 accumulated. Only the output lists (`hudi_blob_deletes`, `external_candidates`) grow, containing
-only orphaned refs (much smaller). Peak heap: ~100MB * `cleanerParallelism` = 400MB-1.6GB.
+only orphaned refs (much smaller). Peak heap for Stage 1: ~100MB * `cleanerParallelism` = 400MB-1.6GB.
+
+Stage 2 output lists (`candidate_paths`, `all_record_keys`) can be large -- each cleaned FG may
+contribute row-level blob refs as candidates. These are backed by engine-context `HoodieData`
+(e.g., Spark RDD) and distributed across executors, avoiding driver memory pressure.
 
 ---
 

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -133,6 +133,7 @@ with the number of candidates, not the table size.
 | Blob identity       | `reference.external_path`                               | Path-based identity for external blobs                         |
 | Cleanup scope       | Per-FG candidate identification + cross-FG verification | Aligns with OCC (C6) and existing cleaner (C5); scales for C11 |
 | Cross-FG mechanism  | MDT secondary index on `reference.external_path`        | Short-circuits on first non-cleaned FG ref                     |
+| Blob delete storage | Sidecar Parquet file (`.hoodie/.aux/clean/`)             | Avoids plan bloat; durable artifact for writer conflict checks |
 | MOR strategy        | Over-retain (union of base + log refs)                  | Safe (C4, R3); cleaned after compaction                        |
 
 ```mermaid
@@ -151,24 +152,27 @@ flowchart LR
         end
 
         S1 --> S2["<b>Stage 2</b><br/>Cross-FG verification<br/>(MDT secondary index)"]
+        S2 --> SC["Write sidecar Parquet<br/>.hoodie/.aux/clean/&lt;instant&gt;<br/>.blob_deletes.parquet"]
     end
 
     subgraph Plan["HoodieCleanerPlan"]
         FP["filePathsToBeDeleted<br/>(existing)"]
-        BP["blobFilesToDelete<br/>(new)"]
+        EM["extraMetadata[blobDeletesPath]<br/>(pointer to sidecar)"]
     end
 
-    S2 --> BP
+    SC --> EM
     CP --> FP
 
     subgraph Execution["CleanActionExecutor.runClean()"]
         direction TB
+        RS["Read sidecar Parquet"]
         DF["Delete file slices<br/>(existing, parallel)"]
         DB["Delete blob files<br/>(new, parallel)"]
+        RS --> DB
     end
 
     FP --> DF
-    BP --> DB
+    EM --> RS
 ```
 
 ---
@@ -362,14 +366,16 @@ sequenceDiagram
    │     └── If hasBlobColumns: Stage 1 per FG
    ├── CleanPlanner: replaced file groups -> Stage 1
    ├── If local orphan candidates non-empty: Stage 2
-   ├── Build HoodieCleanerPlan (+ blobFilesToDelete)
+   ├── Write sidecar Parquet to .hoodie/.aux/clean/<instant>.blob_deletes.parquet
+   ├── Build HoodieCleanerPlan with extraMetadata["blobDeletesPath"]
    └── Persist plan to timeline (REQUESTED state)
 
 2. CleanActionExecutor.runClean()
    ├── Transition to INFLIGHT
+   ├── Read sidecar Parquet (blob delete list)
    ├── Delete file slices (existing, parallelized)
-   ├── Delete blob files (new, same parallelized pattern)
-   ├── Build HoodieCleanMetadata with blobCleanStats
+   ├── Delete blob files (new, parallelized)          // parallel with file slice deletes
+   ├── Build HoodieCleanMetadata with blobCleanStats + blobDeletesSidecarPath
    └── Transition to COMPLETED
 ```
 
@@ -377,6 +383,7 @@ sequenceDiagram
 sequenceDiagram
     participant P as CleanPlanActionExecutor
     participant TL as Timeline
+    participant AUX as .hoodie/.aux/clean/
     participant E as CleanActionExecutor
     participant S as Storage
 
@@ -384,28 +391,31 @@ sequenceDiagram
 
     P->>P: Stage 1: per-FG blob ref set difference
     P->>P: Stage 2: MDT index lookup (if candidates exist)
-    P->>TL: Persist HoodieCleanerPlan
+    P->>AUX: Write sidecar Parquet (blob delete list)
+    P->>TL: Persist HoodieCleanerPlan<br/>(extraMetadata["blobDeletesPath"])
 
     Note over TL: REQUESTED
 
     rect rgb(255, 245, 230)
-        Note right of TL: Crash here → restart fresh<br/>(no plan persisted yet)
+        Note right of TL: Crash before plan → orphaned sidecar<br/>(harmless, cleaned at next startup)
     end
 
     E->>TL: Transition plan state
     Note over TL: INFLIGHT
 
+    E->>AUX: Read sidecar Parquet
+
     rect rgb(255, 245, 230)
-        Note right of TL: Crash here → re-execute plan<br/>(idempotent: FileNotFound = success)
+        Note right of TL: Crash here → re-read sidecar,<br/>re-delete (FileNotFound = success)
     end
 
     par Parallel deletion
         E->>S: Delete file slices (existing)
     and
-        E->>S: Delete blob files (new)
+        E->>S: Delete blob files (from sidecar)
     end
 
-    E->>E: Build HoodieCleanMetadata<br/>(+ blobCleanStats)
+    E->>E: Build HoodieCleanMetadata<br/>(blobCleanStats + sidecarPath)
     E->>TL: Transition plan state
 
     rect rgb(255, 245, 230)
@@ -413,6 +423,7 @@ sequenceDiagram
     end
 
     Note over TL: COMPLETED
+    Note over AUX: Sidecar lives until archival<br/>(for writer conflict checks)
 ```
 
 ---
@@ -448,10 +459,46 @@ produces `FileGroupCleanResult` objects with `retainedSlices = empty` and
 
 ### Schema Changes: HoodieCleanerPlan
 
-One new nullable field with null default (backward compatible):
+**No new fields.** The blob delete list is stored in a sidecar Parquet file, not in the plan. The
+plan references the sidecar via the existing `extraMetadata` map:
 
-- **`blobFilesToDelete`**: `List<HoodieCleanBlobFileInfo>` -- external blob files confirmed as
-  globally orphaned. The executor deletes these.
+- `extraMetadata["blobDeletesPath"]` -- path to the sidecar Parquet file
+  (e.g., `.hoodie/.aux/clean/20240101120000.blob_deletes.parquet`)
+
+This avoids plan bloat regardless of the number of blob candidates. The `extraMetadata` map is
+already part of the `HoodieCleanerPlan` Avro schema -- no schema change is needed.
+
+### Sidecar Parquet File: Blob Delete List
+
+The blob delete list is stored as a sidecar Parquet file at
+`.hoodie/.aux/clean/<instant>.blob_deletes.parquet`. This file is the **single source of truth**
+for blob delete candidates across all clean states (REQUESTED, INFLIGHT, COMPLETED).
+
+**Schema:**
+```
+message BlobDeleteList {
+  required binary external_path (STRING);
+}
+```
+
+**Write sequence:** The sidecar is written **before** the plan is persisted to the timeline.
+By the time the plan is visible, the sidecar is already durable on storage. This ensures
+atomicity: if a writer sees the plan, the sidecar is guaranteed to exist.
+
+**Lifecycle:** The sidecar lives until the clean instant is **archived**. This covers writer
+conflict checks against REQUESTED, INFLIGHT, and COMPLETED clean actions. When the instant is
+archived, the sidecar is deleted as part of archival cleanup.
+
+**Orphan cleanup:** If a crash occurs after writing the sidecar but before persisting the plan,
+the sidecar is orphaned. At cleaner startup, a lightweight cleanup routine lists
+`.hoodie/.aux/clean/` and deletes any sidecar whose instant has no corresponding plan on the
+timeline.
+
+**Rollback:** When a clean plan is rolled back, rollback logic reads
+`extraMetadata["blobDeletesPath"]` and deletes the sidecar.
+
+**Size:** Dictionary encoding on shared path prefixes (e.g., `s3://media-bucket/videos/...`)
+provides good compression. 10K blob paths ≈ a few hundred KB.
 
 ### Schema Changes: HoodieCleanMetadata
 
@@ -459,7 +506,8 @@ A new nullable field `blobCleanStats` of type `HoodieBlobCleanStats`:
 
 - `totalBlobFilesDeleted`, `totalBlobFilesRetained`
 - `totalBlobStorageReclaimed`
-- `deletedBlobFilePaths`, `failedBlobFilePaths`
+- `blobDeletesSidecarPath` -- pointer to the sidecar (for COMPLETED-state conflict checks)
+- `failedBlobFilePaths` -- only failures (expected to be empty or near-empty)
 
 ### hasBlobColumns() Gate
 
@@ -485,31 +533,47 @@ snapshot and its actual file deletion is closed by a commit-time conflict check:
 2. At commit time (in `preCommit()`, under the existing transaction lock), the writer checks all
    three clean states -- COMPLETED, INFLIGHT, and REQUESTED -- because a REQUESTED plan can begin
    executing at any moment (the REQUESTED->INFLIGHT transition doesn't acquire the transaction
-   lock). It checks `deletedBlobFilePaths` (COMPLETED) and `blobFilesToDelete` (INFLIGHT/REQUESTED).
-3. If any overlap is found, the commit is rejected with `HoodieWriteConflictException` and the
+   lock).
+3. For each clean instant, the writer locates the sidecar Parquet file:
+   - REQUESTED/INFLIGHT: reads `extraMetadata["blobDeletesPath"]` from the plan
+   - COMPLETED: reads `blobDeletesSidecarPath` from `HoodieCleanMetadata`
+4. The writer reads the sidecar and checks intersection with its external blob paths.
+5. If any overlap is found, the commit is rejected with `HoodieWriteConflictException` and the
    writer retries.
 
-Cost is zero for non-blob tables. For external blobs: one timeline scan + 1-3 metadata reads.
+The sidecar is the single source of truth across all three states -- no blob paths are stored
+inline in the plan or completed metadata.
+
+**Note:** `ConcurrentOperation` and `TransactionUtils.getInflightAndRequestedInstants()` currently
+exclude `CLEAN_ACTION`. Adding external blob cleanup requires extending conflict resolution to
+include clean actions when blob columns exist.
+
+Cost is zero for non-blob tables. For external blobs: one timeline scan + 1-3 sidecar Parquet
+reads (~50-200ms each on cloud storage), gated on the writer having external blob paths.
 
 ```mermaid
 sequenceDiagram
     participant W as Writer
     participant TL as Timeline
+    participant AUX as Sidecar (.aux)
     participant CL as Cleaner
 
     Note over W,CL: Scenario A: Writer commits BEFORE cleaner plans
 
     W->>TL: Commit (references blob_X)
-    CL->>TL: Plan cleanup
+    CL->>AUX: Write sidecar (blob_X in delete list)
+    CL->>TL: Plan cleanup (extraMetadata -> sidecar path)
     Note right of CL: Sees blob_X in retained slice → not deleted
     Note over W,CL: ✓ Safe
 
     Note over W,CL: Scenario B: Writer commits AFTER cleaner plans, BEFORE delete
 
-    CL->>TL: Plan cleanup (blob_X in blobFilesToDelete)
+    CL->>AUX: Write sidecar (blob_X in delete list)
+    CL->>TL: Plan cleanup
     Note over TL: REQUESTED / INFLIGHT
-    W->>TL: preCommit() -- reads clean plan
-    Note left of W: Intersection found!<br/>HoodieWriteConflictException<br/>→ Writer retries
+    W->>TL: preCommit() -- reads plan, finds sidecar path
+    W->>AUX: Read sidecar Parquet
+    Note left of W: blob_X in sidecar<br/>→ HoodieWriteConflictException<br/>→ Writer retries
     Note over W,CL: ✓ Safe -- conflict detected
 
     Note over W,CL: Scenario C: Writer commits AFTER cleaner deletes, BEFORE COMPLETED
@@ -517,14 +581,16 @@ sequenceDiagram
     CL->>CL: Delete blob_X from storage
     Note over TL: Still INFLIGHT
     W->>TL: preCommit() -- reads INFLIGHT plan
-    Note left of W: blob_X in blobFilesToDelete<br/>→ Rejection
+    W->>AUX: Read sidecar Parquet
+    Note left of W: blob_X in sidecar → Rejection
     Note over W,CL: ✓ Safe -- same as B
 
     Note over W,CL: Scenario D: Cleaner completes, THEN writer acquires lock
 
-    CL->>TL: Transition to COMPLETED
+    CL->>TL: Transition to COMPLETED (metadata has sidecar path)
     W->>TL: preCommit() -- reads COMPLETED metadata
-    Note left of W: blob_X in deletedBlobFilePaths<br/>→ Rejection
+    W->>AUX: Read sidecar Parquet
+    Note left of W: blob_X in sidecar → Rejection
     Note over W,CL: ✓ Safe
 ```
 
@@ -545,14 +611,15 @@ sequenceDiagram
 ### Crash Recovery
 
 Crash recovery is idempotent by construction, using the same mechanisms as existing file slice
-cleaning:
+cleaning. The sidecar Parquet file ensures the blob delete list survives crashes:
 
-| Crash point                             | Recovery                                                                                               |
-|-----------------------------------------|--------------------------------------------------------------------------------------------------------|
-| During planning (before plan persisted) | No REQUESTED instant on timeline. Cleaner starts fresh.                                                |
-| After plan persisted, before execution  | REQUESTED instant found; plan re-read and executed.                                                    |
-| During execution (partial deletes)      | INFLIGHT instant re-executed. Already-deleted files return FileNotFoundException -> treated as success. |
-| After execution, before COMPLETED       | INFLIGHT re-executed. All deletes are no-ops. Metadata written, instant transitions to COMPLETED.      |
+| Crash point                                   | Recovery                                                                                               |
+|-----------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| After sidecar written, before plan persisted  | No REQUESTED instant on timeline. Cleaner starts fresh. Orphaned sidecar cleaned at next startup.      |
+| After plan persisted, before execution        | REQUESTED instant found; plan re-read, sidecar re-read, executed.                                      |
+| During execution (partial deletes)            | INFLIGHT instant re-executed. Sidecar re-read. Already-deleted files return FileNotFoundException -> success. |
+| After execution, before COMPLETED             | INFLIGHT re-executed. All deletes are no-ops. Metadata written, instant transitions to COMPLETED.      |
+| Plan rolled back                              | Rollback reads `extraMetadata["blobDeletesPath"]` and deletes the sidecar.                             |
 
 ---
 
@@ -587,7 +654,7 @@ cleaning:
 
 Per-FG blob ref sets: ~100MB peak (500K records * 100 bytes/ref for expired + retained). FGs are
 processed sequentially within each partition batch -- per-FG sets are computed and discarded, not
-accumulated. Only the output lists (`hudi_blob_deletes`, `external_candidates`) grow, containing
+accumulated. Only the output list (`all_local_orphans`) grows, containing
 only orphaned refs (much smaller). Peak heap for Stage 1: ~100MB * `cleanerParallelism` = 400MB-1.6GB.
 
 Stage 2 output lists (`candidate_paths`, `all_record_keys`) can be large -- each cleaned FG may
@@ -611,8 +678,8 @@ contribute row-level blob refs as candidates. These are backed by engine-context
 ## Rollout / Adoption Plan
 
 **Foundation (shared prerequisite).** `CleanPlanner` refactoring (policy methods return
-`FileGroupCleanResult`), schema changes (nullable `blobFilesToDelete` field), and the
-`hasBlobColumns` zero-cost gate.
+`FileGroupCleanResult`), sidecar Parquet write/read infrastructure, and the `hasBlobColumns`
+zero-cost gate.
 
 **Stage 1 (per-FG cleanup).** Set-difference logic. Produces local orphan candidates for Stage 2.
 
@@ -620,8 +687,12 @@ contribute row-level blob refs as candidates. These are backed by engine-context
 cross-FG verification prevents premature deletion of shared blobs. Requires MDT + record index +
 secondary index on `reference.external_path`. Includes fallback table scan with circuit breaker.
 
-**Writer-side conflict check.** `preCommit()` conflict check for concurrency safety. Closes the
-writer-cleaner race window. Independent of the two stages.
+**Sidecar lifecycle.** Write sidecar at planning time, read at execution time, clean up at archival.
+Orphan cleanup at cleaner startup. Rollback cleanup via `extraMetadata`.
+
+**Writer-side conflict check.** `preCommit()` conflict check reads sidecar for concurrency safety.
+Requires extending `ConcurrentOperation` / `TransactionUtils` to include clean actions when blob
+columns exist.
 
 ### Backward Compatibility
 
@@ -642,24 +713,32 @@ writer-cleaner race window. Independent of the two stages.
 - **Stage 2 index lookup:** Verify short-circuit behavior (stop after first live reference), empty
   results (globally orphaned), and batched prefix scans.
 - **Stage 2 fallback:** Verify table scan correctness and circuit breaker activation.
-- **Writer-side conflict check:** Verify detection of conflicts with COMPLETED, INFLIGHT, and
-  REQUESTED clean actions.
+- **Sidecar Parquet write/read:** Verify round-trip of blob delete list through sidecar file.
+- **Writer-side conflict check:** Verify detection of conflicts via sidecar reads for COMPLETED,
+  INFLIGHT, and REQUESTED clean actions.
 
 ### Integration Tests
 
 - End-to-end clean cycle with external blob table and MDT secondary index (COW and MOR).
 - Clean cycle with replaced file groups (post-clustering, post-insert_overwrite).
+- Sidecar lifecycle: verify sidecar created at planning, read at execution, deleted at archival.
 
 ### Concurrency Tests
 
-- Writer-cleaner race scenarios A-D (from concurrency analysis) with external blobs.
+- Writer-cleaner race scenarios A-D (from concurrency analysis) with external blobs and sidecar.
 - Concurrent clean + compaction with blob tables.
+
+### Sidecar Lifecycle Tests
+
+- Orphan cleanup: sidecar exists without plan → cleaned at next startup.
+- Rollback cleanup: plan rolled back → sidecar deleted.
+- Archival cleanup: clean instant archived → sidecar deleted.
+- Missing sidecar at execution: graceful handling (skip blob cleanup, log warning).
 
 ### Backward Compatibility
 
-- Non-blob table clean cycle produces identical behavior (no `blobFilesToDelete`, no
-  `blobCleanStats`).
-- Clean plan deserialization with and without blob fields (nullable field compatibility).
+- Non-blob table clean cycle produces identical behavior (no sidecar, no `blobCleanStats`).
+- Clean plan deserialization with and without `extraMetadata["blobDeletesPath"]`.
 
 ---
 

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -747,3 +747,31 @@ Closes the writer-cleaner race window. Independent of the three stages.
 - **[Problem Statement, Constraints & Requirements](rfc-100-blob-cleaner-problem.md)**
   -- Complete problem scope, all 13 constraints (C1-C13), all 10 requirements (R1-R10), 8
   illustrative failure mode examples, and open questions.
+
+### Why the MDT Secondary Index Maps to Record Keys (Not File Groups)
+
+Stage 2 uses a two-hop lookup: secondary index → record keys → record index → file group locations.
+This is not an artifact of this RFC — it is the fundamental design of Hudi's secondary index
+([RFC-77](../rfc-77/rfc-77.md)). The rationale:
+
+1. **Secondary keys are non-unique.** Unlike the record index (which maps unique record keys),
+   a secondary index is on arbitrary user columns (e.g., `city`, `status`) where many records
+   share the same value. The composite key format `{secondaryKey}${recordKey}` flattens this
+   non-unique mapping into unique tuples that fit the existing spillable/merge map infrastructure.
+
+2. **Record locations change independently of secondary key values.** Compaction, clustering,
+   and updates move records between file groups. The record index already maintains this mapping
+   correctly. A denormalized `secondary_key → file_group` mapping would duplicate that
+   maintenance burden and risk staleness.
+
+3. **Update handling requires tombstones on old values.** When a record's secondary key changes,
+   the old value may reside in a different file group in the SI partition than the new value.
+   The normalized design handles this with `old-secondary-key → (record-key, deleted)` tombstones,
+   which is simpler than tracking file group transitions directly.
+
+4. **Alternatives were evaluated and rejected.** RFC-77 considered direct `secondary_key →
+   file_group` mapping, Guava MultiMap, Chronicle Map, and separate spillable structures — all
+   rejected due to complexity, external dependencies, or maintenance cost.
+
+For this RFC, the two-hop cost is negligible: Step 1 (prefix scan) and Step 2 (record index lookup)
+are each a single batched HFile forward-scan, adding ~3-7s total for 2K candidates.

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -192,6 +192,9 @@ Output: local_orphan_candidates -- external blobs needing cross-FG verification
 for each file_group being cleaned:
 
     // Collect expired blob refs (base files + log files)
+    // The managed==true filter here is the ELIGIBILITY gate: only blobs Hudi was
+    // asked to manage become deletion candidates. (Liveness, in retained_refs and
+    // Stage 2 below, is managed-agnostic.)
     // Must read log files: blob refs introduced and superseded within the log
     // chain before compaction would otherwise become permanent orphans.
     expired_refs = Set<external_path>()
@@ -210,10 +213,13 @@ for each file_group being cleaned:
     // Cleaning is fenced on compaction: retained base files contain the merged
     // state. Log reads are unnecessary -- any shadowed base ref causes safe
     // over-retention, cleaned after the next compaction cycle.
+    // NOTE: no managed filter here. Liveness is managed-AGNOSTIC -- ANY retained
+    // reference to a path (managed=true OR managed=false) keeps the blob alive
+    // (R1). A managed->unmanaged transition must not make the blob deletable.
     retained_refs = Set<external_path>()
     for slice in retained_slices:
         for ref in extractBlobRefs(slice.baseFile):   // columnar projection only
-            if ref.type == OUT_OF_LINE and ref.managed == true:
+            if ref.type == OUT_OF_LINE:               // NOT ref.managed -- see note above
                 retained_refs.add(ref.external_path)
 
     // Compute local orphans by set difference
@@ -235,6 +241,18 @@ for each file_group being cleaned:
 - **Replaced FGs (replace commits):** `retained_slices` is empty, so all blob refs become
   candidates. For external blobs, clustering copies the pointer to the target FG, so Stage 2
   finds the reference in the target FG and retains the blob.
+- **`managed` flag -- eligibility vs liveness (R1).** The flag has two distinct roles and the
+  design must not conflate them. *Eligibility:* only paths referenced as `managed=true` in the
+  expired set become deletion candidates (the `expired_refs` filter) -- Hudi never deletes a blob
+  it was not asked to manage. *Liveness:* whether a path is still referenced is managed-agnostic --
+  `retained_refs` (and Stage 2's cross-FG check) count references regardless of `managed`, per the
+  problem statement's rule that "if any retained reference to the same `external_path` exists
+  (regardless of the `managed` flag), the blob must not be deleted." This is what makes a
+  managed->unmanaged transition safe: at t1 a record references `video.mp4` with `managed=true`
+  (eligible); at t2 an update sets `managed=false` for the same path (user says "stop managing
+  this"). The t2 reference lands in a retained slice; because `retained_refs` does not filter on
+  `managed`, `video.mp4` stays out of `local_orphans` and survives. The Stage 2 dependency this
+  implies (the secondary index must index unmanaged references too) is stated in Stage 2 below.
 
 ### Stage 2: Cross-File-Group Verification
 
@@ -304,6 +322,17 @@ sequential throughput, 64-256KB HFile blocks. Pending benchmarking.*
 `sourceFields = ["<blob_col>", "reference", "external_path"]`. The nested field path is supported
 by `HoodieSchemaUtils.projectSchema()` and `SecondaryIndexRecordGenerationUtils`. No new index
 infrastructure is needed.
+
+**Managed-agnostic indexing (R1).** The secondary index keys on `reference.external_path` for every
+record whose blob reference is `OUT_OF_LINE`, *regardless of the `managed` flag*: the index
+definition carries no `managed` predicate, and standard SI record generation indexes each record's
+field value without filtering. So the index contains entries for `managed=false` references, and
+Stage 2's lookup finds an unmanaged retained reference exactly as it finds a managed one, keeping
+the blob alive. This is what makes the managed->unmanaged transition safe (Stage 1 note above): the
+`managed=true` filter is applied only when selecting *candidates* from the expired set, never when
+checking *liveness*. The fallback table scan is managed-agnostic for the same reason -- it matches
+candidate paths against every live `external_path`, not only managed ones. A future optimization
+must not add a `managed` filter to the index or the scan, or it breaks R1.
 
 **Index staleness and consistency.** Stage 2 deletes a blob when the index reports no live
 reference, so the only dangerous error is a *false negative* -- the index missing a reference that

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -29,7 +29,7 @@
 
 ## Status
 
-Issue: <Link to GH feature issue>
+Issue: https://github.com/apache/hudi/issues/18111
 
 > Please keep the status updated in `rfc/README.md`.
 
@@ -485,14 +485,25 @@ message BlobDeleteList {
 By the time the plan is visible, the sidecar is already durable on storage. This ensures
 atomicity: if a writer sees the plan, the sidecar is guaranteed to exist.
 
-**Lifecycle:** The sidecar lives until the clean instant is **archived**. This covers writer
-conflict checks against REQUESTED, INFLIGHT, and COMPLETED clean actions. When the instant is
-archived, the sidecar is deleted as part of archival cleanup.
+**Lifecycle:** The sidecar lives until the clean instant is **archived**, covering writer conflict
+checks against REQUESTED, INFLIGHT, and COMPLETED clean actions. Deletion reuses the hook archival
+already has for an archived instant's per-instant side files, rather than a new periodic service.
+In `TimelineArchiverV2.archiveIfRequired` the archiver runs a per-archived-action callback --
+today `deleteAnyLeftOverMarkers(context, activeAction)`, which removes the instant's marker
+directory keyed on `activeAction.getInstantTime()`. Blob-sidecar cleanup extends that callback:
+for an archived `CLEAN_ACTION`, derive the sidecar path by convention from
+`activeAction.getInstantTime()` and delete it (idempotent -- a missing file is success), so no
+plan/metadata read is needed. This is added to both archiver versions (V1 and V2). A crash between
+archiving the instant and deleting its sidecar is caught by the orphan sweep below: an archived
+instant is no longer on the active timeline, so its leftover sidecar is reclaimed on the next
+cleaner run.
 
 **Orphan cleanup:** If a crash occurs after writing the sidecar but before persisting the plan,
 the sidecar is orphaned. At cleaner startup, a lightweight cleanup routine lists
-`.hoodie/.aux/clean/` and deletes any sidecar whose instant has no corresponding plan on the
-timeline.
+`.hoodie/.aux/clean/` and deletes any sidecar whose instant is not present on the active timeline
+-- i.e., never persisted, or already archived. Sidecars for REQUESTED, INFLIGHT, and
+COMPLETED-but-not-yet-archived clean instants are retained (writers may still need them), so this
+sweep never removes a sidecar a conflict check could require.
 
 **Rollback:** When a clean plan is rolled back, rollback logic reads
 `extraMetadata["blobDeletesPath"]` and deletes the sidecar.
@@ -525,15 +536,17 @@ cleaner never conflicts with writers on file slice operations. However, external
 **not** covered by MVCC: a writer's new file slice may reference an external blob that the cleaner
 is simultaneously evaluating for deletion.
 
-**Writer-side conflict check in `preCommit()`.** The gap between the cleaner's planning-time
-snapshot and its actual file deletion is closed by a commit-time conflict check:
+**Writer-side conflict check in `BaseHoodieWriteClient.preCommit()`.** The gap between the
+cleaner's planning-time snapshot and its actual file deletion is closed by a commit-time check:
 
-1. Writers track external managed blob paths in `HoodieWriteStat.externalBlobPaths` (in-memory
-   collection, no additional I/O).
-2. At commit time (in `preCommit()`, under the existing transaction lock), the writer checks all
-   three clean states -- COMPLETED, INFLIGHT, and REQUESTED -- because a REQUESTED plan can begin
-   executing at any moment (the REQUESTED->INFLIGHT transition doesn't acquire the transaction
-   lock).
+1. Writers track external managed blob paths in `HoodieWriteStat.externalBlobPaths` (transient
+   in-memory, no additional I/O -- see below). The collection is empty for non-blob writers, so
+   the check short-circuits at zero cost (R6).
+2. In `preCommit()`, under the existing transaction lock and on a table handle created *after*
+   the lock (so the timeline is current), the writer checks all three clean states -- COMPLETED,
+   INFLIGHT, and REQUESTED. All three are checked because the REQUESTED->INFLIGHT transition and
+   the blob deletes both run *outside* the transaction lock, so a REQUESTED plan may begin
+   executing at any moment.
 3. For each clean instant, the writer locates the sidecar Parquet file:
    - REQUESTED/INFLIGHT: reads `extraMetadata["blobDeletesPath"]` from the plan
    - COMPLETED: reads `blobDeletesSidecarPath` from `HoodieCleanMetadata`
@@ -544,9 +557,105 @@ snapshot and its actual file deletion is closed by a commit-time conflict check:
 The sidecar is the single source of truth across all three states -- no blob paths are stored
 inline in the plan or completed metadata.
 
-**Note:** `ConcurrentOperation` and `TransactionUtils.getInflightAndRequestedInstants()` currently
-exclude `CLEAN_ACTION`. Adding external blob cleanup requires extending conflict resolution to
-include clean actions when blob columns exist.
+**Populating `externalBlobPaths` (writer side).** The collection is filled during the normal
+write pass, not by a separate scan. As each record is written, the write handle already
+materializes the full record -- including the blob column -- to serialize it into the base or log
+file, so extracting `reference.external_path` is a field access on data already in memory. The
+"no additional I/O" claim is precise: no extra read and no extra record deserialization; the only
+added work is a per-record field navigation and a set insert. Only managed external paths
+(`type = OUT_OF_LINE`, `managed = true`) are added, and the set is deduplicated -- so its size is
+the number of *distinct* external paths in the write, not the record count.
+
+The field is **transient**. It lives on the per-file-group `HoodieWriteStat` only long enough for
+the committing writer's own `preCommit()` check, then is discarded. It must **not** be serialized
+into `HoodieCommitMetadata` -- the POJO `HoodieWriteStat` is JSON-persisted into the `.commit`
+file, and the Avro `HoodieWriteStat` is embedded in `HoodieCommitMetadata.avsc` under
+`partitionToWriteStats`, so persisting it would carry the full external-path list in every
+commit's metadata, which is exactly the "store blob references in commit metadata" anti-pattern
+the problem statement rules out (C10: does not scale, breaks at archival). It is therefore kept
+non-serialized (e.g., `@JsonIgnore` on the stat, or carried on the transient `WriteStatus` rather
+than the persisted stat).
+
+Memory is bounded and distributed. Each `HoodieWriteStat` holds only its own file group's distinct
+paths, so the collection is partitioned across write tasks rather than materialized whole on the
+driver. For extreme writes (one distinct blob per row), the `preCommit()` intersection also does
+not need the global set on the driver: the clean sidecar's path set is small and bounded, so it
+can be broadcast to executors and intersected against each task's per-FG paths, reducing only the
+conflicting paths back. The large per-FG sets stay where they were produced.
+
+**Bounding the check -- the writer does not scan all completed cleans.** Reading every COMPLETED
+clean sidecar back to archival would make the check O(completed cleans), unacceptable under
+frequent cleaning. The check is bounded to the writer's own window instead:
+
+- **REQUESTED / INFLIGHT:** at most one by default. With `hoodie.clean.multiple.enabled = false`
+  (the default), `scheduleCleaning` does not schedule a new clean while one is pending
+  (`BaseHoodieTableServiceClient.java:856`), so there is normally a single pending clean whose
+  sidecar could delete the writer's blob imminently.
+- **COMPLETED:** only cleans that completed *after the writer's start snapshot* (the
+  last-completed instant the write began from). That is the window in which a clean could have
+  deleted the writer's blob without seeing the writer's not-yet-committed reference (Scenario D
+  above). A clean that completed *before* the writer began is not a race -- its deletion predates
+  the write, so referencing that path is a stale-path user error, outside R1's scope. The writer
+  therefore filters completed clean instants by completion time greater than its snapshot before
+  reading any sidecar.
+
+Per commit this is O(cleans overlapping this write's window) -- typically zero to two sidecar
+reads -- not O(completed cleans since archival), and the whole check is skipped when the writer
+has no external blob paths (R6). Retention and read cost are decoupled: because the writer filters
+completed clean instants by completion time before opening any sidecar, a long backlog of retained
+sidecars does not inflate per-commit cost, so the sidecar can safely live until archival (covering
+a long-running writer whose window is large) without penalty.
+
+**Which operations this check covers.** `preCommit()` runs under the transaction lock on every
+commit that produces commit metadata, but only operations that introduce or copy an external
+blob reference need the blob check:
+
+| Operation                           | preCommit path                                                              | Blob check           |
+|-------------------------------------|-----------------------------------------------------------------------------|----------------------|
+| INSERT / UPSERT / DELETE            | `BaseHoodieWriteClient.preCommit` (always)                                  | Required -- new refs |
+| insert_overwrite                    | `BaseHoodieWriteClient.preCommit` (always)                                  | Required -- new refs |
+| Clustering                          | `BaseHoodieTableServiceClient.preCommit` (only if `isPreCommitRequired()`)  | Not needed           |
+| Compaction / log compaction         | `BaseHoodieTableServiceClient.preCommit`                                    | Not needed           |
+| Clean, rollback, restore, savepoint | Does not run `preCommit`                                                     | Not needed           |
+
+Only ingestion writes and `insert_overwrite` can introduce a *new* external blob reference the
+cleaner could not have seen at its planning fence, and both flow through
+`BaseHoodieWriteClient.preCommit`, so the check lives there. Clustering and compaction only
+*copy* pointers that were already committed -- and therefore already visible to the cleaner's
+Stage 1/2 -- so they are covered by the existing mechanisms in the [Concurrency
+Matrix](#concurrency-matrix): compaction by `isFileSliceNeededForPendingMajorOrMinorCompaction`
+fencing, clustering by the replaced-FG lifecycle (Stage 2 finds the copied reference in the
+target FG). This is deliberate, not incidental: clustering's `preCommit` is gated on
+`isPreCommitRequired()`, which is `false` for the default
+`SimpleConcurrentFileWritesConflictResolutionStrategy` and `true` only for
+`PreferWriterConflictResolutionStrategy` -- so a blob check placed in `preCommit` could not rely
+on the clustering path anyway. The clean action itself does not run `preCommit`, which is
+correct: the check is on the *writer* (referencing) side; the cleaner side is Stage 1/2 over the
+committed timeline.
+
+**Why a targeted `preCommit` check, not an OCC conflict-resolution extension.** The conflict axis
+here is the external blob *path* (a user-controlled string), which is orthogonal to the
+`(partition, fileId)` model Hudi's OCC conflict resolution is built on. Routing the blob check
+through `ConcurrentOperation` / `ConflictResolutionStrategy.hasConflict()` was considered and
+rejected:
+
+- A clean action has no `(partition, fileId)` set that expresses the conflict.
+  `SimpleConcurrentFileWritesConflictResolutionStrategy.hasConflict()` intersects
+  `getMutatedPartitionAndFileIds()`; the cleaned slices' fileIds are the *expired* ones, which by
+  MVCC never overlap a concurrent writer's new slices -- so the intersection is empty exactly when
+  a blob conflict is real. The useful key (the blob path) cannot be held in that field.
+- Forcing it to fit would touch the shared OCC path every writer traverses: (1) add a
+  `CLEAN_ACTION` case to both switches in `ConcurrentOperation.init()` -- which today throws
+  `IllegalArgumentException` for clean -- plus a new blob-path field populated by reading the
+  sidecar *inside* metadata construction; (2) add a blob-path branch to `hasConflict`; (3) add
+  `CLEAN_ACTION` to the whitelists in `TransactionUtils.getInflightAndRequestedInstants()` and
+  `getCandidateInstants()`, which today draw only from the commits timeline. That widens the
+  candidate set and adds sidecar I/O for *all* writers unless every site is separately gated on
+  `hasBlobColumns`, putting R6 at risk on a sensitive, widely-shared path.
+
+The targeted `preCommit` check reaches the same guarantee while touching none of that shared
+code: it is blob-scoped, gated on the writer having external blob paths, and localizes all
+blob-specific logic to the blob feature.
 
 Cost is zero for non-blob tables. For external blobs: one timeline scan + 1-3 sidecar Parquet
 reads (~50-200ms each on cloud storage), gated on the writer having external blob paths.
@@ -593,6 +702,51 @@ sequenceDiagram
     Note left of W: blob_X in sidecar → Rejection
     Note over W,CL: ✓ Safe
 ```
+
+### Ordering Argument and the Planning-Snapshot Window
+
+The four scenarios above are safe only if the cleaner's liveness snapshot and its plan+sidecar
+become visible to writers atomically. The current scheduling path does not guarantee that, and
+the gap must be stated precisely rather than assumed away.
+
+In `BaseHoodieTableServiceClient.scheduleCleaning()`, the cleaner computes the plan -- Stage 1/2
+liveness and the blob delete set -- in `createCleanerPlan()` **outside** the transaction lock,
+then persists the REQUESTED plan via `saveToCleanRequested()` **under** the lock. Execution
+(REQUESTED->INFLIGHT and the blob deletes) runs later, again **outside** the lock. This leaves a
+window between the liveness snapshot and the plan becoming visible:
+
+```
+t0  cleaner takes fence-T snapshot in createCleanerPlan (UNLOCKED); blob_X judged orphaned
+t1  writer locks, preCommit: no clean instant on timeline yet -> passes -> commits ref to blob_X
+t2  cleaner locks, saveToCleanRequested persists plan (blob_X in sidecar)
+t3  cleaner executes (UNLOCKED), deletes blob_X   -> writer's t1 commit now dangles
+```
+
+Neither side catches this interleaving: the writer's `preCommit` sees no plan (not yet
+persisted), and the cleaner's snapshot predates the writer's commit and is not re-validated
+before deletion. This hazard is unique to blobs -- the standard file-slice cleaner is immune
+because a concurrent writer only creates *newer* slices and never re-references an *older* one,
+whereas a writer can freely re-reference an existing external blob path (C2, C3).
+
+Closing the window requires the liveness check that *authorizes a delete* to run under the
+transaction lock, atomic with a timeline transition that makes the delete intent visible. The
+locked work is only a re-check of the sidecar candidates (a bounded Stage 2 index lookup), not
+full planning:
+
+- **(a) Re-validate at plan-persist.** Re-run Stage 2 for the candidate set under the lock,
+  atomic with `saveToCleanRequested` (the REQUESTED instant becoming visible). A writer
+  committing during unlocked planning is caught by the re-validation; a writer committing after
+  sees the REQUESTED plan and aborts.
+- **(b) Re-validate at execution.** Keep planning unlocked, but before deleting, re-run the Stage
+  2 lookup for the sidecar candidates against the latest timeline under the lock, transitioning
+  to INFLIGHT atomically. A writer committing before is seen by the re-validation; a writer
+  committing after sees the INFLIGHT plan in `preCommit` and aborts.
+
+Either bounds the lock hold to a candidate index lookup rather than full cross-FG verification,
+preserving C6/R4. Option (b) is preferred (it revalidates against the freshest timeline, closest
+to the irreversible act), but the choice is **open** and one of the two is required before the
+writer-side check is sufficient. This is the design's thinnest safety proof and must be resolved
+before implementation.
 
 ### Concurrency Matrix
 

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -305,25 +305,90 @@ sequential throughput, 64-256KB HFile blocks. Pending benchmarking.*
 by `HoodieSchemaUtils.projectSchema()` and `SecondaryIndexRecordGenerationUtils`. No new index
 infrastructure is needed.
 
-**Safety check.** The cleaner verifies the index is fully built before using it via
-`getMetadataPartitions()` and `getMetadataPartitionsInflight()`. A partially-built index falls
-back to the table scan path.
+**Index staleness and consistency.** Stage 2 deletes a blob when the index reports no live
+reference, so the only dangerous error is a *false negative* -- the index missing a reference that
+exists (premature deletion, R1). A *false positive* only over-retains (R2, safe). For a table whose
+secondary index partition is **available (built)**, a false negative from steady-state staleness
+cannot occur, because three MDT mechanisms compose:
 
-#### Fallback path: table scan with circuit breaker
+1. **Same-commit, same-instant maintenance.** SI records are written in the *same* MDT delta-commit
+   as the data commit, at the data commit's instant time (`HoodieBackedTableMetadataWriter.update`
+   -> `processAndCommit`, SI in the same `partitionToRecordMap`). It is not a lazily-maintained
+   cache that can drift out of band.
+2. **Hard failure coupling.** The MDT commit runs *before* the data instant is completed
+   (`BaseHoodieWriteClient.commit`: `writeToMetadataTable`, then `saveAsComplete`). If the MDT
+   update fails, the exception propagates before completion and the data instant stays inflight --
+   so a *completed* data commit implies its SI entries exist.
+3. **Reader consistency watermark.** Every SI read filters MDT records to those whose data instant
+   is completed (`getValidInstantTimestamps`, applied as an `InstantRange` EXACT_MATCH in
+   `HoodieBackedTableMetadata.readSliceWithFilter`). Entries from an uncommitted or failed commit --
+   e.g. a crash after the MDT commit but before `saveAsComplete` -- are hidden; entries from every
+   completed commit are exposed.
+
+Composed, the index cannot miss a reference from a completed commit nor surface one from a failed
+commit. Reading the current index reflects every completed data commit -- a superset of the
+cleaner's planning fence -- so index staleness cannot produce a false negative. (A *new* reference
+committed by a concurrent writer after the fence is a separate concern, handled by the writer-side
+`preCommit` check and the planning-snapshot window above, not by the index.)
+
+**The one unsafe window is bootstrap, and the safety check gates exactly it.** While a secondary
+index is being built or backfilled (async `HoodieIndexer` / `RunIndexActionExecutor`), its
+partition is *inflight*, not *available*. Here the reader watermark does **not** help: a completed
+historical instant can be within `getValidInstantTimestamps` yet still lack the SI entries the
+catch-up task has not reconciled -- a genuine false negative. So the cleaner treats the index as
+authoritative only when the partition is available **and not** inflight
+(`isMetadataPartitionAvailable(SECONDARY_INDEX)` is true and it is absent from
+`getMetadataPartitionsInflight()`); otherwise it falls back to the ground-truth table scan, which
+reads actual file slices and is immune to index state. MDT disable/rebuild and restore either flip
+this availability flag or are reconciled into the watermark, so the same gate covers them.
+
+**One-sided trust (backstop).** The index may authorize *retention* freely, but authorizes
+*deletion* only under the availability guarantee above; any uncertainty resolves to the
+ground-truth scan or to deferral, never to deletion. This keeps R1 intact even if a future
+index-maintenance mode weakened one of the three steady-state mechanisms.
+
+#### Fallback path: table scan, with a durable deferred queue
 
 When the MDT secondary index is unavailable, Stage 2 falls back to a parallelized table scan
-across all partitions. A circuit breaker (`hoodie.cleaner.blob.external.scan.max.candidates`,
-default 1000) defers cleanup if candidates exceed the threshold, preventing the scan from becoming
-a bottleneck on large tables. The operator is warned to enable the MDT secondary index.
+across all partitions. Because that scan is O(candidates * table), a per-cycle cap
+(`hoodie.cleaner.blob.external.scan.max.candidates`, default 1000) limits how many candidates are
+verified in a single clean cycle.
+
+**The cap must not silently drop candidates (R2).** Stage 1 derives candidate paths by reading the
+*expired* file slices' blob refs, and the existing cleaner deletes those slices later in the *same*
+cycle. If the cap simply skipped the overflow, the deleted slices would take the only copy of those
+refs with them -- the candidates could never be re-derived, leaving permanent orphans (a direct R2
+violation). So the cap is a **rate limit backed by a durable queue**, not an all-or-nothing skip:
+
+1. At plan time (before execution deletes any slice), Stage 1's candidate *paths* are already in
+   hand. Up to `max.candidates` are verified this cycle; the overflow is written to a durable
+   deferred-candidates artifact under `.hoodie/.aux/clean/` -- a running queue, separate from a
+   delete sidecar since no deletes are planned for the overflow.
+2. Each subsequent clean cycle loads the deferred queue, merges it with that cycle's new local
+   orphans, verifies up to `max.candidates`, and re-defers the rest. The backlog drains at a
+   bounded rate per cycle.
+3. Because the candidate paths are durable *before* any slice is deleted, deleting the expired
+   slices no longer loses them. Deferred candidates are re-verified against the *current* index or
+   scan when processed -- a point-in-time liveness check that can only over-retain, never wrongly
+   delete -- so they never depend on the now-deleted slices.
+
+This keeps R2 intact regardless of the index: with the index the queue drains quickly; without it
+the scan drains it at `max.candidates` per cycle (bounded, just slower). A growing deferred backlog
+is surfaced as a metric and a warning so operators enable the MDT secondary index.
+
+*Considered and rejected:* gating file-slice deletion on blob planning (refusing to clean slices
+when the cap fires). It preserves the source slices but couples blob cleanup to core cleaning,
+blocks file-slice reclamation, and changes existing cleaner semantics. The durable queue reaches R2
+without touching the file-slice path.
 
 #### Decision matrix
 
-| Condition                   | Path used     | Cost                  | Suitable for              |
-|-----------------------------|---------------|-----------------------|---------------------------|
-| No local orphan candidates  | Skip Stage 2  | Zero                  | No blob work this cycle   |
-| MDT secondary index enabled | Index lookup  | O(candidates)         | Any scale                 |
-| No index, few candidates    | Table scan    | O(candidates * table) | Small tables              |
-| No index, many candidates   | Circuit break | Zero (deferred)       | Large tables need index   |
+| Condition                   | Path used                          | Cost                             | Suitable for                  |
+|-----------------------------|------------------------------------|----------------------------------|-------------------------------|
+| No local orphan candidates  | Skip Stage 2                       | Zero                             | No blob work this cycle       |
+| MDT secondary index enabled | Index lookup                       | O(candidates)                    | Any scale                     |
+| No index, few candidates    | Table scan                         | O(candidates * table)            | Small tables                  |
+| No index, many candidates   | Rate-limited scan + durable defer  | O(max.candidates * table)/cycle  | Drains over cycles; add index |
 
 ```mermaid
 sequenceDiagram
@@ -775,6 +840,49 @@ cleaning. The sidecar Parquet file ensures the blob delete list survives crashes
 | After execution, before COMPLETED             | INFLIGHT re-executed. All deletes are no-ops. Metadata written, instant transitions to COMPLETED.      |
 | Plan rolled back                              | Rollback reads `extraMetadata["blobDeletesPath"]` and deletes the sidecar.                             |
 
+### Premature Deletion: Prevention, Detection, Recovery (Q6)
+
+Problem-statement Q6 (what happens if a blob is prematurely deleted) is left open there by design;
+the design answers it here. Because a hard-deleted external blob is unrecoverable by default (R1),
+the answer is layered -- prevention first, then detection, then recovery as an opt-in.
+
+**Prevention (primary).** This is where the design spends its safety budget: Stage 1 over-retains
+on the MOR side; Stage 2 does cross-FG verification before any deletion; the index is trusted only
+when available and not inflight, else a ground-truth scan ("Index staleness and consistency"); the
+writer-side `preCommit` check plus plan-time durability close the writer-cleaner race (subject to
+the open planning-snapshot window above); and one-sided trust means every uncertain verdict
+resolves to *retain*. Premature deletion therefore requires a genuine defect, not a routine race.
+
+**Detection.** Two signals, which also answer Q6's "distinguish correctly-absent from
+incorrectly-deleted":
+
+- *Query-time.* A dangling `BlobReference` -- a live record whose `external_path` was deleted --
+  produces a blob-fetch failure (`FileNotFoundException` / 404) when that record is read. The
+  reader should surface this as a distinct, catchable error (supporting R9), not a silent null.
+- *Audit trail.* Every deleted path is recorded in the clean's `HoodieCleanMetadata`
+  (`blobCleanStats`) and its sidecar, both retained until archival. On a missing-blob error the
+  path is matched against that history: present in a clean's delete list => the cleaner deleted it
+  (candidate premature deletion, to investigate); absent => it was never a cleaner-managed blob
+  (a user stale-path error, outside R1). This is what tells the two cases apart.
+- *Proactive.* `hoodie.cleaner.blob.dry.run` computes the delete set without deleting, so it can be
+  diffed against a ground-truth scan (shadow mode) to catch a wrong decision before any I/O.
+
+**Recovery.** Once a blob is hard-deleted the bytes are gone, so recoverability is a deliberate
+choice, not a free property:
+
+- *Default -- rely on correctness.* Hard delete; the layered prevention above is the guarantee.
+  Any recovery is out-of-band (the user's own object-store versioning or backups); the table does
+  not promise recovery.
+- *Optional -- quarantine with a grace window.* Instead of hard-deleting, the cleaner moves blobs
+  to a managed trash prefix and hard-deletes only after a grace window, so a premature deletion
+  detected within the window is restorable from trash. This converts R1 from unrecoverable to
+  recoverable-within-window, at the cost of blob-sized data movement and a trash-GC lifecycle
+  (a pure time-based sweep, no liveness logic). Config-gated and off by default; recommended for
+  workloads that cannot tolerate an unrecoverable R1.
+
+Net: the design answers Q6 as "prevention-first, with a durable detection trail, and recovery as an
+opt-in quarantine mode," rather than leaving it open or asserting a bare "no recovery."
+
 ---
 
 ## Performance
@@ -785,7 +893,7 @@ cleaning. The sidecar Parquet file ensures the blob delete list survives crashes
 |------------------------------|---------------------------------|----------------------------|--------------------------------|
 | Non-blob table               | Zero (`hasBlobColumns` gate)    | N/A                        | **Zero**                       |
 | External blobs (index)       | ~6 Parquet reads per cleaned FG | O(C * R_avg)               | O(cleaned_FGs + C * R_avg)     |
-| External blobs (scan)        | ~6 Parquet reads per cleaned FG | O(candidates * table_size) | Circuit breaker limits this    |
+| External blobs (scan)        | ~6 Parquet reads per cleaned FG | O(candidates * table_size) | Rate-limited per cycle; overflow deferred |
 
 ### Back-of-Envelope: Example 6 (50K FGs, 2K External Candidates)
 
@@ -824,7 +932,7 @@ contribute row-level blob refs as candidates. These are backed by engine-context
 | `hoodie.cleaner.blob.enabled`                      | `true`  | Enable blob cleanup during clean action                                           |
 | `hoodie.cleaner.blob.dry.run`                      | `false` | Compute blob cleanup plan and log results but do not execute                      |
 | `hoodie.cleaner.blob.external.scan.parallelism`    | `10`    | Parallelism for Stage 2 fallback table scan                                       |
-| `hoodie.cleaner.blob.external.scan.max.candidates` | `1000`  | Circuit breaker for Stage 2 fallback scan; exceeding defers blob cleanup          |
+| `hoodie.cleaner.blob.external.scan.max.candidates` | `1000`  | Per-cycle cap on candidates verified via the fallback scan; overflow is deferred to a durable queue and drained over subsequent cycles |
 | `hoodie.metadata.index.secondary.column`           | (none)  | Set to `<blob_col>.reference.external_path` for cross-FG verification             |
 
 ---

--- a/rfc/rfc-100/rfc-100-blob-cleaner-design.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-design.md
@@ -15,7 +15,28 @@
   limitations under the License.
 -->
 
-# RFC-100 Part 2: External Blob Cleanup for Unstructured Data
+# RFC-100 Part 2: External Blob Cleanup for Unstructured Data [ABANDONED -- superseded by design v2]
+
+> **This design (SI+RLI) is ABANDONED (2026-07-02)** in favor of
+> [rfc-100-blob-cleaner-design-v2.md](rfc-100-blob-cleaner-design-v2.md) -- a file-granularity
+> blob reference registry with two-phase deletion. The decision was driven by code-verified
+> defects, all structural to the record-granular, snapshot-semantics secondary-index approach
+> this document uses for Stage 2:
+>
+> 1. A secondary index makes `insert_overwrite` / `insert_overwrite_table` / `delete_partition`
+>    throw table-wide (`HoodieBackedTableMetadataWriter.updateSecondaryIndexIfPresent:1648`),
+>    contradicting this document's own operation-coverage claims (C7, R7).
+> 2. SI reads reflect only the latest snapshot, so the problem statement's retained-slice
+>    liveness rule cannot be implemented: a blob referenced only by a superseded-but-retained
+>    slice gets deleted, breaking time-travel and incremental reads inside the retention
+>    window (R1).
+> 3. The Stage 2 `cleaned_fg_ids` discount deletes blobs still referenced by the retained
+>    slices of partially-cleaned file groups -- and partial cleans are the norm (R1).
+>
+> See the v2 document's Motivation section (M1-M3) for the full analysis. Carried forward from
+> this document: the `CleanPlanner`/`FileGroupCleanResult` refactoring, the `hasBlobColumns()`
+> gate, the sidecar-artifact convention, and the writer `preCommit` veto (reduced in scope in
+> v2). The rest is retained for historical context only.
 
 ## Proposers
 
@@ -28,6 +49,8 @@
 - @yihua
 
 ## Status
+
+ABANDONED (2026-07-02) -- superseded by [design v2](rfc-100-blob-cleaner-design-v2.md).
 
 Issue: https://github.com/apache/hudi/issues/18111
 

--- a/rfc/rfc-100/rfc-100-blob-cleaner-problem.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-problem.md
@@ -630,6 +630,74 @@ Why this matters:
   storage indefinitely.
 ```
 
+### Example 9: Why blobFilesToDelete must be in the plan -- writer-cleaner conflict resolution
+
+**Demonstrates:** C7, R1, R5 (extends Example 5, Scenario B)
+
+```
+Setup:
+  File Group FG-1 (partition users/alice):
+    Slice @t1 (expired): row1.blob_ref = (s3://ext/video.mp4, managed=true)
+    Slice @t3 (retained): row1.blob_ref = (s3://ext/photo.png, managed=true)
+    video.mp4 is locally orphaned in FG-1 (updated to photo.png at t3).
+    No other FG references video.mp4 at plan time.
+
+  File Group FG-2 (partition users/bob):
+    (exists, but does not reference video.mp4 yet)
+
+Approach A: blobFilesToDelete NOT in plan (execution-time computation)
+  t1: Cleaner plans at timeline fence T.
+      Plan = {filePathsToBeDeleted: [FG-1/@t1]}
+      No blob info written to plan. Plan goes to timeline as REQUESTED.
+
+  t2: Writer commits to FG-2, adds row2.blob_ref = (s3://ext/video.mp4).
+      Writer checks for conflicts: the clean plan on the timeline has no
+      blob info -- only filePathsToBeDeleted for FG-1. Writer is on FG-2.
+      No conflict detected. Writer succeeds.
+
+  t3: Cleaner transitions to INFLIGHT. Executor computes blob deletes:
+      Reads FG-1/@t1 -> expired_refs = {video.mp4}
+      Reads FG-1/@t3 -> retained_refs = {photo.png}
+      video.mp4 locally orphaned -> Stage 2 cross-FG check at fence T
+      -> does NOT see writer's commit at t2 -> globally orphaned -> DELETE
+
+  Result: FG-2 row2 now has a dangling reference to video.mp4.
+  Bob queries his data and gets a missing blob error. Data corruption.
+
+  Why it cannot be fixed: the blob delete decision existed only in the
+  executor's memory. There was no artifact on the timeline for the writer's
+  conflict resolution to check against. The cross-FG conflict was invisible.
+
+Approach B: blobFilesToDelete IN the plan (plan-time computation)
+  t1: Cleaner plans at timeline fence T.
+      Stage 1: video.mp4 locally orphaned in FG-1.
+      Stage 2: cross-FG check -> no other FG references video.mp4.
+      Plan = {filePathsToBeDeleted: [FG-1/@t1],
+              blobFilesToDelete: [s3://ext/video.mp4]}
+      Plan goes to timeline as REQUESTED.
+
+  t2: Writer commits to FG-2, adds row2.blob_ref = (s3://ext/video.mp4).
+      Writer's conflict resolution checks inflight/requested clean plan.
+      Sees blobFilesToDelete contains video.mp4 -- the same blob the
+      writer is referencing. CONFLICT DETECTED. Writer aborts and retries
+      after the clean cycle completes (or clean plan is rolled back).
+      -> Safe. The conflict is caught before corruption can occur.
+
+  Alternative: if the writer commits first (wins the race), the clean
+  plan's conflict resolution at INFLIGHT transition detects that a new
+  commit references a blob in blobFilesToDelete. Clean plan is invalidated
+  and re-planned in the next cycle, where it will see FG-2's reference
+  and retain video.mp4.
+
+Key insight:
+  Today, clean actions are not part of OCC conflict resolution
+  (TransactionUtils.getInflightAndRequestedInstants excludes CLEAN_ACTION,
+  and ConcurrentOperation.init throws for clean actions). Adding external
+  blob cleanup requires extending conflict resolution to check
+  blobFilesToDelete. This is only possible if the blob delete list is a
+  durable artifact on the timeline -- i.e., part of the plan.
+```
+
 ---
 
 ## 7. Open Questions

--- a/rfc/rfc-100/rfc-100-blob-cleaner-problem.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-problem.md
@@ -1,0 +1,677 @@
+# Blob Cleaner: Problem Statement
+
+## 1. Goal
+
+When old file slices are cleaned, out-of-line blob files they reference may become orphaned -- still
+consuming storage but unreachable by any query. The blob cleaner must identify and delete these
+unreferenced blob files without premature deletion (deleting a blob that is still referenced by a live
+record). This document defines the problem scope, design constraints, requirements, and illustrative
+failure modes. It contains no solution content.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- Cleanup of **out-of-line blob files** when references to them exist only in expired (cleaned) file
+  slices.
+- All table types: **COW** and **MOR**.
+- All cleaning policies: `KEEP_LATEST_COMMITS`, `KEEP_LATEST_FILE_VERSIONS`,
+  `KEEP_LATEST_BY_HOURS`.
+- Interaction with table services: **compaction**, **clustering**, **blob compaction**.
+- Interaction with timeline operations: **savepoints**, **rollback**, **archival**.
+- Single-writer and multi-writer (OCC) concurrency modes.
+- Both **Hudi-created blobs** (stored under `{table}/.hoodie/blobs/...`) and **user-provided
+  external blobs** (arbitrary paths).
+
+### Two entry flows
+
+Blob cleanup must support two distinct entry flows. These are not edge cases of each other --
+they are co-equal paths with different properties, different volumes, and different cleanup costs.
+
+**Flow 1: Path-dispatched (Hudi-created blobs).** Blobs created by Hudi's write path and stored
+under `{table}/.hoodie/blobs/{partition}/{col}/{instant}/{blob_id}`. The path structure guarantees
+uniqueness (C11), file-group scoping, and eliminates cross-FG sharing for normal writes. This is the
+expected majority flow for Phase 3 workloads.
+
+**Flow 2: Non-path-dispatched (user-provided external blobs).** Users have existing blob files in
+external storage (e.g., `s3://media-bucket/videos/`, a shared NFS mount, or any user-controlled
+path). Records reference these blobs directly by path. The user does **not** want to bootstrap --
+they do not want Hudi to copy, move, or reorganize the blob files into `.hoodie/blobs/`. Hudi
+manages the *references*, not the *storage layout*. This is the expected primary flow for Phase 1
+workloads and remains a supported flow in Phase 3.
+
+The non-path-dispatched flow has fundamentally different properties:
+
+| Property                  | Path-dispatched (Hudi-created)    | Non-path-dispatched (external)       |
+|---------------------------|-----------------------------------|--------------------------------------|
+| Path uniqueness           | Guaranteed (instant in path, C11) | Not guaranteed (user controls)       |
+| Cross-FG sharing          | Does not occur (FG-scoped)        | Common (multiple records, same blob) |
+| Writer/cleaner race       | Cannot occur (D2)                 | Can occur (D3)                       |
+| Delete-and-re-add (C2)    | Eliminated                        | Real concern                         |
+| Volume                    | Scales with writes                | Can be large from day one            |
+| Per-FG cleanup sufficient | Yes                               | No -- cross-FG verification needed   |
+
+Any solution that treats the non-path-dispatched flow as a rare edge case will fail at scale for
+Phase 1 workloads. The cleanup algorithm must be efficient for **both** flows independently, and
+must not impose the cost structure of one flow on the other.
+
+### Out of scope
+
+- **Inline blobs.** Inline blob data lives inside the base/log file and is deleted when the file
+  slice is cleaned. No additional cleanup needed.
+- **Blob compaction internals.** Blob compaction (repacking partially-live container files) is a
+  separate service. This document defines the interface point (when to hand off to blob compaction)
+  but not its internal design.
+- **Schema evolution.** Adding or removing blob columns does not change the cleanup problem.
+
+### Stance on the `managed` flag
+
+The BlobReference schema includes a `managed` boolean field
+(`HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED`). The RFC states that only managed blobs are
+cleaned. This document acknowledges the flag and treats it as a **filter** -- unmanaged blobs are
+excluded from cleanup consideration. However, the cleanup design must be **correct regardless of the
+flag's value**. The flag selects *which* blobs enter the cleanup pipeline; it must not be used as a
+correctness lever within the pipeline itself. The flag may later serve as an optimization (skip
+cleanup work for unmanaged blobs), but the problem statement and any solution must not depend on it
+for safety.
+
+---
+
+## 3. Background: Existing Cleaner
+
+The existing Hudi cleaner provides the execution framework that blob cleanup must integrate with.
+
+### Plan-execute model
+
+Cleaning is a two-phase operation:
+
+1. **Plan** (`CleanPlanner`): For each partition and file group, determine which file slices are
+   expired based on the cleaning policy. Produce a `HoodieCleanerPlan` listing file paths to delete.
+2. **Execute** (`CleanActionExecutor`): Delete the files listed in the plan. Record results in
+   `HoodieCleanMetadata` on the timeline.
+
+### Per-partition, per-file-group iteration
+
+`CleanPlanner.getDeletePaths(partitionPath, earliestCommitToRetain)` iterates file groups within a
+partition. For each file group, it compares file slices against the retention policy and produces a
+list of `CleanFileInfo` objects (file paths to delete). The cleaner has no concept of cross-file-group
+dependencies.
+
+### Savepoint awareness
+
+The cleaner collects all savepointed timestamps and their associated data files. File slices that
+overlap with savepointed files are excluded from cleaning
+(`isFileSliceExistInSavepointedFiles`). This preserves the savepoint invariant: a savepoint freezes a
+consistent snapshot including all data files it references.
+
+### OCC conflict resolution
+
+`SimpleConcurrentFileWritesConflictResolutionStrategy` resolves write-write conflicts at the
+`(partition, fileId)` granularity. There is no global serialization point. Concurrent writers to
+different file groups proceed without contention.
+
+### Critical gap
+
+The existing cleaner operates on file paths (base files + log files) within a single file group. It
+has **no concept of transitive references** -- it does not know that a file slice contains pointers
+to external blob files that may need separate cleanup. Blob cleanup requires extending the cleaner
+to follow these references and determine blob-level liveness.
+
+---
+
+## 4. Design Constraints
+
+Each constraint is a fact about the Hudi system that any blob cleanup solution must respect. Violating
+any constraint leads to data corruption, premature deletion, or permanent orphans.
+
+### C1: Blob immutability
+
+Once a blob file is written, its content never changes. Blob files are append-once, read-many. This
+means a blob file's identity is stable for its entire lifetime.
+
+*Source: RFC-100 blob cleaner design, general storage semantics.*
+
+### C2: Delete-and-re-add same path
+
+A blob file can be deleted from storage and a new file created at the same path with different
+content. This is a real concern for user-provided external blobs (the user controls the path). For
+Hudi-created blobs, it is structurally eliminated by C11 (instant in path guarantees uniqueness).
+
+*Source: RFC-100 blob cleaner design; alternatives analysis constraint C2.*
+
+### C3: Cross-file-group blob sharing
+
+An out-of-line blob can be referenced by records in multiple file groups and multiple partitions. This
+is explicitly supported for user-provided external blobs: two records in different file groups can
+point to the same external file. For Hudi-created blobs, cross-FG sharing does not occur because the
+blob is created within a specific file group's storage scope (see C11). However, after clustering
+(C8), references to the same Hudi-created blob could temporarily exist in both the source and target
+file groups until the source is cleaned.
+
+*Source: RFC-100 lines 196-198 (Option 1 scans all active file slices); alternatives analysis F6.*
+
+### C4: Container files
+
+Multiple blobs can be packed into a single container file, distinguished by `(offset, length)` within
+the BlobReference. A container file can only be deleted when **all** byte ranges within it are
+unreferenced. If some ranges are orphaned but others are still live, the container cannot be deleted --
+it must be handed off to blob compaction for repacking.
+
+*Source: BlobReference schema fields `offset` and `length`; RFC-100 lines 164-165 (container config);
+alternatives analysis F1.*
+
+### C5: MOR log updates shadow base file blob refs
+
+In MOR tables, a log file update to a record's blob reference supersedes the base file's blob
+reference for that record. The base file's blob ref appears live (it exists in an active file slice)
+but is actually dead (the log update replaced it). Reading only the base file produces a **superset**
+of live references. Over-retention (keeping the shadowed blob longer) is safe. Under-retention
+(treating the log-shadowed base ref as already cleaned) would cause premature deletion if the log
+update is later rolled back.
+
+*Source: RFC-100 line 122 (merge mode determines which blob reference is returned); MOR semantics.*
+
+### C6: Existing cleaner is per-file-group scoped
+
+`CleanPlanner` iterates per `HoodieFileGroup` within each partition. It determines expired file slices
+within a single file group. There is no existing mechanism to evaluate cross-file-group dependencies
+during cleaning.
+
+*Source: `CleanPlanner.getDeletePaths()`, `CleanPlanner.getFilesToCleanKeepingLatestCommits()`;
+alternatives analysis F11.*
+
+### C7: OCC is per-file-group (no global contention allowed)
+
+Concurrent writer conflict resolution operates at `(partition, fileId)` granularity. Any solution that
+introduces a global contention point (global counter, global lock, global bitmap) violates this
+constraint and degrades write throughput under concurrency.
+
+*Source: `SimpleConcurrentFileWritesConflictResolutionStrategy`; alternatives analysis F12.*
+
+### C8: Clustering moves blob refs between file groups
+
+Clustering reads records from source file groups and rewrites them to target file groups. For
+Hudi-managed blobs, clustering creates **new** blob files in the target file group. For external
+blobs, clustering copies the pointer (same path, same offset/length) to the target file group. After
+clustering, the source file group's slices still reference the original blobs until those slices are
+cleaned. The target file group's slices reference either new blobs (Hudi-managed) or the same
+external blobs.
+
+*Source: RFC-100 lines 212-214.*
+
+### C9: Savepoints freeze file slices and their blob refs
+
+A savepoint preserves a consistent snapshot. File slices covered by a savepoint are excluded from
+cleaning. This means any blob referenced by a savepointed file slice must also be preserved, even if
+the blob would otherwise be considered orphaned. The cleaner already handles savepoint exclusion for
+file slices; blob cleanup must extend this guarantee to the blobs they reference.
+
+*Source: `CleanPlanner.savepointedTimestamps`, `isFileSliceExistInSavepointedFiles()`.*
+
+### C10: Rollback can invalidate or resurrect references
+
+Rolling back a commit can remove file slices that were the sole reference to a blob (the blob becomes
+orphaned). Conversely, rolling back a commit that updated a record's blob reference can resurrect the
+previous reference (an older blob that appeared orphaned is now live again). Any blob cleanup solution
+must account for both directions.
+
+*Source: Hudi rollback semantics; timeline management.*
+
+### C11: Hudi-created blob paths include instant (structurally unique)
+
+Hudi-created blob files are stored at
+`{table_path}/.hoodie/blobs/{partition}/{column_name}/{instant}/{blob_id}`. Because the commit
+instant is embedded in the path, two different writes always produce different blob paths. This
+eliminates the delete-and-re-add problem (C2) for Hudi-created blobs and means they are inherently
+scoped to a single file group's write context.
+
+*Source: RFC-100 line 170; alternatives analysis F3.*
+
+### C12: Archival removes commit metadata from active timeline
+
+Hudi's archival process moves completed commits from the active timeline to the archived timeline.
+If blob cleanup depends on information in commit metadata (e.g., which blobs were written by a
+commit), that information becomes unavailable after archival unless it is persisted elsewhere. The
+cleaner must either complete blob reference resolution before archival, or ensure the necessary
+information survives archival.
+
+*Source: Hudi archival semantics; `HoodieActiveTimeline` vs `HoodieArchivedTimeline`.*
+
+### C13: Non-path-dispatched blobs require cross-FG verification at scale
+
+For the non-path-dispatched flow (Flow 2), cross-file-group blob sharing (C3) is the **common
+case**, not an edge case. Users referencing external blobs (e.g., a shared media library) will
+frequently have multiple records across different file groups and partitions pointing to the same
+blob file. Any cleanup algorithm that treats cross-FG verification as a rare fallback will impose
+disproportionate cost on Flow 2 workloads. The cross-FG verification path must be designed for
+volume, not just correctness.
+
+*Source: Two entry flows (Section 2); C3; alternatives analysis D1, D3.*
+
+---
+
+## 5. Requirements
+
+### R1: No premature deletion (hard invariant)
+
+A blob file must not be deleted while any live record still references it. This is the single most
+critical requirement. A premature deletion causes silent data corruption: queries return null or error
+for the affected records, and the data is unrecoverable.
+
+### R2: No permanent orphans (bounded cleanup)
+
+Every orphaned blob must eventually be cleaned. The number of cleanup cycles required to reclaim an
+orphan must be bounded (e.g., cleaned within N cleaner invocations after the last referencing file
+slice is expired). Unbounded accumulation of orphaned blobs wastes storage indefinitely.
+
+### R3: Container awareness (range-level liveness)
+
+Cleanup must track liveness at the `(path, offset, length)` tuple level, not just the path level.
+A container file may have some live ranges and some dead ranges. Only when all ranges are dead can the
+container file be deleted. Partially-dead containers should be flagged for blob compaction.
+
+### R4: MOR correctness
+
+For MOR tables, blob cleanup must be safe in the presence of log updates that shadow base file blob
+references. Over-retention (keeping a shadowed blob until post-compaction) is acceptable.
+Under-retention (prematurely deleting a blob whose reference appears shadowed but could be resurrected
+by rollback) is not.
+
+### R5: Concurrency safety (no global serialization)
+
+Blob cleanup must not introduce global contention points. Write throughput for tables with blobs must
+not degrade compared to tables without blobs under concurrent writers. Per-file-group scoping (C7)
+must be preserved.
+
+### R6: Scale proportional to work, not table size
+
+For path-dispatched blobs (Flow 1): the cost of blob cleanup must be proportional to the number of
+file groups being cleaned, not the total table size. A table with 100K file groups cleaning 1K of
+them must not scan all 100K file groups.
+
+For non-path-dispatched blobs (Flow 2): cross-FG verification is required (C13), but the cost must
+be proportional to the number of **candidate blobs requiring verification**, not the total number of
+active file slices in the table. A table with 100K file groups where 50 external blob candidates
+need cross-FG verification must not scan all 100K file groups -- it must use targeted lookups or
+indexes to resolve those 50 candidates efficiently.
+
+### R7: No cost for non-blob tables
+
+Tables without blob columns must pay zero additional cost. The blob cleanup path must not be entered
+if no blob columns exist. This includes no additional metadata, no additional timeline entries, and no
+additional I/O.
+
+### R8: All cleaning policies supported
+
+Blob cleanup must work correctly under all three cleaning policies: `KEEP_LATEST_COMMITS`,
+`KEEP_LATEST_FILE_VERSIONS`, and `KEEP_LATEST_BY_HOURS`. The blob cleanup logic should be
+policy-agnostic -- it operates on the set of expired vs. retained file slices determined by the
+policy, not on the policy itself.
+
+### R9: Crash safety and idempotency
+
+If the cleaner crashes after planning but before completing all deletions, restarting must be safe.
+Blob deletions must be idempotent (deleting an already-deleted file is a no-op, not an error).
+The cleaner plan must include enough information to resume blob cleanup without re-reading expired
+file slices (which may no longer exist after a partial execution).
+
+### R10: Observability
+
+Blob cleanup must report metrics: number of blob files deleted, number of blob files retained
+(over-retained due to MOR or containers), number of container files flagged for blob compaction,
+and total storage reclaimed. These metrics enable operators to understand blob storage growth and
+cleanup effectiveness.
+
+---
+
+## 6. Illustrative Examples
+
+Each example demonstrates a specific failure mode. These are not exhaustive -- they are designed to
+make the constraints and requirements concrete.
+
+### Example 1: Cross-file-group sharing -- per-FG cleanup deletes shared blob
+
+**Demonstrates:** C3, C6, R1
+
+```
+Setup:
+  Partition P1, File Group FG-1:
+    Slice @t1: row1.blob_ref = (s3://shared/video.mp4, 0, 10MB, managed=true)
+
+  Partition P2, File Group FG-2:
+    Slice @t1: row2.blob_ref = (s3://shared/video.mp4, 0, 10MB, managed=true)
+
+Action:
+  Cleaner expires FG-1's slice @t1 (no retained slices in FG-1).
+
+Per-FG cleanup (incorrect):
+  FG-1 expired refs = {(s3://shared/video.mp4, 0, 10MB)}
+  FG-1 retained refs = {}
+  Orphaned within FG-1 = {(s3://shared/video.mp4, 0, 10MB)}
+  -> DELETE s3://shared/video.mp4
+
+Result:
+  FG-2 still has an active slice @t1 referencing video.mp4.
+  Query on row2 -> FILE NOT FOUND. Data corruption.
+
+Correct behavior:
+  Before deleting, verify that no other active file slice in any file group
+  references (s3://shared/video.mp4, 0, 10MB). FG-2's active slice references
+  it, so the blob must be retained.
+```
+
+### Example 2: Container file partial liveness -- deleting container destroys live ranges
+
+**Demonstrates:** C4, R3
+
+```
+Setup:
+  File Group FG-1:
+    Slice @t1: row1.blob_ref = (container_A.bin, 0, 1MB, managed=true)
+    Slice @t2: row2.blob_ref = (container_A.bin, 1MB, 2MB, managed=true)
+
+Action:
+  Cleaner expires slice @t1, retains slice @t2.
+
+Path-level cleanup (incorrect):
+  Expired paths = {container_A.bin}
+  Retained paths = {container_A.bin}
+  container_A.bin is in both sets -> retain.
+  (This happens to be safe by accident, but only because the same path appears.)
+
+  Alternative scenario -- different slices, same container:
+    Slice @t1 in FG-1: row1.blob_ref = (container_A.bin, 0, 1MB)  -- expired
+    Slice @t1 in FG-2: row2.blob_ref = (container_A.bin, 1MB, 2MB)  -- retained
+
+  If FG-1 concludes container_A.bin is orphaned (no retained refs within FG-1):
+  -> DELETE container_A.bin
+  FG-2's live range at offset 1MB is destroyed.
+
+Correct behavior:
+  Track liveness at (path, offset, length). Only delete the container file when
+  ALL ranges are unreferenced. If some ranges are dead and others live, flag the
+  container for blob compaction instead of deleting it.
+```
+
+### Example 3: Delete-and-re-add -- path reuse causes identity confusion
+
+**Demonstrates:** C2, R1
+
+```
+Setup:
+  At time t1: User writes row1.blob_ref = (s3://user/photo.jpg, managed=true)
+  At time t2: User deletes the file at s3://user/photo.jpg externally
+  At time t3: User writes row2.blob_ref = (s3://user/photo.jpg, managed=true)
+              (new file at same path, different content)
+
+Cleanup scenario:
+  Cleaner expires slice @t1. Slice @t3 is retained.
+  Expired refs = {s3://user/photo.jpg}
+  Retained refs = {s3://user/photo.jpg}
+  Same path in both sets -> retain. (Correct by coincidence.)
+
+  But consider: if the cleaner had cached blob identity by path and assumed
+  "same path = same blob," it would not detect that the t1 and t3 references
+  point to different physical content.
+
+  Edge case: if t3 is also expired and t1 is the only reference, the cleaner
+  would correctly delete. But if a new writer at t4 references the same path
+  AGAIN (third incarnation), the cleaner's identity model must not confuse the
+  three incarnations.
+
+Note: This problem does not arise for Hudi-created blobs (C11 -- instant in
+path guarantees each write produces a unique path).
+```
+
+### Example 4: MOR log shadow -- base file ref appears live when superseded
+
+**Demonstrates:** C5, R4
+
+```
+Setup (MOR table):
+  File Group FG-1:
+    Base file @t1: row1.blob_ref = (blob_A.bin, managed=true)
+    Log file @t2: row1.blob_ref = (blob_B.bin, managed=true)  -- update
+
+  After merge: row1's effective blob_ref is blob_B.bin.
+  blob_A.bin is no longer referenced by any live record.
+
+Cleanup scenario (pre-compaction):
+  Cleaner does not expire slice @t1 (it's retained).
+  Reading blob refs from the retained slice:
+    Base @t1: {blob_A.bin}
+    Log @t2: {blob_B.bin}
+    Union: {blob_A.bin, blob_B.bin}
+
+  blob_A.bin appears live (it's in the retained set) even though it's been
+  superseded by the log update. This is over-retention -- safe but wasteful.
+
+After compaction:
+  Compacted base @t3: row1.blob_ref = (blob_B.bin, managed=true)
+  Now the only retained ref is {blob_B.bin}.
+  blob_A.bin is no longer in any retained set -> eligible for deletion.
+
+Why over-retention is the correct default:
+  If the log file @t2 is rolled back, row1 reverts to blob_A.bin from the base
+  file. If blob_A.bin had been prematurely deleted, the rollback produces a
+  dangling reference. Over-retention prevents this.
+```
+
+### Example 5: Writer-cleaner race -- three scenarios
+
+**Demonstrates:** C7, R1, R5
+
+```
+A writer and cleaner operate concurrently on the same table.
+
+Scenario A: Writer commits BEFORE cleaner's timeline fence
+  t1: Writer starts, references blob_X
+  t2: Writer commits (blob_X is now in a retained slice)
+  t3: Cleaner plans cleanup
+  t4: Cleaner checks timeline fence -- sees writer's commit at t2
+  t5: Cleaner removes blob_X from orphan candidates
+  -> Safe. Timeline fence catches the new reference.
+
+Scenario B: Writer commits AFTER cleaner's timeline fence, BEFORE delete
+  t1: Cleaner plans cleanup, blob_X is a candidate for deletion
+  t2: Cleaner checks timeline fence -- no new commits
+  t3: Writer commits, referencing blob_X
+  t4: Cleaner deletes blob_X
+  -> UNSAFE. The timeline fence did not see the writer's commit.
+     blob_X is deleted, but the writer's new slice references it.
+
+Scenario C: Writer commits AFTER cleaner deletes
+  t1: Cleaner plans and executes, deletes blob_X
+  t2: Writer commits, referencing blob_X (e.g., user-provided external path)
+  -> UNSAFE. The blob is already gone. The writer's commit creates a dangling
+     reference.
+
+Note: Scenario B and C cannot occur for Hudi-created blobs (C11 + D2 from
+alternatives analysis: new writes always produce new paths, and UPSERT carries
+forward refs from retained slices). They are real concerns for user-provided
+external blobs where the user can reference any path.
+```
+
+### Example 6: Clustering moves refs -- replaced FG appears to have no retained slices
+
+**Demonstrates:** C8, C3, R1
+
+```
+Setup:
+  File Group FG-1:
+    Slice @t1: row1.blob_ref = (blob_A.bin, managed=true)
+
+  Clustering at t2 rewrites FG-1's records to FG-2:
+    File Group FG-2:
+      Slice @t2: row1.blob_ref = (blob_A_new.bin, managed=true)
+                 (Hudi-managed: new blob created in FG-2's scope)
+
+  FG-1 is now a replaced file group. Its slice @t1 is eligible for cleaning
+  after the retention policy expires.
+
+Cleanup:
+  Cleaner cleans FG-1's slice @t1.
+  Expired refs = {blob_A.bin}
+  Retained refs within FG-1 = {} (FG-1 has no retained slices -- it's replaced)
+  blob_A.bin appears orphaned within FG-1 -> DELETE
+
+  This is actually CORRECT for Hudi-managed blobs: clustering created a new
+  blob (blob_A_new.bin) in FG-2, so blob_A.bin is genuinely orphaned.
+
+  BUT if the blob were an external user-provided blob (same path referenced
+  from both FG-1 and FG-2 after clustering):
+
+  File Group FG-2:
+    Slice @t2: row1.blob_ref = (s3://ext/video.mp4, managed=true)
+               (external: pointer copied, same blob)
+
+  FG-1's cleanup concludes s3://ext/video.mp4 is orphaned within FG-1.
+  Deleting it destroys FG-2's live reference.
+
+Correct behavior:
+  For Hudi-managed blobs, per-FG cleanup is safe because clustering always
+  creates new blob files in the target FG. For external blobs, a cross-FG
+  check is required before deletion.
+```
+
+### Example 7: Non-bootstrapped external blobs at scale -- cross-FG verification is the common path
+
+**Demonstrates:** C3, C13, R6 (Flow 2)
+
+```
+Setup:
+  A media company stores 10M video files in s3://media-library/.
+  They create a Hudi table with a blob column referencing these videos.
+  They do NOT bootstrap -- Hudi manages refs, not storage layout.
+
+  The table has 50K file groups across 1K partitions.
+  Many videos are referenced by multiple records (e.g., a popular video
+  appears in multiple user playlists across different partitions).
+
+  Partition users/alice, FG-101:
+    Slice @t1: row1.blob_ref = (s3://media-library/video_X.mp4, managed=true)
+
+  Partition users/bob, FG-202:
+    Slice @t1: row2.blob_ref = (s3://media-library/video_X.mp4, managed=true)
+
+  Partition users/carol, FG-303:
+    Slice @t1: row3.blob_ref = (s3://media-library/video_X.mp4, managed=true)
+
+Action:
+  Cleaner expires FG-101's slice @t1 (alice deleted her playlist entry).
+
+Naive per-FG cleanup (incorrect):
+  FG-101 expired refs = {(s3://media-library/video_X.mp4, 0, 50MB)}
+  FG-101 retained refs = {}
+  Orphaned within FG-101 -> DELETE video_X.mp4
+  Bob and Carol lose their video. Data corruption.
+
+Naive full-table scan (correct but expensive):
+  To verify video_X.mp4 is safe to delete, scan ALL 50K file groups
+  for references. This is correct but violates R6 -- the cost is
+  proportional to table size, not to the number of candidates.
+
+Scale concern:
+  If the cleaner expires 500 file groups and produces 2,000 external
+  blob candidates, and each candidate requires a full-table scan,
+  the cleanup cost is 2,000 * 50K = 100M file group checks.
+  This is prohibitive.
+
+Correct behavior:
+  Cross-FG verification for external blobs must use a targeted
+  mechanism (e.g., index lookup, partitioned scan with predicate
+  pushdown) that scales with the number of candidates, not with
+  the total table size. The mechanism must be a first-class design
+  element, not a fallback path.
+```
+
+### Example 8: MOR log-chain transient blob -- introduced and superseded within logs
+
+**Demonstrates:** C5, R2
+
+```
+Setup (MOR table):
+  File Group FG-1:
+    Base file @t1: row1.blob_ref = (blob_A.bin, managed=true)
+    Log file @t2: row1.blob_ref = (blob_B.bin, managed=true)  -- update
+    Log file @t3: row1.blob_ref = (blob_C.bin, managed=true)  -- another update
+
+  After merge: row1's effective blob_ref is blob_C.bin.
+  blob_B.bin was introduced at t2 and superseded at t3 -- it exists ONLY in log @t2.
+
+After compaction @t4:
+  Compacted base @t4: row1.blob_ref = (blob_C.bin, managed=true)
+  The pre-compaction slice (base @t1 + logs @t2, @t3) is now expired.
+
+Cleanup scenario:
+  Cleaner expires the pre-compaction slice.
+  Retained slice = compacted base @t4, refs = {blob_C.bin}.
+
+  If expired slice reads only the base file:
+    expired_refs = {blob_A.bin}  (from base @t1)
+    local_orphans = {blob_A.bin} - {blob_C.bin} = {blob_A.bin}
+    blob_A.bin is correctly identified as orphaned.
+    blob_B.bin is MISSED -- it exists only in expired log @t2.
+    blob_B.bin becomes a permanent orphan (R2 violation).
+
+  If expired slice reads base + log files:
+    expired_refs = {blob_A.bin, blob_B.bin, blob_C.bin}
+    local_orphans = {blob_A.bin, blob_B.bin, blob_C.bin} - {blob_C.bin}
+                  = {blob_A.bin, blob_B.bin}
+    Both orphaned blobs are correctly identified and deleted.
+
+Why this matters:
+  Transient blob refs that are introduced and superseded entirely within
+  the log chain never appear in any base file. They can only be discovered
+  by reading the expired log files. Without log reads on the expired side,
+  every such transient blob becomes a permanent orphan that accumulates
+  storage indefinitely.
+```
+
+---
+
+## 7. Open Questions
+
+These questions must be answered by any solution design. They are not prescriptive -- multiple valid
+answers exist for each.
+
+**Q1: What is blob identity?**
+How does the cleanup algorithm identify a specific blob? By path alone? By the tuple
+`(path, offset, length)`? By `(path, generation/version)`? The identity model determines how
+deduplication, container handling, and delete-and-re-add (C2) are handled.
+
+**Q2: Where is liveness computed?**
+Is the set of live blob references computed at write time (incremental), at clean time (batch), or
+some combination? Write-time computation amortizes cost but requires additional metadata storage.
+Clean-time computation avoids write overhead but may be expensive at scale.
+
+**Q3: What is the unit of cleanup planning?**
+Does blob cleanup plan per-file-group (aligned with the existing cleaner), per-partition, or globally?
+Per-FG is naturally aligned with OCC (C7) but cannot handle cross-FG sharing (C3) without extension.
+Global planning handles cross-FG sharing but risks violating C7.
+
+**Q4: How does blob cleanup interact with archival?**
+If the cleanup algorithm depends on commit metadata to determine which blobs were written, what
+happens when those commits are archived (C12)? Must blob cleanup complete before archival? Must the
+relevant metadata be persisted outside the active timeline?
+
+**Q5: Extension or separate service?**
+Should blob cleanup be an extension of the existing file slice cleaner (same plan, same execution
+phase) or a separate service (independent schedule, independent timeline action)? Extension aligns
+lifecycle but increases cleaner complexity. Separation simplifies each component but introduces
+coordination challenges.
+
+**Q6: Failure mode and recovery if premature deletion occurs?**
+Despite best efforts, what happens if a blob is prematurely deleted? Is there a detection mechanism
+(query-time error surfacing)? Is there a recovery path (rebuild from an external source)? How does
+the system distinguish "blob correctly not present" from "blob incorrectly deleted"?
+
+**Q7: How does cross-FG verification scale for non-path-dispatched blobs?**
+For Flow 2 workloads where cross-FG sharing is common, what mechanism makes cross-FG verification
+efficient? Options include: an MDT index mapping blob paths to referencing file groups, predicate
+pushdown on the blob ref column during targeted scans, a reference count maintained at write time,
+or a bloom filter index. The chosen mechanism must satisfy R6 (cost proportional to candidates, not
+table size) and C7 (no global serialization). How does this mechanism interact with writes, and what
+is its maintenance cost?

--- a/rfc/rfc-100/rfc-100-blob-cleaner-problem.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-problem.md
@@ -1,12 +1,33 @@
-# Blob Cleaner: Problem Statement
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# External Blob Cleaner: Problem Statement
 
 ## 1. Goal
 
-When old file slices are cleaned, out-of-line blob files they reference may become orphaned -- still
-consuming storage but unreachable by any query. The blob cleaner must identify and delete these
-unreferenced blob files without premature deletion (deleting a blob that is still referenced by a live
-record). This document defines the problem scope, design constraints, requirements, and illustrative
-failure modes. It contains no solution content.
+When old file slices are cleaned, external out-of-line blob files they reference may become orphaned
+-- still consuming storage but unreachable by any query. The blob cleaner must identify and delete
+these unreferenced blob files without premature deletion (deleting a blob that is still referenced by
+a live record). This document defines the problem scope, design constraints, requirements, and
+illustrative failure modes. It contains no solution content.
+
+This document focuses on **external blobs** -- the Phase 1 use case of RFC-100 where users have
+existing blob files in external storage (e.g., `s3://media-bucket/videos/`) and Hudi manages the
+*references* via the `BlobReference` schema, not the *storage layout*.
 
 ---
 
@@ -14,68 +35,58 @@ failure modes. It contains no solution content.
 
 ### In scope
 
-- Cleanup of **out-of-line blob files** when references to them exist only in expired (cleaned) file
-  slices.
+- Cleanup of **external out-of-line blob files** (referenced via `BlobReference.external_path`) when
+  references to them exist only in expired (cleaned) file slices.
 - All table types: **COW** and **MOR**.
 - All cleaning policies: `KEEP_LATEST_COMMITS`, `KEEP_LATEST_FILE_VERSIONS`,
   `KEEP_LATEST_BY_HOURS`.
-- Interaction with table services: **compaction**, **clustering**, **blob compaction**.
-- Interaction with timeline operations: **savepoints**, **rollback**, **archival**.
+- Interaction with table services: **compaction**, **clustering**.
+- Interaction with replace commits: **clustering**, **insert_overwrite**,
+  **insert_overwrite_table**.
+- Interaction with timeline operations: **savepoints**, **rollback**, **restore**, **archival**.
 - Single-writer and multi-writer (OCC) concurrency modes.
-- Both **Hudi-created blobs** (stored under `{table}/.hoodie/blobs/...`) and **user-provided
-  external blobs** (arbitrary paths).
 
-### Two entry flows
-
-Blob cleanup must support two distinct entry flows. These are not edge cases of each other --
-they are co-equal paths with different properties, different volumes, and different cleanup costs.
-
-**Flow 1: Path-dispatched (Hudi-created blobs).** Blobs created by Hudi's write path and stored
-under `{table}/.hoodie/blobs/{partition}/{col}/{instant}/{blob_id}`. The path structure guarantees
-uniqueness (C11), file-group scoping, and eliminates cross-FG sharing for normal writes. This is the
-expected majority flow for Phase 3 workloads.
-
-**Flow 2: Non-path-dispatched (user-provided external blobs).** Users have existing blob files in
-external storage (e.g., `s3://media-bucket/videos/`, a shared NFS mount, or any user-controlled
-path). Records reference these blobs directly by path. The user does **not** want to bootstrap --
-they do not want Hudi to copy, move, or reorganize the blob files into `.hoodie/blobs/`. Hudi
-manages the *references*, not the *storage layout*. This is the expected primary flow for Phase 1
-workloads and remains a supported flow in Phase 3.
-
-The non-path-dispatched flow has fundamentally different properties:
-
-| Property                  | Path-dispatched (Hudi-created)    | Non-path-dispatched (external)       |
-|---------------------------|-----------------------------------|--------------------------------------|
-| Path uniqueness           | Guaranteed (instant in path, C11) | Not guaranteed (user controls)       |
-| Cross-FG sharing          | Does not occur (FG-scoped)        | Common (multiple records, same blob) |
-| Writer/cleaner race       | Cannot occur (D2)                 | Can occur (D3)                       |
-| Delete-and-re-add (C2)    | Eliminated                        | Real concern                         |
-| Volume                    | Scales with writes                | Can be large from day one            |
-| Per-FG cleanup sufficient | Yes                               | No -- cross-FG verification needed   |
-
-Any solution that treats the non-path-dispatched flow as a rare edge case will fail at scale for
-Phase 1 workloads. The cleanup algorithm must be efficient for **both** flows independently, and
-must not impose the cost structure of one flow on the other.
+| Property                  | External blobs                               |
+|---------------------------|----------------------------------------------|
+| Path uniqueness           | Not guaranteed (user controls)               |
+| Cross-FG sharing          | Common (multiple records, same blob)         |
+| Writer/cleaner race       | Can occur (external paths outside MVCC)      |
+| Delete-and-re-add         | Real concern (user controls paths)           |
+| Per-FG cleanup sufficient | No -- cross-FG verification needed           |
 
 ### Out of scope
 
 - **Inline blobs.** Inline blob data lives inside the base/log file and is deleted when the file
   slice is cleaned. No additional cleanup needed.
-- **Blob compaction internals.** Blob compaction (repacking partially-live container files) is a
-  separate service. This document defines the interface point (when to hand off to blob compaction)
-  but not its internal design.
+- **Storing blob references in commit metadata.** Persisting blob reference sets within commit-level
+  metadata is an anti-pattern that does not scale and is not considered in this problem statement.
 - **Schema evolution.** Adding or removing blob columns does not change the cleanup problem.
 
 ### Stance on the `managed` flag
 
-The BlobReference schema includes a `managed` boolean field
-(`HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED`). The RFC states that only managed blobs are
-cleaned. This document acknowledges the flag and treats it as a **filter** -- unmanaged blobs are
-excluded from cleanup consideration. However, the cleanup design must be **correct regardless of the
-flag's value**. The flag selects *which* blobs enter the cleanup pipeline; it must not be used as a
-correctness lever within the pipeline itself. The flag may later serve as an optimization (skip
-cleanup work for unmanaged blobs), but the problem statement and any solution must not depend on it
-for safety.
+The `BlobReference` schema includes a `managed` boolean field (`reference.managed`). The RFC states
+that only managed blobs are cleaned. This document acknowledges the flag and treats it as a
+**filter** -- unmanaged blobs are excluded from cleanup consideration. However, the cleanup design
+must be **correct regardless of the flag's value**. The flag selects *which* blobs enter the cleanup
+pipeline; it must not be used as a correctness lever within the pipeline itself. The flag may later
+serve as an optimization (skip cleanup work for unmanaged blobs), but the problem statement and any
+solution must not depend on it for safety.
+
+**Managed-to-unmanaged transitions.** An external blob's `reference.managed` flag can change across
+writes. At time t1, a record references `s3://ext/video.mp4` with `managed=true`. At time t2, an
+update to the same record changes `managed` to `false` for the same path. The blob was managed in
+the expired slice but is unmanaged in the retained slice. The cleaner must decide: does the t1
+managed reference make the blob eligible for cleanup when t1 is expired, even though the t2
+reference says unmanaged?
+
+To safely handle this: If *any* retained reference to the same `external_path` exists (regardless of
+the `managed` flag), the blob must not be deleted. The `managed` flag filters which blob references
+*enter* the cleanup pipeline, but the liveness check must consider *all* references to a path, not
+just managed ones. A transition from managed to unmanaged is effectively the user saying "Hudi
+should stop managing this blob" -- the blob must survive the transition.
+
+The inverse case (unmanaged at t1, managed at t2) is straightforward: the blob is now managed and
+subject to cleanup when t2's file slice eventually expires.
 
 ---
 
@@ -94,23 +105,48 @@ Cleaning is a two-phase operation:
 
 ### Per-partition, per-file-group iteration
 
-`CleanPlanner.getDeletePaths(partitionPath, earliestCommitToRetain)` iterates file groups within a
-partition. For each file group, it compares file slices against the retention policy and produces a
-list of `CleanFileInfo` objects (file paths to delete). The cleaner has no concept of cross-file-group
-dependencies.
+The cleaner iterates file groups within a partition. For each file group, it compares file slices
+against the retention policy and produces a list of file paths to delete. The cleaner has no concept
+of cross-file-group dependencies.
 
 ### Savepoint awareness
 
 The cleaner collects all savepointed timestamps and their associated data files. File slices that
-overlap with savepointed files are excluded from cleaning
-(`isFileSliceExistInSavepointedFiles`). This preserves the savepoint invariant: a savepoint freezes a
-consistent snapshot including all data files it references.
+overlap with savepointed files are excluded from cleaning. This preserves the savepoint invariant: a
+savepoint freezes a consistent snapshot including all data files it references.
 
 ### OCC conflict resolution
 
-`SimpleConcurrentFileWritesConflictResolutionStrategy` resolves write-write conflicts at the
-`(partition, fileId)` granularity. There is no global serialization point. Concurrent writers to
-different file groups proceed without contention.
+Concurrent writer conflict resolution operates at the `(partition, fileId)` granularity. There is
+no global serialization point. Concurrent writers to different file groups proceed without
+contention.
+
+### MVCC: Cleaner does not conflict with writes
+
+Under Hudi's MVCC design, the cleaner and writers operate on non-overlapping sets of file slices.
+Writers create new file slices; the cleaner deletes old (expired) ones. The cleaner only targets
+file slices that are older than the retention boundary, which by definition are not being written to.
+Consequently, the cleaner never conflicts with concurrent writers in the existing design -- there is
+no write-clean contention on the same file slice.
+
+Blob cleanup must preserve this property: it must not introduce scenarios where the cleaner and a
+writer contend over the same blob file. However, external blob files are **not** covered by MVCC --
+a writer's new file slice may reference an external blob that the cleaner is simultaneously
+evaluating for deletion. This gap is a central problem for external blob cleanup.
+
+### Rollback vs. Restore
+
+Hudi has two distinct undo operations that affect blob liveness:
+
+1. **Rollback of an inflight commit:** Removes the effects of a single uncommitted write and reverts
+   the affected file groups to their previous state. Scope is limited to one commit.
+2. **Table restore to a savepoint:** Reverts the table to a prior consistent snapshot, potentially
+   undoing multiple committed writes. Scope can affect many file groups across many partitions.
+
+Blob cleanup must handle both: rollback may remove the sole reference to a blob (making it orphaned)
+or resurrect a previously-shadowed reference, while restore may revert the table to a state where
+different blob references are live. These are distinct failure modes with different scopes and are
+addressed separately in the constraints.
 
 ### Critical gap
 
@@ -131,38 +167,38 @@ any constraint leads to data corruption, premature deletion, or permanent orphan
 Once a blob file is written, its content never changes. Blob files are append-once, read-many. This
 means a blob file's identity is stable for its entire lifetime.
 
-*Source: RFC-100 blob cleaner design, general storage semantics.*
+*Source: RFC-100, general storage semantics.*
 
 ### C2: Delete-and-re-add same path
 
-A blob file can be deleted from storage and a new file created at the same path with different
-content. This is a real concern for user-provided external blobs (the user controls the path). For
-Hudi-created blobs, it is structurally eliminated by C11 (instant in path guarantees uniqueness).
+A blob file can be deleted from external storage and a new file created at the same path with
+different content. Since the user controls external blob paths, path reuse is a real concern. The
+cleanup algorithm must not assume that two references to the same `reference.external_path` at
+different times refer to the same physical content.
 
-*Source: RFC-100 blob cleaner design; alternatives analysis constraint C2.*
+**Concurrent writer caveat.** Consider two concurrent writers, A and B, both referencing external
+blob X at the same path. Writer A commits first. Later, the cleaner evaluates A's expired slice and
+marks blob X as a deletion candidate. Meanwhile, Writer B is still inflight and also references
+blob X. If the cleaner deletes blob X before Writer B commits, Writer B's commit creates a dangling
+reference. This race exists because external blob paths are not under Hudi's control -- unlike file
+slices, the cleaner cannot rely on MVCC guarantees for external blob files. Any cleanup solution
+must account for inflight writers that may reference the same external blob path being considered
+for deletion.
+
+*Source: RFC-100; external blob storage semantics.*
 
 ### C3: Cross-file-group blob sharing
 
-An out-of-line blob can be referenced by records in multiple file groups and multiple partitions. This
-is explicitly supported for user-provided external blobs: two records in different file groups can
-point to the same external file. For Hudi-created blobs, cross-FG sharing does not occur because the
-blob is created within a specific file group's storage scope (see C11). However, after clustering
-(C8), references to the same Hudi-created blob could temporarily exist in both the source and target
-file groups until the source is cleaned.
+An external blob can be referenced by records in multiple file groups and multiple partitions. This
+is explicitly supported: two records in different file groups can point to the same
+`reference.external_path`. Cross-file-group sharing is the **common case** for external blobs
+(e.g., a shared media library where a popular video appears in multiple user playlists across
+partitions). Any cleanup algorithm that assumes blobs are scoped to a single file group will produce
+premature deletions.
 
-*Source: RFC-100 lines 196-198 (Option 1 scans all active file slices); alternatives analysis F6.*
+*Source: RFC-100 lines 196-198 (Option 1 scans all active file slices).*
 
-### C4: Container files
-
-Multiple blobs can be packed into a single container file, distinguished by `(offset, length)` within
-the BlobReference. A container file can only be deleted when **all** byte ranges within it are
-unreferenced. If some ranges are orphaned but others are still live, the container cannot be deleted --
-it must be handed off to blob compaction for repacking.
-
-*Source: BlobReference schema fields `offset` and `length`; RFC-100 lines 164-165 (container config);
-alternatives analysis F1.*
-
-### C5: MOR log updates shadow base file blob refs
+### C4: MOR log updates shadow base file blob refs
 
 In MOR tables, a log file update to a record's blob reference supersedes the base file's blob
 reference for that record. The base file's blob ref appears live (it exists in an active file slice)
@@ -173,63 +209,78 @@ update is later rolled back.
 
 *Source: RFC-100 line 122 (merge mode determines which blob reference is returned); MOR semantics.*
 
-### C6: Existing cleaner is per-file-group scoped
+### C5: Existing cleaner is per-file-group scoped
 
-`CleanPlanner` iterates per `HoodieFileGroup` within each partition. It determines expired file slices
-within a single file group. There is no existing mechanism to evaluate cross-file-group dependencies
-during cleaning.
+The cleaner iterates per file group within each partition. It determines expired file slices within
+a single file group. There is no existing mechanism to evaluate cross-file-group dependencies during
+cleaning.
 
-*Source: `CleanPlanner.getDeletePaths()`, `CleanPlanner.getFilesToCleanKeepingLatestCommits()`;
-alternatives analysis F11.*
+*Source: `CleanPlanner.getDeletePaths()`, per-file-group iteration in
+`getFilesToCleanKeepingLatestCommits()`.*
 
-### C7: OCC is per-file-group (no global contention allowed)
+### C6: OCC is per-file-group (no global contention allowed)
 
-Concurrent writer conflict resolution operates at `(partition, fileId)` granularity. Any solution that
-introduces a global contention point (global counter, global lock, global bitmap) violates this
+Concurrent writer conflict resolution operates at `(partition, fileId)` granularity. Any solution
+that introduces a global contention point (global counter, global lock, global bitmap) violates this
 constraint and degrades write throughput under concurrency.
 
-*Source: `SimpleConcurrentFileWritesConflictResolutionStrategy`; alternatives analysis F12.*
+*Source: Concurrent writer conflict resolution strategy; per-file-group OCC semantics.*
 
-### C8: Clustering moves blob refs between file groups
+### C7: Replace commits move blob refs between file groups
 
-Clustering reads records from source file groups and rewrites them to target file groups. For
-Hudi-managed blobs, clustering creates **new** blob files in the target file group. For external
-blobs, clustering copies the pointer (same path, same offset/length) to the target file group. After
-clustering, the source file group's slices still reference the original blobs until those slices are
-cleaned. The target file group's slices reference either new blobs (Hudi-managed) or the same
-external blobs.
+Several operations produce `replacecommit` actions that replace one set of file groups with another:
 
-*Source: RFC-100 lines 212-214.*
+- **Clustering:** Reads records from source file groups and rewrites them to target file groups. For
+  external blobs, clustering copies the pointer (same `reference.external_path`) to the target file
+  group. After clustering, the source file group's slices still reference the original external
+  blobs until those slices are cleaned. The target file group's slices reference the same external
+  blobs.
 
-### C9: Savepoints freeze file slices and their blob refs
+- **insert_overwrite / insert_overwrite_table:** Replaces an entire partition (or table) with new
+  data. The replacement records may reference entirely different external blobs, or the same ones,
+  or a mix. The replaced file groups become eligible for cleaning after retention expires.
+
+In all replace commit scenarios, the key property is: after the replace, both the old (replaced) and
+new (replacement) file groups may reference the same external blob. The cleaner must not delete an
+external blob referenced by a replaced file group if the replacement file group (or any other active
+file group) still references it.
+
+For external blobs, the append-vs-replace distinction does not affect blob identity. The cleaner's
+question is always: "Is this `external_path` referenced by any active file slice anywhere in the
+table?" Whether the reference arrived via an append, an upsert, a clustering copy, or an
+insert_overwrite is irrelevant -- if any live reference exists, the blob must not be deleted.
+
+*Source: Hudi replace commit semantics; clustering and insert_overwrite operations.*
+
+### C8: Savepoints freeze file slices and their blob refs
 
 A savepoint preserves a consistent snapshot. File slices covered by a savepoint are excluded from
 cleaning. This means any blob referenced by a savepointed file slice must also be preserved, even if
 the blob would otherwise be considered orphaned. The cleaner already handles savepoint exclusion for
 file slices; blob cleanup must extend this guarantee to the blobs they reference.
 
-*Source: `CleanPlanner.savepointedTimestamps`, `isFileSliceExistInSavepointedFiles()`.*
+*Source: Savepoint handling in CleanPlanner.*
 
-### C10: Rollback can invalidate or resurrect references
+### C9: Rollback and restore can invalidate or resurrect references
 
-Rolling back a commit can remove file slices that were the sole reference to a blob (the blob becomes
-orphaned). Conversely, rolling back a commit that updated a record's blob reference can resurrect the
-previous reference (an older blob that appeared orphaned is now live again). Any blob cleanup solution
-must account for both directions.
+Two distinct undo operations affect blob liveness:
 
-*Source: Hudi rollback semantics; timeline management.*
+**Rollback of an inflight commit:** Can remove file slices that were the sole reference to a blob
+(the blob becomes orphaned). Conversely, rolling back a commit that updated a record's blob
+reference can resurrect the previous reference (an older blob that appeared orphaned is now live
+again).
 
-### C11: Hudi-created blob paths include instant (structurally unique)
+**Table restore to a savepoint:** Can undo multiple committed writes simultaneously. All blob
+references introduced after the restore point become orphaned. All blob references that were live at
+the restore point are resurrected. The scope is broader than single-commit rollback: it may affect
+many file groups across many partitions simultaneously.
 
-Hudi-created blob files are stored at
-`{table_path}/.hoodie/blobs/{partition}/{column_name}/{instant}/{blob_id}`. Because the commit
-instant is embedded in the path, two different writes always produce different blob paths. This
-eliminates the delete-and-re-add problem (C2) for Hudi-created blobs and means they are inherently
-scoped to a single file group's write context.
+Any blob cleanup solution must account for both directions (orphaning and resurrection) under both
+operations.
 
-*Source: RFC-100 line 170; alternatives analysis F3.*
+*Source: Hudi rollback and restore semantics; timeline management.*
 
-### C12: Archival removes commit metadata from active timeline
+### C10: Archival removes commit metadata from active timeline
 
 Hudi's archival process moves completed commits from the active timeline to the archived timeline.
 If blob cleanup depends on information in commit metadata (e.g., which blobs were written by a
@@ -237,18 +288,23 @@ commit), that information becomes unavailable after archival unless it is persis
 cleaner must either complete blob reference resolution before archival, or ensure the necessary
 information survives archival.
 
-*Source: Hudi archival semantics; `HoodieActiveTimeline` vs `HoodieArchivedTimeline`.*
+Note: Storing blob reference sets within commit metadata would compound this problem -- commit
+metadata grows with the number of blob references, and archival would either lose or have to
+specially preserve this information. This is an additional reason not to use commit metadata as the
+source of truth for blob reference liveness.
 
-### C13: Non-path-dispatched blobs require cross-FG verification at scale
+*Source: Hudi archival semantics.*
 
-For the non-path-dispatched flow (Flow 2), cross-file-group blob sharing (C3) is the **common
-case**, not an edge case. Users referencing external blobs (e.g., a shared media library) will
-frequently have multiple records across different file groups and partitions pointing to the same
-blob file. Any cleanup algorithm that treats cross-FG verification as a rare fallback will impose
-disproportionate cost on Flow 2 workloads. The cross-FG verification path must be designed for
-volume, not just correctness.
+### C11: External blobs require cross-file-group verification at scale
 
-*Source: Two entry flows (Section 2); C3; alternatives analysis D1, D3.*
+For external blobs, cross-file-group blob sharing (C3) is the **common case**, not an edge case.
+Users referencing external blobs (e.g., a shared media library) will frequently have multiple
+records across different file groups and partitions pointing to the same blob file. Any cleanup
+algorithm that treats cross-FG verification as a rare fallback will impose disproportionate cost on
+external blob workloads. The cross-FG verification path must be designed for volume, not just
+correctness.
+
+*Source: C3 (cross-FG sharing is common for external blobs).*
 
 ---
 
@@ -266,63 +322,52 @@ Every orphaned blob must eventually be cleaned. The number of cleanup cycles req
 orphan must be bounded (e.g., cleaned within N cleaner invocations after the last referencing file
 slice is expired). Unbounded accumulation of orphaned blobs wastes storage indefinitely.
 
-### R3: Container awareness (range-level liveness)
-
-Cleanup must track liveness at the `(path, offset, length)` tuple level, not just the path level.
-A container file may have some live ranges and some dead ranges. Only when all ranges are dead can the
-container file be deleted. Partially-dead containers should be flagged for blob compaction.
-
-### R4: MOR correctness
+### R3: MOR correctness
 
 For MOR tables, blob cleanup must be safe in the presence of log updates that shadow base file blob
 references. Over-retention (keeping a shadowed blob until post-compaction) is acceptable.
 Under-retention (prematurely deleting a blob whose reference appears shadowed but could be resurrected
 by rollback) is not.
 
-### R5: Concurrency safety (no global serialization)
+### R4: Concurrency safety (no global serialization)
 
 Blob cleanup must not introduce global contention points. Write throughput for tables with blobs must
-not degrade compared to tables without blobs under concurrent writers. Per-file-group scoping (C7)
+not degrade compared to tables without blobs under concurrent writers. Per-file-group scoping (C6)
 must be preserved.
 
-### R6: Scale proportional to work, not table size
+### R5: Scale proportional to work, not table size
 
-For path-dispatched blobs (Flow 1): the cost of blob cleanup must be proportional to the number of
-file groups being cleaned, not the total table size. A table with 100K file groups cleaning 1K of
-them must not scan all 100K file groups.
+Cross-FG verification is required for external blobs (C11), but the cost must be proportional to the
+number of **candidate blobs requiring verification**, not the total number of active file slices in
+the table. A table with 100K file groups where 50 external blob candidates need cross-FG
+verification must not scan all 100K file groups -- it must use targeted lookups or indexes to resolve
+those 50 candidates efficiently.
 
-For non-path-dispatched blobs (Flow 2): cross-FG verification is required (C13), but the cost must
-be proportional to the number of **candidate blobs requiring verification**, not the total number of
-active file slices in the table. A table with 100K file groups where 50 external blob candidates
-need cross-FG verification must not scan all 100K file groups -- it must use targeted lookups or
-indexes to resolve those 50 candidates efficiently.
-
-### R7: No cost for non-blob tables
+### R6: No cost for non-blob tables
 
 Tables without blob columns must pay zero additional cost. The blob cleanup path must not be entered
 if no blob columns exist. This includes no additional metadata, no additional timeline entries, and no
 additional I/O.
 
-### R8: All cleaning policies supported
+### R7: All cleaning policies supported
 
 Blob cleanup must work correctly under all three cleaning policies: `KEEP_LATEST_COMMITS`,
 `KEEP_LATEST_FILE_VERSIONS`, and `KEEP_LATEST_BY_HOURS`. The blob cleanup logic should be
 policy-agnostic -- it operates on the set of expired vs. retained file slices determined by the
 policy, not on the policy itself.
 
-### R9: Crash safety and idempotency
+### R8: Crash safety and idempotency
 
 If the cleaner crashes after planning but before completing all deletions, restarting must be safe.
 Blob deletions must be idempotent (deleting an already-deleted file is a no-op, not an error).
 The cleaner plan must include enough information to resume blob cleanup without re-reading expired
 file slices (which may no longer exist after a partial execution).
 
-### R10: Observability
+### R9: Observability
 
 Blob cleanup must report metrics: number of blob files deleted, number of blob files retained
-(over-retained due to MOR or containers), number of container files flagged for blob compaction,
-and total storage reclaimed. These metrics enable operators to understand blob storage growth and
-cleanup effectiveness.
+(over-retained due to MOR), and total storage reclaimed. These metrics enable operators to understand
+blob storage growth and cleanup effectiveness.
 
 ---
 
@@ -333,23 +378,23 @@ make the constraints and requirements concrete.
 
 ### Example 1: Cross-file-group sharing -- per-FG cleanup deletes shared blob
 
-**Demonstrates:** C3, C6, R1
+**Demonstrates:** C3, C5, R1
 
 ```
 Setup:
   Partition P1, File Group FG-1:
-    Slice @t1: row1.blob_ref = (s3://shared/video.mp4, 0, 10MB, managed=true)
+    Slice @t1: row1.blob_ref = {external_path: "s3://shared/video.mp4", managed: true}
 
   Partition P2, File Group FG-2:
-    Slice @t1: row2.blob_ref = (s3://shared/video.mp4, 0, 10MB, managed=true)
+    Slice @t1: row2.blob_ref = {external_path: "s3://shared/video.mp4", managed: true}
 
 Action:
   Cleaner expires FG-1's slice @t1 (no retained slices in FG-1).
 
 Per-FG cleanup (incorrect):
-  FG-1 expired refs = {(s3://shared/video.mp4, 0, 10MB)}
+  FG-1 expired refs = {"s3://shared/video.mp4"}
   FG-1 retained refs = {}
-  Orphaned within FG-1 = {(s3://shared/video.mp4, 0, 10MB)}
+  Orphaned within FG-1 = {"s3://shared/video.mp4"}
   -> DELETE s3://shared/video.mp4
 
 Result:
@@ -358,58 +403,27 @@ Result:
 
 Correct behavior:
   Before deleting, verify that no other active file slice in any file group
-  references (s3://shared/video.mp4, 0, 10MB). FG-2's active slice references
-  it, so the blob must be retained.
+  references s3://shared/video.mp4. FG-2's active slice references it, so
+  the blob must be retained.
 ```
 
-### Example 2: Container file partial liveness -- deleting container destroys live ranges
-
-**Demonstrates:** C4, R3
-
-```
-Setup:
-  File Group FG-1:
-    Slice @t1: row1.blob_ref = (container_A.bin, 0, 1MB, managed=true)
-    Slice @t2: row2.blob_ref = (container_A.bin, 1MB, 2MB, managed=true)
-
-Action:
-  Cleaner expires slice @t1, retains slice @t2.
-
-Path-level cleanup (incorrect):
-  Expired paths = {container_A.bin}
-  Retained paths = {container_A.bin}
-  container_A.bin is in both sets -> retain.
-  (This happens to be safe by accident, but only because the same path appears.)
-
-  Alternative scenario -- different slices, same container:
-    Slice @t1 in FG-1: row1.blob_ref = (container_A.bin, 0, 1MB)  -- expired
-    Slice @t1 in FG-2: row2.blob_ref = (container_A.bin, 1MB, 2MB)  -- retained
-
-  If FG-1 concludes container_A.bin is orphaned (no retained refs within FG-1):
-  -> DELETE container_A.bin
-  FG-2's live range at offset 1MB is destroyed.
-
-Correct behavior:
-  Track liveness at (path, offset, length). Only delete the container file when
-  ALL ranges are unreferenced. If some ranges are dead and others live, flag the
-  container for blob compaction instead of deleting it.
-```
-
-### Example 3: Delete-and-re-add -- path reuse causes identity confusion
+### Example 2: Delete-and-re-add -- path reuse causes identity confusion
 
 **Demonstrates:** C2, R1
 
 ```
 Setup:
-  At time t1: User writes row1.blob_ref = (s3://user/photo.jpg, managed=true)
+  At time t1: User writes row1 with
+    blob_ref = {external_path: "s3://user/photo.jpg", managed: true}
   At time t2: User deletes the file at s3://user/photo.jpg externally
-  At time t3: User writes row2.blob_ref = (s3://user/photo.jpg, managed=true)
-              (new file at same path, different content)
+  At time t3: User writes row2 with
+    blob_ref = {external_path: "s3://user/photo.jpg", managed: true}
+    (new file at same path, different content)
 
 Cleanup scenario:
   Cleaner expires slice @t1. Slice @t3 is retained.
-  Expired refs = {s3://user/photo.jpg}
-  Retained refs = {s3://user/photo.jpg}
+  Expired refs = {"s3://user/photo.jpg"}
+  Retained refs = {"s3://user/photo.jpg"}
   Same path in both sets -> retain. (Correct by coincidence.)
 
   But consider: if the cleaner had cached blob identity by path and assumed
@@ -421,36 +435,43 @@ Cleanup scenario:
   AGAIN (third incarnation), the cleaner's identity model must not confuse the
   three incarnations.
 
-Note: This problem does not arise for Hudi-created blobs (C11 -- instant in
-path guarantees each write produces a unique path).
+Concurrent writer scenario (C2 caveat):
+  Writer A commits at t1, referencing s3://user/photo.jpg (managed=true).
+  Writer B starts at t0, also referencing s3://user/photo.jpg (managed=true).
+  Cleaner expires A's slice at t1. B is still inflight.
+  Cleaner deletes s3://user/photo.jpg.
+  Writer B commits -> dangling reference. Data corruption.
+
+  This race is specific to external blobs: the cleaner cannot rely on MVCC
+  guarantees for external blob files that are outside Hudi's control.
 ```
 
-### Example 4: MOR log shadow -- base file ref appears live when superseded
+### Example 3: MOR log shadow -- base file ref appears live when superseded
 
-**Demonstrates:** C5, R4
+**Demonstrates:** C4, R3
 
 ```
 Setup (MOR table):
   File Group FG-1:
-    Base file @t1: row1.blob_ref = (blob_A.bin, managed=true)
-    Log file @t2: row1.blob_ref = (blob_B.bin, managed=true)  -- update
+    Base file @t1: row1.blob_ref = {external_path: "s3://ext/blob_A.bin", managed: true}
+    Log file @t2: row1.blob_ref = {external_path: "s3://ext/blob_B.bin", managed: true}
 
-  After merge: row1's effective blob_ref is blob_B.bin.
+  After merge: row1's effective blob_ref points to blob_B.bin.
   blob_A.bin is no longer referenced by any live record.
 
 Cleanup scenario (pre-compaction):
   Cleaner does not expire slice @t1 (it's retained).
   Reading blob refs from the retained slice:
-    Base @t1: {blob_A.bin}
-    Log @t2: {blob_B.bin}
-    Union: {blob_A.bin, blob_B.bin}
+    Base @t1: {"s3://ext/blob_A.bin"}
+    Log @t2: {"s3://ext/blob_B.bin"}
+    Union: {"s3://ext/blob_A.bin", "s3://ext/blob_B.bin"}
 
   blob_A.bin appears live (it's in the retained set) even though it's been
   superseded by the log update. This is over-retention -- safe but wasteful.
 
 After compaction:
-  Compacted base @t3: row1.blob_ref = (blob_B.bin, managed=true)
-  Now the only retained ref is {blob_B.bin}.
+  Compacted base @t3: row1.blob_ref = {external_path: "s3://ext/blob_B.bin", managed: true}
+  Now the only retained ref is {"s3://ext/blob_B.bin"}.
   blob_A.bin is no longer in any retained set -> eligible for deletion.
 
 Why over-retention is the correct default:
@@ -459,15 +480,21 @@ Why over-retention is the correct default:
   dangling reference. Over-retention prevents this.
 ```
 
-### Example 5: Writer-cleaner race -- three scenarios
+### Example 4: Writer-cleaner race -- three scenarios
 
-**Demonstrates:** C7, R1, R5
+**Demonstrates:** C6, R1, R4
 
 ```
 A writer and cleaner operate concurrently on the same table.
 
+Note: Under Hudi's MVCC design, the cleaner and writers operate on non-overlapping
+file slices -- the cleaner never conflicts with writers on file slice operations.
+However, external blob files are NOT covered by MVCC: a writer's new file slice may
+reference an external blob that the cleaner is simultaneously evaluating for deletion.
+The following scenarios illustrate this gap.
+
 Scenario A: Writer commits BEFORE cleaner's timeline fence
-  t1: Writer starts, references blob_X
+  t1: Writer starts, references blob_X (external)
   t2: Writer commits (blob_X is now in a retained slice)
   t3: Cleaner plans cleanup
   t4: Cleaner checks timeline fence -- sees writer's commit at t2
@@ -477,7 +504,7 @@ Scenario A: Writer commits BEFORE cleaner's timeline fence
 Scenario B: Writer commits AFTER cleaner's timeline fence, BEFORE delete
   t1: Cleaner plans cleanup, blob_X is a candidate for deletion
   t2: Cleaner checks timeline fence -- no new commits
-  t3: Writer commits, referencing blob_X
+  t3: Writer commits, referencing blob_X (external)
   t4: Cleaner deletes blob_X
   -> UNSAFE. The timeline fence did not see the writer's commit.
      blob_X is deleted, but the writer's new slice references it.
@@ -488,89 +515,83 @@ Scenario C: Writer commits AFTER cleaner deletes
   -> UNSAFE. The blob is already gone. The writer's commit creates a dangling
      reference.
 
-Note: Scenario B and C cannot occur for Hudi-created blobs (C11 + D2 from
-alternatives analysis: new writes always produce new paths, and UPSERT carries
-forward refs from retained slices). They are real concerns for user-provided
-external blobs where the user can reference any path.
+Scenarios B and C are real concerns for external blobs where the user can
+reference any path. Any solution must close this gap -- for example, via a
+writer-side conflict check at commit time.
 ```
 
-### Example 6: Clustering moves refs -- replaced FG appears to have no retained slices
+### Example 5: Replace commits move refs -- replaced FG appears to have no retained slices
 
-**Demonstrates:** C8, C3, R1
+**Demonstrates:** C7, C3, R1
 
 ```
 Setup:
   File Group FG-1:
-    Slice @t1: row1.blob_ref = (blob_A.bin, managed=true)
+    Slice @t1: row1.blob_ref = {external_path: "s3://ext/video.mp4", managed: true}
 
   Clustering at t2 rewrites FG-1's records to FG-2:
     File Group FG-2:
-      Slice @t2: row1.blob_ref = (blob_A_new.bin, managed=true)
-                 (Hudi-managed: new blob created in FG-2's scope)
+      Slice @t2: row1.blob_ref = {external_path: "s3://ext/video.mp4", managed: true}
+                 (external: pointer copied, same blob)
 
   FG-1 is now a replaced file group. Its slice @t1 is eligible for cleaning
   after the retention policy expires.
 
-Cleanup:
+Cleanup (incorrect per-FG only):
   Cleaner cleans FG-1's slice @t1.
-  Expired refs = {blob_A.bin}
+  Expired refs = {"s3://ext/video.mp4"}
   Retained refs within FG-1 = {} (FG-1 has no retained slices -- it's replaced)
-  blob_A.bin appears orphaned within FG-1 -> DELETE
+  s3://ext/video.mp4 appears orphaned within FG-1 -> DELETE
 
-  This is actually CORRECT for Hudi-managed blobs: clustering created a new
-  blob (blob_A_new.bin) in FG-2, so blob_A.bin is genuinely orphaned.
+  FG-2's live reference is destroyed. Data corruption.
 
-  BUT if the blob were an external user-provided blob (same path referenced
-  from both FG-1 and FG-2 after clustering):
-
-  File Group FG-2:
-    Slice @t2: row1.blob_ref = (s3://ext/video.mp4, managed=true)
-               (external: pointer copied, same blob)
-
-  FG-1's cleanup concludes s3://ext/video.mp4 is orphaned within FG-1.
-  Deleting it destroys FG-2's live reference.
+Alternative scenario -- insert_overwrite:
+  At t2, an insert_overwrite replaces partition P1 with new data in FG-3.
+  FG-3's records also reference s3://ext/video.mp4 (same external blob).
+  FG-1 is replaced. Same per-FG cleanup error: FG-1 concludes the blob is
+  orphaned, but FG-3 still references it.
 
 Correct behavior:
-  For Hudi-managed blobs, per-FG cleanup is safe because clustering always
-  creates new blob files in the target FG. For external blobs, a cross-FG
-  check is required before deletion.
+  For external blobs, a cross-FG check is required before deletion, regardless
+  of which replace commit type (clustering, insert_overwrite, insert_overwrite_table)
+  created the replacement. Per-FG cleanup alone is never sufficient for external blobs.
 ```
 
-### Example 7: Non-bootstrapped external blobs at scale -- cross-FG verification is the common path
+### Example 6: External blobs at scale -- cross-FG verification is the common path
 
-**Demonstrates:** C3, C13, R6 (Flow 2)
+**Demonstrates:** C3, C11, R5
 
 ```
 Setup:
   A media company stores 10M video files in s3://media-library/.
   They create a Hudi table with a blob column referencing these videos.
-  They do NOT bootstrap -- Hudi manages refs, not storage layout.
+  Hudi manages refs, not storage layout.
 
   The table has 50K file groups across 1K partitions.
   Many videos are referenced by multiple records (e.g., a popular video
   appears in multiple user playlists across different partitions).
 
   Partition users/alice, FG-101:
-    Slice @t1: row1.blob_ref = (s3://media-library/video_X.mp4, managed=true)
+    Slice @t1: row1.blob_ref = {external_path: "s3://media-library/video_X.mp4", managed: true}
 
   Partition users/bob, FG-202:
-    Slice @t1: row2.blob_ref = (s3://media-library/video_X.mp4, managed=true)
+    Slice @t1: row2.blob_ref = {external_path: "s3://media-library/video_X.mp4", managed: true}
 
   Partition users/carol, FG-303:
-    Slice @t1: row3.blob_ref = (s3://media-library/video_X.mp4, managed=true)
+    Slice @t1: row3.blob_ref = {external_path: "s3://media-library/video_X.mp4", managed: true}
 
 Action:
   Cleaner expires FG-101's slice @t1 (alice deleted her playlist entry).
 
 Naive per-FG cleanup (incorrect):
-  FG-101 expired refs = {(s3://media-library/video_X.mp4, 0, 50MB)}
+  FG-101 expired refs = {"s3://media-library/video_X.mp4"}
   FG-101 retained refs = {}
   Orphaned within FG-101 -> DELETE video_X.mp4
   Bob and Carol lose their video. Data corruption.
 
 Naive full-table scan (correct but expensive):
   To verify video_X.mp4 is safe to delete, scan ALL 50K file groups
-  for references. This is correct but violates R6 -- the cost is
+  for references. This is correct but violates R5 -- the cost is
   proportional to table size, not to the number of candidates.
 
 Scale concern:
@@ -587,39 +608,41 @@ Correct behavior:
   element, not a fallback path.
 ```
 
-### Example 8: MOR log-chain transient blob -- introduced and superseded within logs
+### Example 7: MOR log-chain transient blob -- introduced and superseded within logs
 
-**Demonstrates:** C5, R2
+**Demonstrates:** C4, R2
 
 ```
 Setup (MOR table):
   File Group FG-1:
-    Base file @t1: row1.blob_ref = (blob_A.bin, managed=true)
-    Log file @t2: row1.blob_ref = (blob_B.bin, managed=true)  -- update
-    Log file @t3: row1.blob_ref = (blob_C.bin, managed=true)  -- another update
+    Base file @t1: row1.blob_ref = {external_path: "s3://ext/blob_A.bin", managed: true}
+    Log file @t2: row1.blob_ref = {external_path: "s3://ext/blob_B.bin", managed: true}
+    Log file @t3: row1.blob_ref = {external_path: "s3://ext/blob_C.bin", managed: true}
 
-  After merge: row1's effective blob_ref is blob_C.bin.
+  After merge: row1's effective blob_ref points to blob_C.bin.
   blob_B.bin was introduced at t2 and superseded at t3 -- it exists ONLY in log @t2.
 
 After compaction @t4:
-  Compacted base @t4: row1.blob_ref = (blob_C.bin, managed=true)
+  Compacted base @t4: row1.blob_ref = {external_path: "s3://ext/blob_C.bin", managed: true}
   The pre-compaction slice (base @t1 + logs @t2, @t3) is now expired.
 
 Cleanup scenario:
   Cleaner expires the pre-compaction slice.
-  Retained slice = compacted base @t4, refs = {blob_C.bin}.
+  Retained slice = compacted base @t4, refs = {"s3://ext/blob_C.bin"}.
 
   If expired slice reads only the base file:
-    expired_refs = {blob_A.bin}  (from base @t1)
-    local_orphans = {blob_A.bin} - {blob_C.bin} = {blob_A.bin}
+    expired_refs = {"s3://ext/blob_A.bin"}  (from base @t1)
+    local_orphans = {"s3://ext/blob_A.bin"} - {"s3://ext/blob_C.bin"}
+                  = {"s3://ext/blob_A.bin"}
     blob_A.bin is correctly identified as orphaned.
     blob_B.bin is MISSED -- it exists only in expired log @t2.
     blob_B.bin becomes a permanent orphan (R2 violation).
 
   If expired slice reads base + log files:
-    expired_refs = {blob_A.bin, blob_B.bin, blob_C.bin}
-    local_orphans = {blob_A.bin, blob_B.bin, blob_C.bin} - {blob_C.bin}
-                  = {blob_A.bin, blob_B.bin}
+    expired_refs = {"s3://ext/blob_A.bin", "s3://ext/blob_B.bin", "s3://ext/blob_C.bin"}
+    local_orphans = {"s3://ext/blob_A.bin", "s3://ext/blob_B.bin", "s3://ext/blob_C.bin"}
+                    - {"s3://ext/blob_C.bin"}
+                  = {"s3://ext/blob_A.bin", "s3://ext/blob_B.bin"}
     Both orphaned blobs are correctly identified and deleted.
 
 Why this matters:
@@ -706,23 +729,24 @@ These questions must be answered by any solution design. They are not prescripti
 answers exist for each.
 
 **Q1: What is blob identity?**
-How does the cleanup algorithm identify a specific blob? By path alone? By the tuple
-`(path, offset, length)`? By `(path, generation/version)`? The identity model determines how
-deduplication, container handling, and delete-and-re-add (C2) are handled.
+How does the cleanup algorithm identify a specific blob? By `reference.external_path` alone? For
+external blobs where container files are out of scope, path-based identity may be sufficient. The
+identity model determines how deduplication and delete-and-re-add (C2) are handled.
 
 **Q2: Where is liveness computed?**
 Is the set of live blob references computed at write time (incremental), at clean time (batch), or
 some combination? Write-time computation amortizes cost but requires additional metadata storage.
-Clean-time computation avoids write overhead but may be expensive at scale.
+Clean-time computation avoids write overhead but may be expensive at scale. Note: storing liveness
+data within commit metadata is not a viable option -- it does not scale (see C10).
 
 **Q3: What is the unit of cleanup planning?**
 Does blob cleanup plan per-file-group (aligned with the existing cleaner), per-partition, or globally?
-Per-FG is naturally aligned with OCC (C7) but cannot handle cross-FG sharing (C3) without extension.
-Global planning handles cross-FG sharing but risks violating C7.
+Per-FG is naturally aligned with OCC (C6) but cannot handle cross-FG sharing (C3) without extension.
+Global planning handles cross-FG sharing but risks violating C6.
 
 **Q4: How does blob cleanup interact with archival?**
 If the cleanup algorithm depends on commit metadata to determine which blobs were written, what
-happens when those commits are archived (C12)? Must blob cleanup complete before archival? Must the
+happens when those commits are archived (C10)? Must blob cleanup complete before archival? Must the
 relevant metadata be persisted outside the active timeline?
 
 **Q5: Extension or separate service?**
@@ -736,10 +760,22 @@ Despite best efforts, what happens if a blob is prematurely deleted? Is there a 
 (query-time error surfacing)? Is there a recovery path (rebuild from an external source)? How does
 the system distinguish "blob correctly not present" from "blob incorrectly deleted"?
 
-**Q7: How does cross-FG verification scale for non-path-dispatched blobs?**
-For Flow 2 workloads where cross-FG sharing is common, what mechanism makes cross-FG verification
-efficient? Options include: an MDT index mapping blob paths to referencing file groups, predicate
-pushdown on the blob ref column during targeted scans, a reference count maintained at write time,
-or a bloom filter index. The chosen mechanism must satisfy R6 (cost proportional to candidates, not
-table size) and C7 (no global serialization). How does this mechanism interact with writes, and what
-is its maintenance cost?
+**Q7: How does cross-FG verification scale for external blobs?**
+For external blob workloads where cross-FG sharing is common, what mechanism makes cross-FG
+verification efficient? Options include: an MDT index mapping blob paths to referencing file groups,
+predicate pushdown on the blob ref column during targeted scans, a reference count maintained at
+write time, or a bloom filter index. The chosen mechanism must satisfy R5 (cost proportional to
+candidates, not table size) and C6 (no global serialization). How does this mechanism interact with
+writes, and what is its maintenance cost?
+
+**Q8: How should the cleaner handle managed-to-unmanaged transitions?**
+If a blob reference transitions from `reference.managed = true` to `reference.managed = false`
+across writes (or vice versa), what is the cleaner's behavior? Should the `managed` flag be
+evaluated at the time of the expired reference, the retained reference, or both? See the managed
+flag discussion in Section 2.
+
+**Q9: How does blob cleanup interact with table restore?**
+Table restore (as distinct from single-commit rollback) can undo multiple committed writes,
+potentially orphaning many blobs at once and resurrecting others. Does the cleaner need special
+handling for post-restore cleanup, or does the standard cleanup algorithm handle it naturally? What
+if a restore occurs after a cleaner run has already deleted blobs that the restored state references?

--- a/rfc/rfc-100/rfc-100-blob-cleaner-problem.md
+++ b/rfc/rfc-100/rfc-100-blob-cleaner-problem.md
@@ -653,9 +653,9 @@ Why this matters:
   storage indefinitely.
 ```
 
-### Example 9: Why blobFilesToDelete must be in the plan -- writer-cleaner conflict resolution
+### Example 8: Delete intent must be durable at plan time, not computed at execution
 
-**Demonstrates:** C7, R1, R5 (extends Example 5, Scenario B)
+**Demonstrates:** C6, R1, R4 (extends Example 4, Scenario B)
 
 ```
 Setup:
@@ -663,62 +663,47 @@ Setup:
     Slice @t1 (expired): row1.blob_ref = (s3://ext/video.mp4, managed=true)
     Slice @t3 (retained): row1.blob_ref = (s3://ext/photo.png, managed=true)
     video.mp4 is locally orphaned in FG-1 (updated to photo.png at t3).
-    No other FG references video.mp4 at plan time.
+    No other file group references video.mp4 when the cleaner plans.
 
   File Group FG-2 (partition users/bob):
-    (exists, but does not reference video.mp4 yet)
+    Exists, but does not reference video.mp4 yet.
 
-Approach A: blobFilesToDelete NOT in plan (execution-time computation)
-  t1: Cleaner plans at timeline fence T.
-      Plan = {filePathsToBeDeleted: [FG-1/@t1]}
-      No blob info written to plan. Plan goes to timeline as REQUESTED.
+Timeline of the race (delete intent computed only at execution):
+  t1: Cleaner plans cleanup at timeline fence T. It records the file slices
+      it will remove (FG-1/@t1), but defers the blob-delete decision to
+      execution time -- nothing recorded at plan time says video.mp4 will be
+      deleted. At T, video.mp4 is locally orphaned in FG-1 and, by the
+      cross-FG check, globally orphaned.
 
-  t2: Writer commits to FG-2, adds row2.blob_ref = (s3://ext/video.mp4).
-      Writer checks for conflicts: the clean plan on the timeline has no
-      blob info -- only filePathsToBeDeleted for FG-1. Writer is on FG-2.
-      No conflict detected. Writer succeeds.
+  t2: A concurrent writer commits to FG-2, adding
+      row2.blob_ref = (s3://ext/video.mp4). Before committing it runs its
+      conflict check against the in-flight clean -- but the clean has
+      recorded only a file-slice deletion for FG-1, nothing about which
+      blobs it will delete. The writer is on FG-2, finds no conflict, and
+      succeeds. video.mp4 is live again, now referenced from a different
+      file group than the one being cleaned.
 
-  t3: Cleaner transitions to INFLIGHT. Executor computes blob deletes:
-      Reads FG-1/@t1 -> expired_refs = {video.mp4}
-      Reads FG-1/@t3 -> retained_refs = {photo.png}
-      video.mp4 locally orphaned -> Stage 2 cross-FG check at fence T
-      -> does NOT see writer's commit at t2 -> globally orphaned -> DELETE
+  t3: Cleaner executes. It computes the blob-delete set now, in memory, from
+      the fence-T snapshot -- which never saw the t2 commit -- concludes
+      video.mp4 is globally orphaned, and deletes it.
 
-  Result: FG-2 row2 now has a dangling reference to video.mp4.
-  Bob queries his data and gets a missing blob error. Data corruption.
+  Result: FG-2 row2 has a dangling reference. Bob queries his data and gets
+  a missing-blob error. Silent data corruption (R1 violation).
 
-  Why it cannot be fixed: the blob delete decision existed only in the
-  executor's memory. There was no artifact on the timeline for the writer's
-  conflict resolution to check against. The cross-FG conflict was invisible.
+Why plan-time durability is required:
+  The t2 conflict check could only have caught this if it had something to
+  check against: a durable record, visible before execution, of which blobs
+  the in-flight clean intends to delete. Because that intent lived only in
+  the executor's memory at t3, there was no artifact for the writer to see,
+  and the cross-FG conflict was invisible. This is the root cause of
+  Example 4, Scenario B.
 
-Approach B: blobFilesToDelete IN the plan (plan-time computation)
-  t1: Cleaner plans at timeline fence T.
-      Stage 1: video.mp4 locally orphaned in FG-1.
-      Stage 2: cross-FG check -> no other FG references video.mp4.
-      Plan = {filePathsToBeDeleted: [FG-1/@t1],
-              blobFilesToDelete: [s3://ext/video.mp4]}
-      Plan goes to timeline as REQUESTED.
-
-  t2: Writer commits to FG-2, adds row2.blob_ref = (s3://ext/video.mp4).
-      Writer's conflict resolution checks inflight/requested clean plan.
-      Sees blobFilesToDelete contains video.mp4 -- the same blob the
-      writer is referencing. CONFLICT DETECTED. Writer aborts and retries
-      after the clean cycle completes (or clean plan is rolled back).
-      -> Safe. The conflict is caught before corruption can occur.
-
-  Alternative: if the writer commits first (wins the race), the clean
-  plan's conflict resolution at INFLIGHT transition detects that a new
-  commit references a blob in blobFilesToDelete. Clean plan is invalidated
-  and re-planned in the next cycle, where it will see FG-2's reference
-  and retain video.mp4.
-
-Key insight:
-  Today, clean actions are not part of OCC conflict resolution
-  (TransactionUtils.getInflightAndRequestedInstants excludes CLEAN_ACTION,
-  and ConcurrentOperation.init throws for clean actions). Adding external
-  blob cleanup requires extending conflict resolution to check
-  blobFilesToDelete. This is only possible if the blob delete list is a
-  durable artifact on the timeline -- i.e., part of the plan.
+  This constrains any solution: the set of blobs a clean intends to delete
+  must be materialized durably at plan time, before execution, so concurrent
+  writers can check against it. A purely execution-time computation cannot
+  support the writer-cleaner conflict check (R4, C6) without risking
+  premature deletion (R1). How the delete intent is stored, and how the
+  conflict check consumes it, are design concerns.
 ```
 
 ---

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -21,14 +21,16 @@
 - @rahil-c
 - @the-other-tim-brown
 - @vinothchandar
+- @voonhous
 
 ## Approvers
  - @balaji-varadarajan-ai
  - @yihua
+ - @rahil-c
 
 ## Status
 
-Issue: <Link to GH feature issue>
+Issue: https://github.com/apache/hudi/issues/18111
 
 > Please keep the status updated in `rfc/README.md`.
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

RFC-100 Part 2: external blob cleanup design (#18111). When the cleaner expires file slices, the external out-of-line blobs they reference can become orphaned; this PR adds the problem statement and the cleanup design.

The active design (v2) tracks blob references at **file granularity** in a new MDT partition (`blob_refs`): an entry `(external_path, file)` is born when the file is committed and tombstoned by the clean that deletes it. Deletion is **two-phase**: candidates enter a durable queue at plan time and are hard-deleted only after a grace window, behind an unlocked snapshot pre-check plus a bounded locked delta re-check.

```mermaid
flowchart LR
    subgraph W["Every commit"]
        WS["Distinct blob paths<br/>per written file"] --> REG["MDT blob_refs:<br/>(path, file) entries,<br/>same delta commit"]
    end
    subgraph C["Clean N"]
        EXP["Expired files'<br/>manifests"] --> CAND["Managed<br/>candidates"] --> Q["Durable pending-<br/>deletes queue"]
        EXP --> HYG["Hygiene sidecar:<br/>registry tombstones"]
    end
    subgraph D["Clean N+k (entry age >= grace)"]
        A["Step A (unlocked):<br/>registry scan @ T0"] --> B["Step B (locked):<br/>re-check commits<br/>after T0 only"] --> V["No live entry: delete<br/>Live ref: defer/annul"]
    end
    W --> C --> D
```

Liveness verification is one prefix scan per candidate: O(candidates), independent of table size. Write-path cost is O(distinct paths per written file), with no previous-slice diffing and no record-index dependency.

The earlier SI+RLI design (v1) is kept in-tree but marked **ABANDONED**, after code-verified defects: a secondary index makes `insert_overwrite`/`delete_partition` throw table-wide; snapshot-semantics SI reads cannot implement the problem statement's retained-slice liveness rule (dangling refs inside the retention window); and its `cleaned_fg_ids` heuristic deletes blobs still referenced by partially-cleaned file groups. Details in the v2 doc's Motivation (M1-M3).

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

- `rfc-100-blob-cleaner-problem.md` -- problem statement only: constraints C1-C11, requirements R1-R9, worked failure-mode examples. Deliberately solution-free.
- `rfc-100-blob-cleaner-design-v2.md` -- the active design: file-granularity blob reference registry (col-stats-lifecycle MDT partition + per-file manifests) and two-phase age-gated deletion. Includes concurrency/lock deployment-mode analysis, crash recovery, observability, full C1-C11 / R1-R9 traceability; all open design questions resolved in place.
- `rfc-100-blob-cleaner-design.md` -- the v1 SI+RLI design, headlined ABANDONED with rationale; retained for history. Pieces carried forward into v2 are named in its banner (`CleanPlanner` refactor, `hasBlobColumns` gate, sidecar convention, writer `preCommit` veto).

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

None - RFC design.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

None - RFC design.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None, RFC design.
### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
