### PR TITLE
fix: JDBC connection leak in HiveIncrementalPuller.saveDelta()

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -178,9 +178,8 @@ public class HiveIncrementalPuller {
         }
       } catch (SQLException e) {
         LOG.error("Could not close the JDBC connection", e);
-      } finally {
-        this.connection = null;
       }
+      this.connection = null;
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -174,9 +174,8 @@ public class HiveIncrementalPuller {
         LOG.error("Could not close the resultSet opened ", e);
       }
       try {
-        Connection toClose = (conn != null) ? conn : this.connection;
-        if (toClose != null) {
-          toClose.close();
+        if (this.connection != null) {
+          this.connection.close();
         }
       } catch (SQLException e) {
         LOG.error("Could not close the JDBC connection", e);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -131,6 +131,7 @@ public class HiveIncrementalPuller {
     conf.set("fs.defaultFS",config.fsDefaultFs);
     FileSystem fs = FileSystem.get(conf);
     Statement stmt = null;
+    Connection conn = null;
     try {
       if (config.fromCommitTime == null) {
         config.fromCommitTime = inferCommitTime(fs);
@@ -145,7 +146,7 @@ public class HiveIncrementalPuller {
         lastCommitTime = config.fromCommitTime;
       }
 
-      Connection conn = getConnection();
+      conn = getConnection();
       stmt = conn.createStatement();
       // drop the temp table if exists
       String tempDbTable = config.tmpDb + "." + config.targetTable + "__" + config.sourceTable;
@@ -166,11 +167,21 @@ public class HiveIncrementalPuller {
       throw new IOException("Could not scan " + config.sourceTable + " incrementally", e);
     } finally {
       try {
-        if (stmt != null) {
+        if (stmt != null)  {
           stmt.close();
         }
       } catch (SQLException e) {
         LOG.error("Could not close the resultSet opened ", e);
+      }
+      try {
+        if (conn != null) {
+          conn.close();
+        }
+      } catch (SQLException e) {
+        LOG.error("Could not close the JDBC connection", e);
+      } finally {
+        this.connection = null;
+      }
       }
     }
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -167,15 +167,16 @@ public class HiveIncrementalPuller {
       throw new IOException("Could not scan " + config.sourceTable + " incrementally", e);
     } finally {
       try {
-        if (stmt != null)  {
+        if (stmt != null) {
           stmt.close();
         }
       } catch (SQLException e) {
         LOG.error("Could not close the resultSet opened ", e);
       }
       try {
-        if (conn != null) {
-          conn.close();
+        Connection toClose = (conn != null) ? conn : this.connection;
+        if (toClose != null) {
+          toClose.close();
         }
       } catch (SQLException e) {
         LOG.error("Could not close the JDBC connection", e);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -146,7 +146,7 @@ public class HiveIncrementalPuller {
       }
 
       getConnection();
-      stmt = this.connection.createStatement();
+      stmt = getConnection().createStatement();
       // drop the temp table if exists
       String tempDbTable = config.tmpDb + "." + config.targetTable + "__" + config.sourceTable;
       String tempDbTablePath =

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -145,7 +145,6 @@ public class HiveIncrementalPuller {
         lastCommitTime = config.fromCommitTime;
       }
 
-      getConnection();
       stmt = getConnection().createStatement();
       // drop the temp table if exists
       String tempDbTable = config.tmpDb + "." + config.targetTable + "__" + config.sourceTable;
@@ -178,8 +177,9 @@ public class HiveIncrementalPuller {
         }
       } catch (SQLException e) {
         LOG.error("Could not close the JDBC connection", e);
+      } finally {
+        this.connection = null;
       }
-      this.connection = null;
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -182,7 +182,6 @@ public class HiveIncrementalPuller {
       } finally {
         this.connection = null;
       }
-      }
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -131,7 +131,6 @@ public class HiveIncrementalPuller {
     conf.set("fs.defaultFS",config.fsDefaultFs);
     FileSystem fs = FileSystem.get(conf);
     Statement stmt = null;
-    Connection conn = null;
     try {
       if (config.fromCommitTime == null) {
         config.fromCommitTime = inferCommitTime(fs);
@@ -146,8 +145,8 @@ public class HiveIncrementalPuller {
         lastCommitTime = config.fromCommitTime;
       }
 
-      conn = getConnection();
-      stmt = conn.createStatement();
+      getConnection();
+      stmt = this.connection.createStatement();
       // drop the temp table if exists
       String tempDbTable = config.tmpDb + "." + config.targetTable + "__" + config.sourceTable;
       String tempDbTablePath =


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

In `HiveIncrementalPuller.saveDelta()`, a JDBC `Connection` object obtained via `getConnection()` was never closed. The variable was declared inside the `try` block, making it inaccessible in the `finally` block where only the `Statement` was being closed.

This causes a JDBC connection leak every time `saveDelta()` is called.

### Summary and Changelog

Fixed a JDBC connection leak in `HiveIncrementalPuller.saveDelta()` by ensuring the `Connection` is always closed in the `finally` block.

- Hoisted `Connection conn` declaration to before the `try` block (initialized to `null`) so it is accessible in `finally`
- Moved `conn = getConnection()` assignment inside the `try` block
- Added a dedicated `try/catch` in `finally` to close `conn` after closing `stmt`, consistent with the existing pattern for `Statement` cleanup

### Impact

No public API or user-facing change. Prevents JDBC connection exhaustion in long-running incremental pull jobs.

### Risk Level

low — Only affects resource cleanup in the `finally` block; no functional logic changed.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable