### PR TITLE
refactor(metadata): Replace misused stream reduce with a plain for-loop

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -479,31 +479,29 @@ public class HoodieTableMetadataUtil {
               String partitionStatName = entry.getKey();
               List<HoodieWriteStat> writeStats = entry.getValue();
 
-              HashMap<String, Long> updatedFilesToSizesMapping =
-                  writeStats.stream().reduce(new HashMap<>(writeStats.size()),
-                      (map, stat) -> {
-                        String pathWithPartition = stat.getPath();
-                        if (pathWithPartition == null) {
-                          // Empty partition
-                          log.warn("Unable to find path in write stat to update metadata table {}", stat);
-                          return map;
-                        }
+              HashMap<String, Long> updatedFilesToSizesMapping = new HashMap<>(writeStats.size());
+              for (HoodieWriteStat stat : writeStats) {
+                String pathWithPartition = stat.getPath();
+                if (pathWithPartition == null) {
+                  // Empty partition
+                  log.warn("Unable to find path in write stat to update metadata table {}", stat);
+                  continue;
+                }
 
-                        String fileName = FSUtils.getFileName(pathWithPartition, partitionStatName);
+                String fileName = FSUtils.getFileName(pathWithPartition, partitionStatName);
 
-                        // Since write-stats are coming in no particular order, if the same
-                        // file have previously been appended to w/in the txn, we simply pick max
-                        // of the sizes as reported after every write, since file-sizes are
-                        // monotonically increasing (ie file-size never goes down, unless deleted)
-                        map.merge(fileName, stat.getFileSizeInBytes(), Math::max);
+                // Since write-stats are coming in no particular order, if the same
+                // file have previously been appended to w/in the txn, we simply pick max
+                // of the sizes as reported after every write, since file-sizes are
+                // monotonically increasing (ie file-size never goes down, unless deleted)
+                updatedFilesToSizesMapping.merge(fileName, stat.getFileSizeInBytes(), Math::max);
 
-                        Map<String, Long> cdcPathAndSizes = stat.getCdcStats();
-                        if (cdcPathAndSizes != null && !cdcPathAndSizes.isEmpty()) {
-                          cdcPathAndSizes.forEach((key, value) -> map.put(FSUtils.getFileName(key, partitionStatName), value));
-                        }
-                        return map;
-                      },
-                      CollectionUtils::combine);
+                Map<String, Long> cdcPathAndSizes = stat.getCdcStats();
+                if (cdcPathAndSizes != null && !cdcPathAndSizes.isEmpty()) {
+                  cdcPathAndSizes.forEach((key, value) ->
+                      updatedFilesToSizesMapping.put(FSUtils.getFileName(key, partitionStatName), value));
+                }
+              }
 
               newFileCount.add(updatedFilesToSizesMapping.size());
               return HoodieMetadataPayload.createPartitionFilesRecord(partitionStatName, updatedFilesToSizesMapping,


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

`HoodieTableMetadataUtil.convertMetadataToFilesPartitionRecords` aggregated per-partition write stats via `writeStats.stream().reduce(new HashMap<>(...), accumulator, CollectionUtils::combine)`. 

The "identity" is a mutable `HashMap` that the accumulator mutates and returns which is a misuse of `Stream.reduce`, whose contract assumes the identity is safe to combine with any element as a no-op. 

The only reason this works is that the stream is sequential and the method runs on the driver (the caller, `HoodieMetadataWriteUtils`, then wraps the returned list via `context.parallelize(..., 1)`). 

A plain for-loop expresses the same aggregation directly and is the idiomatic shape for mutable-accumulation sequential code.

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

Internal readability/idiom cleanup in the metadata-table write path. No behavior change.

- Replaced the `writeStats.stream().reduce(...)` call with an imperative `for (HoodieWriteStat stat : writeStats)` loop that builds the `updatedFilesToSizesMapping` HashMap directly.
- Same merge semantics (`Math::max` on per-file size; CDC path/size entries overlaid).
- No change to the surrounding `partitionToWriteStats.entrySet().stream().map(...)` pipeline.

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

None. Readability and idiom cleanup only; behavior and allocation shape are materially unchanged.

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
