### PR TITLE
fix: prevent parseTypeDescriptor crash for VARIANT

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -103,7 +103,6 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
       // Complex types
       case ArrayType(elementSparkType, containsNull)
           if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
-            HoodieSchema.isCustomLogicalTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)) &&
             HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR =>
         if (depth > 1) {
           throw new HoodieSchemaException(
@@ -138,11 +137,16 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
         HoodieSchema.createMap(valueSchema)
 
       case blobStruct: StructType if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
-        HoodieSchema.isCustomLogicalTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)) &&
         HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.BLOB =>
         // Validate blob structure before accepting
         validateBlobStructure(blobStruct)
         HoodieSchema.createBlob()
+
+      case variantStruct: StructType if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+        HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VARIANT =>
+        validateVariantStructure(variantStruct)
+        HoodieSchema.createVariant(recordName, nameSpace, null)
+
       case st: StructType =>
         val childNameSpace = if (nameSpace != "") s"$nameSpace.$recordName" else recordName
 
@@ -354,6 +358,33 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
       throw new IllegalArgumentException(
         s"""Invalid blob schema structure. Expected schema:
            |${expectedBlobStructType.toDDL}
+           |Got schema:
+           |${structType.toDDL}""".stripMargin)
+    }
+  }
+
+  private lazy val expectedVariantStructType: StructType = {
+    val metadataField = StructField(HoodieSchema.Variant.VARIANT_METADATA_FIELD, BinaryType, nullable = false)
+    val valueField = StructField(HoodieSchema.Variant.VARIANT_VALUE_FIELD, BinaryType, nullable = false)
+    StructType(Seq(metadataField, valueField))
+  }
+
+  /**
+   * Validates that a StructType matches the expected unshredded variant schema
+   * (two non-null {@code BinaryType} fields: {@code metadata} and {@code value}).
+   *
+   * @param structType the StructType to validate
+   * @throws IllegalArgumentException if the structure does not match the expected variant schema
+   */
+  private def validateVariantStructure(structType: StructType): Unit = {
+    val fieldsByName = structType.fields.map(f => f.name -> f).toMap
+    val ok = structType.length == 2 &&
+      fieldsByName.get(HoodieSchema.Variant.VARIANT_METADATA_FIELD).exists(f => f.dataType == BinaryType && !f.nullable) &&
+      fieldsByName.get(HoodieSchema.Variant.VARIANT_VALUE_FIELD).exists(f => f.dataType == BinaryType && !f.nullable)
+    if (!ok) {
+      throw new IllegalArgumentException(
+        s"""Invalid variant schema structure. Expected schema:
+           |${expectedVariantStructType.toDDL}
            |Got schema:
            |${structType.toDDL}""".stripMargin)
     }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -103,6 +103,7 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
       // Complex types
       case ArrayType(elementSparkType, containsNull)
           if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+            HoodieSchema.isCustomLogicalTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)) &&
             HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR =>
         if (depth > 1) {
           throw new HoodieSchemaException(
@@ -137,6 +138,7 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
         HoodieSchema.createMap(valueSchema)
 
       case blobStruct: StructType if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+        HoodieSchema.isCustomLogicalTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)) &&
         HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.BLOB =>
         // Validate blob structure before accepting
         validateBlobStructure(blobStruct)

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
@@ -190,6 +190,24 @@ public class HoodieSchema implements Serializable {
   private static final Set<HoodieSchemaType> CUSTOM_LOGICAL_TYPES =
       EnumSet.of(HoodieSchemaType.VECTOR, HoodieSchemaType.BLOB);
 
+  /**
+   * Returns true if the given descriptor string represents a custom logical type
+   * that can be parsed by {@link #parseTypeDescriptor(String)}.
+   * This is safe to call in pattern-match guards since it never throws.
+   */
+  public static boolean isCustomLogicalTypeDescriptor(String descriptor) {
+    if (descriptor == null || descriptor.trim().isEmpty()) {
+      return false;
+    }
+    int parenStart = descriptor.indexOf('(');
+    String typeName = (parenStart == -1) ? descriptor.trim() : descriptor.substring(0, parenStart).trim();
+    try {
+      HoodieSchemaType type = HoodieSchemaType.valueOf(typeName.toUpperCase(Locale.ROOT));
+      return CUSTOM_LOGICAL_TYPES.contains(type);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
 
   /**
    * Constants for Parquet-style accessor patterns used in nested MAP and ARRAY navigation.

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
@@ -98,8 +98,8 @@ public class HoodieSchema implements Serializable {
   public static final HoodieSchema NULL_SCHEMA = HoodieSchema.create(HoodieSchemaType.NULL);
   /**
    * Constant to use when attaching type metadata to external schema systems like Spark's StructType.
-   * Stores a parameterized type string for custom Hudi logical types such as VECTOR and BLOB.
-   * Examples: "VECTOR(128)", "VECTOR(512, DOUBLE)", "BLOB".
+   * Stores a parameterized type string for custom Hudi logical types such as VECTOR, BLOB, and VARIANT.
+   * Examples: "VECTOR(128)", "VECTOR(512, DOUBLE)", "BLOB", "VARIANT".
    */
   public static final String TYPE_METADATA_FIELD = "hudi_type";
 
@@ -109,8 +109,8 @@ public class HoodieSchema implements Serializable {
   public static final String VARIANT_TYPE_NAME = VariantLogicalType.VARIANT_LOGICAL_TYPE_NAME;
 
   /**
-   * Parses a type descriptor string for custom Hudi logical types such as VECTOR and BLOB.
-   * Examples: "VECTOR(128)", "VECTOR(512, DOUBLE)", "BLOB".
+   * Parses a type descriptor string for custom Hudi logical types such as VECTOR, BLOB, and VARIANT.
+   * Examples: "VECTOR(128)", "VECTOR(512, DOUBLE)", "BLOB", "VARIANT".
    * Throws for non-custom logical type names.
    */
   public static HoodieSchema parseTypeDescriptor(String descriptor) {
@@ -145,6 +145,12 @@ public class HoodieSchema implements Serializable {
               "BLOB type descriptor does not support parameters, got: " + params);
         }
         return createBlob();
+      case VARIANT:
+        if (!params.isEmpty()) {
+          throw new IllegalArgumentException(
+              "VARIANT type descriptor does not support parameters, got: " + params);
+        }
+        return createVariant();
       default:
         throw new IllegalArgumentException(
             "parseTypeDescriptor only supports custom logical types, got: " + type);
@@ -188,26 +194,7 @@ public class HoodieSchema implements Serializable {
   }
 
   private static final Set<HoodieSchemaType> CUSTOM_LOGICAL_TYPES =
-      EnumSet.of(HoodieSchemaType.VECTOR, HoodieSchemaType.BLOB);
-
-  /**
-   * Returns true if the given descriptor string represents a custom logical type
-   * that can be parsed by {@link #parseTypeDescriptor(String)}.
-   * This is safe to call in pattern-match guards since it never throws.
-   */
-  public static boolean isCustomLogicalTypeDescriptor(String descriptor) {
-    if (descriptor == null || descriptor.trim().isEmpty()) {
-      return false;
-    }
-    int parenStart = descriptor.indexOf('(');
-    String typeName = (parenStart == -1) ? descriptor.trim() : descriptor.substring(0, parenStart).trim();
-    try {
-      HoodieSchemaType type = HoodieSchemaType.valueOf(typeName.toUpperCase(Locale.ROOT));
-      return CUSTOM_LOGICAL_TYPES.contains(type);
-    } catch (IllegalArgumentException e) {
-      return false;
-    }
-  }
+      EnumSet.of(HoodieSchemaType.VECTOR, HoodieSchemaType.BLOB, HoodieSchemaType.VARIANT);
 
   /**
    * Constants for Parquet-style accessor patterns used in nested MAP and ARRAY navigation.

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchema.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchema.java
@@ -2855,6 +2855,25 @@ public class TestHoodieSchema {
   }
 
   @Test
+  public void testParseTypeDescriptorVariant() {
+    HoodieSchema parsed = HoodieSchema.parseTypeDescriptor("VARIANT");
+    assertEquals(HoodieSchemaType.VARIANT, parsed.getType());
+    assertInstanceOf(HoodieSchema.Variant.class, parsed);
+  }
+
+  @Test
+  public void testParseTypeDescriptorVariantCaseInsensitive() {
+    HoodieSchema parsed = HoodieSchema.parseTypeDescriptor("variant");
+    assertEquals(HoodieSchemaType.VARIANT, parsed.getType());
+  }
+
+  @Test
+  public void testParseTypeDescriptorVariantRejectsParameters() {
+    assertThrows(IllegalArgumentException.class, () -> HoodieSchema.parseTypeDescriptor("VARIANT(foo)"));
+    assertThrows(IllegalArgumentException.class, () -> HoodieSchema.parseTypeDescriptor("VARIANT(1, 2)"));
+  }
+
+  @Test
   public void testCreateArrayWithNullableVectorThrows() {
     HoodieSchema vectorSchema = HoodieSchema.createNullable(HoodieSchema.createVector(128));
     HoodieSchemaException ex = assertThrows(HoodieSchemaException.class,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/avro/TestSchemaConverters.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/avro/TestSchemaConverters.scala
@@ -250,6 +250,51 @@ class TestSchemaConverters extends SparkAdapterSupport {
   }
 
   @Test
+  def testInvalidVariantSchemaWrongFieldCount(): Unit = {
+    val invalidStruct = new StructType(Array[StructField](
+      StructField(HoodieSchema.Variant.VARIANT_METADATA_FIELD, DataTypes.BinaryType, nullable = false)
+    ))
+    assertInvalidVariantSchema(invalidStruct)
+  }
+
+  @Test
+  def testInvalidVariantSchemaNullableMetadataField(): Unit = {
+    val invalidStruct = new StructType(Array[StructField](
+      StructField(HoodieSchema.Variant.VARIANT_METADATA_FIELD, DataTypes.BinaryType, nullable = true),
+      StructField(HoodieSchema.Variant.VARIANT_VALUE_FIELD, DataTypes.BinaryType, nullable = false)
+    ))
+    assertInvalidVariantSchema(invalidStruct)
+  }
+
+  @Test
+  def testInvalidVariantSchemaWrongValueFieldType(): Unit = {
+    val invalidStruct = new StructType(Array[StructField](
+      StructField(HoodieSchema.Variant.VARIANT_METADATA_FIELD, DataTypes.BinaryType, nullable = false),
+      StructField(HoodieSchema.Variant.VARIANT_VALUE_FIELD, DataTypes.StringType, nullable = false)
+    ))
+    assertInvalidVariantSchema(invalidStruct)
+  }
+
+  @Test
+  def testInvalidVariantSchemaWrongFieldNames(): Unit = {
+    val invalidStruct = new StructType(Array[StructField](
+      StructField("foo", DataTypes.BinaryType, nullable = false),
+      StructField("bar", DataTypes.BinaryType, nullable = false)
+    ))
+    assertInvalidVariantSchema(invalidStruct)
+  }
+
+  private def assertInvalidVariantSchema(invalidStruct: StructType): Unit = {
+    val metadata = new MetadataBuilder()
+      .putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.VARIANT.name())
+      .build()
+    val exception = assertThrows(classOf[IllegalArgumentException], () => {
+      HoodieSparkSchemaConverters.toHoodieType(invalidStruct, metadata = metadata)
+    })
+    assertTrue(exception.getMessage.startsWith("Invalid variant schema structure"))
+  }
+
+  @Test
   def testTopLevelVectorStillAllowed(): Unit = {
     val vectorMetadata = new MetadataBuilder()
       .putString(HoodieSchema.TYPE_METADATA_FIELD, "VECTOR(4)")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -94,10 +94,9 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
     }
   }
 
-  test("Test StructType with hudi_type=VARIANT metadata does not crash parseTypeDescriptor") {
-    // Regression test: a StructType field with hudi_type=VARIANT metadata in the DataFrame API
-    // used to crash in HoodieSparkSchemaConverters because the BLOB guard condition called
-    // parseTypeDescriptor() which threw for non-custom logical types like VARIANT.
+  test("Test StructType with hudi_type=VARIANT metadata is promoted to VARIANT logical type") {
+    // A StructType field in the DataFrame API tagged with hudi_type=VARIANT is treated as a first-class
+    // VARIANT (like BLOB/VECTOR), not a plain struct. On Spark 4.0+ the column round-trips as native VariantType.
     assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
 
     withTempDir { tmp =>
@@ -122,8 +121,6 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
       )
       val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
 
-      // This should NOT crash with "parseTypeDescriptor only supports custom logical types, got: VARIANT".
-      // The struct+metadata VARIANT is treated as a regular struct (the native VariantType path is separate).
       df.write.format("hudi")
         .option("hoodie.table.name", "variant_struct_test")
         .option("hoodie.datasource.write.recordkey.field", "id")
@@ -131,10 +128,49 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
         .mode(SaveMode.Overwrite)
         .save(tmp.getCanonicalPath)
 
-      // Verify the data was written and can be read back
       val readDf = spark.read.format("hudi").load(tmp.getCanonicalPath)
+      val readFieldType = readDf.schema("variant_data").dataType
+      assert(readFieldType.typeName == "variant",
+        s"variant_data should round-trip as native VariantType on Spark 4.0+, got $readFieldType")
       assert(readDf.count() == 1)
-      assert(readDf.select("id", "name").collect()(0).getLong(0) == 1L)
+    }
+  }
+
+  test("Test StructType with hudi_type=VARIANT metadata rejects malformed struct") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withTempDir { tmp =>
+      val variantMetadata = new MetadataBuilder()
+        .putString(HoodieSchema.TYPE_METADATA_FIELD, "VARIANT")
+        .build()
+
+      // VARIANT structure must be {metadata: binary, value: binary}; a single string field is malformed.
+      val malformedVariantStruct = StructType(Seq(
+        StructField("wrong_field", StringType, nullable = false)
+      ))
+
+      val schema = StructType(Seq(
+        StructField("id", LongType, nullable = false),
+        StructField("variant_data", malformedVariantStruct, nullable = false, metadata = variantMetadata),
+        StructField("ts", LongType)
+      ))
+
+      val data = Seq(Row(1L, Row("oops"), 1000L))
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+      val ex = intercept[Exception] {
+        df.write.format("hudi")
+          .option("hoodie.table.name", "variant_malformed_test")
+          .option("hoodie.datasource.write.recordkey.field", "id")
+          .option("hoodie.datasource.write.precombine.field", "ts")
+          .mode(SaveMode.Overwrite)
+          .save(tmp.getCanonicalPath)
+      }
+      val causes = Iterator.iterate[Throwable](ex)(e => e.getCause).takeWhile(_ != null).toList
+      assert(causes.exists(c => c.isInstanceOf[IllegalArgumentException]
+        && c.getMessage != null
+        && c.getMessage.contains("Invalid variant schema structure")),
+        s"Expected IllegalArgumentException with 'Invalid variant schema structure', got: ${causes.map(_.getMessage)}")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -20,11 +20,14 @@
 package org.apache.spark.sql.hudi.dml.schema
 
 import org.apache.hudi.HoodieSparkUtils
+import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.internal.schema.HoodieSchemaException
 
+import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.types._
 
 
 class TestVariantDataType extends HoodieSparkSqlTestBase {
@@ -88,6 +91,50 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
           Seq(1, "row1", "{\"new_field\":123,\"updated\":true}", 1000)
         )
       })
+    }
+  }
+
+  test("Test StructType with hudi_type=VARIANT metadata does not crash parseTypeDescriptor") {
+    // Regression test: a StructType field with hudi_type=VARIANT metadata in the DataFrame API
+    // used to crash in HoodieSparkSchemaConverters because the BLOB guard condition called
+    // parseTypeDescriptor() which threw for non-custom logical types like VARIANT.
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withTempDir { tmp =>
+      val variantMetadata = new MetadataBuilder()
+        .putString(HoodieSchema.TYPE_METADATA_FIELD, "VARIANT")
+        .build()
+
+      val variantStruct = StructType(Seq(
+        StructField("metadata", BinaryType, nullable = false),
+        StructField("value", BinaryType, nullable = false)
+      ))
+
+      val schema = StructType(Seq(
+        StructField("id", LongType, nullable = false),
+        StructField("name", StringType),
+        StructField("variant_data", variantStruct, nullable = false, metadata = variantMetadata),
+        StructField("ts", LongType)
+      ))
+
+      val data = Seq(
+        Row(1L, "row1", Row(Array[Byte](1, 0), """{"key":"value1"}""".getBytes), 1000L)
+      )
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+      // This should NOT crash with "parseTypeDescriptor only supports custom logical types, got: VARIANT".
+      // The struct+metadata VARIANT is treated as a regular struct (the native VariantType path is separate).
+      df.write.format("hudi")
+        .option("hoodie.table.name", "variant_struct_test")
+        .option("hoodie.datasource.write.recordkey.field", "id")
+        .option("hoodie.datasource.write.precombine.field", "ts")
+        .mode(SaveMode.Overwrite)
+        .save(tmp.getCanonicalPath)
+
+      // Verify the data was written and can be read back
+      val readDf = spark.read.format("hudi").load(tmp.getCanonicalPath)
+      assert(readDf.count() == 1)
+      assert(readDf.select("id", "name").collect()(0).getLong(0) == 1L)
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Closes: #18509 

- The BLOB/VECTOR guard conditions in HoodieSparkSchemaConverters called parseTypeDescriptor() for any StructType/ArrayType with hudi_type metadata, which threw IllegalArgumentException for types like VARIANT that are not custom logical types.


### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

- Add isCustomLogicalTypeDescriptor() safe check to short-circuit the guards before parseTypeDescriptor() is called.
- Add regression test that reproduces the struct+metadata VARIANT path.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
Users can now create tables with VARIANT types using Spark4.0 Dataframe API.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->
None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
