### PR TITLE
[MINOR] Optimisation for using supportBatch in Spark34LegacyHoodiePar…

### DIFF
--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark34LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark34LegacyHoodieParquetFileFormat.scala
@@ -161,7 +161,7 @@ class Spark34LegacyHoodieParquetFileFormat(private val shouldAppendPartitionValu
     val resultSchema = StructType(partitionSchema.fields ++ requiredSchema.fields)
     val sqlConf = sparkSession.sessionState.conf
     val enableOffHeapColumnVector = sqlConf.offHeapColumnVectorEnabled
-    val enableVectorizedReader: Boolean = supportsColumnar(sparkSession, resultSchema)
+    val enableVectorizedReader: Boolean = supportBatch(sparkSession, resultSchema)
     val enableRecordFilter: Boolean = sqlConf.parquetRecordFilterEnabled
     val timestampConversion: Boolean = sqlConf.isParquetINT96TimestampConversion
     val capacity = sqlConf.parquetVectorizedReaderBatchSize


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

PR adds a minor optimisation for using supportBatch instead of supportsColumnar for determining vectorized parquet reader is used or not. The optimisation exists in Spark34LegacyHoodieParquetFileFormat and keeps the logic at par with what is used in 0.14.2 as well. Without this optimisation, the vectorized parquet reader is disabled if schema has more than 500 fields.
The PR maintains the original behaviour as existed in 0.15.0 and keeps the changes limited to logical repair for PR 17601 wrt Spark 3.4 legacy parquet file format

### Summary and Changelog

The PR maintains the original behaviour as existed in 0.15.0 and keeps the changes limited to logical repair for PR 17601 wrt Spark 3.4 legacy parquet file format

### Impact

NA

### Risk Level

Low

### Documentation Update

NA

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
