### PR TITLE
feat(common): Ensure schema can be rolled-over and that commit metadata roll-over will apply to clean

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.callback.HoodieClientInitCallback;
 import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
@@ -336,88 +337,130 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       return;  // No rolling metadata configured
     }
 
-    // IMPORTANT: We're inside the lock here. The timeline in 'table' is either:
-    // 1. Fresh from createTable() if no conflict resolution happened
-    // 2. Reloaded during resolveWriteConflict() if conflicts were checked
-    // In both cases, we have the latest view of the timeline.
+    Map<String, String> foundRollingMetadata =
+        findRollingMetadataFromTimeline(table, config, rollingKeys, metadata.getExtraMetadata());
+    for (Map.Entry<String, String> entry : foundRollingMetadata.entrySet()) {
+      metadata.addMetadata(entry.getKey(), entry.getValue());
+    }
+  }
 
-    HoodieTimeline commitsTimeline = table.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
+  /**
+   * Walks back the active timeline (commits + clean instants) to find values for the given
+   * rolling metadata keys. Keys that already have non-empty values in {@code existingExtraMetadata}
+   * are skipped — empty strings are treated as "missing".
+   *
+   * <p>This is a reusable building block used by both {@link #mergeRollingMetadata} (for
+   * {@link HoodieCommitMetadata}) and {@code CleanActionExecutor} (for {@link HoodieCleanMetadata}).
+   *
+   * @param table       HoodieTable with a valid active timeline
+   * @param config      HoodieWriteConfig with rolling metadata settings
+   * @param rollingKeys the set of keys to look for
+   * @param existingExtraMetadata existing metadata from the current commit/clean
+   * @return a map of key→value for keys that were found in prior commits/clean instants
+   */
+  public static Map<String, String> findRollingMetadataFromTimeline(
+      HoodieTable table, HoodieWriteConfig config,
+      Set<String> rollingKeys, Map<String, String> existingExtraMetadata) {
 
-    if (commitsTimeline.empty()) {
-      log.info("No previous commits found. Rolling metadata will start with current commit.");
-      return;  // First commit - nothing to roll forward
+    Map<String, String> foundRollingMetadata = new HashMap<>();
+    Set<String> remainingKeys = new HashSet<>(rollingKeys);
+
+    // Skip keys that already have non-empty values (current values take precedence).
+    // Treat empty string as "missing" — critical for operations like clustering/delete_partition
+    // that may write an empty schema string.
+    for (String key : rollingKeys) {
+      if (existingExtraMetadata.containsKey(key) && !StringUtils.isNullOrEmpty(existingExtraMetadata.get(key))) {
+        remainingKeys.remove(key);
+      }
     }
 
+    if (remainingKeys.isEmpty()) {
+      log.debug("All rolling metadata keys are present in current commit. No walkback needed.");
+      return foundRollingMetadata;
+    }
+
+    HoodieTimeline commitsTimeline = table.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
+    int lookbackLimit = config.getRollingMetadataTimelineLookbackCommits();
+    int instantsWalkedBack = 0;
+
     try {
-      Map<String, String> existingExtraMetadata = metadata.getExtraMetadata();
-      Map<String, String> foundRollingMetadata = new HashMap<>();
-      Set<String> remainingKeys = new HashSet<>(rollingKeys);
+      // Walk back the commits timeline (most recent first)
+      if (!commitsTimeline.empty()) {
+        List<HoodieInstant> recentCommits = commitsTimeline.getReverseOrderedInstantsByCompletionTime()
+            .limit(lookbackLimit)
+            .collect(Collectors.toList());
 
-      // Remove keys that are already present in current commit (current values take precedence)
-      for (String key : rollingKeys) {
-        if (existingExtraMetadata.containsKey(key)) {
-          remainingKeys.remove(key);
-        }
-      }
+        log.debug("Walking back up to {} commits to find rolling metadata for keys: {}",
+            lookbackLimit, remainingKeys);
 
-      if (remainingKeys.isEmpty()) {
-        log.debug("All rolling metadata keys are present in current commit. No walkback needed.");
-        return;
-      }
+        for (HoodieInstant instant : recentCommits) {
+          if (remainingKeys.isEmpty()) {
+            break;
+          }
+          instantsWalkedBack++;
+          HoodieCommitMetadata commitMetadata = table.getMetaClient().getActiveTimeline()
+              .readInstantContent(instant, HoodieCommitMetadata.class);
 
-      int lookbackLimit = config.getRollingMetadataTimelineLookbackCommits();
-      int commitsWalkedBack = 0;
-
-      // Walk back through the timeline in reverse order (most recent first) to find values for all remaining keys
-      List<HoodieInstant> recentCommits = commitsTimeline.getReverseOrderedInstantsByCompletionTime()
-          .limit(lookbackLimit)
-          .collect(Collectors.toList());
-
-      log.debug("Walking back up to {} commits to find rolling metadata for keys: {}",
-          lookbackLimit, remainingKeys);
-
-      for (HoodieInstant instant : recentCommits) {
-        if (remainingKeys.isEmpty()) {
-          break;  // Found all keys
-        }
-
-        commitsWalkedBack++;
-        HoodieCommitMetadata commitMetadata = table.getMetaClient().getActiveTimeline().readInstantContent(instant, HoodieCommitMetadata.class);
-
-        // Check for remaining keys in this commit
-        for (String key : new HashSet<>(remainingKeys)) {
-          String value = commitMetadata.getMetadata(key);
-          if (value != null) {
-            foundRollingMetadata.put(key, value);
-            remainingKeys.remove(key);
-            log.debug("Found rolling metadata key '{}' in commit {} with value: {}",
-                key, instant.requestedTime(), value);
+          for (String key : new HashSet<>(remainingKeys)) {
+            String value = commitMetadata.getMetadata(key);
+            if (!StringUtils.isNullOrEmpty(value)) {
+              foundRollingMetadata.put(key, value);
+              remainingKeys.remove(key);
+              log.debug("Found rolling metadata key '{}' in commit {} with value: {}",
+                  key, instant.requestedTime(), value);
+            }
           }
         }
       }
 
-      // Add found rolling metadata to current commit
-      for (Map.Entry<String, String> entry : foundRollingMetadata.entrySet()) {
-        metadata.addMetadata(entry.getKey(), entry.getValue());
+      // If some keys are still missing, also check clean instants' extraMetadata
+      if (!remainingKeys.isEmpty()) {
+        HoodieTimeline cleanerTimeline = table.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
+        if (!cleanerTimeline.empty()) {
+          List<HoodieInstant> recentCleanInstants = cleanerTimeline.getReverseOrderedInstants()
+              .limit(lookbackLimit)
+              .collect(Collectors.toList());
+          for (HoodieInstant cleanInstant : recentCleanInstants) {
+            if (remainingKeys.isEmpty()) {
+              break;
+            }
+            instantsWalkedBack++;
+            HoodieCleanMetadata cleanMeta = table.getActiveTimeline().readCleanMetadata(cleanInstant);
+            Map<String, String> cleanExtraMetadata = cleanMeta.getExtraMetadata();
+            if (cleanExtraMetadata != null) {
+              for (String key : new HashSet<>(remainingKeys)) {
+                String value = cleanExtraMetadata.get(key);
+                if (!StringUtils.isNullOrEmpty(value)) {
+                  foundRollingMetadata.put(key, value);
+                  remainingKeys.remove(key);
+                  log.debug("Found rolling metadata key '{}' in clean instant {} with value: {}",
+                      key, cleanInstant.requestedTime(), value);
+                }
+              }
+            }
+          }
+        }
       }
 
       int rolledForwardCount = foundRollingMetadata.size();
       int updatedCount = rollingKeys.size() - remainingKeys.size() - rolledForwardCount;
 
       if (rolledForwardCount > 0 || updatedCount > 0 || !remainingKeys.isEmpty()) {
-        log.info("Rolling metadata merge completed. Walked back {} commits. "
-                + "Rolled forward: {}, Updated in current: {}, Not found: {}, Total rolling keys: {}",
-            commitsWalkedBack, rolledForwardCount, updatedCount, remainingKeys.size(), rollingKeys.size());
+        log.info("Rolling metadata: walked back {} instants. "
+                + "Rolled forward: {}, Already present: {}, Not found: {}, Total rolling keys: {}",
+            instantsWalkedBack, rolledForwardCount, updatedCount, remainingKeys.size(), rollingKeys.size());
       }
 
       if (!remainingKeys.isEmpty()) {
-        log.warn("Rolling metadata keys not found in last {} commits: {}. "
-            + "These keys will not be included in the current commit.", lookbackLimit, remainingKeys);
+        log.warn("Rolling metadata keys not found in last {} instants (commits + clean): {}. "
+            + "These keys will not be included in the current commit.", instantsWalkedBack, remainingKeys);
       }
 
     } catch (IOException e) {
       log.error("Failed to read previous commit metadata for rolling metadata keys: {}.", rollingKeys, e);
       throw new HoodieIOException("Failed to read previous commit metadata for rolling metadata keys: " + rollingKeys, e);
     }
+
+    return foundRollingMetadata;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -422,8 +422,9 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       if (!remainingKeys.isEmpty()) {
         HoodieTimeline cleanerTimeline = table.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
         if (!cleanerTimeline.empty()) {
+          int remainingLookback = lookbackLimit - instantsWalkedBack;
           List<HoodieInstant> recentCleanInstants = cleanerTimeline.getReverseOrderedInstants()
-              .limit(lookbackLimit)
+              .limit(Math.max(remainingLookback, 1))
               .collect(Collectors.toList());
           for (HoodieInstant cleanInstant : recentCleanInstants) {
             if (remainingKeys.isEmpty()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -327,6 +327,11 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
    * @param metadata Current commit metadata to be augmented with rolling metadata
    */
   protected void mergeRollingMetadata(HoodieTable table, HoodieCommitMetadata metadata) {
+    // IMPORTANT: We're inside the lock here. The timeline in 'table' is either:
+    // 1. Fresh from createTable() if no conflict resolution happened
+    // 2. Reloaded during resolveWriteConflict() if conflicts were checked
+    // In both cases, we have the latest view of the timeline.
+
     // Skip for metadata table - rolling metadata is only for data tables
     if (table.isMetadataTable()) {
       return;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table.action.clean;
 import org.apache.hudi.avro.model.HoodieActionInstant;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.client.BaseHoodieClient;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.common.HoodieCleanStat;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -49,6 +50,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -224,6 +226,19 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
           cleanStats,
           cleanerPlan.getExtraMetadata()
       );
+      // Merge rolling metadata into clean's extraMetadata
+      Set<String> rollingKeys = config.getRollingMetadataKeys();
+      if (!rollingKeys.isEmpty() && !table.isMetadataTable()) {
+        Map<String, String> existingExtra = metadata.getExtraMetadata() != null
+            ? metadata.getExtraMetadata() : new HashMap<>();
+        Map<String, String> rolledMetadata =
+            BaseHoodieClient.findRollingMetadataFromTimeline(table, config, rollingKeys, existingExtra);
+        if (!rolledMetadata.isEmpty()) {
+          Map<String, String> merged = new HashMap<>(existingExtra);
+          merged.putAll(rolledMetadata);
+          metadata.setExtraMetadata(merged);
+        }
+      }
       this.txnManager.beginStateChange(Option.of(inflightInstant), Option.empty());
       writeTableMetadata(metadata, inflightInstant.requestedTime());
       table.getActiveTimeline().transitionCleanInflightToComplete(

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -226,9 +226,12 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
           cleanStats,
           cleanerPlan.getExtraMetadata()
       );
-      // Merge rolling metadata into clean's extraMetadata
+      this.txnManager.beginStateChange(Option.of(inflightInstant), Option.empty());
+      // Merge rolling metadata inside the state-change lock so we read the latest timeline,
+      // matching the same contract as mergeRollingMetadata for commit metadata.
       Set<String> rollingKeys = config.getRollingMetadataKeys();
       if (!rollingKeys.isEmpty() && !table.isMetadataTable()) {
+        table.getMetaClient().reloadActiveTimeline();
         Map<String, String> existingExtra = metadata.getExtraMetadata() != null
             ? metadata.getExtraMetadata() : new HashMap<>();
         Map<String, String> rolledMetadata =
@@ -239,7 +242,6 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
           metadata.setExtraMetadata(merged);
         }
       }
-      this.txnManager.beginStateChange(Option.of(inflightInstant), Option.empty());
       writeTableMetadata(metadata, inflightInstant.requestedTime());
       table.getActiveTimeline().transitionCleanInflightToComplete(
           false,

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.common.table;
 
-import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -171,6 +172,10 @@ public class TableSchemaResolver {
         (instantOpt.isPresent()
             ? getTableSchemaFromCommitMetadata(instantOpt.get(), includeMetadataFields)
             : getTableSchemaFromLatestCommitMetadata(includeMetadataFields))
+            // Fallback: look in ANY commit type (clustering, compaction, delete_partition, etc.)
+            .or(() -> getTableSchemaFromAnyCommitMetadata(includeMetadataFields))
+            // Fallback: look in clean instants' extraMetadata (populated by rolling metadata)
+            .or(() -> getTableSchemaFromCleanMetadata(includeMetadataFields))
             .or(() ->
                 metaClient.getTableConfig().getTableCreateSchema()
                     .map(tableSchema ->
@@ -211,6 +216,60 @@ public class TableSchemaResolver {
     } else {
       return Option.empty();
     }
+  }
+
+  /**
+   * Fallback: find schema from ANY commit type (including clustering, compaction, delete_partition)
+   * regardless of {@link WriteOperationType#canUpdateSchema}.
+   */
+  private Option<HoodieSchema> getTableSchemaFromAnyCommitMetadata(boolean includeMetadataFields) {
+    Option<Pair<HoodieInstant, HoodieCommitMetadata>> instantAndCommitMetadata =
+        metaClient.getActiveTimeline().getLastCommitMetadataWithSchema();
+    if (instantAndCommitMetadata.isPresent()) {
+      HoodieCommitMetadata commitMetadata = instantAndCommitMetadata.get().getRight();
+      String schemaStr = commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY);
+      HoodieSchema schema = HoodieSchema.parse(schemaStr);
+      if (includeMetadataFields) {
+        schema = HoodieSchemaUtils.addMetadataFields(schema, hasOperationField.get());
+      } else {
+        schema = HoodieSchemaUtils.removeMetadataFields(schema);
+      }
+      return Option.of(schema);
+    }
+    return Option.empty();
+  }
+
+  /**
+   * Fallback: find schema from clean instants' extraMetadata. This is populated by the
+   * rolling metadata feature when schema is configured as a rolling key.
+   */
+  private Option<HoodieSchema> getTableSchemaFromCleanMetadata(boolean includeMetadataFields) {
+    HoodieTimeline cleanerTimeline = metaClient.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
+    if (cleanerTimeline.empty()) {
+      return Option.empty();
+    }
+    return Option.fromJavaOptional(
+        cleanerTimeline.getReverseOrderedInstants()
+            .map(instant -> {
+              try {
+                return cleanerTimeline.readCleanMetadata(instant);
+              } catch (IOException e) {
+                throw new HoodieIOException("Failed to read clean metadata for instant " + instant.requestedTime(), e);
+              }
+            })
+            .filter(cleanMeta -> cleanMeta.getExtraMetadata() != null)
+            .map(cleanMeta -> cleanMeta.getExtraMetadata().get(HoodieCommitMetadata.SCHEMA_KEY))
+            .filter(schemaStr -> !StringUtils.isNullOrEmpty(schemaStr))
+            .map(schemaStr -> {
+              HoodieSchema schema = HoodieSchema.parse(schemaStr);
+              if (includeMetadataFields) {
+                schema = HoodieSchemaUtils.addMetadataFields(schema, hasOperationField.get());
+              } else {
+                schema = HoodieSchemaUtils.removeMetadataFields(schema);
+              }
+              return schema;
+            })
+            .findFirst());
   }
 
   private Option<HoodieSchema> getTableSchemaFromCommitMetadata(HoodieInstant instant, boolean includeMetadataFields) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -203,18 +203,10 @@ public class TableSchemaResolver {
   private Option<HoodieSchema> getTableSchemaFromLatestCommitMetadata(boolean includeMetadataFields) {
     Option<Pair<HoodieInstant, HoodieCommitMetadata>> instantAndCommitMetadata = getLatestCommitMetadataWithValidSchema();
     if (instantAndCommitMetadata.isPresent()) {
-      HoodieCommitMetadata commitMetadata = instantAndCommitMetadata.get().getRight();
-      String schemaStr = commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY);
-      HoodieSchema schema = HoodieSchema.parse(schemaStr);
-      if (includeMetadataFields) {
-        schema = HoodieSchemaUtils.addMetadataFields(schema, hasOperationField.get());
-      } else {
-        schema = HoodieSchemaUtils.removeMetadataFields(schema);
-      }
-      return Option.of(schema);
-    } else {
-      return Option.empty();
+      String schemaStr = instantAndCommitMetadata.get().getRight().getMetadata(HoodieCommitMetadata.SCHEMA_KEY);
+      return parseSchemaString(schemaStr, includeMetadataFields);
     }
+    return Option.empty();
   }
 
   /**
@@ -225,15 +217,8 @@ public class TableSchemaResolver {
     Option<Pair<HoodieInstant, HoodieCommitMetadata>> instantAndCommitMetadata =
         metaClient.getActiveTimeline().getLastCommitMetadataWithSchema();
     if (instantAndCommitMetadata.isPresent()) {
-      HoodieCommitMetadata commitMetadata = instantAndCommitMetadata.get().getRight();
-      String schemaStr = commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY);
-      HoodieSchema schema = HoodieSchema.parse(schemaStr);
-      if (includeMetadataFields) {
-        schema = HoodieSchemaUtils.addMetadataFields(schema, hasOperationField.get());
-      } else {
-        schema = HoodieSchemaUtils.removeMetadataFields(schema);
-      }
-      return Option.of(schema);
+      String schemaStr = instantAndCommitMetadata.get().getRight().getMetadata(HoodieCommitMetadata.SCHEMA_KEY);
+      return parseSchemaString(schemaStr, includeMetadataFields);
     }
     return Option.empty();
   }
@@ -259,34 +244,28 @@ public class TableSchemaResolver {
             .filter(cleanMeta -> cleanMeta.getExtraMetadata() != null)
             .map(cleanMeta -> cleanMeta.getExtraMetadata().get(HoodieCommitMetadata.SCHEMA_KEY))
             .filter(schemaStr -> !StringUtils.isNullOrEmpty(schemaStr))
-            .map(schemaStr -> {
-              HoodieSchema schema = HoodieSchema.parse(schemaStr);
-              if (includeMetadataFields) {
-                schema = HoodieSchemaUtils.addMetadataFields(schema, hasOperationField.get());
-              } else {
-                schema = HoodieSchemaUtils.removeMetadataFields(schema);
-              }
-              return schema;
-            })
+            .map(schemaStr -> parseSchemaString(schemaStr, includeMetadataFields).orElse(null))
+            .filter(schema -> schema != null)
             .findFirst());
+  }
+
+  private Option<HoodieSchema> parseSchemaString(String schemaStr, boolean includeMetadataFields) {
+    if (StringUtils.isNullOrEmpty(schemaStr)) {
+      return Option.empty();
+    }
+    HoodieSchema schema = HoodieSchema.parse(schemaStr);
+    if (includeMetadataFields) {
+      schema = HoodieSchemaUtils.addMetadataFields(schema, hasOperationField.get());
+    } else {
+      schema = HoodieSchemaUtils.removeMetadataFields(schema);
+    }
+    return Option.of(schema);
   }
 
   private Option<HoodieSchema> getTableSchemaFromCommitMetadata(HoodieInstant instant, boolean includeMetadataFields) {
     try {
       HoodieCommitMetadata metadata = getCachedCommitMetadata(instant);
-      String existingSchemaStr = metadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY);
-
-      if (StringUtils.isNullOrEmpty(existingSchemaStr)) {
-        return Option.empty();
-      }
-
-      HoodieSchema schema = HoodieSchema.parse(existingSchemaStr);
-      if (includeMetadataFields) {
-        schema = HoodieSchemaUtils.addMetadataFields(schema, hasOperationField.get());
-      } else {
-        schema = HoodieSchemaUtils.removeMetadataFields(schema);
-      }
-      return Option.of(schema);
+      return parseSchemaString(metadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY), includeMetadataFields);
     } catch (Exception e) {
       throw new HoodieException("Failed to read schema from commit metadata", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -244,8 +244,7 @@ public class TableSchemaResolver {
             .filter(cleanMeta -> cleanMeta.getExtraMetadata() != null)
             .map(cleanMeta -> cleanMeta.getExtraMetadata().get(HoodieCommitMetadata.SCHEMA_KEY))
             .filter(schemaStr -> !StringUtils.isNullOrEmpty(schemaStr))
-            .map(schemaStr -> parseSchemaString(schemaStr, includeMetadataFields).orElse(null))
-            .filter(schema -> schema != null)
+            .flatMap(schemaStr -> parseSchemaString(schemaStr, includeMetadataFields).toJavaOptional().stream())
             .findFirst());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/TableSchemaResolver.java
@@ -232,20 +232,23 @@ public class TableSchemaResolver {
     if (cleanerTimeline.empty()) {
       return Option.empty();
     }
-    return Option.fromJavaOptional(
-        cleanerTimeline.getReverseOrderedInstants()
-            .map(instant -> {
-              try {
-                return cleanerTimeline.readCleanMetadata(instant);
-              } catch (IOException e) {
-                throw new HoodieIOException("Failed to read clean metadata for instant " + instant.requestedTime(), e);
-              }
-            })
-            .filter(cleanMeta -> cleanMeta.getExtraMetadata() != null)
-            .map(cleanMeta -> cleanMeta.getExtraMetadata().get(HoodieCommitMetadata.SCHEMA_KEY))
-            .filter(schemaStr -> !StringUtils.isNullOrEmpty(schemaStr))
-            .flatMap(schemaStr -> parseSchemaString(schemaStr, includeMetadataFields).toJavaOptional().stream())
-            .findFirst());
+    return cleanerTimeline.getReverseOrderedInstants()
+        .map(instant -> {
+          try {
+            return cleanerTimeline.readCleanMetadata(instant);
+          } catch (IOException e) {
+            throw new HoodieIOException("Failed to read clean metadata for instant " + instant.requestedTime(), e);
+          }
+        })
+        .filter(cleanMeta -> cleanMeta.getExtraMetadata() != null)
+        .map(cleanMeta -> cleanMeta.getExtraMetadata().get(HoodieCommitMetadata.SCHEMA_KEY))
+        .filter(schemaStr -> !StringUtils.isNullOrEmpty(schemaStr))
+        .map(schemaStr -> parseSchemaString(schemaStr, includeMetadataFields))
+        .filter(Option::isPresent)
+        .map(Option::get)
+        .findFirst()
+        .map(Option::of)
+        .orElse(Option.empty());
   }
 
   private Option<HoodieSchema> parseSchemaString(String schemaStr, boolean includeMetadataFields) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/CheckpointUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/CheckpointUtils.java
@@ -61,7 +61,15 @@ public class CheckpointUtils {
   }
 
   public static Checkpoint getCheckpoint(HoodieCommitMetadata commitMetadata) {
-    return getCheckpoint(commitMetadata.getExtraMetadata());
+    if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_KEY_V2))
+        || !StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_RESET_KEY_V2))) {
+      return new StreamerCheckpointV2(commitMetadata);
+    }
+    if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_KEY_V1))
+        || !StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_RESET_KEY_V1))) {
+      return new StreamerCheckpointV1(commitMetadata);
+    }
+    throw new HoodieException("Checkpoint is not found in the commit metadata: " + commitMetadata.getExtraMetadata());
   }
 
   public static Checkpoint getCheckpoint(Map<String, String> metadata) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/CheckpointUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/CheckpointUtils.java
@@ -32,6 +32,7 @@ import org.apache.hudi.exception.HoodieException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -60,15 +61,26 @@ public class CheckpointUtils {
   }
 
   public static Checkpoint getCheckpoint(HoodieCommitMetadata commitMetadata) {
-    if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_KEY_V2))
-        || !StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_RESET_KEY_V2))) {
-      return new StreamerCheckpointV2(commitMetadata);
+    return getCheckpoint(commitMetadata.getExtraMetadata());
+  }
+
+  public static Checkpoint getCheckpoint(Map<String, String> metadata) {
+    if (!StringUtils.isNullOrEmpty(metadata.get(STREAMER_CHECKPOINT_KEY_V2))
+        || !StringUtils.isNullOrEmpty(metadata.get(STREAMER_CHECKPOINT_RESET_KEY_V2))) {
+      return new StreamerCheckpointV2(metadata);
     }
-    if (!StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_KEY_V1))
-        || !StringUtils.isNullOrEmpty(commitMetadata.getMetadata(STREAMER_CHECKPOINT_RESET_KEY_V1))) {
-      return new StreamerCheckpointV1(commitMetadata);
+    if (!StringUtils.isNullOrEmpty(metadata.get(STREAMER_CHECKPOINT_KEY_V1))
+        || !StringUtils.isNullOrEmpty(metadata.get(STREAMER_CHECKPOINT_RESET_KEY_V1))) {
+      return new StreamerCheckpointV1(metadata);
     }
-    throw new HoodieException("Checkpoint is not found in the commit metadata: " + commitMetadata.getExtraMetadata());
+    throw new HoodieException("Checkpoint is not found in the metadata: " + metadata);
+  }
+
+  public static boolean hasCheckpointKeys(Map<String, String> metadata) {
+    return !StringUtils.isNullOrEmpty(metadata.get(STREAMER_CHECKPOINT_KEY_V2))
+        || !StringUtils.isNullOrEmpty(metadata.get(STREAMER_CHECKPOINT_RESET_KEY_V2))
+        || !StringUtils.isNullOrEmpty(metadata.get(STREAMER_CHECKPOINT_KEY_V1))
+        || !StringUtils.isNullOrEmpty(metadata.get(STREAMER_CHECKPOINT_RESET_KEY_V1));
   }
 
   public static Checkpoint buildCheckpointFromGeneralSource(

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/StreamerCheckpointV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/StreamerCheckpointV1.java
@@ -47,6 +47,12 @@ public class StreamerCheckpointV1 extends Checkpoint {
     this.checkpointIgnoreKey = commitMetadata.getMetadata(CHECKPOINT_IGNORE_KEY);
   }
 
+  public StreamerCheckpointV1(Map<String, String> metadata) {
+    this.checkpointKey = metadata.get(STREAMER_CHECKPOINT_KEY_V1);
+    this.checkpointResetKey = metadata.get(STREAMER_CHECKPOINT_RESET_KEY_V1);
+    this.checkpointIgnoreKey = metadata.get(CHECKPOINT_IGNORE_KEY);
+  }
+
   @Override
   public Map<String, String> getCheckpointCommitMetadata(String overrideResetKey,
                                                          String overrideIgnoreKey) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/StreamerCheckpointV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/checkpoint/StreamerCheckpointV2.java
@@ -48,6 +48,12 @@ public class StreamerCheckpointV2 extends Checkpoint {
     this.checkpointIgnoreKey = commitMetadata.getMetadata(CHECKPOINT_IGNORE_KEY);
   }
 
+  public StreamerCheckpointV2(Map<String, String> metadata) {
+    this.checkpointKey = metadata.get(STREAMER_CHECKPOINT_KEY_V2);
+    this.checkpointResetKey = metadata.get(STREAMER_CHECKPOINT_RESET_KEY_V2);
+    this.checkpointIgnoreKey = metadata.get(CHECKPOINT_IGNORE_KEY);
+  }
+
   public void addV1Props() {
     this.extraProps.put(STREAMER_CHECKPOINT_KEY_V1, checkpointKey);
     this.extraProps.put(STREAMER_CHECKPOINT_RESET_KEY_V1, checkpointResetKey);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -146,9 +146,18 @@ public interface HoodieActiveTimeline extends HoodieTimeline {
   void deleteInstantFileIfExists(HoodieInstant instant);
 
   /**
-   * Returns most recent instant having valid schema in its {@link HoodieCommitMetadata}
+   * Returns most recent instant having valid schema in its {@link HoodieCommitMetadata},
+   * restricted to operations that can update schema (via {@link WriteOperationType#canUpdateSchema}).
    */
   Option<Pair<HoodieInstant, HoodieCommitMetadata>> getLastCommitMetadataWithValidSchema();
+
+  /**
+   * Returns most recent instant having a non-empty schema in its {@link HoodieCommitMetadata},
+   * regardless of {@link WriteOperationType}. This includes clustering, compaction, delete_partition,
+   * and any other commit type that carries a schema in its extraMetadata.
+   * Used as a fallback when no schema-evolving commits are found.
+   */
+  Option<Pair<HoodieInstant, HoodieCommitMetadata>> getLastCommitMetadataWithSchema();
 
   /**
    * Get the last instant with valid data, and convert this to HoodieCommitMetadata

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -234,7 +234,9 @@ public class TimelineUtils {
 
   /**
    * Get extra metadata for specified key from latest commit/deltacommit/replacecommit(eg. insert_overwrite) instant.
-   * Falls back to clean instants if the key is not found in any commit.
+   * Falls back to clean instants if the key is not found in any commit. This fallback is intentional:
+   * after archival removes all ingestion commits, clean instants carrying rolled-over metadata may
+   * be the only source for checkpoint/schema keys on the active timeline.
    */
   public static Option<String> getExtraMetadataFromLatest(HoodieTableMetaClient metaClient, String extraMetadataKey) {
     Option<String> result = metaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants()
@@ -250,7 +252,8 @@ public class TimelineUtils {
 
   /**
    * Get extra metadata for specified key from latest commit/deltacommit/replacecommit instant including internal commits
-   * such as clustering. Falls back to clean instants if the key is not found in any commit.
+   * such as clustering. Falls back to clean instants if the key is not found in any commit. See
+   * {@link #getExtraMetadataFromLatest} for rationale on the clean-instant fallback.
    */
   public static Option<String> getExtraMetadataFromLatestIncludeClustering(HoodieTableMetaClient metaClient, String extraMetadataKey) {
     Option<String> result = metaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants()

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -234,23 +234,32 @@ public class TimelineUtils {
 
   /**
    * Get extra metadata for specified key from latest commit/deltacommit/replacecommit(eg. insert_overwrite) instant.
+   * Falls back to clean instants if the key is not found in any commit.
    */
   public static Option<String> getExtraMetadataFromLatest(HoodieTableMetaClient metaClient, String extraMetadataKey) {
-    return metaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants()
-        // exclude clustering commits for returning user stored extra metadata 
+    Option<String> result = metaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants()
+        // exclude clustering commits for returning user stored extra metadata
         .filter(instant -> !isClusteringCommit(metaClient, instant))
         .findFirst().map(instant ->
             getMetadataValue(metaClient, extraMetadataKey, instant)).orElse(Option.empty());
+    if (result.isPresent()) {
+      return result;
+    }
+    return getExtraMetadataFromCleanInstants(metaClient, extraMetadataKey);
   }
 
   /**
    * Get extra metadata for specified key from latest commit/deltacommit/replacecommit instant including internal commits
-   * such as clustering.
+   * such as clustering. Falls back to clean instants if the key is not found in any commit.
    */
   public static Option<String> getExtraMetadataFromLatestIncludeClustering(HoodieTableMetaClient metaClient, String extraMetadataKey) {
-    return metaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants()
+    Option<String> result = metaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants()
         .findFirst().map(instant ->
             getMetadataValue(metaClient, extraMetadataKey, instant)).orElse(Option.empty());
+    if (result.isPresent()) {
+      return result;
+    }
+    return getExtraMetadataFromCleanInstants(metaClient, extraMetadataKey);
   }
 
   /**
@@ -259,6 +268,36 @@ public class TimelineUtils {
   public static Map<String, Option<String>> getAllExtraMetadataForKey(HoodieTableMetaClient metaClient, String extraMetadataKey) {
     return metaClient.getCommitsTimeline().filterCompletedInstants().getReverseOrderedInstants().collect(Collectors.toMap(
         HoodieInstant::requestedTime, instant -> getMetadataValue(metaClient, extraMetadataKey, instant)));
+  }
+
+  /**
+   * Search clean instants' extraMetadata for a given key. Returns the value from the most
+   * recent clean instant that contains a non-empty value for the key.
+   */
+  private static Option<String> getExtraMetadataFromCleanInstants(HoodieTableMetaClient metaClient, String extraMetadataKey) {
+    HoodieTimeline cleanerTimeline = metaClient.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
+    if (cleanerTimeline.empty()) {
+      return Option.empty();
+    }
+    return Option.fromJavaOptional(
+        cleanerTimeline.getReverseOrderedInstants()
+            .map(instant -> {
+              try {
+                HoodieCleanMetadata cleanMetadata = cleanerTimeline.readCleanMetadata(instant);
+                Map<String, String> extraMetadata = cleanMetadata.getExtraMetadata();
+                if (extraMetadata != null) {
+                  String value = extraMetadata.get(extraMetadataKey);
+                  if (!StringUtils.isNullOrEmpty(value)) {
+                    return value;
+                  }
+                }
+              } catch (IOException e) {
+                throw new HoodieIOException("Failed to read clean metadata for instant " + instant.requestedTime(), e);
+              }
+              return null;
+            })
+            .filter(v -> v != null)
+            .findFirst());
   }
 
   private static Option<String> getMetadataValue(HoodieTableMetaClient metaClient, String extraMetadataKey, HoodieInstant instant) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/ActiveTimelineV1.java
@@ -286,6 +286,16 @@ public class ActiveTimelineV1 extends BaseTimelineV1 implements HoodieActiveTime
   }
 
   @Override
+  public Option<Pair<HoodieInstant, HoodieCommitMetadata>> getLastCommitMetadataWithSchema() {
+    return Option.fromJavaOptional(
+        getCommitMetadataStream()
+            .filter(instantCommitMetadataPair ->
+                !StringUtils.isNullOrEmpty(instantCommitMetadataPair.getValue().getMetadata(HoodieCommitMetadata.SCHEMA_KEY)))
+            .findFirst()
+    );
+  }
+
+  @Override
   public Option<Pair<HoodieInstant, HoodieCommitMetadata>> getLastCommitMetadataWithValidData() {
     return Option.fromJavaOptional(
         getCommitMetadataStream()

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ActiveTimelineV2.java
@@ -300,6 +300,15 @@ public class ActiveTimelineV2 extends BaseTimelineV2 implements HoodieActiveTime
   }
 
   @Override
+  public Option<Pair<HoodieInstant, HoodieCommitMetadata>> getLastCommitMetadataWithSchema() {
+    return Option.fromJavaOptional(
+        getCommitMetadataStream()
+            .filter(instantCommitMetadataPair ->
+                !StringUtils.isNullOrEmpty(instantCommitMetadataPair.getValue().getMetadata(HoodieCommitMetadata.SCHEMA_KEY)))
+            .findFirst());
+  }
+
+  @Override
   public Option<Pair<HoodieInstant, HoodieCommitMetadata>> getLastCommitMetadataWithValidData() {
     return Option.fromJavaOptional(
         getCommitMetadataStream()

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTimelineUtils.java
@@ -662,4 +662,166 @@ class TestTimelineUtils extends HoodieCommonTestHarness {
     droppedPartitions = TimelineUtils.getDroppedPartitions(metaClient, Option.empty(), Option.empty());
     assertTrue(droppedPartitions.isEmpty());
   }
+
+  @Test
+  void testGetExtraMetadataFallsBackToCleanInstants() throws Exception {
+    String extraMetadataKey = "checkpoint_key";
+    String extraMetadataValue = "kafka:topic:0:100";
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+
+    // Create a clean instant with extraMetadata containing the checkpoint key
+    Map<String, String> cleanExtraMetadata = new HashMap<>();
+    cleanExtraMetadata.put(extraMetadataKey, extraMetadataValue);
+    HoodieInstant cleanInstant = new HoodieInstant(INFLIGHT, CLEAN_ACTION, "1",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(cleanInstant);
+    activeTimeline.saveAsComplete(cleanInstant, getCleanMetadataWithExtraMetadata("p1", "1", cleanExtraMetadata));
+
+    metaClient.reloadActiveTimeline();
+
+    // No commits exist, so getExtraMetadataFromLatest should fall back to clean instants
+    Option<String> result = TimelineUtils.getExtraMetadataFromLatest(metaClient, extraMetadataKey);
+    assertTrue(result.isPresent(), "Should find metadata in clean instant fallback");
+    assertEquals(extraMetadataValue, result.get());
+  }
+
+  @Test
+  void testGetExtraMetadataIncludeClusteringFallsBackToCleanInstants() throws Exception {
+    String extraMetadataKey = "my_checkpoint";
+    String extraMetadataValue = "offset_42";
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+
+    // Create a clean instant with extraMetadata
+    Map<String, String> cleanExtraMetadata = new HashMap<>();
+    cleanExtraMetadata.put(extraMetadataKey, extraMetadataValue);
+    HoodieInstant cleanInstant = new HoodieInstant(INFLIGHT, CLEAN_ACTION, "1",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(cleanInstant);
+    activeTimeline.saveAsComplete(cleanInstant, getCleanMetadataWithExtraMetadata("p1", "1", cleanExtraMetadata));
+
+    metaClient.reloadActiveTimeline();
+
+    Option<String> result = TimelineUtils.getExtraMetadataFromLatestIncludeClustering(metaClient, extraMetadataKey);
+    assertTrue(result.isPresent(), "Should find metadata in clean instant fallback (include clustering path)");
+    assertEquals(extraMetadataValue, result.get());
+  }
+
+  @Test
+  void testGetExtraMetadataCommitTakesPriorityOverClean() throws Exception {
+    String extraMetadataKey = "checkpoint_key";
+    String commitValue = "from_commit";
+    String cleanValue = "from_clean";
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+
+    // Create a commit with the key
+    Map<String, String> commitExtra = new HashMap<>();
+    commitExtra.put(extraMetadataKey, commitValue);
+    HoodieInstant commitInstant = new HoodieInstant(INFLIGHT, COMMIT_ACTION, "1",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(commitInstant);
+    activeTimeline.saveAsComplete(commitInstant, getCommitMetadata(basePath, "1", "1", 2, commitExtra));
+
+    // Also create a clean with a different value
+    Map<String, String> cleanExtra = new HashMap<>();
+    cleanExtra.put(extraMetadataKey, cleanValue);
+    HoodieInstant cleanInstant = new HoodieInstant(INFLIGHT, CLEAN_ACTION, "2",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(cleanInstant);
+    activeTimeline.saveAsComplete(cleanInstant, getCleanMetadataWithExtraMetadata("p1", "2", cleanExtra));
+
+    metaClient.reloadActiveTimeline();
+
+    // Commit value should take priority
+    Option<String> result = TimelineUtils.getExtraMetadataFromLatest(metaClient, extraMetadataKey);
+    assertTrue(result.isPresent());
+    assertEquals(commitValue, result.get());
+  }
+
+  @Test
+  void testGetExtraMetadataCleanFallbackReturnsEmptyWhenKeyNotPresent() throws Exception {
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+
+    // Create a clean instant without the target key
+    Map<String, String> cleanExtraMetadata = new HashMap<>();
+    cleanExtraMetadata.put("other_key", "other_value");
+    HoodieInstant cleanInstant = new HoodieInstant(INFLIGHT, CLEAN_ACTION, "1",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(cleanInstant);
+    activeTimeline.saveAsComplete(cleanInstant, getCleanMetadataWithExtraMetadata("p1", "1", cleanExtraMetadata));
+
+    metaClient.reloadActiveTimeline();
+
+    Option<String> result = TimelineUtils.getExtraMetadataFromLatest(metaClient, "missing_key");
+    assertFalse(result.isPresent(), "Should not find metadata for a key that doesn't exist");
+  }
+
+  @Test
+  void testGetLastCommitMetadataWithSchemaIgnoresOperationType() throws Exception {
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+
+    // Create a clustering commit with schema
+    String schemaStr = "{\"type\":\"record\",\"name\":\"test\",\"fields\":[]}";
+    Map<String, String> extraMetadata = new HashMap<>();
+    extraMetadata.put(HoodieCommitMetadata.SCHEMA_KEY, schemaStr);
+    HoodieInstant clusterInstant = new HoodieInstant(INFLIGHT, CLUSTERING_ACTION, "1",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(clusterInstant);
+    activeTimeline.transitionClusterInflightToComplete(true, clusterInstant,
+        getReplaceCommitMetadata(basePath, "1", "p1", 0, "p1", 3, extraMetadata, WriteOperationType.CLUSTER));
+
+    metaClient.reloadActiveTimeline();
+
+    // getLastCommitMetadataWithValidSchema should NOT find it (filtered by canUpdateSchema)
+    assertFalse(metaClient.getActiveTimeline().getLastCommitMetadataWithValidSchema().isPresent(),
+        "canUpdateSchema filter should exclude clustering");
+
+    // getLastCommitMetadataWithSchema SHOULD find it (no operation type filter)
+    assertTrue(metaClient.getActiveTimeline().getLastCommitMetadataWithSchema().isPresent(),
+        "getLastCommitMetadataWithSchema should find schema in clustering commit");
+    assertEquals(schemaStr,
+        metaClient.getActiveTimeline().getLastCommitMetadataWithSchema().get().getRight()
+            .getMetadata(HoodieCommitMetadata.SCHEMA_KEY));
+  }
+
+  @Test
+  void testGetLastCommitMetadataWithSchemaReturnsEmptyWhenNoSchema() throws Exception {
+    HoodieActiveTimeline activeTimeline = metaClient.getActiveTimeline();
+
+    // Create a commit without schema
+    HoodieInstant instant = new HoodieInstant(INFLIGHT, COMMIT_ACTION, "1",
+        InstantComparatorV2.REQUESTED_TIME_BASED_COMPARATOR);
+    activeTimeline.createNewInstant(instant);
+    activeTimeline.saveAsComplete(instant, getCommitMetadata(basePath, "1", "1", 2, Collections.emptyMap()));
+
+    metaClient.reloadActiveTimeline();
+
+    assertFalse(metaClient.getActiveTimeline().getLastCommitMetadataWithSchema().isPresent(),
+        "Should return empty when no commits have schema");
+  }
+
+  private Option<HoodieCleanMetadata> getCleanMetadataWithExtraMetadata(String partition, String time,
+                                                                        Map<String, String> extraMetadata) {
+    Map<String, HoodieCleanPartitionMetadata> partitionToFilesCleaned = new HashMap<>();
+    List<String> filesDeleted = new ArrayList<>();
+    filesDeleted.add("file-" + partition + "-" + time + "1");
+    HoodieCleanPartitionMetadata partitionMetadata = HoodieCleanPartitionMetadata.newBuilder()
+        .setPartitionPath(partition)
+        .setPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS.name())
+        .setFailedDeleteFiles(Collections.emptyList())
+        .setDeletePathPatterns(Collections.emptyList())
+        .setSuccessDeleteFiles(filesDeleted)
+        .setIsPartitionDeleted(false)
+        .build();
+    partitionToFilesCleaned.put(partition, partitionMetadata);
+    return Option.of(HoodieCleanMetadata.newBuilder()
+        .setVersion(1)
+        .setTimeTakenInMillis(100)
+        .setTotalFilesDeleted(1)
+        .setStartCleanTime(time)
+        .setEarliestCommitToRetain(time)
+        .setLastCompletedCommitTimestamp("")
+        .setPartitionMetadata(partitionToFilesCleaned)
+        .setExtraMetadata(extraMetadata)
+        .build());
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1998,48 +1998,55 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   @Test
   public void testRollingMetadataPreservedAcrossClusteringAfterArchival() throws Exception {
     String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
+    String testPartitionPath = "2016/09/26";
+    dataGen = new HoodieTestDataGenerator(new String[] {testPartitionPath});
 
-    HoodieClusteringConfig clusteringConfig = createClusteringBuilder(false, 1).build();
     HoodieWriteConfig config = getConfigBuilder()
-        .withClusteringConfig(clusteringConfig)
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .compactionSmallFileSize(0).build())
         .withRollingMetadataKeys(schemaKey)
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
             .archiveCommitsWith(2, 3).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder()
-            .withAutoClean(false)
-            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
-            .build())
+            .withAutoClean(false).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .build();
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
-      // Insert + several upserts to create enough commits for archival
-      String firstCommit = WriteClientTestUtils.createNewInstantTime();
-      WriteClientTestUtils.startCommitWithTime(client, firstCommit);
-      List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
-      List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
-      assertNoWriteErrors(statuses);
-
+      // Insert multiple batches so each creates a new file group (smallFileSize=0)
+      List<HoodieRecord> allRecords = new ArrayList<>();
       for (int i = 0; i < 5; i++) {
-        String commitTime = WriteClientTestUtils.createNewInstantTime();
-        WriteClientTestUtils.startCommitWithTime(client, commitTime);
-        List<HoodieRecord> updates = dataGen.generateUpdates(commitTime, records);
-        statuses = client.upsert(jsc.parallelize(updates, 1), commitTime).collect();
+        String commitTime = client.startCommit();
+        List<HoodieRecord> records = dataGen.generateInserts(commitTime, 50);
+        allRecords.addAll(records);
+        List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
         assertNoWriteErrors(statuses);
       }
 
-      // Run clustering twice
-      for (int i = 0; i < 2; i++) {
-        client.scheduleClustering(Option.empty());
-        HoodieTableMetaClient reloadedMeta = HoodieTableMetaClient.reload(metaClient);
-        Option<HoodieInstant> pendingClustering = reloadedMeta.getActiveTimeline()
-            .filterPendingClusteringTimeline().lastInstant();
-        if (pendingClustering.isPresent()) {
-          client.cluster(pendingClustering.get().requestedTime());
+      // Schedule and execute clustering (merges multiple small file groups)
+      HoodieWriteConfig clusterConfig = getConfigBuilder()
+          .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+              .compactionSmallFileSize(0).build())
+          .withClusteringConfig(createClusteringBuilder(true, 1).build())
+          .withRollingMetadataKeys(schemaKey)
+          .withArchivalConfig(HoodieArchivalConfig.newBuilder()
+              .archiveCommitsWith(2, 3).build())
+          .withCleanConfig(HoodieCleanConfig.newBuilder()
+              .withAutoClean(false).build())
+          .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+          .build();
+
+      // Execute clustering twice via separate writer with inline clustering config
+      for (int round = 0; round < 2; round++) {
+        try (SparkRDDWriteClient clusterClient = getHoodieWriteClient(clusterConfig)) {
+          Option<String> clusteringInstant = clusterClient.scheduleClustering(Option.empty());
+          assertTrue(clusteringInstant.isPresent(),
+              "Clustering plan should be created (round " + round + ")");
+          clusterClient.cluster(clusteringInstant.get());
         }
       }
 
-      // Run archival
+      // Run archival to remove old ingestion commits
       client.archive();
 
       // Verify clustering commits carry the schema via rolling metadata
@@ -2073,35 +2080,35 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
 
     HoodieWriteConfig config = getConfigBuilder()
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .compactionSmallFileSize(0).build())
         .withRollingMetadataKeys(schemaKey)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withAutoClean(false)
-            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
-            .retainCommits(2)
+            .retainCommits(1)
             .build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
-            .archiveCommitsWith(4, 6).build())
+            .archiveCommitsWith(10, 12).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .build();
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
-      // Insert + several upserts to create cleanable file versions
-      String firstCommit = WriteClientTestUtils.createNewInstantTime();
-      WriteClientTestUtils.startCommitWithTime(client, firstCommit);
+      // Insert records then upsert to create superseded file versions
+      String firstCommit = client.startCommit();
       List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
       List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
       assertNoWriteErrors(statuses);
 
       for (int i = 0; i < 4; i++) {
-        String commitTime = WriteClientTestUtils.createNewInstantTime();
-        WriteClientTestUtils.startCommitWithTime(client, commitTime);
+        String commitTime = client.startCommit();
         List<HoodieRecord> updates = dataGen.generateUpdates(commitTime, records);
         statuses = client.upsert(jsc.parallelize(updates, 1), commitTime).collect();
         assertNoWriteErrors(statuses);
       }
 
-      // Run clean — should carry rolled-over schema metadata
-      client.clean();
+      // Run clean — retainCommits(1) means old file versions from earlier commits are eligible
+      HoodieCleanMetadata cleanResult = client.clean();
+      assertTrue(cleanResult != null, "Clean should produce metadata (files to clean exist)");
 
       // Verify clean metadata has the schema via rolling metadata
       HoodieTableMetaClient freshMeta = HoodieTableMetaClient.reload(metaClient);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -2033,6 +2033,11 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
       assertTrue(clusteringInstant.isPresent(),
           "Clustering plan should be created (round " + round + ")");
       clusterWriter.cluster(clusteringInstant.get());
+
+      // Insert more data so the next clustering round has new file groups to merge
+      for (int i = 0; i < 3; i++) {
+        insertCommitWithSchema(client, dataGen, 20, TRIP_EXAMPLE_SCHEMA);
+      }
     }
 
     // Run archival to remove old ingestion commits

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -1998,10 +1998,9 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   @Test
   public void testRollingMetadataPreservedAcrossClusteringAfterArchival() throws Exception {
     String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
-    String testPartitionPath = "2016/09/26";
-    dataGen = new HoodieTestDataGenerator(new String[] {testPartitionPath});
+    dataGen = new HoodieTestDataGenerator(new String[] {DEFAULT_FIRST_PARTITION_PATH});
 
-    HoodieWriteConfig config = getConfigBuilder()
+    HoodieWriteConfig writeConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .compactionSmallFileSize(0).build())
         .withRollingMetadataKeys(schemaKey)
@@ -2009,123 +2008,114 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
             .archiveCommitsWith(2, 3).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withAutoClean(false).build())
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .build();
 
-    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
-      // Insert multiple batches so each creates a new file group (smallFileSize=0)
-      List<HoodieRecord> allRecords = new ArrayList<>();
-      for (int i = 0; i < 5; i++) {
-        String commitTime = client.startCommit();
-        List<HoodieRecord> records = dataGen.generateInserts(commitTime, 50);
-        allRecords.addAll(records);
-        List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), commitTime).collect();
-        assertNoWriteErrors(statuses);
-      }
+    SparkRDDWriteClient client = getHoodieWriteClient(writeConfig);
 
-      // Schedule and execute clustering (merges multiple small file groups)
-      HoodieWriteConfig clusterConfig = getConfigBuilder()
-          .withCompactionConfig(HoodieCompactionConfig.newBuilder()
-              .compactionSmallFileSize(0).build())
-          .withClusteringConfig(createClusteringBuilder(true, 1).build())
-          .withRollingMetadataKeys(schemaKey)
-          .withArchivalConfig(HoodieArchivalConfig.newBuilder()
-              .archiveCommitsWith(2, 3).build())
-          .withCleanConfig(HoodieCleanConfig.newBuilder()
-              .withAutoClean(false).build())
-          .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
-          .build();
-
-      // Execute clustering twice via separate writer with inline clustering config
-      for (int round = 0; round < 2; round++) {
-        try (SparkRDDWriteClient clusterClient = getHoodieWriteClient(clusterConfig)) {
-          Option<String> clusteringInstant = clusterClient.scheduleClustering(Option.empty());
-          assertTrue(clusteringInstant.isPresent(),
-              "Clustering plan should be created (round " + round + ")");
-          clusterClient.cluster(clusteringInstant.get());
-        }
-      }
-
-      // Run archival to remove old ingestion commits
-      client.archive();
-
-      // Verify clustering commits carry the schema via rolling metadata
-      HoodieTableMetaClient freshMeta = HoodieTableMetaClient.reload(metaClient);
-      HoodieTimeline completedTimeline = freshMeta.getActiveTimeline()
-          .getCommitsTimeline().filterCompletedInstants();
-
-      boolean foundSchemaInClustering = false;
-      for (HoodieInstant instant : completedTimeline.getInstants()) {
-        HoodieCommitMetadata metadata = completedTimeline.readCommitMetadata(instant);
-        if (metadata.getOperationType() == WriteOperationType.CLUSTER) {
-          String schema = metadata.getMetadata(schemaKey);
-          if (schema != null && !schema.isEmpty()) {
-            foundSchemaInClustering = true;
-            break;
-          }
-        }
-      }
-      assertTrue(foundSchemaInClustering,
-          "Schema should be rolled over into clustering commits via rolling metadata");
-
-      // Verify TableSchemaResolver can find the schema
-      TableSchemaResolver resolver = new TableSchemaResolver(freshMeta);
-      assertTrue(resolver.getTableSchemaIfPresent(false).isPresent(),
-          "TableSchemaResolver should find schema even with clustering-only timeline");
+    // Insert multiple batches — with compactionSmallFileSize(0) each creates new file groups
+    for (int i = 0; i < 5; i++) {
+      insertCommitWithSchema(client, dataGen, 20, TRIP_EXAMPLE_SCHEMA);
     }
+
+    // Schedule and execute clustering with a separate writer (matching existing test patterns)
+    HoodieWriteConfig clusterConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA)
+        .withClusteringConfig(createClusteringBuilder(true, 1).build())
+        .withRollingMetadataKeys(schemaKey)
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder()
+            .archiveCommitsWith(2, 3).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withAutoClean(false).build())
+        .build();
+
+    for (int round = 0; round < 2; round++) {
+      SparkRDDWriteClient clusterWriter = getHoodieWriteClient(clusterConfig);
+      Option<String> clusteringInstant = clusterWriter.scheduleClustering(Option.empty());
+      assertTrue(clusteringInstant.isPresent(),
+          "Clustering plan should be created (round " + round + ")");
+      clusterWriter.cluster(clusteringInstant.get());
+    }
+
+    // Run archival to remove old ingestion commits
+    client.archive();
+
+    // Verify clustering commits carry the schema via rolling metadata
+    HoodieTableMetaClient freshMeta = HoodieTableMetaClient.reload(metaClient);
+    HoodieTimeline completedTimeline = freshMeta.getActiveTimeline()
+        .getCommitsTimeline().filterCompletedInstants();
+
+    boolean foundSchemaInClustering = false;
+    for (HoodieInstant instant : completedTimeline.getInstants()) {
+      HoodieCommitMetadata metadata = completedTimeline.readCommitMetadata(instant);
+      if (metadata.getOperationType() == WriteOperationType.CLUSTER) {
+        String schema = metadata.getMetadata(schemaKey);
+        if (schema != null && !schema.isEmpty()) {
+          foundSchemaInClustering = true;
+          break;
+        }
+      }
+    }
+    assertTrue(foundSchemaInClustering,
+        "Schema should be rolled over into clustering commits via rolling metadata");
+
+    // Verify TableSchemaResolver can find the schema
+    TableSchemaResolver resolver = new TableSchemaResolver(freshMeta);
+    assertTrue(resolver.getTableSchemaIfPresent(false).isPresent(),
+        "TableSchemaResolver should find schema even with clustering-only timeline");
   }
 
   @Test
   public void testRollingMetadataPreservedInCleanCommits() throws Exception {
     String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
+    dataGen = new HoodieTestDataGenerator(new String[] {DEFAULT_FIRST_PARTITION_PATH});
 
-    HoodieWriteConfig config = getConfigBuilder()
+    HoodieWriteConfig config = getConfigBuilder(TRIP_EXAMPLE_SCHEMA)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .compactionSmallFileSize(0).build())
         .withRollingMetadataKeys(schemaKey)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withAutoClean(false)
+            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
             .retainCommits(1)
             .build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
             .archiveCommitsWith(10, 12).build())
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .build();
 
-    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
-      // Insert records then upsert to create superseded file versions
-      String firstCommit = client.startCommit();
-      List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
-      List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
-      assertNoWriteErrors(statuses);
+    SparkRDDWriteClient client = getHoodieWriteClient(config);
 
-      for (int i = 0; i < 4; i++) {
-        String commitTime = client.startCommit();
-        List<HoodieRecord> updates = dataGen.generateUpdates(commitTime, records);
-        statuses = client.upsert(jsc.parallelize(updates, 1), commitTime).collect();
-        assertNoWriteErrors(statuses);
-      }
+    // Insert records
+    String firstCommit = client.startCommit();
+    List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
+    JavaRDD<WriteStatus> firstResult = client.insert(jsc.parallelize(records, 1), firstCommit);
+    client.commit(firstCommit, firstResult);
 
-      // Run clean — retainCommits(1) means old file versions from earlier commits are eligible
-      HoodieCleanMetadata cleanResult = client.clean();
-      assertTrue(cleanResult != null, "Clean should produce metadata (files to clean exist)");
-
-      // Verify clean metadata has the schema via rolling metadata
-      HoodieTableMetaClient freshMeta = HoodieTableMetaClient.reload(metaClient);
-      HoodieTimeline cleanTimeline = freshMeta.getActiveTimeline()
-          .getCleanerTimeline().filterCompletedInstants();
-      assertFalse(cleanTimeline.empty(), "Should have at least one clean instant");
-
-      HoodieInstant lastClean = cleanTimeline.lastInstant().get();
-      HoodieCleanMetadata cleanMetadata = cleanTimeline.readCleanMetadata(lastClean);
-
-      Map<String, String> cleanExtraMetadata = cleanMetadata.getExtraMetadata();
-      assertTrue(cleanExtraMetadata != null, "Clean metadata should have extraMetadata map");
-      assertTrue(cleanExtraMetadata.containsKey(schemaKey),
-          "Clean's extraMetadata should contain rolled-over schema key");
-      assertFalse(cleanExtraMetadata.get(schemaKey).isEmpty(),
-          "Rolled-over schema in clean should be non-empty");
+    // Upsert several times to create superseded file versions
+    for (int i = 0; i < 4; i++) {
+      String commitTime = client.startCommit();
+      List<HoodieRecord> updates = dataGen.generateUpdates(commitTime, records);
+      JavaRDD<WriteStatus> result = client.upsert(jsc.parallelize(updates, 1), commitTime);
+      client.commit(commitTime, result);
     }
+
+    // Run clean — retainCommits(1) means old file versions from earlier commits are eligible
+    HoodieCleanMetadata cleanResult = client.clean();
+    assertTrue(cleanResult != null, "Clean should produce metadata (files to clean exist)");
+
+    // Verify clean metadata has the schema via rolling metadata
+    HoodieTableMetaClient freshMeta = HoodieTableMetaClient.reload(metaClient);
+    HoodieTimeline cleanTimeline = freshMeta.getActiveTimeline()
+        .getCleanerTimeline().filterCompletedInstants();
+    assertFalse(cleanTimeline.empty(), "Should have at least one clean instant");
+
+    HoodieInstant lastClean = cleanTimeline.lastInstant().get();
+    HoodieCleanMetadata cleanMetadata = cleanTimeline.readCleanMetadata(lastClean);
+
+    Map<String, String> cleanExtraMetadata = cleanMetadata.getExtraMetadata();
+    assertTrue(cleanExtraMetadata != null, "Clean metadata should have extraMetadata map");
+    assertTrue(cleanExtraMetadata.containsKey(schemaKey),
+        "Clean's extraMetadata should contain rolled-over schema key");
+    assertFalse(cleanExtraMetadata.get(schemaKey).isEmpty(),
+        "Rolled-over schema in clean should be non-empty");
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.functional;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieClusteringPlan;
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
 import org.apache.hudi.client.BaseHoodieWriteClient;
@@ -55,10 +56,13 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantGenerator;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
+import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -1989,6 +1993,132 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
         throw (Error) throwable;
       }
       throw (HoodieException) throwable;
+    }
+  }
+
+  @Test
+  public void testRollingMetadataPreservedAcrossClusteringAfterArchival() throws Exception {
+    String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
+
+    HoodieClusteringConfig clusteringConfig = createClusteringBuilder(false, 1).build();
+    HoodieWriteConfig config = getConfigBuilder(true)
+        .withClusteringConfig(clusteringConfig)
+        .withRollingMetadataKeys(schemaKey)
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder()
+            .archiveCommitsWith(2, 3).build())
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withAutoClean(false)
+            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .build();
+
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      // Insert + several upserts to create enough commits for archival
+      String firstCommit = client.createNewInstantTime();
+      client.startCommitWithTime(firstCommit);
+      List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
+      List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
+      assertNoWriteErrors(statuses);
+
+      for (int i = 0; i < 5; i++) {
+        String commitTime = client.createNewInstantTime();
+        client.startCommitWithTime(commitTime);
+        List<HoodieRecord> updates = dataGen.generateUpdates(commitTime, records);
+        statuses = client.upsert(jsc.parallelize(updates, 1), commitTime).collect();
+        assertNoWriteErrors(statuses);
+      }
+
+      // Run clustering twice
+      for (int i = 0; i < 2; i++) {
+        client.scheduleClustering(Option.empty());
+        HoodieTableMetaClient reloadedMeta = HoodieTableMetaClient.reload(metaClient);
+        Option<HoodieInstant> pendingClustering = reloadedMeta.getActiveTimeline()
+            .filterPendingClusteringTimeline().lastInstant();
+        if (pendingClustering.isPresent()) {
+          client.cluster(pendingClustering.get().requestedTime());
+        }
+      }
+
+      // Run archival
+      client.archive();
+
+      // Verify clustering commits carry the schema via rolling metadata
+      HoodieTableMetaClient freshMeta = HoodieTableMetaClient.reload(metaClient);
+      HoodieTimeline completedTimeline = freshMeta.getActiveTimeline()
+          .getCommitsTimeline().filterCompletedInstants();
+
+      boolean foundSchemaInClustering = false;
+      for (HoodieInstant instant : completedTimeline.getInstants()) {
+        HoodieCommitMetadata metadata = completedTimeline.readCommitMetadata(instant);
+        if (metadata.getOperationType() == WriteOperationType.CLUSTER) {
+          String schema = metadata.getMetadata(schemaKey);
+          if (schema != null && !schema.isEmpty()) {
+            foundSchemaInClustering = true;
+            break;
+          }
+        }
+      }
+      assertTrue(foundSchemaInClustering,
+          "Schema should be rolled over into clustering commits via rolling metadata");
+
+      // Verify TableSchemaResolver can find the schema
+      TableSchemaResolver resolver = new TableSchemaResolver(freshMeta);
+      assertTrue(resolver.getTableSchemaIfPresent(false).isPresent(),
+          "TableSchemaResolver should find schema even with clustering-only timeline");
+    }
+  }
+
+  @Test
+  public void testRollingMetadataPreservedInCleanCommits() throws Exception {
+    String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
+
+    HoodieWriteConfig config = getConfigBuilder(true)
+        .withRollingMetadataKeys(schemaKey)
+        .withCleanConfig(HoodieCleanConfig.newBuilder()
+            .withAutoClean(false)
+            .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
+            .retainCommits(2)
+            .build())
+        .withArchivalConfig(HoodieArchivalConfig.newBuilder()
+            .archiveCommitsWith(4, 6).build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .build();
+
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      // Insert + several upserts to create cleanable file versions
+      String firstCommit = client.createNewInstantTime();
+      client.startCommitWithTime(firstCommit);
+      List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
+      List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
+      assertNoWriteErrors(statuses);
+
+      for (int i = 0; i < 4; i++) {
+        String commitTime = client.createNewInstantTime();
+        client.startCommitWithTime(commitTime);
+        List<HoodieRecord> updates = dataGen.generateUpdates(commitTime, records);
+        statuses = client.upsert(jsc.parallelize(updates, 1), commitTime).collect();
+        assertNoWriteErrors(statuses);
+      }
+
+      // Run clean — should carry rolled-over schema metadata
+      client.clean();
+
+      // Verify clean metadata has the schema via rolling metadata
+      HoodieTableMetaClient freshMeta = HoodieTableMetaClient.reload(metaClient);
+      HoodieTimeline cleanTimeline = freshMeta.getActiveTimeline()
+          .getCleanerTimeline().filterCompletedInstants();
+      assertFalse(cleanTimeline.empty(), "Should have at least one clean instant");
+
+      HoodieInstant lastClean = cleanTimeline.lastInstant().get();
+      HoodieCleanMetadata cleanMetadata = cleanTimeline.readCleanMetadata(lastClean);
+
+      Map<String, String> cleanExtraMetadata = cleanMetadata.getExtraMetadata();
+      assertTrue(cleanExtraMetadata != null, "Clean metadata should have extraMetadata map");
+      assertTrue(cleanExtraMetadata.containsKey(schemaKey),
+          "Clean's extraMetadata should contain rolled-over schema key");
+      assertFalse(cleanExtraMetadata.get(schemaKey).isEmpty(),
+          "Rolled-over schema in clean should be non-empty");
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -62,7 +62,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.InstantGenerator;
 import org.apache.hudi.common.table.timeline.TimelineFactory;
-import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -2001,7 +2000,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
 
     HoodieClusteringConfig clusteringConfig = createClusteringBuilder(false, 1).build();
-    HoodieWriteConfig config = getConfigBuilder(true)
+    HoodieWriteConfig config = getConfigBuilder()
         .withClusteringConfig(clusteringConfig)
         .withRollingMetadataKeys(schemaKey)
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
@@ -2015,15 +2014,15 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
       // Insert + several upserts to create enough commits for archival
-      String firstCommit = client.createNewInstantTime();
-      client.startCommitWithTime(firstCommit);
+      String firstCommit = WriteClientTestUtils.createNewInstantTime();
+      WriteClientTestUtils.startCommitWithTime(client, firstCommit);
       List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
       List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
       assertNoWriteErrors(statuses);
 
       for (int i = 0; i < 5; i++) {
-        String commitTime = client.createNewInstantTime();
-        client.startCommitWithTime(commitTime);
+        String commitTime = WriteClientTestUtils.createNewInstantTime();
+        WriteClientTestUtils.startCommitWithTime(client, commitTime);
         List<HoodieRecord> updates = dataGen.generateUpdates(commitTime, records);
         statuses = client.upsert(jsc.parallelize(updates, 1), commitTime).collect();
         assertNoWriteErrors(statuses);
@@ -2073,7 +2072,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   public void testRollingMetadataPreservedInCleanCommits() throws Exception {
     String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
 
-    HoodieWriteConfig config = getConfigBuilder(true)
+    HoodieWriteConfig config = getConfigBuilder()
         .withRollingMetadataKeys(schemaKey)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withAutoClean(false)
@@ -2087,15 +2086,15 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
 
     try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
       // Insert + several upserts to create cleanable file versions
-      String firstCommit = client.createNewInstantTime();
-      client.startCommitWithTime(firstCommit);
+      String firstCommit = WriteClientTestUtils.createNewInstantTime();
+      WriteClientTestUtils.startCommitWithTime(client, firstCommit);
       List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
       List<WriteStatus> statuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
       assertNoWriteErrors(statuses);
 
       for (int i = 0; i < 4; i++) {
-        String commitTime = client.createNewInstantTime();
-        client.startCommitWithTime(commitTime);
+        String commitTime = WriteClientTestUtils.createNewInstantTime();
+        WriteClientTestUtils.startCommitWithTime(client, commitTime);
         List<HoodieRecord> updates = dataGen.generateUpdates(commitTime, records);
         statuses = client.upsert(jsc.parallelize(updates, 1), commitTime).collect();
         assertNoWriteErrors(statuses);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.apache.hudi.common.table.checkpoint.CheckpointUtils.HOODIE_INCREMENTAL_SOURCES;
 import static org.apache.hudi.common.table.checkpoint.CheckpointUtils.buildCheckpointFromConfigOverride;
@@ -86,7 +87,7 @@ public class StreamerCheckpointUtils {
     // Fallback: if no checkpoint found in commits timeline, check clean instants' extraMetadata.
     // Clean instants carry rolled-over metadata when rolling metadata is configured.
     if (!checkpoint.isPresent()) {
-      checkpoint = getCheckpointFromCleanInstants(metaClient, streamerConfig, props);
+      checkpoint = getCheckpointFromCleanInstants(metaClient);
     }
     // If there is only streamer config, extract the checkpoint directly.
     checkpoint = useCkpFromOverrideConfigIfAny(streamerConfig, props, checkpoint);
@@ -245,8 +246,7 @@ public class StreamerCheckpointUtils {
    * After archival removes all ingestion commits, clean instants may be the only source
    * of checkpoint metadata on the active timeline.
    */
-  private static Option<Checkpoint> getCheckpointFromCleanInstants(
-      HoodieTableMetaClient metaClient, HoodieStreamer.Config streamerConfig, TypedProperties props) {
+  private static Option<Checkpoint> getCheckpointFromCleanInstants(HoodieTableMetaClient metaClient) {
     HoodieTimeline cleanerTimeline = metaClient.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
     if (cleanerTimeline.empty()) {
       return Option.empty();
@@ -256,7 +256,7 @@ public class StreamerCheckpointUtils {
             .map(instant -> {
               try {
                 HoodieCleanMetadata cleanMetadata = cleanerTimeline.readCleanMetadata(instant);
-                java.util.Map<String, String> extraMetadata = cleanMetadata.getExtraMetadata();
+                Map<String, String> extraMetadata = cleanMetadata.getExtraMetadata();
                 if (extraMetadata == null) {
                   return null;
                 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
@@ -240,8 +240,10 @@ public class StreamerCheckpointUtils {
 
   /**
    * Fallback: search clean instants' extraMetadata for checkpoint keys.
-   * This is used when no commit on the commits timeline has valid checkpoint info,
-   * e.g., after archival removes all ingestion commits and only clean instants remain.
+   * This covers the case where rolling metadata was not configured on other commit types
+   * (e.g., clustering, compaction), so checkpoint info was only rolled into clean commits.
+   * After archival removes all ingestion commits, clean instants may be the only source
+   * of checkpoint metadata on the active timeline.
    */
   private static Option<Checkpoint> getCheckpointFromCleanInstants(
       HoodieTableMetaClient metaClient, HoodieStreamer.Config streamerConfig, TypedProperties props) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.utilities.streamer;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -81,6 +82,11 @@ public class StreamerCheckpointUtils {
     // checkpoint resolution logic to resolve conflicting configurations.
     if (commitsTimelineOpt.isPresent()) {
       checkpoint = resolveCheckpointBetweenConfigAndPrevCommit(commitsTimelineOpt.get(), streamerConfig, props);
+    }
+    // Fallback: if no checkpoint found in commits timeline, check clean instants' extraMetadata.
+    // Clean instants carry rolled-over metadata when rolling metadata is configured.
+    if (!checkpoint.isPresent()) {
+      checkpoint = getCheckpointFromCleanInstants(metaClient, streamerConfig, props);
     }
     // If there is only streamer config, extract the checkpoint directly.
     checkpoint = useCkpFromOverrideConfigIfAny(streamerConfig, props, checkpoint);
@@ -230,5 +236,47 @@ public class StreamerCheckpointUtils {
         throw new HoodieIOException("failed to get latest instant with ValidCheckpointInfo", e);
       }
     }).orElse(Option.empty());
+  }
+
+  /**
+   * Fallback: search clean instants' extraMetadata for checkpoint keys.
+   * This is used when no commit on the commits timeline has valid checkpoint info,
+   * e.g., after archival removes all ingestion commits and only clean instants remain.
+   */
+  private static Option<Checkpoint> getCheckpointFromCleanInstants(
+      HoodieTableMetaClient metaClient, HoodieStreamer.Config streamerConfig, TypedProperties props) {
+    HoodieTimeline cleanerTimeline = metaClient.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
+    if (cleanerTimeline.empty()) {
+      return Option.empty();
+    }
+    return Option.fromJavaOptional(
+        cleanerTimeline.getReverseOrderedInstants()
+            .map(instant -> {
+              try {
+                HoodieCleanMetadata cleanMetadata = cleanerTimeline.readCleanMetadata(instant);
+                java.util.Map<String, String> extraMetadata = cleanMetadata.getExtraMetadata();
+                if (extraMetadata == null) {
+                  return null;
+                }
+                HoodieCommitMetadata facadeMetadata = new HoodieCommitMetadata();
+                for (java.util.Map.Entry<String, String> entry : extraMetadata.entrySet()) {
+                  facadeMetadata.addMetadata(entry.getKey(), entry.getValue());
+                }
+                if (!StringUtils.isNullOrEmpty(facadeMetadata.getMetadata(HoodieStreamer.CHECKPOINT_KEY))
+                    || !StringUtils.isNullOrEmpty(facadeMetadata.getMetadata(HoodieStreamer.CHECKPOINT_RESET_KEY))
+                    || !StringUtils.isNullOrEmpty(facadeMetadata.getMetadata(STREAMER_CHECKPOINT_KEY_V2))
+                    || !StringUtils.isNullOrEmpty(facadeMetadata.getMetadata(STREAMER_CHECKPOINT_RESET_KEY_V2))) {
+                  Checkpoint checkpoint = CheckpointUtils.getCheckpoint(facadeMetadata);
+                  if (!StringUtils.isNullOrEmpty(checkpoint.getCheckpointKey())) {
+                    return checkpoint;
+                  }
+                }
+              } catch (IOException e) {
+                throw new HoodieIOException("Failed to read clean metadata for instant " + instant.requestedTime(), e);
+              }
+              return null;
+            })
+            .filter(cp -> cp != null)
+            .findFirst());
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
@@ -86,7 +86,8 @@ public class StreamerCheckpointUtils {
     }
     // Fallback: if no checkpoint found in commits timeline, check clean instants' extraMetadata.
     // Clean instants carry rolled-over metadata when rolling metadata is configured.
-    if (!checkpoint.isPresent()) {
+    // Skip this fallback when --ignore-checkpoint is set, since the user explicitly wants a fresh start.
+    if (!checkpoint.isPresent() && streamerConfig.ignoreCheckpoint == null) {
       checkpoint = getCheckpointFromCleanInstants(metaClient);
     }
     // If there is only streamer config, extract the checkpoint directly.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamerCheckpointUtils.java
@@ -260,15 +260,8 @@ public class StreamerCheckpointUtils {
                 if (extraMetadata == null) {
                   return null;
                 }
-                HoodieCommitMetadata facadeMetadata = new HoodieCommitMetadata();
-                for (java.util.Map.Entry<String, String> entry : extraMetadata.entrySet()) {
-                  facadeMetadata.addMetadata(entry.getKey(), entry.getValue());
-                }
-                if (!StringUtils.isNullOrEmpty(facadeMetadata.getMetadata(HoodieStreamer.CHECKPOINT_KEY))
-                    || !StringUtils.isNullOrEmpty(facadeMetadata.getMetadata(HoodieStreamer.CHECKPOINT_RESET_KEY))
-                    || !StringUtils.isNullOrEmpty(facadeMetadata.getMetadata(STREAMER_CHECKPOINT_KEY_V2))
-                    || !StringUtils.isNullOrEmpty(facadeMetadata.getMetadata(STREAMER_CHECKPOINT_RESET_KEY_V2))) {
-                  Checkpoint checkpoint = CheckpointUtils.getCheckpoint(facadeMetadata);
+                if (CheckpointUtils.hasCheckpointKeys(extraMetadata)) {
+                  Checkpoint checkpoint = CheckpointUtils.getCheckpoint(extraMetadata);
                   if (!StringUtils.isNullOrEmpty(checkpoint.getCheckpointKey())) {
                     return checkpoint;
                   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

It becomes possible for the active timeline to contain **only non-ingestion instants** (clustering, delete_partition, clean) after a backfill + archival cycle. In addition, currently the metadata roll-over does not handle preserving schema. This breaks readers/writers that rely on finding schema in ingestion commit metadata

This PR ensures that **schema and checkpoint metadata are always discoverable** on the active timeline, regardless of which commit types survive archival.

### Summary and Changelog

Extends the rolling extra metadata feature to **clean operations** and adds **fallback lookup paths** so that schema and checkpoint metadata can always be resolved — even when the active timeline has no ingestion commits and commit roll-over is not set for clustering.

**Changes:**

- **`BaseHoodieClient`**: Refactored `mergeRollingMetadata` to extract a reusable `findRollingMetadataFromTimeline()` utility that searches both the commits timeline and the cleaner timeline. Empty string values are now treated as "missing" for rolling purposes.
- **`CleanActionExecutor`**: `runClean()` now calls `findRollingMetadataFromTimeline()` to populate `HoodieCleanMetadata.extraMetadata` with rolled-over keys (e.g., schema, checkpoint).
- **`TableSchemaResolver`**: Added two fallback methods in `getTableSchemaInternal`:
  - `getTableSchemaFromAnyCommitMetadata` — uses the new `getLastCommitMetadataWithSchema()` (no `canUpdateSchema` filter) to find schema in clustering/delete_partition commits.
  - `getTableSchemaFromCleanMetadata` — searches clean instants' `extraMetadata` for a rolled-over schema.
- **`HoodieActiveTimeline` / `ActiveTimelineV1` / `ActiveTimelineV2`**: Added `getLastCommitMetadataWithSchema()` which returns the latest commit with a non-empty schema, regardless of `WriteOperationType`.
- **`TimelineUtils`**: `getExtraMetadataFromLatest` and `getExtraMetadataFromLatestIncludeClustering` now fall back to searching clean instants' `extraMetadata` when the key is not found in completed commits.
- **`StreamerCheckpointUtils`**: `resolveCheckpointToResumeFrom` now falls back to `getCheckpointFromCleanInstants` when no checkpoint is found on the commits timeline.
- **Error handling**: All fallback paths re-throw `IOException` as `HoodieIOException` instead of suppressing it.

**Tests:**

- **`TestTimelineUtils`**: 6 new unit tests covering clean instant fallback for `getExtraMetadataFromLatest`, `getExtraMetadataFromLatestIncludeClustering`, commit-over-clean priority, missing key in clean, and `getLastCommitMetadataWithSchema` behavior.
- **`TestHoodieClientOnCopyOnWriteStorage`**: 2 new functional tests:
  - `testRollingMetadataPreservedAcrossClusteringAfterArchival` — verifies schema is rolled into clustering commits and `TableSchemaResolver` finds it after archival removes ingestion commits.
  - `testRollingMetadataPreservedInCleanCommits` — verifies clean commits contain rolled-over schema in `extraMetadata`.

### Impact

- **No public API changes.** All changes are internal to metadata propagation and lookup logic.
- Existing behavior is unchanged when rolling metadata is not configured — all new code paths are additive fallbacks.
- When `hoodie.write.rolling.metadata.keys` includes `schema` or checkpoint keys, non-ingestion operations (clustering, delete_partition, clean) will now carry those values forward, making the table resilient to archival of ingestion commits.

### Risk Level

Low — The changes are additive fallback paths that only activate when existing lookups return empty. The core write path is unchanged; only the metadata propagation in `CleanActionExecutor` and the lookup fallbacks in `TableSchemaResolver`, `TimelineUtils`, and `StreamerCheckpointUtils` are new. All changes are covered by unit and functional tests.

### Documentation Update

None — no new configs are introduced. The existing `hoodie.write.rolling.metadata.keys` and `hoodie.write.rolling.metadata.timeline.lookback.commits` configs now apply to clean operations as well, which is a natural extension of their documented behavior.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable