### PR TITLE
feat(flink): extend Flink quickstart example to use source v2

### DIFF
--- a/hudi-examples/hudi-examples-flink/pom.xml
+++ b/hudi-examples/hudi-examples-flink/pom.xml
@@ -161,6 +161,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-base</artifactId>
+            <version>${flink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>

--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
@@ -65,14 +65,26 @@ public final class HoodieFlinkQuickstart {
     return new HoodieFlinkQuickstart();
   }
 
+  /**
+   * Entry point.
+   *
+   * <p>Usage: {@code HoodieFlinkQuickstart <tablePath> <tableName> <tableType> [useSourceV2]}
+   *
+   * <p>When {@code useSourceV2} is {@code true} (default: {@code false}), the Hudi table is
+   * registered with {@code read.source-v2.enabled = true}, which activates the FLIP-27
+   * {@link org.apache.hudi.source.HoodieSource} for both streaming and batch reads.
+   * An additional bounded batch-read step ({@link #queryBatchData}) is executed to demonstrate
+   * the {@link org.apache.hudi.source.enumerator.HoodieStaticSplitEnumerator} path.
+   */
   public static void main(String[] args) throws TableNotExistException, InterruptedException {
     if (args.length < 3) {
-      System.err.println("Usage: HoodieWriteClientExample <tablePath> <tableName> <tableType>");
+      System.err.println("Usage: HoodieFlinkQuickstart <tablePath> <tableName> <tableType> [useSourceV2]");
       System.exit(1);
     }
     String tablePath = args[0];
     String tableName = args[1];
-    String tableType = args[2];
+    HoodieTableType tableType = HoodieTableType.valueOf(args[2]);
+    boolean useSourceV2 = args.length > 3 && Boolean.parseBoolean(args[3]);
 
     HoodieFlinkQuickstart flinkQuickstart = instance();
     flinkQuickstart.initEnv();
@@ -81,13 +93,18 @@ public final class HoodieFlinkQuickstart {
     flinkQuickstart.createFileSource();
 
     // create hudi table
-    flinkQuickstart.createHudiTable(tablePath, tableName, HoodieTableType.valueOf(tableType));
+    flinkQuickstart.createHudiTable(tablePath, tableName, tableType, useSourceV2);
 
     // insert data
     flinkQuickstart.insertData();
 
-    // query data
+    // streaming query (continuous read)
     flinkQuickstart.queryData();
+
+    if (useSourceV2) {
+      // Source V2 also supports a bounded batch read via HoodieStaticSplitEnumerator
+      flinkQuickstart.queryBatchData(tablePath, tableName, tableType);
+    }
 
     // update data
     flinkQuickstart.updateData();
@@ -132,20 +149,45 @@ public final class HoodieFlinkQuickstart {
     return batchTableEnv;
   }
 
+  /**
+   * Creates the Hudi streaming table without Source V2 (legacy SourceFunction path).
+   */
   public void createHudiTable(String tablePath, String tableName,
                               HoodieTableType tableType) {
+    createHudiTable(tablePath, tableName, tableType, false);
+  }
+
+  /**
+   * Creates a Hudi streaming table, optionally enabling the FLIP-27 Source V2 reader.
+   *
+   * <p>When {@code useSourceV2} is {@code true}, {@code read.source-v2.enabled} is added to the
+   * table DDL, routing reads through {@link org.apache.hudi.source.HoodieSource} (split-enumerator
+   * / reader architecture) instead of the legacy SourceFunction path.  The table is created with
+   * {@code READ_AS_STREAMING = true} so the Source V2 enumerator runs in continuous-unbounded mode
+   * ({@link org.apache.hudi.source.enumerator.HoodieContinuousSplitEnumerator}).
+   *
+   * @param tablePath   storage path for the Hudi table
+   * @param tableName   logical table name used in SQL
+   * @param tableType   COPY_ON_WRITE or MERGE_ON_READ
+   * @param useSourceV2 whether to enable the FLIP-27 Source V2 reader
+   */
+  public void createHudiTable(String tablePath, String tableName,
+                              HoodieTableType tableType, boolean useSourceV2) {
     this.tableName = tableName;
 
-    // create hudi table
-    String hoodieTableDDL = sql(tableName)
+    QuickstartConfigurations.Sql sqlBuilder = sql(tableName)
         .option(FlinkOptions.PATH, tablePath)
         .option(FlinkOptions.RECORD_KEY_FIELD, "uuid")
         .option(FlinkOptions.ORDERING_FIELDS, "ts")
         .option(FlinkOptions.READ_AS_STREAMING, true)
         .option(FlinkOptions.TABLE_TYPE, tableType)
-        .option(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), false)
-        .end();
-    streamTableEnv.executeSql(hoodieTableDDL);
+        .option(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), false);
+
+    if (useSourceV2) {
+      sqlBuilder.option(FlinkOptions.READ_SOURCE_V2_ENABLED, true);
+    }
+
+    streamTableEnv.executeSql(sqlBuilder.end());
   }
 
   public void createFileSource() {
@@ -165,6 +207,36 @@ public final class HoodieFlinkQuickstart {
     // query data
     // reading from the latest commit instance.
     return execSelectSql(streamTableEnv, String.format("select * from %s", tableName), 10);
+  }
+
+  /**
+   * Reads the Hudi table in bounded batch mode via Source V2.
+   *
+   * <p>Creates a separate batch {@link TableEnvironment} where {@code READ_AS_STREAMING} is not
+   * set (defaults to {@code false}), causing {@link org.apache.hudi.source.HoodieSource} to use
+   * {@link org.apache.hudi.source.enumerator.HoodieStaticSplitEnumerator}: a bounded, one-shot
+   * snapshot read that enumerates all current file splits exactly once.  The Flink job finishes
+   * naturally once all splits are consumed, in contrast to the streaming counterpart which monitors
+   * for new commits indefinitely.
+   *
+   * @param tablePath storage path of the Hudi table written in the streaming phase
+   * @param tableName logical table name to register in the batch environment
+   * @param tableType COPY_ON_WRITE or MERGE_ON_READ
+   */
+  public List<Row> queryBatchData(String tablePath, String tableName, HoodieTableType tableType)
+      throws InterruptedException, TableNotExistException {
+    TableEnvironment batchEnv = getBatchTableEnv();
+    // READ_AS_STREAMING is omitted (defaults to false): Source V2 enumerates splits exactly once,
+    // making the job bounded.
+    String batchTableDDL = sql(tableName)
+        .option(FlinkOptions.PATH, tablePath)
+        .option(FlinkOptions.RECORD_KEY_FIELD, "uuid")
+        .option(FlinkOptions.ORDERING_FIELDS, "ts")
+        .option(FlinkOptions.TABLE_TYPE, tableType)
+        .option(FlinkOptions.READ_SOURCE_V2_ENABLED, true)
+        .end();
+    batchEnv.executeSql(batchTableDDL);
+    return execBatchSelectSql(batchEnv, String.format("select * from %s", tableName), tableName);
   }
 
   @Nonnull List<Row> updateData() throws InterruptedException, TableNotExistException {
@@ -214,6 +286,36 @@ public final class HoodieFlinkQuickstart {
     // wait for the timeout then cancels the job
     TimeUnit.SECONDS.sleep(timeout);
     tableResult.getJobClient().ifPresent(JobClient::cancel);
+    tEnv.executeSql("DROP TABLE IF EXISTS sink");
+    return CollectSinkTableFactory.RESULT.values().stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Executes a bounded SELECT query via the collect sink and awaits natural job completion.
+   *
+   * <p>Unlike {@link #execSelectSql(TableEnvironment, String, long)} which sleeps for a fixed
+   * timeout and then cancels the job, this method calls {@link TableResult#await()} so it returns
+   * as soon as the Flink job finishes consuming all splits – suitable for bounded batch queries
+   * where the job has a definite end.
+   */
+  public static List<Row> execBatchSelectSql(TableEnvironment tEnv, String select, String sourceTable)
+      throws InterruptedException, TableNotExistException {
+    ObjectPath objectPath = new ObjectPath(tEnv.getCurrentDatabase(), sourceTable);
+    String currentCatalog = tEnv.getCurrentCatalog();
+    Catalog catalog = tEnv.getCatalog(currentCatalog).get();
+    ResolvedCatalogTable table = (ResolvedCatalogTable) catalog.getTable(objectPath);
+    ResolvedSchema schema = table.getResolvedSchema();
+    String sinkDDL = QuickstartConfigurations.getCollectSinkDDL("sink", schema);
+    tEnv.executeSql("DROP TABLE IF EXISTS sink");
+    tEnv.executeSql(sinkDDL);
+    TableResult tableResult = tEnv.executeSql("insert into sink " + select);
+    try {
+      tableResult.await();
+    } catch (ExecutionException ex) {
+      // ignored
+    }
     tEnv.executeSql("DROP TABLE IF EXISTS sink");
     return CollectSinkTableFactory.RESULT.values().stream()
         .flatMap(Collection::stream)

--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
@@ -226,8 +226,6 @@ public final class HoodieFlinkQuickstart {
   public List<Row> queryBatchData(String tablePath, String tableName, HoodieTableType tableType)
       throws InterruptedException, TableNotExistException {
     TableEnvironment batchEnv = getBatchTableEnv();
-    // READ_AS_STREAMING is omitted (defaults to false): Source V2 enumerates splits exactly once,
-    // making the job bounded.
     String batchTableDDL = sql(tableName)
         .option(FlinkOptions.PATH, tablePath)
         .option(FlinkOptions.RECORD_KEY_FIELD, "uuid")
@@ -305,8 +303,8 @@ public final class HoodieFlinkQuickstart {
     ObjectPath objectPath = new ObjectPath(tEnv.getCurrentDatabase(), sourceTable);
     String currentCatalog = tEnv.getCurrentCatalog();
     Catalog catalog = tEnv.getCatalog(currentCatalog).get();
-    ResolvedCatalogTable table = (ResolvedCatalogTable) catalog.getTable(objectPath);
-    ResolvedSchema schema = table.getResolvedSchema();
+    ResolvedCatalogTable resolvedTable = (ResolvedCatalogTable) catalog.getTable(objectPath);
+    ResolvedSchema schema = resolvedTable.getResolvedSchema();
     String sinkDDL = QuickstartConfigurations.getCollectSinkDDL("sink", schema);
     tEnv.executeSql("DROP TABLE IF EXISTS sink");
     tEnv.executeSql(sinkDDL);

--- a/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
+++ b/hudi-examples/hudi-examples-flink/src/main/java/org/apache/hudi/examples/quickstart/HoodieFlinkQuickstart.java
@@ -57,7 +57,7 @@ import static org.apache.hudi.examples.quickstart.utils.QuickstartConfigurations
 public final class HoodieFlinkQuickstart {
   private EnvironmentSettings settings = null;
   @Getter
-  private TableEnvironment streamTableEnv = null;
+  private TableEnvironment tableEnvironment = null;
 
   private String tableName;
 
@@ -73,8 +73,6 @@ public final class HoodieFlinkQuickstart {
    * <p>When {@code useSourceV2} is {@code true} (default: {@code false}), the Hudi table is
    * registered with {@code read.source-v2.enabled = true}, which activates the FLIP-27
    * {@link org.apache.hudi.source.HoodieSource} for both streaming and batch reads.
-   * An additional bounded batch-read step ({@link #queryBatchData}) is executed to demonstrate
-   * the {@link org.apache.hudi.source.enumerator.HoodieStaticSplitEnumerator} path.
    */
   public static void main(String[] args) throws TableNotExistException, InterruptedException {
     if (args.length < 3) {
@@ -101,17 +99,12 @@ public final class HoodieFlinkQuickstart {
     // streaming query (continuous read)
     flinkQuickstart.queryData();
 
-    if (useSourceV2) {
-      // Source V2 also supports a bounded batch read via HoodieStaticSplitEnumerator
-      flinkQuickstart.queryBatchData(tablePath, tableName, tableType);
-    }
-
     // update data
     flinkQuickstart.updateData();
   }
 
   public void initEnv() {
-    if (this.streamTableEnv == null) {
+    if (tableEnvironment == null) {
       settings = EnvironmentSettings.newInstance().build();
       TableEnvironment streamTableEnv = TableEnvironmentImpl.create(settings);
       streamTableEnv.getConfig().getConfiguration()
@@ -121,7 +114,7 @@ public final class HoodieFlinkQuickstart {
       // configure not to retry after failure
       execConf.setString("restart-strategy", "fixed-delay");
       execConf.setString("restart-strategy.fixed-delay.attempts", "0");
-      this.streamTableEnv = streamTableEnv;
+      this.tableEnvironment = streamTableEnv;
     }
   }
 
@@ -150,14 +143,6 @@ public final class HoodieFlinkQuickstart {
   }
 
   /**
-   * Creates the Hudi streaming table without Source V2 (legacy SourceFunction path).
-   */
-  public void createHudiTable(String tablePath, String tableName,
-                              HoodieTableType tableType) {
-    createHudiTable(tablePath, tableName, tableType, false);
-  }
-
-  /**
    * Creates a Hudi streaming table, optionally enabling the FLIP-27 Source V2 reader.
    *
    * <p>When {@code useSourceV2} is {@code true}, {@code read.source-v2.enabled} is added to the
@@ -181,66 +166,35 @@ public final class HoodieFlinkQuickstart {
         .option(FlinkOptions.ORDERING_FIELDS, "ts")
         .option(FlinkOptions.READ_AS_STREAMING, true)
         .option(FlinkOptions.TABLE_TYPE, tableType)
+        .option(FlinkOptions.READ_SOURCE_V2_ENABLED, useSourceV2)
         .option(HoodieWriteConfig.ALLOW_EMPTY_COMMIT.key(), false);
 
-    if (useSourceV2) {
-      sqlBuilder.option(FlinkOptions.READ_SOURCE_V2_ENABLED, true);
-    }
-
-    streamTableEnv.executeSql(sqlBuilder.end());
+    tableEnvironment.executeSql(sqlBuilder.end());
   }
 
   public void createFileSource() {
     // create filesystem table named source
     String createSource = QuickstartConfigurations.getFileSourceDDL("source");
-    streamTableEnv.executeSql(createSource);
+    tableEnvironment.executeSql(createSource);
   }
 
   @Nonnull List<Row> insertData() throws InterruptedException, TableNotExistException {
     // insert data
     String insertInto = String.format("insert into %s select * from source", tableName);
-    execInsertSql(streamTableEnv, insertInto);
+    execInsertSql(tableEnvironment, insertInto);
     return queryData();
   }
 
   List<Row> queryData() throws InterruptedException, TableNotExistException {
     // query data
     // reading from the latest commit instance.
-    return execSelectSql(streamTableEnv, String.format("select * from %s", tableName), 10);
-  }
-
-  /**
-   * Reads the Hudi table in bounded batch mode via Source V2.
-   *
-   * <p>Creates a separate batch {@link TableEnvironment} where {@code READ_AS_STREAMING} is not
-   * set (defaults to {@code false}), causing {@link org.apache.hudi.source.HoodieSource} to use
-   * {@link org.apache.hudi.source.enumerator.HoodieStaticSplitEnumerator}: a bounded, one-shot
-   * snapshot read that enumerates all current file splits exactly once.  The Flink job finishes
-   * naturally once all splits are consumed, in contrast to the streaming counterpart which monitors
-   * for new commits indefinitely.
-   *
-   * @param tablePath storage path of the Hudi table written in the streaming phase
-   * @param tableName logical table name to register in the batch environment
-   * @param tableType COPY_ON_WRITE or MERGE_ON_READ
-   */
-  public List<Row> queryBatchData(String tablePath, String tableName, HoodieTableType tableType)
-      throws InterruptedException, TableNotExistException {
-    TableEnvironment batchEnv = getBatchTableEnv();
-    String batchTableDDL = sql(tableName)
-        .option(FlinkOptions.PATH, tablePath)
-        .option(FlinkOptions.RECORD_KEY_FIELD, "uuid")
-        .option(FlinkOptions.ORDERING_FIELDS, "ts")
-        .option(FlinkOptions.TABLE_TYPE, tableType)
-        .option(FlinkOptions.READ_SOURCE_V2_ENABLED, true)
-        .end();
-    batchEnv.executeSql(batchTableDDL);
-    return execBatchSelectSql(batchEnv, String.format("select * from %s", tableName), tableName);
+    return execSelectSql(tableEnvironment, String.format("select * from %s", tableName), 10);
   }
 
   @Nonnull List<Row> updateData() throws InterruptedException, TableNotExistException {
     // update data
     String insertInto = String.format("insert into %s select * from source", tableName);
-    execInsertSql(getStreamTableEnv(), insertInto);
+    execInsertSql(tableEnvironment, insertInto);
     return queryData();
   }
 
@@ -284,36 +238,6 @@ public final class HoodieFlinkQuickstart {
     // wait for the timeout then cancels the job
     TimeUnit.SECONDS.sleep(timeout);
     tableResult.getJobClient().ifPresent(JobClient::cancel);
-    tEnv.executeSql("DROP TABLE IF EXISTS sink");
-    return CollectSinkTableFactory.RESULT.values().stream()
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
-  }
-
-  /**
-   * Executes a bounded SELECT query via the collect sink and awaits natural job completion.
-   *
-   * <p>Unlike {@link #execSelectSql(TableEnvironment, String, long)} which sleeps for a fixed
-   * timeout and then cancels the job, this method calls {@link TableResult#await()} so it returns
-   * as soon as the Flink job finishes consuming all splits – suitable for bounded batch queries
-   * where the job has a definite end.
-   */
-  public static List<Row> execBatchSelectSql(TableEnvironment tEnv, String select, String sourceTable)
-      throws InterruptedException, TableNotExistException {
-    ObjectPath objectPath = new ObjectPath(tEnv.getCurrentDatabase(), sourceTable);
-    String currentCatalog = tEnv.getCurrentCatalog();
-    Catalog catalog = tEnv.getCatalog(currentCatalog).get();
-    ResolvedCatalogTable resolvedTable = (ResolvedCatalogTable) catalog.getTable(objectPath);
-    ResolvedSchema schema = resolvedTable.getResolvedSchema();
-    String sinkDDL = QuickstartConfigurations.getCollectSinkDDL("sink", schema);
-    tEnv.executeSql("DROP TABLE IF EXISTS sink");
-    tEnv.executeSql(sinkDDL);
-    TableResult tableResult = tEnv.executeSql("insert into sink " + select);
-    try {
-      tableResult.await();
-    } catch (ExecutionException ex) {
-      // ignored
-    }
     tEnv.executeSql("DROP TABLE IF EXISTS sink");
     return CollectSinkTableFactory.RESULT.values().stream()
         .flatMap(Collection::stream)

--- a/hudi-examples/hudi-examples-flink/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieFlinkQuickstart.java
+++ b/hudi-examples/hudi-examples-flink/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieFlinkQuickstart.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.examples.quickstart.TestQuickstartData.assertRowsEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 
 /**
  * IT cases for Hoodie table source and sink.
@@ -78,13 +76,6 @@ public class TestHoodieFlinkQuickstart extends AbstractTestBase {
     // streaming query (continuous read)
     List<Row> rows1 = flinkQuickstart.queryData();
     assertRowsEquals(rows1, TestQuickstartData.DATA_SET_SOURCE_INSERT_LATEST_COMMIT);
-
-    // bounded batch query via Source V2
-    if (useSourceV2) {
-      List<Row> batchRows = flinkQuickstart.queryBatchData(tempFile.getAbsolutePath(), "t1", tableType);
-      // full table scan
-      assertEquals(8, batchRows.size());
-    }
 
     // update data
     List<Row> rows2 = flinkQuickstart.updateData();

--- a/hudi-examples/hudi-examples-flink/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieFlinkQuickstart.java
+++ b/hudi-examples/hudi-examples-flink/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieFlinkQuickstart.java
@@ -25,15 +25,24 @@ import org.apache.flink.types.Row;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.examples.quickstart.TestQuickstartData.assertRowsEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 /**
  * IT cases for Hoodie table source and sink.
+ *
+ * <p>Tests are parameterized over the table type (COW / MOR) and whether to use the FLIP-27
+ * Source V2 reader ({@code useSourceV2}), giving four combinations in total.  When
+ * {@code useSourceV2 = true}, the test additionally exercises the bounded batch-read path
+ * ({@link HoodieFlinkQuickstart#queryBatchData}).
  */
 public class TestHoodieFlinkQuickstart extends AbstractTestBase {
   private final HoodieFlinkQuickstart flinkQuickstart = HoodieFlinkQuickstart.instance();
@@ -46,22 +55,38 @@ public class TestHoodieFlinkQuickstart extends AbstractTestBase {
   @TempDir
   File tempFile;
 
+  static Stream<Arguments> tableTypeAndSourceV2() {
+    return Stream.of(
+        Arguments.of(HoodieTableType.COPY_ON_WRITE, false),
+        Arguments.of(HoodieTableType.COPY_ON_WRITE, true),
+        Arguments.of(HoodieTableType.MERGE_ON_READ, false),
+        Arguments.of(HoodieTableType.MERGE_ON_READ, true)
+    );
+  }
+
   @ParameterizedTest
-  @EnumSource(value = HoodieTableType.class)
-  void testHoodieFlinkQuickstart(HoodieTableType tableType) throws Exception {
+  @MethodSource("tableTypeAndSourceV2")
+  void testHoodieFlinkQuickstart(HoodieTableType tableType, boolean useSourceV2) throws Exception {
     // create filesystem table named source
     flinkQuickstart.createFileSource();
 
-    // create hudi table
-    flinkQuickstart.createHudiTable(tempFile.getAbsolutePath(), "t1", tableType);
+    // create hudi table, with Source V2 enabled when requested
+    flinkQuickstart.createHudiTable(tempFile.getAbsolutePath(), "t1", tableType, useSourceV2);
 
     // insert data
     List<Row> rows = flinkQuickstart.insertData();
     assertRowsEquals(rows, TestQuickstartData.DATA_SET_SOURCE_INSERT_LATEST_COMMIT);
 
-    // query data
+    // streaming query (continuous read)
     List<Row> rows1 = flinkQuickstart.queryData();
     assertRowsEquals(rows1, TestQuickstartData.DATA_SET_SOURCE_INSERT_LATEST_COMMIT);
+
+    // bounded batch query via Source V2
+    if (useSourceV2) {
+      List<Row> batchRows = flinkQuickstart.queryBatchData(tempFile.getAbsolutePath(), "t1", tableType);
+      // full table scan
+      assertEquals(batchRows.size(), 8);
+    }
 
     // update data
     List<Row> rows2 = flinkQuickstart.updateData();

--- a/hudi-examples/hudi-examples-flink/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieFlinkQuickstart.java
+++ b/hudi-examples/hudi-examples-flink/src/test/java/org/apache/hudi/examples/quickstart/TestHoodieFlinkQuickstart.java
@@ -40,9 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * IT cases for Hoodie table source and sink.
  *
  * <p>Tests are parameterized over the table type (COW / MOR) and whether to use the FLIP-27
- * Source V2 reader ({@code useSourceV2}), giving four combinations in total.  When
- * {@code useSourceV2 = true}, the test additionally exercises the bounded batch-read path
- * ({@link HoodieFlinkQuickstart#queryBatchData}).
+ * Source V2 reader ({@code useSourceV2}), giving four combinations in total.
  */
 public class TestHoodieFlinkQuickstart extends AbstractTestBase {
   private final HoodieFlinkQuickstart flinkQuickstart = HoodieFlinkQuickstart.instance();
@@ -85,7 +83,7 @@ public class TestHoodieFlinkQuickstart extends AbstractTestBase {
     if (useSourceV2) {
       List<Row> batchRows = flinkQuickstart.queryBatchData(tempFile.getAbsolutePath(), "t1", tableType);
       // full table scan
-      assertEquals(batchRows.size(), 8);
+      assertEquals(8, batchRows.size());
     }
 
     // update data

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/AbstractHoodieSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/AbstractHoodieSplitEnumerator.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SupportsHandleExecutionAttemptSourceEvent;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import javax.annotation.Nullable;
 
@@ -71,13 +72,16 @@ abstract class AbstractHoodieSplitEnumerator
     this.readersAwaitingSplit = new LinkedHashMap<>();
     this.availableFuture = new AtomicReference<>();
     this.splitProvider = splitProvider;
-    this.enumeratorContext
-        .metricGroup()
-        // This number may not capture the entire backlog due to split discovery throttling to avoid
-        // excessive memory footprint. Some pending splits may not have been discovered yet.
-        .setUnassignedSplitsGauge(() -> Long.valueOf(splitProvider.pendingSplitCount()));
-    this.enumeratorMetrics = new FlinkStreamReadMetrics(enumeratorContext.metricGroup(), tableName);
-    enumeratorMetrics.registerMetrics();
+    if (this.enumeratorContext.metricGroup() != null) {
+      // This number may not capture the entire backlog due to split discovery throttling to avoid
+      // excessive memory footprint. Some pending splits may not have been discovered yet.
+      this.enumeratorContext.metricGroup().setUnassignedSplitsGauge(() -> (long) splitProvider.pendingSplitCount());
+      this.enumeratorMetrics = new FlinkStreamReadMetrics(this.enumeratorContext.metricGroup(), tableName);
+    } else {
+      // The metrics group returned from enumeratorContext is null in Flink 1.17.
+      this.enumeratorMetrics = new FlinkStreamReadMetrics(UnregisteredMetricsGroup.createSplitEnumeratorMetricGroup(), tableName);
+    }
+    this.enumeratorMetrics.registerMetrics();
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/AbstractHoodieSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/AbstractHoodieSplitEnumerator.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SupportsHandleExecutionAttemptSourceEvent;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import javax.annotation.Nullable;
 
@@ -77,11 +76,11 @@ abstract class AbstractHoodieSplitEnumerator
       // excessive memory footprint. Some pending splits may not have been discovered yet.
       this.enumeratorContext.metricGroup().setUnassignedSplitsGauge(() -> (long) splitProvider.pendingSplitCount());
       this.enumeratorMetrics = new FlinkStreamReadMetrics(this.enumeratorContext.metricGroup(), tableName);
+      this.enumeratorMetrics.registerMetrics();
     } else {
       // The metrics group returned from enumeratorContext is null in Flink 1.17.
-      this.enumeratorMetrics = new FlinkStreamReadMetrics(UnregisteredMetricsGroup.createSplitEnumeratorMetricGroup(), tableName);
+      enumeratorMetrics = null;
     }
-    this.enumeratorMetrics.registerMetrics();
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/HoodieContinuousSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/HoodieContinuousSplitEnumerator.java
@@ -110,7 +110,9 @@ public class HoodieContinuousSplitEnumerator extends AbstractHoodieSplitEnumerat
 
     if (!result.getSplits().isEmpty()) {
       splitProvider.onDiscoveredSplits(result.getSplits());
-      position.get().getIssuedInstant().ifPresent(enumeratorMetrics::setIssuedInstant);
+      if (enumeratorMetrics != null) {
+        position.get().getIssuedInstant().ifPresent(enumeratorMetrics::setIssuedInstant);
+      }
       LOG.debug(
           "Added {} splits discovered between ({}, {}] to the assigner",
           result.getSplits().size(),

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieContinuousSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieContinuousSplitEnumerator.java
@@ -444,6 +444,25 @@ public class TestHoodieContinuousSplitEnumerator {
         "discover must be called with the last consumed offset to avoid re-reading commits");
   }
 
+  /**
+   * Verify that when the metricGroup is null (Flink 1.17 path), discovering splits with
+   * non-empty results does not throw a NullPointerException.
+   */
+  @Test
+  public void testProcessDiscoveredSplitsWithNullMetricGroup() {
+    MockSplitEnumeratorContext nullMetricContext = new MockSplitEnumeratorContext(true);
+    splitDiscover.setNextBatch(new HoodieContinuousSplitBatch(
+        Arrays.asList(split1, split2), "20231201000000000", "20231201120000000"));
+
+    HoodieContinuousSplitEnumerator enumeratorWithNullMetrics = new HoodieContinuousSplitEnumerator(
+        TABLE_NAME, nullMetricContext, splitProvider, splitDiscover, scanContext, Option.empty());
+    enumeratorWithNullMetrics.start();
+    nullMetricContext.executeAsyncCallbacks();
+
+    assertEquals(2, splitProvider.pendingSplitCount(),
+        "Splits should be added to the provider even when enumeratorMetrics is null");
+  }
+
   private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
     return new HoodieSourceSplit(
         splitNum,
@@ -497,6 +516,15 @@ public class TestHoodieContinuousSplitEnumerator {
     private final List<Integer> noMoreSplitsSignaled = new ArrayList<>();
     private final List<AsyncTask<?>> asyncTasks = new ArrayList<>();
     private final AtomicInteger asyncCallCount = new AtomicInteger(0);
+    private final boolean returnNullMetricGroup;
+
+    MockSplitEnumeratorContext() {
+      this(false);
+    }
+
+    MockSplitEnumeratorContext(boolean returnNullMetricGroup) {
+      this.returnNullMetricGroup = returnNullMetricGroup;
+    }
 
     public void registerReader(ReaderInfo readerInfo) {
       registeredReaders.put(readerInfo.getSubtaskId(), readerInfo);
@@ -532,7 +560,7 @@ public class TestHoodieContinuousSplitEnumerator {
 
     @Override
     public SplitEnumeratorMetricGroup metricGroup() {
-      return UnregisteredMetricsGroup.createSplitEnumeratorMetricGroup();
+      return returnNullMetricGroup ? null : UnregisteredMetricsGroup.createSplitEnumeratorMetricGroup();
     }
 
     @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieStaticSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/enumerator/TestHoodieStaticSplitEnumerator.java
@@ -26,6 +26,7 @@ import org.apache.hudi.source.split.SplitRequestEvent;
 
 import lombok.Getter;
 import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
@@ -43,7 +44,9 @@ import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -219,6 +222,36 @@ public class TestHoodieStaticSplitEnumerator {
     assertTrue(context.getAssignedSplits().size() > 0, "Should assign split via attempt-aware method");
   }
 
+  @Test
+  public void testConstructorWithNullMetricGroup() {
+    MockSplitEnumeratorContext nullMetricContext = new MockSplitEnumeratorContext(true);
+    HoodieStaticSplitEnumerator enumeratorWithNullMetrics =
+        new HoodieStaticSplitEnumerator("test-table", nullMetricContext, splitProvider);
+
+    assertNotNull(enumeratorWithNullMetrics, "Enumerator should initialize without NPE when metricGroup is null");
+
+    // Basic operations should still work without metrics
+    nullMetricContext.registerReader(new ReaderInfo(1, "localhost"));
+    enumeratorWithNullMetrics.start();
+    splitProvider.onDiscoveredSplits(Arrays.asList(split1));
+    enumeratorWithNullMetrics.handleSplitRequest(1, "localhost");
+    assertTrue(nullMetricContext.getAssignedSplits().containsKey(1),
+        "Splits should still be assigned when metrics are null");
+    assertFalse(nullMetricContext.getNoMoreSplitsSignaled().contains(1),
+        "No-more-splits signal should not be sent when a split was assigned");
+  }
+
+  @Test
+  public void testHandleSourceEventWithUnknownEventThrows() {
+    enumerator.start();
+    context.registerReader(new ReaderInfo(0, "localhost"));
+
+    SourceEvent unknownEvent = new SourceEvent() {};
+    assertThrows(IllegalArgumentException.class,
+        () -> enumerator.handleSourceEvent(0, unknownEvent),
+        "Should throw IllegalArgumentException for unknown source event type");
+  }
+
   private HoodieSourceSplit createTestSplit(int splitNum, String fileId) {
     return new HoodieSourceSplit(
         splitNum,
@@ -243,6 +276,15 @@ public class TestHoodieStaticSplitEnumerator {
     @Getter
     private final List<Integer> noMoreSplitsSignaled = new ArrayList<>();
     private final List<Runnable> coordinatorThreadTasks = new ArrayList<>();
+    private final boolean returnNullMetricGroup;
+
+    MockSplitEnumeratorContext() {
+      this(false);
+    }
+
+    MockSplitEnumeratorContext(boolean returnNullMetricGroup) {
+      this.returnNullMetricGroup = returnNullMetricGroup;
+    }
 
     public void registerReader(ReaderInfo readerInfo) {
       registeredReaders.put(readerInfo.getSubtaskId(), readerInfo);
@@ -254,7 +296,7 @@ public class TestHoodieStaticSplitEnumerator {
 
     @Override
     public SplitEnumeratorMetricGroup metricGroup() {
-      return  UnregisteredMetricsGroup.createSplitEnumeratorMetricGroup();
+      return returnNullMetricGroup ? null : UnregisteredMetricsGroup.createSplitEnumeratorMetricGroup();
     }
 
     @Override


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Extend Flink quick start example to explicitly use Flink Hudi Source V2

Closes #14428 

### Summary and Changelog

1. Add support of configurable source v2 for HoodieFlinkQuickstart
2. Extend TestHoodieFlinkQuickstart to cover source v2 scenarios

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
