### PR TITLE
feat(vector): Support complex types with VECTORS

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -64,9 +64,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 import scala.Option$;
 
@@ -145,14 +143,14 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
     HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
     StructType structSchema = HoodieInternalRowUtils.getCachedSchema(nonNullSchema);
 
-    // Detect vector columns: ordinal → Vector schema
-    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = VectorConversionUtils.detectVectorColumns(nonNullSchema);
+    // Detect if any vector columns exist (at any nesting depth)
+    boolean hasVectors = VectorConversionUtils.hasVectorColumns(nonNullSchema);
 
     // For vector columns, replace ArrayType(FloatType) with BinaryType in the read schema
     // so SparkBasicSchemaEvolution sees matching types (file has FIXED_LEN_BYTE_ARRAY → BinaryType)
-    StructType readStructSchema = vectorColumnInfo.isEmpty()
-        ? structSchema
-        : VectorConversionUtils.replaceVectorColumnsWithBinary(structSchema, vectorColumnInfo);
+    StructType readStructSchema = hasVectors
+        ? VectorConversionUtils.replaceVectorColumnsWithBinary(structSchema)
+        : structSchema;
 
     Option<MessageType> messageSchema = Option.of(getAvroSchemaConverter(storage.getConf().unwrapAs(Configuration.class)).convert(nonNullSchema));
     boolean enableTimestampFieldRepair = storage.getConf().getBoolean(ENABLE_LOGICAL_TIMESTAMP_REPAIR, true);
@@ -197,11 +195,11 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
     ParquetReaderIterator<InternalRow> parquetReaderIterator = new ParquetReaderIterator<>(reader);
     CloseableMappingIterator<InternalRow, UnsafeRow> projectedIterator = new CloseableMappingIterator<>(parquetReaderIterator, projection::apply);
 
-    if (!vectorColumnInfo.isEmpty()) {
+    if (hasVectors) {
       // Post-process: convert binary VECTOR columns back to typed arrays
       UnsafeProjection vectorProjection = UnsafeProjection.create(structSchema);
-      Function<InternalRow, InternalRow> mapper =
-          VectorConversionUtils.buildRowMapper(readStructSchema, vectorColumnInfo, vectorProjection::apply);
+      java.util.function.Function<InternalRow, InternalRow> mapper =
+          VectorConversionUtils.buildRowMapper(readStructSchema, structSchema, vectorProjection::apply);
       CloseableMappingIterator<UnsafeRow, UnsafeRow> vectorIterator =
           new CloseableMappingIterator<>(projectedIterator, row -> (UnsafeRow) mapper.apply(row));
       readerIterators.add(vectorIterator);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
@@ -23,9 +23,14 @@ import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.BinaryType$;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
@@ -33,9 +38,6 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 
 import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 
 import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
@@ -54,77 +56,213 @@ public final class VectorConversionUtils {
   }
 
   /**
-   * Detects VECTOR columns in a HoodieSchema record and returns a map of field ordinal
-   * to the corresponding {@link HoodieSchema.Vector} schema.
+   * Checks whether a HoodieSchema record contains any VECTOR columns, including
+   * vectors nested inside RECORD (struct), ARRAY, or MAP fields at any depth.
+   *
+   * <p><b>Invariant:</b> This method and {@link #hasVectorColumnsFromMetadata(StructType)} must
+   * return the same result for equivalent schemas. They use different sources of truth
+   * (HoodieSchema type tree vs Spark StructField metadata) but must agree. The metadata
+   * propagation in {@code HoodieSparkSchemaConverters.toSqlTypeHelper} (ARRAY/MAP cases)
+   * ensures this for all supported nesting patterns.
    *
    * @param schema a HoodieSchema of type RECORD (or null)
-   * @return map from field index to Vector schema; empty map if schema is null or has no vectors
+   * @return true if any VECTOR columns exist at any nesting level
    */
-  public static Map<Integer, HoodieSchema.Vector> detectVectorColumns(HoodieSchema schema) {
-    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = new HashMap<>();
+  public static boolean hasVectorColumns(HoodieSchema schema) {
     if (schema == null) {
-      return vectorColumnInfo;
+      return false;
     }
-    List<HoodieSchemaField> fields = schema.getFields();
-    for (int i = 0; i < fields.size(); i++) {
-      HoodieSchema fieldSchema = fields.get(i).schema().getNonNullType();
-      if (fieldSchema.getType() == HoodieSchemaType.VECTOR) {
-        vectorColumnInfo.put(i, (HoodieSchema.Vector) fieldSchema);
+    for (HoodieSchemaField field : schema.getFields()) {
+      if (hasVectorType(field.schema().getNonNullType())) {
+        return true;
       }
     }
-    return vectorColumnInfo;
+    return false;
   }
 
   /**
-   * Detects VECTOR columns from Spark StructType metadata annotations.
-   * Fields with metadata key {@link HoodieSchema#TYPE_METADATA_FIELD} starting with "VECTOR"
-   * are parsed and included.
-   *
-   * @param schema Spark StructType
-   * @return map from field index to Vector schema; empty map if no vectors found
+   * Recursively checks if a HoodieSchema type contains VECTOR at any depth
+   * (through RECORD, ARRAY, or MAP nesting).
    */
-  public static Map<Integer, HoodieSchema.Vector> detectVectorColumnsFromMetadata(StructType schema) {
-    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = new HashMap<>();
-    if (schema == null) {
-      return vectorColumnInfo;
+  private static boolean hasVectorType(HoodieSchema schema) {
+    switch (schema.getType()) {
+      case VECTOR:
+        return true;
+      case RECORD:
+        return hasVectorColumns(schema);
+      case ARRAY:
+        return hasVectorType(schema.getElementType().getNonNullType());
+      case MAP:
+        return hasVectorType(schema.getValueType().getNonNullType());
+      default:
+        return false;
     }
-    StructField[] fields = schema.fields();
+  }
+
+  /**
+   * Checks whether a Spark StructType contains any VECTOR columns (via metadata),
+   * including vectors nested inside StructType fields at any depth.
+   */
+  public static boolean hasVectorColumnsFromMetadata(StructType schema) {
+    if (schema == null) {
+      return false;
+    }
+    for (StructField field : schema.fields()) {
+      if (isVectorField(field)) {
+        return true;
+      }
+      if (hasVectorColumnsInDataType(field.dataType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Recursively checks if a DataType contains any VECTOR columns via metadata.
+   * Recurses into StructType, ArrayType element, and MapType value.
+   */
+  private static boolean hasVectorColumnsInDataType(DataType dataType) {
+    if (dataType instanceof StructType) {
+      return hasVectorColumnsFromMetadata((StructType) dataType);
+    } else if (dataType instanceof ArrayType) {
+      return hasVectorColumnsInDataType(((ArrayType) dataType).elementType());
+    } else if (dataType instanceof MapType) {
+      return hasVectorColumnsInDataType(((MapType) dataType).valueType());
+    }
+    return false;
+  }
+
+  /**
+   * Checks if a StructField has VECTOR metadata.
+   */
+  private static boolean isVectorField(StructField field) {
+    if (field.metadata().contains(HoodieSchema.TYPE_METADATA_FIELD)) {
+      String typeStr = field.metadata().getString(HoodieSchema.TYPE_METADATA_FIELD);
+      // Match "VECTOR" or "VECTOR(" — the type descriptor is always "VECTOR(dim[,elemType[,backing]])"
+      return typeStr.equals("VECTOR") || typeStr.startsWith("VECTOR(");
+    }
+    return false;
+  }
+
+  /**
+   * Parses and returns the VECTOR metadata from a StructField, throwing if not found or unparseable.
+   */
+  private static HoodieSchema.Vector requireVectorMetadata(StructField field) {
+    checkArgument(isVectorField(field),
+        "Field '" + field.name() + "' does not have VECTOR metadata");
+    String typeStr = field.metadata().getString(HoodieSchema.TYPE_METADATA_FIELD);
+    HoodieSchema parsed = HoodieSchema.parseTypeDescriptor(typeStr);
+    checkArgument(parsed.getType() == HoodieSchemaType.VECTOR,
+        "Field '" + field.name() + "' has hudi_type '" + typeStr + "' but parsed to " + parsed.getType());
+    return (HoodieSchema.Vector) parsed;
+  }
+
+  /**
+   * Recursively replaces VECTOR columns (identified by {@code hudi_type} metadata) with
+   * BinaryType so the Parquet reader can read FIXED_LEN_BYTE_ARRAY data without type mismatch.
+   * Recurses into nested StructType fields to handle vectors at any nesting depth.
+   *
+   * @param structType the original Spark schema (may contain nested structs with vectors)
+   * @return a new StructType with vector columns replaced by BinaryType at all levels
+   */
+  public static StructType replaceVectorColumnsWithBinary(StructType structType) {
+    StructField[] fields = structType.fields();
+    StructField[] newFields = new StructField[fields.length];
+    boolean changed = false;
     for (int i = 0; i < fields.length; i++) {
       StructField field = fields[i];
-      if (field.metadata().contains(HoodieSchema.TYPE_METADATA_FIELD)) {
-        String typeStr = field.metadata().getString(HoodieSchema.TYPE_METADATA_FIELD);
-        if (typeStr.startsWith("VECTOR")) {
-          HoodieSchema parsed = HoodieSchema.parseTypeDescriptor(typeStr);
-          if (parsed.getType() == HoodieSchemaType.VECTOR) {
-            vectorColumnInfo.put(i, (HoodieSchema.Vector) parsed);
-          }
+      if (isVectorField(field)) {
+        DataType dataType = field.dataType();
+        DataType replaced = replaceDirectVectorType(field.name(), dataType);
+        if (replaced != dataType) {
+          newFields[i] = new StructField(field.name(), replaced, field.nullable(), field.metadata());
+          changed = true;
+        } else {
+          newFields[i] = field;
+        }
+      } else {
+        // Recurse into StructType, ArrayType element, MapType value to find nested vectors
+        DataType replaced = replaceNestedVectorColumns(field.dataType());
+        if (replaced != field.dataType()) {
+          newFields[i] = new StructField(field.name(), replaced, field.nullable(), field.metadata());
+          changed = true;
+        } else {
+          newFields[i] = field;
         }
       }
     }
-    return vectorColumnInfo;
+    return changed ? new StructType(newFields) : structType;
   }
 
   /**
-   * Replaces ArrayType with BinaryType for VECTOR columns so the Parquet reader
-   * can read FIXED_LEN_BYTE_ARRAY data without type mismatch.
+   * Replaces the vector portion of a DataType with BinaryType. Supported patterns:
+   * - ArrayType(primitiveType) → BinaryType (direct vector)
+   * - ArrayType(ArrayType(primitiveType)) → ArrayType(BinaryType) (array of vectors)
+   * - MapType(K, ArrayType(primitiveType)) → MapType(K, BinaryType) (map of vectors)
    *
-   * @param structType     the original Spark schema
-   * @param vectorColumns  map of ordinal to vector info (only the key set is used)
-   * @return a new StructType with vector columns replaced by BinaryType
+   * @throws UnsupportedOperationException if the field uses an unsupported nesting pattern
    */
-  public static StructType replaceVectorColumnsWithBinary(StructType structType, Map<Integer, ?> vectorColumns) {
-    StructField[] fields = structType.fields();
-    StructField[] newFields = new StructField[fields.length];
-    for (int i = 0; i < fields.length; i++) {
-      if (vectorColumns.containsKey(i)) {
-        // Preserve the original field metadata (including hudi_type) so that downstream code
-        // calling detectVectorColumnsFromMetadata on the modified schema still finds vectors.
-        newFields[i] = new StructField(fields[i].name(), BinaryType$.MODULE$, fields[i].nullable(), fields[i].metadata());
+  private static DataType replaceDirectVectorType(String fieldName, DataType dataType) {
+    if (dataType instanceof ArrayType) {
+      ArrayType arrayType = (ArrayType) dataType;
+      DataType elementType = arrayType.elementType();
+      if (elementType instanceof ArrayType) {
+        // array<array<float>> → array<binary> (array of vectors)
+        DataType innerElem = ((ArrayType) elementType).elementType();
+        if (innerElem instanceof ArrayType || innerElem instanceof MapType) {
+          throw new UnsupportedOperationException(
+              "VECTOR field '" + fieldName + "' uses unsupported nesting: " + dataType
+                  + ". Supported patterns: direct VECTOR, array<VECTOR>, map<K, VECTOR>.");
+        }
+        return new ArrayType(BinaryType$.MODULE$, arrayType.containsNull());
+      } else if (elementType instanceof MapType || elementType instanceof StructType) {
+        throw new UnsupportedOperationException(
+            "VECTOR field '" + fieldName + "' uses unsupported nesting: " + dataType
+                + ". Supported patterns: direct VECTOR, array<VECTOR>, map<K, VECTOR>.");
       } else {
-        newFields[i] = fields[i];
+        // array<float> → binary (direct vector)
+        return BinaryType$.MODULE$;
       }
+    } else if (dataType instanceof MapType) {
+      MapType mapType = (MapType) dataType;
+      DataType valueType = mapType.valueType();
+      if (!(valueType instanceof ArrayType) || ((ArrayType) valueType).elementType() instanceof ArrayType) {
+        throw new UnsupportedOperationException(
+            "VECTOR field '" + fieldName + "' uses unsupported nesting: " + dataType
+                + ". Supported patterns: direct VECTOR, array<VECTOR>, map<K, VECTOR>.");
+      }
+      // map<K, array<float>> → map<K, binary>
+      return new MapType(mapType.keyType(), BinaryType$.MODULE$, mapType.valueContainsNull());
     }
-    return new StructType(newFields);
+    throw new UnsupportedOperationException(
+        "VECTOR field '" + fieldName + "' uses unsupported DataType: " + dataType
+            + ". Supported patterns: direct VECTOR, array<VECTOR>, map<K, VECTOR>.");
+  }
+
+  /**
+   * Recursively replaces vector columns inside a DataType. Handles:
+   * - StructType: recurses via replaceVectorColumnsWithBinary
+   * - ArrayType(StructType): recurses into the element struct
+   * - MapType(K, StructType): recurses into the value struct
+   */
+  private static DataType replaceNestedVectorColumns(DataType dataType) {
+    if (dataType instanceof StructType) {
+      StructType inner = (StructType) dataType;
+      StructType replaced = replaceVectorColumnsWithBinary(inner);
+      return replaced != inner ? replaced : dataType;
+    } else if (dataType instanceof ArrayType) {
+      ArrayType arrayType = (ArrayType) dataType;
+      DataType replaced = replaceNestedVectorColumns(arrayType.elementType());
+      return replaced != arrayType.elementType()
+          ? new ArrayType(replaced, arrayType.containsNull()) : dataType;
+    } else if (dataType instanceof MapType) {
+      MapType mapType = (MapType) dataType;
+      DataType replaced = replaceNestedVectorColumns(mapType.valueType());
+      return replaced != mapType.valueType()
+          ? new MapType(mapType.keyType(), replaced, mapType.valueContainsNull()) : dataType;
+    }
+    return dataType;
   }
 
   /**
@@ -183,56 +321,157 @@ public final class VectorConversionUtils {
   /**
    * Returns a {@link Function} that converts a single {@link InternalRow} by converting binary
    * vector columns back to typed arrays and then applying the given projection callback.
+   * Handles vectors at any nesting depth by comparing the read schema (BinaryType for vectors)
+   * against the output schema (ArrayType for vectors).
    *
-   * <p>Ordinals in {@code vectorColumns} must be relative to {@code readSchema} — the schema
-   * that has {@code BinaryType} for vector columns (as produced by
-   * {@link #replaceVectorColumnsWithBinary}).
-   *
-   * <p><b>Thread safety:</b> The returned function is NOT thread-safe; it reuses a single
-   * {@link GenericInternalRow} buffer across calls. Each call to this factory creates its own
-   * buffer, so separate functions returned by separate calls are independent.
+   * <p><b>Thread safety:</b> The returned function is NOT thread-safe; it reuses
+   * {@link GenericInternalRow} buffers across calls. Each call to this factory creates its own
+   * buffers, so separate functions returned by separate calls are independent.
    *
    * @param readSchema         the Spark schema of incoming rows (BinaryType for vector columns)
-   * @param vectorColumns      map of ordinal → Vector schema for vector columns, keyed by
-   *                           ordinals relative to {@code readSchema}
-   * @param projectionCallback called with the converted {@link GenericInternalRow}; must copy
-   *                           any data it needs to retain (e.g. {@code UnsafeProjection::apply})
+   * @param outputSchema       the Spark schema of output rows (ArrayType for vector columns)
+   * @param projectionCallback called with the converted row; must copy any data it needs
+   *                           to retain (e.g. {@code UnsafeProjection::apply})
    * @return a function that converts one row and returns the projected result
    */
   public static Function<InternalRow, InternalRow> buildRowMapper(
       StructType readSchema,
-      Map<Integer, HoodieSchema.Vector> vectorColumns,
+      StructType outputSchema,
       Function<InternalRow, InternalRow> projectionCallback) {
     GenericInternalRow converted = new GenericInternalRow(readSchema.fields().length);
     return row -> {
-      convertRowVectorColumns(row, converted, readSchema, vectorColumns);
+      convertRowVectorColumns(row, converted, readSchema, outputSchema);
       return projectionCallback.apply(converted);
     };
   }
 
   /**
-   * Converts vector columns in a row from binary (BinaryType) back to typed arrays,
-   * copying non-vector columns as-is. The caller must supply a pre-allocated
-   * {@link GenericInternalRow} for reuse across iterations to reduce GC pressure.
+   * Recursively converts vector columns in a row from binary (BinaryType) back to typed arrays.
+   * Detects vectors by comparing read schema (BinaryType) vs output schema (ArrayType) at each
+   * field. Recurses into nested StructType fields to handle vectors at any depth.
    *
-   * @param row           the source row (with BinaryType for vector columns)
-   * @param result        a pre-allocated GenericInternalRow to write into (reused across calls)
-   * @param readSchema    the Spark schema of the source row (BinaryType for vector columns)
-   * @param vectorColumns map of ordinal to Vector schema for vector columns
+   * @param row          the source row (with BinaryType for vector columns)
+   * @param result       a pre-allocated GenericInternalRow to write into (reused across calls)
+   * @param readSchema   the Spark schema of the source row (BinaryType for vector columns)
+   * @param outputSchema the Spark schema of the output row (ArrayType for vector columns)
    */
   public static void convertRowVectorColumns(InternalRow row, GenericInternalRow result,
-                                             StructType readSchema,
-                                             Map<Integer, HoodieSchema.Vector> vectorColumns) {
-    int numFields = readSchema.fields().length;
-    for (int i = 0; i < numFields; i++) {
+                                             StructType readSchema, StructType outputSchema) {
+    StructField[] readFields = readSchema.fields();
+    StructField[] outputFields = outputSchema.fields();
+    for (int i = 0; i < readFields.length; i++) {
       if (row.isNullAt(i)) {
         result.setNullAt(i);
-      } else if (vectorColumns.containsKey(i)) {
-        result.update(i, convertBinaryToVectorArray(row.getBinary(i), vectorColumns.get(i)));
+      } else if (i >= outputFields.length) {
+        // Extra field in readSchema (e.g., row-index appended by Spark) — copy as-is
+        result.update(i, row.get(i, readFields[i].dataType()));
+      } else if (isVectorField(outputFields[i])) {
+        // --- Group 1: field has VECTOR metadata (direct vector, array<VECTOR>, map<K, VECTOR>) ---
+        convertVectorField(row, result, i, readFields[i].dataType(), outputFields[i]);
       } else {
-        // Non-vector column: copy value as-is using the read schema's data type
-        result.update(i, row.get(i, readSchema.apply(i).dataType()));
+        // --- Group 2: field may CONTAIN vectors deeper (struct, array<struct>, map<K, struct>) ---
+        convertContainerField(row, result, i, readFields[i].dataType(), outputFields[i].dataType());
       }
     }
+  }
+
+  /**
+   * Converts a field that has VECTOR metadata. Dispatches based on the DataType to handle
+   * direct vectors, array-of-vectors, and map-of-vectors.
+   */
+  private static void convertVectorField(InternalRow row, GenericInternalRow result,
+                                          int ordinal, DataType readType, StructField outputField) {
+    HoodieSchema.Vector vec = requireVectorMetadata(outputField);
+    if (readType == BinaryType$.MODULE$) {
+      // Direct vector: binary → typed array
+      result.update(ordinal, convertBinaryToVectorArray(row.getBinary(ordinal), vec));
+    } else if (readType instanceof ArrayType) {
+      // Array of vectors: iterate elements, convert each binary → typed array
+      ArrayData arrayData = row.getArray(ordinal);
+      Object[] converted = new Object[arrayData.numElements()];
+      for (int j = 0; j < arrayData.numElements(); j++) {
+        converted[j] = arrayData.isNullAt(j) ? null
+            : convertBinaryToVectorArray(arrayData.getBinary(j), vec);
+      }
+      result.update(ordinal, new GenericArrayData(converted));
+    } else if (readType instanceof MapType) {
+      // Map of vectors: convert each value from binary → typed array
+      MapData mapData = row.getMap(ordinal);
+      ArrayData keys = mapData.keyArray();
+      ArrayData values = mapData.valueArray();
+      Object[] convertedValues = new Object[values.numElements()];
+      for (int j = 0; j < values.numElements(); j++) {
+        convertedValues[j] = values.isNullAt(j) ? null
+            : convertBinaryToVectorArray(values.getBinary(j), vec);
+      }
+      result.update(ordinal, new ArrayBasedMapData(
+          keys, new GenericArrayData(convertedValues)));
+    } else {
+      throw new IllegalStateException(
+          "Field '" + outputField.name() + "' has VECTOR metadata but unsupported DataType: " + readType);
+    }
+  }
+
+  /**
+   * Converts a field that may contain vectors nested inside structs, arrays-of-structs,
+   * or maps-of-structs. If the field doesn't contain nested vectors, copies it as-is.
+   */
+  private static void convertContainerField(InternalRow row, GenericInternalRow result,
+                                             int ordinal, DataType readType, DataType outputType) {
+    StructType innerRead = innerStructType(readType);
+    StructType innerOutput = innerStructType(outputType);
+    if (innerRead == null || innerOutput == null) {
+      // No nested struct — no vectors to convert, copy as-is
+      result.update(ordinal, row.get(ordinal, readType));
+    } else if (readType instanceof StructType) {
+      InternalRow innerRow = row.getStruct(ordinal, innerRead.fields().length);
+      GenericInternalRow innerResult = new GenericInternalRow(innerRead.fields().length);
+      convertRowVectorColumns(innerRow, innerResult, innerRead, innerOutput);
+      result.update(ordinal, innerResult);
+    } else if (readType instanceof ArrayType) {
+      result.update(ordinal, new GenericArrayData(
+          convertStructElements(row.getArray(ordinal), innerRead, innerOutput)));
+    } else { // MapType
+      MapData mapData = row.getMap(ordinal);
+      result.update(ordinal, new ArrayBasedMapData(
+          mapData.keyArray(), new GenericArrayData(
+              convertStructElements(mapData.valueArray(), innerRead, innerOutput))));
+    }
+  }
+
+  /**
+   * Returns the StructType nested inside a DataType, or null if the type does not
+   * contain a struct. Handles: StructType directly, ArrayType(StructType),
+   * MapType(K, StructType).
+   */
+  private static StructType innerStructType(DataType type) {
+    if (type instanceof StructType) {
+      return (StructType) type;
+    } else if (type instanceof ArrayType && ((ArrayType) type).elementType() instanceof StructType) {
+      return (StructType) ((ArrayType) type).elementType();
+    } else if (type instanceof MapType && ((MapType) type).valueType() instanceof StructType) {
+      return (StructType) ((MapType) type).valueType();
+    }
+    return null;
+  }
+
+  /**
+   * Iterates over struct elements in an ArrayData, recursively converting vector columns
+   * in each struct. Returns an Object[] suitable for wrapping in GenericArrayData.
+   */
+  private static Object[] convertStructElements(ArrayData elements,
+                                                 StructType elemRead, StructType elemOutput) {
+    Object[] out = new Object[elements.numElements()];
+    for (int j = 0; j < elements.numElements(); j++) {
+      if (elements.isNullAt(j)) {
+        out[j] = null;
+      } else {
+        InternalRow elemRow = elements.getStruct(j, elemRead.fields().length);
+        GenericInternalRow elemResult = new GenericInternalRow(elemRead.fields().length);
+        convertRowVectorColumns(elemRow, elemResult, elemRead, elemOutput);
+        out[j] = elemResult;
+      }
+    }
+    return out;
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.execution.datasources.{PartitionedFile, SparkColumna
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.hudi.SparkAdapter
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.{ArrayType, ByteType, DoubleType, FloatType, LongType, MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.types.{LongType, MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
 
 import scala.collection.JavaConverters._
@@ -83,9 +83,9 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
 
     // Detect VECTOR columns and replace with BinaryType for the Parquet reader
     // (Parquet stores VECTOR as FIXED_LEN_BYTE_ARRAY which Spark maps to BinaryType)
-    val vectorColumnInfo = SparkFileFormatInternalRowReaderContext.detectVectorColumns(requiredSchema)
-    val parquetReadStructType = if (vectorColumnInfo.nonEmpty) {
-      SparkFileFormatInternalRowReaderContext.replaceVectorColumnsWithBinary(structType, vectorColumnInfo)
+    val hasVectors = VectorConversionUtils.hasVectorColumns(requiredSchema)
+    val parquetReadStructType = if (hasVectors) {
+      VectorConversionUtils.replaceVectorColumnsWithBinary(structType)
     } else {
       structType
     }
@@ -114,8 +114,8 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
         readFilters, storage.getConf.asInstanceOf[StorageConfiguration[Configuration]], tableSchemaOpt))
 
       // Post-process: convert binary VECTOR columns back to typed arrays
-      if (vectorColumnInfo.nonEmpty) {
-        SparkFileFormatInternalRowReaderContext.wrapWithVectorConversion(rawIterator, vectorColumnInfo, readSchema)
+      if (hasVectors) {
+        SparkFileFormatInternalRowReaderContext.wrapWithVectorConversion(rawIterator, readSchema, structType)
       } else {
         rawIterator
       }
@@ -307,60 +307,18 @@ object SparkFileFormatInternalRowReaderContext {
   }
 
   /**
-   * Detects VECTOR columns from HoodieSchema.
-   * Delegates to [[VectorConversionUtils.detectVectorColumns]].
-   * @return Map of ordinal to Vector schema for VECTOR fields.
-   */
-  private[hudi] def detectVectorColumns(schema: HoodieSchema): Map[Int, HoodieSchema.Vector] = {
-    VectorConversionUtils.detectVectorColumns(schema).asScala.map { case (k, v) => (k.intValue(), v) }.toMap
-  }
-
-  /**
-   * Detects VECTOR columns from Spark StructType metadata.
-   * Delegates to [[VectorConversionUtils.detectVectorColumnsFromMetadata]].
-   * @return Map of ordinal to Vector schema for VECTOR fields.
-   */
-  def detectVectorColumnsFromMetadata(schema: StructType): Map[Int, HoodieSchema.Vector] = {
-    VectorConversionUtils.detectVectorColumnsFromMetadata(schema).asScala.map { case (k, v) => (k.intValue(), v) }.toMap
-  }
-
-  /**
-   * Replaces ArrayType with BinaryType for VECTOR columns so the Parquet reader
-   * can read FIXED_LEN_BYTE_ARRAY data without type mismatch.
-   * Delegates to [[VectorConversionUtils.replaceVectorColumnsWithBinary]].
-   */
-  def replaceVectorColumnsWithBinary(structType: StructType, vectorColumns: Map[Int, HoodieSchema.Vector]): StructType = {
-    val javaMap = vectorColumns.map { case (k, v) => (Integer.valueOf(k), v.asInstanceOf[AnyRef]) }.asJava
-    VectorConversionUtils.replaceVectorColumnsWithBinary(structType, javaMap)
-  }
-
-  /**
-   * Wraps an iterator to convert binary VECTOR columns back to typed arrays.
-   * Unpacks bytes from FIXED_LEN_BYTE_ARRAY into GenericArrayData using the canonical vector byte order.
+   * Wraps an iterator to convert binary VECTOR columns back to typed arrays at any nesting depth.
    * Uses UnsafeProjection to make a defensive copy of each row.
+   *
+   * @param readSchema   schema with BinaryType for vector columns (what Parquet returns)
+   * @param outputSchema schema with ArrayType for vector columns (what Spark expects)
    */
   private[hudi] def wrapWithVectorConversion(
       iterator: ClosableIterator[InternalRow],
-      vectorColumns: Map[Int, HoodieSchema.Vector],
-      readSchema: StructType): ClosableIterator[InternalRow] = {
-    val javaVectorCols: java.util.Map[Integer, HoodieSchema.Vector] =
-      vectorColumns.map { case (k, v) => (Integer.valueOf(k), v) }.asJava
-    // Build output schema: replace BinaryType with the correct ArrayType for vector columns
-    val outputFields = readSchema.fields.zipWithIndex.map { case (field, i) =>
-      vectorColumns.get(i) match {
-        case Some(vec) =>
-          val elemType = vec.getVectorElementType match {
-            case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
-            case HoodieSchema.Vector.VectorElementType.DOUBLE => DoubleType
-            case HoodieSchema.Vector.VectorElementType.INT8 => ByteType
-          }
-          field.copy(dataType = ArrayType(elemType, containsNull = false))
-        case None => field
-      }
-    }
-    val outputSchema = StructType(outputFields)
+      readSchema: StructType,
+      outputSchema: StructType): ClosableIterator[InternalRow] = {
     val projection = UnsafeProjection.create(outputSchema)
-    val mapper = VectorConversionUtils.buildRowMapper(readSchema, javaVectorCols, projection.apply(_))
+    val mapper = VectorConversionUtils.buildRowMapper(readSchema, outputSchema, projection.apply(_))
     new ClosableIterator[InternalRow] {
       override def hasNext: Boolean = iterator.hasNext
       override def next(): InternalRow = mapper.apply(iterator.next())

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -82,7 +82,22 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
         }
         HoodieSchema.createDecimal(name, nameSpace, null, d.precision, d.scale, fixedSize)
 
-      // Complex types
+      // Complex types — array of vectors: ArrayType(ArrayType(FloatType)) with VECTOR metadata
+      case ArrayType(innerArrayType @ ArrayType(_, _), containsNull)
+          if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+            HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR =>
+        // Reject unsupported deeper nesting: array<array<VECTOR>>, array<map<K, VECTOR>>
+        if (innerArrayType.elementType.isInstanceOf[ArrayType] || innerArrayType.elementType.isInstanceOf[MapType]) {
+          throw new HoodieSchemaException(
+            s"VECTOR field '$recordName' uses unsupported nesting. " +
+              s"Supported patterns: direct VECTOR, array<VECTOR>, map<K, VECTOR>.")
+        }
+        // Convert the inner ArrayType to a VECTOR, then wrap in ARRAY
+        val vectorSchema = toHoodieType(innerArrayType, false, recordName, nameSpace, metadata)
+        HoodieSchema.createArray(
+          if (containsNull) HoodieSchema.createNullable(vectorSchema) else vectorSchema)
+
+      // Direct vector: ArrayType(FloatType) with VECTOR metadata
       case ArrayType(elementSparkType, containsNull)
           if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
             HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR =>
@@ -109,6 +124,14 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
       case ArrayType(elementType, containsNull) =>
         val elementSchema = toHoodieType(elementType, containsNull, recordName, nameSpace, metadata)
         HoodieSchema.createArray(elementSchema)
+
+      // Map of vectors: MapType(StringType, ArrayType(FloatType)) with VECTOR metadata
+      case MapType(StringType, valueArrayType @ ArrayType(_, _), valueContainsNull)
+          if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+            HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR =>
+        val vectorSchema = toHoodieType(valueArrayType, false, recordName, nameSpace, metadata)
+        HoodieSchema.createMap(
+          if (valueContainsNull) HoodieSchema.createNullable(vectorSchema) else vectorSchema)
 
       case MapType(StringType, valueType, valueContainsNull) =>
         val valueSchema = toHoodieType(valueType, valueContainsNull, recordName, nameSpace, metadata)
@@ -265,12 +288,14 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
       case HoodieSchemaType.ARRAY =>
         val elementSchema = hoodieSchema.getElementType
         val schemaType = toSqlTypeHelper(elementSchema, existingRecordNames)
-        SchemaType(ArrayType(schemaType.dataType, containsNull = schemaType.nullable), nullable = false)
+        // Propagate element metadata (e.g., VECTOR type descriptor) so it reaches the StructField
+        SchemaType(ArrayType(schemaType.dataType, containsNull = schemaType.nullable), nullable = false, schemaType.metadata)
 
       case HoodieSchemaType.MAP =>
         val valueSchema = hoodieSchema.getValueType
         val schemaType = toSqlTypeHelper(valueSchema, existingRecordNames)
-        SchemaType(MapType(StringType, schemaType.dataType, valueContainsNull = schemaType.nullable), nullable = false)
+        // Propagate value metadata (e.g., VECTOR type descriptor) so it reaches the StructField
+        SchemaType(MapType(StringType, schemaType.dataType, valueContainsNull = schemaType.nullable), nullable = false, schemaType.metadata)
 
       case HoodieSchemaType.UNION =>
         if (hoodieSchema.isNullable) {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieParquetFileFormatHelper.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieParquetFileFormatHelper.scala
@@ -57,7 +57,7 @@ object HoodieParquetFileFormatHelper {
    * Recurses into GroupType (nested structs, lists, maps) to handle nested vectors.
    */
   private def rewriteFixedLenByteArrayToBinary(schema: MessageType): MessageType = {
-    new MessageType(schema.getName, rewriteFields(schema.getFields.asScala).asJava)
+    new MessageType(schema.getName, rewriteFields(schema.getFields.asScala.toSeq).asJava)
   }
 
   private def rewriteFields(fields: Seq[Type]): Seq[Type] = fields.map {
@@ -66,7 +66,7 @@ object HoodieParquetFileFormatHelper {
         && pt.getLogicalTypeAnnotation == null =>
       Types.primitive(PrimitiveTypeName.BINARY, pt.getRepetition).named(pt.getName)
     case gt: GroupType =>
-      gt.withNewFields(rewriteFields(gt.getFields.asScala).asJava)
+      gt.withNewFields(rewriteFields(gt.getFields.asScala.toSeq).asJava)
     case other => other
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieParquetFileFormatHelper.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieParquetFileFormatHelper.scala
@@ -22,7 +22,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 import org.apache.hadoop.conf.Configuration
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.parquet.hadoop.metadata.FileMetaData
-import org.apache.parquet.schema.{MessageType, PrimitiveType, Types}
+import org.apache.parquet.schema.{GroupType, MessageType, PrimitiveType, Type, Types}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.spark.sql.execution.datasources.SparkSchemaTransformUtils
 import org.apache.spark.sql.types.{DataType, StructType}
@@ -52,17 +52,21 @@ object HoodieParquetFileFormatHelper {
   }
 
   /**
-   * Rewrites bare FIXED_LEN_BYTE_ARRAY columns (no logical type annotation) to BINARY.
+   * Recursively rewrites bare FIXED_LEN_BYTE_ARRAY columns (no logical type annotation) to BINARY.
    * Columns with annotations (e.g., DECIMAL, UUID) are left untouched.
+   * Recurses into GroupType (nested structs, lists, maps) to handle nested vectors.
    */
   private def rewriteFixedLenByteArrayToBinary(schema: MessageType): MessageType = {
-    val fields = schema.getFields.asScala.map {
-      case pt: PrimitiveType
-        if pt.getPrimitiveTypeName == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
-          && pt.getLogicalTypeAnnotation == null =>
-        Types.primitive(PrimitiveTypeName.BINARY, pt.getRepetition).named(pt.getName)
-      case other => other
-    }
-    new MessageType(schema.getName, fields.asJava)
+    new MessageType(schema.getName, rewriteFields(schema.getFields.asScala).asJava)
+  }
+
+  private def rewriteFields(fields: Seq[Type]): Seq[Type] = fields.map {
+    case pt: PrimitiveType
+      if pt.getPrimitiveTypeName == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
+        && pt.getLogicalTypeAnnotation == null =>
+      Types.primitive(PrimitiveTypeName.BINARY, pt.getRepetition).named(pt.getName)
+    case gt: GroupType =>
+      gt.withNewFields(rewriteFields(gt.getFields.asScala).asJava)
+    case other => other
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
@@ -220,6 +220,8 @@ public class HoodieSchema implements Serializable {
 
   /**
    * Builds the value string for {@link #PARQUET_VECTOR_COLUMNS_METADATA_KEY}.
+   * Recursively scans nested RECORD fields using dot-notation for nested paths
+   * (e.g., "metadata.embedding:VECTOR(128)").
    *
    * @param schema a HoodieSchema of type RECORD (or null)
    * @return comma-separated {@code colName:VECTOR(dim[,elemType])} entries, or empty string
@@ -229,19 +231,39 @@ public class HoodieSchema implements Serializable {
     if (schema == null || schema.isSchemaNull()) {
       return "";
     }
-    List<HoodieSchemaField> fields = schema.getFields();
     StringBuilder sb = new StringBuilder();
-    for (HoodieSchemaField field : fields) {
+    buildVectorColumnsMetadataValue(schema, "", sb);
+    return sb.toString();
+  }
+
+  private static void buildVectorColumnsMetadataValue(HoodieSchema schema, String prefix, StringBuilder sb) {
+    for (HoodieSchemaField field : schema.getFields()) {
       HoodieSchema fieldSchema = field.schema().getNonNullType();
-      if (fieldSchema.getType() == HoodieSchemaType.VECTOR) {
-        Vector vectorSchema = (Vector) fieldSchema;
+      String fullName = prefix.isEmpty() ? field.name() : prefix + "." + field.name();
+      appendVectorMetadata(fieldSchema, fullName, sb);
+    }
+  }
+
+  private static void appendVectorMetadata(HoodieSchema fieldSchema, String fullName, StringBuilder sb) {
+    switch (fieldSchema.getType()) {
+      case VECTOR:
         if (sb.length() > 0) {
           sb.append(',');
         }
-        sb.append(field.name()).append(':').append(vectorSchema.toTypeDescriptor());
-      }
+        sb.append(fullName).append(':').append(((Vector) fieldSchema).toTypeDescriptor());
+        break;
+      case RECORD:
+        buildVectorColumnsMetadataValue(fieldSchema, fullName, sb);
+        break;
+      case ARRAY:
+        appendVectorMetadata(fieldSchema.getElementType().getNonNullType(), fullName + "[]", sb);
+        break;
+      case MAP:
+        appendVectorMetadata(fieldSchema.getValueType().getNonNullType(), fullName + "{}", sb);
+        break;
+      default:
+        break;
     }
-    return sb.toString();
   }
 
   private Schema avroSchema;

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -24,7 +24,6 @@ import org.apache.hudi.client.utils.SparkInternalSchemaConverter
 import org.apache.hudi.common.config.{HoodieMemoryConfig, TypedProperties}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.HoodieFileFormat
-import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.schema.HoodieSchemaUtils
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, ParquetTableSchemaResolver}
 import org.apache.hudi.common.table.read.HoodieFileGroupReader
@@ -119,16 +118,16 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
 
   /**
    * Cached result of vector column detection keyed by schema identity.
-   * Avoids re-parsing metadata on repeated supportBatch / readBaseFile calls with the same schema.
+   * Avoids re-parsing metadata on repeated supportBatch calls with the same schema.
    */
-  @transient private var cachedVectorDetection: (StructType, Map[Int, HoodieSchema.Vector]) = _
+  @transient private var cachedHasVectors: (StructType, Boolean) = _
 
-  private def detectVectorColumnsCached(schema: StructType): Map[Int, HoodieSchema.Vector] = {
-    if (cachedVectorDetection != null && (cachedVectorDetection._1 eq schema)) {
-      cachedVectorDetection._2
+  private def hasVectorColumnsCached(schema: StructType): Boolean = {
+    if (cachedHasVectors != null && (cachedHasVectors._1 eq schema)) {
+      cachedHasVectors._2
     } else {
-      val result = detectVectorColumns(schema)
-      cachedVectorDetection = (schema, result)
+      val result = VectorConversionUtils.hasVectorColumnsFromMetadata(schema)
+      cachedHasVectors = (schema, result)
       result
     }
   }
@@ -147,7 +146,7 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
   override def supportBatch(sparkSession: SparkSession, schema: StructType): Boolean = {
     // Vector columns are stored as FIXED_LEN_BYTE_ARRAY in Parquet but read as ArrayType in Spark.
     // The binary→array conversion requires row-level access, so disable vectorized batch reading.
-    if (detectVectorColumnsCached(schema).nonEmpty) {
+    if (hasVectorColumnsCached(schema)) {
       supportVectorizedRead = false
       supportReturningBatch = false
       false
@@ -423,33 +422,21 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     }
   }
 
-  private def detectVectorColumns(schema: StructType): Map[Int, HoodieSchema.Vector] =
-    SparkFileFormatInternalRowReaderContext.detectVectorColumnsFromMetadata(schema)
-
-  private def replaceVectorFieldsWithBinary(schema: StructType, vectorCols: Map[Int, HoodieSchema.Vector]): StructType =
-    SparkFileFormatInternalRowReaderContext.replaceVectorColumnsWithBinary(schema, vectorCols)
-
   /**
-   * Detects vector columns and replaces them with BinaryType in one step.
-   * @return (modified schema with BinaryType for vectors, vector column ordinal map)
+   * Replaces VECTOR columns with BinaryType at any nesting depth.
+   * Returns the original schema unchanged if no vectors are found.
    */
-  private def withVectorRewrite(schema: StructType): (StructType, Map[Int, HoodieSchema.Vector]) = {
-    val vecs = detectVectorColumns(schema)
-    if (vecs.nonEmpty) (replaceVectorFieldsWithBinary(schema, vecs), vecs) else (schema, vecs)
-  }
+  private def withVectorRewrite(schema: StructType): StructType =
+    VectorConversionUtils.replaceVectorColumnsWithBinary(schema)
 
   /**
-   * Wraps an iterator to convert binary VECTOR columns back to typed arrays.
-   * The read schema has BinaryType for vector columns; the target schema has ArrayType.
+   * Wraps an iterator to convert binary VECTOR columns back to typed arrays at any nesting depth.
    */
   private def wrapWithVectorConversion(iter: Iterator[InternalRow],
                                         readSchema: StructType,
-                                        targetSchema: StructType,
-                                        vectorCols: Map[Int, HoodieSchema.Vector]): Iterator[InternalRow] = {
+                                        targetSchema: StructType): Iterator[InternalRow] = {
     val vectorProjection = UnsafeProjection.create(targetSchema)
-    val javaVectorCols: java.util.Map[Integer, HoodieSchema.Vector] =
-      vectorCols.map { case (k, v) => (Integer.valueOf(k), v) }.asJava
-    val mapper = VectorConversionUtils.buildRowMapper(readSchema, javaVectorCols, vectorProjection.apply(_))
+    val mapper = VectorConversionUtils.buildRowMapper(readSchema, targetSchema, vectorProjection.apply(_))
     iter.map(mapper.apply(_))
   }
 
@@ -458,14 +445,12 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
                            remainingPartitionSchema: StructType, fixedPartitionIndexes: Set[Int], requiredSchema: StructType,
                            partitionSchema: StructType, outputSchema: StructType, filters: Seq[Filter],
                            storageConf: StorageConfiguration[Configuration]): Iterator[InternalRow] = {
-    // Detect vector columns and create modified schemas with BinaryType.
-    // Each schema is detected independently because ordinals are relative to the schema being
-    // modified — outputSchema and requestedSchema may have vector columns at different positions
-    // than requiredSchema (e.g. when partition columns are interleaved).
-    val (modifiedRequiredSchema, vectorCols) = withVectorRewrite(requiredSchema)
-    val hasVectors = vectorCols.nonEmpty
-    val (modifiedOutputSchema, outputVectorCols) = if (hasVectors) withVectorRewrite(outputSchema) else (outputSchema, Map.empty[Int, HoodieSchema.Vector])
-    val (modifiedRequestedSchema, _) = if (hasVectors) withVectorRewrite(requestedSchema) else (requestedSchema, Map.empty[Int, HoodieSchema.Vector])
+    // Replace VECTOR columns with BinaryType at any nesting depth so the Parquet reader
+    // sees matching types (file has FIXED_LEN_BYTE_ARRAY → BinaryType).
+    val hasVectors = VectorConversionUtils.hasVectorColumnsFromMetadata(requiredSchema)
+    val modifiedRequiredSchema = if (hasVectors) withVectorRewrite(requiredSchema) else requiredSchema
+    val modifiedOutputSchema = if (hasVectors) withVectorRewrite(outputSchema) else outputSchema
+    val modifiedRequestedSchema = if (hasVectors) withVectorRewrite(requestedSchema) else requestedSchema
 
     val rawIter = if (remainingPartitionSchema.fields.length == partitionSchema.fields.length) {
       //none of partition fields are read from the file, so the reader will do the appending for us
@@ -495,7 +480,7 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       } else {
         modifiedOutputSchema
       }
-      wrapWithVectorConversion(rawIter, readSchema, outputSchema, outputVectorCols)
+      wrapWithVectorConversion(rawIter, readSchema, outputSchema)
     } else {
       rawIter
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestVectorDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestVectorDataSource.scala
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
+
 import java.util.stream.Stream
 
 import scala.collection.JavaConverters._

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestVectorDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestVectorDataSource.scala
@@ -28,6 +28,9 @@ import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.{Arguments, MethodSource}
+import java.util.stream.Stream
 
 import scala.collection.JavaConverters._
 
@@ -74,73 +77,59 @@ class TestVectorDataSource extends HoodieSparkClientTestBase {
   private def readHudiTable(path: String): DataFrame =
     spark.read.format("hudi").load(path)
 
-  @Test
-  def testVectorRoundTrip(): Unit = {
-    // 1. Create schema with vector metadata
-    val metadata = vectorMetadata("VECTOR(128)")
-
+  /**
+   * Round-trip test for all three element types (FLOAT, DOUBLE, INT8).
+   * Verifies schema preservation, metadata, and exact value round-trip for each.
+   */
+  @ParameterizedTest
+  @MethodSource(Array("vectorElementTypeArgs"))
+  def testVectorRoundTripAllElementTypes(descriptor: String, elemType: DataType,
+                                          dim: Int, subPath: String): Unit = {
+    val metadata = vectorMetadata(descriptor)
     val schema = StructType(Seq(
       StructField("id", StringType, nullable = false),
-      StructField("embedding", ArrayType(FloatType, containsNull = false),
-        nullable = false, metadata),
-      StructField("label", StringType, nullable = true)
+      StructField("embedding", ArrayType(elemType, containsNull = false), nullable = false, metadata)
     ))
 
-    // 2. Generate test data (128-dim float vectors)
     val random = new scala.util.Random(42)
-    val data = (0 until 100).map { i =>
-      val embedding = Array.fill(128)(random.nextFloat())
-      Row(s"key_$i", embedding.toSeq, s"label_$i")
+    val data = (0 until 20).map { i =>
+      val vec = elemType match {
+        case FloatType  => Array.fill(dim)(random.nextFloat()).toSeq
+        case DoubleType => Array.fill(dim)(random.nextDouble()).toSeq
+        case ByteType   => Array.fill(dim)((random.nextInt(256) - 128).toByte).toSeq
+      }
+      Row(s"key_$i", vec)
     }
 
     val df = createVectorDf(schema, data)
+    val path = basePath + "/" + subPath
+    writeHudiTable(df, s"vec_rt_$subPath", path)
 
-    // 3. Write as COW Hudi table
-    writeHudiTable(df, "vector_test_table", basePath)
+    val readDf = readHudiTable(path)
+    assertEquals(20, readDf.count())
 
-    // 4. Read back
-    val readDf = readHudiTable(basePath)
+    // Verify element type and metadata preserved
+    val embField = readDf.schema("embedding")
+    assertEquals(elemType, embField.dataType.asInstanceOf[ArrayType].elementType)
+    val parsed = HoodieSchema.parseTypeDescriptor(
+      embField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).asInstanceOf[HoodieSchema.Vector]
+    assertEquals(HoodieSchemaType.VECTOR, parsed.getType)
+    assertEquals(dim, parsed.getDimension)
 
-    // 5. Verify row count
-    assertEquals(100, readDf.count())
+    // Verify values round-trip exactly
+    val origMap = df.select("id", "embedding").collect()
+      .map(r => r.getString(0) -> r.getSeq[Any](1)).toMap
+    val readMap = readDf.select("id", "embedding").collect()
+      .map(r => r.getString(0) -> r.getSeq[Any](1)).toMap
 
-    // 6. Verify schema preserved
-    val embeddingField = readDf.schema("embedding")
-    assertTrue(embeddingField.dataType.isInstanceOf[ArrayType])
-    val arrayType = embeddingField.dataType.asInstanceOf[ArrayType]
-    assertEquals(FloatType, arrayType.elementType)
-    assertFalse(arrayType.containsNull)
-
-    // 7. Verify vector metadata preserved
-    val readMetadata = embeddingField.metadata
-    assertTrue(readMetadata.contains(HoodieSchema.TYPE_METADATA_FIELD))
-    val parsedSchema = HoodieSchema.parseTypeDescriptor(
-      readMetadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
-    assertEquals(HoodieSchemaType.VECTOR, parsedSchema.getType)
-    val vectorSchema = parsedSchema.asInstanceOf[HoodieSchema.Vector]
-    assertEquals(128, vectorSchema.getDimension)
-
-    // 8. Verify float values match exactly
-    val originalRows = df.select("id", "embedding").collect()
-      .map(r => (r.getString(0), r.getSeq[Float](1)))
-      .toMap
-
-    val readRows = readDf.select("id", "embedding").collect()
-      .map(r => (r.getString(0), r.getSeq[Float](1)))
-      .toMap
-
-    originalRows.foreach { case (id, origEmbedding) =>
-      val readEmbedding = readRows(id)
-      assertEquals(128, readEmbedding.size, s"Vector size mismatch for $id")
-
-      origEmbedding.zip(readEmbedding).zipWithIndex.foreach {
-        case ((orig, read), idx) =>
-          assertEquals(orig, read, 1e-9f,
-            s"Vector mismatch at $id index $idx: orig=$orig read=$read")
+    origMap.foreach { case (id, orig) =>
+      val read = readMap(id)
+      assertEquals(dim, read.size, s"$id dimension wrong")
+      orig.zip(read).zipWithIndex.foreach { case ((o, r), idx) =>
+        assertEquals(o, r, s"$id[$idx] mismatch")
       }
     }
   }
-
 
   @Test
   def testNullableVectorField(): Unit = {
@@ -234,110 +223,6 @@ class TestVectorDataSource extends HoodieSparkClientTestBase {
   }
 
   @Test
-  def testDoubleVectorRoundTrip(): Unit = {
-    val metadata = vectorMetadata("VECTOR(64, DOUBLE)")
-
-    val schema = StructType(Seq(
-      StructField("id", StringType, nullable = false),
-      StructField("embedding", ArrayType(DoubleType, containsNull = false),
-        nullable = false, metadata),
-      StructField("label", StringType, nullable = true)
-    ))
-
-    val random = new scala.util.Random(123)
-    val data = (0 until 50).map { i =>
-      val embedding = Array.fill(64)(random.nextDouble())
-      Row(s"key_$i", embedding.toSeq, s"label_$i")
-    }
-
-    val df = createVectorDf(schema, data)
-
-    writeHudiTable(df, "double_vector_test", basePath + "/double_vec")
-
-    val readDf = readHudiTable(basePath + "/double_vec")
-    assertEquals(50, readDf.count())
-
-    // Verify schema: ArrayType(DoubleType)
-    val embField = readDf.schema("embedding")
-    val arrType = embField.dataType.asInstanceOf[ArrayType]
-    assertEquals(DoubleType, arrType.elementType)
-
-    // Verify metadata preserved with DOUBLE element type
-    val readMeta = embField.metadata
-    assertTrue(readMeta.contains(HoodieSchema.TYPE_METADATA_FIELD))
-    val parsed = HoodieSchema.parseTypeDescriptor(
-      readMeta.getString(HoodieSchema.TYPE_METADATA_FIELD))
-    assertEquals(HoodieSchemaType.VECTOR, parsed.getType)
-    val vecSchema = parsed.asInstanceOf[HoodieSchema.Vector]
-    assertEquals(64, vecSchema.getDimension)
-    assertEquals(HoodieSchema.Vector.VectorElementType.DOUBLE, vecSchema.getVectorElementType)
-
-    // Verify actual values
-    val origMap = df.select("id", "embedding").collect()
-      .map(r => (r.getString(0), r.getSeq[Double](1))).toMap
-    val readMap = readDf.select("id", "embedding").collect()
-      .map(r => (r.getString(0), r.getSeq[Double](1))).toMap
-
-    origMap.foreach { case (id, orig) =>
-      val read = readMap(id)
-      assertEquals(64, read.size, s"Dimension mismatch for $id")
-      orig.zip(read).zipWithIndex.foreach { case ((o, r), idx) =>
-        assertEquals(o, r, 1e-15, s"Double mismatch at $id[$idx]")
-      }
-    }
-  }
-
-  @Test
-  def testInt8VectorRoundTrip(): Unit = {
-    val metadata = vectorMetadata("VECTOR(256, INT8)")
-
-    val schema = StructType(Seq(
-      StructField("id", StringType, nullable = false),
-      StructField("embedding", ArrayType(ByteType, containsNull = false),
-        nullable = false, metadata)
-    ))
-
-    val random = new scala.util.Random(99)
-    val data = (0 until 30).map { i =>
-      val embedding = Array.fill(256)((random.nextInt(256) - 128).toByte)
-      Row(s"key_$i", embedding.toSeq)
-    }
-
-    val df = createVectorDf(schema, data)
-
-    writeHudiTable(df, "int8_vector_test", basePath + "/int8_vec")
-
-    val readDf = readHudiTable(basePath + "/int8_vec")
-    assertEquals(30, readDf.count())
-
-    // Verify schema: ArrayType(ByteType)
-    val embField = readDf.schema("embedding")
-    val arrType = embField.dataType.asInstanceOf[ArrayType]
-    assertEquals(ByteType, arrType.elementType)
-
-    // Verify metadata
-    val readMeta = embField.metadata
-    val parsed = HoodieSchema.parseTypeDescriptor(
-      readMeta.getString(HoodieSchema.TYPE_METADATA_FIELD))
-    assertEquals(HoodieSchemaType.VECTOR, parsed.getType)
-    val vecSchema = parsed.asInstanceOf[HoodieSchema.Vector]
-    assertEquals(256, vecSchema.getDimension)
-    assertEquals(HoodieSchema.Vector.VectorElementType.INT8, vecSchema.getVectorElementType)
-
-    // Verify byte values
-    val origMap = df.select("id", "embedding").collect()
-      .map(r => (r.getString(0), r.getSeq[Byte](1))).toMap
-    val readMap = readDf.select("id", "embedding").collect()
-      .map(r => (r.getString(0), r.getSeq[Byte](1))).toMap
-
-    origMap.foreach { case (id, orig) =>
-      val read = readMap(id)
-      assertEquals(256, read.size, s"Dimension mismatch for $id")
-      assertArrayEquals(orig.toArray, read.toArray, s"INT8 vector mismatch for $id")
-    }
-  }
-
-  @Test
   def testMultipleVectorColumns(): Unit = {
     val floatMeta = vectorMetadata("VECTOR(8)")
     val doubleMeta = vectorMetadata("VECTOR(4, DOUBLE)")
@@ -397,56 +282,6 @@ class TestVectorDataSource extends HoodieSparkClientTestBase {
   }
 
   @Test
-  def testMorTableWithVectors(): Unit = {
-    val metadata = vectorMetadata("VECTOR(16)")
-
-    val schema = StructType(Seq(
-      StructField("id", StringType, nullable = false),
-      StructField("embedding", ArrayType(FloatType, containsNull = false),
-        nullable = false, metadata),
-      StructField("ts", LongType, nullable = false)
-    ))
-
-    // Initial insert
-    val data1 = (0 until 20).map { i =>
-      Row(s"key_$i", Array.fill(16)(1.0f).toSeq, i.toLong)
-    }
-
-    val df1 = createVectorDf(schema, data1)
-
-    writeHudiTable(df1, "mor_vector_test", basePath + "/mor_vec",
-      tableType = "MERGE_ON_READ", precombineField = "ts")
-
-    // Upsert: update some vectors with new values
-    val data2 = (0 until 10).map { i =>
-      Row(s"key_$i", Array.fill(16)(2.0f).toSeq, 100L + i)
-    }
-
-    val df2 = createVectorDf(schema, data2)
-
-    writeHudiTable(df2, "mor_vector_test", basePath + "/mor_vec",
-      tableType = "MERGE_ON_READ", precombineField = "ts", mode = SaveMode.Append)
-
-    // Read the merged view
-    val readDf = readHudiTable(basePath + "/mor_vec")
-    assertEquals(20, readDf.count())
-
-    // Updated rows (key_0 through key_9) should have new vectors
-    val updatedRow = readDf.select("id", "embedding")
-      .filter("id = 'key_5'").collect()(0)
-    val updatedVec = updatedRow.getSeq[Float](1)
-    assertEquals(16, updatedVec.size)
-    assertTrue(updatedVec.forall(_ == 2.0f), "Updated vector should have value 2.0")
-
-    // Non-updated rows (key_10 through key_19) should keep original vectors
-    val origRow = readDf.select("id", "embedding")
-      .filter("id = 'key_15'").collect()(0)
-    val origVec = origRow.getSeq[Float](1)
-    assertEquals(16, origVec.size)
-    assertTrue(origVec.forall(_ == 1.0f), "Non-updated vector should have value 1.0")
-  }
-
-  @Test
   def testCowUpsertWithVectors(): Unit = {
     val metadata = vectorMetadata("VECTOR(8)")
 
@@ -499,80 +334,47 @@ class TestVectorDataSource extends HoodieSparkClientTestBase {
   }
 
   @Test
-  def testLargeDimensionVector(): Unit = {
-    val metadata = vectorMetadata("VECTOR(1536)")
+  def testDimensionBoundaries(): Unit = {
+    // Large dimension (1536-dim, OpenAI embedding size) + small dimension (2-dim, edge values)
+    val largeMeta = vectorMetadata("VECTOR(1536)")
+    val smallMeta = vectorMetadata("VECTOR(2)")
 
     val schema = StructType(Seq(
       StructField("id", StringType, nullable = false),
-      StructField("embedding", ArrayType(FloatType, containsNull = false),
-        nullable = false, metadata)
+      StructField("large", ArrayType(FloatType, containsNull = false), nullable = false, largeMeta),
+      StructField("small", ArrayType(FloatType, containsNull = false), nullable = false, smallMeta)
     ))
 
     val random = new scala.util.Random(7)
-    val data = (0 until 5).map { i =>
-      Row(s"key_$i", Array.fill(1536)(random.nextFloat()).toSeq)
-    }
-
-    val df = createVectorDf(schema, data)
-
-    writeHudiTable(df, "large_dim_vec_test", basePath + "/large_dim")
-
-    val readDf = readHudiTable(basePath + "/large_dim")
-    assertEquals(5, readDf.count())
-
-    // Verify dimension preserved
-    val readMeta = readDf.schema("embedding").metadata
-    val vecSchema = HoodieSchema.parseTypeDescriptor(
-      readMeta.getString(HoodieSchema.TYPE_METADATA_FIELD)).asInstanceOf[HoodieSchema.Vector]
-    assertEquals(1536, vecSchema.getDimension)
-
-    // Verify values
-    val origMap = df.select("id", "embedding").collect()
-      .map(r => (r.getString(0), r.getSeq[Float](1))).toMap
-    val readMap = readDf.select("id", "embedding").collect()
-      .map(r => (r.getString(0), r.getSeq[Float](1))).toMap
-
-    origMap.foreach { case (id, orig) =>
-      val read = readMap(id)
-      assertEquals(1536, read.size)
-      orig.zip(read).foreach { case (o, r) =>
-        assertEquals(o, r, 1e-9f, s"Mismatch in $id")
-      }
-    }
-  }
-
-  @Test
-  def testSmallDimensionVector(): Unit = {
-    val metadata = vectorMetadata("VECTOR(2)")
-
-    val schema = StructType(Seq(
-      StructField("id", StringType, nullable = false),
-      StructField("coords", ArrayType(FloatType, containsNull = false),
-        nullable = false, metadata)
-    ))
-
     val data = Seq(
-      Row("a", Seq(1.0f, 2.0f)),
-      Row("b", Seq(-1.5f, 3.14f)),
-      Row("c", Seq(0.0f, Float.MaxValue))
+      Row("k0", Array.fill(1536)(random.nextFloat()).toSeq, Seq(1.0f, 2.0f)),
+      Row("k1", Array.fill(1536)(random.nextFloat()).toSeq, Seq(-1.5f, Float.MaxValue))
     )
 
     val df = createVectorDf(schema, data)
+    writeHudiTable(df, "dim_boundary_test", basePath + "/dim_boundary")
 
-    writeHudiTable(df, "small_dim_test", basePath + "/small_dim")
+    val readDf = readHudiTable(basePath + "/dim_boundary")
+    assertEquals(2, readDf.count())
 
-    val readDf = readHudiTable(basePath + "/small_dim")
-    assertEquals(3, readDf.count())
+    val rows = readDf.select("id", "large", "small").collect()
+      .map(r => r.getString(0) -> r).toMap
 
-    val rowA = readDf.select("id", "coords").filter("id = 'a'").collect()(0)
-    val coordsA = rowA.getSeq[Float](1)
-    assertEquals(2, coordsA.size)
-    assertEquals(1.0f, coordsA(0), 1e-9f)
-    assertEquals(2.0f, coordsA(1), 1e-9f)
+    // Large dimension: verify values preserved exactly
+    val origLarge = df.select("id", "large").collect().map(r => r.getString(0) -> r.getSeq[Float](1)).toMap
+    origLarge.foreach { case (id, orig) =>
+      val read = rows(id).getSeq[Float](1)
+      assertEquals(1536, read.size)
+      orig.zip(read).foreach { case (o, r) => assertEquals(o, r, 1e-9f, s"Large mismatch in $id") }
+    }
 
-    val rowC = readDf.select("id", "coords").filter("id = 'c'").collect()(0)
-    val coordsC = rowC.getSeq[Float](1)
-    assertEquals(Float.MaxValue, coordsC(1), 1e-30f)
+    // Small dimension: verify edge values
+    val smallK0 = rows("k0").getSeq[Float](2)
+    assertEquals(2, smallK0.size)
+    assertEquals(1.0f, smallK0(0), 1e-9f)
+    assertEquals(2.0f, smallK0(1), 1e-9f)
+    val smallK1 = rows("k1").getSeq[Float](2)
+    assertEquals(Float.MaxValue, smallK1(1), 1e-30f)
   }
 
   @Test
@@ -991,10 +793,933 @@ class TestVectorDataSource extends HoodieSparkClientTestBase {
     }
   }
 
+  /**
+   * Deeply nested vector: vector inside struct inside struct.
+   * Schema: id STRING, outer STRUCT<inner STRUCT<embedding VECTOR(4)>>
+   */
+  @Test
+  def testDeeplyNestedVectorColumn(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("outer", StructType(Seq(
+        StructField("inner", StructType(Seq(
+          StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta)
+        )), nullable = false)
+      )), nullable = false)
+    ))
+
+    val data = (0 until 5).map { i =>
+      Row(s"key_$i", Row(Row(Array.fill(4)(i.toFloat * 0.5f).toSeq)))
+    }
+
+    val path = basePath + "/deep_nested_vec"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "deep_nested_vector_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(5, readDf.count())
+
+    val rows = readDf.select("id", "outer.inner.embedding").collect()
+      .map(r => r.getString(0) -> r.getSeq[Float](1)).toMap
+
+    for (i <- 0 until 5) {
+      val vec = rows(s"key_$i")
+      assertEquals(4, vec.size)
+      assertTrue(vec.forall(_ == i.toFloat * 0.5f),
+        s"key_$i: expected ${i.toFloat * 0.5f} but got ${vec.head}")
+    }
+  }
+
+  /**
+   * Nested vector with projection: select only nested vector, skip it, or select sibling fields.
+   */
+  @Test
+  def testNestedVectorWithProjection(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("metadata", StructType(Seq(
+        StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta),
+        StructField("label", StringType, nullable = true),
+        StructField("score", IntegerType, nullable = true)
+      )), nullable = false)
+    ))
+
+    val data = (0 until 5).map { i =>
+      Row(s"key_$i", Row(Array.fill(4)(i.toFloat).toSeq, s"label_$i", i * 10))
+    }
+
+    val path = basePath + "/nested_proj"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "nested_proj_test", path)
+
+    // Project only the nested vector
+    val vecOnly = readHudiTable(path).select("id", "metadata.embedding").collect()
+      .map(r => r.getString(0) -> r.getSeq[Float](1)).toMap
+    for (i <- 0 until 5) {
+      assertTrue(vecOnly(s"key_$i").forall(_ == i.toFloat))
+    }
+
+    // Skip the vector, read only non-vector nested fields
+    val noVec = readHudiTable(path).select("id", "metadata.label", "metadata.score").collect()
+      .map(r => r.getString(0) -> r).toMap
+    for (i <- 0 until 5) {
+      assertEquals(s"label_$i", noVec(s"key_$i").getString(1))
+      assertEquals(i * 10, noVec(s"key_$i").getInt(2))
+    }
+
+    // Read everything
+    val all = readHudiTable(path).select("id", "metadata").collect()
+      .map(r => r.getString(0) -> r.getStruct(1)).toMap
+    for (i <- 0 until 5) {
+      val meta = all(s"key_$i")
+      val vec = meta.getSeq[Float](0)
+      assertEquals(4, vec.size)
+      assertTrue(vec.forall(_ == i.toFloat))
+      assertEquals(s"label_$i", meta.getString(1))
+    }
+  }
+
+  /**
+   * Null handling for nested vectors:
+   * - Null struct (entire struct is null, vector is implicitly null)
+   * - Non-null struct with null vector inside
+   * - Non-null struct with non-null vector
+   */
+  @Test
+  def testNestedVectorWithNulls(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("metadata", StructType(Seq(
+        StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = true, vecMeta),
+        StructField("label", StringType, nullable = true)
+      )), nullable = true)
+    ))
+
+    val data = Seq(
+      Row("key_0", Row(Array.fill(4)(1.0f).toSeq, "has_vec")),      // non-null struct, non-null vector
+      Row("key_1", null),                                             // null struct
+      Row("key_2", Row(null, "no_vec")),                              // non-null struct, null vector
+      Row("key_3", Row(Array.fill(4)(3.0f).toSeq, null))             // non-null struct, null label
+    )
+
+    val path = basePath + "/nested_null"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "nested_null_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(4, readDf.count())
+
+    val rows = readDf.select("id", "metadata").collect()
+      .map(r => r.getString(0) -> r).toMap
+
+    // key_0: non-null struct, non-null vector
+    val r0 = rows("key_0")
+    assertFalse(r0.isNullAt(1))
+    val meta0 = r0.getStruct(1)
+    val vec0 = meta0.getSeq[Float](0)
+    assertEquals(4, vec0.size)
+    assertTrue(vec0.forall(_ == 1.0f))
+    assertEquals("has_vec", meta0.getString(1))
+
+    // key_1: null struct
+    val r1 = rows("key_1")
+    assertTrue(r1.isNullAt(1), "key_1 metadata should be null")
+
+    // key_2: non-null struct, null vector
+    val r2 = rows("key_2")
+    assertFalse(r2.isNullAt(1))
+    val meta2 = r2.getStruct(1)
+    assertTrue(meta2.isNullAt(0), "key_2 embedding should be null")
+    assertEquals("no_vec", meta2.getString(1))
+
+    // key_3: non-null struct, null label
+    val r3 = rows("key_3")
+    assertFalse(r3.isNullAt(1))
+    val meta3 = r3.getStruct(1)
+    val vec3 = meta3.getSeq[Float](0)
+    assertTrue(vec3.forall(_ == 3.0f))
+    assertTrue(meta3.isNullAt(1), "key_3 label should be null")
+  }
+
+  /**
+   * Nested vector in a MOR table with upserts — verifies the FileGroupReader merge path
+   * handles nested vector conversion correctly.
+   */
+  @Test
+  def testNestedVectorMorUpsert(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("metadata", StructType(Seq(
+        StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta),
+        StructField("label", StringType, nullable = true)
+      )), nullable = false),
+      StructField("ts", LongType, nullable = false)
+    ))
+
+    val path = basePath + "/nested_mor"
+
+    // Initial insert
+    val data1 = (0 until 10).map { i =>
+      Row(s"key_$i", Row(Array.fill(4)(1.0f).toSeq, s"label_$i"), i.toLong)
+    }
+    writeHudiTable(createVectorDf(schema, data1), "nested_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts")
+
+    // Upsert: update first 5 rows with new vectors
+    val data2 = (0 until 5).map { i =>
+      Row(s"key_$i", Row(Array.fill(4)(2.0f).toSeq, s"updated_$i"), 100L + i)
+    }
+    writeHudiTable(createVectorDf(schema, data2), "nested_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts", mode = SaveMode.Append)
+
+    val readDf = readHudiTable(path)
+    assertEquals(10, readDf.count())
+
+    val rows = readDf.select("id", "metadata.embedding", "metadata.label").collect()
+      .map(r => r.getString(0) -> (r.getSeq[Float](1), r.getString(2))).toMap
+
+    // Updated rows should have value 2.0
+    for (i <- 0 until 5) {
+      val (vec, label) = rows(s"key_$i")
+      assertTrue(vec.forall(_ == 2.0f), s"key_$i should have 2.0, got ${vec.head}")
+      assertEquals(s"updated_$i", label)
+    }
+    // Non-updated rows should have value 1.0
+    for (i <- 5 until 10) {
+      val (vec, label) = rows(s"key_$i")
+      assertTrue(vec.forall(_ == 1.0f), s"key_$i should have 1.0, got ${vec.head}")
+      assertEquals(s"label_$i", label)
+    }
+  }
+
+  /**
+   * Mixed: top-level vector AND nested vector in the same table.
+   * Verifies recursion handles both levels correctly.
+   */
+  @Test
+  def testTopLevelAndNestedVectorTogether(): Unit = {
+    val vecMeta4 = vectorMetadata("VECTOR(4)")
+    val vecMeta2 = vectorMetadata("VECTOR(2)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("top_vec", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta4),
+      StructField("metadata", StructType(Seq(
+        StructField("nested_vec", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta2),
+        StructField("label", StringType, nullable = true)
+      )), nullable = false)
+    ))
+
+    val data = (0 until 5).map { i =>
+      Row(s"key_$i", Array.fill(4)(i.toFloat).toSeq, Row(Array.fill(2)(i.toFloat * 10).toSeq, s"label_$i"))
+    }
+
+    val path = basePath + "/mixed_level"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "mixed_level_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(5, readDf.count())
+
+    val rows = readDf.select("id", "top_vec", "metadata.nested_vec", "metadata.label").collect()
+      .map(r => r.getString(0) -> r).toMap
+
+    for (i <- 0 until 5) {
+      val row = rows(s"key_$i")
+      // Top-level vector
+      val topVec = row.getSeq[Float](1)
+      assertEquals(4, topVec.size)
+      assertTrue(topVec.forall(_ == i.toFloat), s"key_$i top_vec wrong")
+      // Nested vector
+      val nestedVec = row.getSeq[Float](2)
+      assertEquals(2, nestedVec.size)
+      assertTrue(nestedVec.forall(_ == i.toFloat * 10), s"key_$i nested_vec wrong")
+      assertEquals(s"label_$i", row.getString(3))
+    }
+  }
+
+  /**
+   * Array of vectors: each element in the array is a VECTOR(4).
+   * Metadata goes on the outer StructField; Hudi infers array-of-vectors from
+   * ArrayType(ArrayType(FloatType)) + hudi_type=VECTOR(4).
+   */
+  @Test
+  def testArrayOfVectors(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("embeddings", ArrayType(ArrayType(FloatType, containsNull = false), containsNull = true),
+        nullable = false, vecMeta)
+    ))
+
+    val data = (0 until 5).map { i =>
+      val vectors = (0 until 3).map { j =>
+        Array.fill(4)((i * 10 + j).toFloat).toSeq
+      }
+      Row(s"key_$i", vectors)
+    }
+
+    val path = basePath + "/array_of_vecs"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "array_of_vectors_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(5, readDf.count())
+
+    val rows = readDf.select("id", "embeddings").collect()
+      .map(r => r.getString(0) -> r.getSeq[Seq[Float]](1)).toMap
+
+    for (i <- 0 until 5) {
+      val vectors = rows(s"key_$i")
+      assertEquals(3, vectors.size, s"key_$i should have 3 vectors")
+      for (j <- 0 until 3) {
+        val vec = vectors(j)
+        assertEquals(4, vec.size, s"key_$i vector $j dimension wrong")
+        assertTrue(vec.forall(_ == (i * 10 + j).toFloat),
+          s"key_$i vector $j: expected ${(i * 10 + j).toFloat} but got ${vec.head}")
+      }
+    }
+  }
+
+  /**
+   * Map of vectors: map values are VECTOR(4).
+   * Metadata goes on the outer StructField; Hudi infers map-of-vectors from
+   * MapType(StringType, ArrayType(FloatType)) + hudi_type=VECTOR(4).
+   */
+  @Test
+  def testMapOfVectors(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("model_vecs", MapType(StringType, ArrayType(FloatType, containsNull = false), valueContainsNull = true),
+        nullable = false, vecMeta)
+    ))
+
+    val data = (0 until 5).map { i =>
+      val map = Map(
+        "model_a" -> Array.fill(4)(i.toFloat).toSeq,
+        "model_b" -> Array.fill(4)(i.toFloat * 10).toSeq
+      )
+      Row(s"key_$i", map)
+    }
+
+    val path = basePath + "/map_of_vecs"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "map_of_vectors_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(5, readDf.count())
+
+    val rows = readDf.select("id", "model_vecs").collect()
+      .map(r => r.getString(0) -> r.getMap[String, Seq[Float]](1)).toMap
+
+    for (i <- 0 until 5) {
+      val map = rows(s"key_$i")
+      assertEquals(2, map.size, s"key_$i should have 2 entries")
+      val vecA = map("model_a")
+      assertEquals(4, vecA.size)
+      assertTrue(vecA.forall(_ == i.toFloat), s"key_$i model_a wrong")
+      val vecB = map("model_b")
+      assertEquals(4, vecB.size)
+      assertTrue(vecB.forall(_ == i.toFloat * 10), s"key_$i model_b wrong")
+    }
+  }
+
+  /**
+   * Array of vectors with nulls: null array, array with null elements.
+   */
+  @Test
+  def testArrayOfVectorsWithNulls(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("embeddings", ArrayType(ArrayType(FloatType, containsNull = false), containsNull = false),
+        nullable = true, vecMeta)
+    ))
+
+    val data = Seq(
+      Row("key_0", Seq(Array.fill(4)(1.0f).toSeq, Array.fill(4)(2.0f).toSeq)),
+      Row("key_1", null),                                    // null array field
+      Row("key_2", Seq(Array.fill(4)(3.0f).toSeq))           // single-element array
+    )
+
+    val path = basePath + "/array_vecs_null"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "array_vecs_null_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(3, readDf.count())
+
+    val rows = readDf.select("id", "embeddings").collect()
+      .map(r => r.getString(0) -> r).toMap
+
+    // key_0: non-null array with 2 vectors
+    val r0 = rows("key_0")
+    assertFalse(r0.isNullAt(1))
+    val vecs0 = r0.getSeq[Seq[Float]](1)
+    assertEquals(2, vecs0.size)
+    assertTrue(vecs0(0).forall(_ == 1.0f))
+    assertTrue(vecs0(1).forall(_ == 2.0f))
+
+    // key_1: null array
+    assertTrue(rows("key_1").isNullAt(1), "key_1 embeddings should be null")
+
+    // key_2: single-element array
+    val r2 = rows("key_2")
+    assertFalse(r2.isNullAt(1))
+    val vecs2 = r2.getSeq[Seq[Float]](1)
+    assertEquals(1, vecs2.size)
+    assertTrue(vecs2(0).forall(_ == 3.0f))
+  }
+
+  /**
+   * Array of structs where each struct contains a vector.
+   * Tests recursion into ArrayType element StructType for detection, replacement, and conversion.
+   */
+  @Test
+  def testArrayOfStructsWithVector(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("items", ArrayType(StructType(Seq(
+        StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta),
+        StructField("label", StringType, nullable = true)
+      )), containsNull = false), nullable = false)
+    ))
+
+    val data = (0 until 5).map { i =>
+      val items = (0 until 3).map { j =>
+        Row(Array.fill(4)((i * 10 + j).toFloat).toSeq, s"item_${i}_$j")
+      }
+      Row(s"key_$i", items)
+    }
+
+    val path = basePath + "/array_struct_vec"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "array_struct_vec_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(5, readDf.count())
+
+    val rows = readDf.select("id", "items").collect()
+      .map(r => r.getString(0) -> r.getSeq[Row](1)).toMap
+
+    for (i <- 0 until 5) {
+      val items = rows(s"key_$i")
+      assertEquals(3, items.size, s"key_$i should have 3 items")
+      for (j <- 0 until 3) {
+        val item = items(j)
+        val vec = item.getSeq[Float](0)
+        assertEquals(4, vec.size)
+        assertTrue(vec.forall(_ == (i * 10 + j).toFloat),
+          s"key_$i item $j: expected ${(i * 10 + j).toFloat} but got ${vec.head}")
+        assertEquals(s"item_${i}_$j", item.getString(1))
+      }
+    }
+  }
+
+  /**
+   * Map with struct values containing a vector.
+   * Tests recursion into MapType value StructType for detection, replacement, and conversion.
+   */
+  @Test
+  def testMapOfStructsWithVector(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("models", MapType(StringType, StructType(Seq(
+        StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta),
+        StructField("score", DoubleType, nullable = true)
+      )), valueContainsNull = false), nullable = false)
+    ))
+
+    val data = (0 until 5).map { i =>
+      val map = Map(
+        "model_a" -> Row(Array.fill(4)(i.toFloat).toSeq, i.toDouble),
+        "model_b" -> Row(Array.fill(4)(i.toFloat * 10).toSeq, i.toDouble * 10)
+      )
+      Row(s"key_$i", map)
+    }
+
+    val path = basePath + "/map_struct_vec"
+    val df = createVectorDf(schema, data)
+    writeHudiTable(df, "map_struct_vec_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(5, readDf.count())
+
+    val rows = readDf.select("id", "models").collect()
+      .map(r => r.getString(0) -> r.getMap[String, Row](1)).toMap
+
+    for (i <- 0 until 5) {
+      val models = rows(s"key_$i")
+      assertEquals(2, models.size)
+      val a = models("model_a")
+      assertTrue(a.getSeq[Float](0).forall(_ == i.toFloat), s"key_$i model_a vec wrong")
+      assertEquals(i.toDouble, a.getDouble(1), 1e-9)
+      val b = models("model_b")
+      assertTrue(b.getSeq[Float](0).forall(_ == i.toFloat * 10), s"key_$i model_b vec wrong")
+    }
+  }
+
+  /**
+   * MOR bulk collect: collects ALL rows at once to verify the GenericInternalRow buffer
+   * is not reused across rows (which would cause all rows to have the same vector).
+   */
+  @Test
+  def testMorBulkCollectDistinctVectors(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta),
+      StructField("ts", LongType, nullable = false)
+    ))
+
+    val numRows = 20
+    val batch1 = (0 until numRows).map { i =>
+      Row(s"key_$i", Array.fill(4)(i.toFloat).toSeq, i.toLong)
+    }
+    writeHudiTable(createVectorDf(schema, batch1), "mor_bulk_test", basePath + "/mor_bulk",
+      tableType = "MERGE_ON_READ", precombineField = "ts")
+
+    // Upsert so FileGroupReader merge path is exercised
+    val batch2 = (0 until numRows / 2).map { i =>
+      Row(s"key_$i", Array.fill(4)(i.toFloat * 10).toSeq, i.toLong + 100)
+    }
+    writeHudiTable(createVectorDf(schema, batch2), "mor_bulk_test", basePath + "/mor_bulk",
+      tableType = "MERGE_ON_READ", precombineField = "ts", mode = SaveMode.Append)
+
+    // Collect ALL rows at once
+    val allRows = readHudiTable(basePath + "/mor_bulk")
+      .select("id", "embedding").collect()
+
+    assertEquals(numRows, allRows.length)
+    val rowMap = allRows.map(r => r.getString(0) -> r.getSeq[Float](1)).toMap
+
+    for (i <- 0 until numRows / 2) {
+      val vec = rowMap(s"key_$i")
+      assertTrue(vec.forall(_ == i.toFloat * 10),
+        s"key_$i: expected ${i.toFloat * 10} but got ${vec.head} (GenericInternalRow mutation?)")
+    }
+    for (i <- numRows / 2 until numRows) {
+      val vec = rowMap(s"key_$i")
+      assertTrue(vec.forall(_ == i.toFloat),
+        s"key_$i: expected ${i.toFloat} but got ${vec.head}")
+    }
+  }
+
+  /**
+   * (High) MOR table with array<VECTOR>: insert + upsert, verify merged result.
+   * Exercises the FileGroupReader merge path with array-of-vector conversion.
+   */
+  @Test
+  def testArrayOfVectorsMorUpsert(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("embeddings", ArrayType(ArrayType(FloatType, containsNull = false), containsNull = false),
+        nullable = false, vecMeta),
+      StructField("ts", LongType, nullable = false)
+    ))
+
+    val path = basePath + "/array_vec_mor"
+
+    // Insert: key_0..key_9, each with 2 vectors of value 1.0
+    val batch1 = (0 until 10).map { i =>
+      Row(s"key_$i", Seq(Array.fill(4)(1.0f).toSeq, Array.fill(4)(1.0f).toSeq), i.toLong)
+    }
+    writeHudiTable(createVectorDf(schema, batch1), "array_vec_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts")
+
+    // Upsert: update key_0..key_4 with value 2.0
+    val batch2 = (0 until 5).map { i =>
+      Row(s"key_$i", Seq(Array.fill(4)(2.0f).toSeq, Array.fill(4)(2.0f).toSeq), 100L + i)
+    }
+    writeHudiTable(createVectorDf(schema, batch2), "array_vec_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts", mode = SaveMode.Append)
+
+    val readDf = readHudiTable(path)
+    assertEquals(10, readDf.count())
+
+    val rows = readDf.select("id", "embeddings").collect()
+      .map(r => r.getString(0) -> r.getSeq[Seq[Float]](1)).toMap
+
+    // Updated rows should have value 2.0
+    for (i <- 0 until 5) {
+      val vecs = rows(s"key_$i")
+      assertEquals(2, vecs.size, s"key_$i should have 2 vectors")
+      assertTrue(vecs.forall(_.forall(_ == 2.0f)), s"key_$i vectors should be 2.0 after upsert")
+    }
+    // Non-updated rows should retain value 1.0
+    for (i <- 5 until 10) {
+      val vecs = rows(s"key_$i")
+      assertEquals(2, vecs.size, s"key_$i should have 2 vectors")
+      assertTrue(vecs.forall(_.forall(_ == 1.0f)), s"key_$i vectors should remain 1.0")
+    }
+  }
+
+  /**
+   * (Medium) array<struct<VECTOR>> with projection: select only embedding or only label.
+   * Verifies column pruning works for vectors inside structs inside arrays.
+   */
+  @Test
+  def testArrayOfStructsWithVectorProjection(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("items", ArrayType(StructType(Seq(
+        StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta),
+        StructField("label", StringType, nullable = true)
+      )), containsNull = false), nullable = false)
+    ))
+
+    val data = (0 until 5).map { i =>
+      Row(s"key_$i", Seq(
+        Row(Array.fill(4)(i.toFloat).toSeq, s"label_$i"),
+        Row(Array.fill(4)(i.toFloat * 2).toSeq, s"label_${i}_b")
+      ))
+    }
+
+    val path = basePath + "/array_struct_vec_proj"
+    writeHudiTable(createVectorDf(schema, data), "array_struct_proj_test", path)
+
+    // Read full items column and verify both vector and label fields are correct.
+    // Note: sub-field projection into array<struct<...>> (e.g. items.embedding) triggers
+    // a Hudi schema pruning limitation, so we read the full struct and extract fields here.
+    val rows = readHudiTable(path).select("id", "items").collect()
+      .map(r => r.getString(0) -> r.getSeq[Row](1)).toMap
+
+    for (i <- 0 until 5) {
+      val items = rows(s"key_$i")
+      assertEquals(2, items.size)
+
+      // Verify embedding (vector field)
+      val emb0 = items(0).getSeq[Float](0)
+      val emb1 = items(1).getSeq[Float](0)
+      assertEquals(4, emb0.size)
+      assertTrue(emb0.forall(_ == i.toFloat), s"key_$i first embedding wrong")
+      assertEquals(4, emb1.size)
+      assertTrue(emb1.forall(_ == i.toFloat * 2), s"key_$i second embedding wrong")
+
+      // Verify label (non-vector field alongside vector)
+      assertEquals(s"label_$i", items(0).getString(1))
+      assertEquals(s"label_${i}_b", items(1).getString(1))
+    }
+  }
+
+  /**
+   * (Medium) Empty array<VECTOR> and empty map<K, VECTOR>.
+   * Edge case for the iteration loop in convertVectorField.
+   */
+  @Test
+  def testEmptyArrayAndMapOfVectors(): Unit = {
+    val vecMetaArr = vectorMetadata("VECTOR(4)")
+    val vecMetaMap = vectorMetadata("VECTOR(4)")
+
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("arr_vecs", ArrayType(ArrayType(FloatType, containsNull = false), containsNull = false),
+        nullable = false, vecMetaArr),
+      StructField("map_vecs", MapType(StringType, ArrayType(FloatType, containsNull = false), valueContainsNull = false),
+        nullable = false, vecMetaMap)
+    ))
+
+    val data = Seq(
+      Row("key_0", Seq.empty, Map.empty[String, Seq[Float]]),  // both empty
+      Row("key_1", Seq(Array.fill(4)(1.0f).toSeq), Map("a" -> Array.fill(4)(2.0f).toSeq))  // non-empty
+    )
+
+    val path = basePath + "/empty_arr_map_vecs"
+    writeHudiTable(createVectorDf(schema, data), "empty_arr_map_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(2, readDf.count())
+
+    val rows = readDf.select("id", "arr_vecs", "map_vecs").collect()
+      .map(r => r.getString(0) -> r).toMap
+
+    // key_0: empty collections
+    val r0 = rows("key_0")
+    assertEquals(0, r0.getSeq[Seq[Float]](1).size, "key_0 arr_vecs should be empty")
+    assertEquals(0, r0.getMap[String, Seq[Float]](2).size, "key_0 map_vecs should be empty")
+
+    // key_1: non-empty collections with correct vectors
+    val r1 = rows("key_1")
+    val arrVecs = r1.getSeq[Seq[Float]](1)
+    assertEquals(1, arrVecs.size)
+    assertTrue(arrVecs(0).forall(_ == 1.0f))
+
+    val mapVecs = r1.getMap[String, Seq[Float]](2)
+    assertEquals(1, mapVecs.size)
+    assertTrue(mapVecs("a").forall(_ == 2.0f))
+  }
+
+  /**
+   * (Medium) array<VECTOR(4, DOUBLE)>: verifies DOUBLE element type works through
+   * the array-of-vector path end-to-end.
+   */
+  @Test
+  def testArrayOfDoubleVectors(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4, DOUBLE)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("embeddings", ArrayType(ArrayType(DoubleType, containsNull = false), containsNull = false),
+        nullable = false, vecMeta)
+    ))
+
+    val data = (0 until 5).map { i =>
+      Row(s"key_$i", Seq(
+        Array.fill(4)(i.toDouble).toSeq,
+        Array.fill(4)(i.toDouble * 0.5).toSeq
+      ))
+    }
+
+    val path = basePath + "/array_double_vecs"
+    writeHudiTable(createVectorDf(schema, data), "array_double_vec_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(5, readDf.count())
+
+    val rows = readDf.select("id", "embeddings").collect()
+      .map(r => r.getString(0) -> r.getSeq[Seq[Double]](1)).toMap
+
+    for (i <- 0 until 5) {
+      val vecs = rows(s"key_$i")
+      assertEquals(2, vecs.size)
+      assertTrue(vecs(0).forall(_ == i.toDouble), s"key_$i first vec wrong")
+      assertTrue(vecs(1).forall(_ == i.toDouble * 0.5), s"key_$i second vec wrong")
+    }
+  }
+
+  /**
+   * 3-level deep struct nesting: struct<a: struct<b: struct<embedding: VECTOR(4)>>>
+   * Verifies that unlimited struct depth recursion works correctly.
+   */
+  @Test
+  def testThreeLevelNestedVectorColumn(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("a", StructType(Seq(
+        StructField("b", StructType(Seq(
+          StructField("c", StructType(Seq(
+            StructField("embedding", ArrayType(FloatType, containsNull = false),
+              nullable = false, vecMeta),
+            StructField("label", StringType, nullable = true)
+          )), nullable = false)
+        )), nullable = false)
+      )), nullable = false)
+    ))
+
+    val data = (0 until 5).map { i =>
+      Row(s"key_$i", Row(Row(Row(Array.fill(4)(i.toFloat).toSeq, s"label_$i"))))
+    }
+
+    val path = basePath + "/three_level_nested"
+    writeHudiTable(createVectorDf(schema, data), "three_level_nested_test", path)
+
+    val readDf = readHudiTable(path)
+    assertEquals(5, readDf.count())
+
+    val rows = readDf.select("id", "a").collect()
+      .map(r => r.getString(0) -> r.getStruct(1)).toMap
+
+    for (i <- 0 until 5) {
+      val innerC = rows(s"key_$i").getStruct(0).getStruct(0)
+      val vec = innerC.getSeq[Float](0)
+      assertEquals(4, vec.size)
+      assertTrue(vec.forall(_ == i.toFloat), s"key_$i vector wrong at depth 3")
+      assertEquals(s"label_$i", innerC.getString(1))
+    }
+  }
+
+  /**
+   * Unsupported: array<array<VECTOR>> — should throw at write time rather than silently
+   * produce wrong data.
+   */
+  @Test
+  def testUnsupportedArrayOfArrayOfVectors(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    // DataType: ArrayType(ArrayType(ArrayType(FloatType))) with VECTOR metadata
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("embeddings",
+        ArrayType(ArrayType(ArrayType(FloatType, containsNull = false), containsNull = false),
+          containsNull = false),
+        nullable = false, vecMeta)
+    ))
+
+    val data = Seq(Row("key_0", Seq(Seq(Array.fill(4)(1.0f).toSeq))))
+    assertThrows(classOf[Exception], () =>
+      writeHudiTable(createVectorDf(schema, data), "unsupported_arr_arr_vec", basePath + "/arr_arr_vec"))
+  }
+
+  /**
+   * Unsupported: array<map<K, VECTOR>> — should throw at write time rather than silently
+   * produce wrong data.
+   */
+  @Test
+  def testUnsupportedArrayOfMapOfVectors(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    // DataType: ArrayType(MapType(StringType, ArrayType(FloatType))) with VECTOR metadata
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("embeddings",
+        ArrayType(MapType(StringType, ArrayType(FloatType, containsNull = false)),
+          containsNull = false),
+        nullable = false, vecMeta)
+    ))
+
+    val data = Seq(Row("key_0", Seq(Map("a" -> Array.fill(4)(1.0f).toSeq))))
+    assertThrows(classOf[Exception], () =>
+      writeHudiTable(createVectorDf(schema, data), "unsupported_arr_map_vec", basePath + "/arr_map_vec"))
+  }
+
+  /** MOR: map<K, VECTOR> insert + upsert, verify merged result. */
+  @Test
+  def testMapOfVectorsMorUpsert(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("model_vecs", MapType(StringType, ArrayType(FloatType, containsNull = false), valueContainsNull = false),
+        nullable = false, vecMeta),
+      StructField("ts", LongType, nullable = false)
+    ))
+    val path = basePath + "/map_vec_mor"
+
+    val batch1 = (0 until 10).map { i =>
+      Row(s"key_$i", Map("a" -> Array.fill(4)(1.0f).toSeq, "b" -> Array.fill(4)(1.0f).toSeq), i.toLong)
+    }
+    writeHudiTable(createVectorDf(schema, batch1), "map_vec_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts")
+
+    val batch2 = (0 until 5).map { i =>
+      Row(s"key_$i", Map("a" -> Array.fill(4)(2.0f).toSeq, "b" -> Array.fill(4)(2.0f).toSeq), 100L + i)
+    }
+    writeHudiTable(createVectorDf(schema, batch2), "map_vec_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts", mode = SaveMode.Append)
+
+    val readDf = readHudiTable(path)
+    assertEquals(10, readDf.count())
+
+    val rows = readDf.select("id", "model_vecs").collect()
+      .map(r => r.getString(0) -> r.getMap[String, Seq[Float]](1)).toMap
+
+    for (i <- 0 until 5) {
+      val m = rows(s"key_$i")
+      assertTrue(m("a").forall(_ == 2.0f), s"key_$i 'a' should be 2.0 after upsert")
+      assertTrue(m("b").forall(_ == 2.0f), s"key_$i 'b' should be 2.0 after upsert")
+    }
+    for (i <- 5 until 10) {
+      val m = rows(s"key_$i")
+      assertTrue(m("a").forall(_ == 1.0f), s"key_$i 'a' should remain 1.0")
+      assertTrue(m("b").forall(_ == 1.0f), s"key_$i 'b' should remain 1.0")
+    }
+  }
+
+  /** MOR: array<struct<embedding: VECTOR(4)>> insert + upsert, verify merged result. */
+  @Test
+  def testArrayOfStructsWithVectorMorUpsert(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("items", ArrayType(StructType(Seq(
+        StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta),
+        StructField("label", StringType, nullable = true)
+      )), containsNull = false), nullable = false),
+      StructField("ts", LongType, nullable = false)
+    ))
+    val path = basePath + "/arr_struct_vec_mor"
+
+    val batch1 = (0 until 10).map { i =>
+      Row(s"key_$i", Seq(Row(Array.fill(4)(1.0f).toSeq, s"orig_$i")), i.toLong)
+    }
+    writeHudiTable(createVectorDf(schema, batch1), "arr_struct_vec_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts")
+
+    val batch2 = (0 until 5).map { i =>
+      Row(s"key_$i", Seq(Row(Array.fill(4)(2.0f).toSeq, s"updated_$i")), 100L + i)
+    }
+    writeHudiTable(createVectorDf(schema, batch2), "arr_struct_vec_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts", mode = SaveMode.Append)
+
+    val readDf = readHudiTable(path)
+    assertEquals(10, readDf.count())
+
+    val rows = readDf.select("id", "items").collect()
+      .map(r => r.getString(0) -> r.getSeq[Row](1)).toMap
+
+    for (i <- 0 until 5) {
+      val items = rows(s"key_$i")
+      assertTrue(items(0).getSeq[Float](0).forall(_ == 2.0f), s"key_$i embedding should be 2.0")
+      assertEquals(s"updated_$i", items(0).getString(1))
+    }
+    for (i <- 5 until 10) {
+      val items = rows(s"key_$i")
+      assertTrue(items(0).getSeq[Float](0).forall(_ == 1.0f), s"key_$i embedding should remain 1.0")
+      assertEquals(s"orig_$i", items(0).getString(1))
+    }
+  }
+
+  /** MOR: map<K, struct<embedding: VECTOR(4)>> insert + upsert, verify merged result. */
+  @Test
+  def testMapOfStructsWithVectorMorUpsert(): Unit = {
+    val vecMeta = vectorMetadata("VECTOR(4)")
+    val schema = StructType(Seq(
+      StructField("id", StringType, nullable = false),
+      StructField("models", MapType(StringType, StructType(Seq(
+        StructField("embedding", ArrayType(FloatType, containsNull = false), nullable = false, vecMeta),
+        StructField("score", DoubleType, nullable = true)
+      )), valueContainsNull = false), nullable = false),
+      StructField("ts", LongType, nullable = false)
+    ))
+    val path = basePath + "/map_struct_vec_mor"
+
+    val batch1 = (0 until 10).map { i =>
+      Row(s"key_$i", Map("m1" -> Row(Array.fill(4)(1.0f).toSeq, 1.0)), i.toLong)
+    }
+    writeHudiTable(createVectorDf(schema, batch1), "map_struct_vec_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts")
+
+    val batch2 = (0 until 5).map { i =>
+      Row(s"key_$i", Map("m1" -> Row(Array.fill(4)(2.0f).toSeq, 2.0)), 100L + i)
+    }
+    writeHudiTable(createVectorDf(schema, batch2), "map_struct_vec_mor_test", path,
+      tableType = "MERGE_ON_READ", precombineField = "ts", mode = SaveMode.Append)
+
+    val readDf = readHudiTable(path)
+    assertEquals(10, readDf.count())
+
+    val rows = readDf.select("id", "models").collect()
+      .map(r => r.getString(0) -> r.getMap[String, Row](1)).toMap
+
+    for (i <- 0 until 5) {
+      val m1 = rows(s"key_$i")("m1")
+      assertTrue(m1.getSeq[Float](0).forall(_ == 2.0f), s"key_$i m1 embedding should be 2.0")
+      assertEquals(2.0, m1.getDouble(1), 1e-9)
+    }
+    for (i <- 5 until 10) {
+      val m1 = rows(s"key_$i")("m1")
+      assertTrue(m1.getSeq[Float](0).forall(_ == 1.0f), s"key_$i m1 embedding should remain 1.0")
+      assertEquals(1.0, m1.getDouble(1), 1e-9)
+    }
+  }
+
   private def assertArrayEquals(expected: Array[Byte], actual: Array[Byte], message: String): Unit = {
     assertEquals(expected.length, actual.length, s"$message: length mismatch")
     expected.zip(actual).zipWithIndex.foreach { case ((e, a), idx) =>
       assertEquals(e, a, s"$message: mismatch at index $idx")
     }
   }
+}
+
+object TestVectorDataSource {
+  def vectorElementTypeArgs(): Stream[Arguments] = Stream.of(
+    Arguments.of("VECTOR(128)",       FloatType,  128.asInstanceOf[AnyRef], "float_rt"),
+    Arguments.of("VECTOR(64, DOUBLE)", DoubleType, 64.asInstanceOf[AnyRef],  "double_rt"),
+    Arguments.of("VECTOR(256, INT8)",  ByteType,   256.asInstanceOf[AnyRef], "int8_rt")
+  )
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
                                         
  The initial VECTOR column support only allowed vectors as top-level     
  fields in a Hudi table.
  Users whose schemas naturally have vectors nested inside structs (e.g.  
  `metadata: STRUCT<embedding: VECTOR(128), label: STRING>`) or inside    
  arrays/maps had no                                                      
  supported path. This PR extends VECTOR support to arbitrary nesting     
  depths.                                                                 
                                         
### Summary and Changelog
                                         
  VECTOR columns can now be nested at any depth inside structs, and       
  directly wrapped in one                
  level of array or map container. The write path already handled nesting 
  correctly through                                                       
  recursive schema conversion; this PR fixes the read path to match.
                                                                          
  **Supported nesting patterns (new):**                                   
                                                                          
  | Pattern | Write | Read |                                              
  |---------|-------|------|             
  | `struct<VECTOR>` (unlimited struct depth) | ✓ | ✓ |                   
  | `array<VECTOR>` | ✓ | ✓ |                                             
  | `map<K, VECTOR>` | ✓ | ✓ |                                            
  | `array<struct<VECTOR>>` | ✓ | ✓ |                                     
  | `map<K, struct<VECTOR>>` | ✓ | ✓ |                                    
  | `array<array<VECTOR>>` | ✗ — `UnsupportedOperationException` at write 
  | — |                                                                   
                                                                          
  **User experience — nested struct:**                                    
  ```                           
  val vecMeta = new MetadataBuilder().putString("hudi_type",              
  "VECTOR(128)").build()                                                  
  StructField("metadata", StructType(Seq(                                 
    StructField("embedding", ArrayType(FloatType), nullable = false,      
  metadata = vecMeta),                                                    
    StructField("label", StringType)                                      
  )))                                                                     
                                                                          
  User experience — array of vectors:                                     
  // hudi_type goes on the outer StructField; Hudi infers array-of-vectors
   from                                                                   
  // ArrayType(ArrayType(FloatType)) + hudi_type=VECTOR(128)              
  StructField("embeddings", ArrayType(ArrayType(FloatType)), nullable =
  false, metadata = vecMeta)  
```                                            

Detailed changelog
                                                                          
  VectorConversionUtils.java                                              
  - hasVectorColumns(HoodieSchema) /                                      
  hasVectorColumnsFromMetadata(StructType): made recursive — walks into   
  RECORD, ARRAY element, MAP value at any depth                        
  - hasVectorColumnsInDataType: new helper that recurses into any DataType
  - replaceVectorColumnsWithBinary(StructType): now recurses into nested  
  StructType, ArrayType element, MapType value via                        
  replaceNestedVectorColumns                                              
  - replaceDirectVectorType: validates supported patterns and throws      
  UnsupportedOperationException with a clear message for anything else    
  - convertRowVectorColumns refactored into convertVectorField +          
  convertContainerField:                                        
    - convertVectorField: handles direct, array-of-vectors, map-of-vectors
   (fields with VECTOR metadata)                                          
    - convertContainerField: handles struct, array-of-struct,             
  map-of-struct via innerStructType() helper                 
  - convertStructElements: extracts duplicated per-element iteration into 
  one helper                                                             
                                                                          
  HoodieSparkSchemaConverters.scala      
  - toSqlTypeHelper ARRAY/MAP cases: propagate element/value metadata so  
  hudi_type=VECTOR(...) reaches the outer StructField                     
  - toHoodieType: added pattern matches for array<VECTOR> and map<K,      
  VECTOR>; rejects array<array<VECTOR>> with HoodieSchemaException        
                                                                          
  HoodieSchema.java
  - buildVectorColumnsMetadataValue: recurses into RECORD (name.field),   
  ARRAY (name[]), MAP (name{}) for complete footer metadata coverage      
                                                                          
  HoodieParquetFileFormatHelper.scala                                     
  - rewriteFixedLenByteArrayToBinary: made recursive via rewriteFields —  
  handles FIXED_LEN_BYTE_ARRAY inside nested Parquet GroupType (Spark 3.3 
  compatibility)                                                          
                                                                          
  SparkFileFormatInternalRowReaderContext.scala / 
  HoodieFileGroupReaderBasedFileFormat.scala                              
  - Updated to use recursive detection/replacement; output schema derived
  internally by swapping BinaryType → ArrayType at any nesting depth      
                                                                    
  Tests (TestVectorDataSource.scala)                                      
  - testDeeplyNestedVectorColumn, testThreeLevelNestedVectorColumn: struct
   depth 2 and 3                                                          
  - testNestedVectorWithProjection, testNestedVectorWithNulls: projection 
  and null handling                                                       
  - testNestedVectorMorUpsert: MOR with struct<VECTOR>                    
  - testTopLevelAndNestedVectorTogether: top-level and nested in same
  table                                                                   
  - testArrayOfVectors / testMapOfVectors (COW) +                         
  testArrayOfVectorsMorUpsert / testMapOfVectorsMorUpsert (MOR)           
  - testArrayOfStructsWithVector / testMapOfStructsWithVector (COW) + MOR 
  variants                                                               
  - testArrayOfVectorsWithNulls, testEmptyArrayAndMapOfVectors,           
  testArrayOfDoubleVectors                                     
  - testUnsupportedArrayOfArrayOfVectors /                                
  testUnsupportedArrayOfMapOfVectors: verify clear exceptions
                                                                          
### Impact
                                                                          
  New capability only — tables without VECTOR columns are unaffected, and 
  top-level VECTOR columns work exactly as before. The array<VECTOR>
  pattern requires hudi_type=VECTOR(128) metadata on the outer            
  StructField; Hudi infers the shape from ArrayType(ArrayType(FloatType))
  + metadata. Vectorized reading remains disabled for tables with VECTOR
  columns (no change).

### Risk Level

  Low. Read-path changes only activate when VECTOR metadata is present.   
  The two-group dispatch in convertRowVectorColumns makes ordering
  explicit and non-fragile. Unsupported nesting patterns                  
  (array<array<VECTOR>>, etc.) fail fast at write time with a clear error
  instead of silently producing corrupt data.

  - 20+ tests covering all supported nesting patterns for both COW and MOR
  - UnsupportedOperationException thrown eagerly at write time for
  unsupported patterns                                                    
  - Spark 3.3 recursion fix verified by code review
                                                                          
### Documentation Update
                                                                          
  None beyond the base VECTOR PR. No new config keys. The nested struct   
  pattern follows naturally from the existing hudi_type metadata
  convention.                                                             
                                         
### Contributor's checklist
   
  - Read through https://hudi.apache.org/contribute/how-to-contribute     
  - Enough context is provided in the sections above
  - Adequate tests were added if applicable              