### PR TITLE
fix: increase confluent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <pulsar.spark.version>${pulsar.spark.scala12.version}</pulsar.spark.version>
     <pulsar.spark.scala12.version>3.1.1.4</pulsar.spark.scala12.version>
     <pulsar.spark.scala13.version>3.4.1.1</pulsar.spark.scala13.version>
-    <confluent.version>5.5.0</confluent.version>
+    <confluent.version>7.5.1</confluent.version>
     <glassfish.version>2.17</glassfish.version>
     <glassfish.el.version>3.0.1-b12</glassfish.el.version>
     <parquet.version>1.13.1</parquet.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Some Hudi users uses confluent schema registry service whose dependency like kafka-avro-serializer is 6.x or 7.x, which causes Hudi schema registry client failed to deserialize their schemas since metadata field is unexpected.
Therefore, we should upgrade corresponding confluent version accordingly.

### Summary and Changelog

Upgrade confluent version to 7.5.1.

### Impact

Reduce the error when parsing schema from confluent schema registry.

### Risk Level

Low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
