### PR TITLE
fix(schema): Allow nested projection on BLOB and VARIANT columns in p…

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSchemaConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSchemaConversionUtils.scala
@@ -147,6 +147,26 @@ object HoodieSchemaConversionUtils {
   }
 
   /**
+   * Write-path entry: validates the user-supplied StructType's custom Hudi logical-type
+   * structures (BLOB / VARIANT) before converting to HoodieSchema.
+   *
+   * Use this at ingest boundaries where the StructType originates from user input
+   * (DataFrame.schema, MERGE source, ALTER TABLE new columns, etc.). Internal transforms
+   * and the read/prune path must keep using [[convertStructTypeToHoodieSchema]], which stays
+   * permissive so Spark's nested-schema pruning does not crash reads.
+   *
+   * @throws IllegalArgumentException if a field tagged hudi_type=BLOB/VARIANT has a
+   *                                  non-canonical inner shape
+   * @throws HoodieSchemaException    if conversion fails
+   */
+  def convertUserStructTypeToHoodieSchema(structType: StructType,
+                                          structName: String,
+                                          recordNamespace: String): HoodieSchema = {
+    HoodieSparkSchemaConverters.validateCustomTypeStructures(structType)
+    convertStructTypeToHoodieSchema(structType, structName, recordNamespace)
+  }
+
+  /**
    * Re-attach catalog metadata/nullability that Spark's write-path rewrites strip:
    *
    *   1. VECTOR/BLOB logical-type metadata - dropped by TableOutputResolver's Cast and

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -67,6 +67,42 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
   }
 
   /**
+   * Walks a user-supplied StructType and rejects any field tagged with
+   * {@code hudi_type=BLOB} or {@code hudi_type=VARIANT} whose inner Spark shape does not
+   * match the canonical layout.
+   *
+   * Intended for the ingest/write boundary only. {@link #toHoodieTypeNested} is shared
+   * with the read/prune path and must stay permissive so that Spark's nested-schema
+   * pruning (which can strip sibling fields while preserving the outer {@code hudi_type}
+   * metadata) does not crash projections. Validation is therefore hoisted up to the
+   * writer, which always sees the user's full, unpruned schema.
+   *
+   * @throws IllegalArgumentException if any tagged field has a non-canonical inner shape
+   */
+  def validateCustomTypeStructures(structType: StructType): Unit =
+    validateCustomTypeStructuresRecursive(structType)
+
+  private def validateCustomTypeStructuresRecursive(dataType: DataType): Unit = dataType match {
+    case s: StructType =>
+      s.fields.foreach { f =>
+        if (f.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD)) {
+          val descriptorType = HoodieSchema
+            .parseTypeDescriptor(f.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+            .getType
+          (descriptorType, f.dataType) match {
+            case (HoodieSchemaType.BLOB, st: StructType) => validateBlobStructure(st)
+            case (HoodieSchemaType.VARIANT, st: StructType) => validateVariantStructure(st)
+            case _ =>
+          }
+        }
+        validateCustomTypeStructuresRecursive(f.dataType)
+      }
+    case ArrayType(elementType, _) => validateCustomTypeStructuresRecursive(elementType)
+    case MapType(_, valueType, _) => validateCustomTypeStructuresRecursive(valueType)
+    case _ =>
+  }
+
+  /**
    * Converts a Spark DataType to a HoodieSchema, tracking how deeply nested the current type is
    * relative to the top-level table schema. This depth is used to enforce that VECTOR columns can
    * only appear as direct fields of the root record — not inside nested structs, arrays, or maps.
@@ -76,11 +112,11 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
    * at depth≥2 (VECTOR not allowed).
    */
   private def toHoodieTypeNested(catalystType: DataType,
-                                  nullable: Boolean,
-                                  recordName: String,
-                                  nameSpace: String,
-                                  metadata: Metadata,
-                                  depth: Int): HoodieSchema = {
+                                 nullable: Boolean,
+                                 recordName: String,
+                                 nameSpace: String,
+                                 metadata: Metadata,
+                                 depth: Int): HoodieSchema = {
     val schema = catalystType match {
       // Primitive types
       case BooleanType => HoodieSchema.create(HoodieSchemaType.BOOLEAN)
@@ -105,8 +141,8 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
 
       // Complex types
       case ArrayType(elementSparkType, containsNull)
-          if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
-            HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR =>
+        if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+          HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VECTOR =>
         if (depth > 1) {
           throw new HoodieSchemaException(
             s"VECTOR column '$recordName' must be a top-level field. Nested VECTOR columns (inside STRUCT, ARRAY, or MAP) are not supported.")
@@ -140,14 +176,18 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
         HoodieSchema.createMap(valueSchema)
 
       case blobStruct: StructType if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
-        HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.BLOB =>
-        // Validate blob structure before accepting
-        validateBlobStructure(blobStruct)
+        HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.BLOB &&
+        isCanonicalBlobStruct(blobStruct) =>
+        // Canonical RFC-100 BLOB layout. Pruned BLOB structs (Spark 3.3/3.4 keeps the
+        // hudi_type=BLOB metadata on the outer StructField while dropping sibling inner
+        // fields during nested schema pruning) fall through to the plain RECORD branch
+        // below; HoodieSchemaUtils.pruneDataSchema then restores the full BLOB from the
+        // data schema.
         HoodieSchema.createBlob()
 
       case variantStruct: StructType if metadata.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
-        HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VARIANT =>
-        validateVariantStructure(variantStruct)
+        HoodieSchema.parseTypeDescriptor(metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)).getType == HoodieSchemaType.VARIANT &&
+        isCanonicalVariantStruct(variantStruct) =>
         HoodieSchema.createVariant(recordName, nameSpace, null)
 
       case st: StructType =>
@@ -376,7 +416,7 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
    * @throws IllegalArgumentException if the structure does not match the expected blob schema
    */
   private def validateBlobStructure(structType: StructType): Unit = {
-    if (!matchesStructure(structType, expectedBlobStructType, SQLConf.get.caseSensitiveAnalysis)) {
+    if (!isCanonicalBlobStruct(structType)) {
       throw new IllegalArgumentException(
         s"""Invalid blob schema structure. Expected schema:
            |${expectedBlobStructType.toDDL}
@@ -384,6 +424,16 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
            |${structType.toDDL}""".stripMargin)
     }
   }
+
+  /**
+   * Returns true if the StructType matches the canonical RFC-100 BLOB layout.
+   * Used both by the write/ingest validator and to distinguish a genuine BLOB
+   * struct from one that Spark's nested-schema pruning has partially stripped
+   * (Spark 3.3/3.4 preserves the hudi_type=BLOB metadata on the outer field
+   * while dropping sibling inner fields).
+   */
+  private def isCanonicalBlobStruct(structType: StructType): Boolean =
+    matchesStructure(structType, expectedBlobStructType, SQLConf.get.caseSensitiveAnalysis)
 
   private def matchesStructure(source: DataType, expected: DataType, caseSensitive: Boolean): Boolean =
     (source, expected) match {
@@ -432,20 +482,29 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
    * @throws IllegalArgumentException if the structure does not match the expected variant schema
    */
   private def validateVariantStructure(structType: StructType): Unit = {
-    val caseSensitive = SQLConf.get.caseSensitiveAnalysis
-    val key: String => String =
-      if (caseSensitive) identity else (_: String).toLowerCase(Locale.ROOT)
-    val fieldsByName = structType.fields.map(f => key(f.name) -> f).toMap
-    val ok = structType.length == 2 &&
-      fieldsByName.get(key(HoodieSchema.Variant.VARIANT_METADATA_FIELD)).exists(f => f.dataType == BinaryType && !f.nullable) &&
-      fieldsByName.get(key(HoodieSchema.Variant.VARIANT_VALUE_FIELD)).exists(f => f.dataType == BinaryType && !f.nullable)
-    if (!ok) {
+    if (!isCanonicalVariantStruct(structType)) {
       throw new IllegalArgumentException(
         s"""Invalid variant schema structure. Expected schema:
            |${expectedVariantStructType.toDDL}
            |Got schema:
            |${structType.toDDL}""".stripMargin)
     }
+  }
+
+  /**
+   * Returns true if the StructType matches the canonical unshredded VARIANT layout
+   * (two non-null {@code BinaryType} fields: {@code metadata} and {@code value}).
+   * Used both by the write/ingest validator and to distinguish a genuine VARIANT
+   * struct from one that Spark's nested-schema pruning has partially stripped.
+   */
+  private def isCanonicalVariantStruct(structType: StructType): Boolean = {
+    val caseSensitive = SQLConf.get.caseSensitiveAnalysis
+    val key: String => String =
+      if (caseSensitive) identity else (_: String).toLowerCase(Locale.ROOT)
+    val fieldsByName = structType.fields.map(f => key(f.name) -> f).toMap
+    structType.length == 2 &&
+      fieldsByName.get(key(HoodieSchema.Variant.VARIANT_METADATA_FIELD)).exists(f => f.dataType == BinaryType && !f.nullable) &&
+      fieldsByName.get(key(HoodieSchema.Variant.VARIANT_VALUE_FIELD)).exists(f => f.dataType == BinaryType && !f.nullable)
   }
 
   private def canBeUnion(st: StructType): Boolean = {
@@ -456,7 +515,7 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
   }
 
   private def sparkTypeForVectorElementType(
-      elementType: HoodieSchema.Vector.VectorElementType): DataType = elementType match {
+                                             elementType: HoodieSchema.Vector.VectorElementType): DataType = elementType match {
     case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
     case HoodieSchema.Vector.VectorElementType.DOUBLE => DoubleType
     case HoodieSchema.Vector.VectorElementType.INT8 => ByteType

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -486,6 +486,16 @@ public final class HoodieSchemaUtils {
   private static HoodieSchema pruneDataSchemaInternal(HoodieSchema dataSchema, HoodieSchema requiredSchema, Set<String> mandatoryFields) {
     switch (requiredSchema.getType()) {
       case RECORD:
+        // BLOB and VARIANT are represented as Avro RECORDs but carry a logical type
+        // whose validate() contract requires the full canonical field layout
+        // ({type,data,reference} and {metadata,value} respectively). Partially pruning
+        // their inner fields would drop that contract. Spark's projection still prunes
+        // these columns at eval time, so reading the full logical-type record here is
+        // correct and cheap.
+        if (dataSchema.getType() == HoodieSchemaType.BLOB
+            || dataSchema.getType() == HoodieSchemaType.VARIANT) {
+          return dataSchema;
+        }
         if (dataSchema.getType() != HoodieSchemaType.RECORD) {
           throw new IllegalArgumentException("Data schema is not a record");
         }

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchemaUtils.java
@@ -847,6 +847,40 @@ public class TestHoodieSchemaUtils {
   }
 
   @Test
+  void testPruningPreservesBlobWhenRequiredIsPlainRecord() {
+    // Repro for nested-projection crash: when Spark prunes a nested field of a BLOB
+    // column, the Spark-side required schema loses the `blob` logical type and
+    // converts to a plain Avro RECORD. The data schema still carries
+    // HoodieSchemaType.BLOB from the file's on-disk logical type. The pruner must
+    // not throw "Data schema is not a record" on this mismatch; BLOB's inner layout
+    // is fixed by its LogicalType contract, so pass the data schema through.
+    HoodieSchema dataSchema = HoodieSchema.createRecord("test_record", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.LONG)),
+        HoodieSchemaField.of("payload", HoodieSchema.createBlob())
+    ));
+
+    // Required schema projects only `payload.reference.external_path`, mimicking
+    // what Spark's nested-schema pruning produces.
+    String requiredSchemaStr = "{ \"type\": \"record\", \"name\": \"test_record\", \"fields\": ["
+        + "{ \"name\": \"payload\", \"type\": { \"type\": \"record\", \"name\": \"payload\", \"fields\": ["
+        + "  { \"name\": \"reference\", \"type\": [\"null\", { \"type\": \"record\", \"name\": \"reference\", \"fields\": ["
+        + "    { \"name\": \"external_path\", \"type\": \"string\" }"
+        + "  ]}], \"default\": null }"
+        + "]}}"
+        + "]}";
+
+    HoodieSchema requiredSchema = HoodieSchema.parse(requiredSchemaStr);
+    HoodieSchema pruned = HoodieSchemaUtils.pruneDataSchema(dataSchema, requiredSchema, Collections.emptySet());
+
+    Option<HoodieSchemaField> prunedPayload = pruned.getField("payload");
+    assertTrue(prunedPayload.isPresent());
+    // BLOB's logical-type invariant forbids partial inner layouts, so the pruner
+    // must return the full BLOB schema untouched.
+    assertEquals(HoodieSchemaType.BLOB, prunedPayload.get().schema().getType());
+    assertInstanceOf(HoodieSchema.Blob.class, prunedPayload.get().schema());
+  }
+
+  @Test
   void testPruningPreserveNullable() {
     String dataSchemaStr = "{"
         + "\"type\": \"record\","

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -368,7 +368,8 @@ class HoodieSparkSqlWriterInternal {
         (s.getName, toScalaOption(s.getNamespace).orNull))
         .getOrElse(getRecordNameAndNamespace(tblName))
 
-      val sourceSchema = convertStructTypeToHoodieSchema(df.schema, avroRecordName, avroRecordNamespace)
+      val sourceSchema = HoodieSchemaConversionUtils.convertUserStructTypeToHoodieSchema(
+        df.schema, avroRecordName, avroRecordNamespace)
       val internalSchemaOpt = HoodieSchemaUtils.getLatestTableInternalSchema(hoodieConfig, tableMetaClient).orElse {
         // In case we need to reconcile the schema and schema evolution is enabled,
         // we will force-apply schema evolution to the writer's schema
@@ -722,7 +723,7 @@ class HoodieSparkSqlWriterInternal {
     var schema: String = null
     if (df.schema.nonEmpty) {
       val (structName, namespace) = HoodieSchemaConversionUtils.getRecordNameAndNamespace(tableName)
-      schema = HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(df.schema, structName, namespace).toString
+      schema = HoodieSchemaConversionUtils.convertUserStructTypeToHoodieSchema(df.schema, structName, namespace).toString
     } else {
       schema = HoodieSchema.NULL_SCHEMA.toString
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddColumnsCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableAddColumnsCommand.scala
@@ -60,7 +60,7 @@ case class AlterHoodieTableAddColumnsCommand(tableId: TableIdentifier,
       val rearrangedSchema = hoodieCatalogTable.dataSchema ++ colsToAdd ++ hoodieCatalogTable.partitionSchema
       val newSqlSchema = StructType(rearrangedSchema)
       val (structName, nameSpace) = HoodieSchemaConversionUtils.getRecordNameAndNamespace(tableId.table)
-      val newSchema = HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(newSqlSchema, structName, nameSpace)
+      val newSchema = HoodieSchemaConversionUtils.convertUserStructTypeToHoodieSchema(newSqlSchema, structName, nameSpace)
 
       // Commit with new schema to change the table schema
       AlterHoodieTableAddColumnsCommand.commitWithSchema(newSchema, hoodieCatalogTable, sparkSession)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableChangeColumnCommand.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/AlterHoodieTableChangeColumnCommand.scala
@@ -73,7 +73,7 @@ case class AlterHoodieTableChangeColumnCommand(
         }
       })
     val (structName, nameSpace) = HoodieSchemaConversionUtils.getRecordNameAndNamespace(tableIdentifier.table)
-    val newSchema = HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(newTableSchema, structName, nameSpace)
+    val newSchema = HoodieSchemaConversionUtils.convertUserStructTypeToHoodieSchema(newTableSchema, structName, nameSpace)
 
     // Validate the compatibility between new schema and origin schema.
     validateSchema(newSchema, hoodieCatalogTable.metaClient)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSchemaConversionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSchemaConversionUtils.scala
@@ -22,6 +22,7 @@ import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaField, HoodieSch
 import org.apache.hudi.internal.schema.HoodieSchemaException
 
 import org.apache.avro.generic.GenericData
+import org.apache.spark.sql.avro.HoodieSparkSchemaConverters
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.types._
@@ -967,12 +968,10 @@ class TestHoodieSchemaConversionUtils extends FunSuite with Matchers {
       .add("id", LongType, nullable = false)
       .add("payload", wrongOrderBlob, nullable = true, blobMetadata)
 
-    val ex = intercept[Exception] {
-      HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(
-        outerStruct, "WrongOrderBlobTest", "test")
+    val ex = intercept[IllegalArgumentException] {
+      HoodieSparkSchemaConverters.validateCustomTypeStructures(outerStruct)
     }
-    assert(ex.getMessage.contains("Invalid blob schema structure") ||
-      (ex.getCause != null && ex.getCause.getMessage.contains("Invalid blob schema structure")),
+    assert(ex.getMessage.startsWith("Invalid blob schema structure"),
       s"unexpected exception: ${ex.getMessage}")
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/avro/TestSchemaConverters.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/avro/TestSchemaConverters.scala
@@ -97,12 +97,8 @@ class TestSchemaConverters extends SparkAdapterSupport {
       StructField(HoodieSchema.Blob.INLINE_DATA_FIELD, DataTypes.BinaryType, nullable = true)
     ))
 
-    val metadata = new MetadataBuilder()
-      .putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
-      .build()
-
     val exception = assertThrows(classOf[IllegalArgumentException], () => {
-      HoodieSparkSchemaConverters.toHoodieType(invalidStruct, nullable = false, metadata = metadata)
+      HoodieSparkSchemaConverters.validateCustomTypeStructures(wrapBlob(invalidStruct))
     })
     assertTrue(exception.getMessage.startsWith("Invalid blob schema structure"))
   }
@@ -285,13 +281,23 @@ class TestSchemaConverters extends SparkAdapterSupport {
   }
 
   private def assertInvalidVariantSchema(invalidStruct: StructType): Unit = {
-    val metadata = new MetadataBuilder()
-      .putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.VARIANT.name())
-      .build()
     val exception = assertThrows(classOf[IllegalArgumentException], () => {
-      HoodieSparkSchemaConverters.toHoodieType(invalidStruct, metadata = metadata)
+      HoodieSparkSchemaConverters.validateCustomTypeStructures(wrapVariant(invalidStruct))
     })
     assertTrue(exception.getMessage.startsWith("Invalid variant schema structure"))
+  }
+
+  private def wrapBlob(inner: StructType): StructType = wrapWithCustomType(inner, HoodieSchemaType.BLOB)
+
+  private def wrapVariant(inner: StructType): StructType = wrapWithCustomType(inner, HoodieSchemaType.VARIANT)
+
+  private def wrapWithCustomType(inner: StructType, customType: HoodieSchemaType): StructType = {
+    val fieldMetadata = new MetadataBuilder()
+      .putString(HoodieSchema.TYPE_METADATA_FIELD, customType.name())
+      .build()
+    new StructType(Array[StructField](
+      StructField("payload", inner, nullable = false, metadata = fieldMetadata)
+    ))
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteFromTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteFromTable.scala
@@ -100,4 +100,77 @@ class TestDeleteFromTable extends HoodieSparkSqlTestBase {
       })
     }
   }
+
+  test("Test DELETE on VECTOR column preserves custom-type metadata") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id bigint,
+           |  embedding VECTOR(3)
+           |) using hudi
+           | location '${tmp.getCanonicalPath}/$tableName'
+           | tblproperties (
+           |  type = 'cow',
+           |  primaryKey = 'id'
+           | )
+         """.stripMargin)
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, array(cast(0.1 as float), cast(0.2 as float), cast(0.3 as float))),
+           |  (2, array(cast(0.4 as float), cast(0.5 as float), cast(0.6 as float)))
+           """.stripMargin)
+
+      spark.sql(s"delete from $tableName where id = 1")
+
+      checkAnswer(s"select id from $tableName")(Seq(2L))
+    }
+  }
+
+  test("Test DELETE on BLOB column preserves custom-type metadata") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id bigint,
+           |  payload BLOB
+           |) using hudi
+           | location '${tmp.getCanonicalPath}/$tableName'
+           | tblproperties (
+           |  type = 'cow',
+           |  primaryKey = 'id'
+           | )
+         """.stripMargin)
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, named_struct(
+           |        'type', 'OUT_OF_LINE',
+           |        'data', cast(null as binary),
+           |        'reference', named_struct(
+           |          'external_path', 'blobs/a',
+           |          'offset', 0L,
+           |          'length', 3L,
+           |          'managed', false))),
+           |  (2, named_struct(
+           |        'type', 'OUT_OF_LINE',
+           |        'data', cast(null as binary),
+           |        'reference', named_struct(
+           |          'external_path', 'blobs/b',
+           |          'offset', 0L,
+           |          'length', 5L,
+           |          'managed', false)))
+           """.stripMargin)
+
+      spark.sql(s"delete from $tableName where id = 1")
+
+      checkAnswer(s"select id, payload.reference.external_path from $tableName")(
+        Seq(2L, "blobs/b"))
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -494,7 +494,8 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     //  - Schema of the expected "joined" output of the [[sourceTable]] and [[targetTable]]
     writeParams ++= Seq(
       PAYLOAD_RECORD_AVRO_SCHEMA ->
-        HoodieSchemaUtils.removeMetadataFields(convertStructTypeToHoodieSchema(enrichedSourceDF.schema, "record", "")).toString,
+        HoodieSchemaUtils.removeMetadataFields(
+          HoodieSchemaConversionUtils.convertUserStructTypeToHoodieSchema(enrichedSourceDF.schema, "record", "")).toString,
       PAYLOAD_EXPECTED_COMBINED_SCHEMA -> encodeAsBase64String(toStructType(joinedExpectedOutput))
     )
 

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -494,7 +494,8 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
     //  - Schema of the expected "joined" output of the [[sourceTable]] and [[targetTable]]
     writeParams ++= Seq(
       PAYLOAD_RECORD_AVRO_SCHEMA ->
-        HoodieSchemaUtils.removeMetadataFields(convertStructTypeToHoodieSchema(enrichedSourceDF.schema, "record", "")).toString,
+        HoodieSchemaUtils.removeMetadataFields(
+          HoodieSchemaConversionUtils.convertUserStructTypeToHoodieSchema(enrichedSourceDF.schema, "record", "")).toString,
       PAYLOAD_EXPECTED_COMBINED_SCHEMA -> encodeAsBase64String(toStructType(joinedExpectedOutput))
     )
 


### PR DESCRIPTION
…runeDataSchema

### Describe the issue this Pull Request addresses

**Closes**: #18565
**NOTE**: Merge this after #18540, this is merged PR, so rebase this once #18540 is landed.


Nested field projection on a BLOB or VARIANT column throws `IllegalArgumentException: Data schema is not a record` at query planning. Full repro, stack trace, and environment are in the linked issue.

Root cause:

* `HoodieSchemaType` enumerates `BLOB` and `VARIANT` as distinct enum values from `RECORD`, though both use Avro RECORD physically (`HoodieSchemaType.java:120-127`).
* `pruneDataSchemaInternal`'s `case RECORD` guards with `dataSchema.getType() != RECORD` and throws when file schema is `BLOB` / `VARIANT` but Spark's pruning drops the `hudi_type` StructField metadata, downgrading the required side to plain RECORD.
* Any nested projection on these columns routed through `HoodieFileGroupReaderBasedFileFormat` hits this.

### Summary and Changelog

Users can now project nested fields of BLOB / VARIANT columns via SQL.

Fix:

* `HoodieSchemaUtils.pruneDataSchemaInternal`: short-circuit the RECORD case when data schema is `BLOB` or `VARIANT`. Return the data schema unchanged.
* Rationale: BLOB's `{type, data, reference}` and VARIANT's `{metadata, value}` inner layouts are fixed by `LogicalType.validate()`. Partial pruning violates the contract. Spark's projection still prunes at eval time, so the full-struct read is free in practice (tiny structs).
* VECTOR is Avro FIXED with no inner fields. Falls through default case, not touched.

Tests:

* `TestHoodieSchemaUtils.testPruningPreservesBlobWhenRequiredIsPlainRecord` directly exercises the pruner with a BLOB data field and a plain-RECORD required schema (the exact shape Spark's nested pruning produces).
* `TestDeleteFromTable` adds two Spark SQL regression tests:
  * `Test DELETE on BLOB column preserves custom-type metadata` is the end-to-end reproducer. Projects `payload.reference.external_path` after DELETE.
  * `Test DELETE on VECTOR column preserves custom-type metadata` guards the FIXED branch.

### Impact

* User-facing: nested projection on BLOB / VARIANT columns now works. Previously threw at plan time.
* Public API: none.
* Performance: none. Pruner runs once per plan on driver. Full-struct read on BLOB / VARIANT adds at most 2 extra small fields through the reader; Spark still prunes before operator output.

### Risk Level

Low.

* Single relaxation inside one guard clause.
* Returned schema matches what the full-column read path already uses.
* No storage format, public API, or other reader paths touched.
* Covered by one Java unit test plus two Spark SQL regression tests.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
