### PR TITLE
[MINOR] Bump lance to 4.0.0 and lance-spark to 0.4.0

### DIFF
--- a/hudi-client/hudi-spark-client/pom.xml
+++ b/hudi-client/hudi-spark-client/pom.xml
@@ -102,7 +102,7 @@
 
     <!-- Lance Spark for Arrow conversion -->
     <dependency>
-      <groupId>com.lancedb</groupId>
+      <groupId>org.lance</groupId>
       <artifactId>${lance.spark.artifact}</artifactId>
     </dependency>
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
@@ -30,7 +30,7 @@ import org.apache.hudi.io.storage.row.HoodieInternalRowFileWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
-import com.lancedb.lance.spark.arrow.LanceArrowWriter;
+import org.lance.spark.arrow.LanceArrowWriter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -121,7 +121,7 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
                                  long maxFileSize) {
     super(file, DEFAULT_BATCH_SIZE, bloomFilterOpt.map(HoodieBloomFilterRowWriteSupport::new));
     this.sparkSchema = sparkSchema;
-    this.arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, DEFAULT_TIMEZONE, true, false);
+    this.arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, DEFAULT_TIMEZONE, true);
     this.fileName = UTF8String.fromString(file.getName());
     this.instantTime = UTF8String.fromString(instantTime);
     this.populateMetaFields = populateMetaFields;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/LanceRecordIterator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/LanceRecordIterator.java
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.apache.spark.sql.vectorized.LanceArrowColumnVector;
+import org.lance.spark.vectorized.LanceArrowColumnVector;
 import org.lance.file.LanceFileReader;
 
 import java.io.IOException;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/LanceRecordIterator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/LanceRecordIterator.java
@@ -110,13 +110,9 @@ public class LanceRecordIterator implements ClosableIterator<UnsafeRow> {
       if (arrowReader.loadNextBatch()) {
         VectorSchemaRoot root = arrowReader.getVectorSchemaRoot();
 
-        // Wrap each Arrow FieldVector in LanceArrowColumnVector, ordered to match the
-        // Spark schema the UnsafeProjection was built for. Starting with lance-spark 0.4.0
-        // the returned VectorSchemaRoot may use the file's on-disk column order rather
-        // than the order of the columnNames we asked for, which caused
-        // UnsafeProjection to dispatch getInt(0) against a VarCharVector (see HUDI issue
-        // discovered on TestLanceDataSource MOR paths). Look each field up by name.
-        // Cache the column wrappers on first batch and reuse for all subsequent batches.
+        // Build ColumnVector[] in Spark-schema order by looking each field up by name;
+        // lance-spark 0.4.0's VectorSchemaRoot may return the file's on-disk order, which
+        // would misalign the UnsafeProjection. Cached on the first batch and reused thereafter.
         if (columnVectors == null) {
           List<FieldVector> fieldVectors = root.getFieldVectors();
           Map<String, FieldVector> byName = new HashMap<>(fieldVectors.size() * 2);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/LanceRecordIterator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/LanceRecordIterator.java
@@ -23,11 +23,13 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
@@ -35,7 +37,10 @@ import org.lance.spark.vectorized.LanceArrowColumnVector;
 import org.lance.file.LanceFileReader;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Shared iterator implementation for reading Lance files and converting Arrow batches to Spark rows.
@@ -56,6 +61,7 @@ public class LanceRecordIterator implements ClosableIterator<UnsafeRow> {
   private final BufferAllocator allocator;
   private final LanceFileReader lanceReader;
   private final ArrowReader arrowReader;
+  private final StructType sparkSchema;
   private final UnsafeProjection projection;
   private final String path;
 
@@ -81,6 +87,7 @@ public class LanceRecordIterator implements ClosableIterator<UnsafeRow> {
     this.allocator = allocator;
     this.lanceReader = lanceReader;
     this.arrowReader = arrowReader;
+    this.sparkSchema = schema;
     this.projection = UnsafeProjection.create(schema);
     this.path = path;
   }
@@ -103,12 +110,35 @@ public class LanceRecordIterator implements ClosableIterator<UnsafeRow> {
       if (arrowReader.loadNextBatch()) {
         VectorSchemaRoot root = arrowReader.getVectorSchemaRoot();
 
-        // Wrap each Arrow FieldVector in LanceArrowColumnVector for type-safe access
-        // Cache the column wrappers on first batch and reuse for all subsequent batches
+        // Wrap each Arrow FieldVector in LanceArrowColumnVector, ordered to match the
+        // Spark schema the UnsafeProjection was built for. Starting with lance-spark 0.4.0
+        // the returned VectorSchemaRoot may use the file's on-disk column order rather
+        // than the order of the columnNames we asked for, which caused
+        // UnsafeProjection to dispatch getInt(0) against a VarCharVector (see HUDI issue
+        // discovered on TestLanceDataSource MOR paths). Look each field up by name.
+        // Cache the column wrappers on first batch and reuse for all subsequent batches.
         if (columnVectors == null) {
-          columnVectors = root.getFieldVectors().stream()
-                  .map(LanceArrowColumnVector::new)
-                  .toArray(ColumnVector[]::new);
+          List<FieldVector> fieldVectors = root.getFieldVectors();
+          Map<String, FieldVector> byName = new HashMap<>(fieldVectors.size() * 2);
+          for (FieldVector fv : fieldVectors) {
+            byName.put(fv.getName(), fv);
+          }
+          StructField[] sparkFields = sparkSchema.fields();
+          if (sparkFields.length != fieldVectors.size()) {
+            throw new HoodieException("Lance batch column count " + fieldVectors.size()
+                + " does not match expected Spark schema size " + sparkFields.length
+                + " for file: " + path);
+          }
+          columnVectors = new ColumnVector[sparkFields.length];
+          for (int i = 0; i < sparkFields.length; i++) {
+            String name = sparkFields[i].name();
+            FieldVector fv = byName.get(name);
+            if (fv == null) {
+              throw new HoodieException("Lance batch missing expected column '" + name
+                  + "' for file: " + path + "; available columns: " + byName.keySet());
+            }
+            columnVectors[i] = new LanceArrowColumnVector(fv);
+          }
         }
 
         // Create ColumnarBatch and keep it alive while iterating

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
@@ -58,18 +58,24 @@ case class DropIndex(table: LogicalPlan,
 
 /**
  * The logical plan of the SHOW INDEXES command.
+ *
+ * NOTE: named `HoodieShowIndexes` (rather than `ShowIndexes`) to avoid a fully-qualified-class-name
+ * collision with `org.apache.spark.sql.catalyst.plans.logical.ShowIndexes` that ships inside
+ * `lance-spark-base` (>=0.4.0). Both jars end up on the classpath of `hudi-spark3.x`/`4.x` modules
+ * and the lance-spark class (which has a different arity) otherwise shadows ours and breaks
+ * pattern matching at compile time.
  */
-case class ShowIndexes(table: LogicalPlan,
-                       override val output: Seq[Attribute] = ShowIndexes.getOutputAttrs) extends Command {
+case class HoodieShowIndexes(table: LogicalPlan,
+                             override val output: Seq[Attribute] = HoodieShowIndexes.getOutputAttrs) extends Command {
 
   override def children: Seq[LogicalPlan] = Seq(table)
 
-  def withNewChildrenInternal(newChild: IndexedSeq[LogicalPlan]): ShowIndexes = {
+  def withNewChildrenInternal(newChild: IndexedSeq[LogicalPlan]): HoodieShowIndexes = {
     copy(table = newChild.head)
   }
 }
 
-object ShowIndexes {
+object HoodieShowIndexes {
   def getOutputAttrs: Seq[Attribute] = Seq(
     AttributeReference("index_name", StringType, nullable = false)(),
     AttributeReference("index_type", StringType, nullable = false)(),

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Index.scala
@@ -59,11 +59,9 @@ case class DropIndex(table: LogicalPlan,
 /**
  * The logical plan of the SHOW INDEXES command.
  *
- * NOTE: named `HoodieShowIndexes` (rather than `ShowIndexes`) to avoid a fully-qualified-class-name
- * collision with `org.apache.spark.sql.catalyst.plans.logical.ShowIndexes` that ships inside
- * `lance-spark-base` (>=0.4.0). Both jars end up on the classpath of `hudi-spark3.x`/`4.x` modules
- * and the lance-spark class (which has a different arity) otherwise shadows ours and breaks
- * pattern matching at compile time.
+ * NOTE: named `HoodieShowIndexes` to avoid an FQCN collision with
+ * `org.apache.spark.sql.catalyst.plans.logical.ShowIndexes` from `lance-spark-base` (>=0.4.0),
+ * which otherwise shadows this class on the `hudi-spark3.x`/`4.x` classpath and breaks pattern matching.
  */
 case class HoodieShowIndexes(table: LogicalPlan,
                              override val output: Seq[Attribute] = HoodieShowIndexes.getOutputAttrs) extends Command {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
@@ -152,7 +152,7 @@ case class DropIndexCommand(table: CatalogTable,
 
 /**
  * Command to show available indexes in hudi. The corresponding logical plan is available at
- * org.apache.spark.sql.catalyst.plans.logical.ShowIndexes
+ * org.apache.spark.sql.catalyst.plans.logical.HoodieShowIndexes
  */
 case class ShowIndexesCommand(table: CatalogTable,
                               override val output: Seq[Attribute]) extends IndexBaseCommand {

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/HoodieSpark33CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/HoodieSpark33CatalystPlanUtils.scala
@@ -100,7 +100,7 @@ object HoodieSpark33CatalystPlanUtils extends BaseHoodieCatalystPlanUtils {
 
   override def unapplyShowIndexes(plan: LogicalPlan): Option[(LogicalPlan, Seq[Attribute])] = {
     plan match {
-      case ci @ ShowIndexes(table, output) =>
+      case ci @ HoodieShowIndexes(table, output) =>
         Some((table, output))
       case _ =>
         None

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
@@ -3400,14 +3400,14 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Show indexes, returning a [[ShowIndexes]] logical plan.
+   * Show indexes, returning a [[HoodieShowIndexes]] logical plan.
    * For example:
    * {{{
    *   SHOW INDEXES (FROM | IN) [TABLE] table_name
    * }}}
    */
   override def visitShowIndexes(ctx: ShowIndexesContext): LogicalPlan = withOrigin(ctx) {
-    ShowIndexes(UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())))
+    HoodieShowIndexes(UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())))
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/HoodieSpark34CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/HoodieSpark34CatalystPlanUtils.scala
@@ -107,7 +107,7 @@ object HoodieSpark34CatalystPlanUtils extends BaseHoodieCatalystPlanUtils {
 
   override def unapplyShowIndexes(plan: LogicalPlan): Option[(LogicalPlan, Seq[Attribute])] = {
     plan match {
-      case ci@ShowIndexes(table, output) =>
+      case ci@HoodieShowIndexes(table, output) =>
         Some((table, output))
       case _ =>
         None

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
@@ -3404,14 +3404,14 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Show indexes, returning a [[ShowIndexes]] logical plan.
+   * Show indexes, returning a [[HoodieShowIndexes]] logical plan.
    * For example:
    * {{{
    *   SHOW INDEXES (FROM | IN) [TABLE] table_name
    * }}}
    */
   override def visitShowIndexes(ctx: ShowIndexesContext): LogicalPlan = withOrigin(ctx) {
-    ShowIndexes(UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())))
+    HoodieShowIndexes(UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())))
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/HoodieSpark35CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/HoodieSpark35CatalystPlanUtils.scala
@@ -106,7 +106,7 @@ object HoodieSpark35CatalystPlanUtils extends BaseHoodieCatalystPlanUtils {
 
   override def unapplyShowIndexes(plan: LogicalPlan): Option[(LogicalPlan, Seq[Attribute])] = {
     plan match {
-      case ci@ShowIndexes(table, output) =>
+      case ci@HoodieShowIndexes(table, output) =>
         Some((table, output))
       case _ =>
         None

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
@@ -3406,14 +3406,14 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Show indexes, returning a [[ShowIndexes]] logical plan.
+   * Show indexes, returning a [[HoodieShowIndexes]] logical plan.
    * For example:
    * {{{
    *   SHOW INDEXES (FROM | IN) [TABLE] table_name
    * }}}
    */
   override def visitShowIndexes(ctx: ShowIndexesContext): LogicalPlan = withOrigin(ctx) {
-    ShowIndexes(UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())))
+    HoodieShowIndexes(UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())))
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/HoodieSpark40CatalystPlanUtils.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/HoodieSpark40CatalystPlanUtils.scala
@@ -106,7 +106,7 @@ object HoodieSpark40CatalystPlanUtils extends BaseHoodieCatalystPlanUtils {
 
   override def unapplyShowIndexes(plan: LogicalPlan): Option[(LogicalPlan, Seq[Attribute])] = {
     plan match {
-      case ci@ShowIndexes(table, output) =>
+      case ci@HoodieShowIndexes(table, output) =>
         Some((table, output))
       case _ =>
         None

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
@@ -3408,14 +3408,14 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Show indexes, returning a [[ShowIndexes]] logical plan.
+   * Show indexes, returning a [[HoodieShowIndexes]] logical plan.
    * For example:
    * {{{
    *   SHOW INDEXES (FROM | IN) [TABLE] table_name
    * }}}
    */
   override def visitShowIndexes(ctx: ShowIndexesContext): LogicalPlan = withOrigin(ctx) {
-    ShowIndexes(UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())))
+    HoodieShowIndexes(UnresolvedRelation(visitTableIdentifier(ctx.tableIdentifier())))
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -241,8 +241,8 @@
     <spring.shell.version>2.1.1</spring.shell.version>
     <snappy.version>1.1.10.7</snappy.version>
     <arrow.version>18.3.0</arrow.version>
-    <lance.version>1.0.2</lance.version>
-    <lance.spark.connector.version>0.0.15</lance.spark.connector.version>
+    <lance.version>4.0.0</lance.version>
+    <lance.spark.connector.version>0.4.0</lance.spark.connector.version>
     <lance.spark.artifact>lance-spark-3.5_${scala.binary.version}</lance.spark.artifact>
     <lance.skip.tests>false</lance.skip.tests>
     <!-- The following properties are only used for Jacoco coverage report aggregation -->
@@ -962,12 +962,12 @@
       </dependency>
       <!-- Lance Spark for Arrow conversion -->
       <dependency>
-        <groupId>com.lancedb</groupId>
+        <groupId>org.lance</groupId>
         <artifactId>${lance.spark.artifact}</artifactId>
         <version>${lance.spark.connector.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>com.lancedb</groupId>
+            <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
           </exclusion>
         </exclusions>


### PR DESCRIPTION
Bumps lance-core from 1.0.2 to 4.0.0 and the lance-spark connector from 0.0.15 to 0.4.0, adapts Hudi to the lance-spark repackaging (`com.lancedb` → `org.lance`) and API signature changes, fixes a column-ordering regression in `LanceRecordIterator` introduced by the new connector's batch layout, and renames Hudi's internal `ShowIndexes` logical plan to `HoodieShowIndexes` so it no longer clashes with Spark 4.0's built-in `ShowIndexes`.

### Describe the issue this Pull Request addresses

Hudi's Lance integration targets an older lance-spark / lance-core release. With lance-spark 0.4.0 the Maven coordinates (`com.lancedb` → `org.lance`), package paths, and a few public signatures changed, and the in-memory Arrow batch layout returned by `VectorSchemaRoot.getFieldVectors()` now reflects the file's on-disk column order rather than the order requested in `LanceFileReader.readAll(columnNames, ...)`. That last change silently broke MoR reads through `LanceRecordIterator`, because the `UnsafeProjection` is built from the Spark schema's column order but the `ColumnVector[]` we were handing it was in the file's on-disk order — so `UnsafeProjection` would dispatch e.g. `getInt(0)` against a `VarCharVector` and throw `UnsupportedOperationException`. Additionally, Spark 4.0 ships a `ShowIndexes` logical plan of its own, so Hudi's identically-named case class needed to be renamed to avoid conflicts once the codebase starts cross-compiling against Spark 4.

### Summary and Changelog

**1. Dependency bump (`[MINOR] Bump lance to 4.0.0 and lance-spark to 0.4.0`)**
- `pom.xml`: `lance.version` `1.0.2` → `4.0.0`, `lance.spark.connector.version` `0.0.15` → `0.4.0`, groupId `com.lancedb` → `org.lance` for both `lance-core` and the `lance-spark-3.5_${scala.binary.version}` artifact.
- `HoodieSparkLanceWriter.java`: update import `com.lancedb.lance.spark.arrow.LanceArrowWriter` → `org.lance.spark.arrow.LanceArrowWriter`, and adapt the `LanceArrowUtils.toArrowSchema(...)` call site — the 0.4.0 signature drops the `errorOnDuplicatedFieldNames` parameter.
- `LanceRecordIterator.java`: update import `com.lancedb.lance.spark.vectorized.LanceArrowColumnVector` → `org.lance.spark.vectorized.LanceArrowColumnVector`.

**2. Fix column-order regression (`fix(lance): look up Arrow vectors by field name in LanceRecordIterator`)**
- In `hasNext()`, the first batch now builds a `Map<String, FieldVector>` from `VectorSchemaRoot.getFieldVectors()` and walks the Spark `StructField[]` in order, looking each vector up by name, instead of trusting positional order.
- Adds a size/name sanity check that throws `HoodieException` with the available column set if Lance returns a mismatched batch.
- This restores the ordering contract the previously-built `UnsafeProjection` expects and unblocks MoR reads (the symptom was `UnsupportedOperationException` from `ArrowVectorAccessor.getInt` during `UnsafeProjection.apply` in `TestLanceDataSource.testBasicUpsertModifyExistingRow` / `testBasicDeleteOperation` on the MoR parameters).

**3. Rename `ShowIndexes` → `HoodieShowIndexes` (`[MINOR] Rename Hudi's ShowIndexes logical plan to HoodieShowIndexes`)**
- `Index.scala`: rename the case class and its companion.
- Pattern-match call-sites updated in `HoodieSpark33CatalystPlanUtils.scala`, `HoodieSpark34CatalystPlanUtils.scala`, `HoodieSpark35CatalystPlanUtils.scala`, `HoodieSpark40CatalystPlanUtils.scala`.
- Constructor call-sites updated in `HoodieSpark3_3ExtendedSqlAstBuilder.scala`, `HoodieSpark3_4ExtendedSqlAstBuilder.scala`, `HoodieSpark3_5ExtendedSqlAstBuilder.scala`, `HoodieSpark4_0ExtendedSqlAstBuilder.scala`.
- Doc reference updated in `IndexCommands.scala`.

### Impact

- **User-facing:** none. Public Hudi APIs, on-disk formats, and config are unchanged. All changes are internal to how Hudi invokes lance-spark and how Hudi's own `SHOW INDEXES` logical plan is named internally.
- **Dependencies:** downstream artifacts will now resolve `org.lance:lance-core:4.0.0` and `org.lance:lance-spark-3.5_${scala.binary.version}:0.4.0` instead of the old `com.lancedb` coordinates. Any external consumers that shade/relocate Lance classes should update their relocations accordingly.

### Risk Level

low — the bump is localized to the Lance reader/writer path, the ordering fix is narrowly scoped to `LanceRecordIterator.hasNext()`, and the rename is a name-only change that mechanically updates every call-site. CI (Azure + GitHub Actions) covers COW and MoR paths in `TestLanceDataSource`, which was the failure mode caught and fixed by commit 2.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (existing `TestLanceDataSource` MoR cases exercise the fixed path)
