### PR TITLE
feat: Add Vortex Spark reader, record iterator, and resource closer

### DIFF
--- a/hudi-client/hudi-spark-client/pom.xml
+++ b/hudi-client/hudi-spark-client/pom.xml
@@ -300,4 +300,48 @@
       </resource>
     </resources>
   </build>
+
+  <profiles>
+    <!-- Vortex requires Java 17 (vortex-jni/vortex-spark ship Java 17 bytecode). Compile the Vortex
+         reader/writer sources under src/main/java-vortex and pull the vortex-spark connector only on
+         JDK 17; Java 11 builds skip them. The factory dispatch (HoodieSparkFile{Reader,Writer}Factory)
+         instantiates these classes reflectively so it stays Java 11 compilable. -->
+    <profile>
+      <id>vortex</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>dev.vortex</groupId>
+          <artifactId>${vortex.spark.artifact}</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-vortex-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <!-- Vortex is only supported on Spark 3.5+/4.x; skip the source on Spark 3.3/3.4
+                       (vortex.skip.tests=true) where its Spark 3.5+ APIs are unavailable. -->
+                  <skipAddSource>${vortex.skip.tests}</skipAddSource>
+                  <sources>
+                    <source>src/main/java-vortex</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/hudi-client/hudi-spark-client/src/main/java-vortex/org/apache/hudi/io/storage/HoodieSparkVortexReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java-vortex/org/apache/hudi/io/storage/HoodieSparkVortexReader.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import org.apache.hudi.HoodieSchemaConversionUtils;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieSparkRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.io.memory.HoodieArrowAllocator;
+import org.apache.hudi.storage.StoragePath;
+
+import dev.vortex.api.DataSource;
+import dev.vortex.api.Scan;
+import dev.vortex.api.ScanOptions;
+import dev.vortex.api.Session;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.ArrowUtils$;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.hudi.common.util.TypeUtils.unsafeCast;
+
+/**
+ * {@link HoodieSparkFileReader} implementation for Vortex file format, backed by the vortex-jni
+ * {@code dev.vortex.api} reader (Session / DataSource / Scan).
+ *
+ * <p>NOTE: vortex-jni 0.76.0 exposes no file-level custom-metadata API, so the Hudi bloom filter
+ * and min/max record-key footers are not available for Vortex files. {@link #readBloomFilter()}
+ * returns {@code null} and {@link #readMinMaxRecordKeys()} is unsupported.
+ * TODO(#18623): surface bloom/min-max footers once Vortex supports file metadata.
+ */
+@Slf4j
+public class HoodieSparkVortexReader implements HoodieSparkFileReader {
+  private final StoragePath path;
+  private final String uri;
+  private final long dataAllocatorSize;
+  // Session/DataSource are held so their native resources are not GC'd while this reader is open;
+  // neither is AutoCloseable in vortex-jni 0.76.0 (cleanup is implicit).
+  private final Session metadataSession;
+  private final DataSource metadataDataSource;
+  private final BufferAllocator metadataAllocator;
+
+  public HoodieSparkVortexReader(StoragePath path) {
+    this(path, Long.parseLong(HoodieStorageConfig.VORTEX_READ_ALLOCATOR_SIZE_BYTES.defaultValue()));
+  }
+
+  public HoodieSparkVortexReader(StoragePath path, long dataAllocatorSize) {
+    this.path = path;
+    this.uri = toVortexUri(path);
+    this.dataAllocatorSize = dataAllocatorSize;
+    this.metadataAllocator = HoodieArrowAllocator.newChildAllocator(
+        getClass().getSimpleName() + "-meta-" + path.getName(),
+        Long.parseLong(HoodieStorageConfig.VORTEX_READ_METADATA_ALLOCATOR_SIZE_BYTES.defaultValue()));
+    try {
+      this.metadataSession = Session.create();
+      this.metadataDataSource = DataSource.open(metadataSession, uri);
+    } catch (Exception e) {
+      metadataAllocator.close();
+      throw new HoodieException("Failed to open Vortex file: " + path, e);
+    }
+  }
+
+  @Override
+  public String[] readMinMaxRecordKeys() {
+    throw new UnsupportedOperationException(
+        "Min/max record keys are not available for Vortex files (no file-metadata support in vortex-jni 0.76.0)");
+  }
+
+  @Override
+  public BloomFilter readBloomFilter() {
+    // Vortex files carry no Hudi bloom filter footer yet; callers treat null as "no bloom filter".
+    return null;
+  }
+
+  @Override
+  public Set<Pair<String, Long>> filterRowKeys(Set<String> candidateRowKeys) {
+    Set<Pair<String, Long>> result = new HashSet<>();
+    long position = 0;
+
+    try (ClosableIterator<String> keyIterator = getRecordKeyIterator()) {
+      while (keyIterator.hasNext()) {
+        String recordKey = keyIterator.next();
+        if (candidateRowKeys == null || candidateRowKeys.isEmpty()
+                || candidateRowKeys.contains(recordKey)) {
+          result.add(Pair.of(recordKey, position));
+        }
+        position++;
+      }
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to filter row keys from Vortex file: " + path, e);
+    }
+
+    return result;
+  }
+
+  @Override
+  public ClosableIterator<HoodieRecord<InternalRow>> getRecordIterator(HoodieSchema readerSchema, HoodieSchema requestedSchema) throws IOException {
+    return getRecordIterator(requestedSchema);
+  }
+
+  @Override
+  public ClosableIterator<HoodieRecord<InternalRow>> getRecordIterator(HoodieSchema schema) throws IOException {
+    ClosableIterator<UnsafeRow> iterator = getUnsafeRowIterator(schema);
+    return new CloseableMappingIterator<>(iterator, data -> unsafeCast(new HoodieSparkRecord(data)));
+  }
+
+  @Override
+  public ClosableIterator<String> getRecordKeyIterator() throws IOException {
+    HoodieSchema recordKeySchema = HoodieSchemaUtils.getRecordKeySchema();
+    ClosableIterator<UnsafeRow> iterator = getUnsafeRowIterator(recordKeySchema);
+    return new CloseableMappingIterator<>(iterator, data -> data.getUTF8String(0).toString());
+  }
+
+  private ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema) {
+    StructType requestedSparkSchema = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(requestedSchema);
+
+    BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
+        getClass().getSimpleName() + "-data-" + path.getName(), dataAllocatorSize);
+
+    try {
+      Session session = Session.create();
+      DataSource dataSource = DataSource.open(session, uri);
+      // Read all columns; VortexRecordIterator projects the requested columns by name.
+      Scan scan = dataSource.scan(ScanOptions.of());
+      return new VortexRecordIterator(allocator, session, dataSource, scan, requestedSparkSchema, uri);
+    } catch (Exception e) {
+      allocator.close();
+      throw new HoodieException("Failed to create Vortex reader for: " + path, e);
+    }
+  }
+
+  @Override
+  public HoodieSchema getSchema() {
+    try {
+      Schema arrowSchema = metadataDataSource.arrowSchema(metadataAllocator);
+      StructType structType = (StructType) ArrowUtils$.MODULE$.fromArrowSchema(arrowSchema);
+      return HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(structType, "record", "", false);
+    } catch (Exception e) {
+      throw new HoodieException("Failed to read schema from Vortex file: " + path, e);
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      metadataAllocator.close();
+    } catch (Exception e) {
+      log.warn("Error while closing Vortex metadata allocator: {}", e.getMessage());
+    }
+  }
+
+  @Override
+  public long getTotalRecords() {
+    try {
+      return metadataDataSource.rowCount().asOptional().orElseThrow(
+          () -> new HoodieException("Vortex row count unavailable for file: " + path));
+    } catch (Exception e) {
+      throw new HoodieException("Failed to get row count from Vortex file: " + path, e);
+    }
+  }
+
+  /**
+   * Vortex requires a well-formed URL. Remote-store {@link StoragePath}s already carry a scheme
+   * (s3://, hdfs://, ...); local paths may not, so qualify them as {@code file://} URIs.
+   */
+  private static String toVortexUri(StoragePath path) {
+    URI parsed = path.toUri();
+    if (parsed.getScheme() == null) {
+      return new java.io.File(parsed.getPath()).toURI().toString();
+    }
+    return parsed.toString();
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java-vortex/org/apache/hudi/io/storage/HoodieSparkVortexWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java-vortex/org/apache/hudi/io/storage/HoodieSparkVortexWriter.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.io.storage.row.HoodieBloomFilterRowWriteSupport;
+import org.apache.hudi.io.storage.row.HoodieInternalRowFileWriter;
+import org.apache.hudi.io.vortex.HoodieBaseVortexWriter;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.arrow.ArrowWriter$;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.ArrowUtils$;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.COMMIT_SEQNO_METADATA_FIELD;
+import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.COMMIT_TIME_METADATA_FIELD;
+import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.FILENAME_METADATA_FIELD;
+import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.PARTITION_PATH_METADATA_FIELD;
+import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.RECORD_KEY_METADATA_FIELD;
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+
+/**
+ * Spark Vortex file writer implementing {@link HoodieSparkFileWriter} and {@link HoodieInternalRowFileWriter}.
+ *
+ * This writer integrates with Hudi's storage I/O layer and supports:
+ * - Hudi metadata field population
+ * - Record key tracking (for bloom filters)
+ * - Sequence ID generation
+ * - Min/max record key tracking
+ */
+public class HoodieSparkVortexWriter extends HoodieBaseVortexWriter<InternalRow, UTF8String>
+    implements HoodieSparkFileWriter, HoodieInternalRowFileWriter {
+
+  private static final String DEFAULT_TIMEZONE = "UTC";
+  private static final long MIN_RECORDS_FOR_SIZE_CHECK = 100L;
+  private static final long MAX_RECORDS_FOR_SIZE_CHECK = 10000L;
+
+  private final StructType sparkSchema;
+  private final Schema arrowSchema;
+  private final UTF8String fileName;
+  private final UTF8String instantTime;
+  private final boolean populateMetaFields;
+  private final Function<Long, String> seqIdGenerator;
+  private final long maxFileSize;
+  private long recordCountForNextSizeCheck = MIN_RECORDS_FOR_SIZE_CHECK;
+
+  @Builder(builderMethodName = "builder")
+  private static HoodieSparkVortexWriter create(
+      StoragePath file,
+      StructType sparkSchema,
+      String instantTime,
+      TaskContextSupplier taskContextSupplier,
+      HoodieStorage storage,
+      boolean populateMetaFields,
+      Option<BloomFilter> bloomFilterOpt,
+      long maxFileSize,
+      long allocatorSize,
+      long flushByteWatermark) {
+    checkArgument(maxFileSize > 0, "maxFileSize must be a positive number");
+    checkArgument(allocatorSize > 0, "allocatorSize must be a positive number");
+    checkArgument(flushByteWatermark > 0, "flushByteWatermark must be a positive number");
+    checkArgument(flushByteWatermark < allocatorSize,
+        "flushByteWatermark (" + flushByteWatermark + ") must be less than allocatorSize ("
+            + allocatorSize + ") so the byte-aware flush prevents reallocations from exceeding the cap");
+    return new HoodieSparkVortexWriter(file, sparkSchema, instantTime,
+        taskContextSupplier, storage, populateMetaFields, bloomFilterOpt, maxFileSize,
+        allocatorSize, flushByteWatermark);
+  }
+
+  /**
+   * Public reflection entry point for {@code HoodieSparkFileWriterFactory}. The factory lives in the
+   * default (Java 11) source set and cannot reference this Vortex-only class directly, so it invokes
+   * this method reflectively (see the vortex profile that compiles this source under JDK 17).
+   */
+  public static HoodieSparkVortexWriter newWriter(
+      StoragePath file,
+      StructType sparkSchema,
+      String instantTime,
+      TaskContextSupplier taskContextSupplier,
+      HoodieStorage storage,
+      boolean populateMetaFields,
+      Option<BloomFilter> bloomFilterOpt,
+      long maxFileSize,
+      long allocatorSize,
+      long flushByteWatermark) {
+    return builder()
+        .file(file)
+        .sparkSchema(sparkSchema)
+        .instantTime(instantTime)
+        .taskContextSupplier(taskContextSupplier)
+        .storage(storage)
+        .populateMetaFields(populateMetaFields)
+        .bloomFilterOpt(bloomFilterOpt)
+        .maxFileSize(maxFileSize)
+        .allocatorSize(allocatorSize)
+        .flushByteWatermark(flushByteWatermark)
+        .build();
+  }
+
+  /**
+   * Manually declared builder class to provide default values for optional parameters.
+   * Lombok fills in the remaining builder methods.
+   */
+  public static class HoodieSparkVortexWriterBuilder {
+    private Option<BloomFilter> bloomFilterOpt = Option.empty();
+    private long maxFileSize = Long.parseLong(HoodieStorageConfig.VORTEX_MAX_FILE_SIZE.defaultValue());
+    private long allocatorSize = Long.parseLong(HoodieStorageConfig.VORTEX_WRITE_ALLOCATOR_SIZE_BYTES.defaultValue());
+    private long flushByteWatermark = Long.parseLong(HoodieStorageConfig.VORTEX_WRITE_FLUSH_BYTE_WATERMARK.defaultValue());
+  }
+
+  private HoodieSparkVortexWriter(StoragePath file,
+                                  StructType sparkSchema,
+                                  String instantTime,
+                                  TaskContextSupplier taskContextSupplier,
+                                  HoodieStorage storage,
+                                  boolean populateMetaFields,
+                                  Option<BloomFilter> bloomFilterOpt,
+                                  long maxFileSize,
+                                  long allocatorSize,
+                                  long flushByteWatermark) {
+    super(file, DEFAULT_BATCH_SIZE, allocatorSize, flushByteWatermark,
+        bloomFilterOpt.map(HoodieBloomFilterRowWriteSupport::new));
+    this.sparkSchema = sparkSchema;
+    this.arrowSchema = ArrowUtils$.MODULE$.toArrowSchema(sparkSchema, DEFAULT_TIMEZONE, false, false);
+    this.fileName = UTF8String.fromString(file.getName());
+    this.instantTime = UTF8String.fromString(instantTime);
+    this.populateMetaFields = populateMetaFields;
+    this.maxFileSize = maxFileSize;
+    this.seqIdGenerator = recordIndex -> {
+      Integer partitionId = taskContextSupplier.getPartitionIdSupplier().get();
+      return HoodieRecord.generateSequenceId(instantTime, partitionId, recordIndex);
+    };
+  }
+
+  @Override
+  public void writeRowWithMetadata(HoodieKey key, InternalRow row) throws IOException {
+    UTF8String recordKey = UTF8String.fromString(key.getRecordKey());
+    bloomFilterWriteSupportOpt.ifPresent(bloomFilterWriteSupport -> bloomFilterWriteSupport.addKey(recordKey));
+    if (populateMetaFields) {
+      updateRecordMetadata(row, recordKey, key.getPartitionPath(), getWrittenRecordCount());
+    }
+    super.write(row);
+  }
+
+  @Override
+  public void writeRow(String recordKey, InternalRow row) throws IOException {
+    bloomFilterWriteSupportOpt.ifPresent(bloomFilterWriteSupport ->
+        bloomFilterWriteSupport.addKey(UTF8String.fromString(recordKey)));
+    super.write(row);
+  }
+
+  @Override
+  public void writeRow(UTF8String key, InternalRow row) throws IOException {
+    bloomFilterWriteSupportOpt.ifPresent(bloomFilterWriteSupport -> bloomFilterWriteSupport.addKey(key));
+    super.write(row);
+  }
+
+  @Override
+  public void writeRow(InternalRow row) throws IOException {
+    super.write(row);
+  }
+
+  @Override
+  protected HoodieBaseVortexWriter.ArrowWriter<InternalRow> createArrowWriter(VectorSchemaRoot root) {
+    return SparkArrowWriterAdapter.of(ArrowWriter$.MODULE$.create(root));
+  }
+
+  /**
+   * Check if writer can accept more records based on estimated data size.
+   *
+   * @return true if writer can accept more records, false if file size limit is reached
+   */
+  public boolean canWrite() {
+    long writtenCount = getWrittenRecordCount();
+    if (writtenCount >= recordCountForNextSizeCheck) {
+      long dataSize = getDataSize();
+      long avgRecordSize = Math.max(dataSize / writtenCount, 1);
+      if (dataSize > (maxFileSize - avgRecordSize * 2)) {
+        return false;
+      }
+      recordCountForNextSizeCheck = writtenCount + Math.min(
+          Math.max(MIN_RECORDS_FOR_SIZE_CHECK, (maxFileSize / avgRecordSize - writtenCount) / 2),
+          MAX_RECORDS_FOR_SIZE_CHECK);
+    }
+    return true;
+  }
+
+  @Override
+  protected Schema getArrowSchema() {
+    return arrowSchema;
+  }
+
+  /**
+   * Update Hudi metadata fields in the InternalRow.
+   */
+  protected void updateRecordMetadata(InternalRow row,
+                                      UTF8String recordKey,
+                                      String partitionPath,
+                                      long recordCount) {
+    row.update(COMMIT_TIME_METADATA_FIELD.ordinal(), instantTime);
+    row.update(COMMIT_SEQNO_METADATA_FIELD.ordinal(), UTF8String.fromString(seqIdGenerator.apply(recordCount)));
+    row.update(RECORD_KEY_METADATA_FIELD.ordinal(), recordKey);
+    row.update(PARTITION_PATH_METADATA_FIELD.ordinal(), UTF8String.fromString(partitionPath));
+    row.update(FILENAME_METADATA_FIELD.ordinal(), fileName);
+  }
+
+  @AllArgsConstructor(staticName = "of")
+  private static class SparkArrowWriterAdapter implements HoodieBaseVortexWriter.ArrowWriter<InternalRow> {
+    // Fully qualified: the inherited HoodieBaseVortexWriter.ArrowWriter nested type would otherwise
+    // shadow this Spark ArrowWriter import.
+    private final org.apache.spark.sql.execution.arrow.ArrowWriter sparkArrowWriter;
+
+    @Override
+    public void write(InternalRow row) {
+      sparkArrowWriter.write(row);
+    }
+
+    @Override
+    public void reset() {
+      sparkArrowWriter.reset();
+    }
+
+    @Override
+    public void finishBatch() {
+      sparkArrowWriter.finish();
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java-vortex/org/apache/hudi/io/storage/VortexRecordIterator.java
+++ b/hudi-client/hudi-spark-client/src/main/java-vortex/org/apache/hudi/io/storage/VortexRecordIterator.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.exception.HoodieException;
+
+import dev.vortex.api.DataSource;
+import dev.vortex.api.Partition;
+import dev.vortex.api.Scan;
+import dev.vortex.api.Session;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ArrowColumnVector;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Iterator for reading Vortex files (vortex-jni 0.76.0) and converting Arrow batches to Spark
+ * {@link UnsafeRow}s.
+ *
+ * <p>A {@link Scan} yields a sequence of {@link Partition}s; each partition is read as an Arrow
+ * {@link ArrowReader} via {@link Partition#scanArrow}, whose {@link VectorSchemaRoot} is reused
+ * across {@code loadNextBatch} calls. Only the columns present in the requested Spark schema are
+ * projected (by name) out of each batch, so the scan may read more columns than requested.
+ *
+ * <p>Lifecycle managed here: the {@link BufferAllocator} and the current {@link ArrowReader}. The
+ * {@link Session}/{@link DataSource}/{@link Scan} handles are held only to keep their native
+ * resources alive during iteration (they are not AutoCloseable in vortex-jni 0.76.0).
+ */
+public final class VortexRecordIterator implements ClosableIterator<UnsafeRow> {
+  private final BufferAllocator allocator;
+  private final Session session;
+  private final DataSource dataSource;
+  private final Scan scan;
+  private final StructType sparkSchema;
+  private final UnsafeProjection projection;
+  private final String path;
+
+  private ArrowReader currentReader;
+  private ColumnVector[] columnVectors;
+  private ColumnarBatch currentBatch;
+  private Iterator<InternalRow> rowIterator;
+  private boolean closed = false;
+
+  public VortexRecordIterator(BufferAllocator allocator,
+                              Session session,
+                              DataSource dataSource,
+                              Scan scan,
+                              StructType schema,
+                              String path) {
+    this.allocator = allocator;
+    this.session = session;
+    this.dataSource = dataSource;
+    this.scan = scan;
+    this.sparkSchema = schema;
+    this.projection = UnsafeProjection.create(schema);
+    this.path = path;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (rowIterator != null && rowIterator.hasNext()) {
+      return true;
+    }
+
+    // Advance within the current partition, then across partitions, until a non-empty batch.
+    while (true) {
+      if (currentReader != null) {
+        if (advanceBatch()) {
+          return true;
+        }
+        // Current partition exhausted.
+        closeCurrentReader();
+      }
+      if (!scan.hasNext()) {
+        return false;
+      }
+      Partition partition = scan.next();
+      currentReader = partition.scanArrow(allocator);
+      columnVectors = null;
+    }
+  }
+
+  /**
+   * Load the next batch from the current ArrowReader (whose VectorSchemaRoot is reused across
+   * batches, so the wrapping column vectors are built once per partition) and set up the row
+   * iterator. Returns false when the current reader is exhausted.
+   */
+  private boolean advanceBatch() {
+    try {
+      while (currentReader.loadNextBatch()) {
+        VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
+        if (columnVectors == null) {
+          columnVectors = buildColumnVectors(root);
+        }
+        currentBatch = new ColumnarBatch(columnVectors, root.getRowCount());
+        rowIterator = currentBatch.rowIterator();
+        if (rowIterator.hasNext()) {
+          return true;
+        }
+      }
+    } catch (IOException e) {
+      throw new HoodieException("Failed to read next batch from Vortex file: " + path, e);
+    }
+    return false;
+  }
+
+  @Override
+  public UnsafeRow next() {
+    if (!hasNext()) {
+      throw new IllegalStateException("No more records available");
+    }
+    InternalRow row = rowIterator.next();
+    return projection.apply(row).copy();
+  }
+
+  /**
+   * Wrap the requested columns of the batch as Spark {@link ColumnVector}s, matched by name. The
+   * batch may carry more columns than requested (the scan reads all columns); extras are ignored.
+   */
+  private ColumnVector[] buildColumnVectors(VectorSchemaRoot root) {
+    List<FieldVector> fieldVectors = root.getFieldVectors();
+    Map<String, FieldVector> byName = new HashMap<>(fieldVectors.size() * 2);
+    for (FieldVector fv : fieldVectors) {
+      byName.put(fv.getName(), fv);
+    }
+    StructField[] sparkFields = sparkSchema.fields();
+    ColumnVector[] vectors = new ColumnVector[sparkFields.length];
+    for (int i = 0; i < sparkFields.length; i++) {
+      String name = sparkFields[i].name();
+      FieldVector fv = byName.get(name);
+      if (fv == null) {
+        throw new HoodieException("Vortex batch missing expected column '" + name
+            + "' for file: " + path + "; available columns: " + byName.keySet());
+      }
+      vectors[i] = new ArrowColumnVector(fv);
+    }
+    return vectors;
+  }
+
+  private void closeCurrentReader() {
+    currentBatch = null;
+    columnVectors = null;
+    rowIterator = null;
+    if (currentReader != null) {
+      try {
+        currentReader.close();
+      } catch (IOException e) {
+        throw new HoodieException("Failed to close Vortex Arrow reader for file: " + path, e);
+      } finally {
+        currentReader = null;
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    ArrowReader reader = currentReader;
+    currentReader = null;
+    currentBatch = null;
+    columnVectors = null;
+    rowIterator = null;
+    VortexResourceCloser.closeAll(reader, allocator, path);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java-vortex/org/apache/hudi/io/storage/VortexResourceCloser.java
+++ b/hudi-client/hudi-spark-client/src/main/java-vortex/org/apache/hudi/io/storage/VortexResourceCloser.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import org.apache.hudi.exception.HoodieException;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.ipc.ArrowReader;
+
+/**
+ * Shared close logic for the Vortex reader iterator (vortex-jni 0.76.0). Closes the current Arrow
+ * reader (which owns the exported VectorSchemaRoot / column vectors) and then the allocator,
+ * rethrowing after the allocator is closed so a failed reader close never leaks the allocator.
+ *
+ * <p>The Vortex Session/DataSource/Scan handles are not AutoCloseable in 0.76.0 (native cleanup is
+ * implicit), so they are not closed here.
+ */
+final class VortexResourceCloser {
+
+  private VortexResourceCloser() {
+  }
+
+  static void closeAll(ArrowReader currentReader, BufferAllocator allocator, String path) {
+    Exception readerException = null;
+
+    if (currentReader != null) {
+      try {
+        currentReader.close();
+      } catch (Exception e) {
+        readerException = e;
+      }
+    }
+    if (allocator != null) {
+      allocator.close();
+    }
+
+    if (readerException != null) {
+      throw new HoodieException("Failed to close Vortex Arrow reader for file: " + path, readerException);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileReaderFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileReaderFactory.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.core.io.storage.HoodieFileReader;
 import org.apache.hudi.core.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.exception.HoodieIOException;
@@ -56,6 +57,16 @@ public class HoodieSparkFileReaderFactory extends HoodieFileReaderFactory {
     long dataAllocatorSize = hoodieConfig.getLongOrDefault(HoodieStorageConfig.LANCE_READ_ALLOCATOR_SIZE_BYTES);
     long metadataAllocatorSize = hoodieConfig.getLongOrDefault(HoodieStorageConfig.LANCE_READ_METADATA_ALLOCATOR_SIZE_BYTES);
     return new HoodieSparkLanceReader(path, dataAllocatorSize, metadataAllocatorSize);
+  }
+
+  @Override
+  protected HoodieFileReader newVortexFileReader(HoodieConfig hoodieConfig, StoragePath path) {
+    long dataAllocatorSize = hoodieConfig.getLongOrDefault(HoodieStorageConfig.VORTEX_READ_ALLOCATOR_SIZE_BYTES);
+    // Vortex sources are compiled only under JDK 17 (see the vortex profile in this module's pom),
+    // so instantiate the reader reflectively to keep this factory compilable on the Java 11 build.
+    return (HoodieFileReader) ReflectionUtils.loadClass(
+        "org.apache.hudi.io.storage.HoodieSparkVortexReader",
+        new Class<?>[] {StoragePath.class, long.class}, path, dataAllocatorSize);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.core.io.HoodieParquetConfigInjector;
 import org.apache.hudi.core.io.storage.HoodieFileWriter;
@@ -138,6 +139,27 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
         .allocatorSize(allocatorSize)
         .flushByteWatermark(flushByteWatermark)
         .build();
+  }
+
+  @Override
+  protected HoodieFileWriter newVortexFileWriter(String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
+                                                 TaskContextSupplier taskContextSupplier) throws IOException {
+    boolean populateMetaFields = config.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS);
+    StructType structType = HoodieInternalRowUtils.getCachedSchema(schema);
+    boolean enableBloomFilter = enableBloomFilter(populateMetaFields, config);
+    Option<BloomFilter> bloomFilter = enableBloomFilter ? Option.of(createBloomFilter(config)) : Option.empty();
+    long maxFileSize = config.getLongOrDefault(HoodieStorageConfig.VORTEX_MAX_FILE_SIZE);
+    long allocatorSize = config.getLongOrDefault(HoodieStorageConfig.VORTEX_WRITE_ALLOCATOR_SIZE_BYTES);
+    long flushByteWatermark = config.getLongOrDefault(HoodieStorageConfig.VORTEX_WRITE_FLUSH_BYTE_WATERMARK);
+
+    // Vortex sources are compiled only under JDK 17 (see the vortex profile in this module's pom),
+    // so build the writer reflectively to keep this factory compilable on the Java 11 build.
+    return (HoodieFileWriter) ReflectionUtils.invokeStaticMethod(
+        "org.apache.hudi.io.storage.HoodieSparkVortexWriter", "newWriter",
+        new Object[] {path, structType, instantTime, taskContextSupplier, storage, populateMetaFields,
+            bloomFilter, maxFileSize, allocatorSize, flushByteWatermark},
+        StoragePath.class, StructType.class, String.class, TaskContextSupplier.class, HoodieStorage.class,
+        boolean.class, Option.class, long.class, long.class, long.class);
   }
 
   private static HoodieRowParquetWriteSupport getHoodieRowParquetWriteSupport(StorageConfiguration<?> conf, HoodieSchema schema,

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -132,6 +132,43 @@ public class HoodieStorageConfig extends HoodieConfig {
       .sinceVersion("1.3.0")
       .withDocumentation("Control whether to write bloom filter or not to HFile.");
 
+  public static final ConfigProperty<String> VORTEX_MAX_FILE_SIZE = ConfigProperty
+      .key("hoodie.vortex.max.file.size")
+      .defaultValue(String.valueOf(120 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Target file size in bytes for Vortex base files.");
+
+  public static final ConfigProperty<String> VORTEX_WRITE_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.vortex.write.allocator.size.bytes")
+      .defaultValue(String.valueOf(256 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Vortex "
+          + "writer for buffering in-flight batch data. Must be large enough that the Arrow "
+          + "buffer's power-of-2 doubling growth never requests a buffer exceeding this cap, "
+          + "otherwise writes fail with OutOfMemoryException.");
+
+  public static final ConfigProperty<String> VORTEX_WRITE_FLUSH_BYTE_WATERMARK = ConfigProperty
+      .key("hoodie.vortex.write.flush.byte.watermark")
+      .defaultValue(String.valueOf(96 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Byte-size watermark on the Vortex writer's in-flight Arrow buffers; "
+          + "the writer flushes the current batch when the sum of FieldVector buffer sizes "
+          + "reaches this value, in addition to the row-count batch threshold.");
+
+  public static final ConfigProperty<String> VORTEX_READ_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.vortex.read.allocator.size.bytes")
+      .defaultValue(String.valueOf(256 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Vortex "
+          + "reader for per-read data buffers.");
+
+  public static final ConfigProperty<String> VORTEX_READ_METADATA_ALLOCATOR_SIZE_BYTES = ConfigProperty
+      .key("hoodie.vortex.read.metadata.allocator.size.bytes")
+      .defaultValue(String.valueOf(8 * 1024 * 1024))
+      .markAdvanced()
+      .withDocumentation("Maximum size in bytes of the Arrow child allocator used by the Vortex "
+          + "reader for footer/metadata operations (schema, bloom filter).");
+
   public static final ConfigProperty<Boolean> HFILE_WRITER_TO_ALLOW_DUPLICATES = ConfigProperty
       .key("hoodie.hfile.writes.allow.duplicates")
       .defaultValue(false)
@@ -629,6 +666,11 @@ public class HoodieStorageConfig extends HoodieConfig {
 
     public Builder lanceMaxFileSize(long maxFileSize) {
       storageConfig.setValue(LANCE_MAX_FILE_SIZE, String.valueOf(maxFileSize));
+      return this;
+    }
+
+    public Builder vortexMaxFileSize(long maxFileSize) {
+      storageConfig.setValue(VORTEX_MAX_FILE_SIZE, String.valueOf(maxFileSize));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -53,11 +53,19 @@ public enum HoodieFileFormat {
 
   @EnumFieldDescription("Lance is a modern columnar data format optimized for random access patterns "
           + "and designed for ML and AI workloads")
-  LANCE(".lance");
+  LANCE(".lance"),
+
+  @EnumFieldDescription("Vortex is a next-generation columnar data format with cascading compression "
+          + "optimized for fast random access and analytical scans")
+  VORTEX(".vortex");
 
   public static final String LANCE_UNSUPPORTED_ERROR_MSG =
       "Lance base file format is not supported by this reader or writer path. "
           + "Please use an engine-specific Lance reader/writer, or use Parquet, ORC, or HFile.";
+
+  public static final String VORTEX_SPARK_ONLY_ERROR_MSG =
+      "Vortex base file format is currently only supported with the Spark engine. "
+          + "Please use Parquet, ORC, or HFile for non-Spark engines (Flink, Hive, Presto, Trino).";
 
   public static final Set<String> BASE_FILE_EXTENSIONS = Arrays.stream(HoodieFileFormat.values())
       .map(HoodieFileFormat::getFileExtension)

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/VortexUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/VortexUtils.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.apache.hudi.common.config.HoodieReaderConfig;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.core.io.storage.HoodieFileReader;
+import org.apache.hudi.core.io.storage.HoodieIOFactory;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.keygen.BaseKeyGenerator;
+import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import org.apache.avro.generic.GenericRecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class VortexUtils extends FileFormatUtils {
+
+  @Override
+  public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage, StoragePath filePath) {
+    return fetchRecordKeysWithPositions(storage, filePath, Option.empty(), Option.empty());
+  }
+
+  @Override
+  public ClosableIterator<Pair<HoodieKey, Long>> fetchRecordKeysWithPositions(HoodieStorage storage,
+                                                                               StoragePath filePath,
+                                                                               Option<BaseKeyGenerator> keyGeneratorOpt,
+                                                                               Option<String> partitionPath) {
+    AtomicLong position = new AtomicLong(0);
+    return new CloseableMappingIterator<>(
+        getHoodieKeyIterator(storage, filePath, keyGeneratorOpt, partitionPath),
+        key -> Pair.of(key, position.getAndIncrement()));
+  }
+
+  @Override
+  public ClosableIterator<HoodieKey> getHoodieKeyIterator(HoodieStorage storage, StoragePath filePath) {
+    return getHoodieKeyIterator(storage, filePath, Option.empty(), Option.empty());
+  }
+
+  @Override
+  public ClosableIterator<HoodieKey> getHoodieKeyIterator(HoodieStorage storage,
+                                                           StoragePath filePath,
+                                                           Option<BaseKeyGenerator> keyGeneratorOpt,
+                                                           Option<String> partitionPath) {
+    try {
+      HoodieSchema keySchema = getKeyIteratorSchema(storage, filePath, keyGeneratorOpt, partitionPath);
+      HoodieFileReader reader = HoodieIOFactory.getIOFactory(storage)
+          .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+          .getFileReader(new HoodieReaderConfig(), filePath, HoodieFileFormat.VORTEX);
+      ClosableIterator<HoodieRecord> recordIterator = reader.getRecordIterator(keySchema);
+
+      return new CloseableMappingIterator<>(
+          recordIterator,
+          record -> {
+            String recordKey;
+            if (keyGeneratorOpt.isPresent()) {
+              recordKey = record.getRecordKey(keySchema, keyGeneratorOpt);
+            } else {
+              recordKey = record.getRecordKey(keySchema, HoodieRecord.RECORD_KEY_METADATA_FIELD);
+            }
+            String partitionPathValue = partitionPath.orElseGet(() ->
+                (String) record.getColumnValueAsJava(keySchema, HoodieRecord.PARTITION_PATH_METADATA_FIELD,
+                    CollectionUtils.emptyProps()));
+            return new HoodieKey(recordKey, partitionPathValue);
+          }
+      );
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read from Vortex file " + filePath, e);
+    }
+  }
+
+  @Override
+  public HoodieSchema readSchema(HoodieStorage storage, StoragePath filePath) {
+    try (HoodieFileReader fileReader =
+                 HoodieIOFactory.getIOFactory(storage)
+                         .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+                         .getFileReader(
+                                 ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER,
+                                 filePath,
+                                 HoodieFileFormat.VORTEX)) {
+      return fileReader.getSchema();
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read schema from Vortex file", e);
+    }
+  }
+
+  @Override
+  public HoodieFileFormat getFormat() {
+    return HoodieFileFormat.VORTEX;
+  }
+
+  @Override
+  public List<GenericRecord> readAvroRecords(HoodieStorage storage, StoragePath filePath) {
+    throw new UnsupportedOperationException("readAvroRecords is not yet supported for Vortex format");
+  }
+
+  @Override
+  public List<GenericRecord> readAvroRecords(HoodieStorage storage, StoragePath filePath, HoodieSchema schema) {
+    throw new UnsupportedOperationException("readAvroRecords with schema is not yet supported for Vortex format");
+  }
+
+  @Override
+  public Map<String, String> readFooter(HoodieStorage storage, boolean required, StoragePath filePath, String... footerNames) {
+    throw new UnsupportedOperationException("readFooter is not yet supported for Vortex format");
+  }
+
+  @Override
+  public long getRowCount(HoodieStorage storage, StoragePath filePath) {
+    try (HoodieFileReader fileReader =
+                 HoodieIOFactory.getIOFactory(storage)
+                         .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+                         .getFileReader(
+                                 ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER,
+                                 filePath,
+                                 HoodieFileFormat.VORTEX)) {
+      return fileReader.getTotalRecords();
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to get row count from Vortex file", e);
+    }
+  }
+
+  @Override
+  public Set<Pair<String, Long>> filterRowKeys(HoodieStorage storage, StoragePath filePath, Set<String> filterKeys) {
+    try (HoodieFileReader fileReader =
+                 HoodieIOFactory.getIOFactory(storage)
+                         .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+                         .getFileReader(
+                                 ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER,
+                                 filePath,
+                                 HoodieFileFormat.VORTEX)) {
+      return fileReader.filterRowKeys(filterKeys);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read filter keys from Vortex file", e);
+    }
+  }
+
+  @Override
+  public List<HoodieColumnRangeMetadata<Comparable>> readColumnStatsFromMetadata(HoodieStorage storage,
+                                                                                  StoragePath filePath,
+                                                                                  List<String> columnList,
+                                                                                  HoodieIndexVersion indexVersion) {
+    throw new UnsupportedOperationException("readColumnStatsFromMetadata is not yet supported for Vortex format");
+  }
+
+  @Override
+  public void writeMetaFile(HoodieStorage storage, StoragePath filePath, Properties props) throws IOException {
+    throw new UnsupportedOperationException("writeMetaFile is not yet supported for Vortex format");
+  }
+
+  @Override
+  public ByteArrayOutputStream serializeRecordsToLogBlock(HoodieStorage storage,
+                                                          List<HoodieRecord> records,
+                                                          HoodieSchema writerSchema,
+                                                          HoodieSchema readerSchema,
+                                                          String keyFieldName,
+                                                          Map<String, String> paramsMap) throws IOException {
+    throw new UnsupportedOperationException("serializeRecordsToLogBlock is not yet supported for Vortex format");
+  }
+
+  @Override
+  public Pair<ByteArrayOutputStream, Object> serializeRecordsToLogBlock(HoodieStorage storage,
+                                                                        Iterator<HoodieRecord> records,
+                                                                        HoodieRecord.HoodieRecordType recordType,
+                                                                        HoodieSchema writerSchema,
+                                                                        HoodieSchema readerSchema,
+                                                                        String keyFieldName,
+                                                                        Map<String, String> paramsMap) throws IOException {
+    throw new UnsupportedOperationException("serializeRecordsToLogBlock with iterator is not yet supported for Vortex format");
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileReaderFactory.java
@@ -33,6 +33,7 @@ import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
 import static org.apache.hudi.common.model.HoodieFileFormat.LANCE;
 import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
 import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
+import static org.apache.hudi.common.model.HoodieFileFormat.VORTEX;
 
 /**
  * Factory methods to create Hudi file reader.
@@ -58,6 +59,9 @@ public class HoodieFileReaderFactory {
     if (LANCE.getFileExtension().equals(extension)) {
       return getFileReader(hoodieConfig, path, LANCE, Option.empty());
     }
+    if (VORTEX.getFileExtension().equals(extension)) {
+      return getFileReader(hoodieConfig, path, VORTEX, Option.empty());
+    }
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
 
@@ -77,6 +81,8 @@ public class HoodieFileReaderFactory {
         return newOrcFileReader(path);
       case LANCE:
         return newLanceFileReader(hoodieConfig, path);
+      case VORTEX:
+        return newVortexFileReader(hoodieConfig, path);
       default:
         throw new UnsupportedOperationException(format + " format not supported yet.");
     }
@@ -135,6 +141,10 @@ public class HoodieFileReaderFactory {
 
   protected HoodieFileReader newLanceFileReader(HoodieConfig hoodieConfig, StoragePath path) {
     throw new UnsupportedOperationException(HoodieFileFormat.LANCE_UNSUPPORTED_ERROR_MSG);
+  }
+
+  protected HoodieFileReader newVortexFileReader(HoodieConfig hoodieConfig, StoragePath path) {
+    throw new UnsupportedOperationException(HoodieFileFormat.VORTEX_SPARK_ONLY_ERROR_MSG);
   }
 
   public HoodieFileReader newBootstrapFileReader(HoodieFileReader skeletonFileReader,

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileWriterFactory.java
@@ -37,6 +37,7 @@ import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
 import static org.apache.hudi.common.model.HoodieFileFormat.LANCE;
 import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
 import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
+import static org.apache.hudi.common.model.HoodieFileFormat.VORTEX;
 
 public class HoodieFileWriterFactory {
   protected final HoodieStorage storage;
@@ -74,6 +75,9 @@ public class HoodieFileWriterFactory {
     }
     if (LANCE.getFileExtension().equals(extension)) {
       return newLanceFileWriter(instantTime, path, config, schema, taskContextSupplier);
+    }
+    if (VORTEX.getFileExtension().equals(extension)) {
+      return newVortexFileWriter(instantTime, path, config, schema, taskContextSupplier);
     }
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
@@ -115,6 +119,12 @@ public class HoodieFileWriterFactory {
       String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier) throws IOException {
     throw new UnsupportedOperationException(HoodieFileFormat.LANCE_UNSUPPORTED_ERROR_MSG);
+  }
+
+  protected HoodieFileWriter newVortexFileWriter(
+      String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
+      TaskContextSupplier taskContextSupplier) throws IOException {
+    throw new UnsupportedOperationException(HoodieFileFormat.VORTEX_SPARK_ONLY_ERROR_MSG);
   }
 
   public static BloomFilter createBloomFilter(HoodieConfig config) {

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieIOFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieIOFactory.java
@@ -114,6 +114,8 @@ public abstract class HoodieIOFactory {
       return getFileFormatUtils(HoodieFileFormat.HFILE);
     } else if (path.getFileExtension().equals(HoodieFileFormat.LANCE.getFileExtension())) {
       return getFileFormatUtils(HoodieFileFormat.LANCE);
+    } else if (path.getFileExtension().equals(HoodieFileFormat.VORTEX.getFileExtension())) {
+      return getFileFormatUtils(HoodieFileFormat.VORTEX);
     }
     throw new UnsupportedOperationException("The format for file " + path + " is not supported yet.");
   }

--- a/hudi-hadoop-common/pom.xml
+++ b/hudi-hadoop-common/pom.xml
@@ -164,4 +164,48 @@
       <artifactId>lance-core</artifactId>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <!-- Vortex requires Java 17: dev.vortex:vortex-jni ships Java 17 bytecode (class file major
+         version 61), which javac 11 (used by the Java 11 CI jobs) cannot read. Compile the Vortex
+         sources under src/main/java-vortex and pull in vortex-jni only when building on JDK 17;
+         Java 8/11 builds skip the format entirely. -->
+    <profile>
+      <id>vortex</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>dev.vortex</groupId>
+          <artifactId>vortex-jni</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-vortex-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <!-- Vortex is only supported on Spark 3.5+/4.x; skip the source on Spark 3.3/3.4
+                       (vortex.skip.tests=true) where its Spark 3.5+ APIs are unavailable. -->
+                  <skipAddSource>${vortex.skip.tests}</skipAddSource>
+                  <sources>
+                    <source>src/main/java-vortex</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/hudi-hadoop-common/src/main/java-vortex/org/apache/hudi/io/vortex/HoodieBaseVortexWriter.java
+++ b/hudi-hadoop-common/src/main/java-vortex/org/apache/hudi/io/vortex/HoodieBaseVortexWriter.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.io.vortex;
+
+import org.apache.hudi.common.avro.HoodieBloomFilterWriteSupport;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.io.memory.HoodieArrowAllocator;
+import org.apache.hudi.storage.StoragePath;
+
+import dev.vortex.api.Session;
+import dev.vortex.api.VortexWriter;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+
+/**
+ * Base class for Hudi Vortex file writers supporting different record types.
+ *
+ * This class handles common Vortex file operations including:
+ * - {@link VortexWriter} lifecycle management (vortex-jni {@code dev.vortex.api})
+ * - BufferAllocator management
+ * - Record buffering and batch flushing. Each flushed batch is exported through the Arrow C Data
+ *   Interface and handed to {@link VortexWriter#writeBatch(long, long)}; because vortex copies the
+ *   batch without invoking the C release callback, {@link ArrowArray#release()} is called after each
+ *   write so the exported buffers are freed.
+ * - File size checks
+ *
+ * Subclasses must implement type-specific conversion to Arrow format and provide the Arrow schema.
+ *
+ * <p>NOTE: vortex-jni 0.76.0 exposes no file-level custom-metadata API, so Hudi's bloom filter and
+ * min/max record-key footers cannot be persisted into the Vortex file yet. Record keys are still
+ * tracked via {@link #bloomFilterWriteSupportOpt} but the finalized metadata is not written.
+ * TODO(#18623): persist bloom/min-max footers once Vortex supports file metadata.
+ *
+ * @param <R> The record type (e.g., GenericRecord, InternalRow)
+ */
+@Slf4j
+@NotThreadSafe
+public abstract class HoodieBaseVortexWriter<R, K extends Comparable<K>> implements Closeable {
+  protected static final int DEFAULT_BATCH_SIZE = 1000;
+  private final StoragePath path;
+  private final BufferAllocator allocator;
+  private final int batchSize;
+  private final long flushByteWatermark;
+  @Getter(value = AccessLevel.PROTECTED)
+  private long writtenRecordCount = 0;
+  private long totalFlushedDataSize = 0;
+  private int currentBatchSize = 0;
+  private VectorSchemaRoot root;
+  private ArrowWriter<R> arrowWriter;
+  protected final Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt;
+
+  // Held for the writer's lifetime. session/nativeAllocator back the native writer; nativeAllocator
+  // is a dedicated allocator isolated from the strict data allocator (see initializeWriter).
+  private Session session;
+  private VortexWriter writer;
+  private BufferAllocator nativeAllocator;
+  private ArrowSchema exportedSchema;
+  private long exportedSchemaAddr;
+
+  /**
+   * Constructor for base Vortex writer.
+   *
+   * @param path Path where Vortex file will be written
+   * @param batchSize Row-count threshold; the current batch is flushed when this many records have been buffered
+   * @param allocatorSize Maximum bytes the per-writer Arrow child allocator may hold at once
+   * @param flushByteWatermark Byte-size threshold; the current batch is flushed when the sum of in-flight
+   *                           FieldVector buffer sizes reaches this value
+   * @param bloomFilterWriteSupportOpt Optional bloom filter write support for record key tracking
+   */
+  protected HoodieBaseVortexWriter(StoragePath path, int batchSize, long allocatorSize, long flushByteWatermark,
+                                   Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt) {
+    this.path = path;
+    this.allocator = HoodieArrowAllocator.newChildAllocator(
+        getClass().getSimpleName() + "-data-" + path.getName(), allocatorSize);
+    this.batchSize = batchSize;
+    this.flushByteWatermark = flushByteWatermark;
+    this.bloomFilterWriteSupportOpt = bloomFilterWriteSupportOpt;
+  }
+
+  /**
+   * Create and initialize the arrow writer for writing records to VectorSchemaRoot.
+   * Called once during lazy initialization when the first record is written.
+   *
+   * @param root The VectorSchemaRoot to write into
+   * @return An arrow writer implementation that writes records of type R to the root
+   */
+  protected abstract ArrowWriter<R> createArrowWriter(VectorSchemaRoot root);
+
+  /**
+   * Get the Arrow schema for this writer. It is passed directly to {@link VortexWriter} and each
+   * written batch must conform to it.
+   *
+   * @return Arrow schema
+   */
+  protected abstract Schema getArrowSchema();
+
+  /**
+   * Write a single record. Records are buffered and flushed in batches.
+   *
+   * @param record Record to write
+   * @throws IOException if write fails
+   */
+  public void write(R record) throws IOException {
+    // Lazy initialization on first write
+    if (writer == null) {
+      initializeWriter();
+    }
+    if (root == null) {
+      root = VectorSchemaRoot.create(getArrowSchema(), allocator);
+    }
+    if (arrowWriter == null) {
+      arrowWriter = createArrowWriter(root);
+    }
+
+    // Reset arrow writer at the start of each new batch
+    if (currentBatchSize == 0) {
+      arrowWriter.reset();
+    }
+
+    arrowWriter.write(record);
+    currentBatchSize++;
+    writtenRecordCount++;
+
+    // Flush when row-count batch is full OR in-flight Arrow buffers cross the byte watermark.
+    if (currentBatchSize >= batchSize || currentBufferBytes() >= flushByteWatermark) {
+      flushBatch();
+    }
+  }
+
+  /**
+   * Bytes currently held by the writer's Arrow child allocator.
+   */
+  private long currentBufferBytes() {
+    return allocator.getAllocatedMemory();
+  }
+
+  /**
+   * Close the writer, flushing any remaining buffered records.
+   *
+   * @throws IOException if close fails
+   */
+  @Override
+  public void close() throws IOException {
+    Exception primaryException = null;
+
+    // 1. Flush remaining records
+    try {
+      if (currentBatchSize > 0) {
+        flushBatch();
+      }
+
+      // Ensure the file is created even if no data was written, by emitting a single empty batch.
+      if (writer == null) {
+        initializeWriter();
+        try (VectorSchemaRoot emptyRoot = VectorSchemaRoot.create(getArrowSchema(), allocator)) {
+          emptyRoot.setRowCount(0);
+          writeBatchFfi(emptyRoot);
+        }
+      }
+    } catch (Exception e) {
+      primaryException = e;
+    }
+
+    // Close Vortex writer (finalizes the file)
+    if (writer != null) {
+      try {
+        writer.close();
+      } catch (Exception e) {
+        primaryException = addSuppressed(primaryException, e);
+      }
+    }
+
+    // Close the exported schema handle.
+    if (exportedSchema != null) {
+      try {
+        exportedSchema.release();
+        exportedSchema.close();
+      } catch (Exception e) {
+        primaryException = addSuppressed(primaryException, e);
+      }
+    }
+
+    // Close VectorSchemaRoot
+    if (root != null) {
+      try {
+        root.close();
+      } catch (Exception e) {
+        primaryException = addSuppressed(primaryException, e);
+      }
+    }
+
+    // Close the strict data allocator (per-batch exports are released, so this should be clean).
+    try {
+      allocator.close();
+    } catch (Exception e) {
+      primaryException = addSuppressed(primaryException, e);
+    }
+
+    // Close the native allocator last. vortex-jni 0.76.0's VortexWriter.create exports the file
+    // schema into this allocator and relies on GC/Cleaner-based cleanup rather than freeing it on
+    // close(), so a small one-time amount can still be outstanding here; tolerate it (it is freed
+    // when the native writer is reclaimed) rather than failing the whole write.
+    // TODO(#18623): drop this once vortex-jni frees the create() schema export on writer close.
+    if (nativeAllocator != null) {
+      try {
+        nativeAllocator.close();
+      } catch (IllegalStateException e) {
+        log.warn("Vortex native allocator retained memory at close for {} (vortex-jni create() "
+            + "schema export, reclaimed on GC): {}", path, e.getMessage());
+      }
+    }
+
+    if (primaryException != null) {
+      throw new HoodieException("Failed to close Vortex writer: " + path, primaryException);
+    }
+  }
+
+  private static Exception addSuppressed(Exception primary, Exception e) {
+    if (primary == null) {
+      return e;
+    }
+    primary.addSuppressed(e);
+    return primary;
+  }
+
+  /**
+   * Returns the estimated data size in bytes, including both flushed batches and the current
+   * in-progress batch.
+   */
+  protected long getDataSize() {
+    long currentBufferSize = currentBatchSize > 0 ? allocator.getAllocatedMemory() : 0;
+    return totalFlushedDataSize + currentBufferSize;
+  }
+
+  /**
+   * Flush buffered records to Vortex file.
+   */
+  private void flushBatch() throws IOException {
+    if (currentBatchSize == 0) {
+      return;
+    }
+
+    arrowWriter.finishBatch();
+
+    for (FieldVector vector : root.getFieldVectors()) {
+      totalFlushedDataSize += vector.getBufferSize();
+    }
+
+    writeBatchFfi(root);
+
+    // Release Arrow buffers so capacity does not accumulate across batches.
+    root.close();
+    root = null;
+    arrowWriter = null;
+
+    currentBatchSize = 0;
+  }
+
+  /**
+   * Export a VectorSchemaRoot's array through the Arrow C Data Interface and write it to the Vortex
+   * file. The array is exported from the strict data allocator and released after the write (vortex
+   * copies the batch but does not invoke the C release callback), so no data-allocator memory leaks.
+   */
+  private void writeBatchFfi(VectorSchemaRoot batch) throws IOException {
+    try (ArrowArray cArray = ArrowArray.allocateNew(allocator)) {
+      Data.exportVectorSchemaRoot(allocator, batch, null, cArray);
+      writer.writeBatch(cArray.memoryAddress(), exportedSchemaAddr);
+      cArray.release();
+    }
+  }
+
+  /**
+   * Initialize the {@link VortexWriter} (lazy initialization). The writer and its exported schema
+   * use a dedicated {@link #nativeAllocator} so the native side's non-deterministic cleanup does
+   * not pollute the strict per-batch data allocator.
+   */
+  private void initializeWriter() throws IOException {
+    session = Session.create();
+    nativeAllocator = new RootAllocator();
+    Schema arrowSchema = getArrowSchema();
+    writer = VortexWriter.create(session, toVortexUri(path), arrowSchema, Collections.emptyMap(), nativeAllocator);
+    exportedSchema = ArrowSchema.allocateNew(nativeAllocator);
+    Data.exportSchema(nativeAllocator, arrowSchema, null, exportedSchema);
+    exportedSchemaAddr = exportedSchema.memoryAddress();
+  }
+
+  /**
+   * Vortex requires a well-formed URL. Hudi {@link StoragePath}s for remote stores already carry a
+   * scheme (s3://, hdfs://, ...); local paths may not, so qualify them as {@code file://} URIs.
+   */
+  private static String toVortexUri(StoragePath path) {
+    URI uri = path.toUri();
+    if (uri.getScheme() == null) {
+      return new File(uri.getPath()).toURI().toString();
+    }
+    return uri.toString();
+  }
+
+  /**
+   * Arrow writer interface for writing records of type T to a VectorSchemaRoot.
+   * @param <T> the record type
+   */
+  protected interface ArrowWriter<T> {
+    void write(T row) throws IOException;
+
+    void finishBatch() throws IOException;
+
+    void reset();
+  }
+}

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieHadoopIOFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieHadoopIOFactory.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.util.LanceUtils;
 import org.apache.hudi.common.util.OrcUtils;
 import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.VortexUtils;
 import org.apache.hudi.core.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.core.io.storage.HoodieIOFactory;
@@ -114,6 +115,8 @@ public class HoodieHadoopIOFactory extends HoodieIOFactory {
         return new HFileUtils();
       case LANCE:
         return new LanceUtils();
+      case VORTEX:
+        return new VortexUtils();
       default:
         throw new UnsupportedOperationException(fileFormat.name() + " format not supported yet.");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,9 @@
     <lance.spark.connector.version>0.4.0</lance.spark.connector.version>
     <lance.spark.artifact>lance-spark-3.5_${scala.binary.version}</lance.spark.artifact>
     <lance.skip.tests>false</lance.skip.tests>
+    <vortex.version>0.76.0</vortex.version>
+    <vortex.spark.artifact>vortex-spark_${scala.binary.version}</vortex.spark.artifact>
+    <vortex.skip.tests>false</vortex.skip.tests>
     <!-- The following properties are only used for Jacoco coverage report aggregation -->
     <copy.files>false</copy.files>
     <copy.files.target.dir>${maven.multiModuleProjectDirectory}</copy.files.target.dir>
@@ -525,6 +528,7 @@
             <systemPropertyVariables>
               <log4j.configurationFile>${surefire-log4j.file}</log4j.configurationFile>
               <lance.skip.tests>${lance.skip.tests}</lance.skip.tests>
+              <vortex.skip.tests>${vortex.skip.tests}</vortex.skip.tests>
             </systemPropertyVariables>
             <useSystemClassLoader>false</useSystemClassLoader>
             <forkedProcessExitTimeoutInSeconds>30</forkedProcessExitTimeoutInSeconds>
@@ -569,6 +573,7 @@
             <systemProperties>
               <log4j.configurationFile>${surefire-log4j.file}</log4j.configurationFile>
               <lance.skip.tests>${lance.skip.tests}</lance.skip.tests>
+              <vortex.skip.tests>${vortex.skip.tests}</vortex.skip.tests>
             </systemProperties>
           </configuration>
           <executions>
@@ -993,6 +998,24 @@
           <exclusion>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- Vortex JNI -->
+      <dependency>
+        <groupId>dev.vortex</groupId>
+        <artifactId>vortex-jni</artifactId>
+        <version>${vortex.version}</version>
+      </dependency>
+      <!-- Vortex Spark connector -->
+      <dependency>
+        <groupId>dev.vortex</groupId>
+        <artifactId>${vortex.spark.artifact}</artifactId>
+        <version>${vortex.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>dev.vortex</groupId>
+            <artifactId>vortex-jni</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -2633,6 +2656,8 @@
         <!-- Lance: Skip tests for Spark 3.3 due to lack of support -->
         <lance.spark.artifact>lance-spark-base_${scala.binary.version}</lance.spark.artifact>
         <lance.skip.tests>true</lance.skip.tests>
+        <!-- Vortex: Skip tests for Spark 3.3 due to lack of support -->
+        <vortex.skip.tests>true</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
@@ -2678,6 +2703,8 @@
         <!-- Lance: Use Spark 3.4-specific artifact -->
         <lance.spark.artifact>lance-spark-3.4_${scala.binary.version}</lance.spark.artifact>
         <lance.skip.tests>true</lance.skip.tests>
+        <!-- Vortex: Skip tests for Spark 3.4 due to lack of support -->
+        <vortex.skip.tests>true</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
@@ -2733,6 +2760,9 @@
         <!-- Lance: Use Spark 3.5-specific artifact -->
         <lance.spark.artifact>lance-spark-3.5_${scala.binary.version}</lance.spark.artifact>
         <lance.skip.tests>false</lance.skip.tests>
+        <!-- Vortex: Use Spark 3.5 artifact -->
+        <vortex.spark.artifact>vortex-spark_${scala.binary.version}</vortex.spark.artifact>
+        <vortex.skip.tests>false</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
@@ -2796,6 +2826,9 @@
         <!-- Lance: Use Spark 4.0-specific artifact (Scala 2.13 only) -->
         <lance.spark.artifact>lance-spark-4.0_2.13</lance.spark.artifact>
         <lance.skip.tests>false</lance.skip.tests>
+        <!-- Vortex: Use Spark 4.0 artifact (Scala 2.13 only) -->
+        <vortex.spark.artifact>vortex-spark_2.13</vortex.spark.artifact>
+        <vortex.skip.tests>false</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are
@@ -2859,6 +2892,9 @@
         <hive.storage.version>2.8.1</hive.storage.version>
         <lance.spark.artifact>lance-spark-4.1_2.13</lance.spark.artifact>
         <lance.skip.tests>false</lance.skip.tests>
+        <!-- Vortex: Use Spark 4.1 artifact (Scala 2.13 only) -->
+        <vortex.spark.artifact>vortex-spark_2.13</vortex.spark.artifact>
+        <vortex.skip.tests>false</vortex.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18627

Implements the Vortex file reader for Spark. Stacked on #18633.

### Summary and Changelog

- Create `HoodieSparkVortexReader` -- reads Vortex files via the real `dev.vortex.api` (vortex-jni 0.76.0): `Session.create()` + `DataSource.open(session, uri)`. `getSchema()` reads the file's Arrow schema (`DataSource.arrowSchema`) and converts it via Spark's `ArrowUtils`; `getTotalRecords()` uses `DataSource.rowCount()`. The row iterator opens a fresh session/data source and issues `DataSource.scan(ScanOptions.of())`. Mirrors `HoodieSparkLanceReader`. Bloom filter and min/max record key extraction are not implemented for the initial scope (bloom returns null; min/max throws `UnsupportedOperationException`).
- Create `VortexRecordIterator` -- iterates the scan's partitions, and for each partition reads Arrow batches via `Partition.scanArrow(allocator)` (an `ArrowReader`), converting each batch to Spark `UnsafeRow` through `ArrowColumnVector`. Requested columns are matched by name against the batch schema (which may contain more columns). Mirrors `LanceRecordIterator` (without the BLOB transform initially).
- Create `VortexResourceCloser` -- ordered cleanup of the current `ArrowReader` then the allocator.
- Override `newVortexFileReader()` in `HoodieSparkFileReaderFactory`

### Impact

Enables reading Hudi base files in Vortex format from Spark. No changes to existing code paths.

### Risk Level

low -- new code only. The read path is exercised end to end (full and projected reads) by the round-trip test in #18630 (stacked on this).

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
