### PR TITLE
fix: ProtoConversionUtil UINT64 default fails Avro 1.12 FIXED validator

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ProtoConversionUtil.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ProtoConversionUtil.java
@@ -53,6 +53,7 @@ import org.apache.kafka.common.utils.CopyOnWriteMap;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -328,7 +329,9 @@ public class ProtoConversionUtil {
         case SFIXED64:
           return 0;
         case UINT64:
-          return DECIMAL_CONVERSION.toFixed(new BigDecimal(BigInteger.ZERO), fieldSchema.toAvroSchema(), fieldSchema.toAvroSchema().getLogicalType()).bytes();
+          return new String(
+              DECIMAL_CONVERSION.toFixed(new BigDecimal(BigInteger.ZERO), fieldSchema.toAvroSchema(), fieldSchema.toAvroSchema().getLogicalType()).bytes(),
+              StandardCharsets.ISO_8859_1);
         case STRING:
         case BYTES:
           return "";

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ProtoConversionUtil.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ProtoConversionUtil.java
@@ -329,6 +329,9 @@ public class ProtoConversionUtil {
         case SFIXED64:
           return 0;
         case UINT64:
+          // Avro 1.12 tightened FIXED default validation to require a String, not byte[].
+          // ISO-8859-1 gives a 1:1 byte-to-char mapping so the raw bytes survive the round-trip
+          // and the wire form matches what Avro 1.11 produced from the byte[] form.
           return new String(
               DECIMAL_CONVERSION.toFixed(new BigDecimal(BigInteger.ZERO), fieldSchema.toAvroSchema(), fieldSchema.toAvroSchema().getLogicalType()).bytes(),
               StandardCharsets.ISO_8859_1);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
@@ -199,6 +199,28 @@ public class TestProtoConversionUtil {
     Assertions.assertEquals(expected, actual);
   }
 
+  @Test
+  void uint64FieldDefaultIsAvroFixedValidatorCompatible() {
+    // Regression for Avro 1.12's tightened Schema.validateDefault for FIXED:
+    // a byte[] default gets base64-encoded ("AAAAAAAAAAAA", 12 chars) and is
+    // rejected because length != fixed size (9). The default must be a String
+    // of length == size (ISO-8859-1 of the raw bytes). Round-tripping the
+    // generated schema through JSON exercises the validator on parse.
+    ProtoConversionUtil.SchemaConfig schemaConfig = new ProtoConversionUtil.SchemaConfig(true, 1, true);
+    HoodieSchema schema = ProtoConversionUtil.getSchemaForMessageClass(Sample.class, schemaConfig);
+
+    Schema reparsed = new Schema.Parser().parse(schema.toAvroSchema().toString());
+    Schema.Field field = reparsed.getField(PRIMITIVE_UNSIGNED_LONG_FIELD_NAME);
+    Assertions.assertNotNull(field);
+    Assertions.assertTrue(field.hasDefaultValue());
+
+    GenericFixed decoded = (GenericFixed) GenericData.get().getDefaultValue(field);
+    Assertions.assertEquals(9, decoded.bytes().length);
+    Assertions.assertEquals(
+        BigInteger.ZERO,
+        DECIMAL_CONVERSION.fromFixed(decoded, field.schema(), field.schema().getLogicalType()).toBigInteger());
+  }
+
   private void assertUnsignedLongCorrectness(Schema fieldSchema, long expectedValue, GenericFixed actual) {
     BigDecimal actualPrimitiveUnsignedLong = DECIMAL_CONVERSION.fromFixed(actual, fieldSchema,
         fieldSchema.getLogicalType());


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18573

### Summary and Changelog

`ProtoConversionUtil$AvroSupport.getDefault` returns a `byte[9]` default for proto `uint64` fields (modelled as a `FIXED(size=9)` + `decimal` logicalType). Avro 1.11 coerced that into its canonical wire form (an ISO-8859-1 string of length == fixed size). Avro 1.12 tightened `Schema.validateDefault` for FIXED to require a `String` directly and reject `byte[]` — the byte array gets base64-encoded by Jackson to `"AAAAAAAAAAAA"` (12 chars, not 9), and the length check fails:

```
org.apache.avro.AvroTypeException: Invalid default for field primitive_unsigned_long:
  "AAAAAAAAAAAA" not a {"type":"fixed","name":"unsigned_long",...,"size":9,
                       "logicalType":"decimal","precision":20,"scale":0}
    at org.apache.hudi.utilities.sources.helpers.ProtoConversionUtil$AvroSupport.lambda$getSchema$0(ProtoConversionUtil.java:…)
```

**Fix:** pre-convert the `byte[]` to a `String` via ISO-8859-1 so it matches the form Avro 1.12's validator expects. Bit-identical wire representation to what 1.11 was emitting; forward-compatible with both Avro versions.

```java
case UINT64:
  return new String(
      DECIMAL_CONVERSION.toFixed(new BigDecimal(BigInteger.ZERO), fieldSchema.toAvroSchema(), fieldSchema.toAvroSchema().getLogicalType()).bytes(),
      StandardCharsets.ISO_8859_1);
```

### Backward compatibility

Empirically verified with a standalone probe against both Avro 1.11.4 and 1.12.0:

- **Avro 1.11.4** — both `byte[]` form and `String` form succeed, byte-identical `Schema.toString(true)` output.
- **Avro 1.12.0** — `byte[]` form throws `AvroTypeException`; `String` form works.

The default value is only consulted when a field is missing on read (decodes to `BigInteger.ZERO` / zero `GenericFixed` either way). Avro Parsing Canonical Form strips `"default"` so fingerprints (CRC-64-AVRO, MD5, SHA-256) are unchanged. Avro compatibility resolution operates on the decoded value, not its JSON encoding.

Corroborating evidence: Hudi's own test fixtures at `hudi-utilities/src/test/resources/schema-provider/proto/sample_schema_defaults.avsc:59` and `sample_schema_wrapped_and_timestamp_as_record.avsc:59` already contain this 9-NUL form — they were generated against Avro 1.11 JSON output, which matches both the old `byte[]` path and the new `String` path.

### Impact

- Hudi's default builds (Avro 1.11.4) — no-op; byte-identical schema JSON output.
- Hudi consumers bumping Avro to 1.12+ — fixes a hard `AvroTypeException` on any proto schema with a `uint64` field.
- No schema or on-disk format change.

Sibling Avro 1.12 fix for the proto overflow BYTES default: #18569.

### Risk Level

none

The changed default value produces the same wire form under Avro 1.11 and is the only form Avro 1.12 accepts. The change is inert for any consumer on the pinned Avro version and fixes a hard failure on newer Avro versions.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable