### PR TITLE
fix: Curator class conflict in ZookeeperBasedLockProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -492,6 +492,10 @@
               <shadedPattern>org.apache.hudi.com.fasterxml.jackson.module
               </shadedPattern>
             </relocation>
+            <relocation>
+              <pattern>org.apache.curator.</pattern>
+              <shadedPattern>org.apache.hudi.org.apache.curator.</shadedPattern>
+            </relocation>
           </relocations>
         </configuration>
       </plugin>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  Closes #18592                                                                                                                                                                                                                                                                                

  When using Hudi 1.0.2 with Spark 3.3.4, enabling optimistic concurrency control with ZookeeperBasedLockProvider throws NoSuchMethodError: CuratorZookeeperClient.startAdvancedTracer. This is caused by a Curator version mismatch on the runtime classpath: curator-framework from a newer
  version (which calls startAdvancedTracer) is loaded alongside curator-client from an older version (which does not have this method).


### Summary and Changelog

Added org.apache.curator relocation pattern in pom.xml shade plugin configuration to ensure proper shading and avoid class conflicts

### Impact

Bug fix

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
