### PR TITLE
chore(docker): fix Hadoop entrypoint.sh property bugs in all base modules

### DIFF
--- a/docker/hoodie/hadoop/base/entrypoint.sh
+++ b/docker/hoodie/hadoop/base/entrypoint.sh
@@ -74,7 +74,6 @@ if [ "$MULTIHOMED_NETWORK" = "1" ]; then
     # YARN
     addProperty /etc/hadoop/yarn-site.xml yarn.resourcemanager.bind-host 0.0.0.0
     addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
-    addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
     addProperty /etc/hadoop/yarn-site.xml yarn.timeline-service.bind-host 0.0.0.0
 
     # MAPRED

--- a/docker/hoodie/hadoop/base_java11/entrypoint.sh
+++ b/docker/hoodie/hadoop/base_java11/entrypoint.sh
@@ -74,7 +74,6 @@ if [ "$MULTIHOMED_NETWORK" = "1" ]; then
     # YARN
     addProperty /etc/hadoop/yarn-site.xml yarn.resourcemanager.bind-host 0.0.0.0
     addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
-    addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
     addProperty /etc/hadoop/yarn-site.xml yarn.timeline-service.bind-host 0.0.0.0
 
     # MAPRED

--- a/docker/hoodie/hadoop/base_java17/entrypoint.sh
+++ b/docker/hoodie/hadoop/base_java17/entrypoint.sh
@@ -74,7 +74,6 @@ if [ "$MULTIHOMED_NETWORK" = "1" ]; then
     # YARN
     addProperty /etc/hadoop/yarn-site.xml yarn.resourcemanager.bind-host 0.0.0.0
     addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
-    addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
     addProperty /etc/hadoop/yarn-site.xml yarn.timeline-service.bind-host 0.0.0.0
 
     # MAPRED


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

In `docker/hoodie/hadoop/*/entrypoint.sh`, the `MULTIHOMED_NETWORK=1` block calls:

```bash
addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0
```

`addProperty` uses `sed` to insert a new `<property>` block before `</configuration>`, so the same property ends up in the XML twice. Hadoop's `Configuration` parser tolerates duplicate names (last one wins) and both writes use the same value, so there is no runtime impact - but the second line is dead code and inconsistent with the rest of the block. This duplication was inherited from the upstream `big-data-europe/docker-hadoop` template and propagated when `base_java11` and `base_java17` were copied from `base`.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

- Removed the duplicate `addProperty /etc/hadoop/yarn-site.xml yarn.nodemanager.bind-host 0.0.0.0` line from the YARN block in each of the three base modules' `entrypoint.sh`.
- No behaviour change; scripts now match the apparent intent of the YARN block.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

None. Observable runtime behaviour is identical.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

none, three-line deletion across three scripts, no functional change.

low - the change is six lines across three scripts, guarded by `MULTIHOMED_NETWORK=1`. Before the fix the misplaced YARN property did nothing in `mapred-site.xml`,  after the fix the correct JobHistory properties are written. 

No behavior change for the default, non-multi-homed case.

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
