### PR TITLE
feat: Wire VORTEX into reader/writer factory dispatch and IOFactory

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -132,6 +132,43 @@ public class HoodieStorageConfig extends HoodieConfig {
       .sinceVersion("1.3.0")
       .withDocumentation("Control whether to write bloom filter or not to HFile.");
 
+  public static final ConfigProperty<String> VORTEX_MAX_FILE_SIZE = ConfigProperty
+      .key("hoodie.vortex.max.file.size")
+      .defaultValue(String.valueOf(120 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Target file size in bytes for Vortex base files.");
+
+  public static final ConfigProperty<String> VORTEX_WRITE_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.vortex.write.allocator.size.bytes")
+      .defaultValue(String.valueOf(256 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Vortex "
+          + "writer for buffering in-flight batch data. Must be large enough that the Arrow "
+          + "buffer's power-of-2 doubling growth never requests a buffer exceeding this cap, "
+          + "otherwise writes fail with OutOfMemoryException.");
+
+  public static final ConfigProperty<String> VORTEX_WRITE_FLUSH_BYTE_WATERMARK = ConfigProperty
+      .key("hoodie.vortex.write.flush.byte.watermark")
+      .defaultValue(String.valueOf(96 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Byte-size watermark on the Vortex writer's in-flight Arrow buffers; "
+          + "the writer flushes the current batch when the sum of FieldVector buffer sizes "
+          + "reaches this value, in addition to the row-count batch threshold.");
+
+  public static final ConfigProperty<String> VORTEX_READ_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.vortex.read.allocator.size.bytes")
+      .defaultValue(String.valueOf(256 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Vortex "
+          + "reader for per-read data buffers.");
+
+  public static final ConfigProperty<String> VORTEX_READ_METADATA_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.vortex.read.metadata.allocator.size.bytes")
+      .defaultValue(String.valueOf(8 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Vortex "
+          + "reader for footer/metadata operations (schema, bloom filter).");
+
   public static final ConfigProperty<Boolean> HFILE_WRITER_TO_ALLOW_DUPLICATES = ConfigProperty
       .key("hoodie.hfile.writes.allow.duplicates")
       .defaultValue(false)
@@ -629,6 +666,11 @@ public class HoodieStorageConfig extends HoodieConfig {
 
     public Builder lanceMaxFileSize(long maxFileSize) {
       storageConfig.setValue(LANCE_MAX_FILE_SIZE, String.valueOf(maxFileSize));
+      return this;
+    }
+
+    public Builder vortexMaxFileSize(long maxFileSize) {
+      storageConfig.setValue(VORTEX_MAX_FILE_SIZE, String.valueOf(maxFileSize));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -53,11 +53,19 @@ public enum HoodieFileFormat {
 
   @EnumFieldDescription("Lance is a modern columnar data format optimized for random access patterns "
           + "and designed for ML and AI workloads")
-  LANCE(".lance");
+  LANCE(".lance"),
+
+  @EnumFieldDescription("Vortex is a next-generation columnar data format with cascading compression "
+          + "optimized for fast random access and analytical scans")
+  VORTEX(".vortex");
 
   public static final String LANCE_UNSUPPORTED_ERROR_MSG =
       "Lance base file format is not supported by this reader or writer path. "
           + "Please use an engine-specific Lance reader/writer, or use Parquet, ORC, or HFile.";
+
+  public static final String VORTEX_SPARK_ONLY_ERROR_MSG =
+      "Vortex base file format is currently only supported with the Spark engine. "
+          + "Please use Parquet, ORC, or HFile for non-Spark engines (Flink, Hive, Presto, Trino).";
 
   public static final Set<String> BASE_FILE_EXTENSIONS = Arrays.stream(HoodieFileFormat.values())
       .map(HoodieFileFormat::getFileExtension)

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/VortexUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/VortexUtils.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.apache.hudi.common.config.HoodieReaderConfig;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.core.io.storage.HoodieFileReader;
+import org.apache.hudi.core.io.storage.HoodieIOFactory;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.keygen.BaseKeyGenerator;
+import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import org.apache.avro.generic.GenericRecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class VortexUtils extends FileFormatUtils {
+
+  @Override
+  public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath) {
+    return fetchRecordKeysWithPositions(storage, filePath, Option.empty(), Option.empty());
+  }
+
+  @Override
+  public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage,
+                                                                               StoragePath filePath,
+                                                                               Option<BaseKeyGenerator> keyGeneratorOpt,
+                                                                               Option<String> partitionPath) {
+    AtomicLong position = new AtomicLong(0);
+    return new CloseableMappingIterator<>(
+        getHoodieKeyIterator(storage, filePath, keyGeneratorOpt, partitionPath),
+        key -> Pair.of(key, position.getAndIncrement()));
+  }
+
+  @Override
+  public ClosableIterator<HoodieKey> getHoodieKeyIterator(HoodieStorage storage, StoragePath filePath) {
+    return getHoodieKeyIterator(storage, filePath, Option.empty(), Option.empty());
+  }
+
+  @Override
+  public ClosableIterator<HoodieKey> getHoodieKeyIterator(HoodieStorage storage,
+                                                           StoragePath filePath,
+                                                           Option<BaseKeyGenerator> keyGeneratorOpt,
+                                                           Option<String> partitionPath) {
+    try {
+      HoodieSchema keySchema = getKeyIteratorSchema(storage, filePath, keyGeneratorOpt, partitionPath);
+      HoodieFileReader reader = HoodieIOFactory.getIOFactory(storage)
+          .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+          .getFileReader(new HoodieReaderConfig(), filePath, HoodieFileFormat.VORTEX);
+      ClosableIterator<HoodieRecord> recordIterator = reader.getRecordIterator(keySchema);
+
+      return new CloseableMappingIterator<>(
+          recordIterator,
+          record -> {
+            String recordKey;
+            if (keyGeneratorOpt.isPresent()) {
+              recordKey = record.getRecordKey(keySchema, keyGeneratorOpt);
+            } else {
+              recordKey = record.getRecordKey(keySchema, HoodieRecord.RECORD_KEY_METADATA_FIELD);
+            }
+            String partitionPathValue = partitionPath.orElseGet(() ->
+                (String) record.getColumnValueAsJava(keySchema, HoodieRecord.PARTITION_PATH_METADATA_FIELD,
+                    CollectionUtils.emptyProps()));
+            return new HoodieKey(recordKey, partitionPathValue);
+          }
+      );
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read from Vortex file " + filePath, e);
+    }
+  }
+
+  @Override
+  public HoodieSchema readSchema(HoodieStorage storage, StoragePath filePath) {
+    try (HoodieFileReader fileReader =
+                 HoodieIOFactory.getIOFactory(storage)
+                         .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+                         .getFileReader(
+                                 ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER,
+                                 filePath,
+                                 HoodieFileFormat.VORTEX)) {
+      return fileReader.getSchema();
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read schema from Vortex file", e);
+    }
+  }
+
+  @Override
+  public HoodieFileFormat getFormat() {
+    return HoodieFileFormat.VORTEX;
+  }
+
+  @Override
+  public List<GenericRecord> readAvroRecords(HoodieStorage storage, StoragePath filePath) {
+    throw new UnsupportedOperationException("readAvroRecords is not yet supported for Vortex format");
+  }
+
+  @Override
+  public List<GenericRecord> readAvroRecords(HoodieStorage storage, StoragePath filePath, HoodieSchema schema) {
+    throw new UnsupportedOperationException("readAvroRecords with schema is not yet supported for Vortex format");
+  }
+
+  @Override
+  public Map<String, String> readFooter(HoodieStorage storage, boolean required, StoragePath filePath, String... footerNames) {
+    throw new UnsupportedOperationException("readFooter is not yet supported for Vortex format");
+  }
+
+  @Override
+  public long getRowCount(HoodieStorage storage, StoragePath filePath) {
+    try (HoodieFileReader fileReader =
+                 HoodieIOFactory.getIOFactory(storage)
+                         .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+                         .getFileReader(
+                                 ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER,
+                                 filePath,
+                                 HoodieFileFormat.VORTEX)) {
+      return fileReader.getTotalRecords();
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to get row count from Vortex file", e);
+    }
+  }
+
+  @Override
+  public Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, Set<String> filterKeys) {
+    try (HoodieFileReader fileReader =
+                 HoodieIOFactory.getIOFactory(storage)
+                         .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+                         .getFileReader(
+                                 ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER,
+                                 filePath,
+                                 HoodieFileFormat.VORTEX)) {
+      return fileReader.filterRowKeys(filterKeys);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read filter keys from Vortex file", e);
+    }
+  }
+
+  @Override
+  public List<HoodieColumnRangeMetadata<Comparable>> readColumnStatsFromMetadata(HoodieStorage storage,
+                                                                                  StoragePath filePath,
+                                                                                  List<String> columnList,
+                                                                                  HoodieIndexVersion indexVersion) {
+    throw new UnsupportedOperationException("readColumnStatsFromMetadata is not yet supported for Vortex format");
+  }
+
+  @Override
+  public void writeMetaFile(HoodieStorage storage, StoragePath filePath, Properties props) throws IOException {
+    throw new UnsupportedOperationException("writeMetaFile is not yet supported for Vortex format");
+  }
+
+  @Override
+  public ByteArrayOutputStream serializeRecordsToLogBlock(HoodieStorage storage,
+                                                          List<HoodieRecord> records,
+                                                          HoodieSchema writerSchema,
+                                                          HoodieSchema readerSchema,
+                                                          String keyFieldName,
+                                                          Map<String, String> paramsMap) throws IOException {
+    throw new UnsupportedOperationException("serializeRecordsToLogBlock is not yet supported for Vortex format");
+  }
+
+  @Override
+  public Pair<ByteArrayOutputStream, Object> serializeRecordsToLogBlock(HoodieStorage storage,
+                                                                        Iterator<HoodieRecord> records,
+                                                                        HoodieRecord.HoodieRecordType recordType,
+                                                                        HoodieSchema writerSchema,
+                                                                        HoodieSchema readerSchema,
+                                                                        String keyFieldName,
+                                                                        Map<String, String> paramsMap) throws IOException {
+    throw new UnsupportedOperationException("serializeRecordsToLogBlock with iterator is not yet supported for Vortex format");
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileReaderFactory.java
@@ -33,6 +33,7 @@ import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
 import static org.apache.hudi.common.model.HoodieFileFormat.LANCE;
 import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
 import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
+import static org.apache.hudi.common.model.HoodieFileFormat.VORTEX;
 
 /**
  * Factory methods to create Hudi file reader.
@@ -58,6 +59,9 @@ public class HoodieFileReaderFactory {
     if (LANCE.getFileExtension().equals(extension)) {
       return getFileReader(hoodieConfig, path, LANCE, Option.empty());
     }
+    if (VORTEX.getFileExtension().equals(extension)) {
+      return getFileReader(hoodieConfig, path, VORTEX, Option.empty());
+    }
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
 
@@ -77,6 +81,8 @@ public class HoodieFileReaderFactory {
         return newOrcFileReader(path);
       case LANCE:
         return newLanceFileReader(hoodieConfig, path);
+      case VORTEX:
+        return newVortexFileReader(hoodieConfig, path);
       default:
         throw new UnsupportedOperationException(format + " format not supported yet.");
     }
@@ -135,6 +141,10 @@ public class HoodieFileReaderFactory {
 
   protected HoodieFileReader newLanceFileReader(HoodieConfig hoodieConfig, StoragePath path) {
     throw new UnsupportedOperationException(HoodieFileFormat.LANCE_UNSUPPORTED_ERROR_MSG);
+  }
+
+  protected HoodieFileReader newVortexFileReader(HoodieConfig hoodieConfig, StoragePath path) {
+    throw new UnsupportedOperationException(HoodieFileFormat.VORTEX_SPARK_ONLY_ERROR_MSG);
   }
 
   public HoodieFileReader newBootstrapFileReader(HoodieFileReader skeletonFileReader,

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileWriterFactory.java
@@ -37,6 +37,7 @@ import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
 import static org.apache.hudi.common.model.HoodieFileFormat.LANCE;
 import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
 import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
+import static org.apache.hudi.common.model.HoodieFileFormat.VORTEX;
 
 public class HoodieFileWriterFactory {
   protected final HoodieStorage storage;
@@ -74,6 +75,9 @@ public class HoodieFileWriterFactory {
     }
     if (LANCE.getFileExtension().equals(extension)) {
       return newLanceFileWriter(instantTime, path, config, schema, taskContextSupplier);
+    }
+    if (VORTEX.getFileExtension().equals(extension)) {
+      return newVortexFileWriter(instantTime, path, config, schema, taskContextSupplier);
     }
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
@@ -115,6 +119,12 @@ public class HoodieFileWriterFactory {
       String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier) throws IOException {
     throw new UnsupportedOperationException(HoodieFileFormat.LANCE_UNSUPPORTED_ERROR_MSG);
+  }
+
+  protected HoodieFileWriter newVortexFileWriter(
+      String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
+      TaskContextSupplier taskContextSupplier) throws IOException {
+    throw new UnsupportedOperationException(HoodieFileFormat.VORTEX_SPARK_ONLY_ERROR_MSG);
   }
 
   public static BloomFilter createBloomFilter(HoodieConfig config) {

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieIOFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieIOFactory.java
@@ -114,6 +114,8 @@ public abstract class HoodieIOFactory {
       return getFileFormatUtils(HoodieFileFormat.HFILE);
     } else if (path.getFileExtension().equals(HoodieFileFormat.LANCE.getFileExtension())) {
       return getFileFormatUtils(HoodieFileFormat.LANCE);
+    } else if (path.getFileExtension().equals(HoodieFileFormat.VORTEX.getFileExtension())) {
+      return getFileFormatUtils(HoodieFileFormat.VORTEX);
     }
     throw new UnsupportedOperationException("The format for file " + path + " is not supported yet.");
   }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieHadoopIOFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieHadoopIOFactory.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.util.LanceUtils;
 import org.apache.hudi.common.util.OrcUtils;
 import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.VortexUtils;
 import org.apache.hudi.core.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.core.io.storage.HoodieIOFactory;
@@ -114,6 +115,8 @@ public class HoodieHadoopIOFactory extends HoodieIOFactory {
         return new HFileUtils();
       case LANCE:
         return new LanceUtils();
+      case VORTEX:
+        return new VortexUtils();
       default:
         throw new UnsupportedOperationException(fileFormat.name() + " format not supported yet.");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,9 @@
     <lance.spark.connector.version>0.4.0</lance.spark.connector.version>
     <lance.spark.artifact>lance-spark-3.5_${scala.binary.version}</lance.spark.artifact>
     <lance.skip.tests>false</lance.skip.tests>
+    <vortex.version>0.76.0</vortex.version>
+    <vortex.spark.artifact>vortex-spark_${scala.binary.version}</vortex.spark.artifact>
+    <vortex.skip.tests>false</vortex.skip.tests>
     <!-- The following properties are only used for Jacoco coverage report aggregation -->
     <copy.files>false</copy.files>
     <copy.files.target.dir>${maven.multiModuleProjectDirectory}</copy.files.target.dir>
@@ -525,6 +528,7 @@
             <systemPropertyVariables>
               <log4j.configurationFile>${surefire-log4j.file}</log4j.configurationFile>
               <lance.skip.tests>${lance.skip.tests}</lance.skip.tests>
+              <vortex.skip.tests>${vortex.skip.tests}</vortex.skip.tests>
             </systemPropertyVariables>
             <useSystemClassLoader>false</useSystemClassLoader>
             <forkedProcessExitTimeoutInSeconds>30</forkedProcessExitTimeoutInSeconds>
@@ -569,6 +573,7 @@
             <systemProperties>
               <log4j.configurationFile>${surefire-log4j.file}</log4j.configurationFile>
               <lance.skip.tests>${lance.skip.tests}</lance.skip.tests>
+              <vortex.skip.tests>${vortex.skip.tests}</vortex.skip.tests>
             </systemProperties>
           </configuration>
           <executions>
@@ -993,6 +998,24 @@
           <exclusion>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- Vortex JNI -->
+      <dependency>
+        <groupId>dev.vortex</groupId>
+        <artifactId>vortex-jni</artifactId>
+        <version>${vortex.version}</version>
+      </dependency>
+      <!-- Vortex Spark connector -->
+      <dependency>
+        <groupId>dev.vortex</groupId>
+        <artifactId>${vortex.spark.artifact}</artifactId>
+        <version>${vortex.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>dev.vortex</groupId>
+            <artifactId>vortex-jni</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -2633,6 +2656,8 @@
         <!-- Lance: Skip tests for Spark 3.3 due to lack of support -->
         <lance.spark.artifact>lance-spark-base_${scala.binary.version}</lance.spark.artifact>
         <lance.skip.tests>true</lance.skip.tests>
+        <!-- Vortex: Skip tests for Spark 3.3 due to lack of support -->
+        <vortex.skip.tests>true</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
@@ -2678,6 +2703,8 @@
         <!-- Lance: Use Spark 3.4-specific artifact -->
         <lance.spark.artifact>lance-spark-3.4_${scala.binary.version}</lance.spark.artifact>
         <lance.skip.tests>true</lance.skip.tests>
+        <!-- Vortex: Skip tests for Spark 3.4 due to lack of support -->
+        <vortex.skip.tests>true</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
@@ -2733,6 +2760,9 @@
         <!-- Lance: Use Spark 3.5-specific artifact -->
         <lance.spark.artifact>lance-spark-3.5_${scala.binary.version}</lance.spark.artifact>
         <lance.skip.tests>false</lance.skip.tests>
+        <!-- Vortex: Use Spark 3.5 artifact -->
+        <vortex.spark.artifact>vortex-spark_${scala.binary.version}</vortex.spark.artifact>
+        <vortex.skip.tests>false</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
@@ -2796,6 +2826,9 @@
         <!-- Lance: Use Spark 4.0-specific artifact (Scala 2.13 only) -->
         <lance.spark.artifact>lance-spark-4.0_2.13</lance.spark.artifact>
         <lance.skip.tests>false</lance.skip.tests>
+        <!-- Vortex: Use Spark 4.0 artifact (Scala 2.13 only) -->
+        <vortex.spark.artifact>vortex-spark_2.13</vortex.spark.artifact>
+        <vortex.skip.tests>false</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
@@ -2859,6 +2892,9 @@
         <hive.storage.version>2.8.1</hive.storage.version>
         <lance.spark.artifact>lance-spark-4.1_2.13</lance.spark.artifact>
         <lance.skip.tests>false</lance.skip.tests>
+        <!-- Vortex: Use Spark 4.1 artifact (Scala 2.13 only) -->
+        <vortex.spark.artifact>vortex-spark_2.13</vortex.spark.artifact>
+        <vortex.skip.tests>false</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18625

Wires the VORTEX file format into Hudi's reader/writer factory dispatch layer and adds VortexUtils. Stacked on #18631.

### Summary and Changelog

- Add `case VORTEX` dispatch in `HoodieFileReaderFactory` (extension-based and enum-based)
- Add `case VORTEX` dispatch in `HoodieFileWriterFactory` (extension-based)
- Add `newVortexFileReader()` and `newVortexFileWriter()` protected methods (default: throws `UnsupportedOperationException` with Spark-only message)
- Add `.vortex` extension dispatch in `HoodieIOFactory.getFileFormatUtils(StoragePath)`
- Add `case VORTEX` in `HoodieHadoopIOFactory.getFileFormatUtils()`
- Create `VortexUtils` extending `FileFormatUtils` with key iteration, schema reads, row count delegation to reader (mirrors `LanceUtils`)

### Impact

No behavioral changes. Default factory methods throw `UnsupportedOperationException` until the Spark reader/writer implementations are added.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable