### PR TITLE
feat: Support spark nested columns comments

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaField.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaField.java
@@ -55,6 +55,8 @@ public class HoodieSchemaField implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
+  public static final String METADATA_DOC_PREFIX = "Hudi metadata field: ";
+
   private final Schema.Field avroField;
   private final HoodieSchema fieldSchema;
 
@@ -148,7 +150,7 @@ public class HoodieSchemaField implements Serializable {
     ValidationUtils.checkArgument(name != null && !name.isEmpty(), "Metadata field name cannot be null or empty");
     ValidationUtils.checkArgument(schema != null, "Metadata field schema cannot be null");
 
-    return HoodieSchemaField.of(name, schema, "Hudi metadata field: " + name, HoodieJsonProperties.NULL_VALUE);
+    return HoodieSchemaField.of(name, schema, METADATA_DOC_PREFIX + name, HoodieJsonProperties.NULL_VALUE);
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnComments.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnComments.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.common.model.{HoodieTableType}
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.testutils.HoodieClientTestUtils.getSparkConfForTest
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql._
+import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+import org.apache.spark.sql.types.StructType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+
+class TestColumnComments {
+  var spark     : SparkSession = _
+  var sqlContext: SQLContext   = _
+  var sc        : SparkContext = _
+
+  def initSparkContext(): Unit = {
+    val sparkConf = getSparkConfForTest(getClass.getSimpleName)
+    spark = SparkSession.builder()
+      .withExtensions(new HoodieSparkSessionExtension)
+      .config(sparkConf)
+      .getOrCreate()
+    sc = spark.sparkContext
+    sc.setLogLevel("ERROR")
+    sqlContext = spark.sqlContext
+  }
+
+  @BeforeEach
+  def setUp() {
+    initSparkContext()
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType], names = Array("COPY_ON_WRITE", "MERGE_ON_READ"))
+  def testColumnCommentWithSparkDatasource(tableType: HoodieTableType): Unit = {
+    val basePath = java.nio.file.Files.createTempDirectory("hoodie_comments_path").toAbsolutePath.toString
+    val opts     = Map(
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_comments",
+      DataSourceWriteOptions.TABLE_TYPE.key -> tableType.toString,
+      DataSourceWriteOptions.OPERATION.key -> "bulk_insert",
+      DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+      DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition"
+    )
+    val inputDF  = spark.sql("select '0' as _row_key, '1' as content, '2' as partition, '3' as ts")
+    val struct   = new StructType()
+      .add("_row_key", "string", true, "dummy comment")
+      .add("content", "string", true)
+      .add("partition", "string", true)
+      .add("ts", "string", true)
+    spark.createDataFrame(inputDF.rdd, struct)
+      .write.format("hudi")
+      .options(opts)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+    spark.read.format("hudi").load(basePath).registerTempTable("test_tbl")
+
+    // now confirm the comment is present at read time
+    assertEquals(1, spark.sql("desc extended test_tbl")
+      .filter("col_name = '_row_key' and comment = 'dummy comment'").count)
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -99,7 +99,9 @@ public class HiveSyncConfigHolder {
       .key("hoodie.datasource.hive_sync.sync_as_datasource")
       .defaultValue("true")
       .markAdvanced()
-      .withDocumentation("");
+      .withDocumentation("Add information to setup the spark datasource, including tables properties and spark schema."
+          + " This allow spark to use optimized reader."
+          + " Column comments are also added for the first level only.");
   public static final ConfigProperty<Integer> HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD = ConfigProperty
       .key("hoodie.datasource.hive_sync.schema_string_length_thresh")
       .defaultValue(4000)

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HiveQueryDDLExecutor.java
@@ -88,7 +88,7 @@ public class HiveQueryDDLExecutor extends QueryBasedDDLExecutor {
       for (String sql : sqls) {
         if (hiveDriver != null) {
           HoodieTimer timer = HoodieTimer.start();
-          responses.add(hiveDriver.run(sql));
+          responses.add(hiveDriver.run(escapeAntiSlash(sql)));
           log.info("Time taken to execute [{}]: {} ms", sql, timer.endTimer());
         }
       }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java
@@ -72,7 +72,7 @@ public class JDBCExecutor extends QueryBasedDDLExecutor {
     try {
       stmt = connection.createStatement();
       log.info("Executing SQL {}", s);
-      stmt.execute(s);
+      stmt.execute(escapeAntiSlash(s));
     } catch (SQLException e) {
       throw new HoodieHiveSyncException("Failed in executing SQL " + s, e);
     } finally {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/QueryBasedDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/QueryBasedDDLExecutor.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
@@ -248,6 +249,14 @@ public abstract class QueryBasedDDLExecutor implements DDLExecutor {
         throw new HoodieHiveSyncException("Partition alter type not supported: " + alterType);
     }
     return result;
+  }
+
+  /**
+   * Escape anti slash for column comment, in case special character
+   * @param sql The raw sql text
+   */
+  protected String escapeAntiSlash(String sql) {
+    return sql.replaceAll("\\\\", Matcher.quoteReplacement("\\\\"));
   }
 
   private enum PartitionAlterType {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/AvroToSparkJson.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/AvroToSparkJson.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sync.common.util;
+
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class to convert Avro schemas directly to Spark SQL schema JSON format.
+ * This bypasses Parquet conversion and eliminates struct-wrapping issues with complex types.
+ *
+ * <p>Based on Spark's SchemaConverters logic but implemented without Spark dependencies.
+ */
+public class AvroToSparkJson {
+
+  private AvroToSparkJson() {
+    // Utility class
+  }
+
+  /**
+   * Convert an Avro schema to Spark SQL schema JSON format.
+   *
+   * @param avroSchema The Avro schema to convert
+   * @return JSON string representing the Spark schema
+   */
+  public static String convertToSparkSchemaJson(Schema avroSchema) {
+    if (avroSchema.getType() != Schema.Type.RECORD) {
+      throw new IllegalArgumentException("Top-level schema must be a RECORD type, got: " + avroSchema.getType());
+    }
+
+    SparkDataType sparkType = convertAvroType(avroSchema);
+    return sparkType.toJson();
+  }
+
+  /**
+   * Convert an Avro schema to Spark SQL schema JSON format with field reordering.
+   * Reorders fields to match Spark DataSource table convention: data columns first, partition columns last.
+   *
+   * @param avroSchema The Avro schema to convert
+   * @param partitionFieldNames List of partition field names to be moved to the end
+   * @return JSON string representing the Spark schema with reordered fields
+   */
+  public static String convertToSparkSchemaJson(Schema avroSchema, List<String> partitionFieldNames) {
+    if (avroSchema.getType() != Schema.Type.RECORD) {
+      throw new IllegalArgumentException("Top-level schema must be a RECORD type, got: " + avroSchema.getType());
+    }
+
+    if (partitionFieldNames == null || partitionFieldNames.isEmpty()) {
+      // No reordering needed, use the standard method
+      return convertToSparkSchemaJson(avroSchema);
+    }
+
+    // Create reordered schema
+    Schema reorderedSchema = reorderSchemaFields(avroSchema, partitionFieldNames);
+    SparkDataType sparkType = convertAvroType(reorderedSchema);
+    return sparkType.toJson();
+  }
+
+  private static SparkDataType convertAvroType(Schema avroSchema) {
+    switch (avroSchema.getType()) {
+      case NULL:
+        return new PrimitiveSparkType("null");
+      case BOOLEAN:
+        return new PrimitiveSparkType("boolean");
+      case INT:
+        if (avroSchema.getLogicalType() instanceof LogicalTypes.Date) {
+          return new PrimitiveSparkType("date");
+        }
+        return new PrimitiveSparkType("integer");
+      case LONG:
+        if (avroSchema.getLogicalType() instanceof LogicalTypes.TimestampMillis
+            || avroSchema.getLogicalType() instanceof LogicalTypes.TimestampMicros) {
+          return new PrimitiveSparkType("timestamp");
+        }
+        return new PrimitiveSparkType("long");
+      case FLOAT:
+        return new PrimitiveSparkType("float");
+      case DOUBLE:
+        return new PrimitiveSparkType("double");
+      case BYTES:
+      case FIXED:
+        if (avroSchema.getLogicalType() instanceof LogicalTypes.Decimal) {
+          LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) avroSchema.getLogicalType();
+          return new DecimalSparkType(decimal.getPrecision(), decimal.getScale());
+        }
+        return new PrimitiveSparkType("binary");
+      case STRING:
+      case ENUM:
+        return new PrimitiveSparkType("string");
+      case ARRAY:
+        SparkDataType elementType = convertAvroType(avroSchema.getElementType());
+        boolean containsNull = isNullable(avroSchema.getElementType());
+        return new ArraySparkType(elementType, containsNull);
+      case MAP:
+        SparkDataType valueType = convertAvroType(avroSchema.getValueType());
+        boolean valueContainsNull = isNullable(avroSchema.getValueType());
+        return new MapSparkType(new PrimitiveSparkType("string"), valueType, valueContainsNull);
+      case RECORD:
+        List<StructFieldType> fields = avroSchema.getFields().stream()
+            .map(field -> {
+              SparkDataType fieldType = convertAvroType(field.schema());
+              boolean nullable = isNullable(field.schema());
+              String comment = field.doc();
+              return new StructFieldType(field.name(), fieldType, nullable, comment);
+            })
+            .collect(Collectors.toList());
+        return new StructSparkType(fields);
+      case UNION:
+        return handleUnion(avroSchema);
+      default:
+        throw new IllegalArgumentException("Unsupported Avro type: " + avroSchema.getType());
+    }
+  }
+
+  private static SparkDataType handleUnion(Schema unionSchema) {
+    List<Schema> types = unionSchema.getTypes();
+
+    // Handle nullable unions (common pattern: [null, actual_type])
+    if (types.size() == 2 && types.stream().anyMatch(s -> s.getType() == Schema.Type.NULL)) {
+      Schema nonNullType = types.stream()
+          .filter(s -> s.getType() != Schema.Type.NULL)
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("Invalid union with only null type"));
+      return convertAvroType(nonNullType);
+    }
+
+    // For complex unions, we could implement more sophisticated logic
+    // For now, treat as string (similar to how some systems handle this)
+    return new PrimitiveSparkType("string");
+  }
+
+  private static boolean isNullable(Schema schema) {
+    if (schema.getType() == Schema.Type.NULL) {
+      return true;
+    }
+    if (schema.getType() == Schema.Type.UNION) {
+      return schema.getTypes().stream().anyMatch(s -> s.getType() == Schema.Type.NULL);
+    }
+    return false;
+  }
+
+  /**
+   * Abstract base class for Spark data types
+   */
+  private abstract static class SparkDataType {
+    public abstract String toJson();
+  }
+
+  /**
+   * Primitive Spark types (string, int, boolean, etc.)
+   */
+  private static class PrimitiveSparkType extends SparkDataType {
+    private final String typeName;
+
+    public PrimitiveSparkType(String typeName) {
+      this.typeName = typeName;
+    }
+
+    @Override
+    public String toJson() {
+      return "\"" + typeName + "\"";
+    }
+  }
+
+  /**
+   * Decimal Spark type with precision and scale
+   */
+  private static class DecimalSparkType extends SparkDataType {
+    private final int precision;
+    private final int scale;
+
+    public DecimalSparkType(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+
+    @Override
+    public String toJson() {
+      return "\"decimal(" + precision + "," + scale + ")\"";
+    }
+  }
+
+  /**
+   * Array Spark type
+   */
+  private static class ArraySparkType extends SparkDataType {
+    private final SparkDataType elementType;
+    private final boolean containsNull;
+
+    public ArraySparkType(SparkDataType elementType, boolean containsNull) {
+      this.elementType = elementType;
+      this.containsNull = containsNull;
+    }
+
+    @Override
+    public String toJson() {
+      return "{\"type\":\"array\",\"elementType\":" + elementType.toJson()
+          + ",\"containsNull\":" + containsNull + "}";
+    }
+  }
+
+  /**
+   * Map Spark type
+   */
+  private static class MapSparkType extends SparkDataType {
+    private final SparkDataType keyType;
+    private final SparkDataType valueType;
+    private final boolean valueContainsNull;
+
+    public MapSparkType(SparkDataType keyType, SparkDataType valueType, boolean valueContainsNull) {
+      this.keyType = keyType;
+      this.valueType = valueType;
+      this.valueContainsNull = valueContainsNull;
+    }
+
+    @Override
+    public String toJson() {
+      return "{\"type\":\"map\",\"keyType\":" + keyType.toJson()
+          + ",\"valueType\":" + valueType.toJson()
+          + ",\"valueContainsNull\":" + valueContainsNull + "}";
+    }
+  }
+
+  /**
+   * Struct Spark type
+   */
+  private static class StructSparkType extends SparkDataType {
+    private final List<StructFieldType> fields;
+
+    public StructSparkType(List<StructFieldType> fields) {
+      this.fields = fields;
+    }
+
+    @Override
+    public String toJson() {
+      String fieldsJson = fields.stream()
+          .map(StructFieldType::toJson)
+          .collect(Collectors.joining(","));
+      return "{\"type\":\"struct\",\"fields\":[" + fieldsJson + "]}";
+    }
+  }
+
+  /**
+   * Struct field type with metadata support
+   */
+  private static class StructFieldType {
+    private final String name;
+    private final SparkDataType dataType;
+    private final boolean nullable;
+    private final String comment;
+
+    public StructFieldType(String name, SparkDataType dataType, boolean nullable, String comment) {
+      this.name = name;
+      this.dataType = dataType;
+      this.nullable = nullable;
+      this.comment = comment;
+    }
+
+    public String toJson() {
+      StringBuilder metadata = new StringBuilder("{");
+      if (comment != null && !comment.trim().isEmpty()) {
+        // Escape quotes in comments
+        String escapedComment = comment.replace("\"", "\\\"");
+        metadata.append("\"comment\":\"").append(escapedComment).append("\"");
+      }
+      metadata.append("}");
+
+      return "{\"name\":\"" + name + "\""
+          + ",\"type\":" + dataType.toJson()
+          + ",\"nullable\":" + nullable
+          + ",\"metadata\":" + metadata.toString() + "}";
+    }
+  }
+
+  /**
+   * Reorder Avro schema fields to match Spark DataSource table convention.
+   * Data columns first, partition columns last.
+   *
+   * @param originalSchema The original Avro schema
+   * @param partitionFieldNames List of partition field names
+   * @return New Avro schema with reordered fields
+   */
+  private static Schema reorderSchemaFields(Schema originalSchema, List<String> partitionFieldNames) {
+    if (originalSchema.getType() != Schema.Type.RECORD) {
+      return originalSchema;
+    }
+
+    List<Schema.Field> originalFields = originalSchema.getFields();
+    List<Schema.Field> dataFields = new ArrayList<>();
+    List<Schema.Field> partitionFields = new ArrayList<>();
+
+    // Separate data fields and partition fields
+    for (Schema.Field field : originalFields) {
+      if (partitionFieldNames.contains(field.name())) {
+        partitionFields.add(field);
+      } else {
+        dataFields.add(field);
+      }
+    }
+
+    // Create reordered field list: data fields first, partition fields last
+    List<Schema.Field> reorderedFields = new ArrayList<>();
+
+    // Add data fields first (with cloned field objects to avoid issues)
+    for (Schema.Field field : dataFields) {
+      Schema.Field clonedField = new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal());
+      // Copy field properties if they exist
+      if (field.getObjectProps() != null) {
+        for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
+          clonedField.addProp(prop.getKey(), prop.getValue());
+        }
+      }
+      reorderedFields.add(clonedField);
+    }
+
+    // Add partition fields last (with cloned field objects)
+    for (Schema.Field field : partitionFields) {
+      Schema.Field clonedField = new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal());
+      // Copy field properties if they exist
+      if (field.getObjectProps() != null) {
+        for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
+          clonedField.addProp(prop.getKey(), prop.getValue());
+        }
+      }
+      reorderedFields.add(clonedField);
+    }
+
+    // Create new schema with reordered fields
+    Schema reorderedSchema = Schema.createRecord(
+        originalSchema.getName(),
+        originalSchema.getDoc(),
+        originalSchema.getNamespace(),
+        originalSchema.isError(),
+        reorderedFields
+    );
+
+    // Copy schema-level properties if they exist
+    if (originalSchema.getObjectProps() != null) {
+      for (Map.Entry<String, Object> prop : originalSchema.getObjectProps().entrySet()) {
+        reorderedSchema.addProp(prop.getKey(), prop.getValue());
+      }
+    }
+
+    return reorderedSchema;
+  }
+}

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkDataSourceTableUtils.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkDataSourceTableUtils.java
@@ -33,8 +33,13 @@ import java.util.Map;
 public class SparkDataSourceTableUtils {
   /**
    * Get Spark Sql related table properties. This is used for spark datasource table.
-   * @param schema  The schema to write to the table.
-   * @return A new parameters added the spark's table properties.
+   *
+   * @param partitionNames List of partition field names
+   * @param sparkVersion Spark version
+   * @param schemaLengthThreshold Schema length threshold
+   * @param schema Hoodie schema with field docs
+   *
+   * @return Map of Spark table properties
    */
   public static Map<String, String> getSparkTableProperties(List<String> partitionNames, String sparkVersion,
                                                             int schemaLengthThreshold, HoodieSchema schema) {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkSchemaUtils.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkSchemaUtils.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.sync.common.util;
 
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 
 /**
@@ -30,14 +31,63 @@ public class SparkSchemaUtils {
 
   public static String convertToSparkSchemaJson(HoodieSchema schema) {
     String fieldsJsonString = schema.getFields().stream().map(field -> {
-      String metadata = "{}";
-      if (field.getNonNullSchema().isBlobField()) {
-        metadata = String.format("{\"%s\":\"%s\"}", HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name());
-      }
       return "{\"name\":\"" + field.name() + "\",\"type\":" + convertFieldType(field.getNonNullSchema())
-                + ",\"nullable\":" + field.isNullable() + ",\"metadata\":" + metadata + "}";
+                + ",\"nullable\":" + field.isNullable() + ",\"metadata\":" + toMetadataJson(field) + "}";
     }).reduce((a, b) -> a + "," + b).orElse("");
     return "{\"type\":\"struct\",\"fields\":[" + fieldsJsonString + "]}";
+  }
+
+  private static String toMetadataJson(HoodieSchemaField field) {
+    StringBuilder builder = new StringBuilder("{");
+    int idx = 0;
+    if (field.doc().isPresent() && !field.doc().get().isEmpty()) {
+      String doc = field.doc().get();
+      if (!doc.startsWith(HoodieSchemaField.METADATA_DOC_PREFIX)) {
+        idx++;
+        builder.append(String.format("\"%s\":\"%s\"", "comment", escapeJson(doc)));
+      }
+    }
+    if (field.getNonNullSchema().isBlobField()) {
+      if (idx > 0) {
+        builder.append(',');
+      }
+      builder.append(String.format("\"%s\":\"%s\"", HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name()));
+    }
+    builder.append("}");
+    return builder.toString();
+  }
+
+  private static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '\\':
+          escaped.append("\\\\");
+          break;
+        case '"':
+          escaped.append("\\\"");
+          break;
+        case '\b':
+          escaped.append("\\b");
+          break;
+        case '\f':
+          escaped.append("\\f");
+          break;
+        case '\n':
+          escaped.append("\\n");
+          break;
+        case '\r':
+          escaped.append("\\r");
+          break;
+        case '\t':
+          escaped.append("\\t");
+          break;
+        default:
+          escaped.append(c);
+      }
+    }
+    return escaped.toString();
   }
 
   private static String convertFieldType(HoodieSchema originalFieldSchema) {

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/util/TestAvroToSparkJson.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/util/TestAvroToSparkJson.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sync.common.util;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestAvroToSparkJson {
+
+  @Test
+  public void testSimpleRecordConversion() {
+    // Create a simple Avro schema with basic types
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"id\", \"type\": \"int\"},\n"
+        + "    {\"name\": \"name\", \"type\": \"string\"},\n"
+        + "    {\"name\": \"active\", \"type\": \"boolean\"},\n"
+        + "    {\"name\": \"score\", \"type\": [\"null\", \"double\"], \"default\": null},\n"
+        + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}},\n"
+        + "    {\"name\": \"metadata\", \"type\": {\"type\": \"map\", \"values\": \"string\"}}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    // Verify the overall structure
+    assertTrue(sparkSchemaJson.contains("\"type\":\"struct\""));
+    assertTrue(sparkSchemaJson.contains("\"fields\":["));
+
+    // Verify basic field types
+    assertTrue(sparkSchemaJson.contains("\"name\":\"id\""));
+    assertTrue(sparkSchemaJson.contains("\"name\":\"name\""));
+    assertTrue(sparkSchemaJson.contains("\"name\":\"active\""));
+    assertTrue(sparkSchemaJson.contains("\"name\":\"score\""));
+    assertTrue(sparkSchemaJson.contains("\"name\":\"tags\""));
+    assertTrue(sparkSchemaJson.contains("\"name\":\"metadata\""));
+
+    // Verify array type is correctly converted (not wrapped in struct)
+    assertTrue(sparkSchemaJson.contains("\"type\":\"array\""));
+    assertTrue(sparkSchemaJson.contains("\"elementType\":\"string\""));
+
+    // Verify map type is correctly converted (not wrapped in struct)
+    assertTrue(sparkSchemaJson.contains("\"type\":\"map\""));
+    assertTrue(sparkSchemaJson.contains("\"keyType\":\"string\""));
+    assertTrue(sparkSchemaJson.contains("\"valueType\":\"string\""));
+
+    // Verify no struct wrapping around arrays or maps
+    assertTrue(!sparkSchemaJson.contains("struct<array:")
+            && !sparkSchemaJson.contains("struct<key_value:"),
+        "Arrays and maps should not be wrapped in structs");
+  }
+
+  @Test
+  public void testNestedRecordWithComments() {
+    // Create Avro schema with nested structure and comments
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"id\", \"type\": \"int\", \"doc\": \"Unique identifier\"},\n"
+        + "    {\"name\": \"name\", \"type\": [\"null\", \"string\"], \"default\": null, \"doc\": \"Person's name\"},\n"
+        + "    {\"name\": \"address\", \"type\": [\"null\", {\n"
+        + "      \"type\": \"record\", \"name\": \"AddressRecord\", \"fields\": [\n"
+        + "        {\"name\": \"street\", \"type\": \"string\", \"doc\": \"Street address\"},\n"
+        + "        {\"name\": \"city\", \"type\": [\"null\", \"string\"], \"default\": null, \"doc\": \"City name\"}\n"
+        + "      ]\n"
+        + "    }], \"default\": null, \"doc\": \"Address information\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    // Verify top-level comments
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Unique identifier\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Person's name\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Address information\""));
+
+    // Verify nested comments within address struct
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Street address\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"City name\""));
+  }
+
+  @Test
+  public void testArrayOfStructs() {
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"users\", \"type\": {\"type\": \"array\", \"items\": {\n"
+        + "      \"type\": \"record\", \"name\": \"UserRecord\", \"fields\": [\n"
+        + "        {\"name\": \"name\", \"type\": \"string\", \"doc\": \"User name\"},\n"
+        + "        {\"name\": \"email\", \"type\": [\"null\", \"string\"], \"default\": null, \"doc\": \"Email address\"}\n"
+        + "      ]\n"
+        + "    }}, \"doc\": \"List of users\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    assertTrue(sparkSchemaJson.contains("\"type\":\"array\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"List of users\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"User name\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Email address\""));
+  }
+
+  @Test
+  public void testMapWithStructValues() {
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"profiles\", \"type\": {\"type\": \"map\", \"values\": {\n"
+        + "      \"type\": \"record\", \"name\": \"ProfileRecord\", \"fields\": [\n"
+        + "        {\"name\": \"preferences\", \"type\": \"string\", \"doc\": \"User preferences\"},\n"
+        + "        {\"name\": \"settings\", \"type\": [\"null\", \"string\"], \"default\": null, \"doc\": \"User settings\"}\n"
+        + "      ]\n"
+        + "    }}, \"doc\": \"User profiles map\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    assertTrue(sparkSchemaJson.contains("\"type\":\"map\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"User profiles map\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"User preferences\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"User settings\""));
+  }
+
+  @Test
+  public void testNestedArrays() {
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"matrix\", \"type\": {\"type\": \"array\", \"items\": {\n"
+        + "      \"type\": \"array\", \"items\": \"int\"\n"
+        + "    }}, \"doc\": \"2D integer matrix\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    assertTrue(sparkSchemaJson.contains("\"type\":\"array\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"2D integer matrix\""));
+  }
+
+  @Test
+  public void testComplexNestedStructure() {
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"organization\", \"type\": {\n"
+        + "      \"type\": \"record\", \"name\": \"OrgRecord\", \"fields\": [\n"
+        + "        {\"name\": \"departments\", \"type\": {\"type\": \"array\", \"items\": {\n"
+        + "          \"type\": \"record\", \"name\": \"DeptRecord\", \"fields\": [\n"
+        + "            {\"name\": \"name\", \"type\": \"string\", \"doc\": \"Department name\"},\n"
+        + "            {\"name\": \"employees\", \"type\": {\"type\": \"map\", \"values\": {\n"
+        + "              \"type\": \"record\", \"name\": \"EmpRecord\", \"fields\": [\n"
+        + "                {\"name\": \"role\", \"type\": \"string\", \"doc\": \"Employee role\"},\n"
+        + "                {\"name\": \"skills\", \"type\": {\"type\": \"array\", \"items\": \"string\"}, \"doc\": \"Skills list\"}\n"
+        + "              ]\n"
+        + "            }}, \"doc\": \"Employee map\"}\n"
+        + "          ]\n"
+        + "        }}, \"doc\": \"Departments list\"}\n"
+        + "      ]\n"
+        + "    }, \"doc\": \"Organization structure\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Organization structure\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Departments list\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Department name\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Employee map\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Employee role\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Skills list\""));
+  }
+
+  @Test
+  public void testEdgeCasesWithSpecialCharacters() {
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"id\", \"type\": \"int\", \"doc\": \"ID with \\\"quotes\\\" and \\\\backslashes\\\\\"},\n"
+        + "    {\"name\": \"special_chars\", \"type\": [\"null\", \"string\"], \"default\": null, \"doc\": \"Special chars: @#$%^&*()+=[]{}|;':,.<>?/~`\"},\n"
+        + "    {\"name\": \"unicode_field\", \"type\": [\"null\", \"string\"], \"default\": null, \"doc\": \"Unicode: 中文 العربية русский\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    // Verify proper escaping and character preservation
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"ID with") && sparkSchemaJson.contains("quotes") && sparkSchemaJson.contains("backslashes"));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Special chars: @#$%^&*()+=[]{}|;':,.<>?/~`\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Unicode: 中文 العربية русский\""));
+  }
+
+  @Test
+  public void testRecordWithoutComments() {
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"id\", \"type\": \"int\"},\n"
+        + "    {\"name\": \"name\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+        + "    {\"name\": \"nested\", \"type\": {\n"
+        + "      \"type\": \"record\", \"name\": \"NestedRecord\", \"fields\": [\n"
+        + "        {\"name\": \"value\", \"type\": \"string\"}\n"
+        + "      ]\n"
+        + "    }}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    // Verify that fields without comments have empty metadata
+    assertTrue(sparkSchemaJson.contains("\"metadata\":{}"));
+    // Verify no comment fields are present
+    assertTrue(!sparkSchemaJson.contains("\"comment\":"));
+  }
+
+  @Test
+  public void testArrayOfMaps() {
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"config_sets\", \"type\": {\"type\": \"array\", \"items\": {\n"
+        + "      \"type\": \"map\", \"values\": \"string\"\n"
+        + "    }}, \"doc\": \"Array of configuration maps\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    assertTrue(sparkSchemaJson.contains("\"type\":\"array\""));
+    assertTrue(sparkSchemaJson.contains("\"type\":\"map\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Array of configuration maps\""));
+  }
+
+  @Test
+  public void testMapWithArrayValues() {
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"tag_groups\", \"type\": {\"type\": \"map\", \"values\": {\n"
+        + "      \"type\": \"array\", \"items\": \"string\"\n"
+        + "    }}, \"doc\": \"Map of tag groups\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    String sparkSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    assertTrue(sparkSchemaJson.contains("\"type\":\"map\""));
+    assertTrue(sparkSchemaJson.contains("\"type\":\"array\""));
+    assertTrue(sparkSchemaJson.contains("\"comment\":\"Map of tag groups\""));
+  }
+
+  @Test
+  public void testFieldReordering() {
+    // Create Avro schema with mixed data and partition fields
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"TestRecord\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"id\", \"type\": \"int\", \"doc\": \"Unique identifier\"},\n"
+        + "    {\"name\": \"partition_col\", \"type\": \"string\", \"doc\": \"Partition column\"},\n"
+        + "    {\"name\": \"name\", \"type\": [\"null\", \"string\"], \"default\": null, \"doc\": \"Person's name\"},\n"
+        + "    {\"name\": \"age\", \"type\": \"int\"},\n"
+        + "    {\"name\": \"year\", \"type\": \"int\", \"doc\": \"Year partition\"}\n"
+        + "  ]\n"
+        + "}";
+
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    List<String> partitionFields = Arrays.asList("partition_col", "year");
+
+    // Test without reordering (original order)
+    String originalSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema);
+
+    // Test with reordering (data fields first, partition fields last)
+    String reorderedSchemaJson = AvroToSparkJson.convertToSparkSchemaJson(avroSchema, partitionFields);
+
+    // Parse JSON to verify field order
+    assertTrue(originalSchemaJson.contains("\"name\":\"id\""));
+    assertTrue(originalSchemaJson.contains("\"name\":\"partition_col\""));
+    assertTrue(reorderedSchemaJson.contains("\"name\":\"id\""));
+    assertTrue(reorderedSchemaJson.contains("\"name\":\"partition_col\""));
+
+    // Verify that reordered schema has data fields (id, name, age) before partition fields (partition_col, year)
+    int idIndex = reorderedSchemaJson.indexOf("\"name\":\"id\"");
+    int nameIndex = reorderedSchemaJson.indexOf("\"name\":\"name\"");
+    int ageIndex = reorderedSchemaJson.indexOf("\"name\":\"age\"");
+    int partitionColIndex = reorderedSchemaJson.indexOf("\"name\":\"partition_col\"");
+    int yearIndex = reorderedSchemaJson.indexOf("\"name\":\"year\"");
+
+    // Data fields should come before partition fields
+    assertTrue(idIndex < partitionColIndex, "id field should come before partition_col");
+    assertTrue(nameIndex < partitionColIndex, "name field should come before partition_col");
+    assertTrue(ageIndex < partitionColIndex, "age field should come before partition_col");
+    assertTrue(ageIndex < yearIndex, "age field should come before year partition field");
+
+    // Verify comments are preserved in reordered schema
+    assertTrue(reorderedSchemaJson.contains("\"comment\":\"Unique identifier\""));
+    assertTrue(reorderedSchemaJson.contains("\"comment\":\"Partition column\""));
+    assertTrue(reorderedSchemaJson.contains("\"comment\":\"Person's name\""));
+    assertTrue(reorderedSchemaJson.contains("\"comment\":\"Year partition\""));
+  }
+}

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/util/TestSparkDataSourceTableUtils.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/util/TestSparkDataSourceTableUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sync.common.util;
+
+import org.apache.avro.Schema;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestSparkDataSourceTableUtils {
+
+  @Test
+  public void testGetSparkTablePropertiesWithComments() {
+    // Create Avro schema with comments
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"test_schema\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"id\", \"type\": \"int\", \"doc\": \"Unique identifier\"},\n"
+        + "    {\"name\": \"name\", \"type\": [\"null\", \"string\"], \"doc\": \"Person's full name\"},\n"
+        + "    {\"name\": \"partition_col\", \"type\": \"string\", \"doc\": \"Partition column for data organization\"}\n"
+        + "  ]\n"
+        + "}";
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    HoodieSchema hoodieSchema = HoodieSchema.fromAvroSchema(avroSchema);
+
+    List<String> partitionNames = Arrays.asList("partition_col");
+    String sparkVersion = "3.3.0";
+    int schemaLengthThreshold = 4000;
+
+    // Get Spark table properties with comments
+    Map<String, String> properties = SparkDataSourceTableUtils.getSparkTableProperties(
+        partitionNames, sparkVersion, schemaLengthThreshold, hoodieSchema);
+
+    // Verify that properties contain the expected Spark DataSource settings
+    assertTrue(properties.containsKey("spark.sql.sources.provider"),
+        "Should contain Spark provider property");
+    assertTrue(properties.containsKey("spark.sql.sources.schema.numParts"),
+        "Should contain schema parts count");
+    assertTrue(properties.containsKey("spark.sql.sources.schema.part.0"),
+        "Should contain schema part");
+
+    // Verify that comments are included in the schema JSON
+    String schemaPart = properties.get("spark.sql.sources.schema.part.0");
+    assertTrue(schemaPart.contains("\"comment\":\"Unique identifier\""),
+        "Should contain comment for id field");
+    assertTrue(schemaPart.contains("\"comment\":\"Person's full name\""),
+        "Should contain comment for name field");
+    assertTrue(schemaPart.contains("\"comment\":\"Partition column for data organization\""),
+        "Should contain comment for partition column");
+  }
+
+  @Test
+  public void testGetSparkTablePropertiesWithoutComments() {
+    // Create equivalent Avro schema without comments (matching the original MessageType)
+    String avroSchemaJson = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"test_schema\",\n"
+        + "  \"fields\": [\n"
+        + "    {\"name\": \"id\", \"type\": \"int\"},\n"
+        + "    {\"name\": \"name\", \"type\": [\"null\", \"string\"]}\n"
+        + "  ]\n"
+        + "}";
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaJson);
+    HoodieSchema hoodieSchema = HoodieSchema.fromAvroSchema(avroSchema);
+
+    List<String> partitionNames = Arrays.asList();
+    String sparkVersion = "3.3.0";
+    int schemaLengthThreshold = 4000;
+
+    // Get Spark table properties with Avro schema but test the behavior without comments
+    Map<String, String> properties = SparkDataSourceTableUtils.getSparkTableProperties(
+        partitionNames, sparkVersion, schemaLengthThreshold, hoodieSchema);
+
+    // Verify that properties are generated correctly
+    assertTrue(properties.containsKey("spark.sql.sources.provider"),
+        "Should contain Spark provider property");
+    assertTrue(properties.containsKey("spark.sql.sources.schema.part.0"),
+        "Should contain schema part");
+
+    // Verify that no comments are present
+    String schemaPart = properties.get("spark.sql.sources.schema.part.0");
+    assertTrue(!schemaPart.contains("\"comment\":"),
+        "Should not contain any comment fields when no comments provided");
+    assertTrue(schemaPart.contains("\"metadata\":{}"),
+        "Should contain empty metadata when no comments provided");
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

fix the sync for Hudi table field comments.

### Summary and Changelog

the current `HoodieSchema` already support bidirectional transformation between Spark struct type and Hudi schema to keep field comments, just to fix cases like metadata sync.

### Impact

support to sync metadata with field comments.

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
