### PR TITLE
chore(deps): Pin AWS v1 SDK BOM to short-circuit transitive version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,7 @@
     <disruptor.version>3.4.2</disruptor.version>
     <antlr.version>4.8</antlr.version>
     <aws.sdk.version>2.29.52</aws.sdk.version>
+    <aws.sdk.v1.version>1.12.797</aws.sdk.v1.version>
     <proto.version>3.25.5</proto.version>
     <protoc.version>3.25.5</protoc.version>
     <dynamodb.lockclient.version>1.2.0</dynamodb.lockclient.version>
@@ -779,6 +780,18 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- AWS v1 SDK BOM. Pins all com.amazonaws:aws-java-sdk-* artifacts to a single
+           version. Without this, transitive deps (notably aws-lambda-java-events 1.1.0
+           via amazon-kinesis-deaggregator) declare AWS SDK ranges like [1.10.5,), which
+           force Maven to walk every published patch version during resolution. -->
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>${aws.sdk.v1.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- Scala -->
       <dependency>
         <groupId>org.scala-lang.modules</groupId>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`amazon-kinesis-deaggregator:1.0.3` (added in #18224) drags in `aws-lambda-java-events:1.1.0`, whose POM declares `aws-java-sdk-*` deps as soft version ranges:

```xml
<version>[1.10.5,)</version>
```

Maven resolves these literally: it fetches `maven-metadata.xml` for every affected artifact, then downloads every intermediate POM (`1.11.35`, `1.11.36`, ... `1.11.49x`, ...) to walk the version graph. A clean build pulls hundreds of `aws-java-sdk-s3-1.11.NNN.pom` files just for graph traversal; the resolved jar is never on the classpath.

Side effects:

- CI cold builds slow down by minutes per module that touches `hudi-utilities`.
- Resolution is non-deterministic since it picks "latest at resolve time" within the open range.

<img width="2506" height="1736" alt="image" src="https://github.com/user-attachments/assets/2498a43d-a2ce-48c8-b81a-eb6ff85fa730" />


### Summary and Changelog

Pin `com.amazonaws:aws-java-sdk-bom` in the root `<dependencyManagement>`. The BOM imports a fixed version for every `com.amazonaws:aws-java-sdk-*` artifact, so Maven's `<dependencyManagement>` short-circuits the transitive ranges before the walk starts.

Changes (`pom.xml`):

- New property `<aws.sdk.v1.version>1.12.797</aws.sdk.v1.version>` next to the existing v2 SDK property. Version chosen to match the highest `aws-java-sdk-core` already in the resolved graph, so this is a behavioral no-op and adopts the SDK version the build was already converging on.
- Import `aws-java-sdk-bom` (scope `import`, type `pom`) at the top of `<dependencyManagement>` with an inline comment explaining the rationale.

### Impact

- **Build time**: clean `mvn` invocations that touch `hudi-utilities` (or any reactor including it) skip the AWS SDK range walk. Hundreds of POM downloads per fresh `~/.m2` go away.
- **Reproducibility**: v1 SDK version is now pinned, not floating. Future bumps go through a deliberate version property change.
- **Runtime**: no change. The pinned version (`1.12.797`) is what the build was already resolving to.
- **Public API**: none.

### Risk Level

low.

- BOM `<scope>import</scope>` only affects dependency resolution; no code change.
- Pinned version matches what was already on the classpath, so no behavioral drift.
- v1 SDK 1.12.x is API-stable (maintenance line, security patches only).
- Verified locally: `mvn dependency:tree -pl hudi-utilities -am` finishes without the AWS SDK range-walk download flood.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
