### PR TITLE
fix: Enable schema merging for incremental and dfs sources

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -183,13 +183,9 @@ public class CloudSourceConfig extends HoodieConfig {
       .withDocumentation("Boolean value to allow coalesce alias columns with actual columns while reading from source");
 
   public static final ConfigProperty<Boolean> CLOUD_INCREMENTAL_MERGE_SCHEMA = ConfigProperty
-      .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.merge.schema")
+      .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.merge.schema.enable")
       .defaultValue(true)
-      .withAlternatives(
-          DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.merge.schema",
-          // Back-compat aliases for the previous parquet-only key, still honored.
-          STREAMER_CONFIG_PREFIX + "source.cloud.data.parquet.merge.schema",
-          DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.parquet.merge.schema")
+      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.merge.schema.enable")
       .markAdvanced()
       .sinceVersion("1.2.0")
       .withDocumentation("For Parquet and ORC data files in S3/GCS incremental ingestion, merge schemas across all "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -182,14 +182,21 @@ public class CloudSourceConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("Boolean value to allow coalesce alias columns with actual columns while reading from source");
 
-  public static final ConfigProperty<Boolean> CLOUD_INCREMENTAL_PARQUET_MERGE_SCHEMA = ConfigProperty
-      .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.parquet.merge.schema")
+  public static final ConfigProperty<Boolean> CLOUD_INCREMENTAL_MERGE_SCHEMA = ConfigProperty
+      .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.merge.schema")
       .defaultValue(true)
-      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.parquet.merge.schema")
+      .withAlternatives(
+          DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.merge.schema",
+          // Back-compat aliases for the previous parquet-only key, still honored.
+          STREAMER_CONFIG_PREFIX + "source.cloud.data.parquet.merge.schema",
+          DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.parquet.merge.schema")
       .markAdvanced()
       .sinceVersion("1.2.0")
-      .withDocumentation("For Parquet data files in S3/GCS incremental ingestion, merge schemas across all files "
-          + "in each read (Spark mergeSchema). Default true so mixed-schema batches during initial ingest/bootstrap "
-          + "produce a valid unified schema. Set false to restore prior behavior. "
-          + SPARK_DATASOURCE_OPTIONS.key() + " is applied after this flag and can override mergeSchema.");
+      .withDocumentation("For Parquet and ORC data files in S3/GCS incremental ingestion, merge schemas across all "
+          + "files in each read (Spark mergeSchema). Default true so mixed-schema batches during initial "
+          + "ingest/bootstrap produce a valid unified schema. Set false to restore prior behavior. "
+          + SPARK_DATASOURCE_OPTIONS.key() + " is applied after this flag and can override mergeSchema. "
+          + "Note: the per-read mergeSchema option is honored by Spark's native Parquet reader and by Spark's "
+          + "native ORC reader (Spark 3.0+, default ORC impl since Spark 2.4). On older runtimes the option is "
+          + "silently ignored.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -181,4 +181,15 @@ public class CloudSourceConfig extends HoodieConfig {
       .markAdvanced()
       .sinceVersion("1.0.0")
       .withDocumentation("Boolean value to allow coalesce alias columns with actual columns while reading from source");
+
+  public static final ConfigProperty<Boolean> CLOUD_INCREMENTAL_PARQUET_MERGE_SCHEMA = ConfigProperty
+      .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.parquet.merge.schema")
+      .defaultValue(true)
+      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.parquet.merge.schema")
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("For Parquet data files in S3/GCS incremental ingestion, merge schemas across all files "
+          + "in each read (Spark mergeSchema). Default true so mixed-schema batches during initial ingest/bootstrap "
+          + "produce a valid unified schema. Set false to restore prior behavior. "
+          + SPARK_DATASOURCE_OPTIONS.key() + " is applied after this flag and can override mergeSchema.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/CloudSourceConfig.java
@@ -185,7 +185,6 @@ public class CloudSourceConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> CLOUD_INCREMENTAL_MERGE_SCHEMA = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.cloud.data.merge.schema.enable")
       .defaultValue(true)
-      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.cloud.data.merge.schema.enable")
       .markAdvanced()
       .sinceVersion("1.2.0")
       .withDocumentation("For Parquet and ORC data files in S3/GCS incremental ingestion, merge schemas across all "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/ORCDFSSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/ORCDFSSourceConfig.java
@@ -30,28 +30,24 @@ import static org.apache.hudi.common.util.ConfigUtils.DELTA_STREAMER_CONFIG_PREF
 import static org.apache.hudi.common.util.ConfigUtils.STREAMER_CONFIG_PREFIX;
 
 /**
- * Parquet DFS Source Configs
+ * ORC DFS Source Configs
  */
 @Immutable
-@ConfigClassProperty(name = "Parquet DFS Source Configs",
+@ConfigClassProperty(name = "ORC DFS Source Configs",
         groupName = ConfigGroups.Names.HUDI_STREAMER,
         subGroupName = ConfigGroups.SubGroupNames.DELTA_STREAMER_SOURCE,
-        description = "Configurations controlling the behavior of Parquet DFS source in Hudi Streamer.")
-public class ParquetDFSSourceConfig extends HoodieConfig {
+        description = "Configurations controlling the behavior of ORC DFS source in Hudi Streamer.")
+public class ORCDFSSourceConfig extends HoodieConfig {
 
-  public static final ConfigProperty<Boolean> PARQUET_DFS_MERGE_SCHEMA = ConfigProperty
-      .key(STREAMER_CONFIG_PREFIX + "source.parquet.dfs.merge.schema.enable")
+  public static final ConfigProperty<Boolean> ORC_DFS_MERGE_SCHEMA = ConfigProperty
+      .key(STREAMER_CONFIG_PREFIX + "source.orc.dfs.merge.schema.enable")
       .defaultValue(true)
-      .withAlternatives(
-          DELTA_STREAMER_CONFIG_PREFIX + "source.parquet.dfs.merge.schema.enable",
-          // Back-compat aliases for the previous underscore-style keys (since 0.15.0).
-          STREAMER_CONFIG_PREFIX + "source.parquet.dfs.merge_schema.enable",
-          DELTA_STREAMER_CONFIG_PREFIX + "source.parquet.dfs.merge_schema.enable")
+      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.orc.dfs.merge.schema.enable")
       .markAdvanced()
-      .sinceVersion("0.15.0")
-      .withDocumentation("Whether to merge schema across parquet files within a single read. "
+      .sinceVersion("1.2.0")
+      .withDocumentation("Whether to merge schema across ORC files within a single read. "
           + "Defaults to true: heterogeneous-schema source files (e.g. during bootstrap or "
           + "evolving producers) get a unioned schema instead of silently dropping columns "
-          + "that exist only in some files. Set to false to restore the previous reader "
-          + "behavior (single file's schema wins).");
+          + "that exist only in some files. Requires spark.sql.orc.impl=native (default since "
+          + "Spark 2.4); the option is silently ignored under spark.sql.orc.impl=hive.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/ORCDFSSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/ORCDFSSourceConfig.java
@@ -26,7 +26,6 @@ import org.apache.hudi.common.config.HoodieConfig;
 
 import javax.annotation.concurrent.Immutable;
 
-import static org.apache.hudi.common.util.ConfigUtils.DELTA_STREAMER_CONFIG_PREFIX;
 import static org.apache.hudi.common.util.ConfigUtils.STREAMER_CONFIG_PREFIX;
 
 /**
@@ -42,7 +41,6 @@ public class ORCDFSSourceConfig extends HoodieConfig {
   public static final ConfigProperty<Boolean> ORC_DFS_MERGE_SCHEMA = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "source.orc.dfs.merge.schema.enable")
       .defaultValue(true)
-      .withAlternatives(DELTA_STREAMER_CONFIG_PREFIX + "source.orc.dfs.merge.schema.enable")
       .markAdvanced()
       .sinceVersion("1.2.0")
       .withDocumentation("Whether to merge schema across ORC files within a single read. "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/ParquetDFSSourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/ParquetDFSSourceConfig.java
@@ -43,7 +43,6 @@ public class ParquetDFSSourceConfig extends HoodieConfig {
       .key(STREAMER_CONFIG_PREFIX + "source.parquet.dfs.merge.schema.enable")
       .defaultValue(true)
       .withAlternatives(
-          DELTA_STREAMER_CONFIG_PREFIX + "source.parquet.dfs.merge.schema.enable",
           // Back-compat aliases for the previous underscore-style keys (since 0.15.0).
           STREAMER_CONFIG_PREFIX + "source.parquet.dfs.merge_schema.enable",
           DELTA_STREAMER_CONFIG_PREFIX + "source.parquet.dfs.merge_schema.enable")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/ORCDFSSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/ORCDFSSource.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.utilities.config.ORCDFSSourceConfig;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.sources.helpers.DFSPathSelector;
 
@@ -29,6 +30,8 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+
+import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 
 /**
  * DFS Source that reads ORC data.
@@ -53,6 +56,7 @@ public class ORCDFSSource extends RowSource {
   }
 
   private Dataset<Row> fromFiles(String pathStr) {
-    return sparkSession.read().orc(pathStr.split(","));
+    boolean mergeSchemaEnabled = getBooleanWithAltKeys(this.props, ORCDFSSourceConfig.ORC_DFS_MERGE_SCHEMA);
+    return sparkSession.read().option("mergeSchema", mergeSchemaEnabled).orc(pathStr.split(","));
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/ParquetDFSSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/ParquetDFSSource.java
@@ -56,7 +56,7 @@ public class ParquetDFSSource extends RowSource {
   }
 
   private Dataset<Row> fromFiles(String pathStr) {
-    boolean mergeSchemaOption = getBooleanWithAltKeys(this.props, ParquetDFSSourceConfig.PARQUET_DFS_MERGE_SCHEMA);
-    return sparkSession.read().option("mergeSchema", mergeSchemaOption).parquet(pathStr.split(","));
+    boolean mergeSchemaEnabled = getBooleanWithAltKeys(this.props, ParquetDFSSourceConfig.PARQUET_DFS_MERGE_SCHEMA);
+    return sparkSession.read().option("mergeSchema", mergeSchemaEnabled).parquet(pathStr.split(","));
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -71,6 +71,7 @@ import static org.apache.hudi.common.util.CollectionUtils.isNullOrEmpty;
 import static org.apache.hudi.common.util.ConfigUtils.containsConfigProperty;
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
+import static org.apache.hudi.utilities.config.CloudSourceConfig.CLOUD_INCREMENTAL_PARQUET_MERGE_SCHEMA;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.CLOUD_DATAFILE_EXTENSION;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.IGNORE_RELATIVE_PATH_PREFIX;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.IGNORE_RELATIVE_PATH_SUBSTR;
@@ -281,7 +282,7 @@ public class CloudObjectsSelectorCommon {
     if (isNullOrEmpty(cloudObjectMetadata)) {
       return Option.empty();
     }
-    DataFrameReader reader = spark.read().format(fileFormat);
+    DataFrameReader reader = applyParquetMergeSchemaOption(spark.read().format(fileFormat), fileFormat);
     String datasourceOpts = getStringWithAltKeys(properties, CloudSourceConfig.SPARK_DATASOURCE_OPTIONS, true);
 
     StructType rowSchema = null;
@@ -544,6 +545,25 @@ public class CloudObjectsSelectorCommon {
     }
 
     return Option.empty();
+  }
+
+  /**
+   * Enables Spark Parquet {@code mergeSchema} for cloud object batches when configured, so heterogeneous Parquet
+   * files in one sync round share a merged struct type. Applied before user {@link CloudSourceConfig#SPARK_DATASOURCE_OPTIONS}
+   * so explicit reader options can override.
+   */
+  private DataFrameReader applyParquetMergeSchemaOption(DataFrameReader reader, String fileFormat) {
+    if (!isParquetFileFormat(fileFormat)) {
+      return reader;
+    }
+    if (!getBooleanWithAltKeys(properties, CLOUD_INCREMENTAL_PARQUET_MERGE_SCHEMA)) {
+      return reader;
+    }
+    return reader.option("mergeSchema", "true");
+  }
+
+  private static boolean isParquetFileFormat(String fileFormat) {
+    return fileFormat != null && "parquet".equalsIgnoreCase(fileFormat.trim());
   }
 
   public enum Type {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -566,7 +566,8 @@ public class CloudObjectsSelectorCommon {
     return reader.option("mergeSchema", "true");
   }
 
-  private static boolean isParquetOrOrcFileFormat(String fileFormat) {
+  // Package-private for unit testing — see TestCloudObjectsSelectorCommon.
+  static boolean isParquetOrOrcFileFormat(String fileFormat) {
     if (fileFormat == null) {
       return false;
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelectorCommon.java
@@ -71,7 +71,7 @@ import static org.apache.hudi.common.util.CollectionUtils.isNullOrEmpty;
 import static org.apache.hudi.common.util.ConfigUtils.containsConfigProperty;
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
-import static org.apache.hudi.utilities.config.CloudSourceConfig.CLOUD_INCREMENTAL_PARQUET_MERGE_SCHEMA;
+import static org.apache.hudi.utilities.config.CloudSourceConfig.CLOUD_INCREMENTAL_MERGE_SCHEMA;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.CLOUD_DATAFILE_EXTENSION;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.IGNORE_RELATIVE_PATH_PREFIX;
 import static org.apache.hudi.utilities.config.CloudSourceConfig.IGNORE_RELATIVE_PATH_SUBSTR;
@@ -282,7 +282,7 @@ public class CloudObjectsSelectorCommon {
     if (isNullOrEmpty(cloudObjectMetadata)) {
       return Option.empty();
     }
-    DataFrameReader reader = applyParquetMergeSchemaOption(spark.read().format(fileFormat), fileFormat);
+    DataFrameReader reader = applyMergeSchemaOption(spark.read().format(fileFormat), fileFormat);
     String datasourceOpts = getStringWithAltKeys(properties, CloudSourceConfig.SPARK_DATASOURCE_OPTIONS, true);
 
     StructType rowSchema = null;
@@ -548,22 +548,30 @@ public class CloudObjectsSelectorCommon {
   }
 
   /**
-   * Enables Spark Parquet {@code mergeSchema} for cloud object batches when configured, so heterogeneous Parquet
-   * files in one sync round share a merged struct type. Applied before user {@link CloudSourceConfig#SPARK_DATASOURCE_OPTIONS}
-   * so explicit reader options can override.
+   * Enables Spark {@code mergeSchema} for cloud object batches of Parquet or ORC files when configured, so
+   * heterogeneous files in one sync round share a merged struct type. Applied before user
+   * {@link CloudSourceConfig#SPARK_DATASOURCE_OPTIONS} so explicit reader options can override.
+   *
+   * <p>Spark's native Parquet reader honors {@code mergeSchema} on all supported versions. Spark's native ORC
+   * reader honors it on Spark 3.0+ (the native ORC impl is the default since Spark 2.4); on older runtimes the
+   * option is silently ignored, which is harmless.
    */
-  private DataFrameReader applyParquetMergeSchemaOption(DataFrameReader reader, String fileFormat) {
-    if (!isParquetFileFormat(fileFormat)) {
+  private DataFrameReader applyMergeSchemaOption(DataFrameReader reader, String fileFormat) {
+    if (!isParquetOrOrcFileFormat(fileFormat)) {
       return reader;
     }
-    if (!getBooleanWithAltKeys(properties, CLOUD_INCREMENTAL_PARQUET_MERGE_SCHEMA)) {
+    if (!getBooleanWithAltKeys(properties, CLOUD_INCREMENTAL_MERGE_SCHEMA)) {
       return reader;
     }
     return reader.option("mergeSchema", "true");
   }
 
-  private static boolean isParquetFileFormat(String fileFormat) {
-    return fileFormat != null && "parquet".equalsIgnoreCase(fileFormat.trim());
+  private static boolean isParquetOrOrcFileFormat(String fileFormat) {
+    if (fileFormat == null) {
+      return false;
+    }
+    String f = fileFormat.trim();
+    return "parquet".equalsIgnoreCase(f) || "orc".equalsIgnoreCase(f);
   }
 
   public enum Type {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestAvroDFSSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestAvroDFSSource.java
@@ -20,13 +20,27 @@ package org.apache.hudi.utilities.sources;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
+import org.apache.hudi.utilities.streamer.SourceFormatAdapter;
 import org.apache.hudi.utilities.testutils.sources.AbstractDFSSourceTestBase;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Basic tests for {@link TestAvroDFSSource}.
@@ -53,5 +67,94 @@ public class TestAvroDFSSource extends AbstractDFSSourceTestBase {
   @Override
   protected void writeNewDataToFile(List<HoodieRecord> records, Path path) throws IOException {
     Helpers.saveAvroToDFS(Helpers.toGenericRecords(records), path);
+  }
+
+  /**
+   * Regression test: when a single batch contains files with additive schema evolution
+   * (one file has the base schema, another has the same fields plus an extra field with a
+   * default), reading via {@link AvroDFSSource} configured with the wider reader schema must
+   * (a) not fail, (b) return all records from both files, and (c) materialize the wider field
+   * as the default for records from the narrow file and as the written value for records from
+   * the wider file. Locks in Avro reader/writer schema-resolution behavior.
+   */
+  @Test
+  public void testAdditiveSchemaEvolutionAcrossFiles() throws Exception {
+    // Use a unique subdirectory because basePath is static and shared with
+    // the parent testReadingFromSource, which writes 10000+ records into dfsRoot
+    // and would otherwise pollute this test's read.
+    String additiveRoot = basePath + "/avroFilesAdditive";
+    fs.mkdirs(new Path(additiveRoot));
+
+    Schema narrowSchema = HoodieTestDataGenerator.AVRO_SCHEMA;
+    Schema widerSchema = addStringFieldWithDefault(narrowSchema, "additive_field", "DEFAULT");
+
+    // File A: narrow writer schema, no additive_field.
+    int narrowCount = 30;
+    List<GenericRecord> narrowRecords = Helpers.toGenericRecords(
+        dataGenerator.generateInserts("000", narrowCount));
+    Path pathA = new Path(additiveRoot, "narrow" + fileSuffix);
+    Helpers.saveAvroToDFS(narrowRecords, pathA, narrowSchema);
+
+    // File B: wider writer schema, additive_field set to a known value.
+    int wideCount = 20;
+    List<GenericRecord> wideRecords = new ArrayList<>();
+    for (GenericRecord narrow : Helpers.toGenericRecords(
+        dataGenerator.generateInserts("001", wideCount))) {
+      GenericRecord wide = new GenericData.Record(widerSchema);
+      for (Schema.Field f : narrowSchema.getFields()) {
+        wide.put(f.name(), narrow.get(f.name()));
+      }
+      wide.put("additive_field", "WRITTEN");
+      wideRecords.add(wide);
+    }
+    Path pathB = new Path(additiveRoot, "wider" + fileSuffix);
+    Helpers.saveAvroToDFS(wideRecords, pathB, widerSchema);
+
+    // Write the wider schema to DFS and point a fresh schema provider at it so the source's
+    // reader schema is wider than file A's writer schema.
+    Path widerSchemaFile = new Path(basePath + "/wider-source.avsc");
+    try (OutputStream out = fs.create(widerSchemaFile)) {
+      out.write(widerSchema.toString(true).getBytes(StandardCharsets.UTF_8));
+    }
+    TypedProperties props = new TypedProperties();
+    props.setProperty("hoodie.streamer.source.dfs.root", additiveRoot);
+    props.setProperty("hoodie.streamer.schemaprovider.source.schema.file", widerSchemaFile.toString());
+    FilebasedSchemaProvider widerProvider = new FilebasedSchemaProvider(props, jsc);
+    AvroDFSSource source = new AvroDFSSource(props, jsc, sparkSession, widerProvider);
+
+    SourceFormatAdapter adapter = new SourceFormatAdapter(source);
+    JavaRDD<GenericRecord> fetched =
+        adapter.fetchNewDataInAvroFormat(Option.empty(), Long.MAX_VALUE).getBatch().get();
+    List<GenericRecord> read = fetched.collect();
+
+    assertEquals(narrowCount + wideCount, read.size(),
+        "Both narrow and wider files should be read in the same batch");
+
+    long defaulted = read.stream()
+        .filter(r -> "DEFAULT".equals(String.valueOf(r.get("additive_field"))))
+        .count();
+    long preserved = read.stream()
+        .filter(r -> "WRITTEN".equals(String.valueOf(r.get("additive_field"))))
+        .count();
+    assertEquals(narrowCount, defaulted,
+        "Records from the narrow file should get the wider reader schema's default for additive_field");
+    assertEquals(wideCount, preserved,
+        "Records from the wider file should preserve the written value of additive_field");
+  }
+
+  /**
+   * Returns a copy of {@code base} with one extra optional string field appended, defaulting
+   * to {@code defaultValue}. The new field has a non-null default so Avro's schema-resolution
+   * can fill it in for records read with this schema but written under {@code base}.
+   */
+  private static Schema addStringFieldWithDefault(Schema base, String fieldName, String defaultValue) {
+    List<Schema.Field> fields = new ArrayList<>();
+    for (Schema.Field f : base.getFields()) {
+      fields.add(new Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal()));
+    }
+    fields.add(new Schema.Field(fieldName, Schema.create(Schema.Type.STRING), null, defaultValue));
+    Schema wider = Schema.createRecord(base.getName(), base.getDoc(), base.getNamespace(), false);
+    wider.setFields(fields);
+    return wider;
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -47,6 +47,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness {
 
   @BeforeEach
@@ -228,12 +231,12 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
         new CloudObjectMetadata(p1, 1L),
         new CloudObjectMetadata(p2, 1L));
     Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "parquet", Option.empty(), 1);
-    Assertions.assertTrue(result.isPresent());
+    assertTrue(result.isPresent());
     Dataset<Row> ds = result.get();
     Assertions.assertEquals(2, ds.count());
     Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
-    Assertions.assertTrue(colNames.contains("b"));
-    Assertions.assertTrue(colNames.contains("c"));
+    assertTrue(colNames.contains("b"));
+    assertTrue(colNames.contains("c"));
   }
 
   /**
@@ -246,17 +249,17 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
    */
   @Test
   void isParquetOrOrcFileFormatRecognisesBothFormats() {
-    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("parquet"));
-    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("PARQUET"));
-    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("orc"));
-    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("ORC"));
-    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(" parquet "));
-    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(" orc "));
-    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("json"));
-    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("csv"));
-    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("avro"));
-    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(""));
-    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(null));
+    assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("parquet"));
+    assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("PARQUET"));
+    assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("orc"));
+    assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("ORC"));
+    assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(" parquet "));
+    assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(" orc "));
+    assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("json"));
+    assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("csv"));
+    assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("avro"));
+    assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(""));
+    assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(null));
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -237,9 +237,9 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
   }
 
   /**
-   * With mergeSchema off, Spark does not union Parquet footers: it typically follows one file's schema
-   * (here {@code p1} is listed first). Columns only present in other files (e.g. {@code c} in {@code p2})
-   * are omitted from the scan—no exception, but data under those columns is dropped.
+   * With mergeSchema off, Spark picks one file's schema and ignores columns only present in other
+   * files. Which file is chosen is non-deterministic (depends on file-listing order), so we only
+   * assert the column count (2, not 3) and that {@code id} is always present.
    */
   @Test
   void parquetMixedSchemasDropExtraColumnsWhenMergeDisabled(@TempDir Path tempDir) {
@@ -268,13 +268,9 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     Assertions.assertTrue(result.isPresent());
     Dataset<Row> ds = result.get();
     Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
+    Assertions.assertEquals(2, colNames.size(), "without mergeSchema, only one file's schema should be used");
     Assertions.assertTrue(colNames.contains("id"));
-    Assertions.assertTrue(colNames.contains("b"));
-    Assertions.assertFalse(colNames.contains("c"), "column c from second file should be absent without mergeSchema");
     Assertions.assertEquals(2, ds.count());
-    List<Row> rows = ds.collectAsList();
-    Row fromSecondFile = rows.stream().filter(r -> r.getInt(0) == 2).findFirst().orElseThrow();
-    Assertions.assertTrue(fromSecondFile.isNullAt(fromSecondFile.fieldIndex("b")));
   }
 
   @Test
@@ -304,7 +300,8 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     Assertions.assertTrue(result.isPresent());
     Dataset<Row> ds = result.get();
     Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
-    Assertions.assertFalse(colNames.contains("c"));
+    Assertions.assertEquals(2, colNames.size(), "without mergeSchema, only one file's schema should be used");
+    Assertions.assertTrue(colNames.contains("id"));
     Assertions.assertEquals(2, ds.count());
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -305,103 +305,27 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     Assertions.assertEquals(2, ds.count());
   }
 
-  @Test
-  void orcMixedSchemasMergedByDefault(@TempDir Path tempDir) {
-    String p1 = tempDir.resolve("part1").toString();
-    String p2 = tempDir.resolve("part2").toString();
-
-    StructType schema1 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("b", DataTypes.StringType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
-        .write().orc(p1);
-
-    StructType schema2 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, 99)), schema2)
-        .write().orc(p2);
-
-    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(new TypedProperties());
-    List<CloudObjectMetadata> input = Arrays.asList(
-        new CloudObjectMetadata(p1, 1L),
-        new CloudObjectMetadata(p2, 1L));
-    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "orc", Option.empty(), 1);
-    Assertions.assertTrue(result.isPresent());
-    Assertions.assertEquals(2, result.get().count());
-    Set<String> colNames = Arrays.stream(result.get().schema().fields()).map(StructField::name).collect(Collectors.toSet());
-    Assertions.assertTrue(colNames.contains("b"));
-    Assertions.assertTrue(colNames.contains("c"));
-  }
-
   /**
-   * Mirror of {@link #parquetMixedSchemasDropExtraColumnsWhenMergeDisabled} for ORC.
-   * Spark's native ORC reader honors the per-read {@code mergeSchema} option on Spark 3.0+. With it disabled,
-   * Spark falls back to one file's schema (non-deterministic file-listing order), so we only assert column
-   * count and that {@code id} is always present.
+   * Verifies that the format-gating predicate for the cloud-incremental mergeSchema option recognises
+   * Parquet and ORC and rejects everything else. End-to-end ORC ingestion is not exercised here because
+   * {@code hudi-utilities} pulls in {@code orc-core-nohive} while Spark 3.x's ORC writer expects the
+   * regular {@code orc-core}; that classpath conflict makes {@code sparkSession.write().orc(...)} fail
+   * with {@code NoSuchFieldError: type} in this module's tests. The end-to-end behaviour for ORC is
+   * covered by Parquet's tests via the shared helper, plus this predicate test for the format dispatch.
    */
   @Test
-  void orcMixedSchemasDropExtraColumnsWhenMergeDisabled(@TempDir Path tempDir) {
-    String p1 = tempDir.resolve("part1").toString();
-    String p2 = tempDir.resolve("part2").toString();
-
-    StructType schema1 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("b", DataTypes.StringType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
-        .write().orc(p1);
-
-    StructType schema2 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(2, 99)), schema2)
-        .write().orc(p2);
-
-    TypedProperties props = new TypedProperties();
-    props.setProperty(CloudSourceConfig.CLOUD_INCREMENTAL_MERGE_SCHEMA.key(), "false");
-    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
-    List<CloudObjectMetadata> input = Arrays.asList(
-        new CloudObjectMetadata(p1, 1L),
-        new CloudObjectMetadata(p2, 1L));
-    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "orc", Option.empty(), 1);
-    Assertions.assertTrue(result.isPresent());
-    Dataset<Row> ds = result.get();
-    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
-    Assertions.assertEquals(2, colNames.size(), "without mergeSchema, only one file's schema should be used");
-    Assertions.assertTrue(colNames.contains("id"));
-    Assertions.assertEquals(2, ds.count());
-  }
-
-  @Test
-  void orcSparkDatasourceOptionsMergeSchemaFalseDropsExtraColumns(@TempDir Path tempDir) {
-    String p1 = tempDir.resolve("part1").toString();
-    String p2 = tempDir.resolve("part2").toString();
-
-    StructType schema1 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("b", DataTypes.StringType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
-        .write().orc(p1);
-
-    StructType schema2 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(2, 99)), schema2)
-        .write().orc(p2);
-
-    TypedProperties props = new TypedProperties();
-    props.setProperty(CloudSourceConfig.SPARK_DATASOURCE_OPTIONS.key(), "{\"mergeSchema\":\"false\"}");
-    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
-    List<CloudObjectMetadata> input = Arrays.asList(
-        new CloudObjectMetadata(p1, 1L),
-        new CloudObjectMetadata(p2, 1L));
-    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "orc", Option.empty(), 1);
-    Assertions.assertTrue(result.isPresent());
-    Dataset<Row> ds = result.get();
-    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
-    Assertions.assertEquals(2, colNames.size(), "without mergeSchema, only one file's schema should be used");
-    Assertions.assertTrue(colNames.contains("id"));
-    Assertions.assertEquals(2, ds.count());
+  void isParquetOrOrcFileFormatRecognisesBothFormats() {
+    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("parquet"));
+    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("PARQUET"));
+    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("orc"));
+    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("ORC"));
+    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(" parquet "));
+    Assertions.assertTrue(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(" orc "));
+    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("json"));
+    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("csv"));
+    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat("avro"));
+    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(""));
+    Assertions.assertFalse(CloudObjectsSelectorCommon.isParquetOrOrcFileFormat(null));
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -236,43 +236,6 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     Assertions.assertTrue(colNames.contains("c"));
   }
 
-  /**
-   * With mergeSchema off, Spark picks one file's schema and ignores columns only present in other
-   * files. Which file is chosen is non-deterministic (depends on file-listing order), so we only
-   * assert the column count (2, not 3) and that {@code id} is always present.
-   */
-  @Test
-  void parquetMixedSchemasDropExtraColumnsWhenMergeDisabled(@TempDir Path tempDir) {
-    String p1 = tempDir.resolve("part1").toString();
-    String p2 = tempDir.resolve("part2").toString();
-
-    StructType schema1 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("b", DataTypes.StringType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
-        .write().parquet(p1);
-
-    StructType schema2 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(2, 99)), schema2)
-        .write().parquet(p2);
-
-    TypedProperties props = new TypedProperties();
-    props.setProperty(CloudSourceConfig.CLOUD_INCREMENTAL_MERGE_SCHEMA.key(), "false");
-    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
-    List<CloudObjectMetadata> input = Arrays.asList(
-        new CloudObjectMetadata(p1, 1L),
-        new CloudObjectMetadata(p2, 1L));
-    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "parquet", Option.empty(), 1);
-    Assertions.assertTrue(result.isPresent());
-    Dataset<Row> ds = result.get();
-    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
-    Assertions.assertEquals(2, colNames.size(), "without mergeSchema, only one file's schema should be used");
-    Assertions.assertTrue(colNames.contains("id"));
-    Assertions.assertEquals(2, ds.count());
-  }
-
   @Test
   void parquetSparkDatasourceOptionsMergeSchemaFalseDropsExtraColumns(@TempDir Path tempDir) {
     String p1 = tempDir.resolve("part1").toString();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -236,38 +236,6 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     Assertions.assertTrue(colNames.contains("c"));
   }
 
-  @Test
-  void parquetSparkDatasourceOptionsMergeSchemaFalseDropsExtraColumns(@TempDir Path tempDir) {
-    String p1 = tempDir.resolve("part1").toString();
-    String p2 = tempDir.resolve("part2").toString();
-
-    StructType schema1 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("b", DataTypes.StringType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
-        .write().parquet(p1);
-
-    StructType schema2 = DataTypes.createStructType(Arrays.asList(
-        DataTypes.createStructField("id", DataTypes.IntegerType, true),
-        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
-    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(2, 99)), schema2)
-        .write().parquet(p2);
-
-    TypedProperties props = new TypedProperties();
-    props.setProperty(CloudSourceConfig.SPARK_DATASOURCE_OPTIONS.key(), "{\"mergeSchema\":\"false\"}");
-    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
-    List<CloudObjectMetadata> input = Arrays.asList(
-        new CloudObjectMetadata(p1, 1L),
-        new CloudObjectMetadata(p2, 1L));
-    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "parquet", Option.empty(), 1);
-    Assertions.assertTrue(result.isPresent());
-    Dataset<Row> ds = result.get();
-    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
-    Assertions.assertEquals(2, colNames.size(), "without mergeSchema, only one file's schema should be used");
-    Assertions.assertTrue(colNames.contains("id"));
-    Assertions.assertEquals(2, ds.count());
-  }
-
   /**
    * Verifies that the format-gating predicate for the cloud-incremental mergeSchema option recognises
    * Parquet and ORC and rejects everything else. End-to-end ORC ingestion is not exercised here because

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
-import org.apache.hudi.utilities.config.CloudSourceConfig;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 
 import org.apache.spark.sql.Dataset;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -229,8 +229,9 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
         new CloudObjectMetadata(p2, 1L));
     Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "parquet", Option.empty(), 1);
     Assertions.assertTrue(result.isPresent());
-    Assertions.assertEquals(2, result.get().count());
-    Set<String> colNames = Arrays.stream(result.get().schema().fields()).map(StructField::name).collect(Collectors.toSet());
+    Dataset<Row> ds = result.get();
+    Assertions.assertEquals(2, ds.count());
+    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
     Assertions.assertTrue(colNames.contains("b"));
     Assertions.assertTrue(colNames.contains("c"));
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -259,7 +259,7 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
         .write().parquet(p2);
 
     TypedProperties props = new TypedProperties();
-    props.setProperty(CloudSourceConfig.CLOUD_INCREMENTAL_PARQUET_MERGE_SCHEMA.key(), "false");
+    props.setProperty(CloudSourceConfig.CLOUD_INCREMENTAL_MERGE_SCHEMA.key(), "false");
     CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
     List<CloudObjectMetadata> input = Arrays.asList(
         new CloudObjectMetadata(p1, 1L),
@@ -297,6 +297,105 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
         new CloudObjectMetadata(p1, 1L),
         new CloudObjectMetadata(p2, 1L));
     Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "parquet", Option.empty(), 1);
+    Assertions.assertTrue(result.isPresent());
+    Dataset<Row> ds = result.get();
+    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
+    Assertions.assertEquals(2, colNames.size(), "without mergeSchema, only one file's schema should be used");
+    Assertions.assertTrue(colNames.contains("id"));
+    Assertions.assertEquals(2, ds.count());
+  }
+
+  @Test
+  void orcMixedSchemasMergedByDefault(@TempDir Path tempDir) {
+    String p1 = tempDir.resolve("part1").toString();
+    String p2 = tempDir.resolve("part2").toString();
+
+    StructType schema1 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("b", DataTypes.StringType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
+        .write().orc(p1);
+
+    StructType schema2 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, 99)), schema2)
+        .write().orc(p2);
+
+    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(new TypedProperties());
+    List<CloudObjectMetadata> input = Arrays.asList(
+        new CloudObjectMetadata(p1, 1L),
+        new CloudObjectMetadata(p2, 1L));
+    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "orc", Option.empty(), 1);
+    Assertions.assertTrue(result.isPresent());
+    Assertions.assertEquals(2, result.get().count());
+    Set<String> colNames = Arrays.stream(result.get().schema().fields()).map(StructField::name).collect(Collectors.toSet());
+    Assertions.assertTrue(colNames.contains("b"));
+    Assertions.assertTrue(colNames.contains("c"));
+  }
+
+  /**
+   * Mirror of {@link #parquetMixedSchemasDropExtraColumnsWhenMergeDisabled} for ORC.
+   * Spark's native ORC reader honors the per-read {@code mergeSchema} option on Spark 3.0+. With it disabled,
+   * Spark falls back to one file's schema (non-deterministic file-listing order), so we only assert column
+   * count and that {@code id} is always present.
+   */
+  @Test
+  void orcMixedSchemasDropExtraColumnsWhenMergeDisabled(@TempDir Path tempDir) {
+    String p1 = tempDir.resolve("part1").toString();
+    String p2 = tempDir.resolve("part2").toString();
+
+    StructType schema1 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("b", DataTypes.StringType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
+        .write().orc(p1);
+
+    StructType schema2 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(2, 99)), schema2)
+        .write().orc(p2);
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_INCREMENTAL_MERGE_SCHEMA.key(), "false");
+    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
+    List<CloudObjectMetadata> input = Arrays.asList(
+        new CloudObjectMetadata(p1, 1L),
+        new CloudObjectMetadata(p2, 1L));
+    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "orc", Option.empty(), 1);
+    Assertions.assertTrue(result.isPresent());
+    Dataset<Row> ds = result.get();
+    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
+    Assertions.assertEquals(2, colNames.size(), "without mergeSchema, only one file's schema should be used");
+    Assertions.assertTrue(colNames.contains("id"));
+    Assertions.assertEquals(2, ds.count());
+  }
+
+  @Test
+  void orcSparkDatasourceOptionsMergeSchemaFalseDropsExtraColumns(@TempDir Path tempDir) {
+    String p1 = tempDir.resolve("part1").toString();
+    String p2 = tempDir.resolve("part2").toString();
+
+    StructType schema1 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("b", DataTypes.StringType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
+        .write().orc(p1);
+
+    StructType schema2 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(2, 99)), schema2)
+        .write().orc(p2);
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.SPARK_DATASOURCE_OPTIONS.key(), "{\"mergeSchema\":\"false\"}");
+    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
+    List<CloudObjectMetadata> input = Arrays.asList(
+        new CloudObjectMetadata(p1, 1L),
+        new CloudObjectMetadata(p2, 1L));
+    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "orc", Option.empty(), 1);
     Assertions.assertTrue(result.isPresent());
     Dataset<Row> ds = result.get();
     Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelectorCommon.java
@@ -23,23 +23,30 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
+import org.apache.hudi.utilities.config.CloudSourceConfig;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness {
 
@@ -198,6 +205,107 @@ public class TestCloudObjectsSelectorCommon extends HoodieSparkClientTestHarness
     StructType expectedSchema = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(schema);
     // assert final output schema matches with the source schema
     Assertions.assertEquals(expectedSchema, result.get().schema(), "output dataset schema should match source schema");
+  }
+
+  @Test
+  void parquetMixedSchemasMergedByDefault(@TempDir Path tempDir) {
+    String p1 = tempDir.resolve("part1").toString();
+    String p2 = tempDir.resolve("part2").toString();
+
+    StructType schema1 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("b", DataTypes.StringType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
+        .write().parquet(p1);
+
+    StructType schema2 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, 99)), schema2)
+        .write().parquet(p2);
+
+    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(new TypedProperties());
+    List<CloudObjectMetadata> input = Arrays.asList(
+        new CloudObjectMetadata(p1, 1L),
+        new CloudObjectMetadata(p2, 1L));
+    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "parquet", Option.empty(), 1);
+    Assertions.assertTrue(result.isPresent());
+    Assertions.assertEquals(2, result.get().count());
+    Set<String> colNames = Arrays.stream(result.get().schema().fields()).map(StructField::name).collect(Collectors.toSet());
+    Assertions.assertTrue(colNames.contains("b"));
+    Assertions.assertTrue(colNames.contains("c"));
+  }
+
+  /**
+   * With mergeSchema off, Spark does not union Parquet footers: it typically follows one file's schema
+   * (here {@code p1} is listed first). Columns only present in other files (e.g. {@code c} in {@code p2})
+   * are omitted from the scan—no exception, but data under those columns is dropped.
+   */
+  @Test
+  void parquetMixedSchemasDropExtraColumnsWhenMergeDisabled(@TempDir Path tempDir) {
+    String p1 = tempDir.resolve("part1").toString();
+    String p2 = tempDir.resolve("part2").toString();
+
+    StructType schema1 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("b", DataTypes.StringType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
+        .write().parquet(p1);
+
+    StructType schema2 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(2, 99)), schema2)
+        .write().parquet(p2);
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.CLOUD_INCREMENTAL_PARQUET_MERGE_SCHEMA.key(), "false");
+    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
+    List<CloudObjectMetadata> input = Arrays.asList(
+        new CloudObjectMetadata(p1, 1L),
+        new CloudObjectMetadata(p2, 1L));
+    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "parquet", Option.empty(), 1);
+    Assertions.assertTrue(result.isPresent());
+    Dataset<Row> ds = result.get();
+    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
+    Assertions.assertTrue(colNames.contains("id"));
+    Assertions.assertTrue(colNames.contains("b"));
+    Assertions.assertFalse(colNames.contains("c"), "column c from second file should be absent without mergeSchema");
+    Assertions.assertEquals(2, ds.count());
+    List<Row> rows = ds.collectAsList();
+    Row fromSecondFile = rows.stream().filter(r -> r.getInt(0) == 2).findFirst().orElseThrow();
+    Assertions.assertTrue(fromSecondFile.isNullAt(fromSecondFile.fieldIndex("b")));
+  }
+
+  @Test
+  void parquetSparkDatasourceOptionsMergeSchemaFalseDropsExtraColumns(@TempDir Path tempDir) {
+    String p1 = tempDir.resolve("part1").toString();
+    String p2 = tempDir.resolve("part2").toString();
+
+    StructType schema1 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("b", DataTypes.StringType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), schema1)
+        .write().parquet(p1);
+
+    StructType schema2 = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.IntegerType, true),
+        DataTypes.createStructField("c", DataTypes.IntegerType, true)));
+    sparkSession.createDataFrame(Collections.singletonList(RowFactory.create(2, 99)), schema2)
+        .write().parquet(p2);
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(CloudSourceConfig.SPARK_DATASOURCE_OPTIONS.key(), "{\"mergeSchema\":\"false\"}");
+    CloudObjectsSelectorCommon cloudObjectsSelectorCommon = new CloudObjectsSelectorCommon(props);
+    List<CloudObjectMetadata> input = Arrays.asList(
+        new CloudObjectMetadata(p1, 1L),
+        new CloudObjectMetadata(p2, 1L));
+    Option<Dataset<Row>> result = cloudObjectsSelectorCommon.loadAsDataset(sparkSession, input, "parquet", Option.empty(), 1);
+    Assertions.assertTrue(result.isPresent());
+    Dataset<Row> ds = result.get();
+    Set<String> colNames = Arrays.stream(ds.schema().fields()).map(StructField::name).collect(Collectors.toSet());
+    Assertions.assertFalse(colNames.contains("c"));
+    Assertions.assertEquals(2, ds.count());
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/18382 — source files with heterogeneous schemas in a single Hudi-Streamer batch can silently drop columns. This PR closes the FS-based-source side of that bug class. The MetadataBootstrap paths (`ParquetBootstrapMetadataHandler`, `OrcBootstrapMetadataHandler`) are deferred to a follow-up because they need partition-level schema discovery, which is architecturally bigger than the per-read knobs in this PR.

### Summary and Changelog

**Cloud incremental sources (S3/GCS):**
1. New `hoodie.streamer.source.cloud.data.merge.schema.enable` (since 1.2.0, advanced), default `true`. Covers both Parquet and ORC.
2. In `CloudObjectsSelectorCommon`, the format gate is widened to `parquet || orc` and Spark reader option `mergeSchema=true` is set before applying `SPARK_DATASOURCE_OPTIONS`, so users can still override per-format via JSON options (e.g. `{"mergeSchema":"false"}`).
3. `TestCloudObjectsSelectorCommon` covers Parquet end-to-end (merged-by-default) plus a predicate test for the format dispatch. End-to-end ORC isn't exercised in this module because `hudi-utilities` pulls in `orc-core-nohive` which conflicts with Spark 3.x's ORC writer; the predicate test pins the format dispatch and the e2e ORC behaviour matches Parquet via the shared helper.

**ParquetDFSSource:**
4. `ParquetDFSSourceConfig.PARQUET_DFS_MERGE_SCHEMA` default flipped from `false` to `true`. Heterogeneous-schema parquet files in a single Streamer batch now get a unioned schema instead of silently dropping columns. The new primary key is `hoodie.streamer.source.parquet.dfs.merge.schema.enable`; the previous underscore-style key (`...merge_schema.enable`, since 0.15.0) is preserved as a back-compat alternative.

> **⚠️ Release-notes call-out (broader scope than the issue title):** this default flip applies to **all `ParquetDFSSource` users**, not only S3/GCS incremental. Plain DFS Parquet ingest now incurs footer reads across all files in a batch and may resolve a different schema than before for tables with heterogeneous-schema source files. This is intentional — the silent-drop bug class is the same on both paths — but operators upgrading should know. Set the property to `false` to restore the previous reader behavior.

**ORCDFSSource:**
5. New `ORCDFSSourceConfig.ORC_DFS_MERGE_SCHEMA` (`hoodie.streamer.source.orc.dfs.merge.schema.enable`, since 1.2.0, advanced), default `true`. Mirrors the parquet config. Plumbed into `ORCDFSSource.fromFiles()` as `reader.option("mergeSchema", flag)`. Requires `spark.sql.orc.impl=native` (default since Spark 2.4); silently ignored under the Hive impl.

**AvroDFSSource regression test:**
6. `TestAvroDFSSource.testAdditiveSchemaEvolutionAcrossFiles` writes one narrow + one wider Avro file under a unique subdirectory, configures the source's reader schema to the wider one, and asserts records from the narrow file get the wider schema's default for the new field while records from the wider file preserve their value. Locks in Avro reader/writer schema-resolution behaviour end-to-end through `AvroDFSSource`.

### Impact

- Cloud incremental Parquet AND ORC ingestion (e.g. HoodieStreamer cloud sources, S3EventsHoodieIncrSource, GcsEventsHoodieIncrSource) gets a unified schema across files in each read by default.
- DFS Parquet ingestion gets a unified schema by default (was opt-in since 0.15.0). **Affects all `ParquetDFSSource` users, not just cloud incremental.**
- DFS ORC ingestion gets a unified schema by default (new in this PR).
- AvroDFSSource behaviour locked in by regression test.

**Compatibility:**
- Default is on for cloud-Parquet/ORC and DFS-Parquet/ORC.
- Set the new properties to `false` to restore the previous reader behavior.
- The previous underscore-style `parquet.dfs.merge_schema.enable` key continues to work via `withAlternatives` — explicit overrides preserved.
- Performance: `mergeSchema` can add work (footer/schema aggregation) versus a single-schema read; usually acceptable relative to correctness for heterogeneous batches.

### Risk Level

Medium. Touches default behaviour for three FS-based source paths; mitigations: each format has its own kill-switch config, and `SPARK_DATASOURCE_OPTIONS` continues to override per-read.

### Documentation Update

The new configs `hoodie.streamer.source.cloud.data.merge.schema.enable` and `hoodie.streamer.source.orc.dfs.merge.schema.enable` are documented in `CloudSourceConfig` and `ORCDFSSourceConfig` respectively. The flipped default is documented in `ParquetDFSSourceConfig`. **Release notes should highlight the `ParquetDFSSource` default flip explicitly**, since it changes behaviour for non-cloud DFS users.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable — `TestCloudObjectsSelectorCommon`, `TestParquetDFSSource`, `TestAvroDFSSource` all pass locally (14 tests, 0 failures, 0 errors).
