### PR TITLE
fix: Remove spaces around partition columns

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -727,6 +727,7 @@ public class HoodieTableConfig extends HoodieConfig {
   public static Option<String[]> getPartitionFields(HoodieConfig config) {
     if (contains(PARTITION_FIELDS, config)) {
       return Option.of(Arrays.stream(config.getString(PARTITION_FIELDS).split(BaseKeyGenerator.FIELD_SEPARATOR))
+          .map(String::trim)
           .filter(p -> !p.isEmpty())
           .map(p -> getPartitionFieldWithoutKeyGenPartitionType(p, config))
           .collect(Collectors.toList()).toArray(new String[] {}));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

 Partition columns can be around by spaces during configuration, like `\sC1`, `C1\s`, or `C1,\sC2`. In those cases, NPE could be thrown since we cannot find any partition columns when spaces. 

### Summary and Changelog

Remove spaces around partition columns during parsing.

### Impact

Avoid NPE.

### Risk Level

None.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
