### PR TITLE
fix: Enhance hudi-azure-bundle

### DIFF
--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -142,7 +142,6 @@
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>META-INF/services/javax.*</exclude>
                     <exclude>**/*.proto</exclude>
-                    <exclude>hbase-webapps/**</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -6,9 +6,9 @@
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
- 
+
        http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -77,8 +77,13 @@
                   <!-- Azure SDK -->
                   <include>com.azure:*</include>
                   <include>com.microsoft.azure:*</include>
+                  <!-- Azure identity deps -->
+                  <include>com.nimbusds:*</include>
+                  <include>net.minidev:*</include>
+                  <!-- Reactor -->
                   <include>io.projectreactor:*</include>
-                  <include>io.netty:*</include>
+                  <include>io.projectreactor.netty:*</include>
+                  <include>org.reactivestreams:reactive-streams</include>
 
                   <!-- Utils -->
                   <include>io.dropwizard.metrics:metrics-core</include>
@@ -116,6 +121,7 @@
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>META-INF/services/javax.*</exclude>
                     <exclude>**/*.proto</exclude>
+                    <exclude>hbase-webapps/**</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -128,6 +134,9 @@
     <resources>
       <resource>
         <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/test/resources</directory>
       </resource>
     </resources>
   </build>
@@ -174,6 +183,13 @@
       <version>${parquet.version}</version>
       <scope>compile</scope>
     </dependency>
+
+    <!-- Avro -->
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>
-

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -155,9 +155,6 @@
       <resource>
         <directory>src/main/resources</directory>
       </resource>
-      <resource>
-        <directory>src/test/resources</directory>
-      </resource>
     </resources>
   </build>
 

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -84,6 +84,9 @@
                   <include>io.projectreactor:*</include>
                   <include>io.projectreactor.netty:*</include>
                   <include>org.reactivestreams:reactive-streams</include>
+                  <!-- Netty: bundled and shaded together with reactor-netty to avoid
+                       version conflicts with Spark's Netty on the classpath -->
+                  <include>io.netty:*</include>
 
                   <!-- Utils -->
                   <include>io.dropwizard.metrics:metrics-core</include>
@@ -109,6 +112,24 @@
                 <relocation>
                   <pattern>org.openjdk.jol.</pattern>
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
+                </relocation>
+                <!-- Shade Netty, Reactor, and Reactive Streams to avoid classpath
+                     conflicts with Spark's bundled Netty -->
+                <relocation>
+                  <pattern>io.netty.</pattern>
+                  <shadedPattern>org.apache.hudi.io.netty.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.projectreactor.</pattern>
+                  <shadedPattern>org.apache.hudi.io.projectreactor.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>reactor.</pattern>
+                  <shadedPattern>org.apache.hudi.reactor.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.reactivestreams.</pattern>
+                  <shadedPattern>org.apache.hudi.org.reactivestreams.</shadedPattern>
                 </relocation>
               </relocations>
               <createDependencyReducedPom>false</createDependencyReducedPom>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/18471

When running Hudi Spark jobs on Azure (ADLS Gen2), the Azure Storage SDK's Netty and Reactor dependencies conflict with Spark's bundled Netty, causing runtime `NoSuchMethodError` and `StacklessClosedChannelException` during lock acquisition. Specifically, `reactor-netty-http` calls `HttpClientCodec.<init>(HttpDecoderConfig, boolean, boolean)` — a constructor that only exists in Netty 4.1.94+ — but Spark's older Netty `HttpClientCodec` is loaded instead. This makes the Azure-based `StorageBasedLockProvider` (added in #17951) unusable in Spark environments.

Additionally, `hudi-azure-bundle` as it stands on master does not include reactor-netty, the Azure identity transitive deps, or Netty/Reactor relocations, so users still have to manage those jars manually on the Spark classpath.

### Summary and Changelog

This PR is purely additive on top of master's existing `hudi-azure-bundle` skeleton. All changes are in `packaging/hudi-azure-bundle/pom.xml`:

- **Includes added to the shaded jar**:
  - `com.nimbusds:*` and `net.minidev:*` — Azure identity transitive deps required for `DefaultAzureCredential` and related auth providers.
  - `io.projectreactor.netty:*` — the actual reactor-netty HTTP client used by the Azure SDK.
  - `org.reactivestreams:reactive-streams` — required by Reactor.
- **Shading relocations added** to isolate Netty/Reactor from Spark's classpath:
  - `io.netty.*` → `org.apache.hudi.io.netty.*`
  - `io.projectreactor.*` → `org.apache.hudi.io.projectreactor.*`
  - `reactor.*` → `org.apache.hudi.reactor.*`
  - `org.reactivestreams.*` → `org.apache.hudi.org.reactivestreams.*`
- **Avro compile dependency added** so the bundle resolves Avro classes referenced by Hudi APIs without relying on the host classpath.
- Minor: two whitespace fixes in the license header.

Note: this PR was rebased onto current master. The original `AzureStorageLockClient` commits were dropped because master already has an implementation of that class via #17951; this PR now contains only the bundle module additions.

### Impact

- Enables Hudi's `StorageBasedLockProvider` to work reliably on Azure/ADLS Gen2 in Spark environments.
- Eliminates the need to manually place `reactor-netty`, `reactor-core`, `reactive-streams`, and `netty-resolver-dns` jars on the Spark classpath — everything is self-contained and relocated in the bundle.
- No impact on existing AWS or GCP bundles — reactor-netty is only included in the Azure bundle.

### Risk Level

Low

- This PR only modifies `packaging/hudi-azure-bundle/pom.xml`; no source changes.
- Shading Netty with relocation is a well-established pattern (used by HBase, gRPC, Snowflake, and DataHub in this same codebase).
- One area to monitor: Netty native transports (epoll/kqueue) reference class names via JNI — however, Azure SDK's HTTP client uses reactor-netty over NIO, so relocated Netty classes function correctly.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable