### PR TITLE
fix(vector): Pass plain FIXED through to VECTOR projection on Hive read

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieArrayWritableSchemaUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieArrayWritableSchemaUtils.java
@@ -304,6 +304,23 @@ public class HoodieArrayWritableSchemaUtils {
           }
         }
         break;
+      case VECTOR:
+        // Parquet stores VECTOR as a bare FIXED_LEN_BYTE_ARRAY without a logical-type
+        // annotation (see AvroSchemaConverterWithTimestampNTZ#convertField VECTOR branch),
+        // so Hive's Parquet reader reconstructs the Avro schema as plain FIXED named after
+        // the column. When Hudi then projects that record to the canonical VECTOR schema
+        // (fixed named vector_<elem>_<dim> with logicalType=vector), oldSchema.getType() is
+        // FIXED while newSchema.getType() is VECTOR. The byte layout is identical for
+        // StorageBacking.FIXED_BYTES as long as sizes match, so the rewrite is a pass-through.
+        if (oldSchema.getType() == HoodieSchemaType.FIXED
+            && newSchema instanceof HoodieSchema.Vector) {
+          HoodieSchema.Vector vector = (HoodieSchema.Vector) newSchema;
+          if (vector.getStorageBacking() == HoodieSchema.Vector.StorageBacking.FIXED_BYTES
+              && oldSchema.getFixedSize() == vector.getFixedSize()) {
+            return writable;
+          }
+        }
+        break;
       default:
     }
     throw new HoodieSchemaException(String.format("cannot support rewrite value for schema type: %s since the old schema type is: %s", newSchema, oldSchema));

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieArrayWritableSchemaUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieArrayWritableSchemaUtils.java
@@ -314,6 +314,24 @@ public class TestHoodieArrayWritableSchemaUtils {
     validateRewriteWithAvro(oldWritable, oldSchema, result, decimalSchema);
   }
 
+  @Test
+  void testRewritePlainFixedToVectorPassesThrough() {
+    // Pins the fix for the Hive vector-read path. Parquet stores VECTOR as bare
+    // FIXED_LEN_BYTE_ARRAY (AvroSchemaConverterWithTimestampNTZ#convertField),
+    // so Hive's Parquet reader reconstructs the Avro schema as plain FIXED using
+    // the column name; Hudi then projects to the canonical VECTOR schema
+    // (vector_float_3, size 12, logicalType=vector). Sizes match and VECTOR's
+    // FIXED_BYTES backing is byte-identical, so the rewrite must pass through.
+    // Before the fix this threw "cannot support rewrite value for schema type".
+    HoodieSchema oldSchema = HoodieSchema.createFixed("embedding", null, null, 12);
+    HoodieSchema newSchema = HoodieSchema.createVector(3, HoodieSchema.Vector.VectorElementType.FLOAT);
+    BytesWritable bytes = new BytesWritable(new byte[12]);
+
+    Writable rewritten = HoodieArrayWritableSchemaUtils.rewritePrimaryType(bytes, oldSchema, newSchema);
+
+    assertSame(bytes, rewritten);
+  }
+
   private void validateRewriteWithAvro(
       Writable oldWritable,
       HoodieSchema oldSchema,


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18579

Hive reads of Hudi VECTOR columns failed with `cannot support rewrite value for schema type` on the projection path.

- Hudi writes VECTOR as bare `FIXED_LEN_BYTE_ARRAY` with no Parquet logical-type annotation.
- Hive's Parquet reader reconstructs the Avro schema from the physical type as plain FIXED named after the column.
- Projecting that to the canonical VECTOR schema hits `rewritePrimaryTypeWithDiffSchemaType`.
- `HoodieSchemaType.FIXED` and `VECTOR` are distinct enum values, no VECTOR case in the switch, throw.

### Summary and Changelog

Add a VECTOR passthrough in `rewritePrimaryTypeWithDiffSchemaType`.

- FIXED_BYTES-backed VECTOR is byte-identical to FIXED at matching size.
- When old is FIXED and new is VECTOR with the same fixed size, return the writable unchanged.

Regression test in `TestHoodieArrayWritableSchemaUtils` pins the behavior:

- Old schema: plain FIXED named after the column.
- New schema: canonical VECTOR.
- Rewrite must succeed and return the same writable bytes.

### Impact

- Unblocks Hive reads over Hudi VECTOR columns.
- No public API change. No on-disk format change. No config change.
- Hot path cost: zero for non-VECTOR rewrites. One extra case entry, reached only when the old/new types actually differ by FIXED vs VECTOR.

### Risk Level

low

- Scoped to the Hive MR reader.
- Passthrough is only taken when the fixed size matches, which VECTOR enforces as the width of its element array (RFC-99).
- Covered by direct unit test in the owning module.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
