### PR TITLE
chore: include table name in recursive listing Spark job descriptions

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -156,12 +156,16 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
       needPushDownExpressions = false;
     }
 
+    int recursiveListingStep = 0;
     while (!pathsToList.isEmpty()) {
+      recursiveListingStep++;
       // TODO: Get the parallelism from HoodieWriteConfig
       int listingParallelism = Math.min(DEFAULT_LISTING_PARALLELISM, pathsToList.size());
+      String recursiveListingJobName =
+          String.format("%s recursive listing step %d", this.getClass().getSimpleName(), recursiveListingStep);
 
       // List all directories in parallel
-      engineContext.setJobStatus(this.getClass().getSimpleName(),
+      engineContext.setJobStatus(recursiveListingJobName,
           "Listing all partitions on " + this.tableName
               + " with prefix " + relativePathPrefix);
       // Need to use serializable file status here, see HUDI-5936
@@ -183,7 +187,8 @@ public class FileSystemBackedTableMetadata extends AbstractHoodieTableMetadata {
       if (!dirToFileListingPairs.isEmpty()) {
         // result below holds a list of pair. first entry in the pair optionally holds the deduced list of partitions.
         // and second entry holds optionally a directory path to be processed further.
-        engineContext.setJobStatus(this.getClass().getSimpleName(), "Processing listed partitions");
+        engineContext.setJobStatus(recursiveListingJobName,
+            "Processing recursively listed partitions on " + this.tableName);
         List<Pair<Option<String>, Option<StoragePath>>> result =
             engineContext.map(dirToFileListingPairs,
                 fileInfoPair -> {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Spark job descriptions for recursive partition listing were not clear enough in the Spark UI. When there are join queries multiple table's recursive calls are getting overlapped. Since, table names are not included in the job description and it was hard to tell which recursive listing pass was running longer.

### Summary and Changelog

Updated recursive partition listing job descriptions in `FileSystemBackedTableMetadata` to include the table name. Also, added a recursive listing step counter and appended it to the job name.

### Impact

Improves Spark UI observability during recursive partition listing. No user-facing behavior
or API changes.

### Risk Level

low

String-only change to Spark job descriptions.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
