### PR TITLE
feat(flink): Vendor Flink 2.1 Dremel nested-reader support classes

### DIFF
--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/utils/BooleanArrayList.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/utils/BooleanArrayList.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.utils;
+
+import java.util.Arrays;
+
+/**
+ * Minimal implementation of an array-backed list of booleans.
+ *
+ * <p>Note: Vendored from Apache Flink (FLINK-35702, {@code
+ * org.apache.flink.runtime.util.BooleanArrayList}) because Flink 1.18 does not ship this helper.
+ */
+public class BooleanArrayList {
+  private int size;
+  private boolean[] array;
+
+  public BooleanArrayList(int capacity) {
+    this.size = 0;
+    this.array = new boolean[capacity];
+  }
+
+  public int size() {
+    return size;
+  }
+
+  public boolean add(boolean element) {
+    grow(size + 1);
+    array[size++] = element;
+    return true;
+  }
+
+  public void clear() {
+    size = 0;
+  }
+
+  public boolean isEmpty() {
+    return (size == 0);
+  }
+
+  public boolean[] toArray() {
+    return Arrays.copyOf(array, size);
+  }
+
+  private void grow(int length) {
+    if (length > array.length) {
+      final int newLength =
+          (int) Math.max(Math.min(2L * array.length, Integer.MAX_VALUE - 8), length);
+      final boolean[] t = new boolean[newLength];
+      System.arraycopy(array, 0, t, 0, size);
+      array = t;
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/utils/IntArrayList.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/utils/IntArrayList.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.utils;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+/**
+ * Minimal implementation of an array-backed list of ints.
+ *
+ * <p>Note: Vendored from Apache Flink ({@code org.apache.flink.runtime.util.IntArrayList}) to
+ * avoid depending on {@code @Internal} Flink runtime classes from Hudi's parquet reader.
+ */
+public class IntArrayList {
+
+  private int size;
+  private int[] array;
+
+  public IntArrayList(final int capacity) {
+    this.size = 0;
+    this.array = new int[capacity];
+  }
+
+  public int size() {
+    return size;
+  }
+
+  public boolean add(final int number) {
+    grow(size + 1);
+    array[size++] = number;
+    return true;
+  }
+
+  public int removeLast() {
+    if (size == 0) {
+      throw new NoSuchElementException();
+    }
+    --size;
+    return array[size];
+  }
+
+  public void clear() {
+    size = 0;
+  }
+
+  public boolean isEmpty() {
+    return size == 0;
+  }
+
+  private void grow(final int length) {
+    if (length > array.length) {
+      final int newLength =
+          (int) Math.max(Math.min(2L * array.length, Integer.MAX_VALUE - 8), length);
+      final int[] t = new int[newLength];
+      System.arraycopy(array, 0, t, 0, size);
+      array = t;
+    }
+  }
+
+  public int[] toArray() {
+    return Arrays.copyOf(array, size);
+  }
+
+  public static final IntArrayList EMPTY =
+      new IntArrayList(0) {
+
+        @Override
+        public boolean add(int number) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int removeLast() {
+          throw new UnsupportedOperationException();
+        }
+      };
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/utils/LongArrayList.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/utils/LongArrayList.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.utils;
+
+import java.util.Arrays;
+
+/**
+ * Minimal implementation of an array-backed list of longs.
+ *
+ * <p>Note: Vendored from Apache Flink ({@code org.apache.flink.runtime.util.LongArrayList}) to
+ * avoid depending on {@code @Internal} Flink runtime classes from Hudi's parquet reader.
+ */
+public class LongArrayList {
+
+  private int size;
+  private long[] array;
+
+  public LongArrayList(int capacity) {
+    this.size = 0;
+    this.array = new long[capacity];
+  }
+
+  public int size() {
+    return size;
+  }
+
+  public boolean add(long number) {
+    grow(size + 1);
+    array[size++] = number;
+    return true;
+  }
+
+  public long removeLong(int index) {
+    if (index >= size) {
+      throw new IndexOutOfBoundsException(
+          "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+    }
+    final long old = array[index];
+    size--;
+    if (index != size) {
+      System.arraycopy(array, index + 1, array, index, size - index);
+    }
+    return old;
+  }
+
+  public void clear() {
+    size = 0;
+  }
+
+  public boolean isEmpty() {
+    return (size == 0);
+  }
+
+  public long[] toArray() {
+    return Arrays.copyOf(array, size);
+  }
+
+  private void grow(int length) {
+    if (length > array.length) {
+      final int newLength =
+          (int) Math.max(Math.min(2L * array.length, Integer.MAX_VALUE - 8), length);
+      final long[] t = new long[newLength];
+      System.arraycopy(array, 0, t, 0, size);
+      array = t;
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/utils/NestedPositionUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/utils/NestedPositionUtil.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.utils;
+
+import org.apache.hudi.table.format.cow.vector.position.CollectionPosition;
+import org.apache.hudi.table.format.cow.vector.position.RowPosition;
+import org.apache.hudi.table.format.cow.vector.type.ParquetField;
+
+import static java.lang.String.format;
+
+/**
+ * Utils to calculate nested type position.
+ *
+ * <p>Note: Vendored from Apache Flink (FLINK-35702, {@code
+ * org.apache.flink.formats.parquet.utils.NestedPositionUtil}).
+ */
+public class NestedPositionUtil {
+
+  /**
+   * Calculate row offsets according to column's max repetition level, definition level, value's
+   * repetition level and definition level. Each row has three situation:
+   * <li>Row is not defined,because it's optional parent fields is null, this is decided by its
+   *     parent's repetition level
+   * <li>Row is null
+   * <li>Row is defined and not empty.
+   *
+   * @param field field that contains the row column message include max repetition level and
+   *     definition level.
+   * @param fieldRepetitionLevels int array with each value's repetition level.
+   * @param fieldDefinitionLevels int array with each value's definition level.
+   * @return {@link RowPosition} contains collections row count and isNull array.
+   */
+  public static RowPosition calculateRowOffsets(
+      ParquetField field, int[] fieldDefinitionLevels, int[] fieldRepetitionLevels) {
+    int rowDefinitionLevel = field.getDefinitionLevel();
+    int rowRepetitionLevel = field.getRepetitionLevel();
+    int nullValuesCount = 0;
+    BooleanArrayList nullRowFlags = new BooleanArrayList(0);
+    for (int i = 0; i < fieldDefinitionLevels.length; i++) {
+      // If a row's last field is an array, the repetition levels for the array's items will
+      // be larger than the parent row's repetition level, so we need to skip those values.
+      if (fieldRepetitionLevels[i] > rowRepetitionLevel) {
+        continue;
+      }
+
+      if (fieldDefinitionLevels[i] >= rowDefinitionLevel) {
+        // current row is defined and not empty
+        nullRowFlags.add(false);
+      } else {
+        // current row is null
+        nullRowFlags.add(true);
+        nullValuesCount++;
+      }
+    }
+    if (nullValuesCount == 0) {
+      return new RowPosition(null, fieldDefinitionLevels.length);
+    }
+    return new RowPosition(nullRowFlags.toArray(), nullRowFlags.size());
+  }
+
+  /**
+   * Calculate the collection's offsets according to column's max repetition level, definition
+   * level, value's repetition level and definition level. Each collection (Array or Map) has four
+   * situation:
+   * <li>Collection is not defined, because optional parent fields is null, this is decided by its
+   *     parent's repetition level
+   * <li>Collection is null
+   * <li>Collection is defined but empty
+   * <li>Collection is defined and not empty. In this case offset value is increased by the number
+   *     of elements in that collection
+   *
+   * @param field field that contains array/map column message include max repetition level and
+   *     definition level.
+   * @param definitionLevels int array with each value's repetition level.
+   * @param repetitionLevels int array with each value's definition level.
+   * @return {@link CollectionPosition} contains collections offset array, length array and isNull
+   *     array.
+   */
+  public static CollectionPosition calculateCollectionOffsets(
+      ParquetField field, int[] definitionLevels, int[] repetitionLevels) {
+    int collectionDefinitionLevel = field.getDefinitionLevel();
+    int collectionRepetitionLevel = field.getRepetitionLevel() + 1;
+    int offset = 0;
+    int valueCount = 0;
+    LongArrayList offsets = new LongArrayList(0);
+    offsets.add(offset);
+    BooleanArrayList emptyCollectionFlags = new BooleanArrayList(0);
+    BooleanArrayList nullCollectionFlags = new BooleanArrayList(0);
+    int nullValuesCount = 0;
+    for (int i = 0;
+        i < definitionLevels.length;
+        i = getNextCollectionStartIndex(repetitionLevels, collectionRepetitionLevel, i)) {
+      valueCount++;
+      if (definitionLevels[i] >= collectionDefinitionLevel - 1) {
+        boolean isNull =
+            isOptionalFieldValueNull(definitionLevels[i], collectionDefinitionLevel);
+        nullCollectionFlags.add(isNull);
+        nullValuesCount += isNull ? 1 : 0;
+        // definitionLevels[i] > collectionDefinitionLevel  => Collection is defined and not
+        // empty
+        // definitionLevels[i] == collectionDefinitionLevel => Collection is defined but
+        // empty
+        if (definitionLevels[i] > collectionDefinitionLevel) {
+          emptyCollectionFlags.add(false);
+          offset += getCollectionSize(repetitionLevels, collectionRepetitionLevel, i + 1);
+        } else if (definitionLevels[i] == collectionDefinitionLevel) {
+          offset++;
+          emptyCollectionFlags.add(true);
+        } else {
+          offset++;
+          emptyCollectionFlags.add(false);
+        }
+        offsets.add(offset);
+      } else {
+        // when definitionLevels[i] < collectionDefinitionLevel - 1, it means the collection
+        // is
+        // not defined, but we need to regard it as null to avoid getting value wrong.
+        nullCollectionFlags.add(true);
+        nullValuesCount++;
+        offsets.add(++offset);
+        emptyCollectionFlags.add(false);
+      }
+    }
+    long[] offsetsArray = offsets.toArray();
+    long[] length = calculateLengthByOffsets(emptyCollectionFlags.toArray(), offsetsArray);
+    if (nullValuesCount == 0) {
+      return new CollectionPosition(null, offsetsArray, length, valueCount);
+    }
+    return new CollectionPosition(
+        nullCollectionFlags.toArray(), offsetsArray, length, valueCount);
+  }
+
+  public static boolean isOptionalFieldValueNull(int definitionLevel, int maxDefinitionLevel) {
+    return definitionLevel == maxDefinitionLevel - 1;
+  }
+
+  public static long[] calculateLengthByOffsets(
+      boolean[] collectionIsEmpty, long[] arrayOffsets) {
+    LongArrayList lengthList = new LongArrayList(arrayOffsets.length);
+    for (int i = 0; i < arrayOffsets.length - 1; i++) {
+      long offset = arrayOffsets[i];
+      long length = arrayOffsets[i + 1] - offset;
+      if (length < 0) {
+        throw new IllegalArgumentException(
+            format(
+                "Offset is not monotonically ascending. offsets[%s]=%s, offsets[%s]=%s",
+                i, arrayOffsets[i], i + 1, arrayOffsets[i + 1]));
+      }
+      if (collectionIsEmpty[i]) {
+        length = 0;
+      }
+      lengthList.add(length);
+    }
+    return lengthList.toArray();
+  }
+
+  private static int getNextCollectionStartIndex(
+      int[] repetitionLevels, int maxRepetitionLevel, int elementIndex) {
+    do {
+      elementIndex++;
+    } while (hasMoreElements(repetitionLevels, elementIndex)
+        && isNotCollectionBeginningMarker(
+            repetitionLevels, maxRepetitionLevel, elementIndex));
+    return elementIndex;
+  }
+
+  /** This method is only called for non-empty collections. */
+  private static int getCollectionSize(
+      int[] repetitionLevels, int maxRepetitionLevel, int nextIndex) {
+    int size = 1;
+    while (hasMoreElements(repetitionLevels, nextIndex)
+        && isNotCollectionBeginningMarker(
+            repetitionLevels, maxRepetitionLevel, nextIndex)) {
+      // Collection elements cannot only be primitive, but also can have nested structure
+      // Counting only elements which belong to current collection, skipping inner elements of
+      // nested collections/structs
+      if (repetitionLevels[nextIndex] <= maxRepetitionLevel) {
+        size++;
+      }
+      nextIndex++;
+    }
+    return size;
+  }
+
+  private static boolean isNotCollectionBeginningMarker(
+      int[] repetitionLevels, int maxRepetitionLevel, int nextIndex) {
+    return repetitionLevels[nextIndex] >= maxRepetitionLevel;
+  }
+
+  private static boolean hasMoreElements(int[] repetitionLevels, int nextIndex) {
+    return nextIndex < repetitionLevels.length;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/position/CollectionPosition.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/position/CollectionPosition.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector.position;
+
+import javax.annotation.Nullable;
+
+/**
+ * To represent collection's position in repeated type.
+ *
+ * <p>Note: Vendored from Apache Flink (FLINK-35702, {@code
+ * org.apache.flink.formats.parquet.vector.position.CollectionPosition}).
+ */
+public class CollectionPosition {
+  @Nullable private final boolean[] isNull;
+  private final long[] offsets;
+  private final long[] length;
+  private final int valueCount;
+
+  public CollectionPosition(boolean[] isNull, long[] offsets, long[] length, int valueCount) {
+    this.isNull = isNull;
+    this.offsets = offsets;
+    this.length = length;
+    this.valueCount = valueCount;
+  }
+
+  public boolean[] getIsNull() {
+    return isNull;
+  }
+
+  public long[] getOffsets() {
+    return offsets;
+  }
+
+  public long[] getLength() {
+    return length;
+  }
+
+  public int getValueCount() {
+    return valueCount;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/position/LevelDelegation.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/position/LevelDelegation.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector.position;
+
+/**
+ * To delegate repetition level and definition level.
+ *
+ * <p>Note: Vendored from Apache Flink (FLINK-35702, {@code
+ * org.apache.flink.formats.parquet.vector.position.LevelDelegation}).
+ */
+public class LevelDelegation {
+  private final int[] repetitionLevel;
+  private final int[] definitionLevel;
+
+  public LevelDelegation(int[] repetitionLevel, int[] definitionLevel) {
+    this.repetitionLevel = repetitionLevel;
+    this.definitionLevel = definitionLevel;
+  }
+
+  public int[] getRepetitionLevel() {
+    return repetitionLevel;
+  }
+
+  public int[] getDefinitionLevel() {
+    return definitionLevel;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/position/RowPosition.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/position/RowPosition.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector.position;
+
+import javax.annotation.Nullable;
+
+/**
+ * To represent struct's position in repeated type.
+ *
+ * <p>Note: Vendored from Apache Flink (FLINK-35702, {@code
+ * org.apache.flink.formats.parquet.vector.position.RowPosition}).
+ */
+public class RowPosition {
+  @Nullable private final boolean[] isNull;
+  private final int positionsCount;
+
+  public RowPosition(boolean[] isNull, int positionsCount) {
+    this.isNull = isNull;
+    this.positionsCount = positionsCount;
+  }
+
+  public boolean[] getIsNull() {
+    return isNull;
+  }
+
+  public int getPositionsCount() {
+    return positionsCount;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/type/ParquetField.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/type/ParquetField.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector.type;
+
+import org.apache.flink.table.types.logical.LogicalType;
+
+/**
+ * Field that represent parquet's field type.
+ *
+ * <p>Note: Vendored from Apache Flink (FLINK-35702, {@code
+ * org.apache.flink.formats.parquet.vector.type.ParquetField}).
+ */
+public abstract class ParquetField {
+  private final LogicalType type;
+  private final int repetitionLevel;
+  private final int definitionLevel;
+  private final boolean required;
+
+  public ParquetField(
+      LogicalType type, int repetitionLevel, int definitionLevel, boolean required) {
+    this.type = type;
+    this.repetitionLevel = repetitionLevel;
+    this.definitionLevel = definitionLevel;
+    this.required = required;
+  }
+
+  public LogicalType getType() {
+    return type;
+  }
+
+  public int getRepetitionLevel() {
+    return repetitionLevel;
+  }
+
+  public int getDefinitionLevel() {
+    return definitionLevel;
+  }
+
+  public boolean isRequired() {
+    return required;
+  }
+
+  @Override
+  public String toString() {
+    return "Field{"
+        + "type="
+        + type
+        + ", repetitionLevel="
+        + repetitionLevel
+        + ", definitionLevel="
+        + definitionLevel
+        + ", required="
+        + required
+        + '}';
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/type/ParquetGroupField.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/type/ParquetGroupField.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector.type;
+
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Field that represent parquet's Group Field.
+ *
+ * <p>Note: Vendored from Apache Flink (FLINK-35702, {@code
+ * org.apache.flink.formats.parquet.vector.type.ParquetGroupField}) with a Hudi-specific extension:
+ * entries in the {@code children} list may be {@code null} to denote a Row child that is absent
+ * from the parquet file but present in the requested logical schema (schema evolution). This
+ * replaces Hudi's previous {@code EmptyColumnReader} branch for Row subtrees.
+ */
+public class ParquetGroupField extends ParquetField {
+
+  private final List<ParquetField> children;
+
+  public ParquetGroupField(
+      LogicalType type,
+      int repetitionLevel,
+      int definitionLevel,
+      boolean required,
+      List<ParquetField> children) {
+    super(type, repetitionLevel, definitionLevel, required);
+    // Use a plain unmodifiable list (not ImmutableList) so that null entries are allowed for
+    // schema-evolution missing children in ROW types.
+    this.children =
+        Collections.unmodifiableList(new ArrayList<>(requireNonNull(children, "children is null")));
+  }
+
+  /** Children of this group. Entries may be {@code null} for absent-in-file Row fields. */
+  public List<ParquetField> getChildren() {
+    return children;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/type/ParquetPrimitiveField.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/type/ParquetPrimitiveField.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector.type;
+
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.parquet.column.ColumnDescriptor;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Field that represent parquet's primitive field.
+ *
+ * <p>Note: Vendored from Apache Flink (FLINK-35702, {@code
+ * org.apache.flink.formats.parquet.vector.type.ParquetPrimitiveField}).
+ */
+public class ParquetPrimitiveField extends ParquetField {
+
+  private final ColumnDescriptor descriptor;
+  private final int id;
+
+  public ParquetPrimitiveField(
+      LogicalType type, boolean required, ColumnDescriptor descriptor, int id) {
+    super(
+        type,
+        descriptor.getMaxRepetitionLevel(),
+        descriptor.getMaxDefinitionLevel(),
+        required);
+    this.descriptor = requireNonNull(descriptor, "descriptor is required");
+    this.id = id;
+  }
+
+  public ColumnDescriptor getDescriptor() {
+    return descriptor;
+  }
+
+  public int getId() {
+    return id;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/test/java/org/apache/hudi/table/format/cow/vector/type/TestParquetGroupField.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/test/java/org/apache/hudi/table/format/cow/vector/type/TestParquetGroupField.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.format.cow.vector.type;
+
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link ParquetGroupField}.
+ */
+public class TestParquetGroupField {
+
+  @Test
+  void testChildrenWithAllNonNullEntriesAreRetained() {
+    ParquetField c0 = new ParquetPrimitiveField(new IntType(), true, descriptor(), 0);
+    ParquetField c1 = new ParquetPrimitiveField(new VarCharType(), true, descriptor(), 1);
+    List<ParquetField> children = Arrays.asList(c0, c1);
+
+    ParquetGroupField group = new ParquetGroupField(rowType(), 0, 1, true, children);
+
+    assertEquals(2, group.getChildren().size());
+    assertSame(c0, group.getChildren().get(0));
+    assertSame(c1, group.getChildren().get(1));
+  }
+
+  @Test
+  void testChildrenMayContainNullForSchemaEvolution() {
+    // A ROW field present in the requested Flink schema but absent from the Parquet file is
+    // represented by a null slot in `children`. The group must allow this (Hudi-specific
+    // extension over Flink's ImmutableList-backed equivalent).
+    ParquetField present = new ParquetPrimitiveField(new IntType(), true, descriptor(), 0);
+    List<ParquetField> children = Arrays.asList(present, null);
+
+    ParquetGroupField group = new ParquetGroupField(rowType(), 0, 1, true, children);
+
+    assertEquals(2, group.getChildren().size());
+    assertNotNull(group.getChildren().get(0));
+    assertNull(group.getChildren().get(1));
+  }
+
+  @Test
+  void testChildrenListIsUnmodifiable() {
+    ParquetField child = new ParquetPrimitiveField(new IntType(), true, descriptor(), 0);
+    ParquetGroupField group =
+        new ParquetGroupField(rowType(), 0, 1, true, Collections.singletonList(child));
+
+    assertThrows(UnsupportedOperationException.class, () -> group.getChildren().add(null));
+    assertThrows(UnsupportedOperationException.class, () -> group.getChildren().remove(0));
+  }
+
+  @Test
+  void testChildrenListIsDefensivelyCopied() {
+    // Mutations to the caller-supplied list must not be visible through the group.
+    ParquetField child = new ParquetPrimitiveField(new IntType(), true, descriptor(), 0);
+    List<ParquetField> mutable = new ArrayList<>();
+    mutable.add(child);
+
+    ParquetGroupField group = new ParquetGroupField(rowType(), 0, 1, true, mutable);
+    mutable.add(null);
+
+    assertEquals(1, group.getChildren().size());
+  }
+
+  @Test
+  void testNullChildrenListThrows() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new ParquetGroupField(rowType(), 0, 1, true, null));
+  }
+
+  @Test
+  void testEmptyChildrenListIsAllowed() {
+    ParquetGroupField group =
+        new ParquetGroupField(rowType(), 0, 1, true, Collections.emptyList());
+
+    assertEquals(0, group.getChildren().size());
+  }
+
+  @Test
+  void testFieldMetadataIsExposed() {
+    ParquetGroupField group =
+        new ParquetGroupField(rowType(), 2, 5, false, Collections.emptyList());
+
+    assertEquals(2, group.getRepetitionLevel());
+    assertEquals(5, group.getDefinitionLevel());
+    assertFalse(group.isRequired());
+  }
+
+  private static LogicalType rowType() {
+    return RowType.of(new IntType());
+  }
+
+  private static ColumnDescriptor descriptor() {
+    PrimitiveType primitive = Types.required(PrimitiveTypeName.INT32).named("f");
+    return new ColumnDescriptor(new String[] {"f"}, primitive, 0, 0);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Hudi-flink's `ParquetColumnarRowSplitReader` raises `ClassCastException` for a range of nested Parquet schemas (`ARRAY<ROW>`, `MAP<*,*>` inside `ARRAY`, nested `ROW` subtrees, legacy 2-level list encodings). Flink 2.1 fixed this class of problems in [FLINK-35702](https://issues.apache.org/jira/browse/FLINK-35702) by rewriting nested reads in Dremel form ("one primitive reader per leaf column" + an assembler that stitches repetition / definition levels into offsets, lengths, and null flags).

This is the 2nd of a series of PRs that port flink 2.1 fixes back into hudi. It is strictly scaffolding: it adds the shared data-holder / utility classes that the new readers will consume, with no existing caller changes and no behavior change yet.

### Summary and Changelog

Vendors ten classes from Apache Flink 2.1 into `hudi-flink1.18.x` so we can adopt the [FLINK-35702](https://issues.apache.org/jira/browse/FLINK-35702) Dremel reader without pulling `@Internal` Flink runtime classes or Flink's shaded Guava into Hudi:
- `org.apache.hudi.table.format.cow.utils`
    - `BooleanArrayList`, `IntArrayList`, `LongArrayList` — vendored from `org.apache.flink.runtime.util.*`
    - `NestedPositionUtil` — vendored from `org.apache.flink.formats.parquet.utils.NestedPositionUtil`. Computes Dremel offsets/lengths/null-flags from repetition / definition levels
- `org.apache.hudi.table.format.cow.vector.position`
    - `CollectionPosition`, `RowPosition`, `LevelDelegation` — position / level-pair data holders, vendored from `org.apache.flink.formats.parquet.vector.position.*`
- `org.apache.hudi.table.format.cow.vector.type`
    - `ParquetField`, `ParquetPrimitiveField`, `ParquetGroupField` — vendored from `org.apache.flink.formats.parquet.vector.type.*`. Express the logical-plus-physical schema tree the new reader walks

**Single intentional divergence from Flink 2.1**: 

`ParquetGroupField`'s children list permits `null` entries. Flink backs its list with `ImmutableList.copyOf(...)` which
would throw NPE on null elements; Hudi backs it with a defensively-copied `Collections.unmodifiableList(new ArrayList<>(...))`. This lets Hudi represent a ROW subtree that is present in the requested logical schema but absent from the Parquet file (schema evolution) as a `null` slot in the children list, subsuming the role played by Hudi's existing `EmptyColumnReader` branch. The divergence is documented in class Javadoc and covered by `TestParquetGroupField` (7 tests covering non-null retention, null-tolerance, unmodifiability, defensive copying, null-list rejection, empty lists,
and field-metadata exposure).

All ten vendored classes are otherwise faithful ports. No Flink class is modified, no Hudi caller is rewired. The vendored classes will be consumed by the new `NestedColumnReader` / `NestedPrimitiveColumnReader` in the next PR and by the rewritten `ParquetSplitReaderUtil` after that.

Part of #18491.

### Impact

No user-visible change in this PR. Nothing wires these classes into the read path yet. `ParquetSplitReaderUtil` and `ParquetColumnarRowSplitReader` are untouched.

### Risk Level

None — pure additions. No existing code paths touched; the module compiles and all existing tests pass unchanged.

### Documentation Update

N/A

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
