### PR TITLE
[MINOR] Handle cancellation error with HoodieMetadataTableValidator

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/exception/ExceptionUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/ExceptionUtil.java
@@ -40,7 +40,7 @@ public final class ExceptionUtil {
 
     Throwable cause = t;
     while (cause != null) {
-      if (cause.getMessage().contains(errorMsg)) {
+      if (cause.getMessage() != null && cause.getMessage().contains(errorMsg)) {
         return true;
       }
       cause = cause.getCause();

--- a/hudi-common/src/main/java/org/apache/hudi/exception/ExceptionUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/ExceptionUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.exception;
+
+import org.apache.hudi.common.util.StringUtils;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Util class for exception analysis.
+ */
+public final class ExceptionUtil {
+  private ExceptionUtil() {
+  }
+
+  /**
+   * Returns true if error message is contained in any nested exception of provided {@link Throwable}.
+   */
+  public static boolean validateErrorMsg(@Nonnull Throwable t, String errorMsg) {
+    if (StringUtils.isNullOrEmpty(errorMsg)) {
+      return false;
+    }
+
+    Throwable cause = t;
+    while (cause != null) {
+      if (cause.getMessage().contains(errorMsg)) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+
+    return false;
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/exception/TestExceptionUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/exception/TestExceptionUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.exception;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.apache.hudi.exception.ExceptionUtil.validateErrorMsg;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestExceptionUtil {
+
+  @Test
+  void testValidateErrorMsgInNestedCause() {
+    IOException rootException = new IOException("File not found: data.parquet");
+    IllegalArgumentException middleException = new IllegalArgumentException("Invalid argument", rootException);
+    RuntimeException topException = new RuntimeException("Operation failed", middleException);
+
+    // Check top level exception msg
+    assertTrue(validateErrorMsg(topException, "File not found"));
+    assertTrue(validateErrorMsg(topException, "data.parquet"));
+    // Check nested exception msg
+    assertTrue(validateErrorMsg(topException, "Invalid argument"));
+    assertTrue(validateErrorMsg(topException, "Operation failed"));
+    // Validate no exception matches
+    assertFalse(validateErrorMsg(topException, "Connection refused"));
+  }
+
+  @Test
+  void testValidateErrorMsgWithEmptyMessage() {
+    RuntimeException exceptionWithMessage = new RuntimeException("Some error");
+    assertFalse(validateErrorMsg(exceptionWithMessage, ""));
+
+    RuntimeException exceptionWithoutMessage = new RuntimeException();
+    // Empty string should not be found in any message (including null)
+    assertFalse(validateErrorMsg(exceptionWithoutMessage, ""));
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieMetadataTableValidator.java
@@ -75,6 +75,7 @@ import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.data.HoodieSparkRDDUtils;
+import org.apache.hudi.exception.ExceptionUtil;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieValidationException;
@@ -690,6 +691,8 @@ public class HoodieMetadataTableValidator implements Serializable {
     } catch (SparkException sparkException) {
       if (sparkException.getCause() instanceof HoodieValidationException) {
         throw (HoodieValidationException) sparkException.getCause();
+      } else if (ExceptionUtil.validateErrorMsg(sparkException, "cancelled because SparkContext was shut down")) {
+        throw new HoodieException(sparkException);
       } else {
         throw new HoodieValidationException("Unexpected spark failure", sparkException);
       }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Currently cancellation error is not handled in HoodieMetadataTableValidator and all spark exceptions are thrown as validation errors. The PR fixes the checks so that cancellation errors are not thrown as validation exceptions.

### Summary and Changelog

Currently cancellation error is not handled in HoodieMetadataTableValidator and all spark exceptions are thrown as validation errors. The PR fixes the checks so that cancellation errors are not thrown as validation exceptions.

### Impact

NA

### Risk Level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
