### PR TITLE
build: pin docusaurus to 3.9.2 and webpack to 5.99.9 to fix CI

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -2,7 +2,7 @@
 title: "Spark Quick Start"
 sidebar_position: 2
 toc: true
-last_modified_at: 2023-08-23T21:14:52+09:00
+last_modified_at: 2025-02-21T03:17:02+09:00
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -458,10 +458,11 @@ values={[
 val adjustedFareDF = spark.read.format("hudi").
   load(basePath).limit(2).
   withColumn("fare", col("fare") * 10)
+
 adjustedFareDF.write.format("hudi").
-option("hoodie.datasource.write.payload.class","com.payloads.CustomMergeIntoConnector").
-mode(Append).
-save(basePath)
+  option("hoodie.datasource.write.payload.class","com.payloads.CustomMergeIntoConnector").
+  mode(Append).
+  save(basePath)
 // Notice Fare column has been updated but all other columns remain intact.
 spark.read.format("hudi").load(basePath).show()
 ```

--- a/website/docs/write_operations.md
+++ b/website/docs/write_operations.md
@@ -68,7 +68,7 @@ Hudi supports migrating your existing large tables into a Hudi table using the `
 ### INSERT_OVERWRITE
 **Type**: _Batch_, **Action**: _REPLACE_COMMIT (CoW + MoR)_
 
-This operation is used to rerwrite the all the partitions that are present in the input. This operation can be faster 
+This operation is used to rewrite the all the partitions that are present in the input. This operation can be faster 
 than `upsert` for batch ETL jobs, that are recomputing entire target partitions at once (as opposed to incrementally 
 updating the target tables). This is because, we are able to bypass indexing, precombining and other repartitioning 
 steps in the upsert write path completely. This comes in handy if you are doing any backfill or any such type of use-cases.

--- a/website/package.json
+++ b/website/package.json
@@ -14,13 +14,13 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.5.1",
-    "@docusaurus/plugin-client-redirects": "^3.5.1",
-    "@docusaurus/plugin-content-docs": "^3.5.1",
-    "@docusaurus/plugin-sitemap": "^3.5.1",
-    "@docusaurus/preset-classic": "^3.5.1",
-    "@docusaurus/theme-classic": "^3.5.1",
-    "@docusaurus/theme-search-algolia": "^3.5.1",
+    "@docusaurus/core": "3.9.2",
+    "@docusaurus/plugin-client-redirects": "3.9.2",
+    "@docusaurus/plugin-content-docs": "3.9.2",
+    "@docusaurus/plugin-sitemap": "3.9.2",
+    "@docusaurus/preset-classic": "3.9.2",
+    "@docusaurus/theme-classic": "3.9.2",
+    "@docusaurus/theme-search-algolia": "3.9.2",
     "@fontsource/comfortaa": "^5.0.20",
     "@mdx-js/react": "^3.0.0",
     "@svgr/webpack": "^8.1.0",
@@ -51,11 +51,14 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
-    "@docusaurus/module-type-aliases": "3.5.1",
-    "@docusaurus/types": "3.5.1",
+    "@docusaurus/module-type-aliases": "3.9.2",
+    "@docusaurus/types": "3.9.2",
     "babel-loader": "^9.1.3"
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "webpack": "5.99.9"
   }
 }

--- a/website/versioned_docs/version-1.0.1/quick-start-guide.md
+++ b/website/versioned_docs/version-1.0.1/quick-start-guide.md
@@ -2,7 +2,7 @@
 title: "Spark Quick Start"
 sidebar_position: 2
 toc: true
-last_modified_at: 2023-08-23T21:14:52+09:00
+last_modified_at: 2025-02-21T03:17:02+09:00
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -458,10 +458,11 @@ values={[
 val adjustedFareDF = spark.read.format("hudi").
   load(basePath).limit(2).
   withColumn("fare", col("fare") * 10)
+
 adjustedFareDF.write.format("hudi").
-option("hoodie.datasource.write.payload.class","com.payloads.CustomMergeIntoConnector").
-mode(Append).
-save(basePath)
+  option("hoodie.datasource.write.payload.class","com.payloads.CustomMergeIntoConnector").
+  mode(Append).
+  save(basePath)
 // Notice Fare column has been updated but all other columns remain intact.
 spark.read.format("hudi").load(basePath).show()
 ```

--- a/website/versioned_docs/version-1.0.1/write_operations.md
+++ b/website/versioned_docs/version-1.0.1/write_operations.md
@@ -68,7 +68,7 @@ Hudi supports migrating your existing large tables into a Hudi table using the `
 ### INSERT_OVERWRITE
 **Type**: _Batch_, **Action**: _REPLACE_COMMIT (CoW + MoR)_
 
-This operation is used to rerwrite the all the partitions that are present in the input. This operation can be faster 
+This operation is used to rewrite the all the partitions that are present in the input. This operation can be faster 
 than `upsert` for batch ETL jobs, that are recomputing entire target partitions at once (as opposed to incrementally 
 updating the target tables). This is because, we are able to bypass indexing, precombining and other repartitioning 
 steps in the upsert write path completely. This comes in handy if you are doing any backfill or any such type of use-cases.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

CI builds on `asf-site` are failing with a `ProgressPlugin` schema validation error from webpack. Example failure: https://github.com/apache/hudi/actions/runs/25124174980/job/73632612546

Root cause: CI runs `npm install` (lock files are gitignored), so the unpinned `^3.5.1` Docusaurus range and the transitive `webpack` dependency pull the newest versions on every fresh build. Docusaurus 3.10.0 and webpack 5.106.x are now incompatible with `webpackbar` 6.0.1, which passes properties (`name`, `color`, `reporters`, `reporter`) that webpack's tightened schema rejects.

### Summary and Changelog

- Pin all `@docusaurus/*` packages from `^3.5.1` to exactly `3.9.2` (the last working version)
- Add an `overrides.webpack` entry pinning `webpack` to `5.99.9` (last known-compatible with `webpackbar` 6.0.1)

### Impact

CI-only build configuration. No effect on the published site contents.

### Risk Level

low - Pinned versions match what local dev has been building successfully. Verified clean install + build locally.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable