### PR TITLE
fix: Fix BufferedReader resource leak in FileIOUtils.readAsUTFStringLines

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
@@ -97,6 +97,8 @@ public class FileIOUtils {
     try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             return bufferedReader.lines().collect(Collectors.toList());
         } catch (IOException e) {
+          // Note: stream errors from lines().collect(...) surface as UncheckedIOException and bypass this block.
+          // This catch handles IOException from close() during try-with-resources teardown.
             throw new RuntimeException(e);
         }
     }

--- a/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
@@ -43,7 +43,6 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -95,13 +94,13 @@ public class FileIOUtils {
    */
   public static List<String> readAsUTFStringLines(InputStream input) {
     try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
-            return bufferedReader.lines().collect(Collectors.toList());
-        } catch (IOException e) {
-          // Note: stream errors from lines().collect(...) surface as UncheckedIOException and bypass this block.
-          // This catch handles IOException from close() during try-with-resources teardown.
-            throw new RuntimeException(e);
-        }
+      return bufferedReader.lines().collect(Collectors.toList());
+    } catch (IOException e) {
+      // Note: stream errors from lines().collect(...) surface as UncheckedIOException and bypass this block.
+      // This catch handles IOException from close() during try-with-resources teardown.
+      throw new RuntimeException(e);
     }
+  }
 
   public static void copy(InputStream inputStream, OutputStream outputStream) throws IOException {
     byte[] buffer = new byte[1024];

--- a/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
@@ -94,11 +94,12 @@ public class FileIOUtils {
    * @return String lines in a list.
    */
   public static List<String> readAsUTFStringLines(InputStream input) {
-    List<String> lines = new ArrayList<>();
-    BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
-    lines = bufferedReader.lines().collect(Collectors.toList());
-    closeQuietly(bufferedReader);
-    return lines;
+    try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+            return bufferedReader.lines().collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
   }
 
   public static void copy(InputStream inputStream, OutputStream outputStream) throws IOException {

--- a/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/util/FileIOUtils.java
@@ -102,7 +102,6 @@ public class FileIOUtils {
             throw new RuntimeException(e);
         }
     }
-  }
 
   public static void copy(InputStream inputStream, OutputStream outputStream) throws IOException {
     byte[] buffer = new byte[1024];


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`FileIOUtils.readAsUTFStringLines` creates a `BufferedReader` but relies on a manual `closeQuietly` call placed after `bufferedReader.lines().collect()`. If `collect()` throws an exception, the `closeQuietly` line is never reached, leaving the `BufferedReader` open — a resource leak.

### Summary and Changelog

Replace manual resource management with try-with-resources in `FileIOUtils.readAsUTFStringLines`, guaranteeing the `BufferedReader` is closed on both normal and exceptional exit paths.

* Replace manual `closeQuietly` call with try-with-resources
* Add `IOException` catch block that wraps and rethrows as `RuntimeException`
* Remove unused `java.util.ArrayList` import

### Impact

No user-facing or API change. Method signature and return type are unchanged. Behaviour under normal execution is identical.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
