### PR TITLE
feat(flink): Introduces dictionary encoding of payload partition path for RocksDBIndexBackend

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/CodedRecordGlobalLocationSerializer.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/CodedRecordGlobalLocationSerializer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Serializer specialization for partitioned tables that dictionary-encodes the partition paths.
+ *
+ * <p>Serialized bytes can only be deserialized correctly by the same serializer instance that encoded them.
+ */
+public class CodedRecordGlobalLocationSerializer extends RecordGlobalLocationSerializer {
+  private final Map<String, Integer> partitionPathToDictId = new HashMap<>();
+  private final List<String> dictIdToPartitionPath = new ArrayList<>();
+
+  @Override
+  protected void writePartitionPath(String partitionPath) throws IOException {
+    outputSerializer.writeInt(getOrCreatePartitionPathId(partitionPath));
+  }
+
+  @Override
+  protected String readPartitionPath() throws IOException {
+    return getPartitionPath(inputDeserializer.readInt());
+  }
+
+  private int getOrCreatePartitionPathId(String partitionPath) {
+    Integer existingId = partitionPathToDictId.get(partitionPath);
+    if (existingId != null) {
+      return existingId;
+    }
+
+    int newId = dictIdToPartitionPath.size();
+    partitionPathToDictId.put(partitionPath, newId);
+    dictIdToPartitionPath.add(partitionPath);
+    return newId;
+  }
+
+  private String getPartitionPath(int partitionPathId) {
+    if (partitionPathId < 0 || partitionPathId >= dictIdToPartitionPath.size()) {
+      throw new IllegalStateException("Unknown partition path dictionary id " + partitionPathId
+          + ", dictionary size is " + dictIdToPartitionPath.size());
+    }
+    return dictIdToPartitionPath.get(partitionPathId);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexBackendFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexBackendFactory.java
@@ -59,7 +59,7 @@ public class IndexBackendFactory {
         return new FlinkStateIndexBackend(indexState);
       case GLOBAL_RECORD_LEVEL_INDEX:
         if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
-          return new RocksDBIndexBackend(conf.get(FlinkOptions.INDEX_BOOTSTRAP_ROCKSDB_PATH));
+          return new RocksDBIndexBackend(conf.get(FlinkOptions.INDEX_BOOTSTRAP_ROCKSDB_PATH), OptionsResolver.isPartitionedTable(conf));
         } else {
           ListState<JobID> jobIdState = context.getOperatorStateStore().getListState(
               new ListStateDescriptor<>(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordGlobalLocationSerializer.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordGlobalLocationSerializer.java
@@ -42,8 +42,8 @@ public class RecordGlobalLocationSerializer implements CustomSerializer<HoodieRe
   // Typical size: 4(partitionLen) + ~30(partition) + 4(instantLen) + ~20(instant) + 8+8+4(UUID+index) ≈ 78 bytes
   private static final int INITIAL_BUFFER_SIZE = 128;
   // Reusable stream objects (single-threaded use only)
-  private final DataOutputSerializer outputSerializer = new DataOutputSerializer(INITIAL_BUFFER_SIZE);
-  private final DataInputDeserializer inputDeserializer = new DataInputDeserializer();
+  protected final DataOutputSerializer outputSerializer = new DataOutputSerializer(INITIAL_BUFFER_SIZE);
+  protected final DataInputDeserializer inputDeserializer = new DataInputDeserializer();
 
   @Override
   public byte[] serialize(HoodieRecordGlobalLocation location) throws IOException {
@@ -51,9 +51,7 @@ public class RecordGlobalLocationSerializer implements CustomSerializer<HoodieRe
     outputSerializer.clear();
 
     // Write partitionPath
-    byte[] partitionBytes = location.getPartitionPath().getBytes(StandardCharsets.UTF_8);
-    outputSerializer.writeInt(partitionBytes.length);
-    outputSerializer.write(partitionBytes);
+    writePartitionPath(location.getPartitionPath());
 
     // Write instantTime
     byte[] instantBytes = location.getInstantTime().getBytes(StandardCharsets.UTF_8);
@@ -87,10 +85,7 @@ public class RecordGlobalLocationSerializer implements CustomSerializer<HoodieRe
       inputDeserializer.setBuffer(bytes);
 
       // Read partitionPath
-      int partitionLen = inputDeserializer.readInt();
-      byte[] partitionBytes = new byte[partitionLen];
-      inputDeserializer.readFully(partitionBytes);
-      String partitionPath = new String(partitionBytes, StandardCharsets.UTF_8);
+      String partitionPath = readPartitionPath();
 
       // Read instantTime
       int instantLen = inputDeserializer.readInt();
@@ -112,5 +107,18 @@ public class RecordGlobalLocationSerializer implements CustomSerializer<HoodieRe
     } catch (IOException e) {
       throw new RuntimeException("Failed to deserialize HoodieRecordGlobalLocation", e);
     }
+  }
+
+  protected void writePartitionPath(String partitionPath) throws IOException {
+    byte[] partitionBytes = partitionPath.getBytes(StandardCharsets.UTF_8);
+    outputSerializer.writeInt(partitionBytes.length);
+    outputSerializer.write(partitionBytes);
+  }
+
+  protected String readPartitionPath() throws IOException {
+    int partitionLen = inputDeserializer.readInt();
+    byte[] partitionBytes = new byte[partitionLen];
+    inputDeserializer.readFully(partitionBytes);
+    return new String(partitionBytes, StandardCharsets.UTF_8);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
@@ -41,10 +41,12 @@ public class RocksDBIndexBackend implements IndexBackend {
   private final RocksDBDAO rocksDBDAO;
   private transient FlinkRocksDBIndexMetrics rocksDBIndexMetrics;
 
-  public RocksDBIndexBackend(String rocksDbBasePath) {
+  public RocksDBIndexBackend(String rocksDbBasePath, boolean isPartitionedTable) {
     // Register custom serializer for HoodieRecordGlobalLocation to minimize storage overhead
     ConcurrentHashMap<String, CustomSerializer<?>> serializers = new ConcurrentHashMap<>();
-    serializers.put(COLUMN_FAMILY, new RecordGlobalLocationSerializer());
+    serializers.put(COLUMN_FAMILY, isPartitionedTable
+        ? new CodedRecordGlobalLocationSerializer()
+        : new RecordGlobalLocationSerializer());
 
     this.rocksDBDAO = new RocksDBDAO("hudi-index-backend", rocksDbBasePath, serializers, true);
     this.rocksDBDAO.addColumnFamily(COLUMN_FAMILY);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestCodedRecordGlobalLocationSerializer.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestCodedRecordGlobalLocationSerializer.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link CodedRecordGlobalLocationSerializer}.
+ */
+public class TestCodedRecordGlobalLocationSerializer {
+
+  private CodedRecordGlobalLocationSerializer serializer;
+
+  @BeforeEach
+  public void setUp() {
+    serializer = new CodedRecordGlobalLocationSerializer();
+  }
+
+  @Test
+  public void testHistoricalBytesRemainReadableAfterDictionaryGrowth() throws IOException {
+    String instantTime = "20240315120000";
+    String firstFileId = UUID.randomUUID().toString();
+    String secondFileId = UUID.randomUUID().toString();
+
+    HoodieRecordGlobalLocation first = new HoodieRecordGlobalLocation("partition/a", instantTime, firstFileId);
+    HoodieRecordGlobalLocation second = new HoodieRecordGlobalLocation("partition/b", instantTime, secondFileId);
+
+    byte[] firstSerialized = serializer.serialize(first);
+    byte[] secondSerialized = serializer.serialize(second);
+
+    assertEquals(first, serializer.deserialize(firstSerialized));
+    assertEquals(second, serializer.deserialize(secondSerialized));
+  }
+
+  @Test
+  public void testSerializedSizeEfficiency() throws IOException {
+    String partitionPath = "partition/path/test/with/repeated/value";
+    String instantTime = "20240315120000";
+    String fileId = UUID.randomUUID().toString();
+
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation(partitionPath, instantTime, fileId);
+    HoodieRecordGlobalLocation samePartitionLocation = new HoodieRecordGlobalLocation(partitionPath, instantTime, fileId);
+
+    byte[] firstSerialized = serializer.serialize(location);
+    byte[] secondSerialized = serializer.serialize(samePartitionLocation);
+
+    int expectedSize = 4 + 4 + instantTime.length() + 8 + 8 + 4;
+    int legacySize = 4 + partitionPath.getBytes(StandardCharsets.UTF_8).length + 4 + instantTime.length() + 8 + 8 + 4;
+
+    assertEquals(expectedSize, firstSerialized.length);
+    assertEquals(expectedSize, secondSerialized.length);
+    assertEquals(firstSerialized.length, secondSerialized.length);
+    assertTrue(firstSerialized.length < legacySize);
+  }
+
+  @Test
+  public void testRepeatedPartitionPathProducesSmallerPayloadThanLegacyFormat() throws IOException {
+    String partitionPath = "year=2024/month=03/day=15/hour=12";
+    String instantTime = "20240315123045";
+    String fileId = UUID.randomUUID().toString();
+
+    byte[] serialized = serializer.serialize(new HoodieRecordGlobalLocation(partitionPath, instantTime, fileId));
+
+    int dictionaryEncodedSize = 4 + 4 + instantTime.length() + 8 + 8 + 4;
+    int legacySize = 4 + partitionPath.getBytes(StandardCharsets.UTF_8).length + 4 + instantTime.length() + 8 + 8 + 4;
+
+    assertEquals(dictionaryEncodedSize, serialized.length);
+    assertEquals(legacySize - partitionPath.getBytes(StandardCharsets.UTF_8).length, serialized.length);
+  }
+
+  @Test
+  public void testDeserializeFailsForUnknownPartitionPathId() {
+    byte[] invalidBytes = new byte[] {
+        0, 0, 0, 7,
+        0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        -1, -1, -1, -1
+    };
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class, () -> serializer.deserialize(invalidBytes));
+    assertEquals("Unknown partition path dictionary id 7, dictionary size is 0", exception.getMessage());
+  }
+
+  @Test
+  public void testFirstPartitionPathUsesFirstDictionaryId() throws IOException {
+    String instantTime = "20240315120000";
+    String fileId = UUID.randomUUID().toString();
+
+    byte[] serialized = serializer.serialize(new HoodieRecordGlobalLocation("partition/a", instantTime, fileId));
+
+    assertEquals(0, readInt(serialized, 0));
+  }
+
+  private int readInt(byte[] bytes, int offset) {
+    return ((bytes[offset] & 0xFF) << 24)
+        | ((bytes[offset + 1] & 0xFF) << 16)
+        | ((bytes[offset + 2] & 0xFF) << 8)
+        | (bytes[offset + 3] & 0xFF);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBIndexBackend.java
@@ -25,6 +25,8 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.util.HashMap;
@@ -48,16 +50,17 @@ public class TestRocksDBIndexBackend {
   @TempDir
   File tempFile;
 
-  @Test
-  void testGetAndUpdate() throws Exception {
-    try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath())) {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testGetAndUpdate(boolean isPartitionedTable) throws Exception {
+    try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath(), isPartitionedTable)) {
       assertNull(rocksDBIndexBackend.get("id1"));
 
-      HoodieRecordGlobalLocation location1 = new HoodieRecordGlobalLocation("par1", "001", UUID.randomUUID().toString());
+      HoodieRecordGlobalLocation location1 = new HoodieRecordGlobalLocation(isPartitionedTable ? "par1" : "", "001", UUID.randomUUID().toString());
       rocksDBIndexBackend.update("id1", location1);
       assertEquals(location1, rocksDBIndexBackend.get("id1"));
 
-      HoodieRecordGlobalLocation location2 = new HoodieRecordGlobalLocation("par2", "002", UUID.randomUUID().toString());
+      HoodieRecordGlobalLocation location2 = new HoodieRecordGlobalLocation(isPartitionedTable ? "par2" : "", "002", UUID.randomUUID().toString());
       rocksDBIndexBackend.update("id2", location2);
       assertEquals(location2, rocksDBIndexBackend.get("id2"));
     }
@@ -65,7 +68,7 @@ public class TestRocksDBIndexBackend {
 
   @Test
   void testMetricsRegistrationAndSnapshot() throws Exception {
-    try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath())) {
+    try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath(), false)) {
       MetricGroup metricGroup = mock(MetricGroup.class);
       Map<String, Gauge<?>> gauges = new HashMap<>();
       doAnswer(invocation -> {
@@ -101,7 +104,7 @@ public class TestRocksDBIndexBackend {
 
   @Test
   void testMetricsReflectWritesReadsAndAutoFlush() throws Exception {
-    try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath())) {
+    try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath(), false)) {
       MetricGroup metricGroup = mock(MetricGroup.class);
       Map<String, Gauge<?>> gauges = new HashMap<>();
       doAnswer(invocation -> {
@@ -168,7 +171,7 @@ public class TestRocksDBIndexBackend {
       return gauge;
     }).when(metricGroup).gauge(anyString(), any(Gauge.class));
 
-    RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath());
+    RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath(), false);
     rocksDBIndexBackend.registerMetrics(metricGroup);
     rocksDBIndexBackend.close();
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR reduces storage overhead in the Flink `RocksDBIndexBackend` path by optimizing how `HoodieRecordGlobalLocation` values are serialized for partitioned tables. The existing serializer stores the full partition path string on every record, which is wasteful when many records share the same partition path.

To keep the change scoped and low-risk, the PR preserves the legacy serializer behavior as the default path and introduces a dedicated coded serializer for partitioned tables only. This allows partitioned workloads to benefit from compact partition-path encoding while leaving non-partitioned table behavior unchanged, fixes #18555 

### Summary and Changelog
- Added `CodedRecordGlobalLocationSerializer` to dictionary-encode partition paths for partitioned-table record locations stored in RocksDB.
- Updated `RocksDBIndexBackend` and `IndexBackendFactory` to choose the coded serializer only when the table is partitioned.
- Added `TestCodedRecordGlobalLocationSerializer` to cover dictionary-id encoding, round-trip correctness, invalid dictionary-id handling, and payload size reduction.

### Impact

-  Partitioned tables using the Flink RocksDB bootstrap index path now store record locations with compact coded partition paths, which would save more storage.

### Risk Level
low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
