### PR TITLE
feat(vector): Add Spark SQL DDL CREATE TABLE support for VECTOR type

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -2163,7 +2163,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
       val schema = spark.table(tableName).schema
       val embeddingField = schema.find(_.name == "embedding").get
       assertTrue(embeddingField.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD))
-      assertEquals("VECTOR(64,DOUBLE)", embeddingField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals("VECTOR(64, DOUBLE)", embeddingField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
       assertEquals(ArrayType(DoubleType, containsNull = false), embeddingField.dataType)
     }
   }
@@ -2176,6 +2176,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
            |CREATE TABLE $tableName (
            |  id BIGINT,
            |  float_vec VECTOR(128),
+           |  float_vec_explicit VECTOR(128, FLOAT),
            |  double_vec VECTOR(64, DOUBLE),
            |  int8_vec VECTOR(256, INT8) NOT NULL
            |) USING hudi
@@ -2192,14 +2193,37 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
       assertEquals(ArrayType(FloatType, containsNull = false), floatVecField.dataType)
       assertTrue(floatVecField.nullable)
 
+      // VECTOR(128, FLOAT) should be normalized to the canonical form "VECTOR(128)"
+      val floatVecExplicitField = schema.find(_.name == "float_vec_explicit").get
+      assertEquals("VECTOR(128)", floatVecExplicitField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals(ArrayType(FloatType, containsNull = false), floatVecExplicitField.dataType)
+
       val doubleVecField = schema.find(_.name == "double_vec").get
-      assertEquals("VECTOR(64,DOUBLE)", doubleVecField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals("VECTOR(64, DOUBLE)", doubleVecField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
       assertEquals(ArrayType(DoubleType, containsNull = false), doubleVecField.dataType)
 
       val int8VecField = schema.find(_.name == "int8_vec").get
-      assertEquals("VECTOR(256,INT8)", int8VecField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals("VECTOR(256, INT8)", int8VecField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
       assertEquals(ArrayType(ByteType, containsNull = false), int8VecField.dataType)
       assertFalse(int8VecField.nullable)
+    }
+  }
+
+  test("test create table with invalid VECTOR type surfaces ParseException") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      // Unsupported element type
+      checkExceptionContain(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id BIGINT,
+           |  embedding VECTOR(128, BOOLEAN)
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id'
+           |)
+           """.stripMargin)("Invalid VECTOR type")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -2120,4 +2120,108 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
       assertTrue(blobPathField.dataType.isInstanceOf[StringType])
     }
   }
+
+  test("test create table with VECTOR column") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id BIGINT,
+           |  embedding VECTOR(128) COMMENT 'document embedding'
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id'
+           |)
+           """.stripMargin)
+
+      val schema = spark.table(tableName).schema
+      val embeddingField = schema.find(_.name == "embedding").get
+      assertTrue(embeddingField.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals("VECTOR(128)", embeddingField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals("document embedding", embeddingField.metadata.getString("comment"))
+      assertEquals(ArrayType(FloatType, containsNull = false), embeddingField.dataType)
+    }
+  }
+
+  test("test create table with VECTOR column with element type") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id BIGINT,
+           |  embedding VECTOR(64, DOUBLE)
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id'
+           |)
+           """.stripMargin)
+
+      val schema = spark.table(tableName).schema
+      val embeddingField = schema.find(_.name == "embedding").get
+      assertTrue(embeddingField.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals("VECTOR(64,DOUBLE)", embeddingField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals(ArrayType(DoubleType, containsNull = false), embeddingField.dataType)
+    }
+  }
+
+  test("test create table with multiple VECTOR columns") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id BIGINT,
+           |  float_vec VECTOR(128),
+           |  double_vec VECTOR(64, DOUBLE),
+           |  int8_vec VECTOR(256, INT8) NOT NULL
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id'
+           |)
+           """.stripMargin)
+
+      val schema = spark.table(tableName).schema
+
+      val floatVecField = schema.find(_.name == "float_vec").get
+      assertEquals("VECTOR(128)", floatVecField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals(ArrayType(FloatType, containsNull = false), floatVecField.dataType)
+      assertTrue(floatVecField.nullable)
+
+      val doubleVecField = schema.find(_.name == "double_vec").get
+      assertEquals("VECTOR(64,DOUBLE)", doubleVecField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals(ArrayType(DoubleType, containsNull = false), doubleVecField.dataType)
+
+      val int8VecField = schema.find(_.name == "int8_vec").get
+      assertEquals("VECTOR(256,INT8)", int8VecField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals(ArrayType(ByteType, containsNull = false), int8VecField.dataType)
+      assertFalse(int8VecField.nullable)
+    }
+  }
+
+  test("test create table with VECTOR column case insensitive") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id BIGINT,
+           |  embedding vector(128)
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id'
+           |)
+           """.stripMargin)
+
+      val schema = spark.table(tableName).schema
+      val embeddingField = schema.find(_.name == "embedding").get
+      assertTrue(embeddingField.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals(ArrayType(FloatType, containsNull = false), embeddingField.dataType)
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -2209,6 +2209,45 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
     }
   }
 
+  test("test create table with INT8 VECTOR column") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id BIGINT,
+           |  embedding VECTOR(256, INT8)
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id'
+           |)
+           """.stripMargin)
+
+      val schema = spark.table(tableName).schema
+      val embeddingField = schema.find(_.name == "embedding").get
+      assertEquals("VECTOR(256, INT8)", embeddingField.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+      assertEquals(ArrayType(ByteType, containsNull = false), embeddingField.dataType)
+    }
+  }
+
+  test("test create table with VECTOR without dimension fails") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      checkExceptionContain(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id BIGINT,
+           |  v VECTOR
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id'
+           |)
+           """.stripMargin)("vector is not supported")
+    }
+  }
+
   test("test create table with invalid VECTOR type surfaces ParseException") {
     withTempDir { tmp =>
       val tableName = generateTableName

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/antlr4/imports/SqlBase.g4
@@ -942,7 +942,7 @@ dataType
     | INTERVAL from=(YEAR | MONTH) (TO to=MONTH)?               #yearMonthIntervalDataType
     | INTERVAL from=(DAY | HOUR | MINUTE | SECOND)
       (TO to=(HOUR | MINUTE | SECOND))?                         #dayTimeIntervalDataType
-    | identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?  #primitiveDataType
+    | typeName=identifier ('(' (INTEGER_VALUE | identifier) (',' (INTEGER_VALUE | identifier))* ')')?  #primitiveDataType
     ;
 
 qualifiedColTypeWithPositionList

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
@@ -2587,7 +2587,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * Resolve/create a primitive type.
    */
   override def visitPrimitiveDataType(ctx: PrimitiveDataTypeContext): DataType = withOrigin(ctx) {
-    val dataType = ctx.identifier.getText.toLowerCase(Locale.ROOT)
+    val dataType = ctx.typeName.getText.toLowerCase(Locale.ROOT)
     (dataType, ctx.INTEGER_VALUE().asScala.toList) match {
       case ("boolean", Nil) => BooleanType
       case ("tinyint" | "byte", Nil) => ByteType
@@ -2606,6 +2606,17 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
       case ("blob", Nil) => BlobType()
+      case ("vector", dim :: Nil) =>
+        val dimension = dim.getText.toInt
+        val identParams = ctx.identifier().asScala.toList.drop(1) // skip type name
+        val elemTypeStr = if (identParams.nonEmpty) identParams.head.getText.toUpperCase(Locale.ROOT) else "FLOAT"
+        val sparkElemType = elemTypeStr match {
+          case "FLOAT" => FloatType
+          case "DOUBLE" => DoubleType
+          case "INT8" => ByteType
+          case other => throw new ParseException(s"Unsupported VECTOR element type: $other. Supported: FLOAT, DOUBLE, INT8", ctx)
+        }
+        ArrayType(sparkElemType, containsNull = false)
       case ("decimal" | "dec" | "numeric", Nil) => DecimalType.USER_DEFAULT
       case ("decimal" | "dec" | "numeric", precision :: Nil) =>
         DecimalType(precision.getText.toInt, 0)
@@ -2704,6 +2715,8 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val typeText = dataType.getText
     if (typeText.equalsIgnoreCase(HoodieSchemaType.BLOB.name())) {
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
+    } else if (typeText.toUpperCase(Locale.ROOT).startsWith("VECTOR(")) {
+      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, typeText.toUpperCase(Locale.ROOT))
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
@@ -2606,15 +2606,19 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
       case ("blob", Nil) => BlobType()
-      case ("vector", dim :: Nil) =>
-        val dimension = dim.getText.toInt
-        val identParams = ctx.identifier().asScala.toList.drop(1) // skip type name
-        val elemTypeStr = if (identParams.nonEmpty) identParams.head.getText.toUpperCase(Locale.ROOT) else "FLOAT"
-        val sparkElemType = elemTypeStr match {
-          case "FLOAT" => FloatType
-          case "DOUBLE" => DoubleType
-          case "INT8" => ByteType
-          case other => throw new ParseException(s"Unsupported VECTOR element type: $other. Supported: FLOAT, DOUBLE, INT8", ctx)
+      case ("vector", _ :: _) =>
+        // Delegate validation to HoodieSchema.parseTypeDescriptor which handles dimension
+        // range checks, element type validation, and canonical normalization.
+        val vectorSchema = try {
+          HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
+        } catch {
+          case e: IllegalArgumentException =>
+            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+        }
+        val sparkElemType = vectorSchema.getVectorElementType match {
+          case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
+          case HoodieSchema.Vector.VectorElementType.DOUBLE => DoubleType
+          case HoodieSchema.Vector.VectorElementType.INT8 => ByteType
         }
         ArrayType(sparkElemType, containsNull = false)
       case ("decimal" | "dec" | "numeric", Nil) => DecimalType.USER_DEFAULT
@@ -2713,10 +2717,13 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   private def addMetadataForType(dataType: HoodieSqlBaseParser.DataTypeContext, builder: MetadataBuilder): Unit = {
     val typeText = dataType.getText
-    if (typeText.equalsIgnoreCase(HoodieSchemaType.BLOB.name())) {
+    val upperTypeText = typeText.toUpperCase(Locale.ROOT)
+    if (upperTypeText == HoodieSchemaType.BLOB.name()) {
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
-    } else if (typeText.toUpperCase(Locale.ROOT).startsWith("VECTOR(")) {
-      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, typeText.toUpperCase(Locale.ROOT))
+    } else if (upperTypeText.startsWith("VECTOR(")) {
+      // Normalize to canonical form (e.g. "VECTOR(128,FLOAT)" -> "VECTOR(128)")
+      val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
+      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlParser.scala
@@ -130,7 +130,7 @@ class HoodieSpark3_3ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("show indexes") ||
       normalized.contains("refresh index") ||
       normalized.contains(" blob") ||
-      normalized.contains(" vector(")
+      normalized.contains(" vector")
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlParser.scala
@@ -129,7 +129,8 @@ class HoodieSpark3_3ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("drop index") ||
       normalized.contains("show indexes") ||
       normalized.contains("refresh index") ||
-      normalized.contains(" blob")
+      normalized.contains(" blob") ||
+      normalized.contains(" vector(")
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/antlr4/imports/SqlBase.g4
@@ -942,7 +942,7 @@ dataType
     | INTERVAL from=(YEAR | MONTH) (TO to=MONTH)?               #yearMonthIntervalDataType
     | INTERVAL from=(DAY | HOUR | MINUTE | SECOND)
       (TO to=(HOUR | MINUTE | SECOND))?                         #dayTimeIntervalDataType
-    | identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?  #primitiveDataType
+    | typeName=identifier ('(' (INTEGER_VALUE | identifier) (',' (INTEGER_VALUE | identifier))* ')')?  #primitiveDataType
     ;
 
 qualifiedColTypeWithPositionList

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
@@ -2609,15 +2609,19 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
       case ("blob", Nil) => BlobType()
-      case ("vector", dim :: Nil) =>
-        val dimension = dim.getText.toInt
-        val identParams = ctx.identifier().asScala.toList.drop(1) // skip type name
-        val elemTypeStr = if (identParams.nonEmpty) identParams.head.getText.toUpperCase(Locale.ROOT) else "FLOAT"
-        val sparkElemType = elemTypeStr match {
-          case "FLOAT" => FloatType
-          case "DOUBLE" => DoubleType
-          case "INT8" => ByteType
-          case other => throw new ParseException(s"Unsupported VECTOR element type: $other. Supported: FLOAT, DOUBLE, INT8", ctx)
+      case ("vector", _ :: _) =>
+        // Delegate validation to HoodieSchema.parseTypeDescriptor which handles dimension
+        // range checks, element type validation, and canonical normalization.
+        val vectorSchema = try {
+          HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
+        } catch {
+          case e: IllegalArgumentException =>
+            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+        }
+        val sparkElemType = vectorSchema.getVectorElementType match {
+          case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
+          case HoodieSchema.Vector.VectorElementType.DOUBLE => DoubleType
+          case HoodieSchema.Vector.VectorElementType.INT8 => ByteType
         }
         ArrayType(sparkElemType, containsNull = false)
       case ("decimal" | "dec" | "numeric", Nil) => DecimalType.USER_DEFAULT
@@ -2716,10 +2720,13 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   private def addMetadataForType(dataType: HoodieSqlBaseParser.DataTypeContext, builder: MetadataBuilder): Unit = {
     val typeText = dataType.getText
-    if (typeText.equalsIgnoreCase(HoodieSchemaType.BLOB.name())) {
+    val upperTypeText = typeText.toUpperCase(Locale.ROOT)
+    if (upperTypeText == HoodieSchemaType.BLOB.name()) {
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
-    } else if (typeText.toUpperCase(Locale.ROOT).startsWith("VECTOR(")) {
-      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, typeText.toUpperCase(Locale.ROOT))
+    } else if (upperTypeText.startsWith("VECTOR(")) {
+      // Normalize to canonical form (e.g. "VECTOR(128,FLOAT)" -> "VECTOR(128)")
+      val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
+      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
@@ -2590,7 +2590,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * Resolve/create a primitive type.
    */
   override def visitPrimitiveDataType(ctx: PrimitiveDataTypeContext): DataType = withOrigin(ctx) {
-    val dataType = ctx.identifier.getText.toLowerCase(Locale.ROOT)
+    val dataType = ctx.typeName.getText.toLowerCase(Locale.ROOT)
     (dataType, ctx.INTEGER_VALUE().asScala.toList) match {
       case ("boolean", Nil) => BooleanType
       case ("tinyint" | "byte", Nil) => ByteType
@@ -2609,6 +2609,17 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
       case ("blob", Nil) => BlobType()
+      case ("vector", dim :: Nil) =>
+        val dimension = dim.getText.toInt
+        val identParams = ctx.identifier().asScala.toList.drop(1) // skip type name
+        val elemTypeStr = if (identParams.nonEmpty) identParams.head.getText.toUpperCase(Locale.ROOT) else "FLOAT"
+        val sparkElemType = elemTypeStr match {
+          case "FLOAT" => FloatType
+          case "DOUBLE" => DoubleType
+          case "INT8" => ByteType
+          case other => throw new ParseException(s"Unsupported VECTOR element type: $other. Supported: FLOAT, DOUBLE, INT8", ctx)
+        }
+        ArrayType(sparkElemType, containsNull = false)
       case ("decimal" | "dec" | "numeric", Nil) => DecimalType.USER_DEFAULT
       case ("decimal" | "dec" | "numeric", precision :: Nil) =>
         DecimalType(precision.getText.toInt, 0)
@@ -2707,6 +2718,8 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val typeText = dataType.getText
     if (typeText.equalsIgnoreCase(HoodieSchemaType.BLOB.name())) {
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
+    } else if (typeText.toUpperCase(Locale.ROOT).startsWith("VECTOR(")) {
+      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, typeText.toUpperCase(Locale.ROOT))
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlParser.scala
@@ -130,7 +130,7 @@ class HoodieSpark3_4ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("show indexes") ||
       normalized.contains("refresh index") ||
       normalized.contains(" blob") ||
-      normalized.contains(" vector(")
+      normalized.contains(" vector")
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlParser.scala
@@ -129,7 +129,8 @@ class HoodieSpark3_4ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("drop index") ||
       normalized.contains("show indexes") ||
       normalized.contains("refresh index") ||
-      normalized.contains(" blob")
+      normalized.contains(" blob") ||
+      normalized.contains(" vector(")
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/antlr4/imports/SqlBase.g4
@@ -942,7 +942,7 @@ dataType
     | INTERVAL from=(YEAR | MONTH) (TO to=MONTH)?               #yearMonthIntervalDataType
     | INTERVAL from=(DAY | HOUR | MINUTE | SECOND)
       (TO to=(HOUR | MINUTE | SECOND))?                         #dayTimeIntervalDataType
-    | identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?  #primitiveDataType
+    | typeName=identifier ('(' (INTEGER_VALUE | identifier) (',' (INTEGER_VALUE | identifier))* ')')?  #primitiveDataType
     ;
 
 qualifiedColTypeWithPositionList

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
@@ -2591,7 +2591,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * Resolve/create a primitive type.
    */
   override def visitPrimitiveDataType(ctx: PrimitiveDataTypeContext): DataType = withOrigin(ctx) {
-    val dataType = ctx.identifier.getText.toLowerCase(Locale.ROOT)
+    val dataType = ctx.typeName.getText.toLowerCase(Locale.ROOT)
     (dataType, ctx.INTEGER_VALUE().asScala.toList) match {
       case ("boolean", Nil) => BooleanType
       case ("tinyint" | "byte", Nil) => ByteType
@@ -2610,6 +2610,17 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
       case ("blob", Nil) => BlobType()
+      case ("vector", dim :: Nil) =>
+        val dimension = dim.getText.toInt
+        val identParams = ctx.identifier().asScala.toList.drop(1) // skip type name
+        val elemTypeStr = if (identParams.nonEmpty) identParams.head.getText.toUpperCase(Locale.ROOT) else "FLOAT"
+        val sparkElemType = elemTypeStr match {
+          case "FLOAT" => FloatType
+          case "DOUBLE" => DoubleType
+          case "INT8" => ByteType
+          case other => throw new ParseException(s"Unsupported VECTOR element type: $other. Supported: FLOAT, DOUBLE, INT8", ctx)
+        }
+        ArrayType(sparkElemType, containsNull = false)
       case ("decimal" | "dec" | "numeric", Nil) => DecimalType.USER_DEFAULT
       case ("decimal" | "dec" | "numeric", precision :: Nil) =>
         DecimalType(precision.getText.toInt, 0)
@@ -2708,6 +2719,10 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val typeText = dataType.getText
     if (typeText.equalsIgnoreCase(HoodieSchemaType.BLOB.name())) {
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
+    } else if (typeText.toUpperCase(Locale.ROOT).startsWith("VECTOR(")) {
+      // Store the raw descriptor (e.g. "VECTOR(128)" or "VECTOR(128,DOUBLE)")
+      // tokenizeTypeDescriptor handles both with and without spaces after comma
+      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, typeText.toUpperCase(Locale.ROOT))
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
@@ -2610,15 +2610,19 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
       case ("blob", Nil) => BlobType()
-      case ("vector", dim :: Nil) =>
-        val dimension = dim.getText.toInt
-        val identParams = ctx.identifier().asScala.toList.drop(1) // skip type name
-        val elemTypeStr = if (identParams.nonEmpty) identParams.head.getText.toUpperCase(Locale.ROOT) else "FLOAT"
-        val sparkElemType = elemTypeStr match {
-          case "FLOAT" => FloatType
-          case "DOUBLE" => DoubleType
-          case "INT8" => ByteType
-          case other => throw new ParseException(s"Unsupported VECTOR element type: $other. Supported: FLOAT, DOUBLE, INT8", ctx)
+      case ("vector", _ :: _) =>
+        // Delegate validation to HoodieSchema.parseTypeDescriptor which handles dimension
+        // range checks, element type validation, and canonical normalization.
+        val vectorSchema = try {
+          HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
+        } catch {
+          case e: IllegalArgumentException =>
+            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+        }
+        val sparkElemType = vectorSchema.getVectorElementType match {
+          case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
+          case HoodieSchema.Vector.VectorElementType.DOUBLE => DoubleType
+          case HoodieSchema.Vector.VectorElementType.INT8 => ByteType
         }
         ArrayType(sparkElemType, containsNull = false)
       case ("decimal" | "dec" | "numeric", Nil) => DecimalType.USER_DEFAULT
@@ -2717,12 +2721,13 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   private def addMetadataForType(dataType: HoodieSqlBaseParser.DataTypeContext, builder: MetadataBuilder): Unit = {
     val typeText = dataType.getText
-    if (typeText.equalsIgnoreCase(HoodieSchemaType.BLOB.name())) {
+    val upperTypeText = typeText.toUpperCase(Locale.ROOT)
+    if (upperTypeText == HoodieSchemaType.BLOB.name()) {
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
-    } else if (typeText.toUpperCase(Locale.ROOT).startsWith("VECTOR(")) {
-      // Store the raw descriptor (e.g. "VECTOR(128)" or "VECTOR(128,DOUBLE)")
-      // tokenizeTypeDescriptor handles both with and without spaces after comma
-      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, typeText.toUpperCase(Locale.ROOT))
+    } else if (upperTypeText.startsWith("VECTOR(")) {
+      // Normalize to canonical form (e.g. "VECTOR(128,FLOAT)" -> "VECTOR(128)")
+      val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
+      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlParser.scala
@@ -129,7 +129,8 @@ class HoodieSpark3_5ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("drop index") ||
       normalized.contains("show indexes") ||
       normalized.contains("refresh index") ||
-      normalized.contains(" blob")
+      normalized.contains(" blob") ||
+      normalized.contains(" vector(")
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlParser.scala
@@ -130,7 +130,7 @@ class HoodieSpark3_5ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("show indexes") ||
       normalized.contains("refresh index") ||
       normalized.contains(" blob") ||
-      normalized.contains(" vector(")
+      normalized.contains(" vector")
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/antlr4/imports/SqlBase.g4
@@ -942,7 +942,7 @@ dataType
     | INTERVAL from=(YEAR | MONTH) (TO to=MONTH)?               #yearMonthIntervalDataType
     | INTERVAL from=(DAY | HOUR | MINUTE | SECOND)
       (TO to=(HOUR | MINUTE | SECOND))?                         #dayTimeIntervalDataType
-    | identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?  #primitiveDataType
+    | typeName=identifier ('(' (INTEGER_VALUE | identifier) (',' (INTEGER_VALUE | identifier))* ')')?  #primitiveDataType
     ;
 
 qualifiedColTypeWithPositionList

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
@@ -2593,7 +2593,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * Resolve/create a primitive type.
    */
   override def visitPrimitiveDataType(ctx: PrimitiveDataTypeContext): DataType = withOrigin(ctx) {
-    val dataType = ctx.identifier.getText.toLowerCase(Locale.ROOT)
+    val dataType = ctx.typeName.getText.toLowerCase(Locale.ROOT)
     (dataType, ctx.INTEGER_VALUE().asScala.toList) match {
       case ("boolean", Nil) => BooleanType
       case ("tinyint" | "byte", Nil) => ByteType
@@ -2612,6 +2612,17 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
       case ("blob", Nil) => BlobType()
+      case ("vector", dim :: Nil) =>
+        val dimension = dim.getText.toInt
+        val identParams = ctx.identifier().asScala.toList.drop(1) // skip type name
+        val elemTypeStr = if (identParams.nonEmpty) identParams.head.getText.toUpperCase(Locale.ROOT) else "FLOAT"
+        val sparkElemType = elemTypeStr match {
+          case "FLOAT" => FloatType
+          case "DOUBLE" => DoubleType
+          case "INT8" => ByteType
+          case other => throw new ParseException(s"Unsupported VECTOR element type: $other. Supported: FLOAT, DOUBLE, INT8", ctx)
+        }
+        ArrayType(sparkElemType, containsNull = false)
       case ("decimal" | "dec" | "numeric", Nil) => DecimalType.USER_DEFAULT
       case ("decimal" | "dec" | "numeric", precision :: Nil) =>
         DecimalType(precision.getText.toInt, 0)
@@ -2710,6 +2721,8 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val typeText = dataType.getText
     if (typeText.equalsIgnoreCase(HoodieSchemaType.BLOB.name())) {
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
+    } else if (typeText.toUpperCase(Locale.ROOT).startsWith("VECTOR(")) {
+      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, typeText.toUpperCase(Locale.ROOT))
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
@@ -2612,15 +2612,19 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("varchar", length :: Nil) => VarcharType(length.getText.toInt)
       case ("binary", Nil) => BinaryType
       case ("blob", Nil) => BlobType()
-      case ("vector", dim :: Nil) =>
-        val dimension = dim.getText.toInt
-        val identParams = ctx.identifier().asScala.toList.drop(1) // skip type name
-        val elemTypeStr = if (identParams.nonEmpty) identParams.head.getText.toUpperCase(Locale.ROOT) else "FLOAT"
-        val sparkElemType = elemTypeStr match {
-          case "FLOAT" => FloatType
-          case "DOUBLE" => DoubleType
-          case "INT8" => ByteType
-          case other => throw new ParseException(s"Unsupported VECTOR element type: $other. Supported: FLOAT, DOUBLE, INT8", ctx)
+      case ("vector", _ :: _) =>
+        // Delegate validation to HoodieSchema.parseTypeDescriptor which handles dimension
+        // range checks, element type validation, and canonical normalization.
+        val vectorSchema = try {
+          HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
+        } catch {
+          case e: IllegalArgumentException =>
+            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+        }
+        val sparkElemType = vectorSchema.getVectorElementType match {
+          case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
+          case HoodieSchema.Vector.VectorElementType.DOUBLE => DoubleType
+          case HoodieSchema.Vector.VectorElementType.INT8 => ByteType
         }
         ArrayType(sparkElemType, containsNull = false)
       case ("decimal" | "dec" | "numeric", Nil) => DecimalType.USER_DEFAULT
@@ -2719,10 +2723,13 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   private def addMetadataForType(dataType: HoodieSqlBaseParser.DataTypeContext, builder: MetadataBuilder): Unit = {
     val typeText = dataType.getText
-    if (typeText.equalsIgnoreCase(HoodieSchemaType.BLOB.name())) {
+    val upperTypeText = typeText.toUpperCase(Locale.ROOT)
+    if (upperTypeText == HoodieSchemaType.BLOB.name()) {
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
-    } else if (typeText.toUpperCase(Locale.ROOT).startsWith("VECTOR(")) {
-      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, typeText.toUpperCase(Locale.ROOT))
+    } else if (upperTypeText.startsWith("VECTOR(")) {
+      // Normalize to canonical form (e.g. "VECTOR(128,FLOAT)" -> "VECTOR(128)")
+      val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
+      builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlParser.scala
@@ -138,7 +138,8 @@ class HoodieSpark4_0ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("drop index") ||
       normalized.contains("show indexes") ||
       normalized.contains("refresh index") ||
-      normalized.contains(" blob")
+      normalized.contains(" blob") ||
+      normalized.contains(" vector(")
   }
 
   override def parseRoutineParam(sqlText: String): StructType = throw new UnsupportedOperationException()

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlParser.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlParser.scala
@@ -139,7 +139,7 @@ class HoodieSpark4_0ExtendedSqlParser(session: SparkSession, delegate: ParserInt
       normalized.contains("show indexes") ||
       normalized.contains("refresh index") ||
       normalized.contains(" blob") ||
-      normalized.contains(" vector(")
+      normalized.contains(" vector")
   }
 
   override def parseRoutineParam(sqlText: String): StructType = throw new UnsupportedOperationException()


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Closes https://github.com/apache/hudi/issues/18360

Enable VECTOR(dim[, elementType]) syntax in Spark SQL DDL so users can create tables with vector columns directly via SQL instead of only through the DataFrame API.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

- Changes:
  - Extend ANTLR grammar to accept identifier params in primitiveDataType
  - Add VECTOR case in visitPrimitiveDataType (supports FLOAT, DOUBLE, INT8)
  - Add VECTOR metadata attachment in addMetadataForType
  - Add DDL tests for VECTOR columns in TestCreateTable

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

Users can create tables with VECTOR columns using Spark-SQL.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

- Any new examples on how to add VECTOR types using Spark-SQL which requires updating the Hudi website.


### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
