### PR TITLE
chore(docker): bump Hive 3.1.3 to 4.0.1 for Spark 4.0.1 compose stack

### DIFF
--- a/docker/compose/docker-compose_hadoop340_hive401_spark401_amd64.yml
+++ b/docker/compose/docker-compose_hadoop340_hive401_spark401_amd64.yml
@@ -20,11 +20,11 @@ services:
     hostname: namenode
     container_name: namenode
     environment:
-      - CLUSTER_NAME=hudi_hadoop340_hive313_spark401
+      - CLUSTER_NAME=hudi_hadoop340_hive401_spark401
     ports:
-      - "50070:50070"
-      - "8020:8020"
-      - "9870:9870"
+      - "8020:8020" # HDFS NameNode IPC
+      - "9000:9000" # HDFS NameNode Client
+      - "9870:9870" # HDFS NameNode Web UI
     env_file:
       - ./hadoop.env
     healthcheck:
@@ -38,7 +38,7 @@ services:
     container_name: datanode1
     hostname: datanode1
     environment:
-      - CLUSTER_NAME=hudi_hadoop340_hive313_spark401
+      - CLUSTER_NAME=hudi_hadoop340_hive401_spark401
     env_file:
       - ./hadoop.env
     ports:
@@ -61,7 +61,7 @@ services:
     hostname: historyserver
     container_name: historyserver
     environment:
-      - CLUSTER_NAME=hudi_hadoop340_hive313_spark401
+      - CLUSTER_NAME=hudi_hadoop340_hive401_spark401
     depends_on:
       - "namenode"
     links:
@@ -86,7 +86,7 @@ services:
     container_name: hive-metastore-postgresql
 
   hivemetastore:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1:latest
     hostname: hivemetastore
     container_name: hivemetastore
     links:
@@ -94,7 +94,10 @@ services:
       - "namenode"
     env_file:
       - ./hadoop.env
-    command: /opt/hive/bin/hive --service metastore
+    command:
+      - /bin/bash
+      - -c
+      - "/opt/hive/bin/schematool -dbType postgres -upgradeSchema -verbose || true; /opt/hive/bin/hive --service metastore"
     environment:
       - "SERVICE_PRECONDITION=namenode:9870 hive-metastore-postgresql:5432"
     ports:
@@ -109,7 +112,7 @@ services:
       - "namenode"
 
   hiveserver:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1:latest
     hostname: hiveserver
     container_name: hiveserver
     env_file:
@@ -148,7 +151,7 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
 
   sparkmaster:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3-sparkmaster_4.0.1:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1-sparkmaster_4.0.1:latest
     hostname: sparkmaster
     container_name: sparkmaster
     env_file:
@@ -169,7 +172,7 @@ services:
       - "namenode"
 
   spark-worker-1:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3-sparkworker_4.0.1:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1-sparkworker_4.0.1:latest
     hostname: spark-worker-1
     container_name: spark-worker-1
     env_file:
@@ -187,7 +190,7 @@ services:
       - "namenode"
 
   adhoc-1:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3-sparkadhoc_4.0.1:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1-sparkadhoc_4.0.1:latest
     hostname: adhoc-1
     container_name: adhoc-1
     env_file:
@@ -207,7 +210,7 @@ services:
       - ${HUDI_WS}:/var/hoodie/ws
 
   adhoc-2:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3-sparkadhoc_4.0.1:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1-sparkadhoc_4.0.1:latest
     hostname: adhoc-2
     container_name: adhoc-2
     env_file:

--- a/docker/compose/docker-compose_hadoop340_hive401_spark401_arm64.yml
+++ b/docker/compose/docker-compose_hadoop340_hive401_spark401_arm64.yml
@@ -20,11 +20,11 @@ services:
     hostname: namenode
     container_name: namenode
     environment:
-      - CLUSTER_NAME=hudi_hadoop340_hive313_spark401
+      - CLUSTER_NAME=hudi_hadoop340_hive401_spark401
     ports:
-      - "50070:50070"
-      - "8020:8020"
-      - "9870:9870"
+      - "8020:8020" # HDFS NameNode IPC
+      - "9000:9000" # HDFS NameNode Client
+      - "9870:9870" # HDFS NameNode Web UI
     env_file:
       - ./hadoop.env
     healthcheck:
@@ -38,7 +38,7 @@ services:
     container_name: datanode1
     hostname: datanode1
     environment:
-      - CLUSTER_NAME=hudi_hadoop340_hive313_spark401
+      - CLUSTER_NAME=hudi_hadoop340_hive401_spark401
     env_file:
       - ./hadoop.env
     ports:
@@ -61,7 +61,7 @@ services:
     hostname: historyserver
     container_name: historyserver
     environment:
-      - CLUSTER_NAME=hudi_hadoop340_hive313_spark401
+      - CLUSTER_NAME=hudi_hadoop340_hive401_spark401
     depends_on:
       - "namenode"
     links:
@@ -86,7 +86,7 @@ services:
     container_name: hive-metastore-postgresql
 
   hivemetastore:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1:latest
     hostname: hivemetastore
     container_name: hivemetastore
     links:
@@ -94,7 +94,10 @@ services:
       - "namenode"
     env_file:
       - ./hadoop.env
-    command: /opt/hive/bin/hive --service metastore
+    command:
+      - /bin/bash
+      - -c
+      - "/opt/hive/bin/schematool -dbType postgres -upgradeSchema -verbose || true; /opt/hive/bin/hive --service metastore"
     environment:
       - "SERVICE_PRECONDITION=namenode:9870 hive-metastore-postgresql:5432"
     ports:
@@ -109,7 +112,7 @@ services:
       - "namenode"
 
   hiveserver:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1:latest
     hostname: hiveserver
     container_name: hiveserver
     env_file:
@@ -148,7 +151,7 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
 
   sparkmaster:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3-sparkmaster_4.0.1:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1-sparkmaster_4.0.1:latest
     hostname: sparkmaster
     container_name: sparkmaster
     env_file:
@@ -169,7 +172,7 @@ services:
       - "namenode"
 
   spark-worker-1:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3-sparkworker_4.0.1:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1-sparkworker_4.0.1:latest
     hostname: spark-worker-1
     container_name: spark-worker-1
     env_file:
@@ -187,7 +190,7 @@ services:
       - "namenode"
 
   adhoc-1:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3-sparkadhoc_4.0.1:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1-sparkadhoc_4.0.1:latest
     hostname: adhoc-1
     container_name: adhoc-1
     env_file:
@@ -207,7 +210,7 @@ services:
       - ${HUDI_WS}:/var/hoodie/ws
 
   adhoc-2:
-    image: apachehudi/hudi-hadoop_3.4.0-hive_3.1.3-sparkadhoc_4.0.1:latest
+    image: apachehudi/hudi-hadoop_3.4.0-hive_4.0.1-sparkadhoc_4.0.1:latest
     hostname: adhoc-2
     container_name: adhoc-2
     env_file:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Spark 4.0.1 docker-compose stack is wired to Hive 3.1.3, which is not JDK 17 compatible:

- `SessionState.<init>:413` casts the system classloader to `URLClassLoader`.
- On JDK 17, this throws `ClassCastException: AppClassLoader cannot be cast to URLClassLoader`.
- The same bug kills HS2's `applyAuthorizationConfigPolicy`, so the server never binds to port 10000.
- Spark 4.0.1 runs on JDK 17 only; there is no downgrade path.

Hive 4.0.0+ fixed this via HIVE-22915. Move the Spark 4 stack to Hive 4.0.1 (current stable).

### Summary and Changelog

Scoped to the Spark 4.0.1 stack only. Spark 3.5 / Hive 2.3.10 is untouched.

- Rename `docker-compose_hadoop340_hive313_spark401_{amd64,arm64}.yml` to `_hive401_spark401_`.
- Bump 6 image refs per file: `hivemetastore`, `hiveserver`, `sparkmaster`, `spark-worker-1`, `adhoc-1`, `adhoc-2` → `apachehudi/hudi-hadoop_3.4.0-hive_4.0.1*`.
- Bump 3 `CLUSTER_NAME` entries per file to `hudi_hadoop340_hive401_spark401`.
- `hivemetastore` command now runs `schematool -dbType postgres -upgradeSchema -verbose || true` before `hive --service metastore`. This upgrades the pre-seeded Hive 3.1 schema on `bde2020/hive-metastore-postgresql:3.1.0` to Hive 4.0 in place. `|| true` keeps restarts idempotent.
- `.github/workflows/bot.yml`: update the `spark4.0` matrix row (`composePrefix`, `sparkAdhocImage`).
- `ITTestBaseTestcontainers.java`: update `DEFAULT_COMPOSE_PREFIX`.


Out of scope:

- Publishing the new `apachehudi/hudi-hadoop_3.4.0-hive_4.0.1*` image set to Docker Hub.
- Root `pom.xml` `<hive.version>`: Hudi jars continue to compile against Hive 2.3.10 and are mounted cross-version into the Hive 4 container via `hive.aux.jars.path` (same pattern already in use for the Hive 2.3.10 stack).

### Impact

- No public API or user-facing behavior change in Hudi itself.
- CI: the `spark4.0` integration job now pulls the new image tags. CI will fail for this job until the images are published to Docker Hub.
- Local dev: anyone running the Spark 4 compose stack locally will need to pull the new images once published.

### Risk Level

Medium.

- The Hudi MR bundle is built against Hive 2.3.10 and mounted into HS2 via `hive.aux.jars.path`. InputFormat and SerDe APIs are stable across Hive 2-4, but a class the bundle transitively references that Hive 4 removed would surface as `NoClassDefFoundError` at query time. The cross-version mount pattern is already in production use elsewhere.
- Beeline output formatting may differ slightly between Hive versions. Existing test assertions are substring checks on row content (column names, partition values), which survive formatting differences.

Mitigation: verify end-to-end once the Hive 4 image set is published:

1. `docker compose -f docker-compose_hadoop340_hive401_spark401_arm64.yml up` and confirm `hiveserver` logs show a clean thrift bind on `:10000` with no `URLClassLoader` ClassCastException.
2. `docker exec hivemetastore schematool -dbType postgres -info` reports `Hive distribution version: 4.0.1`.
3. Run `ITTestCustomTypeHiveSync` on the `spark4.0` matrix row end-to-end.
4. Run `ITTestCustomTypeHiveSync` with the Spark 3.5.3 compose override as a no-op regression check.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable