### PR TITLE
fix(packaging): restore protobuf shade relocation in utilities bundles

### DIFF
--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -177,6 +177,10 @@
                   <pattern>org.apache.spark.sql.avro.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.spark.sql.avro.</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.google.protobuf.</pattern>
+                  <shadedPattern>org.apache.hudi.com.google.protobuf.</shadedPattern>
+                </relocation>
 
                 <relocation>
                   <pattern>com.beust.jcommander.</pattern>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -175,6 +175,10 @@
                   <shadedPattern>org.apache.hudi.org.apache.spark.sql.avro.</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>com.google.protobuf.</pattern>
+                  <shadedPattern>org.apache.hudi.com.google.protobuf.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>com.yammer.metrics.</pattern>
                   <shadedPattern>org.apache.hudi.com.yammer.metrics.</shadedPattern>
                 </relocation>

--- a/packaging/hudi-utilities-slim-bundle/pom.xml
+++ b/packaging/hudi-utilities-slim-bundle/pom.xml
@@ -123,6 +123,10 @@
                   <shadedPattern>org.apache.hudi.org.apache.spark.sql.avro.</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>com.google.protobuf.</pattern>
+                  <shadedPattern>org.apache.hudi.com.google.protobuf.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>com.beust.jcommander.</pattern>
                   <shadedPattern>org.apache.hudi.com.beust.jcommander.</shadedPattern>
                 </relocation>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18242

The `hudi-utilities-bundle`, `hudi-utilities-slim-bundle`, and `hudi-integ-test-bundle` include `com.google.protobuf:protobuf-java` in their shade plugin artifact sets but lack a shade relocation rule, causing 735+ unshaded `com.google.protobuf.*` classes to leak into the bundle JAR. When users have Protobuf-derived Avro schemas with nested records whose Avro namespace matches `com.google.protobuf` (e.g., `google.protobuf.Timestamp`), parquet-avro's `SpecificData` resolves the Avro record name to the actual Protobuf class via `Class.forName()`. Since the Protobuf class does not implement `IndexedRecord`, a `ClassCastException` is thrown during merge operations.

### Summary and Changelog

Added the missing `com.google.protobuf` -> `org.apache.hudi.com.google.protobuf` shade relocation rule to three bundle pom.xml files:

- `packaging/hudi-utilities-bundle/pom.xml`
- `packaging/hudi-utilities-slim-bundle/pom.xml`
- `packaging/hudi-integ-test-bundle/pom.xml`

This matches the existing pattern already used in `hudi-presto-bundle`, `hudi-kafka-connect-bundle`, and `hudi-trino-bundle`. With the relocation in place, `Class.forName("com.google.protobuf.Timestamp")` fails gracefully (since the class is now at `org.apache.hudi.com.google.protobuf.Timestamp`), and parquet-avro falls back to `GenericData.Record` as expected.

### Impact

- Fixes `ClassCastException` during merge when using Protobuf-derived Avro schemas that contain fields with `com.google.protobuf` namespace (e.g., `google.protobuf.Timestamp`, `google.protobuf.Duration`)
- No API changes
- No behavioral changes for users who do not have Protobuf-namespace Avro schemas

### Risk Level

Low. The relocation was previously present (confirmed working in 1.0.2) and follows the established pattern already used in three other bundles.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable