### PR TITLE
docs(build): pin docusaurus to 3.9.2 and webpack to 5.99.9 to fix CI

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -20,13 +20,13 @@
     "lint:md:root": "markdownlint \"../*.md\" --fix"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.2",
-    "@docusaurus/plugin-client-redirects": "^3.9.2",
-    "@docusaurus/plugin-content-docs": "^3.9.2",
-    "@docusaurus/plugin-sitemap": "^3.9.2",
-    "@docusaurus/preset-classic": "^3.9.2",
-    "@docusaurus/theme-classic": "^3.9.2",
-    "@docusaurus/theme-search-algolia": "^3.9.2",
+    "@docusaurus/core": "3.9.2",
+    "@docusaurus/plugin-client-redirects": "3.9.2",
+    "@docusaurus/plugin-content-docs": "3.9.2",
+    "@docusaurus/plugin-sitemap": "3.9.2",
+    "@docusaurus/preset-classic": "3.9.2",
+    "@docusaurus/theme-classic": "3.9.2",
+    "@docusaurus/theme-search-algolia": "3.9.2",
     "@fontsource/comfortaa": "^5.0.20",
     "@mdx-js/react": "^3.0.0",
     "@svgr/webpack": "^8.1.0",
@@ -64,5 +64,8 @@
   },
   "engines": {
     "node": ">=22.0"
+  },
+  "overrides": {
+    "webpack": "5.99.9"
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

CI builds on `asf-site` are failing with a `ProgressPlugin` schema validation error from webpack. Example failure: https://github.com/apache/hudi/actions/runs/25124174980/job/73632612546

Root cause: CI runs `npm install` (lock files are gitignored), so the caret-ranged `^3.9.2` Docusaurus dependencies and the unconstrained transitive `webpack` pull the newest versions on every fresh build. Docusaurus 3.10.0 and webpack 5.106.x are now incompatible with `webpackbar` 6.0.1, which passes properties (`name`, `color`, `reporters`, `reporter`) that webpack's tightened schema rejects.

### Summary and Changelog

- Drop carets on all `@docusaurus/*` dependencies to pin them exactly to `3.9.2`
- Add an `overrides.webpack` entry pinning `webpack` to `5.99.9` (last known-compatible with `webpackbar` 6.0.1)

### Impact

CI-only build configuration. No effect on the published site contents.

### Risk Level

low - Pinned versions match what local dev has been building successfully. Verified clean install + build locally.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable