### PR TITLE
fix(metadata-table): add config to skip zero-size data files on MDT initialization

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -594,7 +594,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     final int fileListingParallelism = metadataWriteConfig.getFileListingParallelism();
     StorageConfiguration<?> storageConf = dataMetaClient.getStorageConf();
     final String dirFilterRegex = dataWriteConfig.getMetadataConfig().getDirectoryFilterRegex();
-    final boolean skipZeroSizeFiles = dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesDuringBootstrap();
+    final boolean skipZeroSizeFiles = dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesOnInitialize();
     StoragePath storageBasePath = dataMetaClient.getBasePath();
     long totalZeroSizeFiles = 0;
 
@@ -636,7 +636,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     final long zeroSizeCount = totalZeroSizeFiles;
-    metrics.ifPresent(m -> m.incrementMetric("bootstrap_zero_size_files", zeroSizeCount));
+    metrics.ifPresent(m -> m.incrementMetric("skipped_zero_size_files_on_initialize", zeroSizeCount));
     return partitionsToBootstrap;
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -595,6 +595,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     StorageConfiguration<?> storageConf = dataMetaClient.getStorageConf();
     final String dirFilterRegex = dataWriteConfig.getMetadataConfig().getDirectoryFilterRegex();
     StoragePath storageBasePath = dataMetaClient.getBasePath();
+    long totalZeroSizeFiles = 0;
 
     while (!pathsToList.isEmpty()) {
       // In each round we will list a section of directories
@@ -614,6 +615,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       // If the listing reveals a directory, add it to queue. If the listing reveals a hoodie partition, add it to
       // the results.
       for (DirectoryInfo dirInfo : processedDirectories) {
+        totalZeroSizeFiles += dirInfo.getZeroSizeFileCount();
         if (!dirFilterRegex.isEmpty()) {
           final String relativePath = dirInfo.getRelativePath();
           if (!relativePath.isEmpty() && relativePath.matches(dirFilterRegex)) {
@@ -632,6 +634,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       }
     }
 
+    final long zeroSizeCount = totalZeroSizeFiles;
+    metrics.ifPresent(m -> m.incrementMetric("bootstrap_zero_size_files", zeroSizeCount));
     return partitionsToBootstrap;
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -404,7 +404,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     } else {
       // if auto initialization is enabled, then we need to list all partitions from the file system
       if (dataWriteConfig.getMetadataConfig().shouldAutoInitialize()) {
-        partitionInfoList = listAllPartitionsFromFilesystem(dataTableInstantTime, pendingDataInstants);
+        partitionInfoList = listAllPartitionsFromFilesystem(dataTableInstantTime, pendingDataInstants,
+            dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesOnInitialize());
       } else {
         // if auto initialization is disabled, we can return an empty list
         partitionInfoList = Collections.emptyList();
@@ -581,9 +582,12 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    *
    * @param initializationTime  Files which have a timestamp after this are neglected
    * @param pendingDataInstants Pending instants on data set
+   * @param skipZeroSizeFiles   Whether zero-size data files should be skipped during listing. This should only be
+   *                            enabled on the initialize path; other callers (e.g. restore) must pass false so that
+   *                            files already tracked in the metadata table are not spuriously deleted.
    * @return List consisting of {@code DirectoryInfo} for each partition found.
    */
-  private List<DirectoryInfo> listAllPartitionsFromFilesystem(String initializationTime, Set<String> pendingDataInstants) {
+  private List<DirectoryInfo> listAllPartitionsFromFilesystem(String initializationTime, Set<String> pendingDataInstants, boolean skipZeroSizeFiles) {
     if (dataMetaClient.getActiveTimeline().countInstants() == 0) {
       return Collections.emptyList();
     }
@@ -594,7 +598,6 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     final int fileListingParallelism = metadataWriteConfig.getFileListingParallelism();
     StorageConfiguration<?> storageConf = dataMetaClient.getStorageConf();
     final String dirFilterRegex = dataWriteConfig.getMetadataConfig().getDirectoryFilterRegex();
-    final boolean skipZeroSizeFiles = dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesOnInitialize();
     StoragePath storageBasePath = dataMetaClient.getBasePath();
     long totalZeroSizeFiles = 0;
 
@@ -1190,7 +1193,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
     // Restore requires the existing pipelines to be shutdown. So we can safely scan the dataset to find the current
     // list of files in the filesystem.
-    List<DirectoryInfo> dirInfoList = listAllPartitionsFromFilesystem(instantTime, Collections.emptySet());
+    List<DirectoryInfo> dirInfoList = listAllPartitionsFromFilesystem(instantTime, Collections.emptySet(), false);
     Map<String, DirectoryInfo> dirInfoMap = dirInfoList.stream().collect(Collectors.toMap(DirectoryInfo::getRelativePath, Function.identity()));
     dirInfoList.clear();
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -594,6 +594,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     final int fileListingParallelism = metadataWriteConfig.getFileListingParallelism();
     StorageConfiguration<?> storageConf = dataMetaClient.getStorageConf();
     final String dirFilterRegex = dataWriteConfig.getMetadataConfig().getDirectoryFilterRegex();
+    final boolean skipZeroSizeFiles = dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesDuringBootstrap();
     StoragePath storageBasePath = dataMetaClient.getBasePath();
     long totalZeroSizeFiles = 0;
 
@@ -609,7 +610,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       List<DirectoryInfo> processedDirectories = engineContext.map(pathsToProcess, path -> {
         HoodieStorage storage = HoodieStorageUtils.getStorage(path, storageConf);
         String relativeDirPath = FSUtils.getRelativePartitionPath(storageBasePath, path);
-        return new DirectoryInfo(relativeDirPath, storage.listDirectEntries(path), initializationTime, pendingDataInstants);
+        return new DirectoryInfo(relativeDirPath, storage.listDirectEntries(path), initializationTime, pendingDataInstants, true, skipZeroSizeFiles);
       }, numDirsToList);
 
       // If the listing reveals a directory, add it to queue. If the listing reveals a hoodie partition, add it to

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -116,12 +116,16 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     doPreBootstrapWriteOperation(testTable, "0000002");
     // Add a zero-size base file — bootstrap should skip it without failing.
     String fileName = UUID.randomUUID().toString();
+    Path zeroSizeFilePath = FileCreateUtilsLegacy.getBaseFilePath(basePath, "p1", "0000003", fileName);
     FileCreateUtilsLegacy.createBaseFile(basePath, "p1", "0000003", fileName, 0);
 
     writeConfig = getWriteConfig(true, true);
     initWriteConfigAndMetatableWriter(writeConfig, true);
     syncTableMetadata(writeConfig);
 
+    // Delete the zero-size file before validation — it was skipped in MDT and must not
+    // exist on disk for the filesystem-vs-MDT consistency check to pass.
+    Files.delete(zeroSizeFilePath);
     validateMetadata(testTable);
     doWriteInsertAndUpsert(testTable);
     validateMetadata(testTable);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -108,6 +108,25 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     validateMetadata(testTable);
   }
 
+  @Test
+  public void testMetadataBootstrapSkipsZeroSizeFiles() throws Exception {
+    HoodieTableType tableType = COPY_ON_WRITE;
+    init(tableType, false);
+    doPreBootstrapWriteOperation(testTable, INSERT, "0000001");
+    doPreBootstrapWriteOperation(testTable, "0000002");
+    // Add a zero-size base file — bootstrap should skip it without failing.
+    String fileName = UUID.randomUUID().toString();
+    FileCreateUtilsLegacy.createBaseFile(basePath, "p1", "0000003", fileName, 0);
+
+    writeConfig = getWriteConfig(true, true);
+    initWriteConfigAndMetatableWriter(writeConfig, true);
+    syncTableMetadata(writeConfig);
+
+    validateMetadata(testTable);
+    doWriteInsertAndUpsert(testTable);
+    validateMetadata(testTable);
+  }
+
   @ParameterizedTest
   @EnumSource(HoodieTableType.class)
   public void testMetadataBootstrapInsertUpsertRollback(HoodieTableType tableType) throws Exception {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -109,7 +109,7 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
   }
 
   @Test
-  public void testMetadataBootstrapSkipsZeroSizeFiles() throws Exception {
+  public void testMetadataSkipsZeroSizeFilesOnInitialize() throws Exception {
     HoodieTableType tableType = COPY_ON_WRITE;
     init(tableType, false);
     doPreBootstrapWriteOperation(testTable, INSERT, "0000001");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -122,7 +122,7 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     writeConfig = getWriteConfigBuilder(true, true, false)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(true)
-            .withSkipZeroSizeFilesDuringBootstrap(true)
+            .withSkipZeroSizeFilesOnInitialize(true)
             .build())
         .build();
     initWriteConfigAndMetatableWriter(writeConfig, true);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -119,7 +119,12 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     Path zeroSizeFilePath = FileCreateUtilsLegacy.getBaseFilePath(basePath, "p1", "0000003", fileName);
     FileCreateUtilsLegacy.createBaseFile(basePath, "p1", "0000003", fileName, 0);
 
-    writeConfig = getWriteConfig(true, true);
+    writeConfig = getWriteConfigBuilder(true, true, false)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withSkipZeroSizeFilesDuringBootstrap(true)
+            .build())
+        .build();
     initWriteConfigAndMetatableWriter(writeConfig, true);
     syncTableMetadata(writeConfig);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -195,13 +195,13 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Directories matching this regex, will be filtered out when initializing metadata table from lake storage for the first time.");
 
-  public static final ConfigProperty<Boolean> SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP = ConfigProperty
-      .key(METADATA_PREFIX + ".bootstrap.skip.zero.size.files")
+  public static final ConfigProperty<Boolean> SKIP_ZERO_SIZE_FILES_ON_INITIALIZE = ConfigProperty
+      .key(METADATA_PREFIX + ".skip.zero.size.files.on.initialize")
       .defaultValue(false)
       .markAdvanced()
       .sinceVersion("1.2.0")
       .withDocumentation("When enabled, zero-size data files encountered while listing the data table during "
-          + "metadata table bootstrap are skipped instead of being recorded in the metadata table.");
+          + "metadata table initialization are skipped instead of being recorded in the metadata table.");
 
   public static final ConfigProperty<Integer> FILE_LISTING_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.file.listing.parallelism")
@@ -820,8 +820,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getString(DIR_FILTER_REGEX);
   }
 
-  public boolean shouldSkipZeroSizeFilesDuringBootstrap() {
-    return getBoolean(SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP);
+  public boolean shouldSkipZeroSizeFilesOnInitialize() {
+    return getBoolean(SKIP_ZERO_SIZE_FILES_ON_INITIALIZE);
   }
 
   public boolean shouldIgnoreSpuriousDeletes() {
@@ -1206,8 +1206,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withSkipZeroSizeFilesDuringBootstrap(boolean skipZeroSizeFiles) {
-      metadataConfig.setValue(SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP, String.valueOf(skipZeroSizeFiles));
+    public Builder withSkipZeroSizeFilesOnInitialize(boolean skipZeroSizeFiles) {
+      metadataConfig.setValue(SKIP_ZERO_SIZE_FILES_ON_INITIALIZE, String.valueOf(skipZeroSizeFiles));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -195,6 +195,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Directories matching this regex, will be filtered out when initializing metadata table from lake storage for the first time.");
 
+  public static final ConfigProperty<Boolean> SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP = ConfigProperty
+      .key(METADATA_PREFIX + ".bootstrap.skip.zero.size.files")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("When enabled, zero-size data files encountered while listing the data table during "
+          + "metadata table bootstrap are skipped instead of being recorded in the metadata table.");
+
   public static final ConfigProperty<Integer> FILE_LISTING_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.file.listing.parallelism")
       .defaultValue(200)
@@ -812,6 +820,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getString(DIR_FILTER_REGEX);
   }
 
+  public boolean shouldSkipZeroSizeFilesDuringBootstrap() {
+    return getBoolean(SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP);
+  }
+
   public boolean shouldIgnoreSpuriousDeletes() {
     return getBoolean(IGNORE_SPURIOUS_DELETES);
   }
@@ -1191,6 +1203,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withDirectoryFilterRegex(String regex) {
       metadataConfig.setValue(DIR_FILTER_REGEX, regex);
+      return this;
+    }
+
+    public Builder withSkipZeroSizeFilesDuringBootstrap(boolean skipZeroSizeFiles) {
+      metadataConfig.setValue(SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP, String.valueOf(skipZeroSizeFiles));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/model/DirectoryInfo.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/model/DirectoryInfo.java
@@ -28,6 +28,7 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -48,6 +49,7 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.compareTim
  * a very large number of files are present in the dataset being initialized.
  */
 @Getter
+@Slf4j
 public class DirectoryInfo implements Serializable {
   private static final long serialVersionUID = 1L;
 
@@ -59,9 +61,10 @@ public class DirectoryInfo implements Serializable {
   private final List<StoragePath> subDirectories = new ArrayList<>();
   // Is this a hoodie partition
   private boolean isHoodiePartition = false;
+  private int zeroSizeFileCount = 0;
 
   public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants) {
-    this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, true);
+    this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, true, false);
   }
 
   /**
@@ -69,6 +72,11 @@ public class DirectoryInfo implements Serializable {
    */
   public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants,
                        boolean validateHoodiePartitions) {
+    this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, validateHoodiePartitions, false);
+  }
+
+  public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants,
+                       boolean validateHoodiePartitions, boolean skipZeroSizeFiles) {
     this.relativePath = relativePath;
 
     // Pre-allocate with the maximum length possible
@@ -89,7 +97,12 @@ public class DirectoryInfo implements Serializable {
         String dataFileCommitTime = FSUtils.getCommitTime(pathInfo.getPath().getName());
         // Limit the file listings to files which were created by successful commits before the maxInstant time.
         if (!pendingDataInstants.contains(dataFileCommitTime) && compareTimestamps(dataFileCommitTime, LESSER_THAN_OR_EQUALS, maxInstantTime)) {
-          filenameToSizeMap.put(pathInfo.getPath().getName(), pathInfo.getLength());
+          if (pathInfo.getLength() > 0 || !skipZeroSizeFiles) {
+            filenameToSizeMap.put(pathInfo.getPath().getName(), pathInfo.getLength());
+          } else {
+            log.warn("Skipping zero-size data file during MDT bootstrap: {}", pathInfo.getPath());
+            zeroSizeFileCount++;
+          }
         }
       }
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

During MDT (Metadata Table) initialization, zero-size data files can be included in the filenameToSizeMap in DirectoryInfo, which could result in initialization job failures.

This change adds a new config `hoodie.metadata.skip.zero.size.files.on.initialize` (default false) that, when enabled, skips files with length == 0 while listing the data table during MDT initialization and logs a warning. A `skipped_zero_size_files_on_initialize` metric is emitted with the total count of skipped files across all partitions.

Closes #18612

### Summary and Changelog

- Adds an opt-in `hoodie.metadata.skip.zero.size.files.on.initialize` config (default false, advanced) to skip zero-size data files while listing the data table during MDT initialization.
- Threads a `skipZeroSizeFiles` boolean parameter through `HoodieBackedTableMetadataWriter#listAllPartitionsFromFilesystem` — the initialize caller passes the config value; the restore caller passes `false` unconditionally so files already tracked in MDT are not spuriously deleted.
- Adds a new `DirectoryInfo` constructor overload that carries the `skipZeroSizeFiles` flag; existing constructors delegate with `false`, preserving current behavior.
- Emits a `skipped_zero_size_files_on_initialize` metric with the total count of skipped files across all partitions and logs a warning per skipped file.
- Adds a functional test (`TestHoodieMetadataBootstrap#testMetadataSkipsZeroSizeFilesOnInitialize`) covering the skip path.

### Impact

Opt-in via config; default behavior is unchanged. When enabled, reinitialize jobs that previously failed due to zero-size data files being included in MDT will succeed. The `skipped_zero_size_files_on_initialize` metric surfaces the count of skipped files.

### Risk Level

Low. The change only affects the MDT initialization file-listing path and is gated behind a config that defaults to off. Restore path explicitly passes `false` to avoid any behavior change there.

### Documentation Update

None required beyond the new advanced config, which is self-documented.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable