### PR TITLE
test(spark): Add date logical type test to TestAvroConversionUtils

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroConversionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroConversionUtils.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, DataTypes, M
 import org.scalatest.{FunSuite, Matchers}
 
 import java.nio.ByteBuffer
+import java.time.LocalDate
 import java.util.Objects
 
 class TestAvroConversionUtils extends FunSuite with Matchers {
@@ -455,5 +456,31 @@ class TestAvroConversionUtils extends FunSuite with Matchers {
     the[HoodieSchemaException] thrownBy {
       HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(struct, "SchemaName", "SchemaNS")
     } should have message "Duplicate field name in record SchemaNS.SchemaName: name type:UNION pos:2 and name type:UNION pos:1."
+  }
+
+  test("Logical type: date") {
+    val dateSchema = s"""
+      {
+        "namespace": "logical",
+        "type": "record",
+        "name": "test",
+        "fields": [
+          {"name": "date", "type": {"type": "int", "logicalType": "date"}}
+        ]
+      }
+    """
+
+    val dateInputData = Seq(7, 365, 0)
+    val schema = HoodieSchema.parse(dateSchema)
+    val convertor = AvroConversionUtils.createConverterToRow(schema, HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(schema))
+
+    val dateOutputData = dateInputData.map(x => {
+      val record = new GenericData.Record(schema.toAvroSchema) {{ put("date", x) }}
+      convertor(record).get(0)
+    })
+
+    assert(dateOutputData(0).toString === LocalDate.ofEpochDay(dateInputData(0)).toString)
+    assert(dateOutputData(1).toString === LocalDate.ofEpochDay(dateInputData(1)).toString)
+    assert(dateOutputData(2).toString === LocalDate.ofEpochDay(dateInputData(2)).toString)
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroConversionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroConversionUtils.scala
@@ -470,13 +470,13 @@ class TestAvroConversionUtils extends FunSuite with Matchers {
       }
     """
 
-    val dateInputData = Seq(7, 365, 0)
+    val dateInputData = Seq(7, 365, 0) // one week, one year, epoch
     val schema = HoodieSchema.parse(dateSchema)
-    val convertor = AvroConversionUtils.createConverterToRow(schema, HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(schema))
+    val converter = AvroConversionUtils.createConverterToRow(schema, HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(schema))
 
     val dateOutputData = dateInputData.map(x => {
       val record = new GenericData.Record(schema.toAvroSchema) {{ put("date", x) }}
-      convertor(record).get(0)
+      converter(record).get(0)
     })
 
     assert(dateOutputData(0).toString === LocalDate.ofEpochDay(dateInputData(0)).toString)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`TestAvroConversionUtils` was missing a test for Avro's `date` logical type (an `int` field with `logicalType=date`). The `createConverterToRow` utility handles this case by converting epoch-day integers to `java.sql.Date`, but this conversion path had no dedicated test coverage.

### Summary and Changelog

- Added a `"Logical type: date"` test in `TestAvroConversionUtils` that verifies `AvroConversionUtils.createConverterToRow` correctly converts an Avro record with an integer date field (epoch days) to a `java.sql.Date` with the expected calendar value.
- Added `import java.time.LocalDate` for the assertion helper.

### Impact

None — test-only change, no production code modified.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable