### PR TITLE
fix: Fix lock expiration metric

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -637,16 +637,20 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
           hoodieLockMetrics.ifPresent(HoodieLockMetrics::updateLockThrottledMetric);
           // Let heartbeat retry later.
           return true;
-        case SUCCESS:
-          // Only positive outcome
-          this.setLock(currentLock.getRight().get());
+        case SUCCESS: {
+          // Only positive outcome. Source the deadline metric and log from the renewed lock file
+          // returned by the storage client (same as the acquisition path), not the locally
+          // computed expiration, so both callers agree on where the deadline comes from.
+          StorageLockFile renewedLock = currentLock.getRight().get();
+          this.setLock(renewedLock);
           hoodieLockMetrics.ifPresent(metrics -> metrics.updateLockExpirationDeadlineMetric(
-              (int) (oldExpirationMs - getCurrentEpochMs())));
-          logger.info("Owner {}: Lock renewal successful. The renewal completes {} ms before expiration for lock {}.",
-              ownerId, oldExpirationMs - getCurrentEpochMs(), lockFilePath);
+              (int) (renewedLock.getValidUntilMs() - getCurrentEpochMs())));
+          logger.info("Owner {}: Lock renewal successful. The renewal completes {} ms before old expiration. The lock will expire in {} ms for lock {}.",
+              ownerId, oldExpirationMs - getCurrentEpochMs(), renewedLock.getValidUntilMs() - getCurrentEpochMs(), lockFilePath);
           recordAuditOperation(AuditOperationState.RENEW, acquisitionTimestamp);
           // Let heartbeat continue to renew lock lease again later.
           return true;
+        }
         default:
           throw new HoodieLockException("Unexpected lock update result: " + currentLock.getLeft());
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -555,9 +555,9 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
           // Only positive outcome
           this.setLock(currentLock.getRight().get());
           hoodieLockMetrics.ifPresent(metrics -> metrics.updateLockExpirationDeadlineMetric(
-              (int) (oldExpirationMs - getCurrentEpochMs())));
-          logger.info("Owner {}: Lock renewal successful. The renewal completes {} ms before expiration for lock {}.",
-              ownerId, oldExpirationMs - getCurrentEpochMs(), lockFilePath);
+              (int) (lockExpirationMs - getCurrentEpochMs())));
+          logger.info("Owner {}: Lock renewal successful. The renewal completes {} ms before old expiration. The lock will expire in {} ms for lock {}.",
+              ownerId, oldExpirationMs - getCurrentEpochMs(), lockExpirationMs - getCurrentEpochMs(), lockFilePath);
           recordAuditOperation(AuditOperationState.RENEW, acquisitionTimestamp);
           // Let heartbeat continue to renew lock lease again later.
           return true;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -643,10 +643,12 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
           // computed expiration, so both callers agree on where the deadline comes from.
           StorageLockFile renewedLock = currentLock.getRight().get();
           this.setLock(renewedLock);
-          hoodieLockMetrics.ifPresent(metrics -> metrics.updateLockExpirationDeadlineMetric(
-              (int) (renewedLock.getValidUntilMs() - getCurrentEpochMs())));
+          // Read the clock once so the metric and the log line below report the same deadline.
+          long renewalCompletionMs = getCurrentEpochMs();
+          long remainingLeaseMs = renewedLock.getValidUntilMs() - renewalCompletionMs;
+          hoodieLockMetrics.ifPresent(metrics -> metrics.updateLockExpirationDeadlineMetric((int) remainingLeaseMs));
           logger.info("Owner {}: Lock renewal successful. The renewal completes {} ms before old expiration. The lock will expire in {} ms for lock {}.",
-              ownerId, oldExpirationMs - getCurrentEpochMs(), renewedLock.getValidUntilMs() - getCurrentEpochMs(), lockFilePath);
+              ownerId, oldExpirationMs - renewalCompletionMs, remainingLeaseMs, lockFilePath);
           recordAuditOperation(AuditOperationState.RENEW, acquisitionTimestamp);
           // Let heartbeat continue to renew lock lease again later.
           return true;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -625,8 +625,49 @@ class TestStorageBasedLockProvider {
     assertTrue(lockProvider.renewLock());
 
     verify(mockLogger).info(
-        eq("Owner {}: Lock renewal successful. The renewal completes {} ms before expiration for lock {}."),
-        eq(this.ownerId), anyLong(), eq("gs://bucket/lake/db/tbl-default/.hoodie/.locks/table_lock.json"));
+        eq("Owner {}: Lock renewal successful. The renewal completes {} ms before old expiration. The lock will expire in {} ms for lock {}."),
+        eq(this.ownerId), anyLong(), anyLong(), eq("gs://bucket/lake/db/tbl-default/.hoodie/.locks/table_lock.json"));
+  }
+
+  @Test
+  void testRenewLockMetricUsesNewLeaseExpiration() {
+    // Regression test for https://github.com/apache/hudi/issues/18493: after a successful
+    // renewal the lock.expiration.deadline metric must reflect the remaining time on the newly
+    // renewed lease, not on the previous (about-to-expire) lease.
+    TypedProperties props = new TypedProperties();
+    props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
+    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
+    props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-default");
+
+    HoodieLockMetrics mockMetrics = mock(HoodieLockMetrics.class);
+    try (StorageBasedLockProvider providerWithMetrics = spy(new StorageBasedLockProvider(
+        ownerId,
+        props,
+        (a, b, c) -> mockHeartbeatManager,
+        (a, b, c) -> mockLockService,
+        mockLogger,
+        mockMetrics))) {
+
+      long t0 = 100_000L;
+      when(providerWithMetrics.getCurrentEpochMs()).thenReturn(t0);
+
+      // The currently held lease is about to expire (only 100 ms left) -- this is what makes the
+      // old vs new distinction observable: the old lease would have reported ~100 ms.
+      StorageLockData oldData = new StorageLockData(false, t0 + 100, ownerId);
+      StorageLockFile oldLockFile = new StorageLockFile(oldData, "v1");
+      doReturn(oldLockFile).when(providerWithMetrics).getLock();
+
+      StorageLockData renewedLockData = new StorageLockData(false, t0 + DEFAULT_LOCK_VALIDITY_MS, ownerId);
+      StorageLockFile renewedLockFile = new StorageLockFile(renewedLockData, "v2");
+      when(mockLockService.tryUpsertLockFile(any(), eq(Option.of(oldLockFile))))
+          .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(renewedLockFile)));
+
+      assertTrue(providerWithMetrics.renewLock());
+
+      // New lease = t0 + 10000ms validity, evaluated at t0 -> 10000 ms remaining (the fix),
+      // not the ~100 ms remaining on the old lease (the bug).
+      verify(mockMetrics).updateLockExpirationDeadlineMetric(DEFAULT_LOCK_VALIDITY_MS);
+    }
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

https://github.com/apache/hudi/issues/18493
After a successful lock renewal in StorageBasedLockProvider, the `lock.expiration.deadline` metric was computed using `oldExpirationMs` (the expiration of the previous lease) instead of `lockExpirationMs` (the expiration of the newly renewed lease). This caused the metric to report the remaining time on the old lease rather than the new one, making it appear that the lock was about to expire even though it had just been extended.

  The adjacent log message correctly uses oldExpirationMs — its purpose is to report how much buffer remained before the old lease would have expired, which is a heartbeat health signal. The metric, on the other hand, should reflect the current state of the lock after renewal.

### Summary and Changelog

Use `lockExpirationMs` to calculate the `lock.expiration.deadline` metric.

### Impact

  The `lock.expiration.deadline` metric now accurately reports how much time remains until the lock actually expires after renewal. No behavioral change to locking logic — only the reported metric value is corrected.

### Risk Level

  Low. Single-line change affecting only metric reporting. No change to lock acquisition, renewal, or release logic.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
