### PR TITLE
refactor: remove HoodieWriteConfig.getOrcCompressionCodec() function

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -94,7 +94,6 @@ import org.apache.hudi.table.storage.HoodieStorageLayout;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.orc.CompressionKind;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -2443,10 +2442,6 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public int getOrcBlockSize() {
     return getInt(HoodieStorageConfig.ORC_BLOCK_SIZE);
-  }
-
-  public CompressionKind getOrcCompressionCodec() {
-    return CompressionKind.valueOf(getString(HoodieStorageConfig.ORC_COMPRESSION_CODEC_NAME));
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Current hudi 1.2 streaming source has a hard dependency on orc due to function HoodieWriteConfig.getOrcCompressionCodec() returns an ORC class. As this function is not used, we can safely remove it so that the hudi 1.2 won't have a hard dependency on orc.

Fixes #18397

### Summary and Changelog

Remove HoodieWriteConfig.getOrcCompressionCodec() function

### Impact

None

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
