### PR TITLE
perf: Improve Serialization Performance of BufferedRecord

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieCommonKryoRegistrar.java
@@ -44,6 +44,7 @@ import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
@@ -114,7 +115,8 @@ public class HoodieCommonKryoRegistrar {
         HoodieTableMetaClient.class,
         HoodieFileGroupId.class,
         ArrayList.class,
-        SerializableIndexedRecord.class
+        SerializableIndexedRecord.class,
+        BufferedRecord.class
     })
         .forEachOrdered(kryo::register);
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This pull request updates the shared Hudi Kryo registrar to include `BufferedRecord`, registering the type explicitly allows Kryo to use a compact class ID instead of repeatedly encoding the full class name during serialization.

### Summary and Changelog
- Add `org.apache.hudi.common.table.read.BufferedRecord` to `HoodieCommonKryoRegistrar`.

### Impact

- No intended behavior change; this is a serialization performance optimization for `BufferedRecord`.

### Risk Level

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
