### PR TITLE
fix: whitelist Flink _2.12 artifacts in scala-2.13 enforcer rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2485,10 +2485,20 @@
                         <exclude>*:*_2.11</exclude>
                         <exclude>*:*_2.12</exclude>
                       </excludes>
+                      <!--
+                        Flink decoupled from Scala starting 1.15; the `_2.12` suffix on
+                        flink-table-planner and its transitives (scala-xml, chill) is a
+                        legacy naming artifact, not a real Scala 2.12 binary dependency.
+                        Flink publishes no `_2.13` variant of flink-table-planner, so
+                        building with `-Dscala-2.13` together with any Flink profile
+                        (e.g. `-Dflink1.20`) would otherwise trip the blanket `*:*_2.12`
+                        ban above. Whitelist only the Flink-side transitives that
+                        actually surface here.
+                      -->
                       <includes>
                         <include>org.apache.flink:*_2.12</include>
-                        <include>org.scala-lang.modules:*_2.12</include>
-                        <include>com.twitter:*_2.12</include>
+                        <include>org.scala-lang.modules:scala-xml_2.12</include>
+                        <include>com.twitter:chill_2.12</include>
                       </includes>
                     </bannedDependencies>
                   </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -2485,6 +2485,11 @@
                         <exclude>*:*_2.11</exclude>
                         <exclude>*:*_2.12</exclude>
                       </excludes>
+                      <includes>
+                        <include>org.apache.flink:*_2.12</include>
+                        <include>org.scala-lang.modules:*_2.12</include>
+                        <include>com.twitter:*_2.12</include>
+                      </includes>
                     </bannedDependencies>
                   </rules>
                 </configuration>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Background: We are introducing Spark4.0, which is required to support Variant types.

Addressing build issues/errors when running the following command:
```shell
mvn clean install -DskipTests -Dspark4.0 -Dscala-2.13 -Dflink1.20
```

Error:
```log
[ERROR] Rule 0: org.apache.maven.enforcer.rules.dependency.BannedDependencies failed with message:
[ERROR] org.apache.hudi:hudi-flink1.20.x:jar:1.2.0-SNAPSHOT
[ERROR]    org.apache.flink:flink-table-planner_2.12:jar:1.20.1
[ERROR]       org.apache.flink:flink-scala_2.12:jar:1.20.1
[ERROR]          org.scala-lang:scala-compiler:jar:2.12.7
[ERROR]             org.scala-lang.modules:scala-xml_2.12:jar:1.0.6 <--- banned via the exclude/include list
[ERROR]          com.twitter:chill_2.12:jar:0.7.6 <--- banned via the exclude/include list
````

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

- Flink only publishes `flink-table-planner_2.12` (no _2.13 variant exists). The `scala-2.13` profile's blanket ban on `*_2.12` artifacts breaks the build when combining `-Dspark4.0 -Dscala-2.13` with `-Dflink1.20`.
- Add `<includes>` exceptions for `org.apache.flink:*_2.12` and its transitive _2.12 dependencies (`org.scala-lang.modules`, `com.twitter`) since Flink has largely decoupled from Scala since **1.15** and the **_2.12** suffix is internal.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

Uses will be able to run the following build command without issues:

```shell
mvn clean install -DskipTests -Dspark4.0 -Dscala-2.13 -Dflink1.20
mvn clean install -DskipTests -Dspark4.0 -Dscala-2.13
```

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

Low.

The one risk worth noting: if a Flink **_2.12** artifact transitively pulls in `org.scala-lang:scala-library:2.12.x`, that could theoretically clash with **Scala 2.13** at runtime. 

But since all the Flink dependencies in the Hudi POMs are `<scope>provided</scope>`, they won't be packaged into the final artifact, so there should not be any runtime classpath conflict. 

For the build/compile step, this is safe. Flink's _2.12 planner internals don't expose Scala types in the APIs that Hudi calls (`SortCodeGenerator`, `ExecNodeUtil`, `SortSpec` are all Java classes).


### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
