### PR TITLE
[HUDI-18410] Optimize LSM timeline migration batch size and compaction during upgrade

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -249,6 +249,12 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     }
   }
 
+  // Use a large batch size for migration to minimize the number of parquet files created
+  // on remote storage. Each write() call involves multiple remote storage operations (exists check,
+  // parquet write, manifest update). Using the default archival batch size (10) with hundreds of
+  // actions creates excessive I/O that significantly increases the total migration time.
+  private static final int MIGRATION_BATCH_SIZE = 500;
+
   static void upgradeToLSMTimeline(HoodieTable table, HoodieEngineContext engineContext, HoodieWriteConfig config) {
     table.getMetaClient().getTableConfig().getTimelineLayoutVersion().ifPresent(
         timelineLayoutVersion -> ValidationUtils.checkState(TimelineLayoutVersion.LAYOUT_VERSION_1.equals(timelineLayoutVersion),
@@ -257,15 +263,12 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
       LegacyArchivedMetaEntryReader reader = new LegacyArchivedMetaEntryReader(table.getMetaClient());
       StoragePath archivePath = new StoragePath(table.getMetaClient().getMetaPath(), "timeline/history");
       LSMTimelineWriter lsmTimelineWriter = LSMTimelineWriter.getInstance(config, table, Option.of(archivePath));
-      int batchSize = config.getCommitArchivalBatchSize();
-      List<ActiveAction> activeActionsBatch = new ArrayList<>(batchSize);
+      List<ActiveAction> activeActionsBatch = new ArrayList<>(MIGRATION_BATCH_SIZE);
       try (ClosableIterator<ActiveAction> iterator = reader.getActiveActionsIterator()) {
         while (iterator.hasNext()) {
           activeActionsBatch.add(iterator.next());
-          // If the batch is full, write it to the LSM timeline
-          if (activeActionsBatch.size() == batchSize) {
+          if (activeActionsBatch.size() == MIGRATION_BATCH_SIZE) {
             lsmTimelineWriter.write(new ArrayList<>(activeActionsBatch), Option.empty(), Option.empty());
-            lsmTimelineWriter.compactAndClean(engineContext);
             activeActionsBatch.clear();
           }
         }
@@ -273,9 +276,11 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
         // Write any remaining actions in the final batch
         if (!activeActionsBatch.isEmpty()) {
           lsmTimelineWriter.write(new ArrayList<>(activeActionsBatch), Option.empty(), Option.empty());
-          lsmTimelineWriter.compactAndClean(engineContext);
         }
       }
+      // Run compaction and clean once at the end instead of after every batch.
+      // Compaction after every small batch causes excessive I/O during migration.
+      lsmTimelineWriter.compactAndClean(engineContext);
     } catch (Exception e) {
       if (config.isFailOnTimelineArchivingEnabled()) {
         throw new HoodieException("Failed to upgrade to LSM timeline", e);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -228,18 +228,14 @@ public class StreamWriteOperatorCoordinator
       this.metaClient = initTableIfNotExists(this.conf);
       // the write client must create after the table creation
       this.writeClient = FlinkWriteClients.createWriteClient(conf);
+      this.writeClient.tryUpgrade(instant, this.metaClient);
+      initMetadataTable(this.writeClient);
 
-      // Create executors BEFORE the upgrade so that the heavy initialization
-      // (upgrade, metadata table init, event restoration) can run on the executor
-      // thread instead of the Pekko dispatcher thread. Running the upgrade
-      // synchronously on the dispatcher thread blocks heartbeat responses and
-      // causes the ResourceManager to disconnect the JobManager when upgrades
-      // take longer than the heartbeat timeout (e.g., LSM timeline migration
-      // with hundreds of archived actions).
-      //
-      // Since the executor is single-threaded and FIFO, submitting the
-      // initialization as the first task guarantees it completes before any
-      // event handling tasks that arrive via handleEventFromOperator().
+      if (tableState.scheduleMdtCompaction) {
+        this.metadataWriteClient = StreamerUtil.createMetadataWriteClient(writeClient);
+      }
+
+      // start the executor
       this.executor = NonThrownExecutor.builder(log)
           .threadFactory(getThreadFactory("meta-event-handle"))
           .exceptionHook((errMsg, t) -> this.context.failJob(new HoodieException(errMsg, t)))
@@ -248,17 +244,6 @@ public class StreamWriteOperatorCoordinator
           .threadFactory(getThreadFactory("instant-request"))
           .exceptionHook((errMsg, t) -> this.context.failJob(new HoodieException(errMsg, t)))
           .build();
-
-      // Run upgrade and post-upgrade initialization on the executor thread.
-      this.executor.execute(() -> {
-        this.writeClient.tryUpgrade(instant, this.metaClient);
-        initMetadataTable(this.writeClient);
-        if (tableState.scheduleMdtCompaction) {
-          this.metadataWriteClient = StreamerUtil.createMetadataWriteClient(writeClient);
-        }
-        restoreEvents();
-      }, "table upgrade and initialization");
-
       // start the executor if required
       if (tableState.syncHive) {
         initHiveSync();
@@ -267,6 +252,7 @@ public class StreamWriteOperatorCoordinator
       if (OptionsResolver.isMultiWriter(conf)) {
         initClientIds(conf);
       }
+      restoreEvents();
     } catch (Throwable throwable) {
       log.error("Failed to start operator coordinator.", throwable);
       context.failJob(throwable);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -196,6 +196,13 @@ public class StreamWriteOperatorCoordinator
   private transient TableState tableState;
 
   /**
+   * Future that completes when async initialization (upgrade, metadata table
+   * init, event restoration) finishes on the executor thread. Coordination
+   * requests are gated on this to prevent races with initialization.
+   */
+  private final CompletableFuture<Void> initFuture = new CompletableFuture<>();
+
+  /**
    * The client id heartbeats.
    */
   private ClientIds clientIds;
@@ -228,14 +235,8 @@ public class StreamWriteOperatorCoordinator
       this.metaClient = initTableIfNotExists(this.conf);
       // the write client must create after the table creation
       this.writeClient = FlinkWriteClients.createWriteClient(conf);
-      this.writeClient.tryUpgrade(instant, this.metaClient);
-      initMetadataTable(this.writeClient);
 
-      if (tableState.scheduleMdtCompaction) {
-        this.metadataWriteClient = StreamerUtil.createMetadataWriteClient(writeClient);
-      }
-
-      // start the executor
+      // Create executors before submitting the heavy initialization task.
       this.executor = NonThrownExecutor.builder(log)
           .threadFactory(getThreadFactory("meta-event-handle"))
           .exceptionHook((errMsg, t) -> this.context.failJob(new HoodieException(errMsg, t)))
@@ -244,15 +245,36 @@ public class StreamWriteOperatorCoordinator
           .threadFactory(getThreadFactory("instant-request"))
           .exceptionHook((errMsg, t) -> this.context.failJob(new HoodieException(errMsg, t)))
           .build();
-      // start the executor if required
-      if (tableState.syncHive) {
-        initHiveSync();
-      }
-      // start client id heartbeats for optimistic concurrency control
-      if (OptionsResolver.isMultiWriter(conf)) {
-        initClientIds(conf);
-      }
-      restoreEvents();
+
+      // Run upgrade, metadata table init, and event restoration on the executor
+      // thread instead of the Pekko dispatcher thread. Running these synchronously
+      // on the dispatcher thread blocks heartbeat responses when the operations
+      // involve heavy I/O (e.g., LSM timeline migration with hundreds of archived
+      // actions), causing the ResourceManager to disconnect the JobManager.
+      //
+      // Safety guarantees:
+      // - Events via handleEventFromOperator() are submitted to the same
+      //   single-threaded executor, so FIFO ordering ensures initialization
+      //   completes before any event processing.
+      // - Coordination requests via handleCoordinationRequest() run on the
+      //   separate instantRequestExecutor and are gated on initFuture to
+      //   prevent startInstant() from racing ahead of the upgrade.
+      this.executor.execute(() -> {
+        this.writeClient.tryUpgrade(instant, this.metaClient);
+        initMetadataTable(this.writeClient);
+        if (tableState.scheduleMdtCompaction) {
+          this.metadataWriteClient = StreamerUtil.createMetadataWriteClient(writeClient);
+        }
+        if (tableState.syncHive) {
+          initHiveSync();
+        }
+        if (OptionsResolver.isMultiWriter(conf)) {
+          initClientIds(conf);
+        }
+        restoreEvents();
+        initFuture.complete(null);
+      }, "table upgrade and initialization");
+
     } catch (Throwable throwable) {
       log.error("Failed to start operator coordinator.", throwable);
       context.failJob(throwable);
@@ -385,16 +407,23 @@ public class StreamWriteOperatorCoordinator
 
   @Override
   public CompletableFuture<CoordinationResponse> handleCoordinationRequest(CoordinationRequest request) {
-    if (request instanceof Correspondent.InstantTimeRequest) {
-      return handleInstantRequest((Correspondent.InstantTimeRequest) request);
-    }
-    if (request instanceof Correspondent.InflightInstantsRequest) {
-      return handleInFlightInstantsRequest((Correspondent.InflightInstantsRequest) request);
-    }
-    if (request instanceof Correspondent.AwaitPendingInstantsRequest) {
-      return handleAwaitPendingInstantsRequest((Correspondent.AwaitPendingInstantsRequest) request);
-    }
-    throw new HoodieException("Unexpected coordination request type: " + request.getClass().getSimpleName());
+    // Gate coordination requests on initialization completion. The upgrade,
+    // metadata table init, and event restoration run asynchronously on the
+    // executor thread (see start()). Coordination requests like startInstant()
+    // run on a separate instantRequestExecutor and must not race ahead of
+    // initialization — e.g., RecordIndexPartitioner depends on MDT init.
+    return initFuture.thenCompose(ignored -> {
+      if (request instanceof Correspondent.InstantTimeRequest) {
+        return handleInstantRequest((Correspondent.InstantTimeRequest) request);
+      }
+      if (request instanceof Correspondent.InflightInstantsRequest) {
+        return handleInFlightInstantsRequest((Correspondent.InflightInstantsRequest) request);
+      }
+      if (request instanceof Correspondent.AwaitPendingInstantsRequest) {
+        return handleAwaitPendingInstantsRequest((Correspondent.AwaitPendingInstantsRequest) request);
+      }
+      throw new HoodieException("Unexpected coordination request type: " + request.getClass().getSimpleName());
+    });
   }
 
   private CompletableFuture<CoordinationResponse> handleInstantRequest(Correspondent.InstantTimeRequest request) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -260,23 +260,29 @@ public class StreamWriteOperatorCoordinator
       //   separate instantRequestExecutor and are gated on initFuture to
       //   prevent startInstant() from racing ahead of the upgrade.
       this.executor.execute(() -> {
-        this.writeClient.tryUpgrade(instant, this.metaClient);
-        initMetadataTable(this.writeClient);
-        if (tableState.scheduleMdtCompaction) {
-          this.metadataWriteClient = StreamerUtil.createMetadataWriteClient(writeClient);
+        try {
+          this.writeClient.tryUpgrade(instant, this.metaClient);
+          initMetadataTable(this.writeClient);
+          if (tableState.scheduleMdtCompaction) {
+            this.metadataWriteClient = StreamerUtil.createMetadataWriteClient(writeClient);
+          }
+          if (tableState.syncHive) {
+            initHiveSync();
+          }
+          if (OptionsResolver.isMultiWriter(conf)) {
+            initClientIds(conf);
+          }
+          restoreEvents();
+          initFuture.complete(null);
+        } catch (Throwable t) {
+          initFuture.completeExceptionally(t);
+          throw t;
         }
-        if (tableState.syncHive) {
-          initHiveSync();
-        }
-        if (OptionsResolver.isMultiWriter(conf)) {
-          initClientIds(conf);
-        }
-        restoreEvents();
-        initFuture.complete(null);
       }, "table upgrade and initialization");
 
     } catch (Throwable throwable) {
       log.error("Failed to start operator coordinator.", throwable);
+      initFuture.completeExceptionally(throwable);
       context.failJob(throwable);
     }
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -228,14 +228,18 @@ public class StreamWriteOperatorCoordinator
       this.metaClient = initTableIfNotExists(this.conf);
       // the write client must create after the table creation
       this.writeClient = FlinkWriteClients.createWriteClient(conf);
-      this.writeClient.tryUpgrade(instant, this.metaClient);
-      initMetadataTable(this.writeClient);
 
-      if (tableState.scheduleMdtCompaction) {
-        this.metadataWriteClient = StreamerUtil.createMetadataWriteClient(writeClient);
-      }
-
-      // start the executor
+      // Create executors BEFORE the upgrade so that the heavy initialization
+      // (upgrade, metadata table init, event restoration) can run on the executor
+      // thread instead of the Pekko dispatcher thread. Running the upgrade
+      // synchronously on the dispatcher thread blocks heartbeat responses and
+      // causes the ResourceManager to disconnect the JobManager when upgrades
+      // take longer than the heartbeat timeout (e.g., LSM timeline migration
+      // with hundreds of archived actions).
+      //
+      // Since the executor is single-threaded and FIFO, submitting the
+      // initialization as the first task guarantees it completes before any
+      // event handling tasks that arrive via handleEventFromOperator().
       this.executor = NonThrownExecutor.builder(log)
           .threadFactory(getThreadFactory("meta-event-handle"))
           .exceptionHook((errMsg, t) -> this.context.failJob(new HoodieException(errMsg, t)))
@@ -244,6 +248,17 @@ public class StreamWriteOperatorCoordinator
           .threadFactory(getThreadFactory("instant-request"))
           .exceptionHook((errMsg, t) -> this.context.failJob(new HoodieException(errMsg, t)))
           .build();
+
+      // Run upgrade and post-upgrade initialization on the executor thread.
+      this.executor.execute(() -> {
+        this.writeClient.tryUpgrade(instant, this.metaClient);
+        initMetadataTable(this.writeClient);
+        if (tableState.scheduleMdtCompaction) {
+          this.metadataWriteClient = StreamerUtil.createMetadataWriteClient(writeClient);
+        }
+        restoreEvents();
+      }, "table upgrade and initialization");
+
       // start the executor if required
       if (tableState.syncHive) {
         initHiveSync();
@@ -252,7 +267,6 @@ public class StreamWriteOperatorCoordinator
       if (OptionsResolver.isMultiWriter(conf)) {
         initClientIds(conf);
       }
-      restoreEvents();
     } catch (Throwable throwable) {
       log.error("Failed to start operator coordinator.", throwable);
       context.failJob(throwable);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When upgrading a Hudi table with many archived timeline actions (e.g., v7→v8 LSM timeline migration), the heavy I/O in `StreamWriteOperatorCoordinator.start()` blocks the Flink Pekko dispatcher thread for extended periods, preventing heartbeat responses and causing the ResourceManager to disconnect the JobManager.

Fixes https://github.com/apache/hudi/issues/18410

### Summary and Changelog

1. **Async initialization with CompletableFuture gating**: Move `tryUpgrade()`, `initMetadataTable()`, Hive sync init, multi-writer init, and `restoreEvents()` to the executor thread. Events via `handleEventFromOperator()` are safe due to FIFO ordering on the same executor. Coordination requests via `handleCoordinationRequest()` are gated on `initFuture.thenCompose()` to prevent `startInstant()` from racing ahead of initialization (addresses `RecordIndexPartitioner` MDT dependency).

2. **LSM timeline migration I/O optimization**: Use `MIGRATION_BATCH_SIZE = 500` instead of `config.getCommitArchivalBatchSize()` (default 10) for the one-time migration, and call `compactAndClean()` once at the end instead of after every batch. For 500 actions: ~250 remote ops → ~6 ops (~97% reduction).

### Impact

No public API changes. Performance improvement for Flink pipelines upgrading from Hudi table version 7 to 8 with large archived timelines. The async initialization prevents heartbeat timeouts during upgrade.

### Risk Level

low — The async initialization preserves the same ordering guarantees via FIFO executor and CompletableFuture gating. All 36 existing `TestStreamWriteOperatorCoordinator` tests pass.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable