### PR TITLE
chore: [DNM] Release 1.2.0 RC1 bundle validation

### DIFF
--- a/.github/workflows/release_candidate_validation.yml
+++ b/.github/workflows/release_candidate_validation.yml
@@ -16,8 +16,8 @@ jobs:
   validate-release-candidate-bundles:
     runs-on: ubuntu-latest
     env:
-      HUDI_VERSION: 1.2.0-rc2
-      STAGING_REPO_NUM: 1181
+      HUDI_VERSION: 1.2.0
+      STAGING_REPO_NUM: 1183
     strategy:
       matrix:
         include:
@@ -66,8 +66,8 @@ jobs:
   validate-release-candidate-bundles-spark4:
     runs-on: ubuntu-latest
     env:
-      HUDI_VERSION: 1.2.0-rc2
-      STAGING_REPO_NUM: 1181
+      HUDI_VERSION: 1.2.0
+      STAGING_REPO_NUM: 1183
     strategy:
       matrix:
         include:
@@ -100,8 +100,8 @@ jobs:
   validate-release-candidate-bundles-flink2:
     runs-on: ubuntu-latest
     env:
-      HUDI_VERSION: 1.2.0-rc2
-      STAGING_REPO_NUM: 1181
+      HUDI_VERSION: 1.2.0
+      STAGING_REPO_NUM: 1183
     strategy:
       matrix:
         include:

--- a/.github/workflows/release_candidate_validation.yml
+++ b/.github/workflows/release_candidate_validation.yml
@@ -15,10 +15,9 @@ env:
 jobs:
   validate-release-candidate-bundles:
     runs-on: ubuntu-latest
-    if: false
     env:
-      HUDI_VERSION: 1.1.0
-      STAGING_REPO_NUM: 1164
+      HUDI_VERSION: 1.2.0-rc2
+      STAGING_REPO_NUM: 1181
     strategy:
       matrix:
         include:
@@ -66,10 +65,9 @@ jobs:
 
   validate-release-candidate-bundles-spark4:
     runs-on: ubuntu-latest
-    if: false
     env:
-      HUDI_VERSION: 1.1.0
-      STAGING_REPO_NUM: 1164
+      HUDI_VERSION: 1.2.0-rc2
+      STAGING_REPO_NUM: 1181
     strategy:
       matrix:
         include:
@@ -77,6 +75,10 @@ jobs:
             flinkProfile: 'flink1.20'
             sparkProfile: 'spark4.0'
             sparkRuntime: 'spark4.0.0'
+          - scalaProfile: 'scala-2.13'
+            flinkProfile: 'flink1.20'
+            sparkProfile: 'spark4.1'
+            sparkRuntime: 'spark4.1.1'
     steps:
       - uses: actions/checkout@v5
       - name: Set up JDK 17
@@ -97,15 +99,18 @@ jobs:
 
   validate-release-candidate-bundles-flink2:
     runs-on: ubuntu-latest
-    if: false
     env:
-      HUDI_VERSION: 1.1.0
-      STAGING_REPO_NUM: 1164
+      HUDI_VERSION: 1.2.0-rc2
+      STAGING_REPO_NUM: 1181
     strategy:
       matrix:
         include:
           - scalaProfile: 'scala-2.12'
             flinkProfile: 'flink2.0'
+            sparkProfile: 'spark3.5'
+            sparkRuntime: 'spark3.5.1'
+          - scalaProfile: 'scala-2.12'
+            flinkProfile: 'flink2.1'
             sparkProfile: 'spark3.5'
             sparkRuntime: 'spark3.5.1'
     steps:

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
 <project version="4">
   <component name="IssueNavigationConfiguration">
     <option name="links">
@@ -32,5 +16,6 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/src_release/hudi-tmp-clone" vcs="Git" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project version="4">
   <component name="IssueNavigationConfiguration">
     <option name="links">
@@ -16,6 +32,5 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/src_release/hudi-tmp-clone" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Release 1.2.0 RC1 bundle validation (orgapachehudi-1176)

### Summary and Changelog

Enable release candidate bundle validation workflow for 1.2.0-rc1 with staging repo 1176.
- Remove `if: false` guards from all validation jobs
- Update `HUDI_VERSION` to `1.2.0-rc1` and `STAGING_REPO_NUM` to `1176`
- Add Spark 4.1 matrix entry to the Spark 4 validation job
- Add Flink 2.1 matrix entry to the Flink 2 validation job

### Impact

RC1 bundle validation only; no user-facing changes.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable