### PR TITLE
feat(docker): add --multi-arch flag for cross-platform image builds

### DIFF
--- a/docker/build_docker_images.sh
+++ b/docker/build_docker_images.sh
@@ -17,13 +17,14 @@
 
 # This script builds all required Hudi Docker images for Hadoop, Spark, and Hive components.
 # It detects the system architecture, sets up Docker build platform, and loops through image configs.
-# Usage: ./build_docker_images.sh [--hadoop-version <version>] [--spark-version <version>] [--hive-version <version>] [--version-tag <tag>]
+# Usage: ./build_docker_images.sh [--hadoop-version <version>] [--spark-version <version>] [--hive-version <version>] [--version-tag <tag>] [--multi-arch]
 
 # Default versions for Hadoop, Spark, and Hive
 HADOOP_VERSION="2.8.4"
 SPARK_VERSION="3.5.3"
 HIVE_VERSION="2.3.10"
 VERSION_TAG_ARG="" # Initialize to empty, will be set by command-line arg if provided
+MULTI_ARCH=false
 
 # Function to get Maven project version
 get_hudi_project_version() {
@@ -43,26 +44,32 @@ while [[ "$#" -gt 0 ]]; do
         --spark-version) SPARK_VERSION="$2"; shift ;;
         --hive-version) HIVE_VERSION="$2"; shift ;;
         --version-tag) VERSION_TAG_ARG="$2"; shift ;;
+        --multi-arch) MULTI_ARCH=true ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
 done
 
 # Detect system architecture and set Docker platform accordingly
-ARCHITECTURE=$(uname -m)
-case "$ARCHITECTURE" in
-  x86_64|amd64)
-    DOCKER_PLATFORM='linux/amd64'
-    ;;
-  aarch64|arm64)
-    DOCKER_PLATFORM='linux/arm64'
-    ;;
-  *)
-    echo "Unsupported architecture: $ARCHITECTURE"
-    exit 1
-    ;;
-esac
-export DOCKER_DEFAULT_PLATFORM="$DOCKER_PLATFORM"
+if [ "$MULTI_ARCH" = true ]; then
+  DOCKER_PLATFORM='linux/amd64,linux/arm64'
+  echo "Building multi-arch images (amd64 + arm64)"
+else
+  ARCHITECTURE=$(uname -m)
+  case "$ARCHITECTURE" in
+    x86_64|amd64)
+      DOCKER_PLATFORM='linux/amd64'
+      ;;
+    aarch64|arm64)
+      DOCKER_PLATFORM='linux/arm64'
+      ;;
+    *)
+      echo "Unsupported architecture: $ARCHITECTURE"
+      exit 1
+      ;;
+  esac
+  export DOCKER_DEFAULT_PLATFORM="$DOCKER_PLATFORM"
+fi
 export BUILDX_EXPERIMENTAL=1
 # Get the directory of this script for relative paths
 SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
@@ -116,13 +123,24 @@ for IMAGE_CONFIG in "${DOCKER_IMAGES[@]}"; do
   TAG_VERSIONED="$IMAGE_BASE:$VERSION_TAG"
   echo "Building $IMAGE_CONTEXT as $TAG_LATEST and $TAG_VERSIONED"
   # Build the Docker image with both latest and versioned tags
-  if ! docker build \
-    --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
-    --build-arg SPARK_VERSION=${SPARK_VERSION} \
-    --build-arg HIVE_VERSION=${HIVE_VERSION} \
-    "$IMAGE_CONTEXT" -t "$TAG_LATEST" -t "$TAG_VERSIONED"; then
-    echo "Error: Failed to build docker image for $IMAGE_CONTEXT"
-    exit 1
+  if [ "$MULTI_ARCH" = true ]; then
+    if ! docker buildx build --platform "$DOCKER_PLATFORM" --push \
+      --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
+      --build-arg SPARK_VERSION=${SPARK_VERSION} \
+      --build-arg HIVE_VERSION=${HIVE_VERSION} \
+      "$IMAGE_CONTEXT" -t "$TAG_LATEST" -t "$TAG_VERSIONED"; then
+      echo "Error: Failed to build docker image for $IMAGE_CONTEXT"
+      exit 1
+    fi
+  else
+    if ! docker build \
+      --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
+      --build-arg SPARK_VERSION=${SPARK_VERSION} \
+      --build-arg HIVE_VERSION=${HIVE_VERSION} \
+      "$IMAGE_CONTEXT" -t "$TAG_LATEST" -t "$TAG_VERSIONED"; then
+      echo "Error: Failed to build docker image for $IMAGE_CONTEXT"
+      exit 1
+    fi
   fi
 done
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The current Docker build script only supports one architecture based on the local hardware.

Closes: https://github.com/apache/hudi/issues/18517

### Summary and Changelog

- Add `--multi-arch` flag to `build_docker_images.sh` for building both `linux/amd64` and `linux/arm64` images via `docker buildx`
- Without the flag, behavior is unchanged (builds for local architecture only)
- Multi-arch builds push directly to the registry since buildx cannot load multi-platform images into the local daemon

Usage:
```bash
# Local build (unchanged)
./build_docker_images.sh --hadoop-version 3.4.0 --spark-version 4.0.1 --hive-version 3.1.3

# Multi-arch build + push
./build_docker_images.sh --hadoop-version 3.4.0 --spark-version 4.0.1 --hive-version 3.1.3 --multi-arch
```

Requires a multi-platform buildx builder and `docker login`:
```bash
docker buildx create --name multiarch --driver docker-container --use
```

### Impact

Makes test docker image generation easier from Macbook

### Risk Level

none

### Documentation Update

Usage docs updated in the script

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
