### PR TITLE
fix(common): FutureUtils:allOf should always throw root cause exception

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FutureUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FutureUtils.java
@@ -53,6 +53,8 @@ public class FutureUtils {
       future.whenComplete((ignored, throwable) -> {
         if (throwable != null) {
           firstFailure.compareAndSet(null, throwable);
+          // Note that {@link CompletableFuture#cancel} does not interrupt the other underlying tasks;
+          // it only marks their futures as cancelled. The tasks will still run to completion.
           futures.forEach(f -> f.cancel(true));
         }
       });

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestFutureUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestFutureUtils.java
@@ -79,17 +79,21 @@ public class TestFutureUtils {
     try {
       CountDownLatch allStarted = new CountDownLatch(3);
 
-      CompletableFuture<String> f1 = CompletableFuture.supplyAsync(() -> {
+      CompletableFuture<String> f1 = new CompletableFuture<>();
+      CompletableFuture<String> f2 = new CompletableFuture<>();
+      CompletableFuture<String> f3 = new CompletableFuture<>();
+
+      executor.submit(() -> {
         allStarted.countDown();
         try {
           allStarted.await(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }
-        throw new CompletionException(originalCause);
-      }, executor);
-
-      CompletableFuture<String> f2 = CompletableFuture.supplyAsync(() -> {
+        f1.completeExceptionally(originalCause);
+        return null;
+      });
+      executor.submit(() -> {
         allStarted.countDown();
         try {
           allStarted.await(5, TimeUnit.SECONDS);
@@ -97,10 +101,10 @@ public class TestFutureUtils {
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }
-        return "b";
-      }, executor);
-
-      CompletableFuture<String> f3 = CompletableFuture.supplyAsync(() -> {
+        f2.complete("b");
+        return null;
+      });
+      executor.submit(() -> {
         allStarted.countDown();
         try {
           allStarted.await(5, TimeUnit.SECONDS);
@@ -108,8 +112,9 @@ public class TestFutureUtils {
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }
-        return "c";
-      }, executor);
+        f3.complete("c");
+        return null;
+      });
 
       CompletableFuture<List<String>> result = FutureUtils.allOf(Arrays.asList(f1, f2, f3));
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`FutureUtils.allOf()` has a race condition that causes the original root-cause exception to be silently replaced by a `CancellationException`, making it impossible to diagnose failures in any code path that uses it — most notably [`MultipleSparkJobExecutionStrategy.performClustering()`](https://github.com/apache/hudi/blob/master/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java#L111-L128), which executes clustering groups in parallel using `FutureUtils.allOf()`.

**The bug:** In the [`whenComplete` callback](https://github.com/apache/hudi/blob/master/hudi-common/src/main/java/org/apache/hudi/common/util/FutureUtils.java#L50-L55), when a future fails, [`cancel(true)`](https://github.com/apache/hudi/blob/master/hudi-common/src/main/java/org/apache/hudi/common/util/FutureUtils.java#L52) is called on all other futures *before* [`union.completeExceptionally(throwable)`](https://github.com/apache/hudi/blob/master/hudi-common/src/main/java/org/apache/hudi/common/util/FutureUtils.java#L53). Since [`CompletableFuture.cancel()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html#cancel(boolean)) is equivalent to `completeExceptionally(new CancellationException())`, it synchronously completes the cancelled futures and triggers their `whenComplete` callbacks on the same thread. Those callbacks see the `CancellationException` as their throwable and call `union.completeExceptionally(CancellationException)` — which succeeds because `union` has not been completed yet. When execution returns to the original callback and reaches `union.completeExceptionally(originalException)`, it is a no-op because [`completeExceptionally`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html#completeExceptionally(java.lang.Throwable)) can only succeed once.


Additionally, the internal [`BiRelay`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html#allOf(java.util.concurrent.CompletableFuture...)) tree inside [`CompletableFuture.allOf()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html#allOf(java.util.concurrent.CompletableFuture...)) also detects the cancelled futures and may independently complete `union` with `CancellationException`, creating a three-way race.

**Example:** Suppose clustering has 3 groups running in parallel. Group 1 fails with `IOException` (e.g., transient DFS error). The `whenComplete` callback for Group 1 fires and calls `cancel()` on Groups 2 and 3. Group 2's cancellation triggers its own `whenComplete` callback, which calls `union.completeExceptionally(CancellationException)` — this succeeds. When Group 1's callback then calls `union.completeExceptionally(IOException)`, it's a no-op. The caller at `.join()` sees only `CompletionException: CancellationException` with no indication of the real failure.

### Summary and Changelog

- Atomically capture the first failure using an `AtomicReference<Throwable>` via `compareAndSet`, which is immune to callback ordering
- Replace `union.thenApply()` with `union.handle()` to intercept both success and failure paths, substituting the real first failure from the `AtomicReference` over whatever exception the `allOf` BiRelay propagated
- Remove the now-unnecessary `union.completeExceptionally()` call
- Added `TestFutureUtils` with tests for: all-succeed, single-failure-preserves-exception-and-cancels-others, and concurrent failure scenario

### Impact

Any code path using `FutureUtils.allOf()` will now correctly propagate the original root-cause exception instead of a misleading `CancellationException`. The primary user-facing impact is in clustering execution (`MultipleSparkJobExecutionStrategy`), where failures will now produce actionable error messages instead of opaque `CancellationException`s.

No public API changes.

### Risk Level

low — The change is limited to `FutureUtils.allOf()` and preserves the same behavioral contract (fail-fast with cancellation of remaining futures). The only difference is which exception is propagated. Unit tests are added to verify correctness.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
