### PR TITLE
fix: ProtoConversionUtil$AvroSupport static init under Avro 1.12

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ProtoConversionUtil.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ProtoConversionUtil.java
@@ -65,7 +65,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.hudi.common.util.ConfigUtils.getBooleanWithAltKeys;
 import static org.apache.hudi.common.util.ConfigUtils.getIntWithAltKeys;
-import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 import static org.apache.hudi.utilities.config.ProtoClassBasedSchemaProviderConfig.PROTO_SCHEMA_MAX_RECURSION_DEPTH;
 import static org.apache.hudi.utilities.config.ProtoClassBasedSchemaProviderConfig.PROTO_SCHEMA_TIMESTAMPS_AS_RECORDS;
 import static org.apache.hudi.utilities.config.ProtoClassBasedSchemaProviderConfig.PROTO_SCHEMA_WRAPPED_PRIMITIVES_AS_RECORDS;
@@ -142,7 +141,7 @@ public class ProtoConversionUtil {
     private static final String OVERFLOW_BYTES_FIELD_NAME = "proto_bytes";
     private static final HoodieSchema RECURSION_OVERFLOW_SCHEMA = HoodieSchema.createRecord("recursion_overflow", null, "org.apache.hudi.proto", false,
         Arrays.asList(HoodieSchemaField.of(OVERFLOW_DESCRIPTOR_FIELD_NAME, STRING_SCHEMA, null, ""),
-            HoodieSchemaField.of(OVERFLOW_BYTES_FIELD_NAME, HoodieSchema.create(HoodieSchemaType.BYTES), null, getUTF8Bytes(""))));
+            HoodieSchemaField.of(OVERFLOW_BYTES_FIELD_NAME, HoodieSchema.create(HoodieSchemaType.BYTES), null, "")));
     // A cache of the proto class name paired with whether wrapped primitives should be flattened as the key and the generated avro schema as the value
     private static final Map<SchemaCacheKey, HoodieSchema> SCHEMA_CACHE = new ConcurrentHashMap<>();
     // A cache with a key as the pair target avro schema and the proto descriptor for the source and the value as an array of proto field descriptors where the order matches the avro ordering.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18569

### Summary and Changelog

`RECURSION_OVERFLOW_SCHEMA` in `ProtoConversionUtil$AvroSupport` passes `new byte[0]` (via `getUTF8Bytes("")`) as the default value of a BYTES `HoodieSchemaField`, which wraps an Avro `Schema.Field`. Avro 1.12.0's `Schema.validateDefault` rejects `byte[]` for BYTES defaults — it now requires a `String` (interpreted as ISO-8859-1 bytes, Avro's canonical JSON form for BYTES defaults). Under 1.11.x the validator was lenient.

Because the failure occurs in a static initializer, the JVM caches the `ExceptionInInitializerError` and every subsequent class access throws `NoClassDefFoundError: Could not initialize class org.apache.hudi.utilities.sources.helpers.ProtoConversionUtil$AvroSupport`. Any downstream service loading this class (e.g. DeltaStreamer using `ProtoClassBasedSchemaProvider`) is permanently broken on JVMs that have Avro 1.12+ on the classpath, even though Hudi itself still pins 1.11.4.

**Observed stack trace:**
```
org.apache.avro.AvroTypeException: Invalid default for field proto_bytes: "" not a "bytes"
    at org.apache.avro.Schema.validateDefault(Schema.java:1681)
    at org.apache.avro.Schema$Field.<init>(Schema.java:539)
    ...
```
→ `ExceptionInInitializerError` → `NoClassDefFoundError` on every subsequent class access.

**Fix:** use `""` (empty string) instead of `getUTF8Bytes("")`. The default value is never read at runtime — it is always overwritten by `ByteBuffer.wrap(messageValue.toByteArray())` at `ProtoConversionUtil.java:~365` before the field is populated — and `""` serializes bit-for-bit identically to `new byte[0]` on the wire under Avro 1.11 (both produce `"default":""` in the JSON schema). Behavior is strictly preserved under Avro 1.11 while satisfying 1.12's stricter validator.

Rejected alternatives (experimental testing against both Avro versions):

| Default argument       | Avro 1.11.x | Avro 1.12.0 |
|------------------------|-------------|-------------|
| `new byte[0]` (current)| OK          | FAIL        |
| `""` (fix)             | OK          | OK          |
| `ByteBuffer.wrap(...)` | OK          | FAIL (`Unknown datum class: HeapByteBuffer`) |
| `null`                 | OK          | OK, but strips the default entirely (changes on-disk schema shape) |

Also drops the now-unused `getUTF8Bytes` static import.

**Scope check:** grepped the repo for BYTES-default patterns with `byte[]`/`ByteBuffer` defaults — there is exactly one occurrence (this line). No other call sites need fixing.

### Impact

- Hudi's default builds (Avro 1.11.4) — no-op; `""` serializes identically to `new byte[0]` on the wire.
- Hudi consumers bumping Avro to 1.12+ — fixes a static-init `NoClassDefFoundError` that currently bricks any pipeline using `ProtoClassBasedSchemaProvider`.
- No schema or on-disk format change.

### Risk Level

none

The changed default value is never materialized into records (always overwritten before the field is populated) and produces the same wire form on Avro 1.11. The change is inert for any consumer on the pinned Avro version and fixes a hard failure on newer Avro versions.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable