### PR TITLE
refactor: introduce static helper method to remove clones

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieNativeAvroHFileReader.java
@@ -177,11 +177,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
       @Override
       public void close() {
-        try {
-          reader.close();
-        } catch (IOException e) {
-          throw new HoodieIOException("Error closing the HFile reader", e);
-        }
+        closeReader(reader, "Error closing the HFile reader");
       }
     };
   }
@@ -345,6 +341,14 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
     }
   }
 
+  private static void closeReader(HFileReader reader, String errorMessage) {
+    try {
+      reader.close();
+    } catch (IOException e) {
+      throw new HoodieIOException(errorMessage, e);
+    }
+  }
+
   private static class RecordIterator implements ClosableIterator<IndexedRecord> {
     private final HFileReader reader;
     private final GenericDatumReader<GenericRecord> datumReader;
@@ -399,11 +403,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
     @Override
     public void close() {
-      try {
-        reader.close();
-      } catch (IOException e) {
-        throw new HoodieIOException("Error closing the HFile reader", e);
-      }
+      closeReader(reader, "Error closing the HFile reader");
     }
   }
 
@@ -476,11 +476,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
     @Override
     public void close() {
-      try {
-        reader.close();
-      } catch (IOException e) {
-        throw new HoodieIOException("Error closing the HFile reader", e);
-      }
+      closeReader(reader, "Error closing the HFile reader");
     }
   }
 
@@ -538,11 +534,7 @@ public class HoodieNativeAvroHFileReader extends HoodieAvroHFileReaderImplBase {
 
     @Override
     public void close() {
-      try {
-        reader.close();
-      } catch (IOException e) {
-        throw new HoodieIOException("Error closing the HFile reader and scanner", e);
-      }
+      closeReader(reader, "Error closing the HFile reader and scanner");
     }
 
     private static Iterator<IndexedRecord> getRecordByKeyPrefixIteratorInternal(HFileReader reader,


### PR DESCRIPTION
Extract same close logic into a separate method in _HoodieNativeAvroHFileReader_


### Describe the issue this Pull Request addresses

In _HoodieNativeAvroHFileReader_, four separate inner classes each implemented their own identical close() method with duplicated try-catch logic for closing an HFileReader, resulting in less maintainability.

### Summary and Changelog

introduce _closeReader_ static helper, removed 4 duplicated try-catch blocks 

### Impact

No functional impact. This is a pure code quality improvement — behavior is identical before and after.

### Risk Level

Low. No logic was changed.

### Documentation Update

None



### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable