### PR TITLE
feat: Update CachedSchemaRegistryClient to have configs passed in constructor which can be used for gcp schema registry

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -67,8 +67,10 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -85,6 +87,8 @@ public class SchemaRegistryProvider extends SchemaProvider {
   private static final Logger LOG = LoggerFactory.getLogger(SchemaRegistryProvider.class);
   private static final Pattern URL_PATTERN = Pattern.compile("(.*/)subjects/(.*)/versions/(.*)");
   private static final String LATEST = "latest";
+  private static final Set<String> SCHEMA_REGISTRY_CONFIG_PREFIXES = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList("bearer.auth.", "basic.auth.", "schema.registry.")));
 
   /**
    * Configs supported.
@@ -123,8 +127,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
         schemaConverter, new Class<?>[] {TypedProperties.class}, config))
         : Option.empty();
     this.restServiceProvider = RestService::new;
-    Map<String, Object> schemaRegistryConfigs = new HashMap<>();
-    config.forEach((k, v) -> schemaRegistryConfigs.put(k.toString(), v));
+    Map<String, Object> schemaRegistryConfigs = extractSchemaRegistryConfigs(config);
     this.registryClientProvider = restService -> new CachedSchemaRegistryClient(restService, 100,
         Arrays.asList(new ProtobufSchemaProvider(), new JsonSchemaProvider(), new AvroSchemaProvider()), schemaRegistryConfigs, null);
   }
@@ -150,6 +153,17 @@ public class SchemaRegistryProvider extends SchemaProvider {
      * @return avro schema string
      */
     String convert(ParsedSchema schema) throws IOException;
+  }
+
+  private static Map<String, Object> extractSchemaRegistryConfigs(TypedProperties config) {
+    Map<String, Object> schemaRegistryConfigs = new HashMap<>();
+    config.forEach((k, v) -> {
+      String key = k.toString();
+      if (v != null && SCHEMA_REGISTRY_CONFIG_PREFIXES.stream().anyMatch(key::startsWith)) {
+        schemaRegistryConfigs.put(key, v);
+      }
+    });
+    return schemaRegistryConfigs;
   }
 
   public Schema parseSchemaFromRegistry(String registryUrl) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -66,7 +66,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -121,8 +123,10 @@ public class SchemaRegistryProvider extends SchemaProvider {
         schemaConverter, new Class<?>[] {TypedProperties.class}, config))
         : Option.empty();
     this.restServiceProvider = RestService::new;
+    Map<String, Object> schemaRegistryConfigs = new HashMap<>();
+    config.forEach((k, v) -> schemaRegistryConfigs.put(k.toString(), v));
     this.registryClientProvider = restService -> new CachedSchemaRegistryClient(restService, 100,
-        Arrays.asList(new ProtobufSchemaProvider(), new JsonSchemaProvider(), new AvroSchemaProvider()), null, null);
+        Arrays.asList(new ProtobufSchemaProvider(), new JsonSchemaProvider(), new AvroSchemaProvider()), schemaRegistryConfigs, null);
   }
 
   @VisibleForTesting

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -159,7 +159,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
     Map<String, Object> schemaRegistryConfigs = new HashMap<>();
     config.forEach((k, v) -> {
       String key = k.toString();
-      if (v != null && SCHEMA_REGISTRY_CONFIG_PREFIXES.stream().anyMatch(key::startsWith)) {
+      if (SCHEMA_REGISTRY_CONFIG_PREFIXES.stream().anyMatch(key::startsWith)) {
         schemaRegistryConfigs.put(key, v);
       }
     });

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -24,13 +24,19 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -148,6 +154,38 @@ class TestSchemaRegistryProvider {
     assertNotNull(actual);
     assertEquals(getExpectedSchema(), actual);
     verify(mockRestService, never()).setHttpHeaders(any());
+  }
+
+  @Test
+  public void testPublicConstructorForwardsConfigsToCachedSchemaRegistryClient() {
+    TypedProperties props = new TypedProperties();
+    props.put("hoodie.deltastreamer.schemaprovider.registry.url",
+        "http://localhost/subjects/test/versions/latest");
+    props.put("bearer.auth.credentials.source", "CUSTOM");
+    props.put("bearer.auth.custom.provider.class",
+        "com.example.GcpBearerAuthCredentialProvider");
+
+    List<Map<String, Object>> capturedConfigs = new ArrayList<>();
+    ParsedSchema mockParsedSchema = mock(ParsedSchema.class);
+    when(mockParsedSchema.canonicalString()).thenReturn(RAW_SCHEMA);
+
+    try (MockedConstruction<RestService> ignoredRest =
+             Mockito.mockConstruction(RestService.class);
+         MockedConstruction<CachedSchemaRegistryClient> ignored =
+             Mockito.mockConstruction(CachedSchemaRegistryClient.class, (mock, context) -> {
+               capturedConfigs.add((Map<String, Object>) context.arguments().get(3));
+               when(mock.getLatestSchemaMetadata(any())).thenReturn(new SchemaMetadata(1, 1, RAW_SCHEMA));
+               when(mock.parseSchema(any(), any(), any())).thenReturn(java.util.Optional.of(mockParsedSchema));
+             })) {
+
+      SchemaRegistryProvider provider = new SchemaRegistryProvider(props, null);
+      provider.fetchSchemaFromRegistry("http://localhost/subjects/test/versions/latest");
+
+      assertEquals(1, capturedConfigs.size());
+      assertEquals("CUSTOM", capturedConfigs.get(0).get("bearer.auth.credentials.source"));
+      assertEquals("com.example.GcpBearerAuthCredentialProvider",
+          capturedConfigs.get(0).get("bearer.auth.custom.provider.class"));
+    }
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSchemaRegistryProvider.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -157,7 +158,7 @@ class TestSchemaRegistryProvider {
   }
 
   @Test
-  public void testPublicConstructorForwardsConfigsToCachedSchemaRegistryClient() {
+  void testPublicConstructorForwardsConfigsToCachedSchemaRegistryClient() {
     TypedProperties props = new TypedProperties();
     props.put("hoodie.deltastreamer.schemaprovider.registry.url",
         "http://localhost/subjects/test/versions/latest");
@@ -185,6 +186,49 @@ class TestSchemaRegistryProvider {
       assertEquals("CUSTOM", capturedConfigs.get(0).get("bearer.auth.credentials.source"));
       assertEquals("com.example.GcpBearerAuthCredentialProvider",
           capturedConfigs.get(0).get("bearer.auth.custom.provider.class"));
+    }
+  }
+
+  @Test
+  void testPublicConstructorFiltersNonSchemaRegistryConfigsFromCachedSchemaRegistryClient() {
+    TypedProperties props = new TypedProperties();
+    props.put("hoodie.deltastreamer.schemaprovider.registry.url",
+        "http://localhost/subjects/test/versions/latest");
+    props.put("hoodie.datasource.write.recordkey.field", "id");
+    props.put("bearer.auth.credentials.source", "CUSTOM");
+    props.put("bearer.auth.custom.provider.class", "com.example.GcpBearerAuthCredentialProvider");
+    props.put("basic.auth.credentials.source", "USER_INFO");
+    props.put("basic.auth.user.info", "key:secret");
+    props.put("schema.registry.url", "http://localhost");
+
+    List<Map<String, Object>> capturedConfigs = new ArrayList<>();
+    ParsedSchema mockParsedSchema = mock(ParsedSchema.class);
+    when(mockParsedSchema.canonicalString()).thenReturn(RAW_SCHEMA);
+
+    try (MockedConstruction<RestService> ignoredRest =
+             Mockito.mockConstruction(RestService.class);
+         MockedConstruction<CachedSchemaRegistryClient> ignored =
+             Mockito.mockConstruction(CachedSchemaRegistryClient.class, (mock, context) -> {
+               capturedConfigs.add((Map<String, Object>) context.arguments().get(3));
+               when(mock.getLatestSchemaMetadata(any())).thenReturn(new SchemaMetadata(1, 1, RAW_SCHEMA));
+               when(mock.parseSchema(any(), any(), any())).thenReturn(java.util.Optional.of(mockParsedSchema));
+             })) {
+
+      SchemaRegistryProvider provider = new SchemaRegistryProvider(props, null);
+      provider.fetchSchemaFromRegistry("http://localhost/subjects/test/versions/latest");
+
+      assertEquals(1, capturedConfigs.size());
+      Map<String, Object> forwarded = capturedConfigs.get(0);
+      // Hudi-specific configs must not be forwarded to the Confluent client
+      assertFalse(forwarded.containsKey("hoodie.deltastreamer.schemaprovider.registry.url"));
+      assertFalse(forwarded.containsKey("hoodie.datasource.write.recordkey.field"));
+      // Only bearer.auth.*, basic.auth.*, schema.registry.* should be forwarded
+      assertEquals("CUSTOM", forwarded.get("bearer.auth.credentials.source"));
+      assertEquals("com.example.GcpBearerAuthCredentialProvider",
+          forwarded.get("bearer.auth.custom.provider.class"));
+      assertEquals("USER_INFO", forwarded.get("basic.auth.credentials.source"));
+      assertEquals("key:secret", forwarded.get("basic.auth.user.info"));
+      assertEquals("http://localhost", forwarded.get("schema.registry.url"));
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

#18435 

Gcp Schema registry is compatible with confluent but it requires additional config for auth. Existing SchemaRegistryProvider have CachedSchemaRegistryClient with null config in constructor, we have updated it to have configs passed as well.

### Summary and Changelog

Updated SchemaRegistryProvider to have configs passed with below prefixes to CachedSchemaRegistryClient:
`"bearer.auth.", "basic.auth.", "schema.registry."`


### Impact

Schema registry client configuration is now supported through TypedProperties, enabling bearer authentication and other settings to be configured.


### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
