### PR TITLE
fix: FileGroupReader drops mandatory partition columns from dataSchema

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -251,7 +251,8 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     partitionSchema.fields.foreach(f => exclusionFields.add(f.name))
     val requestedStructType = StructType(requiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
     val requestedSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(requestedStructType, sanitizedTableName), exclusionFields)
-    val dataSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(dataStructType, sanitizedTableName), exclusionFields)
+    val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
+    val dataSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(dataStructTypeWithMandatoryPartitionFields, sanitizedTableName), exclusionFields)
 
     spark.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", supportVectorizedRead.toString)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestFileGroupReaderPartitionColumn.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestFileGroupReaderPartitionColumn.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+
+import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull}
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression test for the FileGroupReader bug where mandatory partition columns
+ * were dropped from `dataSchema` before pruning, causing the column to read back
+ * as null for untouched rows in MOR file slices containing both a base file and
+ * a log file.
+ *
+ * Scenario: MOR + `CustomKeyGenerator` (`country:simple`) + `PostgresDebeziumAvroPayload`
+ * + `GLOBAL_SIMPLE` index with `update.partition.path=true`, then a round-2 write
+ * that moves two records out of the `country=IN` partition via a partition-key
+ * change. This produces a file slice in `country=IN` with both a base parquet
+ * (round 1) and a log file (round 2 delete markers for the moved records),
+ * while the two untouched records in that slice (id=12 and id=14) remain in
+ * the base file.
+ *
+ * Before the fix: `buildReaderWithPartitionValues` augmented only `requestedStructType`
+ * with mandatory partition fields before pruning, leaving `dataSchema` missing
+ * `country`. The FileGroupReader path then skipped reading the column from
+ * parquet, and the `FileGroupReaderSchemaHandler` (which sets `requiredSchema` to
+ * `this.tableSchema` for a non-projection-compatible CUSTOM merger like Postgres)
+ * propagated that through the output converter, which wrote `null` for every
+ * untouched row in the base+log slice.
+ *
+ * After the fix: `dataSchema` contains `country`, so id=12 and id=14 read back
+ * with the correct `country="IN"`.
+ *
+ * Partitions without log files (`country=US`, `country=CN`) hit the `readBaseFile`
+ * path that appends partition values from the directory and are unaffected either
+ * way — they're included here as negative controls.
+ */
+class TestFileGroupReaderPartitionColumn extends SparkClientFunctionalTestHarness {
+
+  @Test
+  def testMandatoryPartitionColumnReadFromLogFileSlice(): Unit = {
+    val commonOpts = Map(
+      "hoodie.table.name" -> "test_fg_reader_partition_col",
+      "hoodie.datasource.write.table.type" -> "MERGE_ON_READ",
+      "hoodie.write.table.version" -> "6",
+      "hoodie.datasource.write.recordkey.field" -> "id",
+      "hoodie.datasource.write.precombine.field" -> "_event_lsn",
+      "hoodie.datasource.write.partitionpath.field" -> "country:simple",
+      "hoodie.datasource.write.keygenerator.class" -> "org.apache.hudi.keygen.CustomKeyGenerator",
+      "hoodie.datasource.write.hive_style_partitioning" -> "true",
+      "hoodie.datasource.write.partitionpath.urlencode" -> "true",
+      "hoodie.datasource.write.payload.class" ->
+        "org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload",
+      "hoodie.index.type" -> "GLOBAL_SIMPLE",
+      "hoodie.simple.index.update.partition.path" -> "true",
+      "hoodie.datasource.write.operation" -> "upsert",
+      "hoodie.metadata.enable" -> "true",
+      "hoodie.compact.inline" -> "false",
+      "hoodie.clean.automatic" -> "false",
+      "hoodie.datasource.write.reconcile.schema" -> "false"
+    )
+
+    val schema = StructType(Array(
+      StructField("_change_operation_type", StringType, nullable = true),
+      StructField("_event_lsn", LongType, nullable = true),
+      StructField("id", LongType, nullable = true),
+      StructField("country", StringType, nullable = true),
+      StructField("device_id", StringType, nullable = true),
+      StructField("manufacturer", StringType, nullable = true),
+      StructField("event_type", StringType, nullable = true),
+      StructField("price", DoubleType, nullable = true)
+    ))
+
+    // Round 1: 8 records across 3 partitions.
+    //  country=IN: id=2,6,12,14 (4 rows in one base parquet)
+    //  country=US: id=4,10
+    //  country=CN: id=8,16
+    val round1Rows = Seq(
+      Row("c", 2550218872L,  2L, "IN", "0x100000021ce30", "Acme Corp",       "plan change",       11.0),
+      Row("c", 2550219144L,  4L, "US", "0x100000052e763", "Delta corp",      "telecoms activity", 12.0),
+      Row("c", 2550219424L,  6L, "IN", "0x10000008e92b8", "Xyzzy Inc.",      "plan change",       13.0),
+      Row("c", 2550219696L,  8L, "CN", "0x10000008a5eba", "Xyzzy Inc.",      "plan change",       14.0),
+      Row("c", 2550219968L, 10L, "US", "0x10000008df79c", "Lakehouse Ltd",   "device error",      15.0),
+      Row("c", 2550220240L, 12L, "IN", "0x10000007ddfb1", "Embanks Devices", "plan change",       16.0),
+      Row("c", 2550220512L, 14L, "IN", "0x10000008d8892", "Acme Corp",       "deactivation",      17.0),
+      Row("c", 2550220784L, 16L, "CN", "0x10000007352cd", "Acme Corp",       "telecoms activity", 18.0)
+    )
+    spark.createDataFrame(spark.sparkContext.parallelize(round1Rows, 1), schema)
+      .write.format("hudi")
+      .options(commonOpts)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    // Round 2: partition-key changes for id=2 (IN->US), id=6 (IN->US), and a delete
+    // for id=4 (stays in US). With GLOBAL_SIMPLE + update.partition.path=true, the
+    // partition-key changes leave delete markers in the old country=IN partition —
+    // which gives us the base+log file layout in country=IN. id=12 and id=14 are
+    // untouched and must read back with country=IN after the fix.
+    val round2Rows = Seq(
+      Row("u", 2650218872L, 2L, "US", "0x100000021ce30", "Acme Corp",  "plan change",       11.0),
+      Row("d", 2650219144L, 4L, "US", "0x100000052e763", "Delta corp", "telecoms activity", 12.0),
+      Row("u", 2650219424L, 6L, "US", "0x10000008e92b8", "Xyzzy Inc.", "plan change",       13.0)
+    )
+    spark.createDataFrame(spark.sparkContext.parallelize(round2Rows, 1), schema)
+      .write.format("hudi")
+      .options(commonOpts)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val rows = spark.read.format("hudi").load(basePath)
+      .select("id", "country")
+      .collect()
+      .map(r => r.getLong(0) -> (if (r.isNullAt(1)) null else r.getString(1)))
+      .toMap
+
+    // The moved records land in US.
+    assertEquals("US", rows(2L), "id=2 moved to US")
+    assertEquals("US", rows(6L), "id=6 moved to US")
+
+    // id=4 was deleted.
+    assertFalse(rows.contains(4L), "id=4 was deleted")
+
+    // Untouched rows whose slice has no log file — negative controls, these were
+    // never broken.
+    assertEquals("CN", rows(8L), "id=8 untouched in CN (no log file)")
+    assertEquals("US", rows(10L), "id=10 untouched in US (no log file)")
+    assertEquals("CN", rows(16L), "id=16 untouched in CN (no log file)")
+
+    // The regression: untouched rows in the IN slice that now has base+log. Before
+    // the fix these read back as null.
+    assertNotNull(rows(12L),
+      "id=12 (untouched, country=IN slice with base+log) must not be null")
+    assertNotNull(rows(14L),
+      "id=14 (untouched, country=IN slice with base+log) must not be null")
+    assertEquals("IN", rows(12L), "id=12 partition column must be IN")
+    assertEquals("IN", rows(14L), "id=14 partition column must be IN")
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18568

### Summary and Changelog

`HoodieFileGroupReaderBasedFileFormat.buildReaderWithPartitionValues` builds two schemas side-by-side: `requestedSchema` (what to return to Spark) and `dataSchema` (what to read from parquet). It augments `requestedStructType` with any partition fields in `mandatoryFields` before pruning, but pipes `dataStructType` through unchanged. Spark's `dataStructType` excludes partition columns by convention, and `HoodieSchemaUtils.pruneDataSchema` iterates over its second argument, so any mandatory partition field is silently dropped from the resulting `dataSchema`.

The FileGroupReader then does not read the partition column from the parquet base file, and for non-projection-compatible CUSTOM mergers (e.g. `PostgresDebeziumAvroPayload`) the output converter writes `null` for every affected row via `HoodieInternalRowUtils.genUnsafeStructWriter`'s `setNullAt` fallback.

Most visible on MOR file slices that have both a base file and a log file, since the `readBaseFile` path (which would append partition values from the directory name) is skipped in favor of the FileGroupReader path.

Regression introduced by #13711 ("Improve Logical Type Handling on Col Stats"), which added the `pruneDataSchema` wrapping but only on the requested-schema side.

**Fix:** mirror `requestedStructType`'s construction — augment `dataStructType` with the mandatory partition fields before pruning:

```scala
val dataStructTypeWithMandatoryPartition = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
val dataSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(dataStructTypeWithMandatoryPartition, sanitizedTableName), exclusionFields)
```

Strict no-op when `mandatoryFields.filter(partitionSchema)` is empty, which covers all non-CustomKeygen/non-TimestampKeygen tables. The parquet reader projects one extra column per affected row (the mandatory partition column), which the base files already contain (precondition: `drop.partition.columns=false`).

**Matrix of when the bug fires (all must hold):**
- Table uses `CustomKeyGenerator` or `TimestampBasedKeyGenerator`
- The partition columns aren't declared as timestamp fields (so the conservative "read all partition fields from file" fallback kicks in for `CustomKeyGenerator`)
- MOR file slice has both a base file and a log file
- `drop.partition.columns=false`
- Merger is not projection-compatible (e.g. `PostgresDebeziumAvroPayload`)

**Changes:**
- `HoodieFileGroupReaderBasedFileFormat.scala`: augment `dataStructType` with mandatory partition fields before pruning.
- `TestFileGroupReaderPartitionColumn.scala` (new): regression test reproducing the scenario end-to-end — MOR + `CustomKeyGenerator` + `PostgresDebeziumAvroPayload` + `GLOBAL_SIMPLE` with `update.partition.path=true`, round-2 partition-key change producing a base+log slice, then verifies untouched records in that slice read back with the correct partition-column value.

### Impact

Silent data corruption (partition column returning `null`) on MOR reads for the matrix of tables described above. No schema or on-disk format change. Only touches `HoodieFileGroupReaderBasedFileFormat.buildReaderWithPartitionValues`; the RDD-based MOR path (`HoodieMergeOnReadRDDV2`) uses the raw `tableSchema` directly and never had this bug.

### Risk Level

low

The fix is a strict no-op when `mandatoryFields.filter(partitionSchema)` is empty (all non-CustomKeygen/non-TimestampKeygen tables, and any table with `drop.partition.columns=true`). For non-empty cases it only adds the mandatory partition column to the set read from parquet — base files already contain this column as a precondition. Merger behavior is unchanged because `PostgresDebeziumAvroPayload.combineAndGetUpdateValue` / `preCombine` make decisions on the precombine key only.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable