### PR TITLE
chore(spark): bump spark4.version to 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <httpclient.version>4.5.14</httpclient.version>
     <spark.version>${spark3.version}</spark.version>
     <spark3.version>${spark35.version}</spark3.version>
-    <spark4.version>4.0.1</spark4.version>
+    <spark4.version>4.0.2</spark4.version>
     <sparkbundle.version></sparkbundle.version>
     <flink2.1.version>2.1.1</flink2.1.version>
     <flink2.0.version>2.0.0</flink2.0.version>
@@ -173,7 +173,7 @@
     <spark33.version>3.3.4</spark33.version>
     <spark34.version>3.4.3</spark34.version>
     <spark35.version>3.5.5</spark35.version>
-    <spark40.version>4.0.1</spark40.version>
+    <spark40.version>4.0.2</spark40.version>
     <hudi.spark.module>hudi-spark3.5.x</hudi.spark.module>
     <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
     <avro.version>1.11.4</avro.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Bumps the Spark 4 line from 4.0.1 to 4.0.2 to pick up the latest upstream patch release.

### Summary and Changelog

- `pom.xml`: `<spark4.version>` and `<spark40.version>` moved `4.0.1` -> `4.0.2`.

Both properties feed the `spark4.0` Maven profile, so all `hudi-spark4.0.x` / `hudi-spark4-common` compile + test paths and the matrix jobs `test-spark-java17-java-tests-part[1-5]` in `.github/workflows/bot.yml` now run against 4.0.2.

Bundle-validation workflow paths (`validate-bundles-spark4*`) are intentionally left alone. They still execute inside a Docker image that bakes in Spark 4.0.0 via `IMAGE_TAG=flink1200hive313spark400scala213`. Moving that requires publishing a new `apachehudi/hudi-ci-bundle-validation-base` tag on Docker Hub and is out of scope here.

### Impact

No public API or user-facing change. Bundles will be built against Spark 4.0.2 instead of 4.0.1.

### Risk Level

low

Property-only change. The `spark4.0` profile resolves 4.0.2 artifacts from Maven Central. Covered by the existing `test-spark-java17-java-tests-part[1-5]` matrix.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
