### PR TITLE
feat(core): implement file-level sorting for upsert (#18357)

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -719,12 +719,18 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
                                         List<HoodieRecord> records,
                                         Map<HeaderMetadataType, String> header,
                                         String keyField) {
+    if (hoodieTable.requireSortedRecords()) {
+      records.sort(Comparator.comparing(HoodieRecord::getRecordKey));
+      header.put(HeaderMetadataType.IS_SORTED, Boolean.toString(true));
+    }
+
     switch (logDataBlockFormat) {
       case AVRO_DATA_BLOCK:
         return new HoodieAvroDataBlock(records, header, keyField);
       case HFILE_DATA_BLOCK:
         // Not supporting positions in HFile data blocks
         header.remove(HeaderMetadataType.BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS);
+        // HFile format always requires sorted records
         records.sort(Comparator.comparing(HoodieRecord::getRecordKey));
         return new HoodieHFileDataBlock(
             records, header, writeConfig.getHFileCompressionAlgorithm(), new StoragePath(writeConfig.getBasePath()));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -1052,7 +1052,8 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   }
 
   public boolean requireSortedRecords() {
-    return getBaseFileFormat() == HoodieFileFormat.HFILE;
+    return getBaseFileFormat() == HoodieFileFormat.HFILE
+        || config.getLayoutType() == HoodieStorageLayout.LayoutType.LSM_TREE;
   }
 
   public HoodieEngineContext getContext() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/storage/HoodieLSMTreeLayout.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/storage/HoodieLSMTreeLayout.java
@@ -18,30 +18,32 @@
 
 package org.apache.hudi.table.storage;
 
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.exception.HoodieNotSupportedException;
 
 /**
- * A factory to generate layout.
+ * Storage layout with LSM tree organization. Records within each file (base and log)
+ * are sorted by record key, enabling efficient sorted merge for reads and compaction.
  */
-public final class HoodieLayoutFactory {
-  public static HoodieStorageLayout createLayout(HoodieWriteConfig config) {
-    switch (config.getLayoutType()) {
-      case DEFAULT:
-        return new HoodieDefaultLayout(config);
-      case BUCKET:
-        switch (config.getBucketIndexEngineType()) {
-          case SIMPLE:
-            return new HoodieSimpleBucketLayout(config);
-          case CONSISTENT_HASHING:
-            return new HoodieConsistentBucketLayout(config);
-          default:
-            throw new HoodieNotSupportedException("Unknown bucket index engine type: " + config.getBucketIndexEngineType());
-        }
-      case LSM_TREE:
-        return new HoodieLSMTreeLayout(config);
-      default:
-        throw new HoodieNotSupportedException("Unknown layout type, set " + config.getLayoutType());
-    }
+public class HoodieLSMTreeLayout extends HoodieStorageLayout {
+
+  public HoodieLSMTreeLayout(HoodieWriteConfig config) {
+    super(config);
+  }
+
+  @Override
+  public boolean determinesNumFileGroups() {
+    return false;
+  }
+
+  @Override
+  public Option<String> layoutPartitionerClass() {
+    return Option.empty();
+  }
+
+  @Override
+  public boolean writeOperationSupported(WriteOperationType operationType) {
+    return true;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/storage/HoodieStorageLayout.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/storage/HoodieStorageLayout.java
@@ -62,6 +62,10 @@ public abstract class HoodieStorageLayout implements Serializable {
     @EnumFieldDescription("Each file group contains records of a set of keys which map "
         + "to a certain range of hash values, so that using the hash function can easily "
         + "identify the file group a record belongs to, based on the record key.")
-    BUCKET
+    BUCKET,
+
+    @EnumFieldDescription("Each file group contains records sorted by record key within "
+        + "each file (base and log), enabling sorted merge for reads and compaction.")
+    LSM_TREE
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/TestHoodieTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/TestHoodieTable.java
@@ -32,9 +32,12 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SerializationUtils;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieLayoutConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.table.storage.HoodieLayoutFactory;
+import org.apache.hudi.table.storage.HoodieLSMTreeLayout;
 import org.apache.hudi.table.storage.HoodieStorageLayout;
 
 import org.junit.jupiter.api.Test;
@@ -44,6 +47,7 @@ import java.util.function.Function;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -187,5 +191,44 @@ class TestHoodieTable extends HoodieCommonTestHarness {
     // This should not throw and should be a no-op since auto-delete is disabled
     hoodieTable.deleteMetadataIndexIfNecessary();
     // If we reach here without exception, the test passes
+  }
+
+  @Test
+  void testRequireSortedRecordsWithLSMTreeLayout() throws IOException {
+    initMetaClient();
+    HoodieEngineContext context = mock(HoodieEngineContext.class);
+
+    // Default layout: sorted records not required
+    HoodieWriteConfig defaultConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .build();
+    HoodieTable defaultTable = new TestBaseHoodieTable(defaultConfig, context, metaClient);
+    assertFalse(defaultTable.requireSortedRecords());
+
+    // LSM_TREE layout: sorted records required
+    HoodieWriteConfig lsmConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withProperties(HoodieLayoutConfig.newBuilder()
+            .withLayoutType(HoodieStorageLayout.LayoutType.LSM_TREE.name())
+            .build()
+            .getProps())
+        .build();
+    HoodieTable lsmTable = new TestBaseHoodieTable(lsmConfig, context, metaClient);
+    assertTrue(lsmTable.requireSortedRecords());
+  }
+
+  @Test
+  void testLSMTreeLayoutFactory() {
+    HoodieWriteConfig lsmConfig = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp/test_lsm_layout")
+        .withProperties(HoodieLayoutConfig.newBuilder()
+            .withLayoutType(HoodieStorageLayout.LayoutType.LSM_TREE.name())
+            .build()
+            .getProps())
+        .build();
+    HoodieStorageLayout layout = HoodieLayoutFactory.createLayout(lsmConfig);
+    assertTrue(layout instanceof HoodieLSMTreeLayout);
+    assertFalse(layout.determinesNumFileGroups());
+    assertTrue(layout.layoutPartitionerClass().isEmpty());
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -231,7 +231,8 @@ public abstract class HoodieLogBlock {
     RECORD_POSITIONS(HoodieTableVersion.SIX),
     BLOCK_IDENTIFIER(HoodieTableVersion.SIX),
     IS_PARTIAL(HoodieTableVersion.EIGHT),
-    BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS(HoodieTableVersion.EIGHT);
+    BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS(HoodieTableVersion.EIGHT),
+    IS_SORTED(HoodieTableVersion.EIGHT);
 
     @SuppressWarnings("unused")
     private final HoodieTableVersion earliestTableVersion;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

Implements file-level sorting for upsert operations when LSM tree layout is enabled, as part of Phase 1 of RFC-103 (Hudi LSM Tree Layout).

closes #18357


### Impact

No public API changes
No reader-side changes needed -- sorted files are readable by existing readers
Backward compatible -- only affects tables explicitly configured with LSM_TREE layout


### Risk Level
low -- leverages existing requireSortedRecords() infrastructure that is already battle-tested for HFile format



### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->
  
  ## Changes
- Added `LSM_TREE` as a new `LayoutType` enum value alongside `DEFAULT` and `BUCKET`
- Created `HoodieLSMTreeLayout` class and registered it in `HoodieLayoutFactory`
- Extended `HoodieTable.requireSortedRecords()` to return `true` when layout is `LSM_TREE`, which automatically enables:
  - Spark RDD-level sorting via `repartitionAndSortWithinPartitions()`
  - `HoodieSortedMergeHandle` for COW merge writes
  - Sorted key iteration in `BaseCreateHandle`
- Extended `HoodieAppendHandle.getDataBlock()` to sort records for ALL log block formats (AVRO, Parquet) when `requireSortedRecords()` is true (previously only HFile was sorted)
- Added `IS_SORTED` header metadata to `HeaderMetadataType` enum, stamped on sorted log blocks to enable future readers to detect sorted blocks dynamically


### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
