### PR TITLE
[MINOR] Filter spark.sql.* properties in SparkCatalogMetaStoreClient.toCatalogTable

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/SparkCatalogMetaStoreClient.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/SparkCatalogMetaStoreClient.scala
@@ -302,6 +302,14 @@ class SparkCatalogMetaStoreClient(syncConfig: HiveSyncConfig)
     val dataFields = cols.map(fs => StructField(fs.getName, CatalystSqlParser.parseDataType(fs.getType), nullable = true, Metadata.empty))
     val partitionFields = partCols.map(fs => StructField(fs.getName, CatalystSqlParser.parseDataType(fs.getType), nullable = true, Metadata.empty))
 
+    // Strip "spark.sql.*" properties before handing off to Spark's external catalog.
+    // HiveExternalCatalog.alterTable / createTable rejects such keys ("Cannot persist ...
+    // table property keys may not start with 'spark.sql.'") because they are reserved for
+    // Spark's internal use (provider, schema parts, create version). Spark re-derives and
+    // writes these from the CatalogTable itself, so dropping them on the way in is safe.
+    val tableProperties = Option(table.getParameters).map(_.asScala.toMap).getOrElse(Map.empty)
+      .filterNot { case (k, _) => k.startsWith("spark.sql.") }
+
     CatalogTable(
       identifier = TableIdentifier(tbl, Some(db)),
       tableType = if ("EXTERNAL_TABLE".equalsIgnoreCase(table.getTableType)) CatalogTableType.EXTERNAL else CatalogTableType.MANAGED,
@@ -315,7 +323,7 @@ class SparkCatalogMetaStoreClient(syncConfig: HiveSyncConfig)
       schema = StructType(dataFields ++ partitionFields),
       provider = Some("hudi"),
       partitionColumnNames = partCols.map(_.getName),
-      properties = Option(table.getParameters).map(_.asScala.toMap).getOrElse(Map.empty))
+      properties = tableProperties)
   }
 
   private def fromCatalogTable(table: CatalogTable): Table = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18653

`SparkCatalogMetaStoreClient.alter_table` (and `createTable`) fail when the incoming `Table` carries properties starting with `spark.sql.`. Spark's `HiveExternalCatalog.verifyTableProperties` throws `AnalysisException` because those keys are reserved for Spark's internal use.

These keys (`spark.sql.create.version`, `spark.sql.sources.provider`, `spark.sql.sources.schema.*`) are written by Spark itself when persisting any `CatalogTable`. They appear in `getTable` results whenever the table was Spark-managed. `toCatalogTable` currently passes them straight through, so the next `alter_table` call fails before any actual sync work happens.

### Summary and Changelog

Strip `spark.sql.*` keys from the parameter map in `SparkCatalogMetaStoreClient.toCatalogTable` before constructing the `CatalogTable`. Spark re-derives and writes these from the `CatalogTable` itself, so dropping them on the way in is safe — round-tripping was a no-op semantically; we're just preventing Spark's validator from rejecting its own output.

Files changed:
- `hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/SparkCatalogMetaStoreClient.scala` — single-line filter on `tableProperties` plus a comment explaining why.

### Impact

Unblocks `hoodie.datasource.hive_sync.use_spark_catalog=true` for the common case of syncing tables that originated in Spark. No behavior change for non-Spark-managed tables (those don't have `spark.sql.*` keys to strip).

### Risk Level

low

Single-line filter on a parameter map. The dropped keys are documented Spark-internal metadata that Spark re-derives from `CatalogTable`; users cannot meaningfully set them themselves (Spark blocks that path with the same validator). Risk is purely "what if a user wanted to round-trip a property starting with `spark.sql.` for some external purpose" — they couldn't have, because Spark's validator already prevents it on the destination side.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
