### PR TITLE
fix: modify the incorrect Hive configuration in hoodie hive catalog

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieCatalogException;
 import org.apache.hudi.exception.HoodieMetadataException;
@@ -568,14 +569,14 @@ public class HoodieHiveCatalog extends AbstractCatalog {
       properties.put(HoodieIndexConfig.INDEX_TYPE.key(), properties.get(FlinkOptions.INDEX_TYPE.key()));
     }
     properties.remove(FlinkOptions.INDEX_TYPE.key());
-    if (hiveConf.get("hive.metastore.uris") != null) {
-      properties.put("hadoop.hive.metastore.uris", hiveConf.get("hive.metastore.uris"));
+    if (hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname) != null) {
+      properties.put(HadoopConfigurations.HADOOP_PREFIX + HiveConf.ConfVars.METASTOREURIS.varname, hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname));
     }
-    if (hiveConf.get("hive.metastore.sasl.enabled") != null) {
-      properties.put("hadoop.hive.metastore.sasl.enabled", hiveConf.get("hive.metastore.sasl.enabled"));
+    if (hiveConf.get(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL.varname) != null) {
+      properties.put(HadoopConfigurations.HADOOP_PREFIX + HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL.varname, hiveConf.get(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL.varname));
     }
-    if (hiveConf.get("hive.metastore.kerberos.principle") != null) {
-      properties.put("hadoop.hive.metastore.kerberos.principle", hiveConf.get("hive.metastore.kerberos.principle"));
+    if (hiveConf.get(HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL.varname) != null) {
+      properties.put(HadoopConfigurations.HADOOP_PREFIX + HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL.varname, hiveConf.get(HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL.varname));
     }
 
     if (external) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
https://github.com/apache/hudi/pull/18011 The incorrect Hive configuration is introduced. hive.metastore.kerberos.principle is incorrect, and hive.metastore.kerberos.principal is correct.


<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog
To avoid introducing incorrect variables, variable names are directly referenced from HiveConf.

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact
The Hive synchronization fails in the Kerberos environment due to incorrect Hive configuration name.

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
none

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update
none

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
