### PR TITLE
[MINOR] Make SparkCatalogMetaStoreClient.setMetaConf a no-op

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/SparkCatalogMetaStoreClient.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/SparkCatalogMetaStoreClient.scala
@@ -152,7 +152,11 @@ class SparkCatalogMetaStoreClient(syncConfig: HiveSyncConfig)
   override def isLocalMetaStore(): Boolean = unsupported[Boolean]()
   override def reconnect(): Unit = unsupported[Unit]()
   override def close(): Unit = unsupported[Unit]()
-  override def setMetaConf(arg0: String, arg1: String): Unit = unsupported[Unit]()
+  // setMetaConf is no-op: HoodieHiveSyncClient.setMetaConf forwards
+  // hive.metastore.callerContext.* values to the metastore for audit/tracing. With Spark's
+  // external catalog there is no remote HMS to forward to, so accept the call silently
+  // instead of breaking sync clients that exercise the standard IMetaStoreClient contract.
+  override def setMetaConf(arg0: String, arg1: String): Unit = {}
   override def getMetaConf(arg0: String): String = unsupported[String]()
   override def getDatabases(arg0: String): java.util.List[String] = unsupported[java.util.List[String]]()
   override def getAllDatabases(): java.util.List[String] = unsupported[java.util.List[String]]()


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18651

`SparkCatalogMetaStoreClient` (#18203) throws `UnsupportedOperationException` from `setMetaConf`. `HoodieHiveSyncClient` calls `IMetaStoreClient.setMetaConf` unconditionally at construction time (HoodieHiveSyncClient.java:119) to forward `hive.metastore.callerContext.*` properties for audit/tracing. Result: any sync client constructed with `SparkCatalogMetaStoreClient` throws before any catalog operation can run, blocking the entire reason `SparkCatalogMetaStoreClient` was introduced (avoiding the Hive-on-Spark classloader split during Hive sync).

### Summary and Changelog

Make `SparkCatalogMetaStoreClient.setMetaConf` a no-op. `HoodieHiveSyncClient.setMetaConf` only forwards `hive.metastore.callerContext.*` properties, which are diagnostic metadata sent to a remote thrift HMS. With Spark's external catalog there is no remote HMS to receive them; dropping the call is the correct semantic for a non-thrift catalog backend.

Files changed:
- `hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/SparkCatalogMetaStoreClient.scala` — `setMetaConf` now returns `Unit` without throwing.

Other unsupported methods (e.g. `getMetaConf`, `getTables`, `getDatabases`) continue to throw `UnsupportedOperationException` because they have meaningful semantics that the Spark catalog implementation does not provide. Only `setMetaConf` is changed because:
1. Its sole caller in Hudi (`HoodieHiveSyncClient.setMetaConf`) only forwards diagnostic context properties.
2. The Spark catalog has no remote endpoint to receive those properties.
3. Throwing here is strictly worse than dropping silently — it prevents any other catalog operation from running.

### Impact

Unblocks `hoodie.datasource.hive_sync.use_spark_catalog=true`. No behavior change for callers that didn't enable this config. No behavior change for the Spark catalog operations themselves (the dropped properties are diagnostic-only, not behavioral).

### Risk Level

low

Single-method behavior change in a class introduced two months ago (#18203) that is opt-in via a config defaulting to `false`. Users with the config disabled see no change. Users with the config enabled were previously unable to use the feature at all, so the only direction the change can go is "from broken to working".

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
