### PR TITLE
chore(docker): reduce base_java17 and spark_base image size

### DIFF
--- a/docker/hoodie/hadoop/base_java17/Dockerfile
+++ b/docker/hoodie/hadoop/base_java17/Dockerfile
@@ -15,7 +15,23 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:17-jdk
+# --- Stage 1: fetch + extract Hadoop (throwaway) ---
+FROM eclipse-temurin:17-jre-jammy AS hadoop-builder
+
+ARG HADOOP_VERSION=3.4.0
+ARG HADOOP_URL=https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+
+RUN set -x \
+    && DEBIAN_FRONTEND=noninteractive apt-get -yq update \
+    && apt-get -yq install --no-install-recommends curl ca-certificates \
+    && curl -fSL "${HADOOP_URL}" -o /tmp/hadoop.tar.gz \
+    && mkdir -p /opt \
+    && tar -xzf /tmp/hadoop.tar.gz -C /opt/ \
+    && rm /tmp/hadoop.tar.gz \
+    && mkdir -p /opt/hadoop-${HADOOP_VERSION}/logs
+
+# --- Stage 2: runtime ---
+FROM eclipse-temurin:17-jre-jammy
 LABEL maintainer="Hoodie"
 USER root
 
@@ -23,28 +39,23 @@ USER root
 ENV LANG C.UTF-8
 
 ARG HADOOP_VERSION=3.4.0
-ARG HADOOP_URL=https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
-ENV HADOOP_VERSION ${HADOOP_VERSION}
-ENV HADOOP_URL ${HADOOP_URL}
+ENV HADOOP_VERSION=${HADOOP_VERSION}
 
-RUN set -x \
-    && DEBIAN_FRONTEND=noninteractive apt-get -yq update && apt-get -yq install curl wget netcat-openbsd procps \
-    && echo "Fetch URL2 is : ${HADOOP_URL}" \
-    && curl -fSL "${HADOOP_URL}" -o /tmp/hadoop.tar.gz \
-    && curl -fSL "${HADOOP_URL}.asc" -o /tmp/hadoop.tar.gz.asc \
-    && mkdir -p /opt/hadoop-$HADOOP_VERSION/logs \
-    && tar -xvf /tmp/hadoop.tar.gz -C /opt/ \
-    && rm /tmp/hadoop.tar.gz* \
-    && ln -s /opt/hadoop-$HADOOP_VERSION/etc/hadoop /etc/hadoop \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yq update \
+    && apt-get -yq install --no-install-recommends netcat-openbsd procps \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir /hadoop-data
 
-ENV HADOOP_PREFIX=/opt/hadoop-$HADOOP_VERSION
+COPY --from=hadoop-builder /opt/hadoop-${HADOOP_VERSION} /opt/hadoop-${HADOOP_VERSION}
+RUN ln -s /opt/hadoop-${HADOOP_VERSION}/etc/hadoop /etc/hadoop
+
+ENV HADOOP_PREFIX=/opt/hadoop-${HADOOP_VERSION}
 ENV HADOOP_CONF_DIR=/etc/hadoop
 ENV MULTIHOMED_NETWORK=1
 ENV HADOOP_HOME=${HADOOP_PREFIX}
 ENV HADOOP_INSTALL=${HADOOP_HOME}
 ENV USER=root
-ENV PATH /usr/bin:/bin:$HADOOP_PREFIX/bin/:$PATH
+ENV PATH=/usr/bin:/bin:${HADOOP_PREFIX}/bin/:$PATH
 
 # Exposing a union of ports across hadoop versions
 # Well known ports including ssh

--- a/docker/hoodie/hadoop/spark_base/Dockerfile
+++ b/docker/hoodie/hadoop/spark_base/Dockerfile
@@ -41,23 +41,10 @@ RUN echo "Installing Spark-version (${SPARK_VERSION})" \
       && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
       && cd /
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
-    wget build-essential libncursesw5-dev \
-    libssl-dev libgdbm-dev libreadline-dev libbz2-dev \
-    libsqlite3-dev libffi-dev zlib1g-dev curl \
-    && cd /usr/src \
-    && wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz \
-    && tar xzf Python-3.10.14.tgz \
-    && cd Python-3.10.14 \
-    && ./configure --enable-optimizations \
-    && make -j"$(nproc)" \
-    && make altinstall \
-    && ln -sf /usr/local/bin/python3.10 /usr/bin/python \
-    && ln -sf /usr/local/bin/python3.10 /usr/bin/python3 \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install --upgrade pip \
-    && cd / && rm -rf /usr/src/Python-3.10.14* \
+# Install Python runtime from distro package (avoids ~400MB build toolchain)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-minimal python3-pip \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
 #Give permission to execute scripts


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Addresses #18523 — the `apachehudi/hudi-hadoop_3.4.0-base` Java 17 integration-test image is significantly larger than its Java 11 counterpart. This PR applies a first round of size reductions that do not change any runtime behavior.

### Summary and Changelog

Shrinks the Java 17 IT image from **~3.56 GB to ~2.58 GB (~27%, ~900 MB)**. All entrypoints, environment variables, `PATH`, exposed ports, `HADOOP_HOME`, `SPARK_HOME`, and container-level commands remain identical.

**`docker/hoodie/hadoop/base_java17/Dockerfile`**
- Switch base from `eclipse-temurin:17-jdk` to `eclipse-temurin:17-jre-jammy`. The container only *runs* Hadoop; nothing inside the image compiles Java. Saves ~200 MB.
- Convert to a multi-stage build:
  - Stage 1 (`hadoop-builder`): installs `curl` + `ca-certificates`, downloads and extracts the Hadoop tarball.
  - Stage 2 (runtime): `COPY --from=hadoop-builder` of only the extracted Hadoop tree.
  - Effect: the `curl`/`ca-certificates` install and the `tar.gz` never land in the final image layer.
- Use `--no-install-recommends` and `rm -rf /var/lib/apt/lists/*` in the runtime stage.
- Drop the unused `.asc` signature download and the now-dead `wget` dependency.

**`docker/hoodie/hadoop/spark_base/Dockerfile`**
- Replace the Python-3.10.14-from-source build (which installed `build-essential`, `libssl-dev`, `libgdbm-dev`, `libreadline-dev`, `libbz2-dev`, `libsqlite3-dev`, `libffi-dev`, `zlib1g-dev`, then built CPython with `--enable-optimizations`) with the distro packages `python3-minimal` + `python3-pip`. PySpark only needs a Python runtime. Saves ~600 MB.
- `python` and `python3` are symlinked to the distro `python3` exactly as before.

#### Before / After

| Image | Size |
|---|---|
| `base_java17` on master today | ~3.56 GB |
| `base_java17` with this PR | ~2.58 GB |
| `base_java11` (reference, for context) | ~1.68 GB |

#### Usage — identical before and after

```bash
# Build (unchanged)
cd docker
./build_docker_images.sh --hadoop-version 3.4.0 --spark-version 4.0.1 --hive-version 3.1.3

# Bring up demo stack (unchanged)
./setup_demo.sh

# Inside the container (unchanged)
docker exec -it adhoc-1 hadoop fs -ls /
docker exec -it adhoc-1 hadoop version
docker exec -it adhoc-2 pyspark
```

### Impact

- **User-facing:** none. No Hudi source code is touched. The image's API — entrypoint, commands, env vars, `HADOOP_HOME`, `SPARK_HOME`, `PATH`, exposed ports — is unchanged.
- **Performance:** faster `docker pull` and `docker build` due to the smaller image and the removal of the CPython compile step.
- **Behavioral difference to be aware of:** the runtime image no longer contains `javac` (JDK → JRE). Nothing in the default IT stacks invokes `javac` inside the container; if a downstream user was relying on it, they can derive from this image and `apt-get install openjdk-17-jdk-headless`.

### Risk Level

**low**

- Dockerfile-only change; no Hudi Java/Scala/Python source modified.
- Hadoop and Spark versions, layout, and classpaths are unchanged.
- Follow-on, potentially larger reductions (e.g., removing the ~560 MB `share/hadoop/tools/lib/` AWS SDK v2 bundle that ships inside the upstream Hadoop tarball) are deliberately **not** included here, since they narrow the image's out-of-the-box surface area. Happy to add them in a follow-up if maintainers prefer.

### Documentation Update

none — no new configs, no user-facing API or behavior change, no website update required.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable — N/A (Dockerfile-only; validated by building both images and running the existing `setup_demo.sh` stack)