### PR TITLE
fix: Fixing partitioned RLI for nested partitions

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/PartitionPathEncodeUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/PartitionPathEncodeUtils.java
@@ -56,6 +56,7 @@ public class PartitionPathEncodeUtils {
 
     charToEscapeFilename.set('_');
     charToEscapeFilename.set('-');
+    charToEscapeFilename.set('.');
   }
 
   static boolean needsEscaping(char c) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/PartitionPathEncodeUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/PartitionPathEncodeUtils.java
@@ -56,6 +56,11 @@ public class PartitionPathEncodeUtils {
 
     charToEscapeFilename.set('_');
     charToEscapeFilename.set('-');
+    // Escape '.' in MDT file-id encoding. A literal dot in a partition value (e.g. a
+    // partition column named fare.currency) collides with LOG_FILE_PATTERN's parser,
+    // so partitioned RLI was non-functional for such partitions prior to this change.
+    // There is no backward-compat concern: tables that needed this previously could
+    // not produce valid MDT entries at all, so no pre-existing encodings would change.
     charToEscapeFilename.set('.');
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -756,9 +756,7 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase with SparkDatasetMix
     assertEquals(10, usdPartitionLocations.size)
 
     val df = spark.read.format("hudi").load(basePath).collect()
-    if (usdPartitionLocations.nonEmpty) {
-      validateDFWithLocations(df, usdPartitionLocations, "fare.currency=USD")
-    }
+    validateDFWithLocations(df, usdPartitionLocations, "fare.currency=USD")
 
     // Verify partitioned RLI is enabled
     metaClient = HoodieTableMetaClient.reload(metaClient)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -748,8 +748,9 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase with SparkDatasetMix
     val metadata = metadataWriter(writeConfig).getTableMetadata
     val recordKeys = inserts.asScala.map(i => i.getRecordKey).asJava.stream().collect(Collectors.toList())
 
-    // Verify record index entries for both partitions
-    // When using fare.currency field, the actual partition paths will be like "fare.currency=USD"
+    // Verify record index entries for the USD partition. HoodieTestDataGenerator's
+    // FARE_NESTED_SCHEMA populator hard-codes currency="USD", so all 10 records land
+    // in fare.currency=USD and the assertion below is deterministic.
     val usdPartitionLocations = readRecordIndex(metadata, recordKeys, HOption.of("fare.currency=USD"))
 
     // All records should be found

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -711,6 +711,75 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase with SparkDatasetMix
       s"Failed to create empty replacement file $candidateBaseFile")
     candidateBaseFile.getName
   }
+
+  @Test
+  def testPartitionedRecordLevelIndexWithHiveStylePartitioningAndDotInPartitionField(): Unit = {
+    initMetaClient(HoodieTableType.COPY_ON_WRITE)
+    val dataGen = new HoodieTestDataGenerator()
+    val inserts = dataGen.generateInserts("001", 10)
+    val insertDf = toDataset(spark, inserts)
+
+    // Use fare.currency as partition field to test dots in partition field names with Hive-style partitioning
+    val options = Map(HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.COPY_ON_WRITE.name(),
+      RECORDKEY_FIELD.key -> "_row_key",
+      PARTITIONPATH_FIELD.key -> "fare.currency",
+      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+      HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "false",
+      HoodieMetadataConfig.RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "true",
+      HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key() -> "false",
+      HoodieCompactionConfig.INLINE_COMPACT.key() -> "false",
+      HoodieIndexConfig.INDEX_TYPE.key() -> RECORD_LEVEL_INDEX.name(),
+      DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key() -> "true")
+
+    insertDf.write.format("hudi")
+      .options(options)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    assertEquals(10, spark.read.format("hudi").load(basePath).count())
+
+    val props = TypedProperties.fromMap(JavaConverters.mapAsJavaMapConverter(options).asJava)
+    val writeConfig = HoodieWriteConfig.newBuilder()
+      .withProps(props)
+      .withPath(basePath)
+      .build()
+
+    val metadata = metadataWriter(writeConfig).getTableMetadata
+    val recordKeys = inserts.asScala.map(i => i.getRecordKey).asJava.stream().collect(Collectors.toList())
+
+    // Verify record index entries for both partitions
+    // When using fare.currency field, the actual partition paths will be like "fare.currency=USD"
+    val usdPartitionLocations = readRecordIndex(metadata, recordKeys, HOption.of("fare.currency=USD"))
+
+    // All records should be found
+    assertEquals(10, usdPartitionLocations.size)
+
+    val df = spark.read.format("hudi").load(basePath).collect()
+    if (usdPartitionLocations.nonEmpty) {
+      validateDFWithLocations(df, usdPartitionLocations, "fare.currency=USD")
+    }
+
+    // Verify partitioned RLI is enabled
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    assertTrue(HoodieRecordIndex.isPartitioned(metaClient.getIndexMetadata.get().getIndexDefinitions.get(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX)))
+
+    // Do an update to ensure ongoing writes work correctly with dot in partition field
+    val updates = dataGen.generateUniqueUpdates("002", 2)
+    val updateDf = toDataset(spark, updates)
+    updateDf.write.format("hudi")
+      .options(options)
+      .option(DataSourceWriteOptions.OPERATION.key(), UPSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    assertEquals(10, spark.read.format("hudi").load(basePath).count())
+
+    // Verify record index still works after updates
+    val metadataAfterUpdate = metadataWriter(writeConfig).getTableMetadata
+    val usdLocationsAfterUpdate = readRecordIndex(metadataAfterUpdate, recordKeys, HOption.of("fare.currency=USD"))
+    assertEquals(10, usdLocationsAfterUpdate.size)
+  }
 }
 
 object TestRecordLevelIndex {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes an issue with partitioned Record Level Index (RLI) when using nested partition fields containing dots (e.g., fare.currency) combined with Hive-style partitioning. The partition path encoding was not handling dots properly, causing issues with partition path to file ID mapping in the metadata table.

### Summary and Changelog

 Summary: Enables partitioned RLI to work correctly with nested partition fields that contain dots when using Hive-style partitioning.

  Changes:
  - Added '.' (dot) character to the escape list in PartitionPathEncodeUtils.java:59 so partition paths like "fare.currency=USD" are
  properly encoded when stored in the metadata table
  - Added comprehensive functional test testPartitionedRecordLevelIndexWithHiveStylePartitioningAndDotInPartitionField() in
  TestRecordLevelIndex.scala:679-746 that validates:
    - Initial inserts with dot-containing partition field work correctly
    - Record index entries are properly created and retrievable
    - Updates/upserts continue to work after the initial write
    - All 10 records are correctly indexed and queryable
    
### Impact

This fix enables users to use partitioned RLI with nested column names (containing dots) as partition fields when Hive-style
  partitioning is enabled. Without this fix, such configurations would result in incorrect partition path encoding in the metadata table.

  No breaking changes to existing functionality - this is purely a bug fix for a specific edge case.

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
