### PR TITLE
feat(lance): fix lance writer/reader regarding arrow memory limit issue

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileReaderFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileReaderFactory.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.io.storage;
 
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieIOException;
@@ -49,8 +50,10 @@ public class HoodieSparkFileReaderFactory extends HoodieFileReaderFactory {
   }
 
   @Override
-  protected HoodieFileReader newLanceFileReader(StoragePath path) {
-    return new HoodieSparkLanceReader(path);
+  protected HoodieFileReader newLanceFileReader(HoodieConfig hoodieConfig, StoragePath path) {
+    long dataAllocatorSize = hoodieConfig.getLongOrDefault(HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES);
+    long metadataAllocatorSize = hoodieConfig.getLongOrDefault(HoodieStorageConfig.LANCE_READ_METADATA_ALLOCATOR_SIZE_BYTES);
+    return new HoodieSparkLanceReader(path, dataAllocatorSize, metadataAllocatorSize);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -120,6 +120,8 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
     boolean enableBloomFilter = enableBloomFilter(populateMetaFields, config);
     Option<BloomFilter> bloomFilter = enableBloomFilter ? Option.of(createBloomFilter(config)) : Option.empty();
     long maxFileSize = config.getLongOrDefault(HoodieStorageConfig.LANCE_MAX_FILE_SIZE);
+    long allocatorSize = config.getLongOrDefault(HoodieStorageConfig.LANCE_WRITE_ALLOCATOR_SIZE_BYTES);
+    long flushByteWatermark = config.getLongOrDefault(HoodieStorageConfig.LANCE_WRITE_FLUSH_BYTE_WATERMARK);
 
     return HoodieSparkLanceWriter.builder()
         .file(path)
@@ -130,6 +132,8 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
         .populateMetaFields(populateMetaFields)
         .bloomFilterOpt(bloomFilter)
         .maxFileSize(maxFileSize)
+        .allocatorSize(allocatorSize)
+        .flushByteWatermark(flushByteWatermark)
         .build();
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceReader.java
@@ -22,6 +22,7 @@ import org.apache.hudi.HoodieSchemaConversionUtils;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
 import org.apache.hudi.common.bloom.SimpleBloomFilter;
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
@@ -65,23 +66,36 @@ import static org.apache.hudi.common.util.TypeUtils.unsafeCast;
  */
 @Slf4j
 public class HoodieSparkLanceReader implements HoodieSparkFileReader {
-  // Memory size for data read operations: 120MB
-  public static final long LANCE_DATA_ALLOCATOR_SIZE = 120 * 1024 * 1024;
-
-  // Memory size for metadata operations: 8MB
-  private static final long LANCE_METADATA_ALLOCATOR_SIZE = 8 * 1024 * 1024;
-
   // number of rows to read
   private static final int DEFAULT_BATCH_SIZE = 512;
   private final StoragePath path;
+  private final long dataAllocatorSize;
   private final BufferAllocator metadataAllocator;
   private final LanceFileReader lanceMetadataReader;
   private final Schema arrowSchema;
 
+  /**
+   * Convenience constructor using default Arrow allocator sizes from {@link HoodieStorageConfig}.
+   * Prefer {@link #HoodieSparkLanceReader(StoragePath, long, long)} when caller has access to a
+   * configured value (e.g. via the file-reader factory).
+   */
   public HoodieSparkLanceReader(StoragePath path) {
+    this(path,
+        Long.parseLong(HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.defaultValue()),
+        Long.parseLong(HoodieStorageConfig.LANCE_READ_METADATA_ALLOCATOR_SIZE_BYTES.defaultValue()));
+  }
+
+  /**
+   * @param path Lance file to read
+   * @param dataAllocatorSize Maximum bytes for the per-read Arrow child allocator that holds
+   *                          column data. Sized so Arrow's internal buffer doublings stay within cap.
+   * @param metadataAllocatorSize Maximum bytes for the small Arrow allocator backing schema/footer reads.
+   */
+  public HoodieSparkLanceReader(StoragePath path, long dataAllocatorSize, long metadataAllocatorSize) {
     this.path = path;
+    this.dataAllocatorSize = dataAllocatorSize;
     metadataAllocator = HoodieArrowAllocator.newChildAllocator(
-        getClass().getSimpleName() + "-metadata-" + path.getName(), LANCE_METADATA_ALLOCATOR_SIZE);
+        getClass().getSimpleName() + "-metadata-" + path.getName(), metadataAllocatorSize);
     try {
       lanceMetadataReader = LanceFileReader.open(path.toString(), metadataAllocator);
       arrowSchema = lanceMetadataReader.schema();
@@ -180,7 +194,7 @@ public class HoodieSparkLanceReader implements HoodieSparkFileReader {
     StructType requestedSparkSchema = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(requestedSchema);
 
     BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
-        getClass().getSimpleName() + "-data-" + path.getName(), LANCE_DATA_ALLOCATOR_SIZE);
+        getClass().getSimpleName() + "-data-" + path.getName(), dataAllocatorSize);
 
     try {
       LanceFileReader lanceReader = LanceFileReader.open(path.toString(), allocator);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
@@ -107,6 +107,8 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
    *   <li>{@code populateMetaFields} — defaults to {@code false}</li>
    *   <li>{@code bloomFilterOpt} — defaults to {@link Option#empty()}</li>
    *   <li>{@code maxFileSize} — defaults to {@link HoodieStorageConfig#LANCE_MAX_FILE_SIZE}</li>
+   *   <li>{@code allocatorSize} — defaults to {@link HoodieStorageConfig#LANCE_WRITE_ALLOCATOR_SIZE_BYTES}</li>
+   *   <li>{@code flushByteWatermark} — defaults to {@link HoodieStorageConfig#LANCE_WRITE_FLUSH_BYTE_WATERMARK}</li>
    * </ul>
    */
   @Builder(builderMethodName = "builder")
@@ -118,10 +120,18 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
       HoodieStorage storage,
       boolean populateMetaFields,
       Option<BloomFilter> bloomFilterOpt,
-      long maxFileSize) {
+      long maxFileSize,
+      long allocatorSize,
+      long flushByteWatermark) {
     checkArgument(maxFileSize > 0, "maxFileSize must be a positive number");
+    checkArgument(allocatorSize > 0, "allocatorSize must be a positive number");
+    checkArgument(flushByteWatermark > 0, "flushByteWatermark must be a positive number");
+    checkArgument(flushByteWatermark < allocatorSize,
+        "flushByteWatermark (" + flushByteWatermark + ") must be less than allocatorSize ("
+            + allocatorSize + ") so the byte-aware flush prevents reallocations from exceeding the cap");
     return new HoodieSparkLanceWriter(file, sparkSchema, instantTime,
-        taskContextSupplier, storage, populateMetaFields, bloomFilterOpt, maxFileSize);
+        taskContextSupplier, storage, populateMetaFields, bloomFilterOpt, maxFileSize,
+        allocatorSize, flushByteWatermark);
   }
 
   /**
@@ -131,6 +141,8 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
   public static class HoodieSparkLanceWriterBuilder {
     private Option<BloomFilter> bloomFilterOpt = Option.empty();
     private long maxFileSize = Long.parseLong(HoodieStorageConfig.LANCE_MAX_FILE_SIZE.defaultValue());
+    private long allocatorSize = Long.parseLong(HoodieStorageConfig.LANCE_WRITE_ALLOCATOR_SIZE_BYTES.defaultValue());
+    private long flushByteWatermark = Long.parseLong(HoodieStorageConfig.LANCE_WRITE_FLUSH_BYTE_WATERMARK.defaultValue());
   }
 
   private HoodieSparkLanceWriter(StoragePath file,
@@ -140,8 +152,11 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
                                  HoodieStorage storage,
                                  boolean populateMetaFields,
                                  Option<BloomFilter> bloomFilterOpt,
-                                 long maxFileSize) {
-    super(file, DEFAULT_BATCH_SIZE, bloomFilterOpt.map(HoodieBloomFilterRowWriteSupport::new));
+                                 long maxFileSize,
+                                 long allocatorSize,
+                                 long flushByteWatermark) {
+    super(file, DEFAULT_BATCH_SIZE, allocatorSize, flushByteWatermark,
+        bloomFilterOpt.map(HoodieBloomFilterRowWriteSupport::new));
     this.sparkSchema = enrichSparkSchemaForLance(sparkSchema);
     Schema baseArrow = LanceArrowUtils.toArrowSchema(this.sparkSchema, DEFAULT_TIMEZONE, true);
     // Force LargeBinary + `lance-encoding:blob=true` on each BLOB's nested `data` Arrow leaf.

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
@@ -65,7 +65,9 @@ public class HoodieInternalRowFileWriterFactory {
       return newParquetInternalRowFileWriter(path, hoodieTable, writeConfig, schema, tryInstantiateBloomFilter(writeConfig));
     } else if (LANCE.getFileExtension().equals(extension)) {
       long maxFileSize = writeConfig.getLongOrDefault(HoodieStorageConfig.LANCE_MAX_FILE_SIZE);
-      return newLanceInternalRowFileWriter(path, hoodieTable, schema, maxFileSize);
+      long allocatorSize = writeConfig.getLongOrDefault(HoodieStorageConfig.LANCE_WRITE_ALLOCATOR_SIZE_BYTES);
+      long flushByteWatermark = writeConfig.getLongOrDefault(HoodieStorageConfig.LANCE_WRITE_FLUSH_BYTE_WATERMARK);
+      return newLanceInternalRowFileWriter(path, hoodieTable, schema, maxFileSize, allocatorSize, flushByteWatermark);
     }
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
@@ -97,7 +99,9 @@ public class HoodieInternalRowFileWriterFactory {
   private static HoodieInternalRowFileWriter newLanceInternalRowFileWriter(StoragePath path,
                                                                            HoodieTable table,
                                                                            StructType structType,
-                                                                           long maxFileSize)
+                                                                           long maxFileSize,
+                                                                           long allocatorSize,
+                                                                           long flushByteWatermark)
       throws IOException {
     return HoodieSparkLanceWriter.builder()
         .file(path)
@@ -105,6 +109,8 @@ public class HoodieInternalRowFileWriterFactory {
         .taskContextSupplier(new LocalTaskContextSupplier())
         .storage(table.getStorage())
         .maxFileSize(maxFileSize)
+        .allocatorSize(allocatorSize)
+        .flushByteWatermark(flushByteWatermark)
         .build();
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -86,6 +86,45 @@ public class HoodieStorageConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Target file size in bytes for Lance base files.");
 
+  public static final ConfigProperty<String> LANCE_WRITE_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.lance.write.allocator.size.bytes")
+      .defaultValue(String.valueOf(256 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Lance "
+          + "writer for buffering in-flight batch data. Must be large enough that the Arrow "
+          + "BaseLargeVariableWidthVector's power-of-2 doubling growth never requests a buffer "
+          + "exceeding this cap, otherwise writes fail with OutOfMemoryException. The default of "
+          + "256MB clears the 128MB doubling step with headroom; pair with "
+          + "hoodie.lance.write.flush.byte.watermark to bound in-flight memory regardless of "
+          + "blob size or row count.");
+
+  public static final ConfigProperty<String> LANCE_WRITE_FLUSH_BYTE_WATERMARK = ConfigProperty
+      .key("hoodie.lance.write.flush.byte.watermark")
+      .defaultValue(String.valueOf(96 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Byte-size watermark on the Lance writer's in-flight Arrow buffers; "
+          + "the writer flushes the current batch when the sum of FieldVector buffer sizes "
+          + "reaches this value, in addition to the row-count batch threshold. Keeps the data "
+          + "buffer below the next power-of-2 doubling step so reallocation cannot exceed "
+          + "hoodie.lance.write.allocator.size.bytes. Default is roughly 3/8 of the allocator "
+          + "size, leaving room for offset/validity buffers.");
+
+  public static final ConfigProperty<String> LANCE_READ_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.lance.read.allocator.size.bytes")
+      .defaultValue(String.valueOf(256 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Lance "
+          + "reader for the per-read data buffers. Raise this for files with very wide rows or "
+          + "large blob columns.");
+
+  public static final ConfigProperty<String> LANCE_READ_METADATA_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.lance.read.metadata.allocator.size.bytes")
+      .defaultValue(String.valueOf(8 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Lance "
+          + "reader for footer/metadata operations (schema, bloom filter). Independent of the "
+          + "data allocator since metadata allocations are small and short-lived.");
+
   public static final ConfigProperty<Boolean> HFILE_WRITER_TO_ALLOW_DUPLICATES = ConfigProperty
       .key("hoodie.hfile.writes.allow.duplicates")
       .defaultValue(false)

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
@@ -76,7 +76,7 @@ public class HoodieFileReaderFactory {
       case ORC:
         return newOrcFileReader(path);
       case LANCE:
-        return newLanceFileReader(path);
+        return newLanceFileReader(hoodieConfig, path);
       default:
         throw new UnsupportedOperationException(format + " format not supported yet.");
     }
@@ -92,7 +92,7 @@ public class HoodieFileReaderFactory {
       case ORC:
         return newOrcFileReader(pathInfo.getPath());
       case LANCE:
-        return newLanceFileReader(pathInfo.getPath());
+        return newLanceFileReader(hoodieConfig, pathInfo.getPath());
       default:
         throw new UnsupportedOperationException(format + " format not supported yet.");
     }
@@ -133,7 +133,7 @@ public class HoodieFileReaderFactory {
     throw new UnsupportedOperationException();
   }
 
-  protected HoodieFileReader newLanceFileReader(StoragePath path) {
+  protected HoodieFileReader newLanceFileReader(HoodieConfig hoodieConfig, StoragePath path) {
     throw new UnsupportedOperationException(HoodieFileFormat.LANCE_SPARK_ONLY_ERROR_MSG);
   }
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
@@ -56,13 +56,11 @@ import java.util.Map;
  */
 @NotThreadSafe
 public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implements Closeable {
-  /** Memory size for data write operations: 120MB */
-  private static final long LANCE_DATA_ALLOCATOR_SIZE = 120 * 1024 * 1024L;
-
   protected static final int DEFAULT_BATCH_SIZE = 1000;
   private final StoragePath path;
   private final BufferAllocator allocator;
   private final int batchSize;
+  private final long flushByteWatermark;
   @Getter(value = AccessLevel.PROTECTED)
   private long writtenRecordCount = 0;
   private long totalFlushedDataSize = 0;
@@ -77,15 +75,21 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
    * Constructor for base Lance writer.
    *
    * @param path Path where Lance file will be written
-   * @param batchSize Number of records to buffer before flushing to Lance
+   * @param batchSize Row-count threshold; the current batch is flushed when this many records have been buffered
+   * @param allocatorSize Maximum bytes the per-writer Arrow child allocator may hold at once; sized so Arrow's
+   *                      power-of-2 buffer doubling never requests a chunk above this cap
+   * @param flushByteWatermark Byte-size threshold; the current batch is flushed when the sum of in-flight
+   *                           FieldVector buffer sizes reaches this value. Must be small enough that the next
+   *                           doubling step stays below {@code allocatorSize}.
    * @param bloomFilterWriteSupportOpt Optional bloom filter write support for record key tracking
    */
-  protected HoodieBaseLanceWriter(StoragePath path, int batchSize,
+  protected HoodieBaseLanceWriter(StoragePath path, int batchSize, long allocatorSize, long flushByteWatermark,
                                   Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt) {
     this.path = path;
     this.allocator = HoodieArrowAllocator.newChildAllocator(
-        getClass().getSimpleName() + "-data-" + path.getName(), LANCE_DATA_ALLOCATOR_SIZE);
+        getClass().getSimpleName() + "-data-" + path.getName(), allocatorSize);
     this.batchSize = batchSize;
+    this.flushByteWatermark = flushByteWatermark;
     this.bloomFilterWriteSupportOpt = bloomFilterWriteSupportOpt;
   }
 
@@ -147,10 +151,28 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
     currentBatchSize++;
     writtenRecordCount++;
 
-    // Flush when batch is full
-    if (currentBatchSize >= batchSize) {
+    // Flush when row-count batch is full OR in-flight Arrow buffers cross the byte watermark.
+    // The byte-based check bounds in-flight memory so Arrow's power-of-2 vector reallocation
+    // can't escalate to a chunk size above the allocator cap regardless of per-row payload.
+    if (currentBatchSize >= batchSize || currentBufferBytes() >= flushByteWatermark) {
       flushBatch();
     }
+  }
+
+  /**
+   * Bytes currently held by the writer's Arrow child allocator. Used to drive the byte-aware
+   * flush.
+   *
+   * <p>Note: we deliberately do <em>not</em> use {@code FieldVector.getBufferSize()} here.
+   * For variable-width vectors (e.g. {@code BaseLargeVariableWidthVector} backing BLOB columns)
+   * that method short-circuits to 0 when {@code valueCount == 0}, and {@code valueCount} is only
+   * set during {@link ArrowWriter#finishBatch()} — i.e. at flush time. Mid-batch it always
+   * reports zero, so a watermark driven by it never fires. {@link BufferAllocator#getAllocatedMemory()}
+   * tracks the underlying ArrowBuf capacities directly and is exactly the quantity the allocator
+   * cap is enforced against.
+   */
+  private long currentBufferBytes() {
+    return allocator.getAllocatedMemory();
   }
 
   /**
@@ -242,17 +264,13 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
   }
 
   /**
-   * Returns the estimated data size in bytes, including both flushed batches and
-   * the current in-progress batch. The in-progress batch size is derived from
-   * Arrow buffer capacities, which may slightly overestimate due to pre-allocation.
+   * Returns the estimated data size in bytes, including both flushed batches and the current
+   * in-progress batch. The in-progress portion uses {@link BufferAllocator#getAllocatedMemory()}
+   * — see {@link #currentBufferBytes()} for why per-vector {@code getBufferSize()} is unreliable
+   * mid-batch. This may slightly overestimate due to Arrow's pre-allocation overhead.
    */
   protected long getDataSize() {
-    long currentBufferSize = 0;
-    if (root != null && currentBatchSize > 0) {
-      for (FieldVector vector : root.getFieldVectors()) {
-        currentBufferSize += vector.getBufferSize();
-      }
-    }
+    long currentBufferSize = currentBatchSize > 0 ? allocator.getAllocatedMemory() : 0;
     return totalFlushedDataSize + currentBufferSize;
   }
 
@@ -274,6 +292,17 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
 
     // Write VectorSchemaRoot to Lance file
     writer.write(root);
+
+    // Release Arrow buffers so capacity does not accumulate across batches.
+    // Arrow's BaseVariableWidthVector grows by doubling and never shrinks on its own;
+    // without releasing, a vector that doubled to 128MB on one batch would attempt
+    // to double to 256MB on the next, with the old 128MB still held — exceeding the
+    // allocator cap. Closing root here ensures each batch starts from the small
+    // initial capacity, so the watermark-bounded growth within a batch is the only
+    // memory the cap has to accommodate.
+    root.close();
+    root = null;
+    arrowWriter = null;
 
     // Reset batch counter for next batch
     currentBatchSize = 0;

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -20,13 +20,13 @@
 package org.apache.spark.sql.execution.datasources.lance
 
 import org.apache.hudi.SparkAdapterSupport.sparkAdapter
-import org.apache.hudi.common.config.HoodieReaderConfig
+import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
 import org.apache.hudi.common.util
 import org.apache.hudi.common.util.collection.ClosableIterator
 import org.apache.hudi.internal.schema.InternalSchema
 import org.apache.hudi.io.memory.HoodieArrowAllocator
-import org.apache.hudi.io.storage.{BlobDescriptorTransform, HoodieSparkLanceReader, LanceRecordIterator, VectorConversionUtils}
+import org.apache.hudi.io.storage.{BlobDescriptorTransform, LanceRecordIterator, VectorConversionUtils}
 import org.apache.hudi.storage.StorageConfiguration
 
 import org.apache.hadoop.conf.Configuration
@@ -87,8 +87,11 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
       var lanceIterator: ClosableIterator[UnsafeRow] = null
 
       // Create child allocator for reading
-      val allocator = HoodieArrowAllocator.newChildAllocator(getClass.getSimpleName + "-data-" + filePath,
-        HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE);
+      val dataAllocatorSize = storageConf.unwrap().getLong(
+        HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.key(),
+        HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.defaultValue().toLong)
+      val allocator = HoodieArrowAllocator.newChildAllocator(
+        getClass.getSimpleName + "-data-" + filePath, dataAllocatorSize)
 
       try {
         // Open Lance file reader

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceWriter.java
@@ -21,6 +21,7 @@ package org.apache.hudi.io.storage;
 import org.apache.hudi.client.SparkTaskContextSupplier;
 import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.bloom.BloomFilterFactory;
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.Option;
@@ -78,6 +79,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DisabledIfSystemProperty(named = "lance.skip.tests", matches = "true")
 public class TestHoodieSparkLanceWriter {
 
+  private static final long TEST_LANCE_DATA_ALLOCATOR_SIZE =
+      Long.parseLong(HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES.defaultValue());
+
   @TempDir
   File tempDir;
 
@@ -122,7 +126,7 @@ public class TestHoodieSparkLanceWriter {
     assertTrue(storage.exists(path), "Lance file should exist");
 
     try (BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
-             "testWriteRowWithMetadata", HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE);
+             "testWriteRowWithMetadata", TEST_LANCE_DATA_ALLOCATOR_SIZE);
          LanceFileReader reader = LanceFileReader.open(path.toString(), allocator);
          ArrowReader arrowReader = reader.readAll(null, null, Integer.MAX_VALUE)) {
 
@@ -191,7 +195,7 @@ public class TestHoodieSparkLanceWriter {
     assertTrue(storage.exists(path));
 
     try (BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
-             "testWriteRowWithoutMetadataPopulation", HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE);
+             "testWriteRowWithoutMetadataPopulation", TEST_LANCE_DATA_ALLOCATOR_SIZE);
          LanceFileReader reader = LanceFileReader.open(path.toString(), allocator);
          ArrowReader arrowReader = reader.readAll(null, null, Integer.MAX_VALUE)) {
 
@@ -231,7 +235,7 @@ public class TestHoodieSparkLanceWriter {
 
     // Verify file exists and has correct record count
     try (BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
-             "testWriteRowSimple", HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE);
+             "testWriteRowSimple", TEST_LANCE_DATA_ALLOCATOR_SIZE);
          LanceFileReader reader = LanceFileReader.open(path.toString(), allocator)) {
       assertEquals(1, reader.numRows());
     }
@@ -255,7 +259,7 @@ public class TestHoodieSparkLanceWriter {
 
     // Verify all records were written
     try (BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
-             "test", HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE);
+             "test", TEST_LANCE_DATA_ALLOCATOR_SIZE);
          LanceFileReader reader = LanceFileReader.open(path.toString(), allocator)) {
       assertEquals(recordCount, reader.numRows(), "All records should be written");
     }
@@ -291,7 +295,7 @@ public class TestHoodieSparkLanceWriter {
 
     // Verify all types were written correctly
     try (BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
-             "test", HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE);
+             "test", TEST_LANCE_DATA_ALLOCATOR_SIZE);
          LanceFileReader reader = LanceFileReader.open(path.toString(), allocator);
          ArrowReader arrowReader = reader.readAll(null, null, Integer.MAX_VALUE)) {
 
@@ -332,7 +336,7 @@ public class TestHoodieSparkLanceWriter {
 
     // Verify nulls are preserved
     try (BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
-             "test", HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE);
+             "test", TEST_LANCE_DATA_ALLOCATOR_SIZE);
          LanceFileReader reader = LanceFileReader.open(path.toString(), allocator);
          ArrowReader arrowReader = reader.readAll(null, null, Integer.MAX_VALUE)) {
 
@@ -418,7 +422,7 @@ public class TestHoodieSparkLanceWriter {
 
     assertTrue(storage.exists(path), "Lance file with struct type should exist");
     try (BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
-             "test", HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE);
+             "test", TEST_LANCE_DATA_ALLOCATOR_SIZE);
          LanceFileReader reader = LanceFileReader.open(path.toString(), allocator)) {
       assertEquals(rows.size(), reader.numRows(), "Row count should match");
       assertEquals(3, reader.schema().getFields().size(), "Should have 3 top-level fields (id, name, address)");


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Lance writer hardcodes its Arrow child allocator at 120 MB. Arrow's `BaseLargeVariableWidthVector` grows by power-of-2 doubling (32 → 64 → 128 MB), so a batch holding ~64 MB of payload (e.g. PNG blobs) hits a 128 MB reallocation request that exceeds the cap and OOMs. The reader has the same hardcoded constants (120 MB data, 8 MB metadata).

Repro: `HUDI_BASE_FILE_FORMAT=lance HUDI_BLOB_MODE=inline HUDI_INLINE_READ_MODE=descriptor` on the blob demo with ≥256 rows.

### Summary and Changelog

Make the Lance Arrow allocator sizes configurable and add a byte-aware flush so in-flight buffers can't escalate past the cap.

New `HoodieStorageConfig` keys (all `markAdvanced`):
- `hoodie.lance.write.allocator.size.bytes` — default 256 MB
- `hoodie.lance.write.flush.byte.watermark` — default 96 MB
- `hoodie.lance.read.allocator.size.bytes` — default 256 MB
- `hoodie.lance.read.metadata.allocator.size.bytes` — default 8 MB

Writer (`HoodieBaseLanceWriter`):
- Constructor takes `allocatorSize` and `flushByteWatermark`; hardcoded constant removed.
- Flush triggers on `currentBatchSize >= batchSize || allocator.getAllocatedMemory() >= flushByteWatermark`. We use the allocator's tracked memory rather than `FieldVector.getBufferSize()` because the latter short-circuits to 0 for variable-width vectors when `valueCount == 0`, and `valueCount` is only set at `finishBatch()` — so a watermark driven by it never fires mid-batch.
- `flushBatch()` now closes the `VectorSchemaRoot` after writing. Arrow's variable-width vectors grow by doubling and never shrink on `clear()`/`reset()` — without releasing, capacity from one batch is still held when the next starts doubling, so the cap is enforced against accumulated capacity.

Reader (`HoodieSparkLanceReader`, `SparkLanceReaderBase`):
- Sizes plumbed via constructor / read off `storageConf`. `HoodieFileReaderFactory.newLanceFileReader` signature now takes `HoodieConfig`.

Plumbing: `HoodieSparkLanceWriter` builder, `HoodieSparkFileWriterFactory`, `HoodieInternalRowFileWriterFactory`, `HoodieSparkFileReaderFactory` thread the new keys through. Test references to the removed `public` constant updated.

### Impact

Behavioral: default writer/reader allocator caps go from 120 MB → 256 MB; the writer also flushes on the byte watermark in addition to the 1000-row threshold. Tunable per workload via the four new configs. No public API removed; `HoodieFileReaderFactory.newLanceFileReader(StoragePath)` is replaced by `(HoodieConfig, StoragePath)`.

### Risk Level

low — Lance is opt-in (`HUDI_BASE_FILE_FORMAT=lance`), Parquet path untouched. The `newLanceFileReader` signature change is internal-protected. Verified the failing demo passes at 256 / 500 / 5000 rows across `inline+descriptor`, `inline+content`, and `out_of_line` blob modes; Parquet baseline unchanged.

### Documentation Update

The four new `HoodieStorageConfig` keys carry config descriptions and `markAdvanced()`; they will surface in the auto-generated config reference. No website change required.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
