### PR TITLE
fix: Parquet small-precision decimals decode ClassCastException

### DIFF
--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/ParquetDecimalVector.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/ParquetDecimalVector.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,37 +18,222 @@
 
 package org.apache.hudi.table.format.cow.vector;
 
+import org.apache.flink.formats.parquet.utils.ParquetSchemaConverter;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.columnar.vector.BytesColumnVector;
 import org.apache.flink.table.data.columnar.vector.ColumnVector;
 import org.apache.flink.table.data.columnar.vector.DecimalColumnVector;
+import org.apache.flink.table.data.columnar.vector.Dictionary;
+import org.apache.flink.table.data.columnar.vector.IntColumnVector;
+import org.apache.flink.table.data.columnar.vector.LongColumnVector;
+import org.apache.flink.table.data.columnar.vector.writable.WritableBytesVector;
+import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
+import org.apache.flink.table.data.columnar.vector.writable.WritableIntVector;
+import org.apache.flink.table.data.columnar.vector.writable.WritableLongVector;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
- * Parquet write decimal as int32 and int64 and binary, this class wrap the real vector to
- * provide {@link DecimalColumnVector} interface.
+ * Parquet writes decimals as INT32, INT64, or BINARY/FIXED_LEN_BYTE_ARRAY depending on precision
+ * (see {@link ParquetSchemaConverter#is32BitDecimal(int)} /
+ * {@link ParquetSchemaConverter#is64BitDecimal(int)}). This class wraps the underlying vector and
+ * exposes a {@link DecimalColumnVector} view on top whose {@link #getDecimal} dispatches on the
+ * child's physical type, so small-precision decimals encoded as INT32/INT64 are no longer
+ * mis-cast as bytes (see GH-18491).
  *
- * <p>Reference Flink release 1.11.2 {@link org.apache.flink.formats.parquet.vector.ParquetDecimalVector}
- * because it is not public.
+ * <p>In addition it implements {@link WritableLongVector}, {@link WritableIntVector}, and
+ * {@link WritableBytesVector} by delegation so that column readers can write into a
+ * {@code ParquetDecimalVector} without unwrapping to the child.
+ *
+ * <p>Synced with Apache Flink 2.1
+ * ({@code org.apache.flink.formats.parquet.vector.ParquetDecimalVector}); replaces Hudi's
+ * Flink-1.11-era read-only wrapper.
  */
-public class ParquetDecimalVector implements DecimalColumnVector {
+public class ParquetDecimalVector
+    implements DecimalColumnVector, WritableLongVector, WritableIntVector, WritableBytesVector {
 
-  public final ColumnVector vector;
+  private final ColumnVector vector;
 
   public ParquetDecimalVector(ColumnVector vector) {
     this.vector = vector;
   }
 
+  public ColumnVector getVector() {
+    return vector;
+  }
+
   @Override
   public DecimalData getDecimal(int i, int precision, int scale) {
-    return DecimalData.fromUnscaledBytes(
-        ((BytesColumnVector) vector).getBytes(i).getBytes(),
-        precision,
-        scale);
+    if (ParquetSchemaConverter.is32BitDecimal(precision) && vector instanceof IntColumnVector) {
+      return DecimalData.fromUnscaledLong(((IntColumnVector) vector).getInt(i), precision, scale);
+    } else if (ParquetSchemaConverter.is64BitDecimal(precision)
+        && vector instanceof LongColumnVector) {
+      return DecimalData.fromUnscaledLong(((LongColumnVector) vector).getLong(i), precision, scale);
+    } else {
+      checkArgument(
+          vector instanceof BytesColumnVector,
+          "Reading decimal type occur unsupported vector type: %s",
+          vector.getClass());
+      return DecimalData.fromUnscaledBytes(
+          ((BytesColumnVector) vector).getBytes(i).getBytes(), precision, scale);
+    }
   }
 
   @Override
   public boolean isNullAt(int i) {
     return vector.isNullAt(i);
   }
-}
 
+  @Override
+  public void reset() {
+    if (vector instanceof WritableColumnVector) {
+      ((WritableColumnVector) vector).reset();
+    }
+  }
+
+  @Override
+  public void setNullAt(int rowId) {
+    if (vector instanceof WritableColumnVector) {
+      ((WritableColumnVector) vector).setNullAt(rowId);
+    }
+  }
+
+  @Override
+  public void setNulls(int rowId, int count) {
+    if (vector instanceof WritableColumnVector) {
+      ((WritableColumnVector) vector).setNulls(rowId, count);
+    }
+  }
+
+  @Override
+  public void fillWithNulls() {
+    if (vector instanceof WritableColumnVector) {
+      ((WritableColumnVector) vector).fillWithNulls();
+    }
+  }
+
+  @Override
+  public void setDictionary(Dictionary dictionary) {
+    if (vector instanceof WritableColumnVector) {
+      ((WritableColumnVector) vector).setDictionary(dictionary);
+    }
+  }
+
+  @Override
+  public boolean hasDictionary() {
+    if (vector instanceof WritableColumnVector) {
+      return ((WritableColumnVector) vector).hasDictionary();
+    }
+    return false;
+  }
+
+  @Override
+  public WritableIntVector reserveDictionaryIds(int capacity) {
+    if (vector instanceof WritableColumnVector) {
+      return ((WritableColumnVector) vector).reserveDictionaryIds(capacity);
+    }
+    throw new RuntimeException("Child vector must be instance of WritableColumnVector");
+  }
+
+  @Override
+  public WritableIntVector getDictionaryIds() {
+    if (vector instanceof WritableColumnVector) {
+      return ((WritableColumnVector) vector).getDictionaryIds();
+    }
+    throw new RuntimeException("Child vector must be instance of WritableColumnVector");
+  }
+
+  @Override
+  public Bytes getBytes(int i) {
+    if (vector instanceof WritableBytesVector) {
+      return ((WritableBytesVector) vector).getBytes(i);
+    }
+    throw new RuntimeException("Child vector must be instance of WritableColumnVector");
+  }
+
+  @Override
+  public void appendBytes(int rowId, byte[] value, int offset, int length) {
+    if (vector instanceof WritableBytesVector) {
+      ((WritableBytesVector) vector).appendBytes(rowId, value, offset, length);
+    }
+  }
+
+  @Override
+  public void fill(byte[] value) {
+    if (vector instanceof WritableBytesVector) {
+      ((WritableBytesVector) vector).fill(value);
+    }
+  }
+
+  @Override
+  public int getInt(int i) {
+    if (vector instanceof WritableIntVector) {
+      return ((WritableIntVector) vector).getInt(i);
+    }
+    throw new RuntimeException("Child vector must be instance of WritableColumnVector");
+  }
+
+  @Override
+  public void setInt(int rowId, int value) {
+    if (vector instanceof WritableIntVector) {
+      ((WritableIntVector) vector).setInt(rowId, value);
+    }
+  }
+
+  @Override
+  public void setIntsFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+    if (vector instanceof WritableIntVector) {
+      ((WritableIntVector) vector).setIntsFromBinary(rowId, count, src, srcIndex);
+    }
+  }
+
+  @Override
+  public void setInts(int rowId, int count, int value) {
+    if (vector instanceof WritableIntVector) {
+      ((WritableIntVector) vector).setInts(rowId, count, value);
+    }
+  }
+
+  @Override
+  public void setInts(int rowId, int count, int[] src, int srcIndex) {
+    if (vector instanceof WritableIntVector) {
+      ((WritableIntVector) vector).setInts(rowId, count, src, srcIndex);
+    }
+  }
+
+  @Override
+  public void fill(int value) {
+    if (vector instanceof WritableIntVector) {
+      ((WritableIntVector) vector).fill(value);
+    }
+  }
+
+  @Override
+  public long getLong(int i) {
+    if (vector instanceof WritableLongVector) {
+      return ((WritableLongVector) vector).getLong(i);
+    }
+    throw new RuntimeException("Child vector must be instance of WritableColumnVector");
+  }
+
+  @Override
+  public void setLong(int rowId, long value) {
+    if (vector instanceof WritableLongVector) {
+      ((WritableLongVector) vector).setLong(rowId, value);
+    }
+  }
+
+  @Override
+  public void setLongsFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+    if (vector instanceof WritableLongVector) {
+      ((WritableLongVector) vector).setLongsFromBinary(rowId, count, src, srcIndex);
+    }
+  }
+
+  @Override
+  public void fill(long value) {
+    if (vector instanceof WritableLongVector) {
+      ((WritableLongVector) vector).fill(value);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/ParquetDecimalVector.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/ParquetDecimalVector.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,20 +34,8 @@ import org.apache.flink.table.data.columnar.vector.writable.WritableLongVector;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
- * Parquet writes decimals as INT32, INT64, or BINARY/FIXED_LEN_BYTE_ARRAY depending on precision
- * (see {@link ParquetSchemaConverter#is32BitDecimal(int)} /
- * {@link ParquetSchemaConverter#is64BitDecimal(int)}). This class wraps the underlying vector and
- * exposes a {@link DecimalColumnVector} view on top whose {@link #getDecimal} dispatches on the
- * child's physical type, so small-precision decimals encoded as INT32/INT64 are no longer
- * mis-cast as bytes (see GH-18491).
- *
- * <p>In addition it implements {@link WritableLongVector}, {@link WritableIntVector}, and
- * {@link WritableBytesVector} by delegation so that column readers can write into a
- * {@code ParquetDecimalVector} without unwrapping to the child.
- *
- * <p>Synced with Apache Flink 2.1
- * ({@code org.apache.flink.formats.parquet.vector.ParquetDecimalVector}); replaces Hudi's
- * Flink-1.11-era read-only wrapper.
+ * Parquet write decimal as int32 and int64 and binary, this class wrap the real vector to provide
+ * {@link DecimalColumnVector} interface.
  */
 public class ParquetDecimalVector
     implements DecimalColumnVector, WritableLongVector, WritableIntVector, WritableBytesVector {
@@ -56,10 +44,6 @@ public class ParquetDecimalVector
 
   public ParquetDecimalVector(ColumnVector vector) {
     this.vector = vector;
-  }
-
-  public ColumnVector getVector() {
-    return vector;
   }
 
   @Override
@@ -77,6 +61,10 @@ public class ParquetDecimalVector
       return DecimalData.fromUnscaledBytes(
           ((BytesColumnVector) vector).getBytes(i).getBytes(), precision, scale);
     }
+  }
+
+  public ColumnVector getVector() {
+    return vector;
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ArrayColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/ArrayColumnReader.java
@@ -423,13 +423,13 @@ public class ArrayColumnReader extends BaseVectorizedColumnReader {
         switch (primitiveTypeName) {
           case INT32:
             lcv.child = new ParquetDecimalVector(new HeapIntVector(total));
-            ((HeapIntVector) ((ParquetDecimalVector) lcv.child).vector).reset();
+            ((HeapIntVector) ((ParquetDecimalVector) lcv.child).getVector()).reset();
             for (int i = 0; i < valueList.size(); i++) {
               if (valueList.get(i) == null) {
-                ((HeapIntVector) ((ParquetDecimalVector) lcv.child).vector)
+                ((HeapIntVector) ((ParquetDecimalVector) lcv.child).getVector())
                     .setNullAt(i);
               } else {
-                ((HeapIntVector) ((ParquetDecimalVector) lcv.child).vector)
+                ((HeapIntVector) ((ParquetDecimalVector) lcv.child).getVector())
                     .vector[i] =
                     ((List<Integer>) valueList).get(i);
               }
@@ -437,13 +437,13 @@ public class ArrayColumnReader extends BaseVectorizedColumnReader {
             break;
           case INT64:
             lcv.child = new ParquetDecimalVector(new HeapLongVector(total));
-            ((HeapLongVector) ((ParquetDecimalVector) lcv.child).vector).reset();
+            ((HeapLongVector) ((ParquetDecimalVector) lcv.child).getVector()).reset();
             for (int i = 0; i < valueList.size(); i++) {
               if (valueList.get(i) == null) {
-                ((HeapLongVector) ((ParquetDecimalVector) lcv.child).vector)
+                ((HeapLongVector) ((ParquetDecimalVector) lcv.child).getVector())
                     .setNullAt(i);
               } else {
-                ((HeapLongVector) ((ParquetDecimalVector) lcv.child).vector)
+                ((HeapLongVector) ((ParquetDecimalVector) lcv.child).getVector())
                     .vector[i] =
                     ((List<Long>) valueList).get(i);
               }
@@ -451,14 +451,14 @@ public class ArrayColumnReader extends BaseVectorizedColumnReader {
             break;
           default:
             lcv.child = new ParquetDecimalVector(new HeapBytesVector(total));
-            ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).vector).reset();
+            ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).getVector()).reset();
             for (int i = 0; i < valueList.size(); i++) {
               byte[] src = ((List<byte[]>) valueList).get(i);
               if (valueList.get(i) == null) {
-                ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).vector)
+                ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).getVector())
                     .setNullAt(i);
               } else {
-                ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).vector)
+                ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).getVector())
                     .appendBytes(i, src, 0, src.length);
               }
             }

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/test/java/org/apache/hudi/table/format/cow/vector/TestParquetDecimalVector.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/test/java/org/apache/hudi/table/format/cow/vector/TestParquetDecimalVector.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/test/java/org/apache/hudi/table/format/cow/vector/TestParquetDecimalVector.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/test/java/org/apache/hudi/table/format/cow/vector/TestParquetDecimalVector.java
@@ -36,23 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit tests for {@link ParquetDecimalVector}.
- *
- * <p>Primary target is the {@link ParquetDecimalVector#getDecimal} dispatch fixed in GH-18491:
- * small-precision decimals are physically encoded in Parquet as INT32 or INT64, not as bytes.
- * The pre-fix implementation unconditionally cast the child vector to
- * {@link org.apache.flink.table.data.columnar.vector.BytesColumnVector} and threw
- * {@link ClassCastException} at read time.
+ * Tests for {@link ParquetDecimalVector}.
  */
-class TestParquetDecimalVector {
-
-  // ---------------------------------------------------------------------------------------------
-  // getDecimal dispatch: INT32 / INT64 / BYTES
-  // ---------------------------------------------------------------------------------------------
+public class TestParquetDecimalVector {
 
   @Test
-  void getDecimalFromInt32VectorDecodesUnscaledLong() {
-    // precision <= 9 ⇒ ParquetSchemaConverter#is32BitDecimal(precision) == true
+  void testGetDecimalFromInt32Vector() {
+    // precision <= 9 => ParquetSchemaConverter.is32BitDecimal(precision) == true
     HeapIntVector intVector = new HeapIntVector(1);
     intVector.vector[0] = 12345;
     ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
@@ -63,8 +53,8 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void getDecimalFromInt64VectorDecodesUnscaledLong() {
-    // 9 < precision <= 18 ⇒ ParquetSchemaConverter#is64BitDecimal(precision) == true
+  void testGetDecimalFromInt64Vector() {
+    // 9 < precision <= 18 => ParquetSchemaConverter.is64BitDecimal(precision) == true
     HeapLongVector longVector = new HeapLongVector(1);
     longVector.vector[0] = 1234567890123456L;
     ParquetDecimalVector wrapped = new ParquetDecimalVector(longVector);
@@ -75,8 +65,8 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void getDecimalFromBytesVectorDecodesUnscaledBytes() {
-    // precision > 18 ⇒ BINARY / FIXED_LEN_BYTE_ARRAY path
+  void testGetDecimalFromBytesVectorAtLargePrecision() {
+    // precision > 18 => BINARY / FIXED_LEN_BYTE_ARRAY path
     BigDecimal original = new BigDecimal("12345678901234567890.1234567890");
     byte[] unscaled = original.unscaledValue().toByteArray();
     HeapBytesVector bytesVector = new HeapBytesVector(1);
@@ -89,7 +79,7 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void getDecimalFallsBackToBytesWhenChildIsBytesEvenAtSmallPrecision() {
+  void testGetDecimalFromBytesVectorAtSmallPrecision() {
     // A Parquet file can legally encode a small-precision decimal as BINARY. In that case the
     // dispatch must fall through to the bytes branch rather than require an IntColumnVector.
     BigDecimal original = new BigDecimal("123.45");
@@ -104,21 +94,17 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void getDecimalOnUnsupportedVectorTypeThrows() {
+  void testGetDecimalThrowsOnUnsupportedVectorType() {
     // A large-precision request must have a bytes-backed child; any other writable child is an
-    // illegal combination and must be surfaced via Preconditions#checkArgument.
+    // illegal combination and must be surfaced via Preconditions.checkArgument.
     ColumnVector unsupported = new HeapShortVector(1);
     ParquetDecimalVector wrapped = new ParquetDecimalVector(unsupported);
 
     assertThrows(IllegalArgumentException.class, () -> wrapped.getDecimal(0, 30, 10));
   }
 
-  // ---------------------------------------------------------------------------------------------
-  // Null handling delegates to the child
-  // ---------------------------------------------------------------------------------------------
-
   @Test
-  void isNullAtDelegatesToChild() {
+  void testIsNullAtDelegatesToChild() {
     HeapIntVector intVector = new HeapIntVector(2);
     intVector.vector[0] = 1;
     intVector.setNullAt(1);
@@ -128,12 +114,8 @@ class TestParquetDecimalVector {
     assertTrue(wrapped.isNullAt(1));
   }
 
-  // ---------------------------------------------------------------------------------------------
-  // Writable delegation: the new WritableInt / WritableLong / WritableBytes contracts
-  // ---------------------------------------------------------------------------------------------
-
   @Test
-  void writableIntPathRoundTripsThroughWrapper() {
+  void testWritableIntRoundTrip() {
     HeapIntVector intVector = new HeapIntVector(1);
     ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
 
@@ -144,7 +126,7 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void writableLongPathRoundTripsThroughWrapper() {
+  void testWritableLongRoundTrip() {
     HeapLongVector longVector = new HeapLongVector(1);
     ParquetDecimalVector wrapped = new ParquetDecimalVector(longVector);
 
@@ -155,7 +137,7 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void writableBytesPathRoundTripsThroughWrapper() {
+  void testWritableBytesRoundTrip() {
     HeapBytesVector bytesVector = new HeapBytesVector(1);
     ParquetDecimalVector wrapped = new ParquetDecimalVector(bytesVector);
     byte[] payload = new byte[] {0x01, 0x02, 0x03};
@@ -170,7 +152,7 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void resetDelegatesToChild() {
+  void testResetDelegatesToChild() {
     HeapIntVector intVector = new HeapIntVector(1);
     intVector.setNullAt(0);
     ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
@@ -182,7 +164,7 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void fillWithNullsDelegatesToChild() {
+  void testFillWithNullsDelegatesToChild() {
     HeapIntVector intVector = new HeapIntVector(2);
     ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
 
@@ -193,7 +175,7 @@ class TestParquetDecimalVector {
   }
 
   @Test
-  void setNullAtDelegatesToChild() {
+  void testSetNullAtDelegatesToChild() {
     HeapIntVector intVector = new HeapIntVector(2);
     ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
 

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/test/java/org/apache/hudi/table/format/cow/vector/TestParquetDecimalVector.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/test/java/org/apache/hudi/table/format/cow/vector/TestParquetDecimalVector.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector;
+
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.columnar.vector.BytesColumnVector;
+import org.apache.flink.table.data.columnar.vector.ColumnVector;
+import org.apache.flink.table.data.columnar.vector.heap.HeapBytesVector;
+import org.apache.flink.table.data.columnar.vector.heap.HeapIntVector;
+import org.apache.flink.table.data.columnar.vector.heap.HeapLongVector;
+import org.apache.flink.table.data.columnar.vector.heap.HeapShortVector;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ParquetDecimalVector}.
+ *
+ * <p>Primary target is the {@link ParquetDecimalVector#getDecimal} dispatch fixed in GH-18491:
+ * small-precision decimals are physically encoded in Parquet as INT32 or INT64, not as bytes.
+ * The pre-fix implementation unconditionally cast the child vector to
+ * {@link org.apache.flink.table.data.columnar.vector.BytesColumnVector} and threw
+ * {@link ClassCastException} at read time.
+ */
+class TestParquetDecimalVector {
+
+  // ---------------------------------------------------------------------------------------------
+  // getDecimal dispatch: INT32 / INT64 / BYTES
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void getDecimalFromInt32VectorDecodesUnscaledLong() {
+    // precision <= 9 ⇒ ParquetSchemaConverter#is32BitDecimal(precision) == true
+    HeapIntVector intVector = new HeapIntVector(1);
+    intVector.vector[0] = 12345;
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
+
+    DecimalData decoded = wrapped.getDecimal(0, 5, 2);
+
+    assertEquals(new BigDecimal("123.45"), decoded.toBigDecimal());
+  }
+
+  @Test
+  void getDecimalFromInt64VectorDecodesUnscaledLong() {
+    // 9 < precision <= 18 ⇒ ParquetSchemaConverter#is64BitDecimal(precision) == true
+    HeapLongVector longVector = new HeapLongVector(1);
+    longVector.vector[0] = 1234567890123456L;
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(longVector);
+
+    DecimalData decoded = wrapped.getDecimal(0, 18, 4);
+
+    assertEquals(new BigDecimal("123456789012.3456"), decoded.toBigDecimal());
+  }
+
+  @Test
+  void getDecimalFromBytesVectorDecodesUnscaledBytes() {
+    // precision > 18 ⇒ BINARY / FIXED_LEN_BYTE_ARRAY path
+    BigDecimal original = new BigDecimal("12345678901234567890.1234567890");
+    byte[] unscaled = original.unscaledValue().toByteArray();
+    HeapBytesVector bytesVector = new HeapBytesVector(1);
+    bytesVector.appendBytes(0, unscaled, 0, unscaled.length);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(bytesVector);
+
+    DecimalData decoded = wrapped.getDecimal(0, 30, 10);
+
+    assertEquals(original, decoded.toBigDecimal());
+  }
+
+  @Test
+  void getDecimalFallsBackToBytesWhenChildIsBytesEvenAtSmallPrecision() {
+    // A Parquet file can legally encode a small-precision decimal as BINARY. In that case the
+    // dispatch must fall through to the bytes branch rather than require an IntColumnVector.
+    BigDecimal original = new BigDecimal("123.45");
+    byte[] unscaled = original.unscaledValue().toByteArray();
+    HeapBytesVector bytesVector = new HeapBytesVector(1);
+    bytesVector.appendBytes(0, unscaled, 0, unscaled.length);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(bytesVector);
+
+    DecimalData decoded = wrapped.getDecimal(0, 5, 2);
+
+    assertEquals(original, decoded.toBigDecimal());
+  }
+
+  @Test
+  void getDecimalOnUnsupportedVectorTypeThrows() {
+    // A large-precision request must have a bytes-backed child; any other writable child is an
+    // illegal combination and must be surfaced via Preconditions#checkArgument.
+    ColumnVector unsupported = new HeapShortVector(1);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(unsupported);
+
+    assertThrows(IllegalArgumentException.class, () -> wrapped.getDecimal(0, 30, 10));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Null handling delegates to the child
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void isNullAtDelegatesToChild() {
+    HeapIntVector intVector = new HeapIntVector(2);
+    intVector.vector[0] = 1;
+    intVector.setNullAt(1);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
+
+    assertFalse(wrapped.isNullAt(0));
+    assertTrue(wrapped.isNullAt(1));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Writable delegation: the new WritableInt / WritableLong / WritableBytes contracts
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void writableIntPathRoundTripsThroughWrapper() {
+    HeapIntVector intVector = new HeapIntVector(1);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
+
+    wrapped.setInt(0, 42);
+
+    assertEquals(42, wrapped.getInt(0));
+    assertEquals(42, intVector.vector[0]);
+  }
+
+  @Test
+  void writableLongPathRoundTripsThroughWrapper() {
+    HeapLongVector longVector = new HeapLongVector(1);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(longVector);
+
+    wrapped.setLong(0, 9876543210L);
+
+    assertEquals(9876543210L, wrapped.getLong(0));
+    assertEquals(9876543210L, longVector.vector[0]);
+  }
+
+  @Test
+  void writableBytesPathRoundTripsThroughWrapper() {
+    HeapBytesVector bytesVector = new HeapBytesVector(1);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(bytesVector);
+    byte[] payload = new byte[] {0x01, 0x02, 0x03};
+
+    wrapped.appendBytes(0, payload, 0, payload.length);
+
+    BytesColumnVector.Bytes out = wrapped.getBytes(0);
+    assertEquals(payload.length, out.len);
+    assertEquals(0x01, out.data[out.offset]);
+    assertEquals(0x02, out.data[out.offset + 1]);
+    assertEquals(0x03, out.data[out.offset + 2]);
+  }
+
+  @Test
+  void resetDelegatesToChild() {
+    HeapIntVector intVector = new HeapIntVector(1);
+    intVector.setNullAt(0);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
+    assertTrue(wrapped.isNullAt(0));
+
+    wrapped.reset();
+
+    assertFalse(wrapped.isNullAt(0));
+  }
+
+  @Test
+  void fillWithNullsDelegatesToChild() {
+    HeapIntVector intVector = new HeapIntVector(2);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
+
+    wrapped.fillWithNulls();
+
+    assertTrue(wrapped.isNullAt(0));
+    assertTrue(wrapped.isNullAt(1));
+  }
+
+  @Test
+  void setNullAtDelegatesToChild() {
+    HeapIntVector intVector = new HeapIntVector(2);
+    ParquetDecimalVector wrapped = new ParquetDecimalVector(intVector);
+
+    wrapped.setNullAt(0);
+    wrapped.setNulls(1, 1);
+
+    assertTrue(wrapped.isNullAt(0));
+    assertTrue(wrapped.isNullAt(1));
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Hudi-Flink's `ParquetDecimalVector` predated Flink's support for `INT32` /`INT64`-backed decimals and unconditionally cast the child vector to `BytesColumnVector` inside `getDecimal()`, throwing `ClassCastException` at read time whenever the reader materialized a small-precision decimal as a `HeapIntVector` / `HeapLongVector`.

### Summary and Changelog

This PR syncs `ParquetDecimalVector` with Apache Flink 2.1's implementation (`org.apache.flink.formats.parquet.vector.ParquetDecimalVector`):
- `getDecimal` dispatches on the physical child vector type (`ParquetSchemaConverter#is32BitDecimal` / `is64BitDecimal`) and decodes `int` / `long` / `bytes` accordingly.
- Wrapper additionally implements `WritableLongVector`, `WritableIntVector`, and `WritableBytesVector` by delegation so that column readers can write through it without unwrapping.
- Underlying `vector` field is now `private`; accessed via `getVector()`. Migrated `ArrayColumnReader`'s nine direct-field accesses.

Part of #18491.

### Impact

`DECIMAL` columns whose precision ≤ 18 and whose Parquet file stores them physically as `INT32` / `INT64` are now readable through `hudi-flink1.18.x`. No behavior change for `BINARY` / `FIXED_LEN_BYTE_ARRAY`-encoded decimals.

### Risk Level

None — strictly additive; the fallback `bytes` branch preserves existing behavior for the legacy path. Unit-test coverage added for every dispatch.

### Documentation Update

N/A

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
