### PR TITLE
perf(common): avoid stream allocation in CollectionUtils.createImmuta…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CollectionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CollectionUtils.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.util.collection.Pair;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -252,7 +253,7 @@ public class CollectionUtils {
 
   @SafeVarargs
   public static <T> List<T> createImmutableList(final T... elements) {
-    return Collections.unmodifiableList(Stream.of(elements).collect(Collectors.toList()));
+    return Collections.unmodifiableList(new ArrayList<>(Arrays.asList(elements)));
   }
 
   public static <T> List<T> createImmutableList(final List<T> list) {


### PR DESCRIPTION
bleList

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

`CollectionUtils.createImmutableList(T... elements)` built its backing list with `Stream.of(elements).collect(Collectors.toList())`, which allocates a `Stream` pipeline (and its `Spliterator` and collector state) only to copy a varargs array into a list. `new ArrayList<>(Arrays.asList(elements))` does the same thing with one allocation instead of several.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

Internal utility refactor. No behavior change.

- Replaced the stream pipeline with `new ArrayList<>(Arrays.asList(elements))` inside `Collections.unmodifiableList(...)`.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

One fewer short-lived allocation per call. Most callers are static initializers, so the aggregate impact is unlikely to show up in a profiler - this is a hygiene cleanup rather than a hot-path optimization.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
