### PR TITLE
feat: Add option to skip invalid JSON records in HoodieStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieStreamerConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/HoodieStreamerConfig.java
@@ -140,6 +140,15 @@ public class HoodieStreamerConfig extends HoodieConfig {
       .sinceVersion("0.15.0")
       .withDocumentation("When enabled, the dataframe generated from reading source data is wrapped with an exception handler to explicitly surface exceptions.");
 
+  public static final ConfigProperty<Boolean> SKIP_INVALID_JSON_RECORDS = ConfigProperty
+      .key(STREAMER_CONFIG_PREFIX + "source.json.skip.invalid.records")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("When enabled, invalid JSON records that fail deserialization are "
+          + "skipped instead of causing the pipeline to crash. Skipped records are logged "
+          + "at WARN level. This is a lightweight alternative to the error table for handling bad records.");
+
   public static final ConfigProperty<Boolean> SCHEMA_MAKE_COLUMNS_NULLABLE = ConfigProperty
       .key(STREAMER_CONFIG_PREFIX + "schema.make.columns.nullable")
       .defaultValue(false)

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SourceFormatAdapter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SourceFormatAdapter.java
@@ -54,9 +54,14 @@ import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import scala.util.Either;
@@ -64,6 +69,7 @@ import scala.util.Either;
 import static org.apache.hudi.utilities.config.HoodieStreamerConfig.ROW_THROW_EXPLICIT_EXCEPTIONS;
 import static org.apache.hudi.utilities.config.HoodieStreamerConfig.SANITIZE_SCHEMA_FIELD_NAMES;
 import static org.apache.hudi.utilities.config.HoodieStreamerConfig.SCHEMA_FIELD_NAME_INVALID_CHAR_MASK;
+import static org.apache.hudi.utilities.config.HoodieStreamerConfig.SKIP_INVALID_JSON_RECORDS;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_NAMESPACE;
 import static org.apache.hudi.utilities.schema.RowBasedSchemaProvider.HOODIE_RECORD_STRUCT_NAME;
 import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABLE_CURRUPT_RECORD_COL_NAME;
@@ -73,8 +79,11 @@ import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABL
  */
 public class SourceFormatAdapter implements Closeable {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SourceFormatAdapter.class);
+
   private final Source source;
   private boolean shouldSanitize = SANITIZE_SCHEMA_FIELD_NAMES.defaultValue();
+  private boolean skipInvalidJsonRecords = false;
 
   private  boolean wrapWithException = ROW_THROW_EXPLICIT_EXCEPTIONS.defaultValue();
   private String invalidCharMask = SCHEMA_FIELD_NAME_INVALID_CHAR_MASK.defaultValue();
@@ -95,6 +104,7 @@ public class SourceFormatAdapter implements Closeable {
       this.shouldSanitize = SanitizationUtils.shouldSanitize(props.get());
       this.invalidCharMask = SanitizationUtils.getInvalidCharMask(props.get());
       this.wrapWithException = ConfigUtils.getBooleanWithAltKeys(props.get(), ROW_THROW_EXPLICIT_EXCEPTIONS);
+      this.skipInvalidJsonRecords = ConfigUtils.getBooleanWithAltKeys(props.get(), SKIP_INVALID_JSON_RECORDS);
       this.useJava8api = (boolean) getSource().getSparkSession().conf().get(SQLConf.DATETIME_JAVA8API_ENABLED());
     }
     if (this.shouldSanitize && source.getSourceType() == Source.SourceType.PROTO) {
@@ -136,6 +146,21 @@ public class SourceFormatAdapter implements Closeable {
         errorTableWriter.get().addErrorEvents(javaRDD.filter(x -> x.isRight()).map(x ->
             new ErrorEvent<>(x.right().get(), ErrorEvent.ErrorReason.JSON_AVRO_DESERIALIZATION_FAILURE)));
         return javaRDD.filter(x -> x.isLeft()).map(x -> x.left().get());
+      } else if (skipInvalidJsonRecords) {
+        return rdd.map(convertor::fromJsonWithError).mapPartitions(iter -> {
+          List<GenericRecord> results = new ArrayList<>();
+          while (iter.hasNext()) {
+            Either<GenericRecord, String> either = iter.next();
+            if (either.isLeft()) {
+              results.add(either.left().get());
+            } else {
+              String badRecord = either.right().get();
+              LOG.warn("Skipping invalid JSON record during Avro conversion: {}",
+                  badRecord.length() > 1000 ? badRecord.substring(0, 1000) + "...[truncated]" : badRecord);
+            }
+          }
+          return results.iterator();
+        });
       } else {
         return rdd.map(convertor::fromJson);
       }
@@ -151,6 +176,21 @@ public class SourceFormatAdapter implements Closeable {
         errorTableWriter.get().addErrorEvents(javaRDD.filter(Either::isRight).map(x ->
             new ErrorEvent<>(x.right().get(), ErrorEvent.ErrorReason.JSON_ROW_DESERIALIZATION_FAILURE)));
         return javaRDD.filter(Either::isLeft).map(x -> x.left().get());
+      } else if (skipInvalidJsonRecords) {
+        return rdd.map(convertor::fromJsonToRowWithError).mapPartitions(iter -> {
+          List<Row> results = new ArrayList<>();
+          while (iter.hasNext()) {
+            Either<Row, String> either = iter.next();
+            if (either.isLeft()) {
+              results.add(either.left().get());
+            } else {
+              String badRecord = either.right().get();
+              LOG.warn("Skipping invalid JSON record during Row conversion: {}",
+                  badRecord.length() > 1000 ? badRecord.substring(0, 1000) + "...[truncated]" : badRecord);
+            }
+          }
+          return results.iterator();
+        });
       } else {
         return rdd.map(convertor::fromJson);
       }
@@ -293,6 +333,24 @@ public class SourceFormatAdapter implements Closeable {
           return new InputBatch<>(
               eventsDataset,
               r.getCheckpointForNextBatch(), r.getSchemaProvider());
+        } else if (skipInvalidJsonRecords) {
+          String corruptCol = "_corrupt_record";
+          StructType dataType = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(sourceSchema)
+              .add(new StructField(corruptCol, DataTypes.StringType, true, Metadata.empty()));
+          StructType nullableStruct = dataType.asNullable();
+          Option<Dataset<Row>> dataset = r.getBatch().map(rdd -> {
+            Dataset<Row> df = source.getSparkSession().read()
+                .option("columnNameOfCorruptRecord", corruptCol)
+                .schema(nullableStruct)
+                .option("mode", "PERMISSIVE")
+                .json(rdd);
+            long corruptCount = df.filter(new Column(corruptCol).isNotNull()).count();
+            if (corruptCount > 0) {
+              LOG.warn("Skipping {} invalid JSON record(s) during Row format ingestion", corruptCount);
+            }
+            return df.filter(new Column(corruptCol).isNull()).drop(corruptCol);
+          });
+          return new InputBatch<>(dataset, r.getCheckpointForNextBatch(), r.getSchemaProvider());
         } else {
           StructType dataType = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(sourceSchema);
           return new InputBatch<>(

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonKafkaSource.java
@@ -463,6 +463,64 @@ public class TestJsonKafkaSource extends BaseTestKafkaSource {
   }
 
   @Test
+  public void testSkipInvalidJsonRecordsInAvroFormat() {
+    final String topic = TEST_TOPIC_PREFIX + "testSkipInvalidJsonRecordsInAvroFormat";
+
+    testUtils.createTopic(topic, 2);
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+    testUtils.sendMessages(topic, jsonifyRecords(dataGenerator.generateInsertsAsPerSchema("000", 1000,
+        HoodieTestDataGenerator.SHORT_TRIP_SCHEMA)));
+    testUtils.sendMessages(topic, new String[] {"error_event1", "error_event2"});
+
+    TypedProperties props = createPropsForKafkaSource(topic, null, "earliest");
+    props.put(ENABLE_KAFKA_COMMIT_OFFSET.key(), "true");
+    props.put(HoodieStreamerConfig.SKIP_INVALID_JSON_RECORDS.key(), "true");
+
+    Source jsonSource = new JsonKafkaSource(props, jsc(), spark(), schemaProvider, metrics);
+    SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, Option.empty(), Option.of(props));
+    InputBatch<JavaRDD<GenericRecord>> fetch1 = kafkaSource.fetchNewDataInAvroFormat(Option.empty(), Long.MAX_VALUE);
+    assertEquals(1000, fetch1.getBatch().get().count());
+  }
+
+  @Test
+  public void testSkipInvalidJsonRecordsInRowFormat() {
+    final String topic = TEST_TOPIC_PREFIX + "testSkipInvalidJsonRecordsInRowFormat";
+
+    testUtils.createTopic(topic, 2);
+    sendJsonSafeMessagesToKafka(topic, 1000, 2);
+    testUtils.sendMessages(topic, new String[] {"error_event1", "error_event2"});
+
+    TypedProperties props = createPropsForKafkaSource(topic, null, "earliest");
+    props.put(ENABLE_KAFKA_COMMIT_OFFSET.key(), "true");
+    props.put(HoodieStreamerConfig.SKIP_INVALID_JSON_RECORDS.key(), "true");
+
+    Source jsonSource = new JsonKafkaSource(props, jsc(), spark(), schemaProvider, metrics);
+    SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, Option.empty(), Option.of(props));
+    InputBatch<Dataset<Row>> fetch1 = kafkaSource.fetchNewDataInRowFormat(Option.empty(), Long.MAX_VALUE);
+    assertEquals(1000, fetch1.getBatch().get().count());
+  }
+
+  @Test
+  public void testDefaultBehaviorCrashesOnInvalidJson() {
+    final String topic = TEST_TOPIC_PREFIX + "testDefaultBehaviorCrashesOnInvalidJson";
+
+    testUtils.createTopic(topic, 2);
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
+    testUtils.sendMessages(topic, jsonifyRecords(dataGenerator.generateInsertsAsPerSchema("000", 10,
+        HoodieTestDataGenerator.SHORT_TRIP_SCHEMA)));
+    testUtils.sendMessages(topic, new String[] {"error_event1"});
+
+    TypedProperties props = createPropsForKafkaSource(topic, null, "earliest");
+    props.put(ENABLE_KAFKA_COMMIT_OFFSET.key(), "true");
+
+    Source jsonSource = new JsonKafkaSource(props, jsc(), spark(), schemaProvider, metrics);
+    SourceFormatAdapter kafkaSource = new SourceFormatAdapter(jsonSource, Option.empty(), Option.of(props));
+    InputBatch<JavaRDD<GenericRecord>> fetch1 = kafkaSource.fetchNewDataInAvroFormat(Option.empty(), Long.MAX_VALUE);
+    // Without skip config, counting records should throw due to invalid JSON
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> fetch1.getBatch().get().count());
+  }
+
+  @Test
   public void testAppendKafkaOffset() {
     final String topic = TEST_TOPIC_PREFIX + "testKafkaOffsetAppend";
     int numPartitions = 2;


### PR DESCRIPTION

### Describe the issue this Pull Request addresses

Closes #15942

When HoodieStreamer is configured to ingest JSON records, a single invalid record (e.g., plain text instead of valid JSON) causes the entire pipeline to crash with a `HoodieJsonToAvroConversionException`. The only existing workaround is configuring the full error table infrastructure, which is heavyweight for users who simply want to skip bad records and continue processing.

### Summary and Changelog

Adds a new config `hoodie.streamer.source.json.skip.invalid.records` (default `false`) that allows HoodieStreamer to skip invalid JSON records instead of crashing. When enabled, bad records are logged at WARN level and dropped. This reuses the existing safe conversion methods (`fromJsonWithError`, `fromJsonToRowWithError`) that were previously only available when the error table was configured.

- Added `SKIP_INVALID_JSON_RECORDS` config property to `HoodieStreamerConfig`
- Modified `SourceFormatAdapter.transformJsonToGenericRdd()` to skip bad records during Avro conversion when config is enabled
- Modified `SourceFormatAdapter.transformJsonToRowRdd()` to skip bad records during Row conversion when config is enabled
- Modified `SourceFormatAdapter.fetchNewDataInRowFormat()` to use Spark's PERMISSIVE mode to skip corrupt records in the Spark JSON read path when config is enabled
- Added 3 tests: skip in Avro format, skip in Row format, and default crash behavior preserved

### Impact

New user facing config: `hoodie.streamer.source.json.skip.invalid.records`
- Default: `false` (no behavior change for existing users)
- When `true`: invalid JSON records are skipped with WARN-level logging instead of crashing the pipeline

No breaking changes. No public API changes. No performance impact for users who do not enable the config.

### Risk Level

Low. The feature is opt in and default behavior is unchanged. 

### Documentation Update

None, will open another PR to update the documentation if the current PR is merged

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
