### PR TITLE
fix: Update hudi-azure-bundle dependencies

### DIFF
--- a/hudi-azure/src/main/java/org/apache/hudi/azure/transaction/lock/AzureStorageLockClient.java
+++ b/hudi-azure/src/main/java/org/apache/hudi/azure/transaction/lock/AzureStorageLockClient.java
@@ -1,0 +1,364 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.
+ * See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.apache.hudi.azure.transaction.lock;
+
+import org.apache.hudi.azure.utils.AzureStorageUtils;
+import org.apache.hudi.azure.utils.AzureStorageUtils.AzureStorageUriComponents;
+import org.apache.hudi.client.transaction.lock.StorageLockClient;
+import org.apache.hudi.client.transaction.lock.models.LockGetResult;
+import org.apache.hudi.client.transaction.lock.models.LockUpsertResult;
+import org.apache.hudi.client.transaction.lock.models.StorageLockData;
+import org.apache.hudi.client.transaction.lock.models.StorageLockFile;
+import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.StorageBasedLockConfig;
+
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
+import com.azure.core.util.HttpClientOptions;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobDownloadContentResponse;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.BlockBlobItem;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.azure.storage.common.policy.RetryPolicyType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Properties;
+
+/**
+ * Azure Blob Storage-based distributed lock client using ETag checks.
+ * Supports both WASB(S) and ABFS(S) URI schemes for Azure Data Lake Storage Gen2.
+ *
+ * <p>Authentication is handled automatically via DefaultAzureCredential which supports:
+ * <ul>
+ *   <li>Managed Identity (Azure VMs, App Service, Container Instances, AKS)</li>
+ *   <li>Workload Identity (Kubernetes service accounts)</li>
+ *   <li>Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)</li>
+ *   <li>Azure CLI credentials (for local development)</li>
+ *   <li>VS Code, IntelliJ, and Azure PowerShell credentials</li>
+ * </ul>
+ *
+ * <p>No configuration is required when running on Azure infrastructure.
+ * See RFC: <a href="https://github.com/apache/hudi/blob/master/rfc/rfc-91/rfc-91.md">RFC-91</a>
+ */
+@ThreadSafe
+public class AzureStorageLockClient implements StorageLockClient {
+  private static final Logger LOG = LoggerFactory.getLogger(AzureStorageLockClient.class);
+  private static final int PRECONDITION_FAILURE_ERROR_CODE = 412;
+  private static final int NOT_FOUND_ERROR_CODE = 404;
+  private static final int CONFLICT_ERROR_CODE = 409;
+  private static final int RATE_LIMIT_ERROR_CODE = 429;
+  private static final int INTERNAL_SERVER_ERROR_CODE_MIN = 500;
+
+  private final Logger logger;
+  private final BlobClient blobClient;
+  private final String containerName;
+  private final String blobPath;
+  private final String ownerId;
+
+  /**
+   * Constructor that is used by reflection to instantiate an Azure-based storage locking client.
+   *
+   * @param ownerId     The owner id.
+   * @param lockFileUri The full table base path where the lock will be written.
+   * @param props       The properties for the lock config, can be used to customize client.
+   */
+  public AzureStorageLockClient(String ownerId, String lockFileUri, Properties props) {
+    this(ownerId, lockFileUri, props, createDefaultBlobClient(), LOG);
+  }
+
+  @VisibleForTesting
+  AzureStorageLockClient(String ownerId, String lockFileUri, Properties props,
+                         Functions.Function2<String, Properties, BlobClient> blobClientSupplier,
+                         Logger logger) {
+    AzureStorageUriComponents uriComponents = AzureStorageUtils.parseAzureUri(lockFileUri);
+    this.containerName = uriComponents.containerName;
+    this.blobPath = uriComponents.blobPath;
+
+    this.blobClient = blobClientSupplier.apply(lockFileUri, props);
+    this.ownerId = ownerId;
+    this.logger = logger;
+  }
+
+  @Override
+  public Pair<LockGetResult, Option<StorageLockFile>> readCurrentLockFile() {
+    try {
+      BlobDownloadContentResponse response = blobClient.downloadContentWithResponse(
+          null,
+          null,
+          null,
+          Context.NONE
+      );
+
+      // Get ETag from response headers
+      String eTag = response.getHeaders().getValue("ETag");
+      if (eTag != null) {
+        // Azure returns ETags wrapped in quotes, remove them
+        eTag = eTag.replaceAll("^\"|\"$", "");
+      }
+
+      byte[] content = response.getValue().toBytes();
+      ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
+
+      return Pair.of(LockGetResult.SUCCESS,
+          Option.of(StorageLockFile.createFromStream(inputStream, eTag)));
+    } catch (BlobStorageException e) {
+      int status = e.getStatusCode();
+      LockGetResult result = LockGetResult.UNKNOWN_ERROR;
+
+      if (status == NOT_FOUND_ERROR_CODE || e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+        logger.info("OwnerId: {}, Blob not found: {}", ownerId, blobPath);
+        result = LockGetResult.NOT_EXISTS;
+      } else if (status == CONFLICT_ERROR_CODE) {
+        logger.info("OwnerId: {}, Conflicting operation has occurred: {}", ownerId, blobPath);
+      } else if (status == RATE_LIMIT_ERROR_CODE) {
+        logger.warn("OwnerId: {}, Rate limit exceeded: {}", ownerId, blobPath);
+      } else if (status >= INTERNAL_SERVER_ERROR_CODE_MIN) {
+        logger.warn("OwnerId: {}, Azure internal server error: {}", ownerId, blobPath, e);
+      } else {
+        throw e;
+      }
+      return Pair.of(result, Option.empty());
+    }
+  }
+
+  @Override
+  public Pair<LockUpsertResult, Option<StorageLockFile>> tryUpsertLockFile(
+      StorageLockData newLockData, Option<StorageLockFile> previousLockFile) {
+    boolean isLockRenewal = previousLockFile.isPresent();
+    String currentEtag = isLockRenewal ? previousLockFile.get().getVersionId() : null;
+
+    try {
+      StorageLockFile updated = createOrUpdateLockFileInternal(newLockData, currentEtag);
+      return Pair.of(LockUpsertResult.SUCCESS, Option.of(updated));
+    } catch (BlobStorageException e) {
+      LockUpsertResult result = handleUpsertBlobStorageException(e);
+      return Pair.of(result, Option.empty());
+    } catch (HttpResponseException e) {
+      logger.error("OwnerId: {}, Unexpected Azure SDK error while writing lock file: {}",
+          ownerId, blobPath, e);
+      if (!isLockRenewal) {
+        // We should always throw errors early when we are creating the lock file.
+        // This is likely indicative of a larger issue that should bubble up sooner.
+        throw e;
+      }
+      return Pair.of(LockUpsertResult.UNKNOWN_ERROR, Option.empty());
+    }
+  }
+
+  /**
+   * Internal helper to create or update the lock file with optional ETag precondition.
+   */
+  private StorageLockFile createOrUpdateLockFileInternal(StorageLockData lockData, String expectedEtag) {
+    byte[] bytes = StorageLockFile.toByteArray(lockData);
+    BinaryData binaryData = BinaryData.fromBytes(bytes);
+    BlobRequestConditions requestConditions = new BlobRequestConditions();
+
+    // ETag-based constraints:
+    // - If expectedEtag is not null:
+    //    We assume that the blob already exists with the ETag "expectedEtag".
+    //    The update operation will include an ifMatch(expectedEtag) condition, meaning the update will only
+    //    succeed if the current blob's ETag exactly matches expectedEtag.
+    //    If the actual ETag of the blob differs from expectedEtag, the update attempt will fail.
+    // - If expectedEtag is null:
+    //    We assume that the blob does not currently exist.
+    //    The operation will use ifNoneMatch("*"), which instructs Azure to create the blob only if it doesn't already exist.
+    //    If a blob with the same name is present (i.e., there is an existing ETag), the creation attempt will fail.
+    if (expectedEtag == null) {
+      requestConditions.setIfNoneMatch("*");
+    } else {
+      requestConditions.setIfMatch(expectedEtag);
+    }
+
+    BlobParallelUploadOptions options = new BlobParallelUploadOptions(binaryData)
+        .setRequestConditions(requestConditions);
+
+    Response<BlockBlobItem> response = blobClient.uploadWithResponse(options, null, Context.NONE);
+    String newEtag = response.getValue().getETag();
+
+    return new StorageLockFile(lockData, newEtag);
+  }
+
+  private LockUpsertResult handleUpsertBlobStorageException(BlobStorageException e) {
+    int status = e.getStatusCode();
+
+    // Both conditions check for HTTP 412 Precondition Failed
+    // status == 412: Numeric HTTP status code
+    // errorCode == CONDITION_NOT_MET: Azure's semantic error code for the same condition
+    // We check both for robustness across different SDK versions and error scenarios
+    if (status == PRECONDITION_FAILURE_ERROR_CODE
+        || e.getErrorCode() == BlobErrorCode.CONDITION_NOT_MET) {
+      logger.info("OwnerId: {}, Lock file modified by another process: {}", ownerId, blobPath);
+      return LockUpsertResult.ACQUIRED_BY_OTHERS;
+    } else if (status == CONFLICT_ERROR_CODE) {
+      logger.info("OwnerId: {}, Retriable conditional request conflict error: {}", ownerId, blobPath);
+    } else if (status == RATE_LIMIT_ERROR_CODE) {
+      logger.warn("OwnerId: {}, Rate limit exceeded for: {}", ownerId, blobPath);
+    } else if (status >= INTERNAL_SERVER_ERROR_CODE_MIN) {
+      logger.warn("OwnerId: {}, Internal server error for: {}", ownerId, blobPath, e);
+    } else {
+      logger.warn("OwnerId: {}, Error writing lock file: {}", ownerId, blobPath, e);
+    }
+
+    return LockUpsertResult.UNKNOWN_ERROR;
+  }
+
+  private static Functions.Function2<String, Properties, BlobClient> createDefaultBlobClient() {
+    return (lockFileUri, props) -> {
+      AzureStorageUriComponents uriComponents = AzureStorageUtils.parseAzureUri(lockFileUri);
+
+      URI uri = URI.create(lockFileUri);
+      String scheme = uri.getScheme();
+
+      // Always use the Blob endpoint (blob.core.windows.net) since BlobServiceClient uses the
+      // Blob Storage REST API. The DFS endpoint (dfs.core.windows.net) uses a different API
+      // (Data Lake Storage Gen2) with different required headers, causing MissingRequiredHeader
+      // errors on Put Blob operations.
+      String endpoint = String.format("https://%s.blob.core.windows.net", uriComponents.accountName);
+
+      // Configure timeout options based on lock validity timeout
+      // Set all request timeouts to be 1/5 of the default validity.
+      // Each call to acquire a lock requires 2 requests.
+      // Each renewal requires 1 request.
+      long validityTimeoutSecs = ((Number) props.getOrDefault(
+          StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(),
+          StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.defaultValue()
+      )).longValue();
+      long azureCallTimeoutSecs = validityTimeoutSecs / 5;
+
+      // Disable retries for lock operations - retries can cause deadlocks and unpredictable timing
+      // Lock operations should fail fast to allow higher-level retry logic to handle conflicts
+      RequestRetryOptions retryOptions = new RequestRetryOptions(
+          RetryPolicyType.EXPONENTIAL,
+          1,                                      // maxTries - 1 means no retries (try once only)
+          (int) azureCallTimeoutSecs,            // tryTimeout - max time per HTTP request attempt (seconds)
+          null,                                   // retryDelay - not used with maxTries=1
+          null,                                   // maxRetryDelay - not used with maxTries=1
+          null                                    // secondaryHost - not using secondary regions
+      );
+
+      // Configure HTTP client timeouts
+      HttpClientOptions clientOptions = new HttpClientOptions()
+          .responseTimeout(Duration.ofSeconds(azureCallTimeoutSecs))
+          .readTimeout(Duration.ofSeconds(azureCallTimeoutSecs));
+
+      // Use DefaultAzureCredential for automatic authentication
+      // This supports: Managed Identity, Workload Identity, Environment Variables,
+      // Azure CLI, VS Code, IntelliJ, and Azure PowerShell credentials
+      BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+          .endpoint(endpoint)
+          .credential(new DefaultAzureCredentialBuilder().build())
+          .retryOptions(retryOptions)
+          .clientOptions(clientOptions)
+          .buildClient();
+
+      BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(uriComponents.containerName);
+      return containerClient.getBlobClient(uriComponents.blobPath);
+    };
+  }
+
+  @Override
+  public Option<String> readObject(String filePath, boolean checkExistsFirst) {
+    try {
+      AzureStorageUriComponents uriComponents = AzureStorageUtils.parseAzureUri(filePath);
+
+      // Validate that the container name matches the lock client's container
+      ValidationUtils.checkArgument(
+          uriComponents.containerName.equals(this.containerName),
+          String.format("Container name mismatch: expected '%s' but got '%s' in path '%s'",
+              this.containerName, uriComponents.containerName, filePath));
+
+      BlobClient client = blobClient.getContainerClient()
+          .getBlobClient(uriComponents.blobPath);
+
+      if (checkExistsFirst) {
+        // Note: client.exists() returns false for missing blobs without throwing an exception
+        // No need to catch BlobStorageException with NOT_FOUND here
+        if (!client.exists()) {
+          logger.debug("JSON config file not found: {}", filePath);
+          return Option.empty();
+        }
+      }
+
+      String content = client.downloadContent().toString();
+      return Option.of(content);
+    } catch (BlobStorageException e) {
+      // Handle NOT_FOUND errors when checkExistsFirst is false
+      if (e.getStatusCode() == NOT_FOUND_ERROR_CODE
+          || e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+        logger.debug("JSON config file not found: {}", filePath);
+      } else {
+        logger.error("Error reading JSON config file: {}", filePath, e);
+      }
+      return Option.empty();
+    } catch (Exception e) {
+      logger.error("Error reading JSON config file: {}", filePath, e);
+      return Option.empty();
+    }
+  }
+
+  @Override
+  public boolean writeObject(String filePath, String content) {
+    try {
+      AzureStorageUriComponents uriComponents = AzureStorageUtils.parseAzureUri(filePath);
+
+      // Validate that the container name matches the lock client's container
+      ValidationUtils.checkArgument(
+          uriComponents.containerName.equals(this.containerName),
+          String.format("Container name mismatch: expected '%s' but got '%s' in path '%s'",
+              this.containerName, uriComponents.containerName, filePath));
+
+      BlobClient client = blobClient.getContainerClient()
+          .getBlobClient(uriComponents.blobPath);
+
+      client.upload(BinaryData.fromString(content), true);
+
+      logger.debug("Successfully wrote object to: {}", filePath);
+      return true;
+    } catch (Exception e) {
+      logger.error("Error writing object to: {}", filePath, e);
+      return false;
+    }
+  }
+
+  @Override
+  public void close() {
+    // BlobClient doesn't require explicit cleanup
+  }
+}

--- a/hudi-azure/src/main/java/org/apache/hudi/azure/transaction/lock/AzureStorageLockClient.java
+++ b/hudi-azure/src/main/java/org/apache/hudi/azure/transaction/lock/AzureStorageLockClient.java
@@ -48,7 +48,6 @@ import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.BlockBlobItem;
-import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.azure.storage.common.policy.RequestRetryOptions;
 import com.azure.storage.common.policy.RetryPolicyType;
 import org.slf4j.Logger;
@@ -206,10 +205,13 @@ public class AzureStorageLockClient implements StorageLockClient {
       requestConditions.setIfMatch(expectedEtag);
     }
 
-    BlobParallelUploadOptions options = new BlobParallelUploadOptions(binaryData)
-        .setRequestConditions(requestConditions);
-
-    Response<BlockBlobItem> response = blobClient.uploadWithResponse(options, null, Context.NONE);
+    // Use BlockBlobClient.uploadWithResponse directly instead of BlobClient.uploadWithResponse
+    // with BlobParallelUploadOptions. The parallel upload path in azure-storage-blob:12.14.0
+    // may not set required headers (x-ms-blob-type) correctly for small payloads.
+    long contentLength = bytes.length;
+    Response<BlockBlobItem> response = blobClient.getBlockBlobClient().uploadWithResponse(
+        binaryData.toStream(), contentLength, null, null, null, null,
+        requestConditions, null, Context.NONE);
     String newEtag = response.getValue().getETag();
 
     return new StorageLockFile(lockData, newEtag);

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -106,6 +106,25 @@
                                     <pattern>org.openjdk.jol.</pattern>
                                     <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
                                 </relocation>
+                                <!-- Shade Azure SDK classes so they don't collide with other Azure
+                                     SDK versions on the classpath (e.g., azure-security-keyvault-secrets
+                                     which may pull a different azure-core version). -->
+                                <relocation>
+                                    <pattern>com.azure.</pattern>
+                                    <shadedPattern>org.apache.hudi.com.azure.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.microsoft.azure.</pattern>
+                                    <shadedPattern>org.apache.hudi.com.microsoft.azure.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.nimbusds.</pattern>
+                                    <shadedPattern>org.apache.hudi.com.nimbusds.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.minidev.</pattern>
+                                    <shadedPattern>org.apache.hudi.net.minidev.</shadedPattern>
+                                </relocation>
                                 <!-- Shade Netty, Reactor, and Reactive Streams to avoid classpath
                                      conflicts with Spark's bundled Netty -->
                                 <relocation>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -84,13 +84,10 @@
                                     <include>com.microsoft.azure:*</include>
                                     <include>com.nimbusds:*</include>
                                     <include>net.minidev:*</include>
-                                    <!-- Reactor -->
-                                    <include>io.projectreactor:*</include>
-                                    <include>io.projectreactor.netty:*</include>
-                                    <include>org.reactivestreams:reactive-streams</include>
-                                    <!-- Netty: bundled and shaded together with reactor-netty to avoid
-                                         version conflicts with Spark's Netty on the classpath -->
-                                    <include>io.netty:*</include>
+                                    <!-- Reactor, Netty, and Reactive Streams are NOT bundled.
+                                         They are provided at runtime via Dockerfile jars and Spark's classpath.
+                                         Shading Netty causes JNI native transport failures; instead we
+                                         control the exact versions externally. -->
                                     <!-- Misc -->
                                     <include>com.beust:jcommander</include>
                                     <include>commons-io:commons-io</include>
@@ -125,24 +122,9 @@
                                     <pattern>net.minidev.</pattern>
                                     <shadedPattern>org.apache.hudi.net.minidev.</shadedPattern>
                                 </relocation>
-                                <!-- Shade Netty, Reactor, and Reactive Streams to avoid classpath
-                                     conflicts with Spark's bundled Netty -->
-                                <relocation>
-                                    <pattern>io.netty.</pattern>
-                                    <shadedPattern>org.apache.hudi.io.netty.</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>io.projectreactor.</pattern>
-                                    <shadedPattern>org.apache.hudi.io.projectreactor.</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>reactor.</pattern>
-                                    <shadedPattern>org.apache.hudi.reactor.</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.reactivestreams.</pattern>
-                                    <shadedPattern>org.apache.hudi.org.reactivestreams.</shadedPattern>
-                                </relocation>
+                                <!-- Netty, Reactor, and Reactive Streams are NOT shaded.
+                                     They use unshaded class names at runtime, provided by
+                                     Dockerfile jars and Spark's classpath. -->
                             </relocations>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
@@ -155,20 +137,6 @@
                                         <exclude>META-INF/services/javax.*</exclude>
                                         <exclude>**/*.proto</exclude>
                                         <exclude>hbase-webapps/**</exclude>
-                                    </excludes>
-                                </filter>
-                                <!-- Exclude only Netty native .so/.dylib libraries (not Java classes).
-                                     After shading, JNI callbacks in native libraries still reference
-                                     original class names (io.netty.channel.epoll.*), but the Java
-                                     classes are relocated to org.apache.hudi.io.netty.*.
-                                     The epoll/kqueue Java classes are KEPT so that transport detection
-                                     (e.g., Epoll.isAvailable()) works — it returns false when the
-                                     native lib can't load, causing reactor-netty to fall back to NIO. -->
-                                <filter>
-                                    <artifact>io.netty:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/native/**</exclude>
-                                        <exclude>META-INF/native-image/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -126,9 +126,9 @@
                                     <pattern>net.minidev.</pattern>
                                     <shadedPattern>org.apache.hudi.net.minidev.</shadedPattern>
                                 </relocation>
-                                <!-- Netty, Reactor, and Reactive Streams are NOT shaded.
-                                     They use unshaded class names at runtime, provided by
-                                     Dockerfile jars and Spark's classpath. -->
+                                <!-- Netty, Reactor, and Reactive Streams are NOT bundled (see above).
+                                     No relocation rules for io.netty, reactor, or org.reactivestreams —
+                                     they are provided at runtime via Dockerfile jars and Spark's classpath. -->
                             </relocations>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
@@ -222,14 +222,62 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-core</artifactId>
+            <version>1.0.10</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
             <version>3.4.38</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <version>1.0.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <version>4.1.96.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
+            <version>4.1.96.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.15.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.5.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>stax2-api</artifactId>
+            <version>4.2.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
+            <version>5.13.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
             <version>5.13.0</version>
             <scope>provided</scope>
         </dependency>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>hudi</artifactId>
+        <groupId>org.apache.hudi</groupId>
+        <version>0.14.1-rc2</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hudi-azure-bundle</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <checkstyle.skip>true</checkstyle.skip>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+        <skipTests>true</skipTests>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>${shadeSources}</createSourcesJar>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <addHeader>true</addHeader>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/LICENSE</resource>
+                                    <file>target/classes/META-INF/LICENSE</file>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <!-- Hudi modules -->
+                                    <include>org.apache.hudi:hudi-common</include>
+                                    <include>org.apache.hudi:hudi-hadoop-mr</include>
+                                    <include>org.apache.hudi:hudi-sync-common</include>
+                                    <include>org.apache.hudi:hudi-hive-sync</include>
+                                    <include>org.apache.hudi:hudi-azure</include>
+                                    <!-- Azure SDK -->
+                                    <include>com.azure:*</include>
+                                    <!-- Azure identity deps -->
+                                    <include>com.microsoft.azure:*</include>
+                                    <include>com.nimbusds:*</include>
+                                    <include>net.minidev:*</include>
+                                    <!-- Reactor -->
+                                    <include>io.projectreactor:*</include>
+                                    <include>io.projectreactor.netty:*</include>
+                                    <include>org.reactivestreams:reactive-streams</include>
+                                    <!-- Misc -->
+                                    <include>com.beust:jcommander</include>
+                                    <include>commons-io:commons-io</include>
+                                    <include>org.openjdk.jol:jol-core</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations combine.children="append">
+                                <relocation>
+                                    <pattern>org.apache.commons.io.</pattern>
+                                    <shadedPattern>org.apache.hudi.org.apache.commons.io.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.openjdk.jol.</pattern>
+                                    <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/services/javax.*</exclude>
+                                        <exclude>**/*.proto</exclude>
+                                        <exclude>hbase-webapps/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <finalName>${project.artifactId}-${project.version}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/test/resources</directory>
+            </resource>
+        </resources>
+    </build>
+
+    <dependencies>
+        <!-- Hoodie -->
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-hive-sync</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-azure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Parquet -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <version>${parquet.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Avro -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -157,6 +157,23 @@
                                         <exclude>hbase-webapps/**</exclude>
                                     </excludes>
                                 </filter>
+                                <!-- Exclude Netty native transport classes and libraries.
+                                     After shading, JNI callbacks in native .so/.dylib files still
+                                     reference original class names (io.netty.channel.epoll.*), but
+                                     the Java classes are relocated to org.apache.hudi.io.netty.*.
+                                     This mismatch causes static initializer failures.
+                                     Excluding native transports forces reactor-netty to use Java NIO,
+                                     which works correctly with shaded classes. -->
+                                <filter>
+                                    <artifact>io.netty:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/native/**</exclude>
+                                        <exclude>META-INF/native-image/**</exclude>
+                                        <exclude>io/netty/channel/epoll/**</exclude>
+                                        <exclude>io/netty/channel/kqueue/**</exclude>
+                                        <exclude>io/netty/channel/unix/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <finalName>${project.artifactId}-${project.version}</finalName>
                         </configuration>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -157,21 +157,18 @@
                                         <exclude>hbase-webapps/**</exclude>
                                     </excludes>
                                 </filter>
-                                <!-- Exclude Netty native transport classes and libraries.
-                                     After shading, JNI callbacks in native .so/.dylib files still
-                                     reference original class names (io.netty.channel.epoll.*), but
-                                     the Java classes are relocated to org.apache.hudi.io.netty.*.
-                                     This mismatch causes static initializer failures.
-                                     Excluding native transports forces reactor-netty to use Java NIO,
-                                     which works correctly with shaded classes. -->
+                                <!-- Exclude only Netty native .so/.dylib libraries (not Java classes).
+                                     After shading, JNI callbacks in native libraries still reference
+                                     original class names (io.netty.channel.epoll.*), but the Java
+                                     classes are relocated to org.apache.hudi.io.netty.*.
+                                     The epoll/kqueue Java classes are KEPT so that transport detection
+                                     (e.g., Epoll.isAvailable()) works — it returns false when the
+                                     native lib can't load, causing reactor-netty to fall back to NIO. -->
                                 <filter>
                                     <artifact>io.netty:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/native/**</exclude>
                                         <exclude>META-INF/native-image/**</exclude>
-                                        <exclude>io/netty/channel/epoll/**</exclude>
-                                        <exclude>io/netty/channel/kqueue/**</exclude>
-                                        <exclude>io/netty/channel/unix/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -115,6 +115,10 @@
                                     <shadedPattern>org.apache.hudi.com.microsoft.azure.</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.microsoft.aad.</pattern>
+                                    <shadedPattern>org.apache.hudi.com.microsoft.aad.</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.nimbusds.</pattern>
                                     <shadedPattern>org.apache.hudi.com.nimbusds.</shadedPattern>
                                 </relocation>
@@ -184,6 +188,50 @@
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-azure</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <!--
+          Runtime-required dependencies NOT bundled in this fat jar.
+          The shaded com.azure classes retain unshaded bytecode references to these packages.
+          They MUST be provided at runtime via Dockerfile jars or Spark's classpath.
+
+          Why not bundled: Shading Netty breaks JNI native transport (epoll) because native
+          .so libraries reference class names by string that the shade plugin cannot rewrite.
+          Instead, we rely on a single controlled version provided externally.
+
+          Required runtime jars (see Dockerfiles in onehouse-dataplane and spark-connect-server):
+            - reactor-netty-http-1.0.10.jar
+            - reactor-netty-core-1.0.10.jar
+            - reactor-core-3.4.38.jar
+            - reactive-streams-1.0.4.jar
+            - netty-resolver-dns-4.1.96.Final.jar
+            - netty-codec-dns-4.1.96.Final.jar
+            - jackson-dataformat-xml-2.15.2.jar
+            - woodstox-core-6.5.1.jar
+            - stax2-api-4.2.1.jar
+            - jna-5.13.0.jar
+            - jna-platform-5.13.0.jar
+
+          Spark 3.x ships unshaded io.netty.* in $SPARK_HOME/jars/ (Spark 2.x shaded Netty
+          as org.spark_project.io.netty.* — this bundle is NOT compatible with Spark 2.x).
+        -->
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+            <version>1.0.10</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.4.38</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.13.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Parquet -->

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -88,6 +88,9 @@
                                     <include>io.projectreactor:*</include>
                                     <include>io.projectreactor.netty:*</include>
                                     <include>org.reactivestreams:reactive-streams</include>
+                                    <!-- Netty: bundled and shaded together with reactor-netty to avoid
+                                         version conflicts with Spark's Netty on the classpath -->
+                                    <include>io.netty:*</include>
                                     <!-- Misc -->
                                     <include>com.beust:jcommander</include>
                                     <include>commons-io:commons-io</include>
@@ -102,6 +105,24 @@
                                 <relocation>
                                     <pattern>org.openjdk.jol.</pattern>
                                     <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
+                                </relocation>
+                                <!-- Shade Netty, Reactor, and Reactive Streams to avoid classpath
+                                     conflicts with Spark's bundled Netty -->
+                                <relocation>
+                                    <pattern>io.netty.</pattern>
+                                    <shadedPattern>org.apache.hudi.io.netty.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.projectreactor.</pattern>
+                                    <shadedPattern>org.apache.hudi.io.projectreactor.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>reactor.</pattern>
+                                    <shadedPattern>org.apache.hudi.reactor.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.reactivestreams.</pattern>
+                                    <shadedPattern>org.apache.hudi.org.reactivestreams.</shadedPattern>
                                 </relocation>
                             </relocations>
                             <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <module>packaging/hudi-hive-sync-bundle</module>
     <module>packaging/hudi-aws-bundle</module>
     <module>packaging/hudi-gcp-bundle</module>
+    <module>packaging/hudi-azure-bundle</module>
     <module>packaging/hudi-spark-bundle</module>
     <module>packaging/hudi-presto-bundle</module>
     <module>packaging/hudi-utilities-bundle</module>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/18471

### Summary and Changelog

Rework hudi-azure-bundle shading strategy to resolve Netty classpath conflicts in Spark environments.

Context: The initial hudi-azure-bundle (merged in https://github.com/onehouseinc/hudi-internal/pull/1806) shaded Reactor-Netty and Netty inside the bundle. This caused NoClassDefFoundError at runtime because Netty's native transport (epoll) uses JNI — the native .so libraries reference class names by hardcoded strings (io.netty.channel.epoll.) that the shade plugin cannot rewrite. Additionally, the bundle's unshaded com.azure. classes collided with different Azure SDK versions used by downstream consumers (onehouse-dataplane for Key Vault, spark-connect-server for catalog).

Changes to packaging/hudi-azure-bundle/pom.xml:

Shade Azure SDK classes — added relocations for com.azure., com.microsoft.azure., com.microsoft.aad.* (msal4j), com.nimbusds., net.minidev. under org.apache.hudi.*. This isolates the bundle's Azure SDK (v1.20.0) from other Azure SDK versions on the classpath
Remove Reactor/Netty from bundle — removed io.projectreactor:, io.projectreactor.netty:, org.reactivestreams:reactive-streams, and io.netty:* from the artifact set and all their relocation rules. These are now expected at runtime from Dockerfile jars and Spark's classpath
Add provided scope dependencies — declared reactor-netty-http:1.0.10, reactor-core:3.4.38, jna:5.13.0, etc as provided to document the runtime dependency for future maintainers
Document required runtime jars — listed all jars that must be present at runtime in POM comments (reactor-netty, reactor-core, reactive-streams, netty-resolver-dns, netty-codec-dns, jackson-dataformat-xml, woodstox-core, stax2-api, jna, jna-platform)

### Impact

Fixes NoClassDefFoundError / NoSuchMethodError when using StorageBasedLockProvider on Azure in Spark 3.x environments
The bundle now has a hard runtime dependency on reactor-netty and Netty provided externally (via Dockerfile jars and Spark's classpath). This is documented in the POM but not enforced at build time
Not compatible with Spark 2.x (which shades Netty as org.spark_project.io.netty.*)
No changes to existing modules — hudi-aws-bundle, hudi-gcp-bundle, hudi-spark-bundle are unaffected

### Risk Level

Medium.

Verification:

Bundle shading verified via jar tf and javap: no unshaded com.azure., com.microsoft.aad. classes. No reactor.netty.* or io.netty.* classes in the bundle
SPI service files correctly shaded (org.apache.hudi.com.azure.core.http.HttpClientProvider)
Reactor-netty 1.0.10 calls old HttpClientCodec(int,int,int,boolean,boolean,int,boolean,boolean) constructor — compatible with all Netty 4.1.x (Spark 3.4+)
Tested on Azure Kubernetes with DeltaStreamer and Spark write jobs against ADLS Gen2
Dockerfile jars in both onehouse-dataplane and spark-connect-server verified to contain all required runtime dependencies

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
