### PR TITLE
fix(vector): Register VECTOR HMS column as BINARY on Spark CREATE

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{isUsingHiveCatalog, isUsi
 import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand.validateTableSchema
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
 import org.apache.spark.sql.internal.StaticSQLConf.SCHEMA_STRING_LENGTH_THRESHOLD
-import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, MapType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, MapType, Metadata, StructField, StructType}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -254,7 +254,7 @@ object CreateHoodieTableCommand extends SparkAdapterSupport {
    *   - VECTOR (Hudi custom logical type, exposed in Spark as ArrayType with `hudi_type`
    *     metadata) -> `BinaryType`, matching its on-disk fixed_len_byte_array layout
    *     (RFC-99). Field metadata is preserved so the full logical schema is still
-   *     serialised into `spark.sql.sources.schema.*` TBLPROPERTIES by the caller.
+   *     serialized into `spark.sql.sources.schema.*` TBLPROPERTIES by the caller.
    *
    * Recurses into nested StructType, ArrayType, and MapType so variants embedded in
    * complex types (e.g. `STRUCT<a: VARIANT>`, `ARRAY<VARIANT>`, `MAP<STRING, VARIANT>`)
@@ -264,7 +264,8 @@ object CreateHoodieTableCommand extends SparkAdapterSupport {
     toHiveCompatibleType(schema).asInstanceOf[StructType]
   }
 
-  private def toHiveCompatibleType(dataType: DataType): DataType = dataType match {
+  private def toHiveCompatibleType(dataType: DataType,
+                                   metadata: Metadata = Metadata.empty): DataType = dataType match {
     case dt if sparkAdapter.isVariantType(dt) =>
       // Canonical field order (metadata, value) matches the Parquet spec and Iceberg convention,
       // mirroring HoodieSchema.createVariant().
@@ -272,14 +273,12 @@ object CreateHoodieTableCommand extends SparkAdapterSupport {
         StructField(HoodieSchema.Variant.VARIANT_METADATA_FIELD, BinaryType, nullable = false),
         StructField(HoodieSchema.Variant.VARIANT_VALUE_FIELD, BinaryType, nullable = false)
       ))
+    case _: ArrayType if isVectorType(metadata) =>
+      // VECTOR is exposed in Spark as ArrayType(FloatType) with hudi_type metadata.
+      // HMS must store the column as BINARY matching the on-disk fixed_len_byte_array (RFC-99).
+      BinaryType
     case st: StructType =>
-      StructType(st.fields.map { f =>
-        if (isVectorField(f)) {
-          f.copy(dataType = BinaryType)
-        } else {
-          f.copy(dataType = toHiveCompatibleType(f.dataType))
-        }
-      })
+      StructType(st.fields.map(f => f.copy(dataType = toHiveCompatibleType(f.dataType, f.metadata))))
     case at: ArrayType =>
       at.copy(elementType = toHiveCompatibleType(at.elementType))
     case mt: MapType =>
@@ -289,13 +288,11 @@ object CreateHoodieTableCommand extends SparkAdapterSupport {
     case other => other
   }
 
-  private def isVectorField(field: StructField): Boolean = {
-    // Mirrors the detection pattern in HoodieSparkSchemaConverters.toHoodieTypeNested. The
-    // TYPE_METADATA_FIELD is documented to only hold custom-logical-type descriptors
-    // (VECTOR, BLOB, VARIANT), so parseTypeDescriptor is safe once the key is present.
-    field.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+  /** Mirrors the detection in HoodieSparkSchemaConverters.toHoodieTypeNested. */
+  private def isVectorType(metadata: Metadata): Boolean = {
+    metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
       HoodieSchema.parseTypeDescriptor(
-        field.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR
+        metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR
   }
 
   // This code is forked from org.apache.spark.sql.hive.HiveExternalCatalog#tableMetaToTableProps

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hudi.command
 
 import org.apache.hudi.{DataSourceWriteOptions, SparkAdapterSupport}
 import org.apache.hudi.common.model.HoodieTableType
-import org.apache.hudi.common.schema.HoodieSchema
+import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.util.ConfigUtils
 import org.apache.hudi.exception.{HoodieException, HoodieValidationException}
@@ -249,7 +249,13 @@ object CreateHoodieTableCommand extends SparkAdapterSupport {
 
   /**
    * Converts Spark DataTypes that Hive doesn't support to their physical representations.
-   * Currently handles VariantType (Spark 4.0+) -> `struct<metadata:binary, value:binary>`.
+   * Currently handles:
+   *   - VariantType (Spark 4.0+) -> `struct<metadata:binary, value:binary>`
+   *   - VECTOR (Hudi custom logical type, exposed in Spark as ArrayType with `hudi_type`
+   *     metadata) -> `BinaryType`, matching its on-disk fixed_len_byte_array layout
+   *     (RFC-99). Field metadata is preserved so the full logical schema is still
+   *     serialised into `spark.sql.sources.schema.*` TBLPROPERTIES by the caller.
+   *
    * Recurses into nested StructType, ArrayType, and MapType so variants embedded in
    * complex types (e.g. `STRUCT<a: VARIANT>`, `ARRAY<VARIANT>`, `MAP<STRING, VARIANT>`)
    * are also converted.
@@ -267,7 +273,13 @@ object CreateHoodieTableCommand extends SparkAdapterSupport {
         StructField(HoodieSchema.Variant.VARIANT_VALUE_FIELD, BinaryType, nullable = false)
       ))
     case st: StructType =>
-      StructType(st.fields.map(f => f.copy(dataType = toHiveCompatibleType(f.dataType))))
+      StructType(st.fields.map { f =>
+        if (isVectorField(f)) {
+          f.copy(dataType = BinaryType)
+        } else {
+          f.copy(dataType = toHiveCompatibleType(f.dataType))
+        }
+      })
     case at: ArrayType =>
       at.copy(elementType = toHiveCompatibleType(at.elementType))
     case mt: MapType =>
@@ -275,6 +287,15 @@ object CreateHoodieTableCommand extends SparkAdapterSupport {
         keyType = toHiveCompatibleType(mt.keyType),
         valueType = toHiveCompatibleType(mt.valueType))
     case other => other
+  }
+
+  private def isVectorField(field: StructField): Boolean = {
+    // Mirrors the detection pattern in HoodieSparkSchemaConverters.toHoodieTypeNested. The
+    // TYPE_METADATA_FIELD is documented to only hold custom-logical-type descriptors
+    // (VECTOR, BLOB, VARIANT), so parseTypeDescriptor is safe once the key is present.
+    field.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+      HoodieSchema.parseTypeDescriptor(
+        field.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR
   }
 
   // This code is forked from org.apache.spark.sql.hive.HiveExternalCatalog#tableMetaToTableProps

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, HoodieCatalogTable}
 import org.apache.spark.sql.functions.{col, concat, expr, lit}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
+import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.{disableComplexKeygenValidation, getLastCommitMetadata}
 import org.apache.spark.sql.types._
@@ -2286,5 +2287,50 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
       assertTrue(embeddingField.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD))
       assertEquals(ArrayType(FloatType, containsNull = false), embeddingField.dataType)
     }
+  }
+
+  test("toHiveCompatibleSchema rewrites VECTOR field to BinaryType and preserves metadata") {
+    // VECTOR's on-disk layout is Parquet fixed_len_byte_array (RFC-99); the HMS column must be
+    // BINARY so Hive-side Parquet reads match the physical type. The logical ArrayType(FloatType)
+    // view is preserved in spark.sql.sources.schema.* TBLPROPERTIES via the retained metadata.
+    val vectorMetadata = new MetadataBuilder()
+      .putString(HoodieSchema.TYPE_METADATA_FIELD, "VECTOR(3)")
+      .putString("comment", "embedding")
+      .build()
+
+    val schema = StructType(Seq(
+      StructField("id", LongType, nullable = false),
+      StructField("name", StringType),
+      StructField(
+        "embedding",
+        ArrayType(FloatType, containsNull = false),
+        nullable = true,
+        metadata = vectorMetadata),
+      StructField("dt", StringType)))
+
+    val hiveSchema = CreateHoodieTableCommand.toHiveCompatibleSchema(schema)
+
+    val embedding = hiveSchema("embedding")
+    assertEquals(BinaryType, embedding.dataType)
+    assertEquals("binary", embedding.dataType.catalogString)
+    assertTrue(embedding.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD))
+    assertEquals("VECTOR(3)", embedding.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+    assertEquals("embedding", embedding.metadata.getString("comment"))
+
+    // Non-VECTOR fields must pass through unchanged.
+    assertEquals(LongType, hiveSchema("id").dataType)
+    assertEquals(StringType, hiveSchema("name").dataType)
+    assertEquals(StringType, hiveSchema("dt").dataType)
+  }
+
+  test("toHiveCompatibleSchema leaves plain ArrayType(FloatType) without VECTOR marker alone") {
+    // Guard against accidentally rewriting any ArrayType(FloatType). Only fields carrying the
+    // VECTOR descriptor in hudi_type metadata should be converted to BinaryType.
+    val schema = StructType(Seq(
+      StructField("id", LongType, nullable = false),
+      StructField("floats", ArrayType(FloatType, containsNull = false))))
+
+    val hiveSchema = CreateHoodieTableCommand.toHiveCompatibleSchema(schema)
+    assertEquals(ArrayType(FloatType, containsNull = false), hiveSchema("floats").dataType)
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes: #18541

Hive sync of a Hudi VECTOR table fails at HMS with:

`columns have types incompatible with the existing columns` on the VECTOR field.

Root cause:

- Spark's Hive-backed catalog pre-registers the table using the Spark logical StructType.
- Hudi exposes VECTOR as `ArrayType(FloatType)` with `hudi_type` metadata, so HMS stores the column as `array<float>`.
- Hudi Hive sync then tries to ALTER the column to `binary` (the correct Parquet `fixed_len_byte_array` mapping per RFC-99). HMS rejects the positional type change.

### Summary and Changelog

Register the VECTOR column as `binary` at CREATE time so HMS holds the correct physical type upfront. No ALTER, no sync diff.

Changes:

- `CreateHoodieTableCommand.toHiveCompatibleType`: StructType branch now rewrites any VECTOR-marked field to `BinaryType`. Field metadata is preserved.
- New `isVectorField` helper. Detection mirrors `HoodieSparkSchemaConverters.toHoodieTypeNested` (`hudi_type` metadata + `HoodieSchema.parseTypeDescriptor` == VECTOR).
- Spark reads unaffected. The full logical StructType (ArrayType(FloatType)) is still written into `spark.sql.sources.schema.*` TBLPROPERTIES by the unchanged caller.

Tests (TestCreateTable):

- VECTOR field is rewritten to BinaryType; metadata including `hudi_type` and `comment` is preserved; non-VECTOR fields pass through.
- Plain `ArrayType(FloatType)` without the VECTOR marker is left alone.

### Impact

- User-facing: `CREATE TABLE ... (col VECTOR(n))` via Spark SQL now flows through Hive sync without the HMS type-mismatch error. No API change.
- Storage format: no change. On-disk layout stays `fixed_len_byte_array` per RFC-99.
- Performance: none. Only the CREATE path is touched.

### Risk Level

Low.

- Localised to one StructType rewrite rule in `toHiveCompatibleType`.
- Guarded by `isVectorField`; plain `ArrayType(FloatType)` is unaffected (covered by the second test).
- No format change.
- Unit tests cover both the rewrite and the guard.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
