### PR TITLE
fix: VARIANT Hive sync error when performing CREATE table DDL

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hudi.command
 
 import org.apache.hudi.{DataSourceWriteOptions, SparkAdapterSupport}
 import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.util.ConfigUtils
 import org.apache.hudi.exception.{HoodieException, HoodieValidationException}
@@ -40,7 +41,7 @@ import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{isUsingHiveCatalog, isUsi
 import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand.validateTableSchema
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
 import org.apache.spark.sql.internal.StaticSQLConf.SCHEMA_STRING_LENGTH_THRESHOLD
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, MapType, StructField, StructType}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -93,7 +94,7 @@ case class CreateHoodieTableCommand(table: CatalogTable, ignoreIfExists: Boolean
   }
 }
 
-object CreateHoodieTableCommand {
+object CreateHoodieTableCommand extends SparkAdapterSupport {
 
   def validateTableSchema(userDefinedSchema: StructType, hoodieTableSchema: StructType): Boolean = {
     if (userDefinedSchema.fields.length != 0 &&
@@ -222,14 +223,58 @@ object CreateHoodieTableCommand {
     if (!dbExists) {
       throw new NoSuchDatabaseException(dbName)
     }
-    // append some table properties need for spark data source table.
+    // Store original schema (with VariantType) in properties so Spark can reconstruct it when reading;
+    // schema passed to Hive is converted to Hive-compatible types so Hive 2.x/3.x does not reject VARIANT.
     val dataSourceProps = tableMetaToTableProps(sparkSession.sparkContext.conf,
       table, table.schema)
-
-    val tableWithDataSourceProps = table.copy(properties = dataSourceProps ++ table.properties)
+    val tableWithDataSourceProps = buildHiveCompatibleCatalogTable(table, dataSourceProps)
     val client = HiveClientUtils.getSingletonClientForMetadata(sparkSession)
     // create hive table.
     client.createTable(tableWithDataSourceProps, ignoreIfExists = true)
+  }
+
+  /**
+   * Returns a copy of `table` with a Hive-compatible schema and data-source properties merged in.
+   * The schema passed to the Hive metastore has VariantType (and other Hive-incompatible types)
+   * replaced by their physical representations, while `dataSourceProps` carries the original
+   * schema JSON so Spark can restore the logical types on read.
+   */
+  private[hudi] def buildHiveCompatibleCatalogTable(
+      table: CatalogTable,
+      dataSourceProps: Map[String, String]): CatalogTable = {
+    table.copy(
+      schema = toHiveCompatibleSchema(table.schema),
+      properties = dataSourceProps ++ table.properties)
+  }
+
+  /**
+   * Converts Spark DataTypes that Hive doesn't support to their physical representations.
+   * Currently handles VariantType (Spark 4.0+) -> `struct<metadata:binary, value:binary>`.
+   * Recurses into nested StructType, ArrayType, and MapType so variants embedded in
+   * complex types (e.g. `STRUCT<a: VARIANT>`, `ARRAY<VARIANT>`, `MAP<STRING, VARIANT>`)
+   * are also converted.
+   */
+  private[hudi] def toHiveCompatibleSchema(schema: StructType): StructType = {
+    toHiveCompatibleType(schema).asInstanceOf[StructType]
+  }
+
+  private def toHiveCompatibleType(dataType: DataType): DataType = dataType match {
+    case dt if sparkAdapter.isVariantType(dt) =>
+      // Canonical field order (metadata, value) matches the Parquet spec and Iceberg convention,
+      // mirroring HoodieSchema.createVariant().
+      StructType(Seq(
+        StructField(HoodieSchema.Variant.VARIANT_METADATA_FIELD, BinaryType, nullable = false),
+        StructField(HoodieSchema.Variant.VARIANT_VALUE_FIELD, BinaryType, nullable = false)
+      ))
+    case st: StructType =>
+      StructType(st.fields.map(f => f.copy(dataType = toHiveCompatibleType(f.dataType))))
+    case at: ArrayType =>
+      at.copy(elementType = toHiveCompatibleType(at.elementType))
+    case mt: MapType =>
+      mt.copy(
+        keyType = toHiveCompatibleType(mt.keyType),
+        valueType = toHiveCompatibleType(mt.valueType))
+    case other => other
   }
 
   // This code is forked from org.apache.spark.sql.hive.HiveExternalCatalog#tableMetaToTableProps

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -26,8 +26,11 @@ import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.internal.schema.HoodieSchemaException
 
 import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, LongType, MapType, MetadataBuilder, StringType, StructField, StructType}
 
 
 class TestVariantDataType extends HoodieSparkSqlTestBase {
@@ -92,6 +95,93 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
         )
       })
     }
+  }
+
+  test("Test toHiveCompatibleSchema converts VariantType to physical struct") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    val variantType = DataType.fromDDL("variant")
+    val schema = StructType(Seq(
+      StructField("id", LongType, nullable = false),
+      StructField("name", StringType),
+      StructField("variant_col", variantType, nullable = true),
+      StructField("nested_struct", StructType(Seq(
+        StructField("inner_variant", variantType)
+      ))),
+      StructField("variant_array", ArrayType(variantType)),
+      StructField("variant_map", MapType(StringType, variantType)),
+      StructField("ts", LongType)
+    ))
+
+    val hiveSchema = CreateHoodieTableCommand.toHiveCompatibleSchema(schema)
+
+    // Non-variant fields should be unchanged
+    assert(hiveSchema("id").dataType == LongType)
+    assert(hiveSchema("name").dataType == StringType)
+    assert(hiveSchema("ts").dataType == LongType)
+
+    // Top-level variant should be converted with canonical (metadata, value) field order.
+    val variantStruct = assertVariantStruct(hiveSchema("variant_col").dataType)
+    assert(variantStruct.fields(0).name == HoodieSchema.Variant.VARIANT_METADATA_FIELD)
+    assert(variantStruct.fields(1).name == HoodieSchema.Variant.VARIANT_VALUE_FIELD)
+
+    // Variant nested inside a StructType should be converted recursively.
+    val nestedStruct = hiveSchema("nested_struct").dataType.asInstanceOf[StructType]
+    assertVariantStruct(nestedStruct("inner_variant").dataType)
+
+    // Variant as ArrayType element should be converted.
+    val arrayType = hiveSchema("variant_array").dataType.asInstanceOf[ArrayType]
+    assertVariantStruct(arrayType.elementType)
+
+    // Variant as MapType value should be converted.
+    val mapType = hiveSchema("variant_map").dataType.asInstanceOf[MapType]
+    assert(mapType.keyType == StringType)
+    assertVariantStruct(mapType.valueType)
+  }
+
+  private def assertVariantStruct(dataType: DataType): StructType = {
+    assert(dataType.isInstanceOf[StructType])
+    val structType = dataType.asInstanceOf[StructType]
+    assert(structType.length == 2)
+    assert(structType(HoodieSchema.Variant.VARIANT_METADATA_FIELD).dataType == BinaryType)
+    assert(structType(HoodieSchema.Variant.VARIANT_VALUE_FIELD).dataType == BinaryType)
+    structType
+  }
+
+  test("Test buildHiveCompatibleCatalogTable converts schema and merges properties") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    val variantType = DataType.fromDDL("variant")
+    val table = CatalogTable(
+      identifier = TableIdentifier("test_table", Some("default")),
+      tableType = CatalogTableType.MANAGED,
+      storage = CatalogStorageFormat.empty,
+      schema = StructType(Seq(
+        StructField("id", LongType, nullable = false),
+        StructField("variant_col", variantType, nullable = true)
+      )),
+      provider = Some("hudi"),
+      properties = Map("existing_key" -> "table_value", "shared_key" -> "table_value"))
+
+    val dataSourceProps = Map(
+      "spark.sql.sources.provider" -> "hudi",
+      "shared_key" -> "datasource_value")
+
+    val result = CreateHoodieTableCommand.buildHiveCompatibleCatalogTable(table, dataSourceProps)
+
+    // VariantType replaced with the canonical (metadata, value) struct.
+    assertVariantStruct(result.schema("variant_col").dataType)
+    // Non-variant columns preserved.
+    assert(result.schema("id").dataType == LongType)
+    // Existing-only table properties survive.
+    assert(result.properties("existing_key") == "table_value")
+    // dataSource-only keys are merged in.
+    assert(result.properties("spark.sql.sources.provider") == "hudi")
+    // On conflict, CatalogTable.properties wins over dataSourceProps (right-biased `++`).
+    assert(result.properties("shared_key") == "table_value")
+    // Identity/provider fields pass through unchanged.
+    assert(result.identifier == table.identifier)
+    assert(result.provider == table.provider)
   }
 
   test("Test StructType with hudi_type=VARIANT metadata is promoted to VARIANT logical type") {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

Closes :#18512

Hive 2.x/3.x does not support VARIANT type natively.

When creating a Hudi table with VARIANT columns via SQL CREATE TABLE, Spark's HiveClient passes "variant" as a literal type string which Hive rejects.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

- Convert VariantType to struct<value:binary, metadata:binary> in the CatalogTable schema before passing to HiveClient, while preserving the original VariantType in table properties so Spark can reconstruct it when reading.
- Add unit test for the conversion.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

User can now perform `CREATE TABLE` DDL with VARIANT column type.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

Low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
