### PR TITLE
docs: Document muttley package as internal/optional for OSS users

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md
@@ -1,0 +1,19 @@
+# Internal Uber Components (Optional)
+
+This package contains integration with internal Uber services and is **optional** for Apache Hudi users.
+
+## Components
+
+- **AthenaIngestionGateway** - Integration with Uber's Athena Ingestion Gateway service
+- **FlinkHudiMuttleyClient** - RPC client using Uber's Muttley framework
+
+## Usage
+
+These components are used by `FlinkCheckpointClient` for Kafka offset checkpoint validation in Uber's infrastructure.
+
+**For open-source Apache Hudi users**: You can safely ignore this package. The checkpoint validation feature requires access to Uber's internal services and will not function outside of Uber's infrastructure.
+
+## Dependencies
+
+- Requires Uber's internal Muttley RPC framework
+- Requires access to Athena Ingestion Gateway service

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md
@@ -4,16 +4,22 @@ This package contains integration with internal Uber services and is **optional*
 
 ## Components
 
-- **AthenaIngestionGateway** - Integration with Uber's Athena Ingestion Gateway service
-- **FlinkHudiMuttleyClient** - RPC client using Uber's Muttley framework
+- **FlinkHudiMuttleyClient** - Abstract base class providing HTTP retry logic for Muttley RPC communication
+- **AthenaIngestionGateway** - Concrete Muttley RPC client for Uber's Athena Ingestion Gateway service (extends `FlinkHudiMuttleyClient`)
+- **FlinkHudiMuttleyException** - Base exception for Muttley errors
+- **FlinkHudiMuttleyClientException** - Exception for client-side Muttley errors
+- **FlinkHudiMuttleyServerException** - Exception for server-side Muttley errors
 
 ## Usage
 
-These components are used by `FlinkCheckpointClient` for Kafka offset checkpoint validation in Uber's infrastructure.
+These components are used by `FlinkCheckpointClient` to collect Kafka offset metadata and attach it to Hudi commits as part of Uber's Kafka offset tracking feature.
 
-**For open-source Apache Hudi users**: You can safely ignore this package. The checkpoint validation feature requires access to Uber's internal services and will not function outside of Uber's infrastructure.
+**Feature flag**: The feature is controlled by `write.extra.metadata.enabled` (default: `false`). It is disabled by default and has no effect in standard Apache Hudi deployments.
+
+**For open-source Apache Hudi users**: You can safely ignore this package. If `write.extra.metadata.enabled` is inadvertently set to `true` outside of Uber's infrastructure, Kafka offset collection will be silently skipped and Hudi commits will proceed normally (fail-open behavior).
 
 ## Dependencies
 
-- Requires Uber's internal Muttley RPC framework
-- Requires access to Athena Ingestion Gateway service
+- Runtime: Uber's internal Muttley RPC framework
+- Runtime: Access to Athena Ingestion Gateway service
+- Compile-time: Jackson (`jackson-databind`) for JSON serialization of RPC request/response payloads


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

PR #18127 introduced Kafka offset checkpoint tracking functionality that uses internal Uber services (Athena/Muttley). This created confusion about whether these components are required for Apache Hudi users. This PR adds documentation to clarify that the muttley package is optional.

### Summary and Changelog

Adds a README.md file to the `hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/` package that clearly documents:
- The package contains integration with internal Uber services (Athena Ingestion Gateway and Muttley RPC framework)
- These components are optional for Apache Hudi users
- The checkpoint validation feature requires Uber infrastructure

**Changes:**
- Added `hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md` (19 lines)

### Impact

Documentation only - no code changes, no API changes, no user-facing changes.

### Risk Level

none

### Documentation Update

This PR adds inline documentation in the form of a README file within the muttley package. No website or config documentation changes needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable