### PR TITLE
refactor: modularize long test methods in TestHoodieClientOnCopyOnWriteStorage

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -485,7 +485,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     }).collect();
   }
 
-  private void performMergeValidationCheck(HoodieWriteConfig cfg, String instantTime, HoodieTable table,
+  private static void performMergeValidationCheck(HoodieWriteConfig cfg, String instantTime, HoodieTable table,
                                            String partitionPath, HoodieBaseFile baseFile,
                                            boolean expectCorruptedException) throws Exception {
     HoodieWriteMergeHandle handle = null;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #14508

```TestHoodieClientOnCopyOnWriteStorage``` contained a lot of very long test methods with duplicated setup and validation logic, refactoring it to make the file easier to maintain

### Summary and Changelog

Refactored ```TestHoodieClientOnCopyOnWriteStorage``` by extracting repeated logic into private helper methods. No test behavior was changed.

**New helpers added:**

- `upsertBatchRecords`: wraps the upsert + commit boilerplate shared across multiple tests
- `performMergeValidationCheck` (static): de-duplicates the two near-identical merge validation blocks in `testMergeHandle`
- `getFileGroupIds`: de-duplicates repeated `getAllFileGroups` stream in `testUpdateRejectForClustering`
- `verifyExpandedFile`: extracts Avro scan + record count assertion loop
- `verifyTwoFileCommitDistribution`: asserts the two-file, two-commit layout expectation
- `verifyInsertExpandedFile`: extracts commit-2 Avro scan loop in `testSmallInsertHandlingForInserts`
- `verifyAllFilesAtCommit`: asserts all files belong to a given commit
- `insertCommitWithSchema`: de-duplicates the two identical insert-commit blocks in `testWriteSchemaUsageOnPreCommitValidators`
- `getLatestBaseFilesForPartition`: reduces repeated `String.format` + file listing pattern in `verifyDeletePartitionsHandling`
- `createOccProperties` / `buildOccWriteConfig`: de-duplicate OCC config setup shared across three clustering/ingestion concurrency tests
- `seedTableWithFirstCommit`: de-duplicates shared table seeding in OCC test trio
- `startInflightInsertOverwrite`: de-duplicates the two identical uncommitted insert-overwrite blocks in `testParallelInsertOverwriteOperations`


### Impact

No public API or user-facing changes. This is a pure internal test refactoring.


### Risk Level

None. 

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".
None.

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
