### PR TITLE
Fix BufferedReader resource leak in InputStreamConsumer

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/InputStreamConsumer.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/InputStreamConsumer.java
@@ -39,7 +39,7 @@ public class InputStreamConsumer extends Thread {
   @Override
   public void run() {
     try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
-             BufferedReader br = new BufferedReader(isr)) {)
+             BufferedReader br = new BufferedReader(isr)) {
       br.lines().forEach(log::info);
     } catch (Exception e) {
       log.warn("Error consuming input stream", e);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
### Problem

`InputStreamConsumer.run()` creates an `InputStreamReader` and `BufferedReader` inside a plain `try` block. If an exception occurs during `br.lines().forEach(...)`, neither reader is closed, causing a resource leak.

### Solution

Convert the plain `try` block to a try-with-resources statement that declares both `InputStreamReader` and `BufferedReader` as managed resources, ensuring they are automatically closed on both normal and exceptional exit.

### Changes

- `hudi-cli/src/main/java/org/apache/hudi/cli/utils/InputStreamConsumer.java`: Wrap `InputStreamReader` and `BufferedReader` construction in a try-with-resources statement in the `run()` method.
<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
