### PR TITLE
feat(utilities): Add HoodieStashPartitionsTool for backing up and removing partitions

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/DefaultStashPartitionRenameHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/DefaultStashPartitionRenameHelper.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.validator;
+
+import org.apache.hudi.io.util.FileIOUtils;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of {@link StashPartitionRenameHelper} that copies files
+ * individually from source to target and then deletes them from source.
+ * <p>
+ * This implementation is correct but may be slow for large partitions on cloud
+ * storage. For production use on HDFS or cloud storage with efficient rename APIs,
+ * a custom implementation can be plugged in via the
+ * {@code hoodie.stash.rename.helper.class} configuration.
+ */
+public class DefaultStashPartitionRenameHelper implements StashPartitionRenameHelper {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultStashPartitionRenameHelper.class);
+
+  @Override
+  public void movePartitionFiles(HoodieStorage storage, StoragePath sourcePath, StoragePath targetPath) throws IOException {
+    // Ensure target directory exists
+    if (!storage.exists(targetPath)) {
+      storage.createDirectory(targetPath);
+    }
+
+    List<StoragePathInfo> sourceFiles = storage.listDirectEntries(sourcePath);
+    if (sourceFiles.isEmpty()) {
+      LOG.info("Source path {} has no files, nothing to move.", sourcePath);
+      return;
+    }
+
+    // Determine which files already exist in target (from a prior partial attempt)
+    Set<String> existingTargetFileNames = getExistingFileNames(storage, targetPath);
+
+    // Copy files not already in target
+    for (StoragePathInfo sourceFileInfo : sourceFiles) {
+      String fileName = sourceFileInfo.getPath().getName();
+      if (existingTargetFileNames.contains(fileName)) {
+        LOG.info("File {} already exists in target {}, skipping copy.", fileName, targetPath);
+      } else {
+        StoragePath destFilePath = new StoragePath(targetPath, fileName);
+        LOG.info("Copying file {} to {}", sourceFileInfo.getPath(), destFilePath);
+        FileIOUtils.copy(storage, sourceFileInfo.getPath(), destFilePath);
+      }
+    }
+
+    // Delete all source files after successful copy
+    for (StoragePathInfo sourceFileInfo : sourceFiles) {
+      LOG.info("Deleting source file {}", sourceFileInfo.getPath());
+      storage.deleteFile(sourceFileInfo.getPath());
+    }
+  }
+
+  private Set<String> getExistingFileNames(HoodieStorage storage, StoragePath targetPath) throws IOException {
+    if (!storage.exists(targetPath)) {
+      return java.util.Collections.emptySet();
+    }
+    return storage.listDirectEntries(targetPath).stream()
+        .map(info -> info.getPath().getName())
+        .collect(Collectors.toSet());
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/DefaultStashPartitionRenameHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/DefaultStashPartitionRenameHelper.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -47,7 +48,16 @@ public class DefaultStashPartitionRenameHelper implements StashPartitionRenameHe
   private static final Logger LOG = LoggerFactory.getLogger(DefaultStashPartitionRenameHelper.class);
 
   @Override
-  public void movePartitionFiles(HoodieStorage storage, StoragePath sourcePath, StoragePath targetPath) throws IOException {
+  public void stashPartitionFiles(HoodieStorage storage, StoragePath partitionPath, StoragePath stashPath) throws IOException {
+    moveFiles(storage, partitionPath, stashPath);
+  }
+
+  @Override
+  public void restorePartitionFiles(HoodieStorage storage, StoragePath stashPath, StoragePath partitionPath) throws IOException {
+    moveFiles(storage, stashPath, partitionPath);
+  }
+
+  private void moveFiles(HoodieStorage storage, StoragePath sourcePath, StoragePath targetPath) throws IOException {
     // Ensure target directory exists
     if (!storage.exists(targetPath)) {
       storage.createDirectory(targetPath);
@@ -83,7 +93,7 @@ public class DefaultStashPartitionRenameHelper implements StashPartitionRenameHe
 
   private Set<String> getExistingFileNames(HoodieStorage storage, StoragePath targetPath) throws IOException {
     if (!storage.exists(targetPath)) {
-      return java.util.Collections.emptySet();
+      return Collections.emptySet();
     }
     return storage.listDirectEntries(targetPath).stream()
         .map(info -> info.getPath().getName())

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/StashPartitionRenameHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/StashPartitionRenameHelper.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.validator;
+
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Interface for moving partition files from a source path to a target stash path.
+ * <p>
+ * This is used by {@link StashPartitionsPreCommitValidator} to move data files
+ * to a stash location before a deletePartitions commit completes.
+ * <p>
+ * Implementations must be idempotent: if some files already exist in the target
+ * from a prior partial attempt, only the remaining files should be moved.
+ * <p>
+ * The default implementation ({@link DefaultStashPartitionRenameHelper}) copies
+ * files individually and then deletes from source. Custom implementations can
+ * leverage efficient filesystem-level rename/move APIs where available.
+ */
+public interface StashPartitionRenameHelper extends Serializable {
+
+  /**
+   * Move all files from the source partition path to the target stash path.
+   * <p>
+   * Must be idempotent — if files already exist in target from a prior partial
+   * attempt, only move files not yet present in target.
+   *
+   * @param storage    the storage instance to use for file operations
+   * @param sourcePath the source partition directory (e.g., basepath/datestr=2023-01-01)
+   * @param targetPath the target stash directory (e.g., stashpath/datestr=2023-01-01)
+   * @throws IOException if any file operation fails
+   */
+  void movePartitionFiles(HoodieStorage storage, StoragePath sourcePath, StoragePath targetPath) throws IOException;
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/StashPartitionRenameHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/StashPartitionRenameHelper.java
@@ -26,30 +26,56 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * Interface for moving partition files from a source path to a target stash path.
+ * Interface for moving partition files between a table's partition path and a stash path.
  * <p>
  * This is used by {@link StashPartitionsPreCommitValidator} to move data files
- * to a stash location before a deletePartitions commit completes.
+ * to a stash location before a deletePartitions commit completes, and by the
+ * stash tool to restore files back from stash during recovery or rollback.
  * <p>
- * Implementations must be idempotent: if some files already exist in the target
+ * Two separate methods are provided because the stash and restore directions may
+ * require different storage APIs or strategies. For example, an implementation
+ * may use a fast filesystem-level rename for stashing but a verified copy for
+ * restoring data back to the table.
+ * <p>
+ * Both methods must be idempotent: if some files already exist in the target
  * from a prior partial attempt, only the remaining files should be moved.
  * <p>
  * The default implementation ({@link DefaultStashPartitionRenameHelper}) copies
- * files individually and then deletes from source. Custom implementations can
- * leverage efficient filesystem-level rename/move APIs where available.
+ * files individually and then deletes from source for both directions. Custom
+ * implementations can leverage efficient filesystem-level rename/move APIs where
+ * available.
  */
 public interface StashPartitionRenameHelper extends Serializable {
 
   /**
-   * Move all files from the source partition path to the target stash path.
+   * Move all files from a table partition path to the stash path (stash direction).
    * <p>
-   * Must be idempotent — if files already exist in target from a prior partial
-   * attempt, only move files not yet present in target.
+   * Called by the pre-commit validator during a deletePartitions operation to back up
+   * partition data before the replace commit lands.
+   * <p>
+   * Must be idempotent — if files already exist in stash from a prior partial
+   * attempt, only move files not yet present in stash.
    *
-   * @param storage    the storage instance to use for file operations
-   * @param sourcePath the source partition directory (e.g., basepath/datestr=2023-01-01)
-   * @param targetPath the target stash directory (e.g., stashpath/datestr=2023-01-01)
+   * @param storage        the storage instance to use for file operations
+   * @param partitionPath  the source partition directory (e.g., basepath/datestr=2023-01-01)
+   * @param stashPath      the target stash directory (e.g., stashpath/datestr=2023-01-01)
    * @throws IOException if any file operation fails
    */
-  void movePartitionFiles(HoodieStorage storage, StoragePath sourcePath, StoragePath targetPath) throws IOException;
+  void stashPartitionFiles(HoodieStorage storage, StoragePath partitionPath, StoragePath stashPath) throws IOException;
+
+  /**
+   * Restore all files from the stash path back to the table partition path (restore direction).
+   * <p>
+   * Called during pre-check recovery (to move partially stashed files back before retry)
+   * and during rollback_stash (to undo a stash operation).
+   * <p>
+   * Must be idempotent — if files already exist in the partition from a prior partial
+   * attempt, only move files not yet present in the partition.
+   *
+   * @param storage        the storage instance to use for file operations
+   * @param stashPath      the source stash directory (e.g., stashpath/datestr=2023-01-01)
+   * @param partitionPath  the target partition directory (e.g., basepath/datestr=2023-01-01)
+   * @throws IOException if any file operation fails
+   */
+  void restorePartitionFiles(HoodieStorage storage, StoragePath stashPath, StoragePath partitionPath) throws IOException;
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/validator/TestDefaultStashPartitionRenameHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/validator/TestDefaultStashPartitionRenameHelper.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.validator;
+
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link DefaultStashPartitionRenameHelper}.
+ */
+public class TestDefaultStashPartitionRenameHelper {
+
+  @TempDir
+  private Path tempDir;
+
+  private HoodieStorage storage;
+  private DefaultStashPartitionRenameHelper helper;
+  private StoragePath sourcePath;
+  private StoragePath targetPath;
+
+  @BeforeEach
+  public void init() throws IOException {
+    String basePath = tempDir.toAbsolutePath().toUri().toString();
+    storage = HoodieTestUtils.getStorage(basePath);
+    helper = new DefaultStashPartitionRenameHelper();
+    sourcePath = new StoragePath(basePath, "source_partition");
+    targetPath = new StoragePath(basePath, "target_partition");
+    storage.createDirectory(sourcePath);
+  }
+
+  /**
+   * Given: Source has files, target is empty.
+   * When: movePartitionFiles is called.
+   * Then: All files are copied to target and deleted from source.
+   */
+  @Test
+  public void testMoveAllFilesFromSourceToEmptyTarget() throws IOException {
+    createTestFile(sourcePath, "file1.parquet", "data1");
+    createTestFile(sourcePath, "file2.parquet", "data2");
+    createTestFile(sourcePath, "file3.parquet", "data3");
+
+    helper.movePartitionFiles(storage, sourcePath, targetPath);
+
+    // Target should have all 3 files
+    Set<String> targetFiles = getFileNames(targetPath);
+    assertEquals(3, targetFiles.size());
+    assertTrue(targetFiles.contains("file1.parquet"));
+    assertTrue(targetFiles.contains("file2.parquet"));
+    assertTrue(targetFiles.contains("file3.parquet"));
+
+    // Source should be empty
+    List<StoragePathInfo> sourceFiles = storage.listDirectEntries(sourcePath);
+    assertTrue(sourceFiles.isEmpty(), "Source should have no files after move");
+  }
+
+  /**
+   * Given: Source has files, target already has some of the same files (partial prior move).
+   * When: movePartitionFiles is called.
+   * Then: Only missing files are copied to target, all source files are deleted.
+   */
+  @Test
+  public void testIdempotentMoveWithPartialPriorAttempt() throws IOException {
+    // Source has 3 files
+    createTestFile(sourcePath, "file1.parquet", "data1");
+    createTestFile(sourcePath, "file2.parquet", "data2");
+    createTestFile(sourcePath, "file3.parquet", "data3");
+
+    // Target already has file1 from a prior partial move
+    storage.createDirectory(targetPath);
+    createTestFile(targetPath, "file1.parquet", "data1");
+
+    helper.movePartitionFiles(storage, sourcePath, targetPath);
+
+    // Target should have all 3 files
+    Set<String> targetFiles = getFileNames(targetPath);
+    assertEquals(3, targetFiles.size());
+    assertTrue(targetFiles.contains("file1.parquet"));
+    assertTrue(targetFiles.contains("file2.parquet"));
+    assertTrue(targetFiles.contains("file3.parquet"));
+
+    // Source should be empty
+    List<StoragePathInfo> sourceFiles = storage.listDirectEntries(sourcePath);
+    assertTrue(sourceFiles.isEmpty(), "Source should have no files after move");
+  }
+
+  /**
+   * Given: Source has files, target already has all the same files.
+   * When: movePartitionFiles is called.
+   * Then: No copies happen, but source files are still deleted.
+   */
+  @Test
+  public void testMoveWhenTargetAlreadyHasAllFiles() throws IOException {
+    createTestFile(sourcePath, "file1.parquet", "data1");
+    createTestFile(sourcePath, "file2.parquet", "data2");
+
+    // Target has all files already
+    storage.createDirectory(targetPath);
+    createTestFile(targetPath, "file1.parquet", "data1");
+    createTestFile(targetPath, "file2.parquet", "data2");
+
+    helper.movePartitionFiles(storage, sourcePath, targetPath);
+
+    // Target still has 2 files
+    assertEquals(2, getFileNames(targetPath).size());
+
+    // Source should be empty
+    assertTrue(storage.listDirectEntries(sourcePath).isEmpty());
+  }
+
+  /**
+   * Given: Source is empty.
+   * When: movePartitionFiles is called.
+   * Then: No-op, target remains unchanged.
+   */
+  @Test
+  public void testMoveFromEmptySourceIsNoOp() throws IOException {
+    // Source is empty dir, target doesn't exist
+
+    helper.movePartitionFiles(storage, sourcePath, targetPath);
+
+    // Target should not have been created (or if created, should be empty)
+    assertFalse(storage.exists(targetPath) && !storage.listDirectEntries(targetPath).isEmpty(),
+        "Target should remain empty when source has no files");
+  }
+
+  /**
+   * Given: Target directory does not exist.
+   * When: movePartitionFiles is called.
+   * Then: Target directory is created and files are moved.
+   */
+  @Test
+  public void testTargetDirectoryCreatedIfNotExists() throws IOException {
+    createTestFile(sourcePath, "file1.parquet", "data1");
+
+    assertFalse(storage.exists(targetPath), "Target should not exist before move");
+
+    helper.movePartitionFiles(storage, sourcePath, targetPath);
+
+    assertTrue(storage.exists(targetPath), "Target should be created");
+    assertEquals(1, getFileNames(targetPath).size());
+    assertTrue(storage.listDirectEntries(sourcePath).isEmpty());
+  }
+
+  // ---- Helper methods ----
+
+  private void createTestFile(StoragePath dir, String fileName, String content) throws IOException {
+    StoragePath filePath = new StoragePath(dir, fileName);
+    try (OutputStream out = storage.create(filePath, true)) {
+      out.write(content.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  private Set<String> getFileNames(StoragePath dir) throws IOException {
+    return storage.listDirectEntries(dir).stream()
+        .map(info -> info.getPath().getName())
+        .collect(Collectors.toSet());
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/validator/TestDefaultStashPartitionRenameHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/validator/TestDefaultStashPartitionRenameHelper.java
@@ -65,7 +65,7 @@ public class TestDefaultStashPartitionRenameHelper {
 
   /**
    * Given: Source has files, target is empty.
-   * When: movePartitionFiles is called.
+   * When: stashPartitionFiles is called.
    * Then: All files are copied to target and deleted from source.
    */
   @Test
@@ -74,7 +74,7 @@ public class TestDefaultStashPartitionRenameHelper {
     createTestFile(sourcePath, "file2.parquet", "data2");
     createTestFile(sourcePath, "file3.parquet", "data3");
 
-    helper.movePartitionFiles(storage, sourcePath, targetPath);
+    helper.stashPartitionFiles(storage, sourcePath, targetPath);
 
     // Target should have all 3 files
     Set<String> targetFiles = getFileNames(targetPath);
@@ -90,7 +90,7 @@ public class TestDefaultStashPartitionRenameHelper {
 
   /**
    * Given: Source has files, target already has some of the same files (partial prior move).
-   * When: movePartitionFiles is called.
+   * When: stashPartitionFiles is called.
    * Then: Only missing files are copied to target, all source files are deleted.
    */
   @Test
@@ -104,7 +104,7 @@ public class TestDefaultStashPartitionRenameHelper {
     storage.createDirectory(targetPath);
     createTestFile(targetPath, "file1.parquet", "data1");
 
-    helper.movePartitionFiles(storage, sourcePath, targetPath);
+    helper.stashPartitionFiles(storage, sourcePath, targetPath);
 
     // Target should have all 3 files
     Set<String> targetFiles = getFileNames(targetPath);
@@ -120,7 +120,7 @@ public class TestDefaultStashPartitionRenameHelper {
 
   /**
    * Given: Source has files, target already has all the same files.
-   * When: movePartitionFiles is called.
+   * When: stashPartitionFiles is called.
    * Then: No copies happen, but source files are still deleted.
    */
   @Test
@@ -133,7 +133,7 @@ public class TestDefaultStashPartitionRenameHelper {
     createTestFile(targetPath, "file1.parquet", "data1");
     createTestFile(targetPath, "file2.parquet", "data2");
 
-    helper.movePartitionFiles(storage, sourcePath, targetPath);
+    helper.stashPartitionFiles(storage, sourcePath, targetPath);
 
     // Target still has 2 files
     assertEquals(2, getFileNames(targetPath).size());
@@ -144,14 +144,14 @@ public class TestDefaultStashPartitionRenameHelper {
 
   /**
    * Given: Source is empty.
-   * When: movePartitionFiles is called.
+   * When: stashPartitionFiles is called.
    * Then: No-op, target remains unchanged.
    */
   @Test
   public void testMoveFromEmptySourceIsNoOp() throws IOException {
     // Source is empty dir, target doesn't exist
 
-    helper.movePartitionFiles(storage, sourcePath, targetPath);
+    helper.stashPartitionFiles(storage, sourcePath, targetPath);
 
     // Target should not have been created (or if created, should be empty)
     assertFalse(storage.exists(targetPath) && !storage.listDirectEntries(targetPath).isEmpty(),
@@ -160,7 +160,7 @@ public class TestDefaultStashPartitionRenameHelper {
 
   /**
    * Given: Target directory does not exist.
-   * When: movePartitionFiles is called.
+   * When: stashPartitionFiles is called.
    * Then: Target directory is created and files are moved.
    */
   @Test
@@ -169,11 +169,62 @@ public class TestDefaultStashPartitionRenameHelper {
 
     assertFalse(storage.exists(targetPath), "Target should not exist before move");
 
-    helper.movePartitionFiles(storage, sourcePath, targetPath);
+    helper.stashPartitionFiles(storage, sourcePath, targetPath);
 
     assertTrue(storage.exists(targetPath), "Target should be created");
     assertEquals(1, getFileNames(targetPath).size());
     assertTrue(storage.listDirectEntries(sourcePath).isEmpty());
+  }
+
+  /**
+   * Given: Files were previously stashed to target.
+   * When: restorePartitionFiles is called.
+   * Then: All files are copied back from target to source, target is emptied.
+   */
+  @Test
+  public void testRestorePartitionFilesMovesFilesBack() throws IOException {
+    // Stash files first
+    createTestFile(sourcePath, "file1.parquet", "data1");
+    createTestFile(sourcePath, "file2.parquet", "data2");
+    helper.stashPartitionFiles(storage, sourcePath, targetPath);
+
+    // Source should be empty, target should have files
+    assertTrue(storage.listDirectEntries(sourcePath).isEmpty());
+    assertEquals(2, getFileNames(targetPath).size());
+
+    // Restore
+    helper.restorePartitionFiles(storage, targetPath, sourcePath);
+
+    // Source should have files back, target should be empty
+    Set<String> restoredFiles = getFileNames(sourcePath);
+    assertEquals(2, restoredFiles.size());
+    assertTrue(restoredFiles.contains("file1.parquet"));
+    assertTrue(restoredFiles.contains("file2.parquet"));
+    assertTrue(storage.listDirectEntries(targetPath).isEmpty());
+  }
+
+  /**
+   * Given: Files were partially restored (some already in source from prior attempt).
+   * When: restorePartitionFiles is called.
+   * Then: Only missing files are copied, all target files are deleted (idempotent).
+   */
+  @Test
+  public void testRestoreIsIdempotentWithPartialPriorRestore() throws IOException {
+    // Set up: target has 3 files, source already has 1 from prior partial restore
+    storage.createDirectory(targetPath);
+    createTestFile(targetPath, "file1.parquet", "data1");
+    createTestFile(targetPath, "file2.parquet", "data2");
+    createTestFile(targetPath, "file3.parquet", "data3");
+    createTestFile(sourcePath, "file1.parquet", "data1");
+
+    helper.restorePartitionFiles(storage, targetPath, sourcePath);
+
+    Set<String> restoredFiles = getFileNames(sourcePath);
+    assertEquals(3, restoredFiles.size());
+    assertTrue(restoredFiles.contains("file1.parquet"));
+    assertTrue(restoredFiles.contains("file2.parquet"));
+    assertTrue(restoredFiles.contains("file3.parquet"));
+    assertTrue(storage.listDirectEntries(targetPath).isEmpty());
   }
 
   // ---- Helper methods ----

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/StashPartitionsPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/StashPartitionsPreCommitValidator.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.validator;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieValidationException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.table.HoodieSparkTable;
+import org.apache.hudi.table.action.HoodieWriteMetadata;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A special-purpose pre-commit validator that moves partition files to a stash
+ * location before a deletePartitions commit completes.
+ *
+ * <p><strong>WARNING: This is NOT a standard validator pattern.</strong>
+ * Unlike typical pre-commit validators that are read-only checks, this validator
+ * performs destructive side-effects (moving/deleting files). It is designed exclusively
+ * for use with the {@code HoodieStashPartitionsTool} and the DELETE_PARTITION operation.
+ * Do NOT use this as a pattern for other validators.</p>
+ *
+ * <h3>Why move files inside a pre-commit validator?</h3>
+ *
+ * <p>The stash operation needs to both move data files to a backup location and mark
+ * the partitions as deleted via a replace commit. These two actions must be coupled:
+ * if the replace commit lands on the timeline but the file move has not happened yet,
+ * the Hudi cleaner will eventually delete the physical data files for the replaced
+ * file groups (based on its retention policy), permanently losing the data that was
+ * intended to be stashed.
+ *
+ * <p>By performing the file move inside this pre-commit validator, the move happens
+ * <b>before</b> the replace commit is finalized. If the move fails, the validator
+ * throws an exception, the commit does not land, and the table remains unchanged.
+ * This guarantees that data is never in a state where it has been marked as deleted
+ * but has not been safely backed up to the stash location.</p>
+ *
+ * <p>This validator requires the following configs to be set:
+ * <ul>
+ *   <li>{@link #STASH_PATH_CONFIG} — the target stash directory</li>
+ *   <li>{@link #RENAME_HELPER_CLASS_CONFIG} (optional) — custom rename helper class</li>
+ * </ul>
+ *
+ * <p>Guards:
+ * <ul>
+ *   <li>Fails if RLI (Record Level Index) is enabled on the table</li>
+ *   <li>Must only be used with DELETE_PARTITION operation</li>
+ * </ul>
+ */
+public class StashPartitionsPreCommitValidator<T, I, K, O extends HoodieData<WriteStatus>>
+    extends SparkPreCommitValidator<T, I, K, O> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StashPartitionsPreCommitValidator.class);
+
+  /**
+   * Config key for the stash target directory path.
+   */
+  public static final String STASH_PATH_CONFIG = "hoodie.stash.partitions.target.path";
+
+  /**
+   * Config key for the custom rename helper class. Defaults to {@link DefaultStashPartitionRenameHelper}.
+   */
+  public static final String RENAME_HELPER_CLASS_CONFIG = "hoodie.stash.rename.helper.class";
+
+  public StashPartitionsPreCommitValidator(HoodieSparkTable<T> table,
+                                           HoodieEngineContext engineContext,
+                                           HoodieWriteConfig writeConfig) {
+    super(table, engineContext, writeConfig);
+  }
+
+  /**
+   * Override validate to extract affected partitions from partitionToReplaceFileIds rather than
+   * write stats, since deletePartitions produces empty write stats but populates the replacement map.
+   */
+  @Override
+  public void validate(String instantTime, HoodieWriteMetadata<O> writeResult,
+                       Dataset<Row> before, Dataset<Row> after) throws HoodieValidationException {
+    Set<String> partitionsAffected = new HashSet<>(writeResult.getPartitionToReplaceFileIds().keySet());
+    if (partitionsAffected.isEmpty()) {
+      // Fall back to write stats if partitionToReplaceFileIds is not populated
+      partitionsAffected = getPartitionsModified(writeResult);
+    }
+    validateRecordsBeforeAndAfter(before, after, partitionsAffected);
+  }
+
+  @Override
+  protected void validateRecordsBeforeAndAfter(Dataset<Row> before,
+                                                Dataset<Row> after,
+                                                Set<String> partitionsAffected) {
+    // Guard: ensure RLI is not enabled
+    HoodieMetadataConfig metadataConfig = getWriteConfig().getMetadataConfig();
+    ValidationUtils.checkState(
+        !metadataConfig.isRecordLevelIndexEnabled() && !metadataConfig.isGlobalRecordLevelIndexEnabled(),
+        "StashPartitionsPreCommitValidator does not support tables with Record Level Index (RLI) enabled. "
+            + "Disable RLI before using the stash partitions tool.");
+
+    // Read stash path from config
+    String stashPath = getWriteConfig().getProps().getProperty(STASH_PATH_CONFIG);
+    ValidationUtils.checkState(!StringUtils.isNullOrEmpty(stashPath),
+        "Stash path must be configured via " + STASH_PATH_CONFIG);
+
+    // Instantiate rename helper
+    StashPartitionRenameHelper renameHelper = createRenameHelper();
+
+    HoodieStorage storage = getHoodieTable().getStorage();
+    StoragePath basePath = getHoodieTable().getMetaClient().getBasePath();
+
+    LOG.info("Stashing {} partition(s) to {}", partitionsAffected.size(), stashPath);
+
+    for (String partition : partitionsAffected) {
+      StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
+      StoragePath targetPartitionPath = new StoragePath(stashPath, partition);
+
+      try {
+        // Check if source directory exists and has files
+        if (!storage.exists(sourcePartitionPath) || isDirectoryEmpty(storage, sourcePartitionPath)) {
+          LOG.info("Partition {} source path is empty or does not exist, skipping (already stashed).", partition);
+          continue;
+        }
+
+        LOG.info("Moving partition {} files from {} to {}", partition, sourcePartitionPath, targetPartitionPath);
+        renameHelper.movePartitionFiles(storage, sourcePartitionPath, targetPartitionPath);
+        LOG.info("Successfully moved partition {} to stash location.", partition);
+      } catch (IOException e) {
+        LOG.error("Failed to stash partition {}", partition, e);
+        throw new HoodieValidationException(
+            "Failed to move partition files for partition: " + partition + " from " + sourcePartitionPath + " to " + targetPartitionPath, e);
+      }
+    }
+
+    LOG.info("All partitions stashed successfully.");
+  }
+
+  private boolean isDirectoryEmpty(HoodieStorage storage, StoragePath path) throws IOException {
+    List<StoragePathInfo> entries = storage.listDirectEntries(path);
+    return entries.isEmpty();
+  }
+
+  private StashPartitionRenameHelper createRenameHelper() {
+    String helperClass = getWriteConfig().getProps().getProperty(RENAME_HELPER_CLASS_CONFIG);
+    if (StringUtils.isNullOrEmpty(helperClass)) {
+      return new DefaultStashPartitionRenameHelper();
+    }
+    LOG.info("Using custom rename helper: {}", helperClass);
+    return (StashPartitionRenameHelper) ReflectionUtils.loadClass(helperClass);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/StashPartitionsPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/StashPartitionsPreCommitValidator.java
@@ -110,23 +110,37 @@ public class StashPartitionsPreCommitValidator<T, I, K, O extends HoodieData<Wri
   public void validate(String instantTime, HoodieWriteMetadata<O> writeResult,
                        Dataset<Row> before, Dataset<Row> after) throws HoodieValidationException {
     Set<String> partitionsAffected = new HashSet<>(writeResult.getPartitionToReplaceFileIds().keySet());
-    if (partitionsAffected.isEmpty()) {
-      // Fall back to write stats if partitionToReplaceFileIds is not populated
-      partitionsAffected = getPartitionsModified(writeResult);
-    }
     validateRecordsBeforeAndAfter(before, after, partitionsAffected);
   }
 
+  /**
+   * Moves partition files to the stash location before the replace commit lands.
+   *
+   * <p><b>Partial failure semantics:</b> if the move fails partway through the partition list
+   * (e.g., partition k succeeded but partition k+1 throws), the exception aborts the commit —
+   * but partitions 0..k have already had their files physically moved to the stash location.
+   * The on-disk layout is now partially mutated even though no commit landed. This validator
+   * does NOT attempt to roll back already-moved partitions on failure.
+   *
+   * <p>The {@code HoodieStashPartitionsTool} compensates for this via its pre-check, which
+   * detects partially stashed partitions and restores them before retrying. Callers using this
+   * validator outside the tool must perform their own recovery (restore files from stash back
+   * to source) before any subsequent write to the affected partitions.
+   */
   @Override
   protected void validateRecordsBeforeAndAfter(Dataset<Row> before,
                                                 Dataset<Row> after,
                                                 Set<String> partitionsAffected) {
-    // Guard: ensure RLI is not enabled
+    // Guard: ensure RLI and secondary index are not enabled
     HoodieMetadataConfig metadataConfig = getWriteConfig().getMetadataConfig();
     ValidationUtils.checkState(
         !metadataConfig.isRecordLevelIndexEnabled() && !metadataConfig.isGlobalRecordLevelIndexEnabled(),
         "StashPartitionsPreCommitValidator does not support tables with Record Level Index (RLI) enabled. "
             + "Disable RLI before using the stash partitions tool.");
+    ValidationUtils.checkState(
+        !metadataConfig.isSecondaryIndexEnabled(),
+        "StashPartitionsPreCommitValidator does not support tables with Secondary Index enabled. "
+            + "Disable secondary index before using the stash partitions tool.");
 
     // Read stash path from config
     String stashPath = getWriteConfig().getProps().getProperty(STASH_PATH_CONFIG);
@@ -153,7 +167,7 @@ public class StashPartitionsPreCommitValidator<T, I, K, O extends HoodieData<Wri
         }
 
         LOG.info("Moving partition {} files from {} to {}", partition, sourcePartitionPath, targetPartitionPath);
-        renameHelper.movePartitionFiles(storage, sourcePartitionPath, targetPartitionPath);
+        renameHelper.stashPartitionFiles(storage, sourcePartitionPath, targetPartitionPath);
         LOG.info("Successfully moved partition {} to stash location.", partition);
       } catch (IOException e) {
         LOG.error("Failed to stash partition {}", partition, e);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/validator/TestStashPartitionsPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/validator/TestStashPartitionsPreCommitValidator.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.client.validator;
+
+import org.apache.hudi.client.HoodieWriteResult;
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodiePreCommitValidatorConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieValidationException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.table.HoodieSparkTable;
+import org.apache.hudi.testutils.HoodieClientTestBase;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH;
+import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link StashPartitionsPreCommitValidator}.
+ */
+public class TestStashPartitionsPreCommitValidator extends HoodieClientTestBase {
+
+  /**
+   * A test validator that extends StashPartitionsPreCommitValidator and can simulate
+   * failures at specific points during the stash process.
+   *
+   * Set {@link #failAfterNPartitions} to control after how many partitions the validator
+   * should throw an exception. Set to -1 (default) for no failure.
+   */
+  public static class FailingStashValidator<T, I, K, O extends HoodieData<WriteStatus>>
+      extends StashPartitionsPreCommitValidator<T, I, K, O> {
+
+    /** Number of partitions to successfully stash before throwing. -1 means no failure. */
+    public static volatile int failAfterNPartitions = -1;
+
+    private static final AtomicInteger PARTITIONS_PROCESSED = new AtomicInteger(0);
+
+    public FailingStashValidator(HoodieSparkTable<T> table,
+                                  HoodieEngineContext engineContext,
+                                  HoodieWriteConfig writeConfig) {
+      super(table, engineContext, writeConfig);
+    }
+
+    public static void reset() {
+      failAfterNPartitions = -1;
+      PARTITIONS_PROCESSED.set(0);
+    }
+
+    @Override
+    protected void validateRecordsBeforeAndAfter(Dataset<Row> before,
+                                                  Dataset<Row> after,
+                                                  Set<String> partitionsAffected) {
+      if (failAfterNPartitions < 0) {
+        super.validateRecordsBeforeAndAfter(before, after, partitionsAffected);
+        return;
+      }
+
+      HoodieStorage storage = getHoodieTable().getStorage();
+      StoragePath basePath = getHoodieTable().getMetaClient().getBasePath();
+      String stashPath = getWriteConfig().getProps().getProperty(STASH_PATH_CONFIG);
+      StashPartitionRenameHelper renameHelper = new DefaultStashPartitionRenameHelper();
+
+      for (String partition : partitionsAffected) {
+        if (PARTITIONS_PROCESSED.get() >= failAfterNPartitions) {
+          throw new HoodieValidationException(
+              "Simulated failure after stashing " + failAfterNPartitions + " partition(s)");
+        }
+
+        StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
+        StoragePath targetPartitionPath = new StoragePath(stashPath, partition);
+
+        try {
+          if (!storage.exists(sourcePartitionPath) || storage.listDirectEntries(sourcePartitionPath).isEmpty()) {
+            continue;
+          }
+          renameHelper.movePartitionFiles(storage, sourcePartitionPath, targetPartitionPath);
+          PARTITIONS_PROCESSED.incrementAndGet();
+        } catch (IOException e) {
+          throw new HoodieValidationException("Failed to move partition: " + partition, e);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testValidatorMovesFilesToStashOnDeletePartition() throws Exception {
+    String stashPath = createStashDir();
+    insertRecords("001", 10);
+
+    HoodieStorage storage = metaClient.getStorage();
+    StoragePath sourcePartition = new StoragePath(basePath, DEFAULT_FIRST_PARTITION_PATH);
+    assertTrue(storage.exists(sourcePartition));
+    assertFalse(storage.listDirectEntries(sourcePartition).isEmpty());
+
+    HoodieWriteConfig config = getConfigWithStashValidator(stashPath);
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+      HoodieWriteResult result = client.deletePartitions(
+          Arrays.asList(DEFAULT_FIRST_PARTITION_PATH), instantTime);
+      client.commit(instantTime, result.getWriteStatuses(), Option.empty(),
+          HoodieTimeline.REPLACE_COMMIT_ACTION,
+          result.getPartitionToReplaceFileIds(), Option.empty());
+    }
+
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    assertTrue(storage.exists(stashPartition));
+    assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+    assertSourceEmpty(storage, sourcePartition);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    assertFalse(metaClient.getActiveTimeline().getCompletedReplaceTimeline().empty());
+  }
+
+  @Test
+  public void testValidatorSkipsAlreadyStashedPartition() throws Exception {
+    String stashPath = createStashDir();
+    insertRecords("001", 10);
+
+    HoodieWriteConfig config = getConfigWithStashValidator(stashPath);
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+      HoodieWriteResult result = client.deletePartitions(
+          Arrays.asList(DEFAULT_FIRST_PARTITION_PATH), instantTime);
+      client.commit(instantTime, result.getWriteStatuses(), Option.empty(),
+          HoodieTimeline.REPLACE_COMMIT_ACTION,
+          result.getPartitionToReplaceFileIds(), Option.empty());
+    }
+
+    HoodieStorage storage = metaClient.getStorage();
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    List<StoragePathInfo> stashFilesFirst = storage.listDirectEntries(stashPartition);
+    assertFalse(stashFilesFirst.isEmpty());
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      String instantTime2 = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+      HoodieWriteResult result2 = client.deletePartitions(
+          Arrays.asList(DEFAULT_FIRST_PARTITION_PATH), instantTime2);
+      client.commit(instantTime2, result2.getWriteStatuses(), Option.empty(),
+          HoodieTimeline.REPLACE_COMMIT_ACTION,
+          result2.getPartitionToReplaceFileIds(), Option.empty());
+    }
+
+    List<StoragePathInfo> stashFilesSecond = storage.listDirectEntries(stashPartition);
+    assertEquals(stashFilesFirst.size(), stashFilesSecond.size());
+  }
+
+  @Test
+  public void testValidatorHandlesPartialPriorMove() throws Exception {
+    String stashPath = createStashDir();
+    insertRecords("001", 10);
+
+    HoodieStorage storage = metaClient.getStorage();
+    StoragePath sourcePartition = new StoragePath(basePath, DEFAULT_FIRST_PARTITION_PATH);
+    List<StoragePathInfo> sourceFiles = storage.listDirectEntries(sourcePartition);
+    assertTrue(sourceFiles.size() > 0);
+
+    // Simulate a prior partial move: copy one file to stash
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    storage.createDirectory(stashPartition);
+    StoragePathInfo firstFile = sourceFiles.get(0);
+    org.apache.hudi.io.util.FileIOUtils.copy(storage, firstFile.getPath(),
+        new StoragePath(stashPartition, firstFile.getPath().getName()));
+
+    int totalSourceFiles = sourceFiles.size();
+
+    HoodieWriteConfig config = getConfigWithStashValidator(stashPath);
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+      HoodieWriteResult result = client.deletePartitions(
+          Arrays.asList(DEFAULT_FIRST_PARTITION_PATH), instantTime);
+      client.commit(instantTime, result.getWriteStatuses(), Option.empty(),
+          HoodieTimeline.REPLACE_COMMIT_ACTION,
+          result.getPartitionToReplaceFileIds(), Option.empty());
+    }
+
+    List<StoragePathInfo> stashFiles = storage.listDirectEntries(stashPartition);
+    assertEquals(totalSourceFiles, stashFiles.size());
+    assertSourceEmpty(storage, sourcePartition);
+  }
+
+  @Test
+  public void testValidatorFailsWithoutStashPathConfig() throws Exception {
+    insertRecords("001", 10);
+
+    HoodieWriteConfig config = getConfigBuilder()
+        .withPreCommitValidatorConfig(
+            HoodiePreCommitValidatorConfig.newBuilder()
+                .withPreCommitValidator(StashPartitionsPreCommitValidator.class.getName())
+                .build())
+        .build();
+
+    assertThrows(HoodieException.class, () -> {
+      try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+        String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+        HoodieWriteResult result = client.deletePartitions(
+            Arrays.asList(DEFAULT_FIRST_PARTITION_PATH), instantTime);
+        client.commit(instantTime, result.getWriteStatuses(), Option.empty(),
+            HoodieTimeline.REPLACE_COMMIT_ACTION,
+            result.getPartitionToReplaceFileIds(), Option.empty());
+      }
+    });
+  }
+
+  @Test
+  public void testValidatorStashesMultiplePartitions() throws Exception {
+    String stashPath = createStashDir();
+    insertRecords("001", 20);
+
+    HoodieWriteConfig config = getConfigWithStashValidator(stashPath);
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+      HoodieWriteResult result = client.deletePartitions(
+          Arrays.asList(DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH), instantTime);
+      client.commit(instantTime, result.getWriteStatuses(), Option.empty(),
+          HoodieTimeline.REPLACE_COMMIT_ACTION,
+          result.getPartitionToReplaceFileIds(), Option.empty());
+    }
+
+    HoodieStorage storage = metaClient.getStorage();
+    for (String partition : new String[]{DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH}) {
+      StoragePath stashPartition = new StoragePath(stashPath, partition);
+      assertTrue(storage.exists(stashPartition));
+      assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+      assertSourceEmpty(storage, new StoragePath(basePath, partition));
+    }
+  }
+
+  /**
+   * Scenario (b): Validator stashes 1 partition then crashes. Retry with real validator succeeds.
+   */
+  @Test
+  public void testRetryAfterValidatorPartiallyStashedAndCrashed() throws Exception {
+    String stashPath = createStashDir();
+    insertRecords("001", 30);
+
+    HoodieStorage storage = metaClient.getStorage();
+    List<String> allPartitions = Arrays.asList(
+        DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH, DEFAULT_THIRD_PARTITION_PATH);
+
+    // First attempt: validator stashes 1 partition then throws
+    FailingStashValidator.reset();
+    FailingStashValidator.failAfterNPartitions = 1;
+
+    HoodieWriteConfig failingConfig = getConfigBuilder()
+        .withPreCommitValidatorConfig(
+            HoodiePreCommitValidatorConfig.newBuilder()
+                .withPreCommitValidator(FailingStashValidator.class.getName())
+                .build())
+        .withProperties(buildStashProps(stashPath))
+        .build();
+
+    assertThrows(HoodieException.class, () -> {
+      try (SparkRDDWriteClient client = getHoodieWriteClient(failingConfig)) {
+        String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+        HoodieWriteResult result = client.deletePartitions(allPartitions, instantTime);
+        client.commit(instantTime, result.getWriteStatuses(), Option.empty(),
+            HoodieTimeline.REPLACE_COMMIT_ACTION,
+            result.getPartitionToReplaceFileIds(), Option.empty());
+      }
+    });
+
+    FailingStashValidator.reset();
+
+    // Retry with the real validator
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieWriteConfig retryConfig = getConfigWithStashValidator(stashPath);
+    try (SparkRDDWriteClient client = getHoodieWriteClient(retryConfig)) {
+      String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+      HoodieWriteResult result = client.deletePartitions(allPartitions, instantTime);
+      client.commit(instantTime, result.getWriteStatuses(), Option.empty(),
+          HoodieTimeline.REPLACE_COMMIT_ACTION,
+          result.getPartitionToReplaceFileIds(), Option.empty());
+    }
+
+    for (String partition : allPartitions) {
+      StoragePath stashPartition = new StoragePath(stashPath, partition);
+      assertTrue(storage.exists(stashPartition));
+      assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+      assertSourceEmpty(storage, new StoragePath(basePath, partition));
+    }
+  }
+
+  /**
+   * Scenario (d): Validator succeeded for all partitions (files moved), but crashed before
+   * commit. Retry should succeed — validator skips already-moved partitions.
+   */
+  @Test
+  public void testRetryAfterValidatorSucceededButCrashedBeforeCommit() throws Exception {
+    String stashPath = createStashDir();
+    insertRecords("001", 30);
+
+    HoodieStorage storage = metaClient.getStorage();
+    List<String> allPartitions = Arrays.asList(
+        DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH, DEFAULT_THIRD_PARTITION_PATH);
+
+    // Manually move all files to stash (simulating validator succeeded but commit didn't land)
+    DefaultStashPartitionRenameHelper renameHelper = new DefaultStashPartitionRenameHelper();
+    for (String partition : allPartitions) {
+      StoragePath src = new StoragePath(basePath, partition);
+      StoragePath dest = new StoragePath(stashPath, partition);
+      if (storage.exists(src) && !storage.listDirectEntries(src).isEmpty()) {
+        renameHelper.movePartitionFiles(storage, src, dest);
+      }
+    }
+
+    // Retry with real validator — sources are empty, validator skips all
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieWriteConfig retryConfig = getConfigWithStashValidator(stashPath);
+    try (SparkRDDWriteClient client = getHoodieWriteClient(retryConfig)) {
+      String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+      HoodieWriteResult result = client.deletePartitions(allPartitions, instantTime);
+      client.commit(instantTime, result.getWriteStatuses(), Option.empty(),
+          HoodieTimeline.REPLACE_COMMIT_ACTION,
+          result.getPartitionToReplaceFileIds(), Option.empty());
+    }
+
+    // All partitions should be stashed and commit should exist
+    for (String partition : allPartitions) {
+      StoragePath stashPartition = new StoragePath(stashPath, partition);
+      assertTrue(storage.exists(stashPartition));
+      assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+    }
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    assertFalse(metaClient.getActiveTimeline().getCompletedReplaceTimeline().empty());
+  }
+
+  // ---- Helper methods ----
+
+  private void insertRecords(String commitTime, int numRecords) throws IOException {
+    HoodieWriteConfig writeConfig = getConfigBuilder().build();
+    try (SparkRDDWriteClient client = getHoodieWriteClient(writeConfig)) {
+      List<HoodieRecord> records = dataGen.generateInserts(commitTime, numRecords);
+      JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 2);
+      WriteClientTestUtils.startCommitWithTime(client, commitTime);
+      JavaRDD<WriteStatus> statusesRdd = client.insert(writeRecords, commitTime);
+      List<WriteStatus> statuses = statusesRdd.collect();
+      assertNoWriteErrors(statuses);
+      client.commit(commitTime, jsc.parallelize(statuses));
+    }
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+  }
+
+  private HoodieWriteConfig getConfigWithStashValidator(String stashPath) {
+    return getConfigBuilder()
+        .withPreCommitValidatorConfig(
+            HoodiePreCommitValidatorConfig.newBuilder()
+                .withPreCommitValidator(StashPartitionsPreCommitValidator.class.getName())
+                .build())
+        .withProperties(buildStashProps(stashPath))
+        .build();
+  }
+
+  private java.util.Properties buildStashProps(String stashPath) {
+    java.util.Properties props = new java.util.Properties();
+    props.setProperty(StashPartitionsPreCommitValidator.STASH_PATH_CONFIG, stashPath);
+    return props;
+  }
+
+  private String createStashDir() throws IOException {
+    Path stashDir = Paths.get(basePath).getParent().resolve("stash_" + System.currentTimeMillis());
+    Files.createDirectories(stashDir);
+    return stashDir.toAbsolutePath().toUri().toString();
+  }
+
+  private void assertSourceEmpty(HoodieStorage storage, StoragePath sourcePartition) throws IOException {
+    if (storage.exists(sourcePartition)) {
+      List<StoragePathInfo> remaining = storage.listDirectEntries(sourcePartition).stream()
+          .filter(f -> !f.getPath().getName().startsWith("."))
+          .collect(Collectors.toList());
+      assertTrue(remaining.isEmpty(),
+          "Source partition should have no data files, but found: " + remaining);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/validator/TestStashPartitionsPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/validator/TestStashPartitionsPreCommitValidator.java
@@ -121,7 +121,7 @@ public class TestStashPartitionsPreCommitValidator extends HoodieClientTestBase 
           if (!storage.exists(sourcePartitionPath) || storage.listDirectEntries(sourcePartitionPath).isEmpty()) {
             continue;
           }
-          renameHelper.movePartitionFiles(storage, sourcePartitionPath, targetPartitionPath);
+          renameHelper.stashPartitionFiles(storage, sourcePartitionPath, targetPartitionPath);
           PARTITIONS_PROCESSED.incrementAndGet();
         } catch (IOException e) {
           throw new HoodieValidationException("Failed to move partition: " + partition, e);
@@ -348,7 +348,7 @@ public class TestStashPartitionsPreCommitValidator extends HoodieClientTestBase 
       StoragePath src = new StoragePath(basePath, partition);
       StoragePath dest = new StoragePath(stashPath, partition);
       if (storage.exists(src) && !storage.listDirectEntries(src).isEmpty()) {
-        renameHelper.movePartitionFiles(storage, src, dest);
+        renameHelper.stashPartitionFiles(storage, src, dest);
       }
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieStashPartitionsTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieStashPartitionsTool.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.client.HoodieWriteResult;
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.validator.DefaultStashPartitionRenameHelper;
+import org.apache.hudi.client.validator.StashPartitionRenameHelper;
+import org.apache.hudi.client.validator.StashPartitionsPreCommitValidator;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.config.HoodiePreCommitValidatorConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.HoodieStorageUtils;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A spark-submit tool for stashing (backing up and removing) Hudi table partitions.
+ *
+ * <p>This tool supports three modes:
+ * <ul>
+ *   <li><b>stash</b> — Moves data files from specified partitions to a stash location
+ *       and issues a deletePartitions operation on the Hudi table. Uses a custom
+ *       {@link StashPartitionsPreCommitValidator} to move files atomically before commit.</li>
+ *   <li><b>rollback_stash</b> — Copies any data found in the stash location back to the
+ *       original partition paths. Used when the user no longer wants to proceed with stashing.</li>
+ *   <li><b>dry_run</b> — Shows which partitions and file groups would be affected.</li>
+ * </ul>
+ *
+ * <p>For restoring stashed partitions back into the Hudi table, use the standard
+ * {@code insert_overwrite} write operation reading from the stash location.
+ *
+ * <p>Example usage:
+ * <pre>
+ * spark-submit \
+ *   --class org.apache.hudi.utilities.HoodieStashPartitionsTool \
+ *   --master local[*] \
+ *   --driver-memory 1g \
+ *   --executor-memory 1g \
+ *   hudi-utilities-bundle.jar \
+ *   --base-path /path/to/hudi/table \
+ *   --table-name myTable \
+ *   --stash-path /path/to/stash/folder \
+ *   --partitions datestr=2023-01-01,datestr=2023-01-02 \
+ *   --mode stash
+ * </pre>
+ */
+public class HoodieStashPartitionsTool implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieStashPartitionsTool.class);
+
+  private final transient JavaSparkContext jsc;
+  private final Config cfg;
+  private final TypedProperties props;
+  private final HoodieTableMetaClient metaClient;
+
+  public HoodieStashPartitionsTool(JavaSparkContext jsc, Config cfg) {
+    this.jsc = jsc;
+    this.cfg = cfg;
+    this.props = cfg.propsFilePath == null
+        ? UtilHelpers.buildProperties(cfg.configs)
+        : readConfigFromFileSystem(jsc, cfg);
+    this.metaClient = HoodieTableMetaClient.builder()
+        .setConf(HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration()))
+        .setBasePath(cfg.basePath)
+        .setLoadActiveTimelineOnLoad(true)
+        .build();
+  }
+
+  public enum Mode {
+    STASH,
+    ROLLBACK_STASH,
+    DRY_RUN
+  }
+
+  public static class Config implements Serializable {
+    @Parameter(names = {"--base-path", "-sp"}, description = "Base path for the Hudi table.", required = true)
+    public String basePath = null;
+
+    @Parameter(names = {"--table-name", "-tn"}, description = "Table name.", required = true)
+    public String tableName = null;
+
+    @Parameter(names = {"--stash-path"}, description = "Target path for stashing partition data.", required = true)
+    public String stashPath = null;
+
+    @Parameter(names = {"--partitions", "-p"}, description = "Comma separated list of partitions to stash.", required = true)
+    public String partitions = null;
+
+    @Parameter(names = {"--mode", "-m"}, description = "Set job mode: "
+        + "\"stash\" to move partition data to stash location and delete partitions; "
+        + "\"rollback_stash\" to copy stashed data back to table and abort stashing; "
+        + "\"dry_run\" to preview which partitions and files would be affected.", required = true)
+    public String runningMode = null;
+
+    @Parameter(names = {"--parallelism", "-pl"}, description = "Parallelism for hoodie operations.", required = false)
+    public int parallelism = 1500;
+
+    @Parameter(names = {"--rename-helper-class"}, description = "Fully qualified class name of a custom "
+        + "StashPartitionRenameHelper implementation. Defaults to DefaultStashPartitionRenameHelper.", required = false)
+    public String renameHelperClass = null;
+
+    @Parameter(names = {"--spark-master", "-ms"}, description = "Spark master.", required = false)
+    public String sparkMaster = null;
+
+    @Parameter(names = {"--spark-memory", "-sm"}, description = "Spark memory to use.", required = false)
+    public String sparkMemory = "1g";
+
+    @Parameter(names = {"--props"}, description = "Path to properties file on localfs or dfs, with configurations for "
+        + "hoodie client for stashing partitions.")
+    public String propsFilePath = null;
+
+    @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file "
+        + "(using the CLI parameter \"--props\") can also be passed via command line using this parameter. This can be repeated.",
+        splitter = IdentitySplitter.class)
+    public List<String> configs = new ArrayList<>();
+
+    @Parameter(names = {"--help", "-h"}, help = true)
+    public Boolean help = false;
+
+    @Override
+    public String toString() {
+      return "HoodieStashPartitionsToolConfig {\n"
+          + "   --base-path " + basePath + ", \n"
+          + "   --table-name " + tableName + ", \n"
+          + "   --stash-path " + stashPath + ", \n"
+          + "   --partitions " + partitions + ", \n"
+          + "   --mode " + runningMode + ", \n"
+          + "   --parallelism " + parallelism + ", \n"
+          + "   --rename-helper-class " + renameHelperClass + ", \n"
+          + "   --spark-master " + sparkMaster + ", \n"
+          + "   --spark-memory " + sparkMemory + ", \n"
+          + "   --props " + propsFilePath + ", \n"
+          + "   --hoodie-conf " + configs
+          + "\n}";
+    }
+  }
+
+  public static void main(String[] args) {
+    final Config cfg = new Config();
+    JCommander cmd = new JCommander(cfg, null, args);
+    if (cfg.help || args.length == 0) {
+      cmd.usage();
+      System.exit(1);
+    }
+    Map<String, String> sparkConfigMap = new HashMap<>();
+    sparkConfigMap.put("spark.executor.memory", cfg.sparkMemory);
+    JavaSparkContext jsc = UtilHelpers.buildSparkContext("Hoodie-Stash-Partitions",
+        cfg.sparkMaster, false, sparkConfigMap);
+
+    HoodieStashPartitionsTool tool = new HoodieStashPartitionsTool(jsc, cfg);
+    try {
+      tool.run();
+    } catch (Throwable throwable) {
+      LOG.error("Fail to run stash partitions for " + cfg, throwable);
+    } finally {
+      jsc.stop();
+    }
+  }
+
+  public void run() {
+    try {
+      LOG.info(cfg.toString());
+      Mode mode = Mode.valueOf(cfg.runningMode.toUpperCase());
+      switch (mode) {
+        case STASH:
+          LOG.info(" ****** The Hoodie Stash Partitions Tool is in stash mode ****** ");
+          doStash();
+          break;
+        case ROLLBACK_STASH:
+          LOG.info(" ****** The Hoodie Stash Partitions Tool is in rollback_stash mode ****** ");
+          doRollbackStash();
+          break;
+        case DRY_RUN:
+          LOG.info(" ****** The Hoodie Stash Partitions Tool is in dry-run mode ****** ");
+          doDryRun();
+          break;
+        default:
+          LOG.info("Unsupported running mode [" + cfg.runningMode + "], quit the job directly");
+      }
+    } catch (Exception e) {
+      throw new HoodieException("Unable to stash partitions in " + cfg.basePath, e);
+    }
+  }
+
+  /**
+   * Stash partitions: pre-check to recover any partial stash from a prior failed attempt,
+   * then issue deletePartitions with custom pre-commit validator. Hudi internally handles
+   * rollback of any prior failed instants. The pre-commit validator handles already-stashed
+   * partitions gracefully (source empty -> skip).
+   *
+   * <p>The pre-check runs regardless of whether MDT is enabled. Even with MDT, a prior failed
+   * attempt may have had its pre-commit validator move files to the stash location before
+   * crashing. Those files need to be moved back so that the subsequent deletePartitions
+   * sees the complete partition state.
+   */
+  private void doStash() {
+    List<String> partitionsToStash = Arrays.asList(cfg.partitions.split(","));
+
+    preCheckAndRecoverPartialStash(partitionsToStash);
+
+    // Set up props with stash-specific configs for the pre-commit validator
+    TypedProperties stashProps = new TypedProperties();
+    stashProps.putAll(props);
+    stashProps.setProperty(HoodiePreCommitValidatorConfig.VALIDATOR_CLASS_NAMES.key(),
+        StashPartitionsPreCommitValidator.class.getName());
+    stashProps.setProperty(StashPartitionsPreCommitValidator.STASH_PATH_CONFIG, cfg.stashPath);
+    if (!StringUtils.isNullOrEmpty(cfg.renameHelperClass)) {
+      stashProps.setProperty(StashPartitionsPreCommitValidator.RENAME_HELPER_CLASS_CONFIG, cfg.renameHelperClass);
+    }
+
+    try (SparkRDDWriteClient<HoodieRecordPayload> client =
+             UtilHelpers.createHoodieClient(jsc, cfg.basePath, "", cfg.parallelism, Option.empty(), stashProps)) {
+      String instantTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
+      LOG.info("Starting deletePartitions with instant {} for partitions: {}", instantTime, partitionsToStash);
+      HoodieWriteResult result = client.deletePartitions(partitionsToStash, instantTime);
+      client.commit(instantTime, result.getWriteStatuses(), Option.empty(), HoodieTimeline.REPLACE_COMMIT_ACTION,
+          result.getPartitionToReplaceFileIds(), Option.empty());
+      LOG.info("Successfully stashed partitions: {}", partitionsToStash);
+    }
+  }
+
+  /**
+   * Pre-check: if files exist in the stash location from a prior failed attempt,
+   * copy them back to source before retrying deletePartitions. This ensures the
+   * subsequent deletePartitions sees the complete partition state and creates
+   * a correct replace commit. Runs for both MDT and non-MDT tables, since the
+   * pre-commit validator may have moved files before crashing.
+   */
+  private void preCheckAndRecoverPartialStash(List<String> partitions) {
+    LOG.info("Running pre-check for partial stash recovery (non-MDT table).");
+    HoodieStorage storage = HoodieStorageUtils.getStorage(
+        cfg.basePath, metaClient.getStorageConf());
+    StashPartitionRenameHelper renameHelper = createRenameHelper();
+    StoragePath basePath = metaClient.getBasePath();
+
+    for (String partition : partitions) {
+      StoragePath stashPartitionPath = new StoragePath(cfg.stashPath, partition);
+      StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
+
+      try {
+        if (!storage.exists(stashPartitionPath) || isDirectoryEmpty(storage, stashPartitionPath)) {
+          LOG.info("Partition {} has no stashed data from prior attempt, skipping pre-check.", partition);
+          continue;
+        }
+        // Files exist in stash — copy them back to source to ensure deletePartitions
+        // sees all files and creates a complete replace commit.
+        LOG.info("Found stashed files for partition {} from prior attempt. Moving back to source.", partition);
+        renameHelper.movePartitionFiles(storage, stashPartitionPath, sourcePartitionPath);
+        LOG.info("Recovered partition {} back to source.", partition);
+      } catch (IOException e) {
+        throw new HoodieException("Failed to recover partition " + partition + " from stash during pre-check.", e);
+      }
+    }
+  }
+
+  /**
+   * Rollback stash: copy any data from stash location back to original partition paths.
+   * This is for when the user no longer wants to proceed with stashing.
+   */
+  private void doRollbackStash() {
+    List<String> partitions = Arrays.asList(cfg.partitions.split(","));
+    HoodieStorage storage = HoodieStorageUtils.getStorage(
+        cfg.basePath, metaClient.getStorageConf());
+    StashPartitionRenameHelper renameHelper = createRenameHelper();
+    StoragePath basePath = metaClient.getBasePath();
+
+    for (String partition : partitions) {
+      StoragePath stashPartitionPath = new StoragePath(cfg.stashPath, partition);
+      StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
+
+      try {
+        if (!storage.exists(stashPartitionPath) || isDirectoryEmpty(storage, stashPartitionPath)) {
+          LOG.info("No stashed data found for partition {}, skipping.", partition);
+          continue;
+        }
+        LOG.info("Rolling back stash for partition {}: moving from {} to {}", partition, stashPartitionPath, sourcePartitionPath);
+        renameHelper.movePartitionFiles(storage, stashPartitionPath, sourcePartitionPath);
+        LOG.info("Successfully rolled back stash for partition {}.", partition);
+      } catch (IOException e) {
+        throw new HoodieException("Failed to rollback stash for partition: " + partition, e);
+      }
+    }
+    LOG.info("Stash rollback complete.");
+  }
+
+  /**
+   * Dry run: show partitions and file groups that would be affected.
+   */
+  private void doDryRun() {
+    try (SparkRDDWriteClient<HoodieRecordPayload> client =
+             UtilHelpers.createHoodieClient(jsc, cfg.basePath, "", cfg.parallelism, Option.empty(), props)) {
+      org.apache.hudi.table.HoodieSparkTable<HoodieRecordPayload> table =
+          org.apache.hudi.table.HoodieSparkTable.create(client.getConfig(), client.getEngineContext());
+      List<String> parts = Arrays.asList(cfg.partitions.split(","));
+      HoodieStorage storage = HoodieStorageUtils.getStorage(
+          cfg.basePath, metaClient.getStorageConf());
+      StoragePath basePath = metaClient.getBasePath();
+
+      LOG.info("=== Dry Run: Partitions and files that would be stashed ===");
+      for (String partition : parts) {
+        StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
+        StoragePath stashPartitionPath = new StoragePath(cfg.stashPath, partition);
+
+        List<String> fileIds = table.getSliceView()
+            .getLatestFileSlices(partition)
+            .map(fs -> fs.getFileId())
+            .distinct()
+            .collect(Collectors.toList());
+
+        boolean sourceExists;
+        boolean stashExists;
+        try {
+          sourceExists = storage.exists(sourcePartitionPath) && !isDirectoryEmpty(storage, sourcePartitionPath);
+          stashExists = storage.exists(stashPartitionPath) && !isDirectoryEmpty(storage, stashPartitionPath);
+        } catch (IOException e) {
+          throw new HoodieException("Failed to check paths for partition: " + partition, e);
+        }
+
+        LOG.info("Partition: {}", partition);
+        LOG.info("  Source path: {} (exists={})", sourcePartitionPath, sourceExists);
+        LOG.info("  Stash path: {} (exists={})", stashPartitionPath, stashExists);
+        LOG.info("  File group IDs: {}", fileIds);
+      }
+    }
+  }
+
+  private boolean isDirectoryEmpty(HoodieStorage storage, StoragePath path) throws IOException {
+    List<StoragePathInfo> entries = storage.listDirectEntries(path);
+    return entries.isEmpty();
+  }
+
+  private StashPartitionRenameHelper createRenameHelper() {
+    if (!StringUtils.isNullOrEmpty(cfg.renameHelperClass)) {
+      LOG.info("Using custom rename helper: {}", cfg.renameHelperClass);
+      return (StashPartitionRenameHelper) ReflectionUtils.loadClass(cfg.renameHelperClass);
+    }
+    return new DefaultStashPartitionRenameHelper();
+  }
+
+  private TypedProperties readConfigFromFileSystem(JavaSparkContext jsc, Config cfg) {
+    return UtilHelpers.readConfig(jsc.hadoopConfiguration(), new Path(cfg.propsFilePath), cfg.configs)
+        .getProps(true);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieStashPartitionsTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieStashPartitionsTool.java
@@ -24,20 +24,29 @@ import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.validator.DefaultStashPartitionRenameHelper;
 import org.apache.hudi.client.validator.StashPartitionRenameHelper;
 import org.apache.hudi.client.validator.StashPartitionsPreCommitValidator;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodiePreCommitValidatorConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieValidationException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.table.HoodieSparkTable;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
@@ -51,6 +60,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -211,6 +221,7 @@ public class HoodieStashPartitionsTool implements Serializable {
       tool.run();
     } catch (Throwable throwable) {
       LOG.error("Fail to run stash partitions for " + cfg, throwable);
+      throw new HoodieException("Fail to run stash partitions for " + cfg, throwable);
     } finally {
       jsc.stop();
     }
@@ -242,20 +253,28 @@ public class HoodieStashPartitionsTool implements Serializable {
   }
 
   /**
-   * Stash partitions: pre-check to recover any partial stash from a prior failed attempt,
-   * then issue deletePartitions with custom pre-commit validator. Hudi internally handles
-   * rollback of any prior failed instants. The pre-commit validator handles already-stashed
-   * partitions gracefully (source empty -> skip).
+   * Stash partitions: validates partition state using table metadata, recovers any partial
+   * stash from a prior failed attempt, then issues deletePartitions with a custom pre-commit
+   * validator.
    *
-   * <p>The pre-check runs regardless of whether MDT is enabled. Even with MDT, a prior failed
-   * attempt may have had its pre-commit validator move files to the stash location before
-   * crashing. Those files need to be moved back so that the subsequent deletePartitions
-   * sees the complete partition state.
+   * <p>The pre-check uses {@link HoodieTableMetadata} (MDT-backed when available) to determine
+   * whether each partition still has active files. This allows the tool to distinguish between:
+   * <ul>
+   *   <li>A prior successful stash (partition deleted + data in stash) → no-op, return early</li>
+   *   <li>A partial prior attempt (partition has files + data in stash) → recover from stash, retry</li>
+   *   <li>A fresh run (partition has files + no stash data) → proceed normally</li>
+   * </ul>
    */
   private void doStash() {
     List<String> partitionsToStash = Arrays.asList(cfg.partitions.split(","));
 
-    preCheckAndRecoverPartialStash(partitionsToStash);
+    if (!preCheckAndRecoverPartialStash(partitionsToStash)) {
+      // All partitions already stashed successfully — nothing to do.
+      return;
+    }
+
+    // Validate that all partitions are in a clean, compacted state before stashing.
+    validatePartitionsForStash(partitionsToStash);
 
     // Set up props with stash-specific configs for the pre-commit validator
     TypedProperties stashProps = new TypedProperties();
@@ -279,67 +298,274 @@ public class HoodieStashPartitionsTool implements Serializable {
   }
 
   /**
-   * Pre-check: if files exist in the stash location from a prior failed attempt,
-   * copy them back to source before retrying deletePartitions. This ensures the
-   * subsequent deletePartitions sees the complete partition state and creates
-   * a correct replace commit. Runs for both MDT and non-MDT tables, since the
-   * pre-commit validator may have moved files before crashing.
+   * Pre-check: evaluates partition states and recovers any partial stash from a prior
+   * failed attempt. For partitions with a partial stash (active files + stash data),
+   * restores files from stash back to source so deletePartitions sees the complete state.
+   *
+   * @return true if deletePartitions should proceed, false if all partitions are already stashed
    */
-  private void preCheckAndRecoverPartialStash(List<String> partitions) {
-    LOG.info("Running pre-check for partial stash recovery (non-MDT table).");
-    HoodieStorage storage = HoodieStorageUtils.getStorage(
-        cfg.basePath, metaClient.getStorageConf());
+  private boolean preCheckAndRecoverPartialStash(List<String> partitions) {
+    LOG.info("Running pre-check: validating partition state via table metadata.");
+    Map<String, PartitionStashState> stateMap = evaluatePartitionStates(partitions);
+    HoodieStorage storage = HoodieStorageUtils.getStorage(cfg.basePath, metaClient.getStorageConf());
+    StashPartitionRenameHelper renameHelper = createRenameHelper();
+    StoragePath basePath = metaClient.getBasePath();
+    int alreadyStashedCount = 0;
+
+    for (Map.Entry<String, PartitionStashState> entry : stateMap.entrySet()) {
+      String partition = entry.getKey();
+      PartitionStashState state = entry.getValue();
+
+      switch (state) {
+        case ALREADY_STASHED:
+          LOG.info("Partition {} already stashed (no active files in table, data exists in stash). Skipping.", partition);
+          alreadyStashedCount++;
+          break;
+        case PARTIAL_STASH:
+          LOG.info("Partition {} has active files and stash data from a prior partial attempt. "
+              + "Restoring stash data back to source before retry.", partition);
+          restorePartitionFromStash(renameHelper, storage, partition, basePath);
+          break;
+        case NOT_STASHED:
+          LOG.info("Partition {} has active files and no prior stash data. Will proceed with stash.", partition);
+          break;
+        case NO_DATA:
+          LOG.warn("Partition {} has no active files and no stash data. "
+              + "It may have been deleted by another operation.", partition);
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (alreadyStashedCount == partitions.size()) {
+      LOG.info("All {} partition(s) are already stashed successfully. Nothing to do.", partitions.size());
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Rollback stash: evaluates partition states and restores stashed data back to the
+   * original partition paths only if the stash was partial (replace commit never landed).
+   * If the stash fully completed (replace commit landed), rollback is not applicable —
+   * the user must run an {@code insert_overwrite} from the stash location.
+   */
+  private void doRollbackStash() {
+    List<String> partitions = Arrays.asList(cfg.partitions.split(","));
+    Map<String, PartitionStashState> stateMap = evaluatePartitionStates(partitions);
+    HoodieStorage storage = HoodieStorageUtils.getStorage(cfg.basePath, metaClient.getStorageConf());
     StashPartitionRenameHelper renameHelper = createRenameHelper();
     StoragePath basePath = metaClient.getBasePath();
 
-    for (String partition : partitions) {
+    for (Map.Entry<String, PartitionStashState> entry : stateMap.entrySet()) {
+      String partition = entry.getKey();
+      PartitionStashState state = entry.getValue();
       StoragePath stashPartitionPath = new StoragePath(cfg.stashPath, partition);
-      StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
 
-      try {
-        if (!storage.exists(stashPartitionPath) || isDirectoryEmpty(storage, stashPartitionPath)) {
-          LOG.info("Partition {} has no stashed data from prior attempt, skipping pre-check.", partition);
-          continue;
-        }
-        // Files exist in stash — copy them back to source to ensure deletePartitions
-        // sees all files and creates a complete replace commit.
-        LOG.info("Found stashed files for partition {} from prior attempt. Moving back to source.", partition);
-        renameHelper.movePartitionFiles(storage, stashPartitionPath, sourcePartitionPath);
-        LOG.info("Recovered partition {} back to source.", partition);
-      } catch (IOException e) {
-        throw new HoodieException("Failed to recover partition " + partition + " from stash during pre-check.", e);
+      switch (state) {
+        case ALREADY_STASHED:
+          LOG.warn("Partition {} stash completed (replace commit landed). Rollback is not applicable. "
+              + "To restore this partition, run an insert_overwrite from the stash location: {}", partition, stashPartitionPath);
+          break;
+        case PARTIAL_STASH:
+          LOG.info("Partition {} has active files and stash data from a partial attempt. Restoring stash data to source.", partition);
+          restorePartitionFromStash(renameHelper, storage, partition, basePath);
+          LOG.info("Successfully rolled back partial stash for partition {}.", partition);
+          break;
+        case NOT_STASHED:
+          LOG.info("No stash data found for partition {} and partition has active files. Nothing to rollback.", partition);
+          break;
+        case NO_DATA:
+          LOG.warn("Partition {} has no active files and no stash data. Nothing to rollback.", partition);
+          break;
+        default:
+          break;
       }
+    }
+    LOG.info("Stash rollback complete.");
+  }
+
+  // ---- Partition state evaluation ----
+
+  /**
+   * Classifies the stash state of each partition by checking active files via
+   * {@link HoodieTableMetadata} and data in the stash location.
+   */
+  enum PartitionStashState {
+    /** No active files in table, data exists in stash — stash fully completed. */
+    ALREADY_STASHED,
+    /** Active files in table and data in stash — partial prior attempt. */
+    PARTIAL_STASH,
+    /** Active files in table, no stash data — fresh partition, not yet stashed. */
+    NOT_STASHED,
+    /** No active files and no stash data — partition empty or deleted elsewhere. */
+    NO_DATA
+  }
+
+  /**
+   * Evaluates the stash state for each partition using {@link HoodieTableMetadata}
+   * (MDT-backed when available, otherwise filesystem-based).
+   */
+  private Map<String, PartitionStashState> evaluatePartitionStates(List<String> partitions) {
+    HoodieStorage storage = HoodieStorageUtils.getStorage(cfg.basePath, metaClient.getStorageConf());
+    StoragePath basePath = metaClient.getBasePath();
+
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+        .enable(metaClient.getTableConfig().isMetadataTableAvailable())
+        .build();
+
+    Map<String, PartitionStashState> stateMap = new LinkedHashMap<>();
+
+    try (HoodieTableMetadata tableMetadata = metaClient.getTableFormat().getMetadataFactory()
+        .create(new HoodieLocalEngineContext(metaClient.getStorageConf()),
+            metaClient.getStorage(), metadataConfig, basePath.toString(), true)) {
+
+      for (String partition : partitions) {
+        StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
+        StoragePath stashPartitionPath = new StoragePath(cfg.stashPath, partition);
+
+        boolean partitionHasFiles = hasFilesInPartition(tableMetadata, sourcePartitionPath);
+        boolean stashHasData = hasStashData(storage, stashPartitionPath);
+
+        if (!partitionHasFiles && stashHasData) {
+          stateMap.put(partition, PartitionStashState.ALREADY_STASHED);
+        } else if (partitionHasFiles && stashHasData) {
+          stateMap.put(partition, PartitionStashState.PARTIAL_STASH);
+        } else if (partitionHasFiles) {
+          stateMap.put(partition, PartitionStashState.NOT_STASHED);
+        } else {
+          stateMap.put(partition, PartitionStashState.NO_DATA);
+        }
+      }
+    } catch (Exception e) {
+      throw new HoodieException("Failed to evaluate partition stash states.", e);
+    }
+
+    return stateMap;
+  }
+
+  private void restorePartitionFromStash(StashPartitionRenameHelper renameHelper, HoodieStorage storage,
+                                          String partition, StoragePath basePath) {
+    StoragePath stashPartitionPath = new StoragePath(cfg.stashPath, partition);
+    StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
+    try {
+      renameHelper.restorePartitionFiles(storage, stashPartitionPath, sourcePartitionPath);
+      LOG.info("Recovered partition {} back to source.", partition);
+    } catch (IOException e) {
+      throw new HoodieException("Failed to restore partition " + partition + " from stash.", e);
     }
   }
 
   /**
-   * Rollback stash: copy any data from stash location back to original partition paths.
-   * This is for when the user no longer wants to proceed with stashing.
+   * Validates that all partitions are in a clean, compacted state suitable for stashing.
+   * Builds a file system view from {@link HoodieTableMetadata} and delegates to
+   * {@link #validateFileGroupsForStash(HoodieTableFileSystemView, List)}.
    */
-  private void doRollbackStash() {
-    List<String> partitions = Arrays.asList(cfg.partitions.split(","));
-    HoodieStorage storage = HoodieStorageUtils.getStorage(
-        cfg.basePath, metaClient.getStorageConf());
-    StashPartitionRenameHelper renameHelper = createRenameHelper();
+  private void validatePartitionsForStash(List<String> partitions) {
+    LOG.info("Validating partitions are in a clean state for stashing.");
     StoragePath basePath = metaClient.getBasePath();
 
-    for (String partition : partitions) {
-      StoragePath stashPartitionPath = new StoragePath(cfg.stashPath, partition);
-      StoragePath sourcePartitionPath = new StoragePath(basePath, partition);
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+        .enable(metaClient.getTableConfig().isMetadataTableAvailable())
+        .build();
 
-      try {
-        if (!storage.exists(stashPartitionPath) || isDirectoryEmpty(storage, stashPartitionPath)) {
-          LOG.info("No stashed data found for partition {}, skipping.", partition);
-          continue;
+    try (HoodieTableMetadata tableMetadata = metaClient.getTableFormat().getMetadataFactory()
+        .create(new HoodieLocalEngineContext(metaClient.getStorageConf()),
+            metaClient.getStorage(), metadataConfig, basePath.toString(), true)) {
+
+      // Collect files across all partitions to build a single FSV
+      List<StoragePathInfo> allFiles = new ArrayList<>();
+      for (String partition : partitions) {
+        StoragePath partitionPath = new StoragePath(basePath, partition);
+        try {
+          allFiles.addAll(tableMetadata.getAllFilesInPartition(partitionPath));
+        } catch (IOException e) {
+          throw new HoodieException("Failed to list files for partition: " + partition, e);
         }
-        LOG.info("Rolling back stash for partition {}: moving from {} to {}", partition, stashPartitionPath, sourcePartitionPath);
-        renameHelper.movePartitionFiles(storage, stashPartitionPath, sourcePartitionPath);
-        LOG.info("Successfully rolled back stash for partition {}.", partition);
-      } catch (IOException e) {
-        throw new HoodieException("Failed to rollback stash for partition: " + partition, e);
+      }
+
+      try (HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(
+          metaClient, metaClient.getActiveTimeline(), allFiles)) {
+        validateFileGroupsForStash(fsView, partitions);
+      }
+    } catch (HoodieValidationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new HoodieException("Failed to validate partitions for stash.", e);
+    }
+
+    LOG.info("All partitions validated successfully for stashing.");
+  }
+
+  /**
+   * Validates that all file groups in the given partitions are in a clean state for stashing.
+   * For each file group, checks that:
+   * <ul>
+   *   <li>There is exactly one file slice — no pending compaction or older slices.</li>
+   *   <li>The file slice contains a base file.</li>
+   *   <li>The file slice has no log files — no uncompacted delta data.</li>
+   * </ul>
+   *
+   * @param fsView     the file system view to query
+   * @param partitions the partitions to validate
+   * @throws HoodieValidationException if any file group violates the conditions
+   */
+  static void validateFileGroupsForStash(HoodieTableFileSystemView fsView, List<String> partitions) {
+    for (String partition : partitions) {
+      List<HoodieFileGroup> fileGroups = fsView.getAllFileGroups(partition)
+          .collect(Collectors.toList());
+
+      for (HoodieFileGroup fileGroup : fileGroups) {
+        List<FileSlice> allSlices = fileGroup.getAllFileSlices().collect(Collectors.toList());
+
+        if (allSlices.size() != 1) {
+          throw new HoodieValidationException(
+              "Partition " + partition + " file group " + fileGroup.getFileGroupId()
+                  + " has " + allSlices.size() + " file slice(s), expected exactly 1. "
+                  + "Ensure all compactions are complete before stashing.");
+        }
+
+        FileSlice slice = allSlices.get(0);
+        if (!slice.getBaseFile().isPresent()) {
+          throw new HoodieValidationException(
+              "Partition " + partition + " file group " + fileGroup.getFileGroupId()
+                  + " has a file slice with no base file. "
+                  + "Ensure the partition is in a valid state before stashing.");
+        }
+
+        if (slice.getLogFiles().findAny().isPresent()) {
+          throw new HoodieValidationException(
+              "Partition " + partition + " file group " + fileGroup.getFileGroupId()
+                  + " has log files in its file slice. "
+                  + "Ensure all compactions are complete before stashing.");
+        }
       }
     }
-    LOG.info("Stash rollback complete.");
+  }
+
+  private boolean hasFilesInPartition(HoodieTableMetadata tableMetadata, StoragePath partitionPath) {
+    HoodieTableFileSystemView fileSystemView = null;
+    try {
+      List<StoragePathInfo> files = tableMetadata.getAllFilesInPartition(partitionPath);
+
+      fileSystemView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), files);
+      return fileSystemView.getLatestFileSlices(FSUtils.getRelativePartitionPath(metaClient.getBasePath(), partitionPath)).findFirst().isPresent();
+    } catch (IOException e) {
+      throw new HoodieException("Failed to list files in partition: " + partitionPath, e);
+    } finally {
+      if (fileSystemView != null) {
+        fileSystemView.close();
+      }
+    }
+  }
+
+  private boolean hasStashData(HoodieStorage storage, StoragePath stashPartitionPath) {
+    try {
+      return storage.exists(stashPartitionPath) && !isDirectoryEmpty(storage, stashPartitionPath);
+    } catch (IOException e) {
+      throw new HoodieException("Failed to check stash path: " + stashPartitionPath, e);
+    }
   }
 
   /**
@@ -348,8 +574,8 @@ public class HoodieStashPartitionsTool implements Serializable {
   private void doDryRun() {
     try (SparkRDDWriteClient<HoodieRecordPayload> client =
              UtilHelpers.createHoodieClient(jsc, cfg.basePath, "", cfg.parallelism, Option.empty(), props)) {
-      org.apache.hudi.table.HoodieSparkTable<HoodieRecordPayload> table =
-          org.apache.hudi.table.HoodieSparkTable.create(client.getConfig(), client.getEngineContext());
+      HoodieSparkTable<HoodieRecordPayload> table =
+          HoodieSparkTable.create(client.getConfig(), client.getEngineContext());
       List<String> parts = Arrays.asList(cfg.partitions.split(","));
       HoodieStorage storage = HoodieStorageUtils.getStorage(
           cfg.basePath, metaClient.getStorageConf());

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieStashPartitionsTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieStashPartitionsTool.java
@@ -68,6 +68,23 @@ import java.util.stream.Collectors;
  *   <li><b>dry_run</b> — Shows which partitions and file groups would be affected.</li>
  * </ul>
  *
+ * <h3>Why a pre-commit validator instead of moving files in the tool?</h3>
+ *
+ * <p>A naive approach would be to first run {@code deletePartitions} in the tool, and then
+ * move the data files to the stash location as a separate step. However, this is unsafe:
+ * if the tool crashes or fails after {@code deletePartitions} succeeds but before the data
+ * is moved to the stash location, the data is at risk. Once the replace commit from
+ * {@code deletePartitions} lands on the timeline, the Hudi cleaner will eventually delete
+ * the physical data files for the replaced file groups based on its configured retention
+ * policy (e.g., retain last N commits). If the cleaner runs before the tool is retried,
+ * the data intended for stashing is permanently lost.
+ *
+ * <p>By using a {@link StashPartitionsPreCommitValidator}, the file move happens
+ * <b>before</b> the {@code deletePartitions} commit is finalized. If the move fails, the
+ * commit does not land, and the table remains in its original state — the cleaner has
+ * nothing to clean. This ensures that data is never in a state where it has been marked
+ * as deleted (via a replace commit) but has not yet been safely copied to the stash location.
+ *
  * <p>For restoring stashed partitions back into the Hudi table, use the standard
  * {@code insert_overwrite} write operation reading from the stash location.
  *

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieStashPartitionsTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieStashPartitionsTool.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.client.SparkRDDWriteClient;
+import org.apache.hudi.client.WriteClientTestUtils;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.validator.DefaultStashPartitionRenameHelper;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH;
+import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link HoodieStashPartitionsTool}.
+ */
+public class TestHoodieStashPartitionsTool extends SparkClientFunctionalTestHarness {
+
+  private HoodieTableMetaClient metaClient;
+  private HoodieTestDataGenerator dataGen;
+  private String stashPath;
+
+  @BeforeEach
+  public void init() throws IOException {
+    metaClient = getHoodieMetaClient(HoodieTableType.COPY_ON_WRITE);
+    dataGen = new HoodieTestDataGenerator();
+    Path stashDir = tempDir.resolve("stash");
+    Files.createDirectories(stashDir);
+    stashPath = stashDir.toAbsolutePath().toUri().toString();
+  }
+
+  /**
+   * Given: A COW table with data in multiple partitions.
+   * When: Stash tool runs in stash mode for one partition.
+   * Then: Files are moved to stash location, partition is deleted from table,
+   *       and a replace commit exists on the timeline.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testStashSinglePartition(boolean enableMetadata) throws IOException {
+    insertRecords("001", 20, enableMetadata);
+
+    HoodieStorage storage = hoodieStorage();
+    StoragePath sourcePartition = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+
+    assertTrue(storage.exists(sourcePartition));
+    assertFalse(storage.listDirectEntries(sourcePartition).isEmpty());
+
+    HoodieStashPartitionsTool.Config cfg = buildConfig(DEFAULT_FIRST_PARTITION_PATH, "stash", enableMetadata);
+    new HoodieStashPartitionsTool(jsc(), cfg).run();
+
+    assertTrue(storage.exists(stashPartition));
+    assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+    assertSourcePartitionEmpty(storage, sourcePartition);
+
+    HoodieTableMetaClient reloadedMetaClient = HoodieTableMetaClient.reload(metaClient);
+    assertFalse(reloadedMetaClient.getActiveTimeline().getCompletedReplaceTimeline().empty());
+
+    // Other partitions should be untouched
+    StoragePath secondPartition = new StoragePath(basePath(), DEFAULT_SECOND_PARTITION_PATH);
+    assertTrue(storage.exists(secondPartition));
+    assertFalse(storage.listDirectEntries(secondPartition).isEmpty());
+  }
+
+  /**
+   * Given: A COW table with data, and one partition already stashed.
+   * When: Stash tool runs in stash mode for the same partition again (retry/MDT case).
+   * Then: The validator skips the already-stashed partition gracefully.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testStashAlreadyStashedPartitionIsIdempotent(boolean enableMetadata) throws IOException {
+    insertRecords("001", 20, enableMetadata);
+
+    HoodieStashPartitionsTool.Config cfg = buildConfig(DEFAULT_FIRST_PARTITION_PATH, "stash", enableMetadata);
+    new HoodieStashPartitionsTool(jsc(), cfg).run();
+
+    HoodieStorage storage = hoodieStorage();
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    List<StoragePathInfo> stashFilesAfterFirst = storage.listDirectEntries(stashPartition);
+
+    // Run again
+    new HoodieStashPartitionsTool(jsc(), cfg).run();
+
+    List<StoragePathInfo> stashFilesAfterSecond = storage.listDirectEntries(stashPartition);
+    assertEquals(stashFilesAfterFirst.size(), stashFilesAfterSecond.size());
+  }
+
+  /**
+   * Given: A COW table with data in multiple partitions.
+   * When: Stash tool runs in stash mode for multiple partitions.
+   * Then: All specified partitions are moved to stash location.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testStashMultiplePartitions(boolean enableMetadata) throws IOException {
+    insertRecords("001", 30, enableMetadata);
+
+    String partitions = DEFAULT_FIRST_PARTITION_PATH + "," + DEFAULT_SECOND_PARTITION_PATH;
+    HoodieStashPartitionsTool.Config cfg = buildConfig(partitions, "stash", enableMetadata);
+    new HoodieStashPartitionsTool(jsc(), cfg).run();
+
+    HoodieStorage storage = hoodieStorage();
+    for (String partition : new String[]{DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH}) {
+      StoragePath stashPartition = new StoragePath(stashPath, partition);
+      assertTrue(storage.exists(stashPartition));
+      assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+      assertSourcePartitionEmpty(storage, new StoragePath(basePath(), partition));
+    }
+
+    // Third partition untouched
+    StoragePath thirdPartition = new StoragePath(basePath(), DEFAULT_THIRD_PARTITION_PATH);
+    assertTrue(storage.exists(thirdPartition));
+    assertFalse(storage.listDirectEntries(thirdPartition).isEmpty());
+  }
+
+  /**
+   * Given: A partition has been stashed.
+   * When: Rollback stash is run.
+   * Then: Files are copied back from stash to the original source location.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRollbackStash(boolean enableMetadata) throws IOException {
+    insertRecords("001", 20, enableMetadata);
+
+    HoodieStorage storage = hoodieStorage();
+    StoragePath sourcePartition = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
+    List<String> originalFileNames = storage.listDirectEntries(sourcePartition).stream()
+        .map(info -> info.getPath().getName()).sorted().collect(Collectors.toList());
+
+    new HoodieStashPartitionsTool(jsc(), buildConfig(DEFAULT_FIRST_PARTITION_PATH, "stash", enableMetadata)).run();
+    assertSourcePartitionEmpty(storage, sourcePartition);
+
+    new HoodieStashPartitionsTool(jsc(), buildConfig(DEFAULT_FIRST_PARTITION_PATH, "rollback_stash", enableMetadata)).run();
+
+    assertTrue(storage.exists(sourcePartition));
+    List<String> restoredFileNames = storage.listDirectEntries(sourcePartition).stream()
+        .map(info -> info.getPath().getName()).sorted().collect(Collectors.toList());
+    assertEquals(originalFileNames, restoredFileNames);
+
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    assertTrue(!storage.exists(stashPartition) || storage.listDirectEntries(stashPartition).isEmpty());
+  }
+
+  /**
+   * Given: No partition has been stashed.
+   * When: Rollback stash is run.
+   * Then: Tool completes without error (no-op).
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRollbackStashWithNothingToRollback(boolean enableMetadata) throws IOException {
+    insertRecords("001", 10, enableMetadata);
+
+    HoodieStashPartitionsTool.Config cfg = buildConfig(DEFAULT_FIRST_PARTITION_PATH, "rollback_stash", enableMetadata);
+    new HoodieStashPartitionsTool(jsc(), cfg).run();
+  }
+
+  /**
+   * Given: A COW table with data.
+   * When: Dry run mode is executed.
+   * Then: No files are moved, no commits created.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testDryRunDoesNotModifyTable(boolean enableMetadata) throws IOException {
+    insertRecords("001", 20, enableMetadata);
+
+    HoodieStorage storage = hoodieStorage();
+    StoragePath sourcePartition = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
+    List<StoragePathInfo> filesBefore = storage.listDirectEntries(sourcePartition);
+    int commitCountBefore = metaClient.getActiveTimeline().countInstants();
+
+    new HoodieStashPartitionsTool(jsc(), buildConfig(DEFAULT_FIRST_PARTITION_PATH, "dry_run", enableMetadata)).run();
+
+    List<StoragePathInfo> filesAfter = storage.listDirectEntries(sourcePartition);
+    assertEquals(filesBefore.size(), filesAfter.size());
+
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    assertFalse(storage.exists(stashPartition) && !storage.listDirectEntries(stashPartition).isEmpty());
+
+    HoodieTableMetaClient reloaded = HoodieTableMetaClient.reload(metaClient);
+    assertEquals(commitCountBefore, reloaded.getActiveTimeline().countInstants());
+  }
+
+  /**
+   * Scenario (a): Stash for multiple partitions was started. Operation failed before reaching
+   * the pre-commit validator (no files moved, no commit). Retry should succeed without issues.
+   *
+   * We simulate this by manually creating a requested replace commit instant (as if startCommit
+   * ran but deletePartitions failed), then retrying with the tool.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRetryAfterFailureBeforePreCommitValidator(boolean enableMetadata) throws IOException {
+    insertRecords("001", 30, enableMetadata);
+
+    HoodieStorage storage = hoodieStorage();
+    String partitions = DEFAULT_FIRST_PARTITION_PATH + "," + DEFAULT_SECOND_PARTITION_PATH;
+
+    // Verify all partitions have data and nothing is in stash
+    for (String partition : new String[]{DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH}) {
+      StoragePath src = new StoragePath(basePath(), partition);
+      assertTrue(storage.exists(src));
+      assertFalse(storage.listDirectEntries(src).isEmpty());
+    }
+
+    // The first attempt "failed" before reaching the validator — no files moved, no commit.
+    // This is the initial state. Just retry the tool — it should work from scratch.
+    HoodieStashPartitionsTool.Config cfg = buildConfig(partitions, "stash", enableMetadata);
+    new HoodieStashPartitionsTool(jsc(), cfg).run();
+
+    // Verify success
+    for (String partition : new String[]{DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH}) {
+      StoragePath stashPartition = new StoragePath(stashPath, partition);
+      assertTrue(storage.exists(stashPartition));
+      assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+      assertSourcePartitionEmpty(storage, new StoragePath(basePath(), partition));
+    }
+  }
+
+  /**
+   * Scenario (b): Stash for multiple partitions was started. The pre-commit validator
+   * stashed some partitions (moved files) but crashed before completing. On retry, the
+   * tool's pre-check (non-MDT) should recover partial state, and the validator (MDT)
+   * should handle it. The stash should eventually succeed.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRetryAfterValidatorPartiallyStashedAndCrashed(boolean enableMetadata) throws IOException {
+    insertRecords("001", 30, enableMetadata);
+
+    HoodieStorage storage = hoodieStorage();
+    String[] partitions = {DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH, DEFAULT_THIRD_PARTITION_PATH};
+
+    // Simulate partial stash: move first partition's files to stash (as if validator did it),
+    // but no commit landed.
+    DefaultStashPartitionRenameHelper renameHelper = new DefaultStashPartitionRenameHelper();
+    StoragePath src = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
+    StoragePath dest = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    renameHelper.movePartitionFiles(storage, src, dest);
+
+    // Verify partial state: first partition in stash, others untouched
+    assertTrue(storage.exists(dest));
+    assertFalse(storage.listDirectEntries(dest).isEmpty());
+    assertSourcePartitionEmpty(storage, src);
+
+    // Retry with the tool — should handle partial state and complete all partitions
+    String allPartitions = String.join(",", partitions);
+    HoodieStashPartitionsTool.Config cfg = buildConfig(allPartitions, "stash", enableMetadata);
+    new HoodieStashPartitionsTool(jsc(), cfg).run();
+
+    // Verify: all partitions stashed
+    for (String partition : partitions) {
+      StoragePath stashPartition = new StoragePath(stashPath, partition);
+      assertTrue(storage.exists(stashPartition), "Stash should exist for: " + partition);
+      assertFalse(storage.listDirectEntries(stashPartition).isEmpty(),
+          "Stash should have files for: " + partition);
+      assertSourcePartitionEmpty(storage, new StoragePath(basePath(), partition));
+    }
+
+    HoodieTableMetaClient reloaded = HoodieTableMetaClient.reload(metaClient);
+    assertFalse(reloaded.getActiveTimeline().getCompletedReplaceTimeline().empty());
+  }
+
+  /**
+   * Scenario (d): Pre-commit validator succeeded for all partitions (files moved), but
+   * crashed just after that (before the commit landed). On retry, the tool should handle
+   * the state where all files are in stash but no commit exists, and succeed.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRetryAfterValidatorSucceededButCrashedBeforeCommit(boolean enableMetadata) throws IOException {
+    insertRecords("001", 30, enableMetadata);
+
+    HoodieStorage storage = hoodieStorage();
+    String[] partitions = {DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH, DEFAULT_THIRD_PARTITION_PATH};
+
+    // Simulate: validator moved all files to stash, but commit never landed
+    DefaultStashPartitionRenameHelper renameHelper = new DefaultStashPartitionRenameHelper();
+    for (String partition : partitions) {
+      StoragePath src = new StoragePath(basePath(), partition);
+      StoragePath dest = new StoragePath(stashPath, partition);
+      if (storage.exists(src) && !storage.listDirectEntries(src).isEmpty()) {
+        renameHelper.movePartitionFiles(storage, src, dest);
+      }
+    }
+
+    // Verify: all files in stash, source empty, NO commit on timeline
+    for (String partition : partitions) {
+      StoragePath stashPartition = new StoragePath(stashPath, partition);
+      assertTrue(storage.exists(stashPartition));
+      assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+      assertSourcePartitionEmpty(storage, new StoragePath(basePath(), partition));
+    }
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    assertTrue(metaClient.getActiveTimeline().getCompletedReplaceTimeline().empty(),
+        "No replace commit should exist yet");
+
+    // Retry with the tool
+    String allPartitions = String.join(",", partitions);
+    HoodieStashPartitionsTool.Config cfg = buildConfig(allPartitions, "stash", enableMetadata);
+    new HoodieStashPartitionsTool(jsc(), cfg).run();
+
+    // Verify: commit exists now
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    assertFalse(metaClient.getActiveTimeline().getCompletedReplaceTimeline().empty());
+
+    // Stash files should still be there
+    for (String partition : partitions) {
+      StoragePath stashPartition = new StoragePath(stashPath, partition);
+      assertTrue(storage.exists(stashPartition));
+      assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+    }
+  }
+
+  // ---- Helper methods ----
+
+  private void insertRecords(String commitTime, int numRecords, boolean enableMetadata) throws IOException {
+    HoodieWriteConfig writeConfig = getConfigBuilder(false)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(enableMetadata).build())
+        .build();
+    try (SparkRDDWriteClient writeClient = getHoodieWriteClient(writeConfig)) {
+      List<HoodieRecord> records = dataGen.generateInserts(commitTime, numRecords);
+      JavaRDD<HoodieRecord> writeRecords = jsc().parallelize(records, 2);
+      WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
+      JavaRDD<WriteStatus> statusesRdd = writeClient.insert(writeRecords, commitTime);
+      List<WriteStatus> statuses = statusesRdd.collect();
+      assertNoWriteErrors(statuses);
+      writeClient.commit(commitTime, jsc().parallelize(statuses));
+    }
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+  }
+
+  private void assertSourcePartitionEmpty(HoodieStorage storage, StoragePath sourcePartition) throws IOException {
+    if (storage.exists(sourcePartition)) {
+      List<StoragePathInfo> remainingFiles = storage.listDirectEntries(sourcePartition).stream()
+          .filter(f -> !f.getPath().getName().startsWith("."))
+          .collect(Collectors.toList());
+      assertTrue(remainingFiles.isEmpty(),
+          "Source partition should have no data files after stash, but found: " + remainingFiles);
+    }
+  }
+
+  private HoodieStashPartitionsTool.Config buildConfig(String partitions, String mode, boolean enableMetadata) {
+    HoodieStashPartitionsTool.Config cfg = new HoodieStashPartitionsTool.Config();
+    cfg.basePath = basePath();
+    cfg.tableName = "test-trip-table";
+    cfg.stashPath = stashPath;
+    cfg.partitions = partitions;
+    cfg.runningMode = mode;
+    cfg.parallelism = 2;
+    if (enableMetadata) {
+      cfg.configs.add(HoodieMetadataConfig.ENABLE.key() + "=true");
+    } else {
+      cfg.configs.add(HoodieMetadataConfig.ENABLE.key() + "=false");
+    }
+    return cfg;
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieStashPartitionsTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieStashPartitionsTool.java
@@ -36,6 +36,7 @@ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -158,46 +159,125 @@ public class TestHoodieStashPartitionsTool extends SparkClientFunctionalTestHarn
   }
 
   /**
-   * Given: A partition has been stashed.
+   * Given: A stash fully completed (replace commit landed, data in stash, no active files).
    * When: Rollback stash is run.
-   * Then: Files are copied back from stash to the original source location.
+   * Then: Rollback is skipped — files stay in stash, source remains empty. The user must
+   *       use insert_overwrite to restore the partition.
    */
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void testRollbackStash(boolean enableMetadata) throws IOException {
+  public void testRollbackStashSkipsCompletedStash(boolean enableMetadata) throws IOException {
     insertRecords("001", 20, enableMetadata);
 
     HoodieStorage storage = hoodieStorage();
     StoragePath sourcePartition = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
-    List<String> originalFileNames = storage.listDirectEntries(sourcePartition).stream()
-        .map(info -> info.getPath().getName()).sorted().collect(Collectors.toList());
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
 
+    // Stash the partition (replace commit lands)
     new HoodieStashPartitionsTool(jsc(), buildConfig(DEFAULT_FIRST_PARTITION_PATH, "stash", enableMetadata)).run();
     assertSourcePartitionEmpty(storage, sourcePartition);
+    assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
 
+    // Run rollback — should be a no-op since stash fully completed
     new HoodieStashPartitionsTool(jsc(), buildConfig(DEFAULT_FIRST_PARTITION_PATH, "rollback_stash", enableMetadata)).run();
 
-    assertTrue(storage.exists(sourcePartition));
-    List<String> restoredFileNames = storage.listDirectEntries(sourcePartition).stream()
-        .map(info -> info.getPath().getName()).sorted().collect(Collectors.toList());
-    assertEquals(originalFileNames, restoredFileNames);
-
-    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
-    assertTrue(!storage.exists(stashPartition) || storage.listDirectEntries(stashPartition).isEmpty());
+    // Stash files should still be in stash (not moved back)
+    assertFalse(storage.listDirectEntries(stashPartition).isEmpty(),
+        "Stash files should remain in stash after rollback of a completed stash");
+    // Source should still be empty
+    assertSourcePartitionEmpty(storage, sourcePartition);
   }
 
   /**
-   * Given: No partition has been stashed.
+   * Given: A partial stash attempt — pre-commit validator moved files to stash but the
+   *        commit never landed, so partition still has active files and stash has data.
    * When: Rollback stash is run.
-   * Then: Tool completes without error (no-op).
+   * Then: Files are restored from stash back to source, making the partition whole again.
    */
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void testRollbackStashWithNothingToRollback(boolean enableMetadata) throws IOException {
+  public void testRollbackStashRestoresPartialAttempt(boolean enableMetadata) throws IOException {
+    insertRecords("001", 20, enableMetadata);
+
+    HoodieStorage storage = hoodieStorage();
+    StoragePath sourcePartition = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
+    List<StoragePathInfo> originalFiles = storage.listDirectEntries(sourcePartition);
+    int originalFileCount = originalFiles.size();
+    assertTrue(originalFileCount > 0);
+
+    // Simulate partial stash: the rename helper copies all files to stash first, then deletes
+    // from source. A crash after copy but before delete leaves files in both locations.
+    // We simulate this by copying the source files to stash without deleting them from source.
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    storage.createDirectory(stashPartition);
+    for (StoragePathInfo fileInfo : originalFiles) {
+      StoragePath destFile = new StoragePath(stashPartition, fileInfo.getPath().getName());
+      org.apache.hudi.io.util.FileIOUtils.copy(storage, fileInfo.getPath(), destFile);
+    }
+
+    // Verify: partition still has files, stash also has data
+    assertFalse(storage.listDirectEntries(sourcePartition).isEmpty());
+    assertFalse(storage.listDirectEntries(stashPartition).isEmpty());
+
+    // Run rollback — should restore stash data back to source
+    new HoodieStashPartitionsTool(jsc(), buildConfig(DEFAULT_FIRST_PARTITION_PATH, "rollback_stash", enableMetadata)).run();
+
+    // Stash should be empty after rollback
+    assertTrue(storage.listDirectEntries(stashPartition).isEmpty(),
+        "Stash should be empty after rollback of partial attempt");
+    // Source should still have all its files
+    assertFalse(storage.listDirectEntries(sourcePartition).isEmpty());
+  }
+
+  /**
+   * Given: No partition has been stashed (no stash data), partition has active files.
+   * When: Rollback stash is run.
+   * Then: Tool completes without error (no-op), partition is untouched.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRollbackStashNoOpWhenNothingStashed(boolean enableMetadata) throws IOException {
     insertRecords("001", 10, enableMetadata);
+
+    HoodieStorage storage = hoodieStorage();
+    StoragePath sourcePartition = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
+    int fileCountBefore = storage.listDirectEntries(sourcePartition).size();
 
     HoodieStashPartitionsTool.Config cfg = buildConfig(DEFAULT_FIRST_PARTITION_PATH, "rollback_stash", enableMetadata);
     new HoodieStashPartitionsTool(jsc(), cfg).run();
+
+    // Source should be untouched
+    assertEquals(fileCountBefore, storage.listDirectEntries(sourcePartition).size());
+  }
+
+  /**
+   * Given: No stash data and no active files in the partition.
+   * When: Rollback stash is run.
+   * Then: Tool completes without error (no-op, warns).
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRollbackStashNoOpWhenNoDataAnywhere(boolean enableMetadata) throws IOException {
+    insertRecords("001", 20, enableMetadata);
+
+    // Stash the partition first (so it gets deleted), then clean up stash manually
+    // to simulate a state where there's no data anywhere.
+    new HoodieStashPartitionsTool(jsc(), buildConfig(DEFAULT_FIRST_PARTITION_PATH, "stash", enableMetadata)).run();
+
+    HoodieStorage storage = hoodieStorage();
+    StoragePath stashPartition = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
+    // Remove stash data to simulate the "no data anywhere" state
+    for (StoragePathInfo file : storage.listDirectEntries(stashPartition)) {
+      storage.deleteFile(file.getPath());
+    }
+    assertTrue(storage.listDirectEntries(stashPartition).isEmpty());
+
+    // Run rollback — should be a no-op with warning
+    new HoodieStashPartitionsTool(jsc(), buildConfig(DEFAULT_FIRST_PARTITION_PATH, "rollback_stash", enableMetadata)).run();
+
+    // Nothing should change
+    StoragePath sourcePartition = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
+    assertSourcePartitionEmpty(storage, sourcePartition);
   }
 
   /**
@@ -282,7 +362,7 @@ public class TestHoodieStashPartitionsTool extends SparkClientFunctionalTestHarn
     DefaultStashPartitionRenameHelper renameHelper = new DefaultStashPartitionRenameHelper();
     StoragePath src = new StoragePath(basePath(), DEFAULT_FIRST_PARTITION_PATH);
     StoragePath dest = new StoragePath(stashPath, DEFAULT_FIRST_PARTITION_PATH);
-    renameHelper.movePartitionFiles(storage, src, dest);
+    renameHelper.stashPartitionFiles(storage, src, dest);
 
     // Verify partial state: first partition in stash, others untouched
     assertTrue(storage.exists(dest));
@@ -311,26 +391,25 @@ public class TestHoodieStashPartitionsTool extends SparkClientFunctionalTestHarn
    * Scenario (d): Pre-commit validator succeeded for all partitions (files moved), but
    * crashed just after that (before the commit landed). On retry, the tool should handle
    * the state where all files are in stash but no commit exists, and succeed.
+   *
+   * We simulate this by running a real stash (which lands the replace commit), then deleting
+   * the completed replace commit from the timeline. This leaves the table in a state where
+   * files are in stash, source is empty, and no replace commit exists — exactly the scenario
+   * where the validator succeeded but the commit failed to persist.
    */
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testRetryAfterValidatorSucceededButCrashedBeforeCommit(boolean enableMetadata) throws IOException {
-    insertRecords("001", 30, enableMetadata);
+  @Test
+  public void testRetryAfterValidatorSucceededButCrashedBeforeCommit() throws IOException {
+    insertRecords("001", 30, true);
 
     HoodieStorage storage = hoodieStorage();
     String[] partitions = {DEFAULT_FIRST_PARTITION_PATH, DEFAULT_SECOND_PARTITION_PATH, DEFAULT_THIRD_PARTITION_PATH};
+    String allPartitions = String.join(",", partitions);
 
-    // Simulate: validator moved all files to stash, but commit never landed
-    DefaultStashPartitionRenameHelper renameHelper = new DefaultStashPartitionRenameHelper();
-    for (String partition : partitions) {
-      StoragePath src = new StoragePath(basePath(), partition);
-      StoragePath dest = new StoragePath(stashPath, partition);
-      if (storage.exists(src) && !storage.listDirectEntries(src).isEmpty()) {
-        renameHelper.movePartitionFiles(storage, src, dest);
-      }
-    }
+    // Step 1: Run a real stash — this moves files and lands a replace commit
+    HoodieStashPartitionsTool.Config stashCfg = buildConfig(allPartitions, "stash", true);
+    new HoodieStashPartitionsTool(jsc(), stashCfg).run();
 
-    // Verify: all files in stash, source empty, NO commit on timeline
+    // Verify stash completed: files in stash, source empty, replace commit exists
     for (String partition : partitions) {
       StoragePath stashPartition = new StoragePath(stashPath, partition);
       assertTrue(storage.exists(stashPartition));
@@ -338,15 +417,20 @@ public class TestHoodieStashPartitionsTool extends SparkClientFunctionalTestHarn
       assertSourcePartitionEmpty(storage, new StoragePath(basePath(), partition));
     }
     metaClient = HoodieTableMetaClient.reload(metaClient);
+    assertFalse(metaClient.getActiveTimeline().getCompletedReplaceTimeline().empty());
+
+    // Step 2: Delete the completed replace commit to simulate a crash before commit landed
+    metaClient.getActiveTimeline().getCompletedReplaceTimeline().getInstantsAsStream()
+        .forEach(instant -> metaClient.getActiveTimeline().deleteInstantFileIfExists(instant));
+    metaClient = HoodieTableMetaClient.reload(metaClient);
     assertTrue(metaClient.getActiveTimeline().getCompletedReplaceTimeline().empty(),
-        "No replace commit should exist yet");
+        "Replace commit should be removed to simulate crash");
 
-    // Retry with the tool
-    String allPartitions = String.join(",", partitions);
-    HoodieStashPartitionsTool.Config cfg = buildConfig(allPartitions, "stash", enableMetadata);
-    new HoodieStashPartitionsTool(jsc(), cfg).run();
+    // Step 3: Retry with the tool — should restore files from stash, then re-run stash
+    HoodieStashPartitionsTool.Config retryCfg = buildConfig(allPartitions, "stash", true);
+    new HoodieStashPartitionsTool(jsc(), retryCfg).run();
 
-    // Verify: commit exists now
+    // Verify: replace commit exists now
     metaClient = HoodieTableMetaClient.reload(metaClient);
     assertFalse(metaClient.getActiveTimeline().getCompletedReplaceTimeline().empty());
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestStashPartitionValidation.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestStashPartitionValidation.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities;
+
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.exception.HoodieValidationException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link HoodieStashPartitionsTool#validateFileGroupsForStash}.
+ * Uses {@link HoodieTestTable} to create controlled file layouts without running
+ * actual Spark writes.
+ */
+public class TestStashPartitionValidation {
+
+  @TempDir
+  private Path tempDir;
+
+  private HoodieTableMetaClient metaClient;
+  private HoodieStorage storage;
+  private String basePath;
+
+  private static final String PARTITION = "2023/01/01";
+  private static final String FILE_ID_1 = "file-group-1";
+  private static final String FILE_ID_2 = "file-group-2";
+
+  @BeforeEach
+  public void init() throws Exception {
+    basePath = tempDir.toAbsolutePath().toUri().toString();
+    metaClient = HoodieTestUtils.init(basePath, HoodieTableType.COPY_ON_WRITE);
+    storage = metaClient.getStorage();
+  }
+
+  /**
+   * Given: A partition with one file group, one file slice, base file only.
+   * When: validateFileGroupsForStash is called.
+   * Then: Validation passes.
+   */
+  @Test
+  public void testValidationPassesForCleanPartition() throws Exception {
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
+    testTable.addCommit("001")
+        .withBaseFilesInPartition(PARTITION, FILE_ID_1);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    try (HoodieTableFileSystemView fsView = buildFsView(metaClient, PARTITION)) {
+      assertDoesNotThrow(() ->
+          HoodieStashPartitionsTool.validateFileGroupsForStash(fsView, Collections.singletonList(PARTITION)));
+    }
+  }
+
+  /**
+   * Given: A partition with multiple file groups, each having one file slice with base file only.
+   * When: validateFileGroupsForStash is called.
+   * Then: Validation passes.
+   */
+  @Test
+  public void testValidationPassesForMultipleCleanFileGroups() throws Exception {
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
+    testTable.addCommit("001")
+        .withBaseFilesInPartition(PARTITION, FILE_ID_1, FILE_ID_2);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    try (HoodieTableFileSystemView fsView = buildFsView(metaClient, PARTITION)) {
+      assertDoesNotThrow(() ->
+          HoodieStashPartitionsTool.validateFileGroupsForStash(fsView, Collections.singletonList(PARTITION)));
+    }
+  }
+
+  /**
+   * Given: A partition with a file group that has two file slices (two commits).
+   * When: validateFileGroupsForStash is called.
+   * Then: Validation fails — more than one file slice.
+   */
+  @Test
+  public void testValidationFailsForMultipleFileSlices() throws Exception {
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
+    testTable.addCommit("001")
+        .withBaseFilesInPartition(PARTITION, FILE_ID_1);
+    testTable.addCommit("002")
+        .withBaseFilesInPartition(PARTITION, FILE_ID_1);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    try (HoodieTableFileSystemView fsView = buildFsView(metaClient, PARTITION)) {
+      HoodieValidationException ex = assertThrows(HoodieValidationException.class, () ->
+          HoodieStashPartitionsTool.validateFileGroupsForStash(fsView, Collections.singletonList(PARTITION)));
+      assertTrue(ex.getMessage().contains("file slice(s), expected exactly 1"));
+    }
+  }
+
+  /**
+   * Given: A partition with a file group that has a base file and log files.
+   * When: validateFileGroupsForStash is called.
+   * Then: Validation fails — log files present.
+   */
+  @Test
+  public void testValidationFailsForLogFiles() throws Exception {
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
+    testTable.addCommit("001")
+        .withBaseFilesInPartition(PARTITION, FILE_ID_1);
+    testTable.addDeltaCommit("002")
+        .withLogFile(PARTITION, FILE_ID_1, 0);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    try (HoodieTableFileSystemView fsView = buildFsView(metaClient, PARTITION)) {
+      HoodieValidationException ex = assertThrows(HoodieValidationException.class, () ->
+          HoodieStashPartitionsTool.validateFileGroupsForStash(fsView, Collections.singletonList(PARTITION)));
+      assertTrue(ex.getMessage().contains("log files") || ex.getMessage().contains("file slice(s), expected exactly 1"));
+    }
+  }
+
+  /**
+   * Given: Two partitions — one clean, one with multiple file slices.
+   * When: validateFileGroupsForStash is called for both.
+   * Then: Validation fails for the dirty partition.
+   */
+  @Test
+  public void testValidationFailsIfAnyPartitionIsDirty() throws Exception {
+    String cleanPartition = "2023/01/01";
+    String dirtyPartition = "2023/01/02";
+
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
+    testTable.addCommit("001")
+        .withBaseFilesInPartition(cleanPartition, FILE_ID_1)
+        .getLeft()
+        .withBaseFilesInPartition(dirtyPartition, FILE_ID_2);
+    testTable.addCommit("002")
+        .withBaseFilesInPartition(dirtyPartition, FILE_ID_2);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    try (HoodieTableFileSystemView fsView = buildFsView(metaClient, cleanPartition, dirtyPartition)) {
+      HoodieValidationException ex = assertThrows(HoodieValidationException.class, () ->
+          HoodieStashPartitionsTool.validateFileGroupsForStash(fsView, Arrays.asList(cleanPartition, dirtyPartition)));
+      assertTrue(ex.getMessage().contains(dirtyPartition));
+    }
+  }
+
+  /**
+   * Given: An empty partition (no file groups).
+   * When: validateFileGroupsForStash is called.
+   * Then: Validation passes — nothing to check.
+   */
+  @Test
+  public void testValidationPassesForEmptyPartition() throws Exception {
+    HoodieTestTable testTable = HoodieTestTable.of(metaClient);
+    testTable.addCommit("001");
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    try (HoodieTableFileSystemView fsView = buildFsView(metaClient, PARTITION)) {
+      assertDoesNotThrow(() ->
+          HoodieStashPartitionsTool.validateFileGroupsForStash(fsView, Collections.singletonList(PARTITION)));
+    }
+  }
+
+  // ---- Helper methods ----
+
+  /**
+   * Builds a {@link HoodieTableFileSystemView} by listing files from the given partitions.
+   */
+  private HoodieTableFileSystemView buildFsView(HoodieTableMetaClient metaClient, String... partitions) throws IOException {
+    List<StoragePathInfo> allFiles = new ArrayList<>();
+    StoragePath base = metaClient.getBasePath();
+    HoodieStorage stor = metaClient.getStorage();
+    for (String partition : partitions) {
+      StoragePath partitionPath = new StoragePath(base, partition);
+      if (stor.exists(partitionPath)) {
+        allFiles.addAll(stor.listDirectEntries(partitionPath));
+      }
+    }
+    return new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline(), allFiles);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

 Closes #17866                                                                                                                             
                                                                                                                                          
  Users need the ability to back up certain partitions to a separate location and remove them from the original Hudi table, with the option to restore them later. This is driven by use cases like partition TTL where stashed data needs to be retained for a grace period before permanent deletion.

### Summary and Changelog

Adds a new spark-submit tool HoodieStashPartitionsTool that moves partition data to a stash location and issues a deletePartitions operation. The tool uses a custom SparkPreCommitValidator to atomically move files before the replace commit completes.
                                                                                                                                                        
  Stash operation:                                                                                                                                    
  1. Pre-check via HoodieTableMetadata: Evaluates each partition's state by checking active file slices (MDT-backed when available, FS-based fallback)  and stash directory contents. Classifies each partition into one of four states (ALREADY_STASHED, PARTIAL_STASH, NOT_STASHED, NO_DATA). If all partitions are already stashed, returns early. For partial stash (prior failed attempt left files in stash but no commit landed), restores files from stash back to source before retrying.                                                                                                                 
  2. File group validation: Before proceeding, validates that every file group in the target partitions has exactly one file slice containing only a base file (no log files). This ensures the partition is in a clean, fully compacted state — MoR tables with uncompacted log files or tables with multiple file slices from pending compactions are rejected.                                                                                           
  3. deletePartitions with StashPartitionsPreCommitValidator: The validator moves partition files to the stash location before the replace commit is finalized. If the move fails, the commit does not land and the table remains unchanged.                                                               
  4. On commit success, the replace commit marks file groups as replaced; partition data is already safely at the stash location.                       
   
  Why a pre-commit validator instead of moving files in the tool?                                                                                       
                                                                                                                                                      
  A simpler approach would be to first call deletePartitions from the tool, then move data files to the stash location as a separate step. However, this is unsafe: if the tool crashes after the deletePartitions replace commit succeeds but before the data is moved, the data is at risk. Once the replace commit lands on the timeline, the Hudi cleaner will eventually delete the physical data files for the replaced file groups based on its configured retention policy. If the cleaner runs before the tool is retried, the data intended for stashing is permanently lost.                               

  By using a StashPartitionsPreCommitValidator, the file move happens before the commit is finalized. If the move fails, the commit does not land, and  the table remains in its original state — the cleaner has nothing to clean. This ensures data is never in a state where it has been marked as deleted but has not been safely copied to the stash location.                                                                                                 
                                                                                                                                                      
  Rollback stash (rollback_stash mode):                                                                                                                 
  Evaluates partition states using the same HoodieTableMetadata-based classification. Only restores files for partitions in PARTIAL_STASH state (active files exist + stash has data — the commit never landed). For partitions where the stash fully completed (ALREADY_STASHED — replace commit landed), rollback is skipped with a warning directing the user to use insert_overwrite from the stash location instead, since simply moving files back does not undo the replace commit on the timeline.                                                                                                             
                                                                                                                                                      
  Restore: Users use the standard insert_overwrite write operation reading from the stash location (no new tooling).                                    
   
  Changelog:                                                                                                                                            
                                                                                                                                                      
  - StashPartitionRenameHelper — pluggable interface with two separate methods: stashPartitionFiles (table→stash) and restorePartitionFiles             
  (stash→table). Separate APIs allow custom implementations to use different storage strategies per direction (e.g., fast rename for stashing, verified copy for restoring).                                                                                                                                  
  - DefaultStashPartitionRenameHelper — default implementation using copy + delete for both directions. Custom implementations can leverage efficient 
  FS-level rename APIs.                                                                                                                                 
  - StashPartitionsPreCommitValidator — special-purpose pre-commit validator that moves files to stash before deletePartitions commit. Overrides validate() to extract affected partitions from partitionToReplaceFileIds. Guards against RLI-enabled and secondary-index-enabled tables. Documents partial failure semantics (already-moved partitions are not rolled back on failure; the tool's pre-check handles recovery).                         
  - HoodieStashPartitionsTool — spark-submit tool with three modes: stash, rollback_stash, dry_run. Uses PartitionStashState enum and shared evaluatePartitionStates() method to classify partitions consistently across stash and rollback operations. Includes validateFileGroupsForStash() pre-flight check ensuring partitions are in a clean, compacted state.
  - New configs: hoodie.stash.partitions.target.path, hoodie.stash.rename.helper.class                                                       
                                          
### Impact

 - No changes to public APIs or storage format. The tool is a standalone utility in hudi-utilities.                                                  
  - Pre-commit validators are used in an unconventional way (performing side-effects rather than read-only checks). This is explicitly documented as a special-purpose pattern not to be followed.                                                                                                           
  - Tables with Record Level Index (RLI) or Secondary Index enabled are not supported — the validator fails fast with a clear error message.
  - The StashPartitionRenameHelper interface allows custom implementations for environments with efficient rename APIs (e.g., HDFS atomic rename).      
 
### Risk Level

  Low.
  - All new code — no modifications to existing Hudi write paths, timeline operations, or metadata table logic.
  - The tool delegates to the existing deletePartitions API for all timeline/MDT operations.                                                            
  - The pre-commit validator is only activated when explicitly configured by the tool; it does not affect any existing write operations.
  - Failure scenarios are handled: the tool's pre-check uses HoodieTableMetadata to evaluate partition state and recover partial stash on retry. The validator is idempotent (skips already-stashed partitions). 

### Documentation Update

 - New tool usage documentation needed for HoodieStashPartitionsTool (spark-submit command, CLI arguments, modes).                                   
  - New config keys to document:
    - hoodie.stash.partitions.target.path — target stash directory (required when using the stash validator)
    - hoodie.stash.rename.helper.class — custom rename helper class (optional, defaults to DefaultStashPartitionRenameHelper)                           
 
 Test Plan                                                                                                                                             
                                                                                                                                                      
  - TestDefaultStashPartitionRenameHelper — unit tests for both stashPartitionFiles and restorePartitionFiles (idempotency, partial prior attempts, empty source, target creation)                                                                                                                      
  - TestStashPartitionsPreCommitValidator — functional tests covering stash, skip-already-stashed, partial prior move handling, retry after partial failure, retry after validator-succeeded-but-commit-didn't-land                                                                                       
  - TestHoodieStashPartitionsTool — end-to-end tests (parameterized for MDT enabled/disabled) covering: single/multi partition stash, idempotent re-stash, rollback of completed stash (skipped), rollback of partial stash (restored), rollback no-ops, dry run, retry scenarios (failure before  validator, partial stash, validator succeeded but commit deleted)                                                                                   
  - TestStashPartitionValidation — unit tests for validateFileGroupsForStash using HoodieTestTable to create controlled file layouts: clean partition  (pass), multiple clean file groups (pass), multiple file slices (fail), log files present (fail), mixed clean/dirty partitions (fail), empty partition (pass)
        
 

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
