### PR TITLE
feat(flink): Support streaming RLI write for simple bucket index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -29,6 +29,7 @@ import org.apache.hudi.client.RunsTableService;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.EngineType;
@@ -1478,6 +1479,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    */
   protected Pair<List<HoodieFileGroupId>, HoodieData<HoodieRecord>> tagRecordsWithLocationForStreamingWrites(HoodieData<HoodieRecord> untaggedRecords,
                                                                                                              Set<String> enabledMetadataPartitions) {
+    // no need to tag of the incoming records is empty.
+    if (untaggedRecords instanceof HoodieListData && untaggedRecords.isEmpty()) {
+      return Pair.of(Collections.emptyList(), untaggedRecords);
+    }
     List<HoodieFileGroupId> updatedFileGroupIds = new ArrayList<>();
     // Fetch latest file slices for all enabled MDT partitions
     Map<String, List<FileSlice>> partitionToLatestFileSlices = new HashMap<>();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1479,7 +1479,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    */
   protected Pair<List<HoodieFileGroupId>, HoodieData<HoodieRecord>> tagRecordsWithLocationForStreamingWrites(HoodieData<HoodieRecord> untaggedRecords,
                                                                                                              Set<String> enabledMetadataPartitions) {
-    // no need to tag of the incoming records is empty.
+    // no need to tag if the incoming records is empty.
     if (untaggedRecords instanceof HoodieListData && untaggedRecords.isEmpty()) {
       return Pair.of(Collections.emptyList(), untaggedRecords);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -23,6 +23,7 @@ import org.apache.hudi.client.transaction.BucketIndexConcurrentFileWritesConflic
 import org.apache.hudi.client.transaction.ConflictResolutionStrategy;
 import org.apache.hudi.client.transaction.SimpleConcurrentFileWritesConflictResolutionStrategy;
 import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
@@ -200,13 +201,13 @@ public class OptionsResolver {
   /**
    * Returns whether {@link org.apache.hudi.sink.partitioner.MinibatchBucketAssignFunction} should be used for bucket assigning.
    */
-  public static boolean isRecordLevelIndex(Configuration conf) {
+  public static boolean isGlobalRecordLevelIndex(Configuration conf) {
     HoodieIndex.IndexType indexType = OptionsResolver.getIndexType(conf);
     return indexType == HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX;
   }
 
   public static boolean isRLIWithBootstrap(Configuration conf) {
-    return isRecordLevelIndex(conf) && conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED);
+    return isGlobalRecordLevelIndex(conf) && conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED);
   }
 
   /**
@@ -233,6 +234,16 @@ public class OptionsResolver {
    */
   public static boolean isSimpleBucketIndexType(Configuration conf) {
     return isBucketIndexType(conf) && getBucketEngineType(conf).equals(HoodieIndex.BucketIndexEngineType.SIMPLE);
+  }
+
+  /**
+   * Returns whether simple bucket index additionally streams partitioned RLI records.
+   */
+  public static boolean isSimpleBucketIndexWithRecordLevelIndex(Configuration conf) {
+    return isSimpleBucketIndexType(conf)
+        && Boolean.parseBoolean(conf.getString(
+        HoodieMetadataConfig.RECORD_LEVEL_INDEX_ENABLE_PROP.key(),
+        HoodieMetadataConfig.RECORD_LEVEL_INDEX_ENABLE_PROP.defaultValue().toString()));
   }
 
   /**
@@ -459,7 +470,8 @@ public class OptionsResolver {
    */
   public static boolean isStreamingIndexWriteEnabled(Configuration conf) {
     return conf.get(FlinkOptions.METADATA_ENABLED)
-        && OptionsResolver.getIndexType(conf) == HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX
+        && (OptionsResolver.getIndexType(conf) == HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX
+        || OptionsResolver.isSimpleBucketIndexWithRecordLevelIndex(conf))
         && WriteOperationType.streamingWritesToMetadataSupported(WriteOperationType.fromValue(conf.get(FlinkOptions.OPERATION)));
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -20,20 +20,26 @@ package org.apache.hudi.sink.bucket;
 
 import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.hash.BucketIndexUtil;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.hudi.sink.StreamWriteFunction;
+import org.apache.hudi.sink.partitioner.index.IndexRowUtils;
+import org.apache.hudi.sink.partitioner.index.RecordLevelIndexBackend;
 import org.apache.hudi.utils.RuntimeContextUtils;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
 import java.io.IOException;
@@ -50,9 +56,7 @@ import java.util.Set;
  * The index is local because different partition paths have separate items in the index.
  */
 @Slf4j
-public class BucketStreamWriteFunction extends StreamWriteFunction {
-
-  private int parallelism;
+public class BucketStreamWriteFunction extends StreamWriteFunction implements CheckpointListener {
 
   private String indexKeyFields;
 
@@ -85,6 +89,8 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
    */
   private boolean isInsertOverwrite;
 
+  private transient Option<RecordLevelIndexBackend> recordLevelIndexBackendOpt;
+
   /**
    * Constructs a BucketStreamWriteFunction.
    *
@@ -100,13 +106,19 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
     this.indexKeyFields = OptionsResolver.getIndexKeyField(config);
     this.isNonBlockingConcurrencyControl = OptionsResolver.isNonBlockingConcurrencyControl(config);
     this.taskID = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
-    this.parallelism = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());
+    int parallelism = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());
     this.bucketIndex = new HashMap<>();
     this.incBucketIndex = new HashSet<>();
     this.partitionIndexFunc = BucketIndexUtil.getPartitionIndexFunc(parallelism);
     this.isInsertOverwrite = OptionsResolver.isInsertOverwrite(config);
     this.numBucketsFunction = new NumBucketsFunction(config.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         config.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), config.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
+    if (OptionsResolver.isStreamingIndexWriteEnabled(config)) {
+      this.recordLevelIndexBackendOpt = Option.of(new RecordLevelIndexBackend(config, (partitionPath, recordKey, fileId) ->
+          isBucketToLoad(BucketIdentifier.bucketIdFromFileId(fileId), partitionPath)));
+    } else {
+      this.recordLevelIndexBackendOpt = Option.empty();
+    }
   }
 
   @Override
@@ -121,11 +133,37 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
   }
 
   @Override
+  public void snapshotState(FunctionSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    this.recordLevelIndexBackendOpt.ifPresent(recordLevelIndexBackend ->
+        recordLevelIndexBackend.onCheckpoint(context.getCheckpointId()));
+  }
+
+  @Override
   public void processElement(HoodieFlinkInternalRow record,
                              ProcessFunction<HoodieFlinkInternalRow, RowData>.Context context,
                              Collector<RowData> collector) throws Exception {
     defineRecordLocation(record);
+    processRecordIndex(record, collector);
     bufferRecord(record);
+  }
+
+  private void processRecordIndex(HoodieFlinkInternalRow record, Collector<RowData> collector) {
+    if (!recordLevelIndexBackendOpt.isPresent() || !shouldEmitRecordIndex(record)) {
+      return;
+    }
+    RecordLevelIndexBackend recordLevelIndexBackend = recordLevelIndexBackendOpt.get();
+    String fileId = recordLevelIndexBackend.get(record.getPartitionPath(), record.getRecordKey());
+    if (fileId == null) {
+      recordLevelIndexBackend.update(record.getPartitionPath(), record.getRecordKey(), record.getFileId());
+      record.setOperationType("I");
+      collector.collect(IndexRowUtils.createRecordIndexRow(record));
+    }
+  }
+
+  private boolean shouldEmitRecordIndex(HoodieFlinkInternalRow record) {
+    RowKind rowKind = record.getRowData().getRowKind();
+    return rowKind != RowKind.DELETE && rowKind != RowKind.UPDATE_BEFORE;
   }
 
   private void defineRecordLocation(HoodieFlinkInternalRow record) {
@@ -191,5 +229,22 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
       }
     });
     bucketIndex.put(partition, bucketToFileIDMap);
+  }
+
+  @Override
+  public void notifyCheckpointComplete(long checkpointId) {
+    this.recordLevelIndexBackendOpt.ifPresent(recordLevelIndexBackend ->
+        recordLevelIndexBackend.onCheckpointComplete(this.correspondent, checkpointId));
+  }
+
+  @Override
+  public void close() throws Exception {
+    try {
+      if (this.recordLevelIndexBackendOpt.isPresent()) {
+        this.recordLevelIndexBackendOpt.get().close();
+      }
+    } finally {
+      super.close();
+    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
@@ -31,7 +31,7 @@ import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.sink.event.Correspondent;
-import org.apache.hudi.sink.partitioner.index.IndexBackend;
+import org.apache.hudi.sink.partitioner.index.GlobalIndexBackend;
 import org.apache.hudi.sink.partitioner.index.IndexBackendFactory;
 import org.apache.hudi.table.action.commit.BucketInfo;
 import org.apache.hudi.util.FlinkTaskContextSupplier;
@@ -84,7 +84,7 @@ public class BucketAssignFunction
    * </ul>
    */
   @Getter
-  private transient IndexBackend indexBackend;
+  private transient GlobalIndexBackend indexBackend;
 
   /**
    * Bucket assigner to assign new bucket IDs or reuse existing ones.

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/GlobalRecordIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/GlobalRecordIndexPartitioner.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.util.StreamerUtil;
+
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Global record index input partitioner.
+ *
+ * <p>The partitioner is aligned with the record-key to metadata-table file-group mapping used by
+ * global RLI. This prevents multiple index write subtasks from writing the same record-index file
+ * group and reduces small files in the metadata table.
+ */
+public class GlobalRecordIndexPartitioner implements Partitioner<HoodieKey> {
+  private final Configuration conf;
+  /**
+   * The number of file groups for record index partition in metadata data table. The number
+   * cannot be calculated during compiling the writing pipeline, since the hoodie table may
+   * not be created yet, so the number is lazily calculated during job running.
+   */
+  private int numFileGroupsForRecordIndexPartition = -1;
+
+  /**
+   * Creates a partitioner for global RLI index writes.
+   *
+   * @param conf Flink write configuration
+   */
+  public GlobalRecordIndexPartitioner(Configuration conf) {
+    this.conf = conf;
+  }
+
+  /**
+   * Routes an index row to the writer responsible for its global RLI file group.
+   *
+   * @param recordKey index row key, where the partition path is ignored for global RLI
+   * @param numPartitions downstream index writer parallelism
+   * @return downstream subtask index
+   */
+  @Override
+  public int partition(HoodieKey recordKey, int numPartitions) {
+    // initialize numFileGroupsForRecordIndexPartition lazily.
+    if (numFileGroupsForRecordIndexPartition < 0) {
+      numFileGroupsForRecordIndexPartition = getNumFileGroupsForRecordIndexPartition();
+    }
+    int fgIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(
+        recordKey.getRecordKey(), numFileGroupsForRecordIndexPartition);
+    return fgIndex % numPartitions;
+  }
+
+  /**
+   * Get the number of file groups for record index partition in metadata table.
+   */
+  private int getNumFileGroupsForRecordIndexPartition() {
+    HoodieTableMetaClient metaClient = StreamerUtil.createMetaClient(conf);
+    try (HoodieTableMetadata metadataTable = metaClient.getTableFormat().getMetadataFactory().create(
+        HoodieFlinkEngineContext.DEFAULT,
+        metaClient.getStorage(),
+        StreamerUtil.metadataConfig(conf),
+        conf.get(FlinkOptions.PATH))) {
+      return metadataTable.getNumFileGroupsForPartition(MetadataPartitionType.RECORD_INDEX);
+    } catch (Exception e) {
+      throw new HoodieException("Failed to get file group count for global record index partition.", e);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/RecordIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/RecordIndexPartitioner.java
@@ -44,8 +44,12 @@ import java.util.Map;
  * index write subtasks from writing the same record index file group, thereby effectively
  * reducing the number of small files.
  *
- * <p>The partitioner first spreads data partitions across downstream tasks, then maps
- * record keys to the subtask for the selected record-index file group.
+ * <p>Partitioned RLI stores record-index file groups under the corresponding data table
+ * partition. Since RLI file groups for different data partitions can have the same bucket id,
+ * shuffling only by bucket id only would route those equally numbered buckets to the same
+ * downstream task and can easily cause data skew. Therefore an index row must be routed by
+ * its data partition first, then by the record-key hash within that partition's RLI file
+ * group range.
  */
 public class RecordIndexPartitioner implements Partitioner<HoodieKey> {
   private final Configuration conf;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/RecordIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/RecordIndexPartitioner.java
@@ -19,9 +19,13 @@
 package org.apache.hudi.sink.partitioner;
 
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.hash.BucketIndexUtil;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
@@ -30,47 +34,92 @@ import org.apache.hudi.util.StreamerUtil;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.configuration.Configuration;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
- * Record index input partitioner, which is aligned with the mapping of record key
+ * Partitioned record index input partitioner, which is aligned with the mapping of record key
  * to the file group of record index partition in metadata table. It prevents multiple
  * index write subtasks from writing the same record index file group, thereby effectively
  * reducing the number of small files.
+ *
+ * <p>The partitioner first spreads data partitions across downstream tasks, then maps
+ * record keys to the subtask for the selected record-index file group.
  */
 public class RecordIndexPartitioner implements Partitioner<HoodieKey> {
   private final Configuration conf;
-  /**
-   * The number of file groups for record index partition in metadata data table. The number
-   * cannot be calculated during compiling the writing pipeline, since the hoodie table may
-   * not be created yet, so the number is lazily calculated during job running.
-   */
-  private int numFileGroupsForRecordIndexPartition = -1;
+  private Map<String, Integer> partitionedRLIFileGroupCounts;
+  private Functions.Function3<Integer, String, Integer, Integer> partitionIndexFunc;
 
+  /**
+   * Creates a partitioner for partitioned RLI index writes.
+   *
+   * @param conf Flink write configuration
+   */
   public RecordIndexPartitioner(Configuration conf) {
     this.conf = conf;
   }
 
+  /**
+   * Routes an index row by data partition and record-key-derived partitioned RLI file group.
+   *
+   * @param recordKey index row key containing both record key and data partition path
+   * @param numPartitions downstream index writer parallelism
+   * @return downstream subtask index
+   */
   @Override
   public int partition(HoodieKey recordKey, int numPartitions) {
-    // initialize numFileGroupsForRecordIndexPartition lazily.
-    if (numFileGroupsForRecordIndexPartition < 0) {
-      numFileGroupsForRecordIndexPartition = getNumFileGroupsForRecordIndexPartition();
+    if (partitionedRLIFileGroupCounts == null) {
+      partitionedRLIFileGroupCounts = getPartitionedRLIFileGroupCounts();
     }
-    // note: the hashing is in line with GLOBAL_RECORD_LEVEL_INDEX currently.
-    // if partitioned record level index is supported, the partition path should be considered here as well.
-    int fgIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(recordKey.getRecordKey(), numFileGroupsForRecordIndexPartition);
-    return fgIndex % numPartitions;
+    int fileGroupCount = getFileGroupCountForPartitionedRLI(recordKey.getPartitionPath());
+    int fgIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(recordKey.getRecordKey(), fileGroupCount);
+    if (partitionIndexFunc == null) {
+      partitionIndexFunc = BucketIndexUtil.getPartitionIndexFunc(numPartitions);
+    }
+    return partitionIndexFunc.apply(fileGroupCount, recordKey.getPartitionPath(), fgIndex);
   }
 
   /**
-   * Get the number of file groups for record index partition in metadata table.
+   * Get the file group count for each data partition in the partitioned record index.
    */
-  private int getNumFileGroupsForRecordIndexPartition() {
+  private Map<String, Integer> getPartitionedRLIFileGroupCounts() {
     HoodieTableMetaClient metaClient = StreamerUtil.createMetaClient(conf);
-    HoodieTableMetadata metadataTable = metaClient.getTableFormat().getMetadataFactory().create(
+    if (!metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)) {
+      return Collections.emptyMap();
+    }
+    try (HoodieTableMetadata metadataTable = metaClient.getTableFormat().getMetadataFactory().create(
         HoodieFlinkEngineContext.DEFAULT,
         metaClient.getStorage(),
         StreamerUtil.metadataConfig(conf),
-        conf.get(FlinkOptions.PATH));
-    return metadataTable.getNumFileGroupsForPartition(MetadataPartitionType.RECORD_INDEX);
+        conf.get(FlinkOptions.PATH))) {
+      Map<String, Integer> fileGroupCounts = new HashMap<>();
+      metadataTable.getBucketizedFileGroupsForPartitionedRLI(MetadataPartitionType.RECORD_INDEX)
+          .forEach((partitionPath, fileSlices) -> fileGroupCounts.put(partitionPath, fileSlices.size()));
+      return fileGroupCounts;
+    } catch (Exception e) {
+      throw new HoodieException("Failed to get file group counts for partitioned record index.", e);
+    }
+  }
+
+  /**
+   * Get the partitioned record index file group count for the given data partition.
+   */
+  private int getFileGroupCountForPartitionedRLI(String partitionPath) {
+    int fileGroupCount = partitionedRLIFileGroupCounts.getOrDefault(partitionPath, 0);
+    // HoodieBackedTableMetadataWriter initializes record-index file groups for a newly seen
+    // data partition with RECORD_LEVEL_INDEX_MIN_FILE_GROUP_COUNT_PROP, so the writer-side
+    // partitioner should use the same count before that partition appears in the MDT view.
+    return fileGroupCount > 0 ? fileGroupCount : getMinFileGroupCountForPartitionedRLI();
+  }
+
+  /**
+   * Get the minimum file group count used to initialize newly seen partitioned record index partitions.
+   */
+  private int getMinFileGroupCountForPartitionedRLI() {
+    return Integer.parseInt(conf.getString(
+        HoodieMetadataConfig.RECORD_LEVEL_INDEX_MIN_FILE_GROUP_COUNT_PROP.key(),
+        HoodieMetadataConfig.RECORD_LEVEL_INDEX_MIN_FILE_GROUP_COUNT_PROP.defaultValue().toString()));
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalIndexBackend.java
@@ -20,33 +20,26 @@ package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 
-import org.apache.flink.api.common.state.ValueState;
-
 import java.io.IOException;
 
 /**
- * An implementation of {@link GlobalIndexBackend} based on flink keyed value state.
+ * Index backend for managing global record location mappings keyed by record key.
  */
-public class FlinkStateIndexBackend implements GlobalIndexBackend {
+public interface GlobalIndexBackend extends IndexBackend {
 
-  private final ValueState<HoodieRecordGlobalLocation> indexState;
+  /**
+   * Retrieves the global location of a record based on its key.
+   *
+   * @param recordKey the unique key identifying the record
+   * @return the global location of the record, or null if the record is not found in the index
+   */
+  HoodieRecordGlobalLocation get(String recordKey) throws IOException;
 
-  public FlinkStateIndexBackend(ValueState<HoodieRecordGlobalLocation> indexState) {
-    this.indexState = indexState;
-  }
-
-  @Override
-  public HoodieRecordGlobalLocation get(String recordKey) throws IOException {
-    return indexState.value();
-  }
-
-  @Override
-  public void update(String recordKey, HoodieRecordGlobalLocation recordGlobalLocation) throws IOException {
-    this.indexState.update(recordGlobalLocation);
-  }
-
-  @Override
-  public void close() throws IOException {
-    // do nothing.
-  }
+  /**
+   * Updates the global location of a record in the index.
+   *
+   * @param recordKey the unique key identifying the record
+   * @param recordGlobalLocation the new global location of the record
+   */
+  void update(String recordKey, HoodieRecordGlobalLocation recordGlobalLocation) throws IOException;
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordIndexCache.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordIndexCache.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.sink.utils.PeriodicActionExecutor;
 import org.apache.hudi.util.FlinkWriteClients;
 
 import lombok.Getter;
@@ -45,7 +46,7 @@ import java.util.TreeMap;
  * todo: use map backed by flink managed memory.
  */
 @Slf4j
-public class RecordIndexCache implements Closeable {
+public class GlobalRecordIndexCache implements Closeable {
   @VisibleForTesting
   @Getter
   private final TreeMap<Long, ExternalSpillableMap<String, HoodieRecordGlobalLocation>> caches;
@@ -55,12 +56,7 @@ public class RecordIndexCache implements Closeable {
   private final long maxCacheSizeInBytes;
   // the minimum checkpoint id retained in the cache.
   private long minRetainedCheckpointId;
-  private long recordCnt = 0;
-
-  /**
-   * Step size to check the total memory size of the cache.
-   */
-  private static final int NUMBER_OF_RECORDS_TO_CHECK_MEMORY_SIZE = 1000;
+  private final PeriodicActionExecutor memoryCheckExecutor = new PeriodicActionExecutor();
 
   /**
    * Factor for estimating the real size of memory used by a spilled map.
@@ -68,7 +64,7 @@ public class RecordIndexCache implements Closeable {
   @VisibleForTesting
   public static final double FACTOR_FOR_MEMORY_SIZE_OF_SPILLED_MAP = 0.8;
 
-  public RecordIndexCache(Configuration conf, long initCheckpointId) {
+  public GlobalRecordIndexCache(Configuration conf, long initCheckpointId) {
     this.caches = new TreeMap<>(Comparator.reverseOrder());
     this.writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
     this.maxCacheSizeInBytes = conf.get(FlinkOptions.INDEX_RLI_CACHE_SIZE) * 1024 * 1024;
@@ -163,10 +159,7 @@ public class RecordIndexCache implements Closeable {
     // get the cache with the largest checkpoint ID (first entry in the reverse-ordered TreeMap).
     caches.firstEntry().getValue().put(recordKey, recordGlobalLocation);
 
-    if ((++recordCnt) % NUMBER_OF_RECORDS_TO_CHECK_MEMORY_SIZE == 0) {
-      cleanIfNecessary(0L);
-      recordCnt = 0;
-    }
+    memoryCheckExecutor.runIfNecessary(() -> cleanIfNecessary(0L));
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordIndexCache.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordIndexCache.java
@@ -27,7 +27,7 @@ import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
-import org.apache.hudi.sink.utils.PeriodicActionExecutor;
+import org.apache.hudi.sink.utils.SamplingActionExecutor;
 import org.apache.hudi.util.FlinkWriteClients;
 
 import lombok.Getter;
@@ -56,7 +56,7 @@ public class GlobalRecordIndexCache implements Closeable {
   private final long maxCacheSizeInBytes;
   // the minimum checkpoint id retained in the cache.
   private long minRetainedCheckpointId;
-  private final PeriodicActionExecutor memoryCheckExecutor = new PeriodicActionExecutor();
+  private final SamplingActionExecutor memoryCheckExecutor = new SamplingActionExecutor();
 
   /**
    * Factor for estimating the real size of memory used by a spilled map.

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordLevelIndexBackend.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.common.data.HoodieListData;
+import org.apache.hudi.common.data.HoodiePairData;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.HoodieDataUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.sink.event.Correspondent;
+import org.apache.hudi.util.StreamerUtil;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.configuration.Configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Global record-level-index backend backed by the metadata table.
+ *
+ * <p>The backend serves the global RLI path: lookups are keyed by record key only and return
+ * {@link HoodieRecordGlobalLocation}. A checkpoint-aware {@link GlobalRecordIndexCache} keeps recently
+ * accessed locations locally and falls back to metadata table reads for cache misses.
+ */
+@Slf4j
+public class GlobalRecordLevelIndexBackend implements MinibatchIndexBackend {
+  @VisibleForTesting
+  @Getter
+  private final GlobalRecordIndexCache globalRecordIndexCache;
+  private final Configuration conf;
+  private final HoodieTableMetaClient metaClient;
+  private HoodieTableMetadata metadataTable;
+
+  /**
+   * Creates a global RLI backend with a checkpoint-aware cache.
+   *
+   * @param conf Flink write configuration
+   * @param initCheckpointId restored checkpoint id used to seed cache eviction state, or {@code -1}
+   */
+  public GlobalRecordLevelIndexBackend(Configuration conf, long initCheckpointId) {
+    this.metaClient = StreamerUtil.createMetaClient(conf);
+    this.conf = conf;
+    this.globalRecordIndexCache = new GlobalRecordIndexCache(conf, initCheckpointId);
+    reloadMetadataTable();
+  }
+
+  @Override
+  public HoodieRecordGlobalLocation get(String recordKey) throws IOException {
+    return get(Collections.singletonList(recordKey)).get(recordKey);
+  }
+
+  @Override
+  public void update(String recordKey, HoodieRecordGlobalLocation recordGlobalLocation) {
+    globalRecordIndexCache.update(recordKey, recordGlobalLocation);
+  }
+
+  @Override
+  public Map<String, HoodieRecordGlobalLocation> get(List<String> recordKeys) throws IOException {
+    // use a linked hash map to keep the natural order.
+    Map<String, HoodieRecordGlobalLocation> keysAndLocations = new LinkedHashMap<>();
+    List<String> missedKeys = new ArrayList<>();
+    for (String key: recordKeys) {
+      HoodieRecordGlobalLocation location = globalRecordIndexCache.get(key);
+      if (location == null) {
+        missedKeys.add(key);
+      }
+      // insert anyway even the location is null to keep the natural order.
+      keysAndLocations.put(key, location);
+    }
+    if (!missedKeys.isEmpty()) {
+      HoodiePairData<String, HoodieRecordGlobalLocation> recordIndexData =
+          metadataTable.readRecordIndexLocationsWithKeys(HoodieListData.eager(missedKeys));
+      List<Pair<String, HoodieRecordGlobalLocation>> recordIndexLocations = HoodieDataUtils.dedupeAndCollectAsList(recordIndexData);
+      recordIndexLocations.forEach(keyAndLocation -> {
+        globalRecordIndexCache.update(keyAndLocation.getKey(), keyAndLocation.getValue());
+        keysAndLocations.put(keyAndLocation.getKey(), keyAndLocation.getValue());
+      });
+    }
+    return keysAndLocations;
+  }
+
+  @Override
+  public void update(List<Pair<String, HoodieRecordGlobalLocation>> recordKeysAndLocations) throws IOException {
+    recordKeysAndLocations.forEach(keyAndLocation -> globalRecordIndexCache.update(keyAndLocation.getKey(), keyAndLocation.getValue()));
+  }
+
+  /**
+   * Starts a new checkpoint generation in the local record-index cache.
+   *
+   * @param checkpointId checkpoint id from the bucket assign operator
+   */
+  @Override
+  public void onCheckpoint(long checkpointId) {
+    globalRecordIndexCache.addCheckpointCache(checkpointId);
+  }
+
+  /**
+   * Marks older cache generations evictable after a checkpoint completes.
+   *
+   * <p>The minimum inflight checkpoint is used as the retention boundary. If no instant is inflight,
+   * the completed checkpoint id is safe because the writer coordinator has already advanced past it.
+   *
+   * @param correspondent writer coordinator correspondent used to query inflight instants
+   * @param completedCheckpointID completed checkpoint id reported by Flink
+   */
+  @Override
+  public void onCheckpointComplete(Correspondent correspondent, long completedCheckpointID) {
+    Map<Long, String> inflightInstants = correspondent.requestInflightInstants();
+    log.info("Inflight instants and the corresponding checkpoints: {}, notified completed checkpoints: {}",
+        inflightInstants, completedCheckpointID);
+    // if there are no inflight instants,
+    // the latest completed checkpoint id is used as the minimum checkpoint id,
+    // since the streaming write operator always uses previous checkpoint id to request the new instant.
+    globalRecordIndexCache.markAsEvictable(inflightInstants.keySet().stream().min(Long::compareTo).orElse(completedCheckpointID));
+    this.metaClient.reloadActiveTimeline();
+    reloadMetadataTable();
+  }
+
+  private void reloadMetadataTable() {
+    this.metadataTable = metaClient.getTableFormat().getMetadataFactory().create(
+        HoodieFlinkEngineContext.DEFAULT,
+        metaClient.getStorage(),
+        StreamerUtil.metadataConfig(conf),
+        conf.get(FlinkOptions.PATH));
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.globalRecordIndexCache.close();
+    if (this.metadataTable == null) {
+      return;
+    }
+    try {
+      this.metadataTable.close();
+    } catch (Exception e) {
+      throw new HoodieException("Exception happened during close metadata table.", e);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexBackend.java
@@ -18,35 +18,16 @@
 
 package org.apache.hudi.sink.partitioner.index;
 
-import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.sink.event.Correspondent;
 
 import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Closeable;
-import java.io.IOException;
 
 /**
- * An interface that provides an abstraction for managing record location mappings in the index system.
- * It serves as the backend for storing and retrieving the location of records identified by their unique keys.
+ * An interface that provides common lifecycle hooks for index backends.
  */
 public interface IndexBackend extends Closeable {
-
-  /**
-   * Retrieves the global location of a record based on its key.
-   *
-   * @param recordKey the unique key identifying the record
-   * @return the global location of the record, or null if the record is not found in the index
-   */
-  HoodieRecordGlobalLocation get(String recordKey) throws IOException;
-
-  /**
-   * Updates the global location of a record in the index.
-   *
-   * @param recordKey the unique key identifying the record
-   * @param recordGlobalLocation the new global location of the record
-   */
-  void update(String recordKey, HoodieRecordGlobalLocation recordGlobalLocation) throws IOException;
 
   /**
    * Listener method called when the bucket assign operator finishes the checkpoint with {@code checkpointId}.

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexBackendFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexBackendFactory.java
@@ -39,10 +39,21 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import java.util.stream.StreamSupport;
 
 /**
- * Factory to create an {@link IndexBackend} based on the configured index type.
+ * Factory to create a {@link GlobalIndexBackend} based on the configured index type.
  */
 public class IndexBackendFactory {
-  public static IndexBackend create(Configuration conf, FunctionInitializationContext context, RuntimeContext runtimeContext) throws Exception {
+  /**
+   * Creates the global index backend used by the legacy bucket assign function.
+   *
+   * <p>Flink state index stores locations in keyed state. Global RLI either uses the bootstrap
+   * RocksDB cache or a metadata-table-backed backend with checkpoint-aware cache eviction.
+   *
+   * @param conf Flink write configuration
+   * @param context Flink function initialization context
+   * @param runtimeContext Flink runtime context for job and attempt metadata
+   * @return global index backend for record-key lookups
+   */
+  public static GlobalIndexBackend create(Configuration conf, FunctionInitializationContext context, RuntimeContext runtimeContext) throws Exception {
     HoodieIndex.IndexType indexType = OptionsResolver.getIndexType(conf);
     switch (indexType) {
       case FLINK_STATE:
@@ -74,7 +85,7 @@ public class IndexBackendFactory {
           // set the jobId state with current job id.
           jobIdState.clear();
           jobIdState.add(RuntimeContextUtils.getJobId(runtimeContext));
-          return new RecordLevelIndexBackend(conf, initCheckpointId);
+          return new GlobalRecordLevelIndexBackend(conf, initCheckpointId);
         }
       default:
         throw new UnsupportedOperationException("Index type " + indexType + " is not supported for bucket assigning yet.");

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexWriteFunction.java
@@ -51,6 +51,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * A Flink stream writing function that handles writing index records to the metadata table.
@@ -83,6 +84,8 @@ public class IndexWriteFunction extends AbstractStreamWriteFunction<RowData> {
    */
   private transient HoodieFlinkTable<?> flinkTable;
 
+  private transient Function<RowData, String> dedupKeyExtractor;
+
   public IndexWriteFunction(Configuration conf) {
     super(conf, true);
   }
@@ -95,6 +98,8 @@ public class IndexWriteFunction extends AbstractStreamWriteFunction<RowData> {
         config,
         config.get(FlinkOptions.INDEX_RLI_WRITE_BUFFER_SIZE) * 1024 * 1024);
     this.indexDataBuffer = BufferUtils.createBuffer(IndexRowUtils.INDEX_ROW_TYPE, memorySegmentPool);
+    this.dedupKeyExtractor = this.writeClient.getConfig().isRecordLevelIndexEnabled()
+        ? IndexWriteFunction::getPartitionedDedupKey : IndexRowUtils::getRecordKey;
   }
 
   @Override
@@ -171,17 +176,17 @@ public class IndexWriteFunction extends AbstractStreamWriteFunction<RowData> {
     Map<String, HoodieRecord> keyAndRecordMap = new LinkedHashMap<>();
     while (rowItr.hasNext()) {
       RowData indexRow = rowItr.next();
-      keyAndRecordMap.put(getDedupKey(indexRow, writeConfig), IndexRowUtils.convertToHoodieRecord(this.currentInstant, indexRow, writeConfig));
+      keyAndRecordMap.put(
+          dedupKeyExtractor.apply(indexRow),
+          IndexRowUtils.convertToHoodieRecord(this.currentInstant, indexRow, writeConfig));
       dataPartitions.add(IndexRowUtils.getPartition(indexRow));
     }
     return Pair.of(new ArrayList<>(keyAndRecordMap.values()), dataPartitions);
   }
 
-  private String getDedupKey(RowData indexRow, HoodieWriteConfig writeConfig) {
+  private static String getPartitionedDedupKey(RowData indexRow) {
     String recordKey = IndexRowUtils.getRecordKey(indexRow);
-    return writeConfig.isRecordLevelIndexEnabled()
-        ? IndexRowUtils.getPartition(indexRow) + "/" + recordKey
-        : recordKey;
+    return IndexRowUtils.getPartition(indexRow) + "/" + recordKey;
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexWriteFunction.java
@@ -171,11 +171,17 @@ public class IndexWriteFunction extends AbstractStreamWriteFunction<RowData> {
     Map<String, HoodieRecord> keyAndRecordMap = new LinkedHashMap<>();
     while (rowItr.hasNext()) {
       RowData indexRow = rowItr.next();
-      String recordKey = IndexRowUtils.getRecordKey(indexRow);
-      keyAndRecordMap.put(recordKey, IndexRowUtils.convertToHoodieRecord(this.currentInstant, indexRow, writeConfig));
+      keyAndRecordMap.put(getDedupKey(indexRow, writeConfig), IndexRowUtils.convertToHoodieRecord(this.currentInstant, indexRow, writeConfig));
       dataPartitions.add(IndexRowUtils.getPartition(indexRow));
     }
     return Pair.of(new ArrayList<>(keyAndRecordMap.values()), dataPartitions);
+  }
+
+  private String getDedupKey(RowData indexRow, HoodieWriteConfig writeConfig) {
+    String recordKey = IndexRowUtils.getRecordKey(indexRow);
+    return writeConfig.isRecordLevelIndexEnabled()
+        ? IndexRowUtils.getPartition(indexRow) + "/" + recordKey
+        : recordKey;
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/MinibatchIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/MinibatchIndexBackend.java
@@ -28,9 +28,23 @@ import java.util.Map;
 /**
  * Index delegator which supports mini-batch index operations.
  */
-public interface MinibatchIndexBackend extends IndexBackend {
+public interface MinibatchIndexBackend extends GlobalIndexBackend {
 
-  Map<String, HoodieRecordGlobalLocation> get(List<String> recordKey) throws IOException;
+  /**
+   * Retrieves locations for a batch of record keys.
+   *
+   * <p>The returned map should contain one entry for each requested key and preserve the request
+   * order when the implementation can do so. Missing keys should map to {@code null}.
+   *
+   * @param recordKeys record keys to look up
+   * @return record-key to global-location mapping
+   */
+  Map<String, HoodieRecordGlobalLocation> get(List<String> recordKeys) throws IOException;
 
+  /**
+   * Updates locations for a batch of record keys.
+   *
+   * @param recordKeysAndLocations record-key and location pairs to write into the backend
+   */
   void update(List<Pair<String, HoodieRecordGlobalLocation>> recordKeysAndLocations) throws IOException;
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/PartitionedIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/PartitionedIndexBackend.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+/**
+ * Index backend for partition-scoped record-to-file-group mappings.
+ *
+ * <p>Unlike {@link GlobalIndexBackend}, this backend is addressed by both data partition and record
+ * key. It is used by the partitioned RLI based dynamic bucket assignment path, where the persisted
+ * index value is the file group id selected by {@code BucketAssigner}.
+ */
+public interface PartitionedIndexBackend extends IndexBackend {
+
+  /**
+   * Retrieves the file group id for a record in the given partition.
+   *
+   * @param partitionPath the partition path of the record
+   * @param recordKey the unique key identifying the record
+   * @return the file group id, or null if the record is not found in the index
+   */
+  String get(String partitionPath, String recordKey);
+
+  /**
+   * Updates the file group id for a record in the given partition.
+   *
+   * @param partitionPath the partition path of the record
+   * @param recordKey the unique key identifying the record
+   * @param fileId the file group id, usually the file id prefix produced by bucket assignment
+   */
+  void update(String partitionPath, String recordKey, String fileId);
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,108 +19,205 @@
 package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
-import org.apache.hudi.common.data.HoodieListData;
+import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.data.HoodiePairData;
+import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.common.serialization.DefaultSerializer;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.util.HoodieDataUtils;
+import org.apache.hudi.common.util.DefaultSizeEstimator;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
-import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.sink.event.Correspondent;
+import org.apache.hudi.sink.utils.PeriodicActionExecutor;
+import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.StreamerUtil;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * An implementation of {@link IndexBackend} based on the record level index in metadata table.
+ * Partition-scoped index backend backed by partitioned record level index.
+ *
+ * <p>The backend keeps a lazy cache per data partition. Each cache maps record keys owned by the
+ * current Flink assign subtask to the file group id stored in the partitioned RLI. New records are
+ * added to the cache after bucket assignment, while existing records keep their original RLI routing.
+ *
+ * <p>Partition caches are evicted lazily: checkpoint completion only advances the safe eviction
+ * watermark, and cleanup happens when the total in-memory cache size exceeds
+ * {@link FlinkOptions#INDEX_RLI_CACHE_SIZE}.
  */
 @Slf4j
-public class RecordLevelIndexBackend implements MinibatchIndexBackend {
-  @VisibleForTesting
-  @Getter
-  private final RecordIndexCache recordIndexCache;
+public class RecordLevelIndexBackend implements PartitionedIndexBackend {
+
   private final Configuration conf;
+  private final HoodieWriteConfig writeConfig;
   private final HoodieTableMetaClient metaClient;
+  private final boolean isInsertOverwrite;
+  private final long maxCacheSizeInBytes;
+  private final BootstrapFilter bootstrapFilter;
   private HoodieTableMetadata metadataTable;
 
-  public RecordLevelIndexBackend(Configuration conf, long initCheckpointId) {
-    this.metaClient = StreamerUtil.createMetaClient(conf);
+  @Getter
+  private final Map<String, BucketCache> partitionBucketCaches = new LinkedHashMap<>(16, 0.75f, true);
+  private long currentCheckpointId = -1L;
+  private long minRetainedCheckpointId = Long.MIN_VALUE;
+  private final PeriodicActionExecutor memoryCheckExecutor = new PeriodicActionExecutor();
+
+  /**
+   * Creates a partitioned RLI backend with custom ownership filtering.
+   *
+   * <p>This constructor is used by simple bucket index, whose write ownership is determined by
+   * partition and bucket file id rather than Flink record-key key groups.
+   *
+   * @param conf Flink write configuration
+   * @param bootstrapFilter filter for deciding whether a bootstrapped RLI record belongs to this task
+   */
+  public RecordLevelIndexBackend(Configuration conf, BootstrapFilter bootstrapFilter) {
     this.conf = conf;
-    this.recordIndexCache = new RecordIndexCache(conf, initCheckpointId);
+    this.writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
+    this.metaClient = StreamerUtil.createMetaClient(conf);
+    this.isInsertOverwrite = OptionsResolver.isInsertOverwrite(conf);
+    this.maxCacheSizeInBytes = conf.get(FlinkOptions.INDEX_RLI_CACHE_SIZE) * 1024 * 1024;
+    this.bootstrapFilter = bootstrapFilter;
     reloadMetadataTable();
   }
 
   @Override
-  public HoodieRecordGlobalLocation get(String recordKey) throws IOException {
-    return get(Collections.singletonList(recordKey)).get(recordKey);
+  public String get(String partitionPath, String recordKey) {
+    BucketCache cache = getOrBootstrapPartition(partitionPath);
+    return cache.getFileGroupId(recordKey);
   }
 
   @Override
-  public void update(String recordKey, HoodieRecordGlobalLocation recordGlobalLocation) {
-    recordIndexCache.update(recordKey, recordGlobalLocation);
+  public void update(String partitionPath, String recordKey, String fileId) {
+    BucketCache cache = getOrBootstrapPartition(partitionPath);
+    cache.putRecordKey(recordKey, fileId, false);
+    memoryCheckExecutor.runIfNecessary(() -> cleanIfNecessary(0L, partitionPath));
   }
 
-  @Override
-  public Map<String, HoodieRecordGlobalLocation> get(List<String> recordKeys) throws IOException {
-    // use a linked hash map to keep the natural order.
-    Map<String, HoodieRecordGlobalLocation> keysAndLocations = new LinkedHashMap<>();
-    List<String> missedKeys = new ArrayList<>();
-    for (String key: recordKeys) {
-      HoodieRecordGlobalLocation location = recordIndexCache.get(key);
-      if (location == null) {
-        missedKeys.add(key);
-      }
-      // insert anyway even the location is null to keep the natural order.
-      keysAndLocations.put(key, location);
-    }
-    if (!missedKeys.isEmpty()) {
-      HoodiePairData<String, HoodieRecordGlobalLocation> recordIndexData =
-          metadataTable.readRecordIndexLocationsWithKeys(HoodieListData.eager(missedKeys));
-      List<Pair<String, HoodieRecordGlobalLocation>> recordIndexLocations = HoodieDataUtils.dedupeAndCollectAsList(recordIndexData);
-      recordIndexLocations.forEach(keyAndLocation -> {
-        recordIndexCache.update(keyAndLocation.getKey(), keyAndLocation.getValue());
-        keysAndLocations.put(keyAndLocation.getKey(), keyAndLocation.getValue());
-      });
-    }
-    return keysAndLocations;
-  }
-
-  @Override
-  public void update(List<Pair<String, HoodieRecordGlobalLocation>> recordKeysAndLocations) throws IOException {
-    recordKeysAndLocations.forEach(keyAndLocation -> recordIndexCache.update(keyAndLocation.getKey(), keyAndLocation.getValue()));
-  }
-
+  /**
+   * Records the latest checkpoint id seen by this assign subtask.
+   *
+   * <p>New record-key mappings written after this point are tagged with the checkpoint id so lazy
+   * eviction can avoid removing partition caches that may still be needed for recovery.
+   *
+   * @param checkpointId checkpoint id from the bucket assign operator
+   */
   @Override
   public void onCheckpoint(long checkpointId) {
-    recordIndexCache.addCheckpointCache(checkpointId);
+    this.currentCheckpointId = checkpointId;
   }
 
+  /**
+   * Advances the lazy eviction watermark after a completed checkpoint.
+   *
+   * <p>The watermark is derived from the minimum inflight checkpoint so caches that may still be
+   * needed for recovery are retained. Metadata table state is reloaded after the coordinator has
+   * committed or advanced instants for the completed checkpoint.
+   *
+   * @param correspondent writer coordinator correspondent used to query inflight instants
+   * @param completedCheckpointId completed checkpoint id reported by Flink
+   */
   @Override
-  public void onCheckpointComplete(Correspondent correspondent, long completedCheckpointID) {
+  public void onCheckpointComplete(Correspondent correspondent, long completedCheckpointId) {
     Map<Long, String> inflightInstants = correspondent.requestInflightInstants();
-    log.info("Inflight instants and the corresponding checkpoints: {}, notified completed checkpoints: {}",
-        inflightInstants, completedCheckpointID);
-    // if there are no inflight instants,
-    // the latest completed checkpoint id is used as the minimum checkpoint id,
-    // since the streaming write operator always uses previous checkpoint id to request the new instant.
-    recordIndexCache.markAsEvictable(inflightInstants.keySet().stream().min(Long::compareTo).orElse(completedCheckpointID));
-    this.metaClient.reloadActiveTimeline();
+    updateEvictableCkp(inflightInstants.keySet().stream().min(Long::compareTo).orElse(completedCheckpointId));
+    metaClient.reloadActiveTimeline();
     reloadMetadataTable();
+  }
+
+  private BucketCache getOrBootstrapPartition(String partitionPath) {
+    BucketCache cache = partitionBucketCaches.get(partitionPath);
+    if (cache != null) {
+      return cache;
+    }
+
+    cache = isInsertOverwrite ? createBucketCache(partitionPath) : bootstrapPartition(partitionPath);
+    partitionBucketCaches.put(partitionPath, cache);
+    cleanIfNecessary(0L, partitionPath);
+    return cache;
+  }
+
+  private BucketCache bootstrapPartition(String partitionPath) {
+    BucketCache cache = createBucketCache(partitionPath);
+    if (!metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)) {
+      log.info("Record index is not available yet. Start partitioned RLI cache empty for partition {}", partitionPath);
+      return cache;
+    }
+
+    try {
+      Map<String, List<FileSlice>> partitionedFileGroups =
+          metadataTable.getBucketizedFileGroupsForPartitionedRLI(MetadataPartitionType.RECORD_INDEX);
+      List<FileSlice> fileSlices = partitionedFileGroups.get(partitionPath);
+      if (fileSlices == null || fileSlices.isEmpty()) {
+        return cache;
+      }
+      HoodiePairData<String, HoodieRecordGlobalLocation> locations =
+          metadataTable.readRecordIndexLocations(fileSlicesToFilter -> fileSlices);
+      final AtomicLong totalCnt = new AtomicLong();
+      locations.forEach(locationPair -> {
+        String recordKey = locationPair.getLeft();
+        String fileId = locationPair.getRight().getFileId();
+        if (bootstrapFilter.shouldLoad(partitionPath, recordKey, fileId)) {
+          cache.putRecordKey(recordKey, fileId, true);
+        }
+        totalCnt.incrementAndGet();
+      });
+      log.info("Bootstrapped partitioned RLI cache for partition {} with {} owned records from total {} RLI records.",
+          partitionPath, cache.size(), totalCnt.get());
+      return cache;
+    } catch (Exception e) {
+      cache.close();
+      throw new HoodieException("Failed to bootstrap partitioned RLI cache for partition " + partitionPath, e);
+    }
+  }
+
+  private BucketCache createBucketCache(String partitionPath) {
+    long inferredCacheSize = inferMemorySizeForCache();
+    cleanIfNecessary(inferredCacheSize, partitionPath);
+    return newBucketCache(createSpillableMap(partitionPath, inferredCacheSize), Long.MIN_VALUE);
+  }
+
+  private ExternalSpillableMap<String, Integer> createSpillableMap(String partitionPath, long inferredCacheSize) {
+    // preserve some memory for fileId dict, assuming the average file group number as Short.MAX_VALUE, then the size will be about 1MB.
+    long maxInMemorySizeInBytes = Math.max(inferredCacheSize - BucketCache.FILE_ID_DICT_ENTRY_SIZE * Short.MAX_VALUE, 1);
+    try {
+      return new ExternalSpillableMap<>(
+          maxInMemorySizeInBytes,
+          writeConfig.getSpillableMapBasePath(),
+          new DefaultSizeEstimator<>(),
+          new DefaultSizeEstimator<>(),
+          ExternalSpillableMap.DiskMapType.ROCKS_DB,
+          new DefaultSerializer<>(),
+          writeConfig.getBoolean(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED),
+          "PartitionedRLICache-" + partitionPath);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to create partitioned RLI cache for partition " + partitionPath, e);
+    }
   }
 
   private void reloadMetadataTable() {
+    closeMetadataTable();
     this.metadataTable = metaClient.getTableFormat().getMetadataFactory().create(
         HoodieFlinkEngineContext.DEFAULT,
         metaClient.getStorage(),
@@ -128,16 +225,172 @@ public class RecordLevelIndexBackend implements MinibatchIndexBackend {
         conf.get(FlinkOptions.PATH));
   }
 
+  private void updateEvictableCkp(long checkpointId) {
+    ValidationUtils.checkArgument(checkpointId >= minRetainedCheckpointId,
+        String.format("The minimum retained checkpoint id should be increased, previous: %s, received: %s",
+            minRetainedCheckpointId, checkpointId));
+    minRetainedCheckpointId = checkpointId;
+  }
+
+  private long inferMemorySizeForCache() {
+    if (partitionBucketCaches.isEmpty()) {
+      return maxCacheSizeInBytes / 2;
+    }
+    long averageMemorySize = getCurrentHeapSize() / partitionBucketCaches.size();
+    if (averageMemorySize <= 0) {
+      return maxCacheSizeInBytes / 2;
+    }
+    return averageMemorySize;
+  }
+
+  private long getCurrentHeapSize() {
+    return partitionBucketCaches.values().stream()
+        .map(BucketCache::getHeapSize)
+        .reduce(Long::sum)
+        .orElse(0L);
+  }
+
+  @VisibleForTesting
+  void cleanIfNecessary(long nextCacheSize, String protectedPartitionPath) {
+    while (getCurrentHeapSize() + nextCacheSize > maxCacheSizeInBytes) {
+      boolean cleaned = false;
+      Iterator<Map.Entry<String, BucketCache>> iterator = partitionBucketCaches.entrySet().iterator();
+      while (iterator.hasNext()) {
+        Map.Entry<String, BucketCache> entry = iterator.next();
+        if (entry.getKey().equals(protectedPartitionPath)) {
+          continue;
+        }
+        BucketCache cache = entry.getValue();
+        if (cache.lastUpdatedCheckpoint < minRetainedCheckpointId) {
+          cache.close();
+          iterator.remove();
+          cleaned = true;
+          log.info("Evict partitioned RLI cache for partition {}", entry.getKey());
+          break;
+        }
+      }
+      if (!cleaned) {
+        return;
+      }
+    }
+  }
+
   @Override
   public void close() throws IOException {
-    this.recordIndexCache.close();
-    if (this.metadataTable == null) {
-      return;
+    partitionBucketCaches.values().forEach(BucketCache::close);
+    partitionBucketCaches.clear();
+    closeMetadataTable();
+  }
+
+  private void closeMetadataTable() {
+    if (metadataTable != null) {
+      try {
+        metadataTable.close();
+      } catch (Exception e) {
+        throw new HoodieException("Failed to close metadata table", e);
+      } finally {
+        metadataTable = null;
+      }
     }
-    try {
-      this.metadataTable.close();
-    } catch (Exception e) {
-      throw new HoodieException("Exception happened during close metadata table.", e);
+  }
+
+  /**
+   * Creates a bucket cache with an injected spillable map for tests.
+   *
+   * @param recordKeyToFileGroupIdCode encoded record-key to file-group-id mapping
+   * @param lastUpdatedCheckpoint checkpoint id of the latest non-bootstrap update
+   * @return bucket cache for one data partition
+   */
+  @VisibleForTesting
+  public BucketCache newBucketCache(
+      ExternalSpillableMap<String, Integer> recordKeyToFileGroupIdCode,
+      long lastUpdatedCheckpoint) {
+    return new BucketCache(recordKeyToFileGroupIdCode, lastUpdatedCheckpoint);
+  }
+
+  @FunctionalInterface
+  public interface BootstrapFilter {
+    boolean shouldLoad(String partitionPath, String recordKey, String fileId);
+  }
+
+  /**
+   * Bucket Cache of one data table partition.
+   *
+   * <p>The spillable map stores {@code recordKey -> fileGroupIdCode}. File group ids are dictionary
+   * encoded inside the cache so hot partitions do not repeat UUID-style file group id strings for
+   * every record key entry.
+   */
+  public class BucketCache implements Closeable {
+    @Getter
+    private final ExternalSpillableMap<String, Integer> recordKeyToFileGroupIdCode;
+    // Keep file group ids in a partition-local dictionary so the spillable record map stores
+    // compact integer codes instead of repeating long UUID-style file group id strings.
+    private final Map<String, Integer> fileGroupIdToDictId;
+    private final List<String> dictIdToFileGroupId;
+    private long lastUpdatedCheckpoint;
+    // File group ids generated by bucket assign are UUID-style 36-character strings.
+    // Each dictionary entry keeps one file group id and one 4-byte integer code.
+    private static final long FILE_ID_DICT_ENTRY_SIZE = 36L + Integer.BYTES;
+
+    BucketCache(ExternalSpillableMap<String, Integer> recordKeyToFileGroupIdCode, long lastUpdatedCheckpoint) {
+      this.recordKeyToFileGroupIdCode = recordKeyToFileGroupIdCode;
+      this.fileGroupIdToDictId = new HashMap<>();
+      this.dictIdToFileGroupId = new ArrayList<>();
+      this.lastUpdatedCheckpoint = lastUpdatedCheckpoint;
+    }
+
+    /**
+     * Returns the decoded file group id for the record key, or {@code null} when the key is unknown.
+     */
+    String getFileGroupId(String recordKey) {
+      Integer fileGroupIdCode = this.recordKeyToFileGroupIdCode.get(recordKey);
+      return fileGroupIdCode == null ? null : dictIdToFileGroupId.get(fileGroupIdCode);
+    }
+
+    /**
+     * Returns the number of cached record-key mappings in this partition.
+     */
+    int size() {
+      return this.recordKeyToFileGroupIdCode.size();
+    }
+
+    private long getHeapSize() {
+      return this.recordKeyToFileGroupIdCode.getCurrentInMemoryMapSize() + getFileGroupIdDictHeapSize();
+    }
+
+    /**
+     * Adds or updates a record-key mapping.
+     *
+     * @param isBootstrap {@code true} when loading existing RLI mappings; bootstrap entries should not
+     *                    advance {@code lastUpdatedCheckpoint}
+     */
+    void putRecordKey(String recordKey, String fileGroupId, boolean isBootstrap) {
+      this.recordKeyToFileGroupIdCode.put(recordKey, getOrCreateFileGroupIdCode(fileGroupId));
+      if (!isBootstrap) {
+        this.lastUpdatedCheckpoint = currentCheckpointId;
+      }
+    }
+
+    private int getOrCreateFileGroupIdCode(String fileGroupId) {
+      // Encode each unique file group id once, and reuse the code for all record keys routed to it.
+      Integer existingCode = fileGroupIdToDictId.get(fileGroupId);
+      if (existingCode != null) {
+        return existingCode;
+      }
+
+      int newCode = dictIdToFileGroupId.size();
+      fileGroupIdToDictId.put(fileGroupId, newCode);
+      dictIdToFileGroupId.add(fileGroupId);
+      return newCode;
+    }
+
+    private long getFileGroupIdDictHeapSize() {
+      return dictIdToFileGroupId.size() * FILE_ID_DICT_ENTRY_SIZE;
+    }
+
+    @Override
+    public void close() {
+      this.recordKeyToFileGroupIdCode.close();
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -37,7 +37,7 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.sink.event.Correspondent;
-import org.apache.hudi.sink.utils.PeriodicActionExecutor;
+import org.apache.hudi.sink.utils.SamplingActionExecutor;
 import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.StreamerUtil;
 
@@ -81,7 +81,7 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
   private final Map<String, BucketCache> partitionBucketCaches = new LinkedHashMap<>(16, 0.75f, true);
   private long currentCheckpointId = -1L;
   private long minRetainedCheckpointId = Long.MIN_VALUE;
-  private final PeriodicActionExecutor memoryCheckExecutor = new PeriodicActionExecutor();
+  private final SamplingActionExecutor memoryCheckExecutor = new SamplingActionExecutor();
 
   /**
    * Creates a partitioned RLI backend with custom ownership filtering.
@@ -270,6 +270,8 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
         }
       }
       if (!cleaned) {
+        // All remaining partition caches are either protected or too recent to evict safely.
+        // Returning avoids retrying the same scan without making progress.
         return;
       }
     }
@@ -391,6 +393,8 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
     @Override
     public void close() {
       this.recordKeyToFileGroupIdCode.close();
+      this.fileGroupIdToDictId.clear();
+      this.dictIdToFileGroupId.clear();
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
@@ -32,10 +32,10 @@ import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * An implementation of {@link IndexBackend} based on RocksDB.
+ * An implementation of {@link GlobalIndexBackend} based on RocksDB.
  */
 @Slf4j
-public class RocksDBIndexBackend implements IndexBackend {
+public class RocksDBIndexBackend implements GlobalIndexBackend {
   private static final String COLUMN_FAMILY = "index_cache";
 
   private final RocksDBDAO rocksDBDAO;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/PeriodicActionExecutor.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/PeriodicActionExecutor.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.utils;
+
+/**
+ * Executes an action after a fixed number of record updates.
+ */
+public class PeriodicActionExecutor {
+  static final int DEFAULT_RECORD_INTERVAL = 1000;
+
+  private final int interval;
+  private long recordCnt;
+
+  public PeriodicActionExecutor() {
+    this(DEFAULT_RECORD_INTERVAL);
+  }
+
+  public PeriodicActionExecutor(int interval) {
+    this.interval = interval;
+  }
+
+  public void runIfNecessary(Runnable action) {
+    if ((++recordCnt) % interval == 0) {
+      action.run();
+      recordCnt = 0L;
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -56,6 +56,7 @@ import org.apache.hudi.sink.compact.CompactionPlanEvent;
 import org.apache.hudi.sink.compact.CompactionPlanOperator;
 import org.apache.hudi.sink.partitioner.BucketAssignFunction;
 import org.apache.hudi.sink.partitioner.BucketIndexPartitioner;
+import org.apache.hudi.sink.partitioner.GlobalRecordIndexPartitioner;
 import org.apache.hudi.sink.partitioner.MiniBatchBucketAssignOperator;
 import org.apache.hudi.sink.partitioner.RecordIndexPartitioner;
 import org.apache.hudi.sink.partitioner.index.IndexRowUtils;
@@ -285,7 +286,7 @@ public class Pipelines {
     DataStream<HoodieFlinkInternalRow> dataStream1 = rowDataToHoodieRecord(conf, rowType, dataStream);
 
     if (conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED) || bounded) {
-      boolean isRliBootstrap = OptionsResolver.isRecordLevelIndex(conf);
+      boolean isRliBootstrap = OptionsResolver.isGlobalRecordLevelIndex(conf);
       dataStream1 = dataStream1
           .transform(
               "index_bootstrap",
@@ -364,6 +365,8 @@ public class Pipelines {
       switch (bucketIndexEngineType) {
         case SIMPLE:
           String indexKeyFields = OptionsResolver.getIndexKeyField(conf);
+          String writeOperatorUid = opUID("bucket_write", conf);
+          boolean isStreamingIndexWriteEnabled = OptionsResolver.isStreamingIndexWriteEnabled(conf);
           // [HUDI-9036] BucketIndexPartitioner is also used in bulk insert mode,
           // keep use of HoodieKey here in partitionCustom for now
           BucketIndexPartitioner<HoodieKey> partitioner = new BucketIndexPartitioner<>(conf, indexKeyFields);
@@ -373,12 +376,12 @@ public class Pipelines {
                   record -> new HoodieKey(record.getRecordKey(), record.getPartitionPath()))
               .transform(
                   opName("bucket_write", conf),
-                  TypeInformation.of(RowData.class),
+                  isStreamingIndexWriteEnabled ? InternalTypeInfo.of(IndexRowUtils.INDEX_ROW_TYPE) : TypeInformation.of(RowData.class),
                   BucketStreamWriteOperator.getFactory(conf, rowType))
-              .uid(opUID("bucket_write", conf))
+              .uid(writeOperatorUid)
               .setParallelism(conf.get(FlinkOptions.WRITE_TASKS));
           declareManagedMemoryIfNecessary(conf, bucketWriteStream, () -> OptionsResolver.getWriteBufferSizeInBytes(conf));
-          return bucketWriteStream;
+          return isStreamingIndexWriteEnabled ? createIndexWriteStream(bucketWriteStream, conf, writeOperatorUid) : bucketWriteStream;
         case CONSISTENT_HASHING:
           if (OptionsResolver.isInsertOverwrite(conf)) {
             // TODO support insert overwrite for consistent bucket index
@@ -421,22 +424,39 @@ public class Pipelines {
               .uid(writeOperatorUid)
               .setParallelism(conf.get(FlinkOptions.WRITE_TASKS));
       declareManagedMemoryIfNecessary(conf, writeDatastream, () -> OptionsResolver.getWriteBufferSizeInBytes(conf));
-      if (isStreamingIndexWriteEnabled) {
-        // index writing pipeline
-        SingleOutputStreamOperator<RowData> indexWriteDatastream = writeDatastream
-            .partitionCustom(new RecordIndexPartitioner(conf), IndexRowUtils::getHoodieKey)
-            .transform(
-                opName("index_write", conf),
-                TypeInformation.of(RowData.class),
-                new IndexWriteOperator(conf, OperatorIDGenerator.fromUid(writeOperatorUid)))
-            .uid(opUID("index_write", conf))
-            .setParallelism(conf.get(FlinkOptions.INDEX_WRITE_TASKS));
-        declareManagedMemoryIfNecessary(conf, indexWriteDatastream, () -> conf.get(FlinkOptions.INDEX_RLI_WRITE_BUFFER_SIZE) * 1024L * 1024L);
-        return indexWriteDatastream;
-      } else {
-        return writeDatastream;
-      }
+      return isStreamingIndexWriteEnabled ? createIndexWriteStream(writeDatastream, conf, writeOperatorUid) : writeDatastream;
     }
+  }
+
+  /**
+   * Creates the streaming index write pipeline that persists emitted RLI rows into the metadata table.
+   *
+   * <p>The upstream data write operator emits only index rows when streaming index write is enabled.
+   * This method repartitions those rows so each metadata record-index file group is handled by one
+   * index write task. Global RLI routes by record key only, while partitioned RLI routes by data
+   * partition and record key to match the metadata table file-group assignment.
+   *
+   * <p>The index writer coordinates with the same data-write coordinator instant, so the upstream
+   * write operator uid is used to derive the coordinator operator id.
+   *
+   * @param dataStream       the stream of index rows emitted by the data write operator
+   * @param conf             the Flink write configuration
+   * @param writeOperatorUid uid of the upstream data write operator
+   * @return the index write stream
+   */
+  private static SingleOutputStreamOperator<RowData> createIndexWriteStream(
+      SingleOutputStreamOperator<RowData> dataStream, Configuration conf, String writeOperatorUid) {
+    Partitioner<HoodieKey> partitioner = OptionsResolver.isGlobalRecordLevelIndex(conf) ? new GlobalRecordIndexPartitioner(conf) : new RecordIndexPartitioner(conf);
+    SingleOutputStreamOperator<RowData> indexWriteDatastream = dataStream
+        .partitionCustom(partitioner, IndexRowUtils::getHoodieKey)
+        .transform(
+            opName("index_write", conf),
+            TypeInformation.of(RowData.class),
+            new IndexWriteOperator(conf, OperatorIDGenerator.fromUid(writeOperatorUid)))
+        .uid(opUID("index_write", conf))
+        .setParallelism(conf.get(FlinkOptions.INDEX_WRITE_TASKS));
+    declareManagedMemoryIfNecessary(conf, indexWriteDatastream, () -> conf.get(FlinkOptions.INDEX_RLI_WRITE_BUFFER_SIZE) * 1024L * 1024L);
+    return indexWriteDatastream;
   }
 
   /**
@@ -450,9 +470,9 @@ public class Pipelines {
   private static DataStream<HoodieFlinkInternalRow> createBucketAssignStream(
       DataStream<HoodieFlinkInternalRow> inputStream, Configuration conf, RowType rowType, String writeOperatorUid) {
     String assignerOperatorName = "bucket_assigner";
-    if (OptionsResolver.isRecordLevelIndex(conf) && !conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
+    if (OptionsResolver.isGlobalRecordLevelIndex(conf) && !conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED)) {
       return inputStream
-          .partitionCustom(new RecordIndexPartitioner(conf), row -> new HoodieKey(row.getRecordKey(), row.getPartitionPath()))
+          .partitionCustom(new GlobalRecordIndexPartitioner(conf), row -> new HoodieKey(row.getRecordKey(), row.getPartitionPath()))
           .transform(
               assignerOperatorName,
               new HoodieFlinkInternalRowTypeInfo(rowType),

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/SamplingActionExecutor.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/SamplingActionExecutor.java
@@ -21,22 +21,22 @@ package org.apache.hudi.sink.utils;
 /**
  * Executes an action after a fixed number of record updates.
  */
-public class PeriodicActionExecutor {
+public class SamplingActionExecutor {
   static final int DEFAULT_RECORD_INTERVAL = 1000;
 
-  private final int interval;
+  private final int stepSize;
   private long recordCnt;
 
-  public PeriodicActionExecutor() {
+  public SamplingActionExecutor() {
     this(DEFAULT_RECORD_INTERVAL);
   }
 
-  public PeriodicActionExecutor(int interval) {
-    this.interval = interval;
+  public SamplingActionExecutor(int stepSize) {
+    this.stepSize = stepSize;
   }
 
   public void runIfNecessary(Runnable action) {
-    if ((++recordCnt) % interval == 0) {
+    if ((++recordCnt) % stepSize == 0) {
       action.run();
       recordCnt = 0L;
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -445,6 +445,12 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
       if (!conf.contains(FlinkOptions.INDEX_RLI_WRITE_BUFFER_SIZE)) {
         conf.set(FlinkOptions.INDEX_RLI_WRITE_BUFFER_SIZE, OptionsResolver.getWriteBufferSizeInBytes(conf) / 1024 / 1024 / 4);
       }
+    } else if (OptionsResolver.isSimpleBucketIndexWithRecordLevelIndex(conf)) {
+      conf.set(FlinkOptions.INDEX_GLOBAL_ENABLED, false);
+      conf.setString(HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key(), "true");
+      if (!conf.contains(FlinkOptions.INDEX_RLI_WRITE_BUFFER_SIZE)) {
+        conf.set(FlinkOptions.INDEX_RLI_WRITE_BUFFER_SIZE, OptionsResolver.getWriteBufferSizeInBytes(conf) / 1024 / 1024 / 4);
+      }
     } else {
       conf.setString(HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key(), "false");
     }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.configuration;
 
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.config.HoodieCleanConfig;
@@ -50,6 +51,20 @@ public class TestOptionsResolver {
     // set lowercase index
     conf.set(FlinkOptions.INDEX_TYPE, "bloom");
     assertEquals(HoodieIndex.IndexType.BLOOM, OptionsResolver.getIndexType(conf));
+  }
+
+  @Test
+  void testSimpleBucketRecordLevelIndexStreamingWrite() {
+    Configuration conf = getConf();
+    conf.set(FlinkOptions.METADATA_ENABLED, true);
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+
+    assertFalse(OptionsResolver.isSimpleBucketIndexWithRecordLevelIndex(conf));
+    assertFalse(OptionsResolver.isStreamingIndexWriteEnabled(conf));
+
+    conf.setString(HoodieMetadataConfig.RECORD_LEVEL_INDEX_ENABLE_PROP.key(), "true");
+    assertTrue(OptionsResolver.isSimpleBucketIndexWithRecordLevelIndex(conf));
+    assertTrue(OptionsResolver.isStreamingIndexWriteEnabled(conf));
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
@@ -18,30 +18,43 @@
 
 package org.apache.hudi.sink.bucket;
 
+import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.HoodieDataUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieIndex.IndexType;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.FlinkMiniCluster;
 import org.apache.hudi.utils.TestConfigurations;
 import org.apache.hudi.utils.TestData;
 import org.apache.hudi.utils.TestSQL;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
@@ -54,10 +67,12 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration test cases for {@link BucketStreamWriteFunction}.
@@ -79,6 +94,16 @@ public class ITTestBucketStreamWrite {
       EXPECTED.put(entry.getKey(), "[" + value + "]");
     }
   }
+
+  private static final List<String> EXPECTED_ROWS = Arrays.asList(
+      "id1,Danny,23,1970-01-01T00:00:01,par1",
+      "id2,Stephen,33,1970-01-01T00:00:02,par1",
+      "id3,Julian,53,1970-01-01T00:00:03,par2",
+      "id4,Fabian,31,1970-01-01T00:00:04,par2",
+      "id5,Sophia,18,1970-01-01T00:00:05,par3",
+      "id6,Emma,20,1970-01-01T00:00:06,par3",
+      "id7,Bob,44,1970-01-01T00:00:07,par4",
+      "id8,Han,56,1970-01-01T00:00:08,par4");
 
   @TempDir
   File tempFile;
@@ -111,6 +136,28 @@ public class ITTestBucketStreamWrite {
     } else {
       TestData.checkWrittenDataMOR(tempFile, EXPECTED, 4);
     }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true,true", "false,true", "true,false", "false,false"})
+  public void testBucketWriteWithPartitionedRLI(boolean isCow, boolean partitionedTable) throws Exception {
+    String tablePath = tempFile.getAbsolutePath();
+    Map<String, String> customOptions = new HashMap<>();
+    customOptions.put(HoodieMetadataConfig.RECORD_LEVEL_INDEX_ENABLE_PROP.key(), "true");
+    doWrite(tablePath, isCow, 2, customOptions, partitionedTable);
+    checkWrittenData(tablePath, isCow);
+
+    // do another write to trigger lazy bootstrap of rli index backend.
+    doWrite(tablePath, isCow, 2, customOptions, partitionedTable);
+    checkWrittenData(tablePath, isCow);
+
+    assertRecordIndexMetadataPartitionExists(tablePath);
+    String expectedPartitionPath = partitionedTable ? "par1" : "";
+    Map<String, HoodieRecordGlobalLocation> locationMap = getRecordKeyIndex(
+        tablePath, isCow, Arrays.asList("id1", "id2"), Option.of(expectedPartitionPath));
+    assertEquals(2, locationMap.size());
+    assertTrue(locationMap.values().stream()
+        .allMatch(location -> location.getPartitionPath().equals(expectedPartitionPath)));
   }
 
   @ParameterizedTest
@@ -159,11 +206,69 @@ public class ITTestBucketStreamWrite {
     });
   }
 
+  private static void assertRecordIndexMetadataPartitionExists(String tablePath) {
+    org.apache.hadoop.conf.Configuration hadoopConf = new org.apache.hadoop.conf.Configuration();
+    String mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(tablePath);
+    assertTrue(StreamerUtil.tableExists(mdtBasePath, hadoopConf),
+        "Metadata table should exist for table with simple bucket RLI stream write");
+    assertTrue(StreamerUtil.partitionExists(mdtBasePath, MetadataPartitionType.RECORD_INDEX.getPartitionPath(), hadoopConf),
+        "RECORD_INDEX partition should exist for table with simple bucket RLI stream write");
+  }
+
+  private static void checkWrittenData(String tablePath, boolean isCow) {
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+    TableEnvironment tableEnv = TableEnvironmentImpl.create(settings);
+    Map<String, String> options = new HashMap<>();
+    options.put(FlinkOptions.PATH.key(), tablePath);
+    options.put(FlinkOptions.TABLE_TYPE.key(),
+        isCow ? FlinkOptions.TABLE_TYPE_COPY_ON_WRITE : FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
+    options.put(FlinkOptions.INDEX_TYPE.key(), IndexType.BUCKET.name());
+    tableEnv.executeSql(TestConfigurations.getCreateHoodieTableDDL("t1", options, false, "partition"));
+
+    List<String> actual = CollectionUtil.iterableToList(() -> tableEnv.sqlQuery("select * from t1").execute().collect())
+        .stream()
+        .map(ITTestBucketStreamWrite::formatDataRow)
+        .sorted()
+        .collect(Collectors.toList());
+    assertEquals(EXPECTED_ROWS, actual);
+  }
+
+  private static String formatDataRow(Row row) {
+    return IntStream.range(0, row.getArity()).mapToObj(i -> row.getField(i).toString()).collect(Collectors.joining(","));
+  }
+
+  private static Map<String, HoodieRecordGlobalLocation> getRecordKeyIndex(
+      String tablePath, boolean isCow, List<String> keys, Option<String> dataPartition) {
+    HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(tablePath);
+    Configuration conf = TestConfigurations.getDefaultConf(metaClient.getBasePath().toString());
+    conf.set(FlinkOptions.TABLE_TYPE, isCow ? FlinkOptions.TABLE_TYPE_COPY_ON_WRITE : FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
+    try (HoodieTableMetadata metadataTable = metaClient.getTableFormat().getMetadataFactory().create(
+        HoodieFlinkEngineContext.DEFAULT,
+        metaClient.getStorage(),
+        StreamerUtil.metadataConfig(conf),
+        conf.get(FlinkOptions.PATH))) {
+      return HoodieDataUtils.dedupeAndCollectAsMap(
+          metadataTable.readRecordIndexLocationsWithKeys(HoodieListData.eager(keys), dataPartition));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private static void doWrite(String path, boolean isCow, int bucketNum) throws ExecutionException, InterruptedException {
     doWrite(path, isCow, bucketNum, null);
   }
 
   private static void doWrite(String path, boolean isCow, int bucketNum, Map<String, String> customOptions)
+      throws InterruptedException, ExecutionException {
+    doWrite(path, isCow, bucketNum, customOptions, true);
+  }
+
+  private static void doWrite(
+      String path,
+      boolean isCow,
+      int bucketNum,
+      Map<String, String> customOptions,
+      boolean partitionedTable)
       throws InterruptedException, ExecutionException {
     EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
     TableEnvironment tableEnv = TableEnvironmentImpl.create(settings);
@@ -180,7 +285,8 @@ public class ITTestBucketStreamWrite {
     options.put(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), String.valueOf(bucketNum));
 
     // create hoodie table and perform writes
-    String hoodieTableDDL = TestConfigurations.getCreateHoodieTableDDL("t1", options);
+    String hoodieTableDDL = TestConfigurations.getCreateHoodieTableDDL(
+        "t1", options, partitionedTable, "partition");
     tableEnv.executeSql(hoodieTableDDL);
     tableEnv.executeSql(TestSQL.INSERT_T1).await();
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestGlobalRecordIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestGlobalRecordIndexPartitioner.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.utils.TestConfigurations;
+import org.apache.hudi.utils.TestData;
+
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link GlobalRecordIndexPartitioner}.
+ */
+public class TestGlobalRecordIndexPartitioner {
+
+  private static GlobalRecordIndexPartitioner partitioner;
+
+  @TempDir
+  static File tempFile;
+
+  @BeforeAll
+  public static void beforeAll() throws Exception {
+    final String basePath = tempFile.getAbsolutePath();
+    Configuration conf = TestConfigurations.getDefaultConf(basePath);
+    conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key(), "true");
+    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+    partitioner = new GlobalRecordIndexPartitioner(conf);
+  }
+
+  @Test
+  void testPartitionMethod() {
+    // Test partitioning with different record keys
+    HoodieKey key1 = new HoodieKey("record_key_1", "partition_path");
+    HoodieKey key2 = new HoodieKey("record_key_2", "partition_path");
+    HoodieKey key3 = new HoodieKey("another_record_key", "partition_path");
+
+    int numPartitions = 10;
+
+    // Test that partitioning works consistently
+    int partition1 = partitioner.partition(key1, numPartitions);
+    int partition2 = partitioner.partition(key2, numPartitions);
+    int partition3 = partitioner.partition(key3, numPartitions);
+
+    // Each partition should be within the range [0, numPartitions)
+    assertTrue(partition1 >= 0 && partition1 < numPartitions);
+    assertTrue(partition2 >= 0 && partition2 < numPartitions);
+    assertTrue(partition3 >= 0 && partition3 < numPartitions);
+
+    // Same key should always map to the same partition
+    assertEquals(partitioner.partition(key1, numPartitions), partitioner.partition(key1, numPartitions));
+  }
+
+  @Test
+  void testPartitionConsistency() {
+    HoodieKey key = new HoodieKey("consistent_test_key", "partition_path");
+    int numPartitions = 5;
+
+    // Test that the same key always maps to the same partition
+    int expectedPartition = partitioner.partition(key, numPartitions);
+    for (int i = 0; i < 10; i++) {
+      assertEquals(expectedPartition, partitioner.partition(key, numPartitions));
+    }
+  }
+
+  @Test
+  void testEdgeCaseSinglePartition() {
+    HoodieKey key = new HoodieKey("any_key", "partition_path");
+    int numPartitions = 1; // Single partition
+
+    // With single partition, everything should go to partition 0
+    assertEquals(0, partitioner.partition(key, numPartitions));
+  }
+
+  @Test
+  void testLargeNumberOfPartitions() {
+    HoodieKey key = new HoodieKey("test_key_for_large_partition", "partition_path");
+    int numPartitions = 100; // Large number of partitions
+
+    int partition = partitioner.partition(key, numPartitions);
+    assertTrue(partition >= 0 && partition < numPartitions);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestRecordIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestRecordIndexPartitioner.java
@@ -20,88 +20,90 @@ package org.apache.hudi.sink.partitioner;
 
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.hash.BucketIndexUtil;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
-import org.apache.hudi.utils.TestData;
 
 import org.apache.flink.configuration.Configuration;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Test cases for {@link RecordIndexPartitioner}.
+ * Test cases for partitioned record level index routing in {@link RecordIndexPartitioner}.
  */
 public class TestRecordIndexPartitioner {
-
-  private static RecordIndexPartitioner partitioner;
+  private static final int FILE_GROUP_COUNT = 3;
+  private static final int NUM_PARTITIONS = 4;
 
   @TempDir
-  static File tempFile;
+  File tempFile;
 
-  @BeforeAll
-  public static void beforeAll() throws Exception {
-    final String basePath = tempFile.getAbsolutePath();
-    Configuration conf = TestConfigurations.getDefaultConf(basePath);
-    conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key(), "true");
-    TestData.writeData(TestData.DATA_SET_INSERT, conf);
-    partitioner = new RecordIndexPartitioner(conf);
+  @Test
+  void testNewPartitionUsesMinFileGroupCount() throws Exception {
+    RecordIndexPartitioner partitioner = newPartitioner();
+    String recordKey = "record_key";
+
+    assertEquals(
+        expectedPartition(recordKey, "par1"),
+        partitioner.partition(new HoodieKey(recordKey, "par1"), NUM_PARTITIONS));
+    assertEquals(
+        expectedPartition(recordKey, "par2"),
+        partitioner.partition(new HoodieKey(recordKey, "par2"), NUM_PARTITIONS));
   }
 
   @Test
-  void testPartitionMethod() {
-    // Test partitioning with different record keys
-    HoodieKey key1 = new HoodieKey("record_key_1", "partition_path");
-    HoodieKey key2 = new HoodieKey("record_key_2", "partition_path");
-    HoodieKey key3 = new HoodieKey("another_record_key", "partition_path");
-    
-    int numPartitions = 10;
-    
-    // Test that partitioning works consistently
-    int partition1 = partitioner.partition(key1, numPartitions);
-    int partition2 = partitioner.partition(key2, numPartitions);
-    int partition3 = partitioner.partition(key3, numPartitions);
-    
-    // Each partition should be within the range [0, numPartitions)
-    assertTrue(partition1 >= 0 && partition1 < numPartitions);
-    assertTrue(partition2 >= 0 && partition2 < numPartitions);
-    assertTrue(partition3 >= 0 && partition3 < numPartitions);
-    
-    // Same key should always map to the same partition
-    assertEquals(partitioner.partition(key1, numPartitions), partitioner.partition(key1, numPartitions));
-  }
-
-  @Test
-  void testPartitionConsistency() {
+  void testPartitionConsistency() throws Exception {
+    RecordIndexPartitioner partitioner = newPartitioner();
     HoodieKey key = new HoodieKey("consistent_test_key", "partition_path");
-    int numPartitions = 5;
-    
-    // Test that the same key always maps to the same partition
-    int expectedPartition = partitioner.partition(key, numPartitions);
+
+    int expectedPartition = partitioner.partition(key, NUM_PARTITIONS);
     for (int i = 0; i < 10; i++) {
-      assertEquals(expectedPartition, partitioner.partition(key, numPartitions));
+      assertEquals(expectedPartition, partitioner.partition(key, NUM_PARTITIONS));
     }
   }
 
   @Test
-  void testEdgeCaseSinglePartition() {
-    HoodieKey key = new HoodieKey("any_key", "partition_path");
-    int numPartitions = 1; // Single partition
-    
-    // With single partition, everything should go to partition 0
-    assertEquals(0, partitioner.partition(key, numPartitions));
+  void testPartitionWithinRange() throws Exception {
+    RecordIndexPartitioner partitioner = newPartitioner();
+
+    int partition1 = partitioner.partition(new HoodieKey("record_key", "par1"), NUM_PARTITIONS);
+    int partition2 = partitioner.partition(new HoodieKey("record_key", "par2"), NUM_PARTITIONS);
+    int partition3 = partitioner.partition(new HoodieKey("record_key", "par3"), NUM_PARTITIONS);
+
+    assertTrue(partition1 >= 0 && partition1 < NUM_PARTITIONS);
+    assertTrue(partition2 >= 0 && partition2 < NUM_PARTITIONS);
+    assertTrue(partition3 >= 0 && partition3 < NUM_PARTITIONS);
+
+    assertNotEquals(partition1, partition2);
+    assertNotEquals(partition1, partition3);
   }
 
   @Test
-  void testLargeNumberOfPartitions() {
-    HoodieKey key = new HoodieKey("test_key_for_large_partition", "partition_path");
-    int numPartitions = 100; // Large number of partitions
-    
-    int partition = partitioner.partition(key, numPartitions);
-    assertTrue(partition >= 0 && partition < numPartitions);
+  void testSinglePartition() throws Exception {
+    RecordIndexPartitioner partitioner = newPartitioner();
+
+    assertEquals(0, partitioner.partition(new HoodieKey("any_key", "par1"), 1));
+  }
+
+  private RecordIndexPartitioner newPartitioner() throws Exception {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.RECORD_LEVEL_INDEX.name());
+    conf.setString(HoodieMetadataConfig.RECORD_LEVEL_INDEX_MIN_FILE_GROUP_COUNT_PROP.key(), String.valueOf(FILE_GROUP_COUNT));
+    StreamerUtil.initTableIfNotExists(conf);
+    return new RecordIndexPartitioner(conf);
+  }
+
+  private int expectedPartition(String recordKey, String partitionPath) {
+    int recordIndexFileGroup = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(recordKey, FILE_GROUP_COUNT);
+    return BucketIndexUtil.getPartitionIndexFunc(NUM_PARTITIONS).apply(FILE_GROUP_COUNT, partitionPath, recordIndexFileGroup);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestGlobalRecordIndexCache.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestGlobalRecordIndexCache.java
@@ -44,18 +44,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**
- * Test cases for {@link RecordIndexCache}.
+ * Test cases for {@link GlobalRecordIndexCache}.
  */
-public class TestRecordIndexCache {
+public class TestGlobalRecordIndexCache {
   @TempDir
   File tempDir;
-  private RecordIndexCache cache;
+  private GlobalRecordIndexCache cache;
 
   @BeforeEach
   void setUp() {
     Configuration conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
     conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 100L); // 100MB cache size
-    this.cache = new RecordIndexCache(conf, 1L);
+    this.cache = new GlobalRecordIndexCache(conf, 1L);
   }
 
   @AfterEach
@@ -155,7 +155,7 @@ public class TestRecordIndexCache {
   void testMarkAsEvictable() {
     Configuration conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
     conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L); // 100MB cache size
-    cache = new RecordIndexCache(conf, 1L);
+    cache = new GlobalRecordIndexCache(conf, 1L);
 
     HoodieRecordGlobalLocation location1 = new HoodieRecordGlobalLocation("partition1", "1001", "file_id1");
     HoodieRecordGlobalLocation location2 = new HoodieRecordGlobalLocation("partition2", "1002", "file_id2");
@@ -233,7 +233,7 @@ public class TestRecordIndexCache {
     Configuration conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
     conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L); // 1MB cache size to force spilling
 
-    try (RecordIndexCache smallCache = new RecordIndexCache(conf, 1L)) {
+    try (GlobalRecordIndexCache smallCache = new GlobalRecordIndexCache(conf, 1L)) {
       String recordKeyPrefix = "key";
       List<HoodieRecordGlobalLocation> locations = new ArrayList<>();
       for (int i = 0; i < 5000; i++) {
@@ -260,7 +260,7 @@ public class TestRecordIndexCache {
     Configuration conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
     conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L); // 1MB cache size to force spilling
 
-    try (RecordIndexCache smallCache = new RecordIndexCache(conf, 1L)) {
+    try (GlobalRecordIndexCache smallCache = new GlobalRecordIndexCache(conf, 1L)) {
       // Add records to multiple checkpoints
       String recordKeyPrefix = "key";
       for (int i = 0; i < 5000; i++) {
@@ -341,7 +341,7 @@ public class TestRecordIndexCache {
     cache.getCaches().put(2L, spilledMap);
     cache.getCaches().put(1L, inMemoryMap);
 
-    long expected = (long) ((800L / RecordIndexCache.FACTOR_FOR_MEMORY_SIZE_OF_SPILLED_MAP) + 500L) / 2;
+    long expected = (long) ((800L / GlobalRecordIndexCache.FACTOR_FOR_MEMORY_SIZE_OF_SPILLED_MAP) + 500L) / 2;
     assertEquals(expected, cache.inferMemorySizeForCache());
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestGlobalRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestGlobalRecordLevelIndexBackend.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner.index;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.sink.event.Correspondent;
+import org.apache.hudi.util.StreamerUtil;
+import org.apache.hudi.utils.TestConfigurations;
+import org.apache.hudi.utils.TestData;
+import org.apache.hudi.utils.TestUtils;
+
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link GlobalRecordLevelIndexBackend}.
+ */
+public class TestGlobalRecordLevelIndexBackend {
+
+  private Configuration conf;
+
+  @TempDir
+  File tempFile;
+
+  @BeforeEach
+  void beforeEach() throws IOException {
+    conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.TABLE_TYPE, COPY_ON_WRITE.name());
+    conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key(), "true");
+    StreamerUtil.initTableIfNotExists(conf);
+  }
+
+  @Test
+  void testRecordLevelIndexBackend() throws Exception {
+    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+
+    String firstCommitTime = TestUtils.getLastCompleteInstant(tempFile.toURI().toString());
+
+    try (GlobalRecordLevelIndexBackend globalRecordLevelIndexBackend = new GlobalRecordLevelIndexBackend(conf, -1)) {
+      // get record location
+      HoodieRecordGlobalLocation location = globalRecordLevelIndexBackend.get("id1");
+      assertNotNull(location);
+      assertEquals("par1", location.getPartitionPath());
+      assertEquals(firstCommitTime, location.getInstantTime());
+
+      // get record location with non existed key
+      location = globalRecordLevelIndexBackend.get("new_key");
+      assertNull(location);
+
+      // get records locations for multiple record keys
+      Map<String, HoodieRecordGlobalLocation> locations = globalRecordLevelIndexBackend.get(Arrays.asList("id1", "id2", "id3"));
+      assertEquals(3, locations.size());
+      locations.values().forEach(Assertions::assertNotNull);
+
+      // get records locations for multiple record keys with unexisted key
+      locations = globalRecordLevelIndexBackend.get(Arrays.asList("id1", "id2", "new_key"));
+      assertEquals(3, locations.size());
+      assertNull(locations.get("new_key"));
+
+      // new checkpoint
+      globalRecordLevelIndexBackend.onCheckpoint(1);
+
+      // update record location
+      HoodieRecordGlobalLocation newLocation = new HoodieRecordGlobalLocation("par5", "1003", "file_id_4");
+      globalRecordLevelIndexBackend.update("new_key", newLocation);
+      location = globalRecordLevelIndexBackend.get("new_key");
+      assertEquals(newLocation, location);
+
+      // previous instant commit success, clean
+      Correspondent correspondent = mock(Correspondent.class);
+      Map<Long, String> inflightInstants = new HashMap<>();
+      inflightInstants.put(1L, "0001");
+      when(correspondent.requestInflightInstants()).thenReturn(inflightInstants);
+      globalRecordLevelIndexBackend.onCheckpointComplete(correspondent, 1);
+      assertEquals(2, globalRecordLevelIndexBackend.getGlobalRecordIndexCache().getCaches().size());
+      // the cache contains 'new_key', and other old locations
+      location = globalRecordLevelIndexBackend.getGlobalRecordIndexCache().get("new_key");
+      assertEquals(newLocation, location);
+      location = globalRecordLevelIndexBackend.getGlobalRecordIndexCache().get("id1");
+      assertNotNull(location);
+    }
+  }
+
+  @Test
+  void testRecordLevelIndexCacheClean() throws Exception {
+    // set a small value for RLI cache
+    conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L);
+
+    try (GlobalRecordLevelIndexBackend globalRecordLevelIndexBackend = new GlobalRecordLevelIndexBackend(conf, -1)) {
+
+      for (int i = 0; i < 1500; i++) {
+        globalRecordLevelIndexBackend.update("id1_" + i,
+            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
+      }
+      // new checkpoint
+      globalRecordLevelIndexBackend.onCheckpoint(1);
+      Correspondent correspondent = mock(Correspondent.class);
+      Map<Long, String> inflightInstants = new HashMap<>();
+      inflightInstants.put(1L, "0001");
+      when(correspondent.requestInflightInstants()).thenReturn(inflightInstants);
+      globalRecordLevelIndexBackend.onCheckpointComplete(correspondent, 1);
+
+      for (int i = 0; i < 2000; i++) {
+        globalRecordLevelIndexBackend.update("id2_" + i,
+            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
+      }
+
+      // new checkpoint
+      globalRecordLevelIndexBackend.onCheckpoint(2);
+      correspondent = mock(Correspondent.class);
+      inflightInstants = new HashMap<>();
+      inflightInstants.put(2L, "0002");
+      when(correspondent.requestInflightInstants()).thenReturn(inflightInstants);
+      globalRecordLevelIndexBackend.onCheckpointComplete(correspondent, 2);
+
+      for (int i = 0; i < 2000; i++) {
+        globalRecordLevelIndexBackend.update("id3_" + i,
+            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
+      }
+
+      // the cache for the first instant is evicted
+      assertEquals(2, globalRecordLevelIndexBackend.getGlobalRecordIndexCache().getCaches().size());
+
+      // new checkpoint
+      globalRecordLevelIndexBackend.onCheckpoint(3);
+      correspondent = mock(Correspondent.class);
+      inflightInstants = new HashMap<>();
+      inflightInstants.put(3L, "0003");
+      when(correspondent.requestInflightInstants()).thenReturn(inflightInstants);
+      globalRecordLevelIndexBackend.onCheckpointComplete(correspondent, 3);
+
+      for (int i = 0; i < 500; i++) {
+        globalRecordLevelIndexBackend.update("id4_" + i,
+            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
+      }
+
+      assertEquals(3, globalRecordLevelIndexBackend.getGlobalRecordIndexCache().getCaches().size());
+
+      // insert another batch of records, which will trigger the cleaning of the cache.
+      // another cache clean is triggered
+      for (int i = 500; i < 1500; i++) {
+        globalRecordLevelIndexBackend.update("id4_" + i,
+            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
+      }
+      assertEquals(3, globalRecordLevelIndexBackend.getGlobalRecordIndexCache().getCaches().size());
+      // cache for the oldest ckp id will be cleaned
+      assertNull(globalRecordLevelIndexBackend.getGlobalRecordIndexCache().getCaches().get(-1L));
+      // caches for the latest 3 ckp id still in the cache
+      assertEquals("par1", globalRecordLevelIndexBackend.get("id2_0").getPartitionPath());
+      assertEquals("par1", globalRecordLevelIndexBackend.get("id3_0").getPartitionPath());
+      assertEquals("par1", globalRecordLevelIndexBackend.get("id4_0").getPartitionPath());
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
@@ -18,34 +18,28 @@
 
 package org.apache.hudi.sink.partitioner.index;
 
-import org.apache.hudi.common.config.HoodieMetadataConfig;
-import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
-import org.apache.hudi.utils.TestData;
-import org.apache.hudi.utils.TestUtils;
 
 import org.apache.flink.configuration.Configuration;
-import org.junit.jupiter.api.Assertions;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
-import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -53,138 +47,147 @@ import static org.mockito.Mockito.when;
  */
 public class TestRecordLevelIndexBackend {
 
+  private static final long ONE_MB = 1024 * 1024;
+
   private Configuration conf;
 
   @TempDir
   File tempFile;
 
   @BeforeEach
-  void beforeEach() throws IOException {
+  public void before() throws Exception {
     conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
-    conf.set(FlinkOptions.TABLE_TYPE, COPY_ON_WRITE.name());
-    conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key(), "true");
+    conf.setString("hadoop.fs.defaultFS", "file:///");
+    conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L);
     StreamerUtil.initTableIfNotExists(conf);
   }
 
   @Test
-  void testRecordLevelIndexBackend() throws Exception {
-    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+  public void testCheckpointCompleteDoesNotEagerEvict() throws Exception {
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      backend.getPartitionBucketCaches().put("par1", cacheWithHeapSize(backend, 2 * ONE_MB, 1L));
 
-    String firstCommitTime = TestUtils.getLastCompleteInstant(tempFile.toURI().toString());
+      backend.onCheckpointComplete(new TestCorrespondent(Collections.emptyMap()), 2L);
 
-    try (RecordLevelIndexBackend recordLevelIndexBackend = new RecordLevelIndexBackend(conf, -1)) {
-      // get record location
-      HoodieRecordGlobalLocation location = recordLevelIndexBackend.get("id1");
-      assertNotNull(location);
-      assertEquals("par1", location.getPartitionPath());
-      assertEquals(firstCommitTime, location.getInstantTime());
-
-      // get record location with non existed key
-      location = recordLevelIndexBackend.get("new_key");
-      assertNull(location);
-
-      // get records locations for multiple record keys
-      Map<String, HoodieRecordGlobalLocation> locations = recordLevelIndexBackend.get(Arrays.asList("id1", "id2", "id3"));
-      assertEquals(3, locations.size());
-      locations.values().forEach(Assertions::assertNotNull);
-
-      // get records locations for multiple record keys with unexisted key
-      locations = recordLevelIndexBackend.get(Arrays.asList("id1", "id2", "new_key"));
-      assertEquals(3, locations.size());
-      assertNull(locations.get("new_key"));
-
-      // new checkpoint
-      recordLevelIndexBackend.onCheckpoint(1);
-
-      // update record location
-      HoodieRecordGlobalLocation newLocation = new HoodieRecordGlobalLocation("par5", "1003", "file_id_4");
-      recordLevelIndexBackend.update("new_key", newLocation);
-      location = recordLevelIndexBackend.get("new_key");
-      assertEquals(newLocation, location);
-
-      // previous instant commit success, clean
-      Correspondent correspondent = mock(Correspondent.class);
-      Map<Long, String> inflightInstants = new HashMap<>();
-      inflightInstants.put(1L, "0001");
-      when(correspondent.requestInflightInstants()).thenReturn(inflightInstants);
-      recordLevelIndexBackend.onCheckpointComplete(correspondent, 1);
-      assertEquals(2, recordLevelIndexBackend.getRecordIndexCache().getCaches().size());
-      // the cache contains 'new_key', and other old locations
-      location = recordLevelIndexBackend.getRecordIndexCache().get("new_key");
-      assertEquals(newLocation, location);
-      location = recordLevelIndexBackend.getRecordIndexCache().get("id1");
-      assertNotNull(location);
+      assertTrue(backend.getPartitionBucketCaches().containsKey("par1"));
     }
   }
 
   @Test
-  void testRecordLevelIndexCacheClean() throws Exception {
-    // set a small value for RLI cache
-    conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L);
+  public void testLazyEvictOldPartitionsWhenHeapExceedsLimit() throws Exception {
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      backend.getPartitionBucketCaches().put("par1", cacheWithHeapSize(backend, 800 * 1024, 1L));
+      backend.getPartitionBucketCaches().put("par2", cacheWithHeapSize(backend, 800 * 1024, 1L));
+      backend.onCheckpointComplete(new TestCorrespondent(Collections.emptyMap()), 2L);
+      backend.getPartitionBucketCaches().put("par3", cacheWithHeapSize(backend, 1L, 2L));
 
-    try (RecordLevelIndexBackend recordLevelIndexBackend = new RecordLevelIndexBackend(conf, -1)) {
+      backend.cleanIfNecessary(0L, "par3");
 
-      for (int i = 0; i < 1500; i++) {
-        recordLevelIndexBackend.update("id1_" + i,
-            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
-      }
-      // new checkpoint
-      recordLevelIndexBackend.onCheckpoint(1);
-      Correspondent correspondent = mock(Correspondent.class);
-      Map<Long, String> inflightInstants = new HashMap<>();
-      inflightInstants.put(1L, "0001");
-      when(correspondent.requestInflightInstants()).thenReturn(inflightInstants);
-      recordLevelIndexBackend.onCheckpointComplete(correspondent, 1);
+      assertFalse(backend.getPartitionBucketCaches().containsKey("par1"));
+      assertTrue(backend.getPartitionBucketCaches().containsKey("par2"));
+      assertTrue(backend.getPartitionBucketCaches().containsKey("par3"));
+    }
+  }
 
-      for (int i = 0; i < 2000; i++) {
-        recordLevelIndexBackend.update("id2_" + i,
-            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
-      }
+  @Test
+  public void testLazyEvictKeepsRecentPartition() throws Exception {
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      backend.getPartitionBucketCaches().put("old", cacheWithHeapSize(backend, 800 * 1024, 1L));
+      backend.getPartitionBucketCaches().put("recent", cacheWithHeapSize(backend, 800 * 1024, 2L));
+      backend.onCheckpointComplete(new TestCorrespondent(Collections.emptyMap()), 2L);
 
-      // new checkpoint
-      recordLevelIndexBackend.onCheckpoint(2);
-      correspondent = mock(Correspondent.class);
-      inflightInstants = new HashMap<>();
-      inflightInstants.put(2L, "0002");
-      when(correspondent.requestInflightInstants()).thenReturn(inflightInstants);
-      recordLevelIndexBackend.onCheckpointComplete(correspondent, 2);
+      backend.cleanIfNecessary(0L, null);
 
-      for (int i = 0; i < 2000; i++) {
-        recordLevelIndexBackend.update("id3_" + i,
-            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
-      }
+      assertFalse(backend.getPartitionBucketCaches().containsKey("old"));
+      assertTrue(backend.getPartitionBucketCaches().containsKey("recent"));
+    }
+  }
 
-      // the cache for the first instant is evicted
-      assertEquals(2, recordLevelIndexBackend.getRecordIndexCache().getCaches().size());
+  @Test
+  public void testGetDoesNotRefreshLastUpdatedCheckpoint() throws Exception {
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      backend.getPartitionBucketCaches().put("old", cacheWithHeapSize(backend, 2 * ONE_MB, 1L));
+      backend.onCheckpoint(2L);
 
-      // new checkpoint
-      recordLevelIndexBackend.onCheckpoint(3);
-      correspondent = mock(Correspondent.class);
-      inflightInstants = new HashMap<>();
-      inflightInstants.put(3L, "0003");
-      when(correspondent.requestInflightInstants()).thenReturn(inflightInstants);
-      recordLevelIndexBackend.onCheckpointComplete(correspondent, 3);
+      backend.get("old", "key1");
+      backend.onCheckpointComplete(new TestCorrespondent(Collections.emptyMap()), 2L);
+      backend.cleanIfNecessary(0L, null);
 
-      for (int i = 0; i < 500; i++) {
-        recordLevelIndexBackend.update("id4_" + i,
-            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
-      }
+      assertFalse(backend.getPartitionBucketCaches().containsKey("old"));
+    }
+  }
 
-      assertEquals(3, recordLevelIndexBackend.getRecordIndexCache().getCaches().size());
+  @Test
+  public void testPartitionCacheDictionaryEncodesFileGroupId() throws Exception {
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      ExternalSpillableMap<String, Integer> recordKeyToFileGroupIdCode = mapWithStorage(0L);
+      RecordLevelIndexBackend.BucketCache cache = backend.newBucketCache(recordKeyToFileGroupIdCode, 1L);
 
-      // insert another batch of records, which will trigger the cleaning of the cache.
-      // another cache clean is triggered
-      for (int i = 500; i < 1500; i++) {
-        recordLevelIndexBackend.update("id4_" + i,
-            new HoodieRecordGlobalLocation("par1", "000000001", UUID.randomUUID().toString(), -1));
-      }
-      assertEquals(3, recordLevelIndexBackend.getRecordIndexCache().getCaches().size());
-      // cache for the oldest ckp id will be cleaned
-      assertNull(recordLevelIndexBackend.getRecordIndexCache().getCaches().get(-1L));
-      // caches for the latest 3 ckp id still in the cache
-      assertEquals("par1", recordLevelIndexBackend.get("id2_0").getPartitionPath());
-      assertEquals("par1", recordLevelIndexBackend.get("id3_0").getPartitionPath());
-      assertEquals("par1", recordLevelIndexBackend.get("id4_0").getPartitionPath());
+      cache.putRecordKey("key1", "file-group-id-000000000000000000000001", false);
+      cache.putRecordKey("key2", "file-group-id-000000000000000000000001", false);
+      cache.putRecordKey("key3", "file-group-id-000000000000000000000002", false);
+
+      assertEquals("file-group-id-000000000000000000000001", cache.getFileGroupId("key1"));
+      assertEquals("file-group-id-000000000000000000000001", cache.getFileGroupId("key2"));
+      assertEquals("file-group-id-000000000000000000000002", cache.getFileGroupId("key3"));
+      assertEquals(Integer.valueOf(0), recordKeyToFileGroupIdCode.get("key1"));
+      assertEquals(Integer.valueOf(0), recordKeyToFileGroupIdCode.get("key2"));
+      assertEquals(Integer.valueOf(1), recordKeyToFileGroupIdCode.get("key3"));
+    }
+  }
+
+  @Test
+  public void testLazyEvictUsesAccessOrder() throws Exception {
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      backend.getPartitionBucketCaches().put("par1", cacheWithHeapSize(backend, 500 * 1024, 1L));
+      backend.getPartitionBucketCaches().put("par2", cacheWithHeapSize(backend, 500 * 1024, 1L));
+      backend.getPartitionBucketCaches().get("par1");
+      backend.getPartitionBucketCaches().put("par3", cacheWithHeapSize(backend, 100 * 1024, 2L));
+      backend.onCheckpointComplete(new TestCorrespondent(Collections.emptyMap()), 2L);
+
+      backend.cleanIfNecessary(0L, "par3");
+
+      assertTrue(backend.getPartitionBucketCaches().containsKey("par1"));
+      assertFalse(backend.getPartitionBucketCaches().containsKey("par2"));
+      assertTrue(backend.getPartitionBucketCaches().containsKey("par3"));
+    }
+  }
+
+  private RecordLevelIndexBackend createBackend() {
+    return new RecordLevelIndexBackend(conf,
+        (partitionPath, recordKey, fileId)
+            -> KeyGroupRangeAssignment.assignKeyToParallelOperator(recordKey, 1, 1) == 0);
+  }
+
+  private RecordLevelIndexBackend.BucketCache cacheWithHeapSize(
+      RecordLevelIndexBackend indexBackend,
+      long heapSize,
+      long lastUpdatedCheckpoint) {
+    return indexBackend.newBucketCache(mapWithStorage(heapSize), lastUpdatedCheckpoint);
+  }
+
+  private ExternalSpillableMap<String, Integer> mapWithStorage(long heapSize) {
+    Map<String, Integer> storage = new HashMap<>();
+    ExternalSpillableMap<String, Integer> recordKeyToFileGroupIdCode = Mockito.mock(ExternalSpillableMap.class);
+    when(recordKeyToFileGroupIdCode.getCurrentInMemoryMapSize()).thenReturn(heapSize);
+    when(recordKeyToFileGroupIdCode.size()).thenAnswer(invocation -> storage.size());
+    when(recordKeyToFileGroupIdCode.get(Mockito.anyString()))
+        .thenAnswer(invocation -> storage.get(invocation.getArgument(0)));
+    doAnswer(invocation -> storage.put(invocation.getArgument(0), invocation.getArgument(1)))
+        .when(recordKeyToFileGroupIdCode).put(Mockito.anyString(), Mockito.anyInt());
+    return recordKeyToFileGroupIdCode;
+  }
+
+  private static class TestCorrespondent extends Correspondent {
+    private final Map<Long, String> inflightInstants;
+
+    TestCorrespondent(Map<Long, String> inflightInstants) {
+      this.inflightInstants = inflightInstants;
+    }
+
+    @Override
+    public Map<Long, String> requestInflightInstants() {
+      return inflightInstants;
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestWriteBase.java
@@ -36,7 +36,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.sink.event.CommitAckEvent;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
 import org.apache.hudi.sink.partitioner.index.IndexBackend;
-import org.apache.hudi.sink.partitioner.index.RecordLevelIndexBackend;
+import org.apache.hudi.sink.partitioner.index.GlobalRecordLevelIndexBackend;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
@@ -366,8 +366,8 @@ public class TestWriteBase {
      */
     public TestHarness assertInflightCachesOfBucketAssigner(int expected) {
       IndexBackend indexBackend = pipeline.getBucketAssignFunction().getIndexBackend();
-      if (indexBackend instanceof RecordLevelIndexBackend) {
-        assertEquals(expected, ((RecordLevelIndexBackend) indexBackend).getRecordIndexCache().getCaches().size());
+      if (indexBackend instanceof GlobalRecordLevelIndexBackend) {
+        assertEquals(expected, ((GlobalRecordLevelIndexBackend) indexBackend).getGlobalRecordIndexCache().getCaches().size());
       }
       return this;
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink streaming writes previously only supported streaming Record Level Index (RLI) writes for the global RLI path. Simple bucket index could assign records to bucket file groups, but it did not emit partitioned RLI records during streaming writes, so the metadata table record index could not be populated for touched keys in this mode.

This PR enables explicit simple bucket + RLI configurations to support streaming partitioned RLI writes.

### Summary and Changelog
- Adds explicit config detection for simple bucket index with metadata record level index enabled, and wires that mode into Flink streaming index writes.
- Updates `BucketStreamWriteFunction` to use `RecordLevelIndexBackend` for partitioned RLI lookups, emit index rows for missing keys, and forward checkpoint lifecycle events to the backend.
- Extends `RecordLevelIndexBackend` with partition-scoped cache support, partitioned RLI bootstrap, file-id dictionary encoding, checkpoint-aware lazy eviction, metadata table reload/close hygiene, and small-cache spillable-map guarding.
- Refactors index stream creation in `Pipelines` and adds partitioner selection between global RLI and partitioned RLI index records.

### Impact
-  Simple bucket Flink streaming writes can now populate partitioned RLI records when metadata and record level index are explicitly enabled.

### Risk Level
low

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
