### PR TITLE
feat(schema) Ensure spark SQL insert into preserves hudi_type for VEC…

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSchemaConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSchemaConversionUtils.scala
@@ -146,6 +146,60 @@ object HoodieSchemaConversionUtils {
   }
 
   /**
+   * Re-attaches per-field StructField.metadata from a catalog-derived
+   * StructType onto a source StructType, matched by field name.
+   *
+   * Spark's INSERT INTO column resolution drops user-defined StructField
+   * metadata when projecting the SELECT output against the target table's
+   * schema. For Hudi's BLOB and VECTOR logical types — whose detection
+   * depends on the `hudi_type` metadata key — this means downstream
+   * conversion via `convertStructTypeToHoodieSchema` produces a plain
+   * Avro record / array instead of the logical-typed equivalent, and the
+   * write fails with `SchemaBackwardsCompatibilityException:
+   * MISSING_UNION_BRANCH`.
+   *
+   * This helper compensates by copying StructField metadata from a
+   * catalog-derived StructType (which still has the metadata Spark
+   * preserved through the catalog round-trip) onto the source StructType
+   * (whose metadata Spark stripped during INSERT resolution). Recurses
+   * into nested StructType fields so BLOB nested inside another STRUCT
+   * is handled too. Falls back to source's own metadata when the catalog
+   * has no matching field or its metadata is empty.
+   *
+   * @param sourceSchema  the StructType whose metadata may have been stripped
+   *                      (typically `df.schema` from an INSERT plan)
+   * @param catalogSchema a StructType carrying authoritative
+   *                      StructField.metadata (typically derived from the
+   *                      Hudi catalog HoodieSchema)
+   * @return a StructType matching `sourceSchema`'s field shape but with
+   *         metadata re-stamped from `catalogSchema` where matching
+   */
+  def alignSchemaMetadataFromCatalog(sourceSchema: StructType,
+                                     catalogSchema: StructType): StructType = {
+    val byName = catalogSchema.fields.map(f => f.name -> f).toMap
+    val aligned = sourceSchema.fields.map { src =>
+      byName.get(src.name) match {
+        case Some(cat) =>
+          val newMetadata =
+            if (cat.metadata != org.apache.spark.sql.types.Metadata.empty) cat.metadata
+            else src.metadata
+          // Spark's INSERT INTO column resolution can also tighten field nullability
+          // (e.g. SELECT 1 AS id resolves as nullable=false even when the catalog
+          //  declares the column as nullable=true). Align with the catalog so the
+          //  resulting Avro schema's union shape matches the persisted schema.
+          val newNullable = cat.nullable
+          val newDataType = (src.dataType, cat.dataType) match {
+            case (s: StructType, c: StructType) => alignSchemaMetadataFromCatalog(s, c)
+            case _ => src.dataType
+          }
+          src.copy(dataType = newDataType, nullable = newNullable, metadata = newMetadata)
+        case None => src
+      }
+    }
+    StructType(aligned)
+  }
+
+  /**
    * Recursively aligns the nullable property of Spark schema fields with HoodieSchema.
    *
    * @param sourceSchema Source Spark StructType to align

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSchemaConversionUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSchemaConversionUtils.scala
@@ -158,13 +158,18 @@ object HoodieSchemaConversionUtils {
    * write fails with `SchemaBackwardsCompatibilityException:
    * MISSING_UNION_BRANCH`.
    *
-   * This helper compensates by copying StructField metadata from a
-   * catalog-derived StructType (which still has the metadata Spark
-   * preserved through the catalog round-trip) onto the source StructType
-   * (whose metadata Spark stripped during INSERT resolution). Recurses
-   * into nested StructType fields so BLOB nested inside another STRUCT
-   * is handled too. Falls back to source's own metadata when the catalog
-   * has no matching field or its metadata is empty.
+   * Scoping rules:
+   *   - For a catalog field carrying `hudi_type` (BLOB / VECTOR / VARIANT),
+   *     the catalog defines the canonical Avro union shape. Both metadata
+   *     and nullability are re-stamped, and nested structs are recursed so
+   *     inner-field nullability matches the layout the logical-type
+   *     validator expects.
+   *   - For ordinary fields, only metadata is re-stamped. Nullability is
+   *     left untouched and we do NOT recurse — Spark's TableOutputResolver
+   *     already produced an Avro-compatible shape, and forcing the catalog's
+   *     nullability across unrelated columns shifts their Avro union layout
+   *     and breaks readers (surfacing as `Malformed data. Length is negative`
+   *     in Avro deserialization across MergeInto / partial-update paths).
    *
    * @param sourceSchema  the StructType whose metadata may have been stripped
    *                      (typically `df.schema` from an INSERT plan)
@@ -172,7 +177,8 @@ object HoodieSchemaConversionUtils {
    *                      StructField.metadata (typically derived from the
    *                      Hudi catalog HoodieSchema)
    * @return a StructType matching `sourceSchema`'s field shape but with
-   *         metadata re-stamped from `catalogSchema` where matching
+   *         metadata re-stamped from `catalogSchema` where matching, and
+   *         nullability re-stamped only for logical-type fields
    */
   def alignSchemaMetadataFromCatalog(sourceSchema: StructType,
                                      catalogSchema: StructType): StructType = {
@@ -183,16 +189,16 @@ object HoodieSchemaConversionUtils {
           val newMetadata =
             if (cat.metadata != org.apache.spark.sql.types.Metadata.empty) cat.metadata
             else src.metadata
-          // Spark's INSERT INTO column resolution can also tighten field nullability
-          // (e.g. SELECT 1 AS id resolves as nullable=false even when the catalog
-          //  declares the column as nullable=true). Align with the catalog so the
-          //  resulting Avro schema's union shape matches the persisted schema.
-          val newNullable = cat.nullable
-          val newDataType = (src.dataType, cat.dataType) match {
-            case (s: StructType, c: StructType) => alignSchemaMetadataFromCatalog(s, c)
-            case _ => src.dataType
+          val isLogical = cat.metadata.contains("hudi_type")
+          if (isLogical) {
+            val newDataType = (src.dataType, cat.dataType) match {
+              case (s: StructType, c: StructType) => alignSchemaMetadataFromCatalog(s, c)
+              case _ => src.dataType
+            }
+            src.copy(dataType = newDataType, nullable = cat.nullable, metadata = newMetadata)
+          } else {
+            src.copy(metadata = newMetadata)
           }
-          src.copy(dataType = newDataType, nullable = newNullable, metadata = newMetadata)
         case None => src
       }
     }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -350,16 +350,38 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
   /**
    * Validates that a StructType matches the expected blob schema structure defined in {@link HoodieSchema.Blob}.
    *
+   * Compares structurally (field names, positions, data types, recursing into nested
+   * structs) but does NOT require nullability to match. Spark's INSERT INTO resolution
+   * can change a field's nullability based on the source's nullability — e.g. a BINARY
+   * field whose source expression is non-null gets resolved as `nullable=false` even if
+   * the target's catalog declares it as `nullable=true`. The on-disk Avro side enforces
+   * its own non-null invariants via {@link HoodieSchema.Blob} regardless of what the
+   * Spark layer chose, so the validator only needs to confirm the structural shape.
+   *
    * @param structType the StructType to validate
    * @throws IllegalArgumentException if the structure does not match the expected blob schema
    */
   private def validateBlobStructure(structType: StructType): Unit = {
-    if (!structType.equals(expectedBlobStructType)) {
+    if (!matchesStructureIgnoringNullability(structType, expectedBlobStructType)) {
       throw new IllegalArgumentException(
         s"""Invalid blob schema structure. Expected schema:
            |${expectedBlobStructType.toDDL}
            |Got schema:
            |${structType.toDDL}""".stripMargin)
+    }
+  }
+
+  private def matchesStructureIgnoringNullability(actual: StructType, expected: StructType): Boolean = {
+    if (actual.fields.length != expected.fields.length) return false
+    actual.fields.zip(expected.fields).forall { case (a, e) =>
+      a.name == e.name && matchesDataTypeIgnoringNullability(a.dataType, e.dataType)
+    }
+  }
+
+  private def matchesDataTypeIgnoringNullability(actual: DataType, expected: DataType): Boolean = {
+    (actual, expected) match {
+      case (a: StructType, e: StructType) => matchesStructureIgnoringNullability(a, e)
+      case (a, e) => a == e
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemaUtils.java
@@ -486,6 +486,16 @@ public final class HoodieSchemaUtils {
   private static HoodieSchema pruneDataSchemaInternal(HoodieSchema dataSchema, HoodieSchema requiredSchema, Set<String> mandatoryFields) {
     switch (requiredSchema.getType()) {
       case RECORD:
+        // BLOB and VARIANT are represented as Avro RECORDs but carry a logical type
+        // whose validate() contract requires the full canonical field layout
+        // ({type,data,reference} and {metadata,value} respectively). Partially pruning
+        // their inner fields would drop that contract. Spark's projection still prunes
+        // these columns at eval time, so reading the full logical-type record here is
+        // correct and cheap.
+        if (dataSchema.getType() == HoodieSchemaType.BLOB
+            || dataSchema.getType() == HoodieSchemaType.VARIANT) {
+          return dataSchema;
+        }
         if (dataSchema.getType() != HoodieSchemaType.RECORD) {
           throw new IllegalArgumentException("Data schema is not a record");
         }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -368,7 +368,29 @@ class HoodieSparkSqlWriterInternal {
         (s.getName, toScalaOption(s.getNamespace).orNull))
         .getOrElse(getRecordNameAndNamespace(tblName))
 
-      val sourceSchema = convertStructTypeToHoodieSchema(df.schema, avroRecordName, avroRecordNamespace)
+      // Spark's INSERT INTO column resolution drops user-defined StructField metadata
+      // when projecting the SELECT output against the target table's schema. For Hudi's
+      // BLOB and VECTOR logical types — whose detection depends on the `hudi_type`
+      // metadata key — this means df.schema arrives without the metadata that the
+      // converter needs, and the conversion produces a plain Avro record / array
+      // instead of the logical-typed equivalent. The schema compatibility check then
+      // fails with `SchemaBackwardsCompatibilityException: MISSING_UNION_BRANCH`.
+      //
+      // When the SQL command provides a catalog-derived schema (schemaFromCatalog),
+      // re-stamp the missing StructField metadata onto df.schema before conversion.
+      // For direct DataFrame writers that don't pass schemaFromCatalog, this is a
+      // no-op and the original behavior is preserved.
+      val alignedDfSchema = schemaFromCatalog match {
+        case Some(catalog) =>
+          val catalogStructType = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(catalog)
+          // Strip Hudi meta fields from the catalog StructType — df.schema doesn't have them.
+          val catalogDataFields = catalogStructType.fields
+            .filterNot(f => HoodieRecord.HOODIE_META_COLUMNS.contains(f.name))
+          HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog(
+            df.schema, StructType(catalogDataFields))
+        case None => df.schema
+      }
+      val sourceSchema = convertStructTypeToHoodieSchema(alignedDfSchema, avroRecordName, avroRecordNamespace)
       val internalSchemaOpt = HoodieSchemaUtils.getLatestTableInternalSchema(hoodieConfig, tableMetaClient).orElse {
         // In case we need to reconcile the schema and schema evolution is enabled,
         // we will force-apply schema evolution to the writer's schema

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSchemaConversionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSchemaConversionUtils.scala
@@ -895,4 +895,120 @@ class TestHoodieSchemaConversionUtils extends FunSuite with Matchers {
   private def checkNull(left: Any, right: Any): Boolean = {
     (left == null && right != null) || (left != null && right == null)
   }
+
+  // ==========================================================
+  // Tests for alignSchemaMetadataFromCatalog
+  //
+  // Spark's INSERT INTO column resolution drops user-defined StructField
+  // metadata and can tighten/loosen nullability. For Hudi's BLOB and
+  // VECTOR logical types — whose detection depends on `hudi_type`
+  // metadata — this means df.schema arrives at the writer without the
+  // information needed to produce a logical-typed Avro schema.
+  // alignSchemaMetadataFromCatalog re-stamps both metadata and
+  // nullability from the catalog StructType onto the source StructType.
+  // ==========================================================
+
+  private val HUDI_TYPE = "hudi_type"
+
+  private def metaWithHudiType(value: String): Metadata =
+    new MetadataBuilder().putString(HUDI_TYPE, value).build()
+
+  /** Construct a plain (no logical-type metadata) BLOB-shaped struct. */
+  private def blobInnerStruct: StructType = new StructType()
+    .add("type", StringType, nullable = false)
+    .add("data", BinaryType, nullable = true)
+    .add("reference", new StructType()
+      .add("external_path", StringType, nullable = false)
+      .add("offset", LongType, nullable = true)
+      .add("length", LongType, nullable = true)
+      .add("managed", BooleanType, nullable = false),
+      nullable = true)
+
+  test("alignSchemaMetadataFromCatalog stamps BLOB metadata onto source field") {
+    val source = new StructType()
+      .add("payload", blobInnerStruct, nullable = true)
+    val catalog = new StructType()
+      .add(StructField("payload", blobInnerStruct, nullable = true, metaWithHudiType("BLOB")))
+
+    val aligned = HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog(source, catalog)
+    val payload = aligned.fields.find(_.name == "payload").get
+    assertEquals("BLOB", payload.metadata.getString(HUDI_TYPE))
+  }
+
+  test("alignSchemaMetadataFromCatalog stamps VECTOR metadata onto source field") {
+    val source = new StructType()
+      .add("emb", ArrayType(FloatType, containsNull = false), nullable = true)
+    val catalog = new StructType()
+      .add(StructField("emb", ArrayType(FloatType, containsNull = false),
+        nullable = true, metaWithHudiType("VECTOR(3)")))
+
+    val aligned = HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog(source, catalog)
+    val emb = aligned.fields.find(_.name == "emb").get
+    assertEquals("VECTOR(3)", emb.metadata.getString(HUDI_TYPE))
+  }
+
+  test("alignSchemaMetadataFromCatalog widens source nullability when catalog is nullable") {
+    val source = new StructType().add(StructField("id", IntegerType, nullable = false))
+    val catalog = new StructType().add(StructField("id", IntegerType, nullable = true))
+
+    val aligned = HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog(source, catalog)
+    val id = aligned.fields.find(_.name == "id").get
+    assertEquals(true, id.nullable)
+  }
+
+  test("alignSchemaMetadataFromCatalog narrows source nullability when catalog is non-null") {
+    val source = new StructType().add(StructField("pk", LongType, nullable = true))
+    val catalog = new StructType().add(StructField("pk", LongType, nullable = false))
+
+    val aligned = HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog(source, catalog)
+    val pk = aligned.fields.find(_.name == "pk").get
+    assertEquals(false, pk.nullable)
+  }
+
+  test("alignSchemaMetadataFromCatalog recurses into nested structs") {
+    // Source: media: STRUCT<title, content: STRUCT<...>> — content has empty metadata.
+    val sourceContent = blobInnerStruct
+    val sourceMedia = new StructType()
+      .add("title", StringType, nullable = false)
+      .add("content", sourceContent, nullable = true)
+    val source = new StructType().add("media", sourceMedia, nullable = true)
+
+    // Catalog: same shape, but media.content carries hudi_type=BLOB.
+    val catalogMedia = new StructType()
+      .add("title", StringType, nullable = false)
+      .add(StructField("content", sourceContent, nullable = true, metaWithHudiType("BLOB")))
+    val catalog = new StructType().add("media", catalogMedia, nullable = true)
+
+    val aligned = HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog(source, catalog)
+    val mediaField = aligned.fields.find(_.name == "media").get
+    val mediaStruct = mediaField.dataType.asInstanceOf[StructType]
+    val contentField = mediaStruct.fields.find(_.name == "content").get
+    assertEquals("BLOB", contentField.metadata.getString(HUDI_TYPE))
+  }
+
+  test("alignSchemaMetadataFromCatalog passes fields through when catalog has no match") {
+    val source = new StructType()
+      .add(StructField("bonus", StringType, nullable = false, metaWithHudiType("PLACEHOLDER")))
+    val catalog = new StructType().add(StructField("other", StringType, nullable = true))
+
+    val aligned = HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog(source, catalog)
+    val bonus = aligned.fields.find(_.name == "bonus").get
+    // bonus is unchanged: original metadata + nullability preserved.
+    assertEquals("PLACEHOLDER", bonus.metadata.getString(HUDI_TYPE))
+    assertEquals(false, bonus.nullable)
+  }
+
+  test("alignSchemaMetadataFromCatalog preserves source metadata when catalog metadata is empty") {
+    val sourceMeta = new MetadataBuilder().putString("comment", "x").build()
+    val source = new StructType()
+      .add(StructField("tag", StringType, nullable = true, sourceMeta))
+    // Catalog field with same name but no metadata.
+    val catalog = new StructType()
+      .add(StructField("tag", StringType, nullable = true, Metadata.empty))
+
+    val aligned = HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog(source, catalog)
+    val tag = aligned.fields.find(_.name == "tag").get
+    // Source's `comment` metadata is preserved (we don't blow it away with empty).
+    assertEquals("x", tag.metadata.getString("comment"))
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -2333,4 +2333,111 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
     val hiveSchema = CreateHoodieTableCommand.toHiveCompatibleSchema(schema)
     assertEquals(ArrayType(FloatType, containsNull = false), hiveSchema("floats").dataType)
   }
+
+  test("CREATE TABLE with BLOB + VECTOR persists logical types and allows INSERT INTO SELECT") {
+    // Reproduces the SchemaBackwardsCompatibilityException seen in the
+    // hudi_sql_vector_blob_demo.py demo:
+    //
+    //   org.apache.hudi.exception.SchemaBackwardsCompatibilityException:
+    //     {MISSING_UNION_BRANCH: reader union lacking writer type: BLOB ...,
+    //      MISSING_UNION_BRANCH: reader union lacking writer type: VECTOR ...}
+    //
+    // Root cause: the Spark-StructType -> Avro converter used at CREATE TABLE
+    // time persists BLOB / VECTOR fields as plain Avro records / arrays
+    // (no logicalType annotation). At INSERT time the writer-side schema
+    // correctly emits the BLOB / VECTOR Avro logical types, the schema
+    // compatibility check sees the table-side branch missing, and the write
+    // aborts.
+    //
+    // Existing CREATE TABLE BLOB / VECTOR tests assert against the Spark-side
+    // StructField.metadata only, which round-trips fine via Spark's catalog.
+    // This test asserts the persisted Avro table-create-schema and exercises
+    // an end-to-end INSERT INTO ... SELECT FROM <view>, which is the shape
+    // that surfaces the bug.
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val sourceView = s"${tableName}_source"
+
+      // Source — bytes + array, plain Spark types, NO Hudi metadata. The
+      // logical types must come exclusively from the target table's DDL.
+      spark.sql(
+        s"""
+           |CREATE TEMPORARY VIEW $sourceView AS
+           |SELECT 1 AS id,
+           |       'first'                                          AS name,
+           |       cast(X'010203' as binary)                        AS bytes_raw,
+           |       array(cast(0.1 as float),
+           |             cast(0.2 as float),
+           |             cast(0.3 as float))                        AS emb_raw
+           |""".stripMargin)
+
+      // Target — BLOB + VECTOR(3) declared natively via Hudi-extended SQL.
+      // The DefaultSparkRecordMerger TBLPROPERTY mirrors the demo and flips
+      // the writer factory to the SPARK record type whose schema-extraction
+      // path emits the logical-typed Avro (i.e. exposes the asymmetry).
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id      INT,
+           |  name    STRING,
+           |  payload BLOB,
+           |  emb     VECTOR(3)
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id',
+           |  preCombineField = 'id',
+           |  type = 'cow',
+           |  'hoodie.write.record.merge.custom.implementation.classes' =
+           |      'org.apache.hudi.DefaultSparkRecordMerger'
+           |)
+           |""".stripMargin)
+
+      // Assert the persisted Avro schema carries the BLOB / VECTOR logical
+      // types BEFORE we attempt the INSERT. This isolates "schema
+      // persistence is wrong" from "INSERT path is wrong" — if these
+      // assertions fail, the INSERT will too.
+      val metaClient = createMetaClient(spark, tmp.getCanonicalPath)
+      val persisted = metaClient.getTableConfig.getTableCreateSchema.get()
+      val payloadField = persisted.getField("payload").get().schema().getNonNullType()
+      val embField = persisted.getField("emb").get().schema().getNonNullType()
+      assertEquals(HoodieSchemaType.BLOB, payloadField.getType,
+        "Persisted Avro schema for `payload` must be a BLOB logical type")
+      assertEquals(HoodieSchemaType.VECTOR, embField.getType,
+        "Persisted Avro schema for `emb` must be a VECTOR logical type")
+
+      // Now the INSERT INTO ... SELECT path. Currently fails with
+      // SchemaBackwardsCompatibilityException. Once the converter fix lands,
+      // this should succeed.
+      spark.sql(
+        s"""
+           |INSERT INTO $tableName
+           |SELECT id, name,
+           |       named_struct(
+           |         'type',      'INLINE',
+           |         'data',      bytes_raw,
+           |         'reference', cast(null as struct<external_path:string,
+           |                                          offset:bigint,
+           |                                          length:bigint,
+           |                                          managed:boolean>)
+           |       ) AS payload,
+           |       emb_raw AS emb
+           |FROM $sourceView
+           |""".stripMargin)
+
+      // Verify the row round-trips end-to-end.
+      val rows = spark.sql(
+        s"""SELECT id, name,
+           |       length(payload.data) AS bytes_len,
+           |       size(emb)            AS emb_len
+           |FROM $tableName""".stripMargin
+      ).collect()
+
+      assertEquals(1, rows.length)
+      assertEquals(1, rows.head.getInt(0))
+      assertEquals("first", rows.head.getString(1))
+      assertEquals(3, rows.head.getInt(2))    // bytes_raw was X'010203'
+      assertEquals(3, rows.head.getInt(3))    // 3-D vector
+    }
+  }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

VECTOR and BLOB columns lose their `hudi_type` `StructField` metadata
during Spark's INSERT INTO column resolution. By the time
`HoodieSparkSqlWriter` converts `df.schema` to a HoodieSchema, the
metadata is gone and the converter falls through to the plain Avro
record/array branches. The schema-compat check then sees a logical-typed
catalog schema versus a plain incoming schema and fails with
`SchemaBackwardsCompatibilityException: MISSING_UNION_BRANCH`.

A nested projection on a BLOB column (`SELECT payload.reference.external_path FROM t`)
hits the same metadata-loss pattern on the read path inside
`pruneDataSchemaInternal`, throwing `Data schema is not a record`.

### Summary and Changelog

A scoped fix focused on the SQL INSERT INTO and read paths. Smaller than
#18540 — does not cover UPDATE/MERGE call-site rewiring, the BLOB
Spark-shape flip in `toSqlType`, or `ArrayType.containsNull` recursion.
The read-side change is the same short-circuit as #18566.

- `HoodieSchemaConversionUtils.alignSchemaMetadataFromCatalog` (new) —
  re-stamps `StructField.metadata` and `nullable` from the catalog
  StructType onto the source StructType, recursing into nested structs.
- `HoodieSparkSqlWriter.write` — calls the helper before
  `convertStructTypeToHoodieSchema(df.schema, ...)` when
  `schemaFromCatalog` is provided. No-op for direct DataFrame writers
  that don't pass it.
- `HoodieSparkSchemaConverters.validateBlobStructure` — replaces strict
  `.equals` with a recursive structural matcher that ignores nullability
  differences. Spark's INSERT can tighten a field's nullability from the
  source's expression; the on-disk Avro side enforces non-null invariants
  separately.
- `HoodieSchemaUtils.pruneDataSchemaInternal` — short-circuits the
  `case RECORD` branch when the data schema is BLOB or VARIANT. Both
  carry `LogicalType.validate()` contracts requiring the full canonical
  inner layout, so partial pruning is not legal anyway. (Same patch as
  #18566.)

Tests:

- `TestHoodieSchemaConversionUtils` — 7 unit cases for the helper
  (BLOB/VECTOR metadata copy, nullability widen + narrow, nested-struct
  recursion, field-not-in-catalog passthrough, empty-catalog-metadata
  preservation).
- `TestCreateTable` — end-to-end regression test:
  `CREATE TABLE t (id INT, payload BLOB, emb VECTOR(3)) USING hudi` →
  `INSERT INTO t SELECT … FROM tempview` → round-trip read.

### Example

Before — fails:

```sql
CREATE TABLE pets (id INT, payload BLOB, emb VECTOR(3)) USING hudi
TBLPROPERTIES (primaryKey = 'id', ...);

CREATE TEMPORARY VIEW src AS
SELECT 1 AS id, cast(X'010203' as binary) AS bytes, array(0.1f, 0.2f, 0.3f) AS emb;

INSERT INTO pets SELECT id,
  named_struct('type','INLINE','data', bytes, 'reference', cast(null as struct<...>)) AS payload,
  emb FROM src;
-- SchemaBackwardsCompatibilityException: MISSING_UNION_BRANCH
--   reader union lacking writer type: BLOB / VECTOR
```

After — succeeds:

```sql
INSERT INTO pets SELECT ...; -- ok
SELECT id, length(payload.data), size(emb) FROM pets;
-- 1 | 3 | 3
```

### Impact

- User-facing: SQL `INSERT INTO ... SELECT` and nested projection now
  work on tables with BLOB / VECTOR columns. No public API change. No
  config change.
- Performance: one extra `StructType` traversal per write command
  (bounded by catalog schema size). Negligible.

### Risk Level

Low. The helper runs only when `schemaFromCatalog` is provided
(`InsertIntoHoodieTableCommand` path); direct DataFrame writers fall back
to existing behavior. The validator change relaxes a strict-equality
check to structural matching, which is strictly more permissive on the
Spark side; on-disk Avro invariants are unchanged. The pruner short-circuit
returns the unmodified data schema, matching what a non-projected read
already does.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
