### PR TITLE
Log structured schema-change diffs in DeltaStreamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SchemaChangeLogger.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SchemaChangeLogger.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.streamer;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaCompatibilityChecker;
+import org.apache.hudi.common.schema.HoodieSchemaCompatibilityChecker.SchemaPairCompatibility;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Logs schema change events in DeltaStreamer in a way that is easy to scan when an incident
+ * happens. When a customer changes a column's type, adds a column, removes a column, or otherwise
+ * mutates the schema (either through a schema-registry update or by editing a schema file consumed
+ * via {@link org.apache.hudi.utilities.schema.FilebasedSchemaProvider}), oncall typically wants to
+ * answer three questions quickly:
+ *
+ * <ol>
+ *   <li>What changed? (added/removed/type-changed fields)</li>
+ *   <li>Is the change compatible with what Hudi expects?</li>
+ *   <li>If a write is failing immediately after, is the schema change the likely culprit?</li>
+ * </ol>
+ *
+ * <p>This logger emits a single structured INFO line per detected change with a per-field diff,
+ * plus a WARN line when the change is classified as INCOMPATIBLE per Avro reader/writer rules
+ * (e.g. {@code double -> decimal} type change, removal of a required field, etc.). The full
+ * pre/post schema text is only emitted at WARN level, so log volume stays low for routine additive
+ * evolution but bumps up for the cases that need attention.
+ *
+ * <p>Comparison is shallow (top-level fields). Nested record evolution is summarised at the
+ * top-level field's type change. The full schemas are still logged on INCOMPATIBLE so an operator
+ * can drill down.
+ */
+public final class SchemaChangeLogger {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaChangeLogger.class);
+  private static final String NULL_PLACEHOLDER = "null";
+
+  private SchemaChangeLogger() {
+    // Utility class — no instances.
+  }
+
+  /**
+   * Logs the difference between {@code previous} and {@code current} for a given role
+   * ("Source" or "Target") if they differ.
+   *
+   * @param role        Human-readable label, used as a prefix on the log line. Convention:
+   *                    {@code "Source"} for the schema records arrive in, {@code "Target"} for
+   *                    the schema Hudi will write.
+   * @param previous    The previously-active schema for this role, or {@code null} if this is the
+   *                    first observation.
+   * @param current     The current schema (just observed). May be {@code null} if the role isn't
+   *                    being used in this batch.
+   * @param providerClass The fully-qualified class name of the SchemaProvider that produced
+   *                    {@code current}. Logged so operators can tell whether the schema came from
+   *                    the schema registry, a file, an upstream Hudi table, etc. May be
+   *                    {@code null} if not known.
+   */
+  public static void logIfChanged(String role,
+                                  HoodieSchema previous,
+                                  HoodieSchema current,
+                                  String providerClass) {
+    if (current == null) {
+      return;
+    }
+    if (Objects.equals(previous, current)) {
+      return;
+    }
+    String provider = providerClass == null ? "unknown" : providerClass;
+    if (previous == null) {
+      LOG.info("{} schema initialised. provider={}, fields={}",
+          role, provider, summariseTopLevel(current));
+      return;
+    }
+
+    SchemaDiff diff = computeTopLevelDiff(previous, current);
+
+    if (diff.isEmpty()) {
+      // Different identity, structurally identical. Almost always a fingerprint cache miss.
+      LOG.info("{} schema reference changed but content is identical. provider={}",
+          role, provider);
+      return;
+    }
+
+    Compatibility compat = classify(previous, current);
+    LOG.info(
+        "{} schema changed [{}]. provider={}, added={}, removed={}, type_changes={}",
+        role, compat.label, provider, diff.added, diff.removed, diff.typeChanges);
+
+    if (compat == Compatibility.INCOMPATIBLE) {
+      // Log the full schemas only on the unsafe path so we have everything needed to investigate.
+      LOG.warn(
+          "{} schema change is INCOMPATIBLE per Avro reader/writer rules. Reason: {}\n"
+              + "Previous schema:\n{}\nNew schema:\n{}",
+          role,
+          compat.detail,
+          previous.toString(true),
+          current.toString(true));
+    }
+  }
+
+  // -------- internals --------
+
+  private static SchemaDiff computeTopLevelDiff(HoodieSchema previous, HoodieSchema current) {
+    SchemaDiff diff = new SchemaDiff();
+    if (!previous.hasFields() || !current.hasFields()) {
+      // Top-level isn't a record on at least one side. Treat as a single "type change" for
+      // visibility; the full schemas will be logged if the compatibility check flags it.
+      diff.typeChanges.put("<root>",
+          new TypeChange(typeOf(previous), typeOf(current)));
+      return diff;
+    }
+
+    Map<String, HoodieSchemaField> prevByName = new LinkedHashMap<>();
+    for (HoodieSchemaField f : previous.getFields()) {
+      prevByName.put(f.name(), f);
+    }
+    Map<String, HoodieSchemaField> currByName = new LinkedHashMap<>();
+    for (HoodieSchemaField f : current.getFields()) {
+      currByName.put(f.name(), f);
+    }
+
+    for (HoodieSchemaField currField : current.getFields()) {
+      HoodieSchemaField prevField = prevByName.get(currField.name());
+      if (prevField == null) {
+        diff.added.add(currField.name() + ":" + typeOf(currField.schema()));
+      } else if (!schemaEquals(prevField.schema(), currField.schema())) {
+        diff.typeChanges.put(currField.name(),
+            new TypeChange(typeOf(prevField.schema()), typeOf(currField.schema())));
+      }
+    }
+    for (HoodieSchemaField prevField : previous.getFields()) {
+      if (!currByName.containsKey(prevField.name())) {
+        diff.removed.add(prevField.name() + ":" + typeOf(prevField.schema()));
+      }
+    }
+    return diff;
+  }
+
+  private static Compatibility classify(HoodieSchema previous, HoodieSchema current) {
+    // Standard Avro reader/writer compatibility. The semantic question is "can a reader using the
+    // current schema decode data written under the previous schema?". If yes → COMPATIBLE.
+    try {
+      SchemaPairCompatibility result =
+          HoodieSchemaCompatibilityChecker.checkReaderWriterCompatibility(current, previous, false);
+      switch (result.getType()) {
+        case COMPATIBLE:
+          return Compatibility.COMPATIBLE;
+        case INCOMPATIBLE:
+        default:
+          return new Compatibility("INCOMPATIBLE", result.getDescription());
+      }
+    } catch (Exception e) {
+      // Compatibility check should never throw, but guard against any odd input shape so logging
+      // never breaks ingestion.
+      return new Compatibility("UNKNOWN", "compat check failed: " + e.getClass().getSimpleName());
+    }
+  }
+
+  private static String summariseTopLevel(HoodieSchema schema) {
+    if (!schema.hasFields()) {
+      return typeOf(schema);
+    }
+    List<String> parts = new ArrayList<>();
+    for (HoodieSchemaField f : schema.getFields()) {
+      parts.add(f.name() + ":" + typeOf(f.schema()));
+    }
+    return parts.toString();
+  }
+
+  private static String typeOf(HoodieSchema s) {
+    if (s == null) {
+      return NULL_PLACEHOLDER;
+    }
+    // Compact rendering: include the type name; for unions, list non-null branches; for records,
+    // list the record name. Avoids dumping the full schema JSON in the diff line.
+    switch (s.getType()) {
+      case UNION:
+        List<HoodieSchema> branches = s.getTypes();
+        List<String> nonNull = new ArrayList<>();
+        boolean hasNull = false;
+        for (HoodieSchema b : branches) {
+          if (b.getType().name().equals("NULL")) {
+            hasNull = true;
+          } else {
+            nonNull.add(typeOf(b));
+          }
+        }
+        if (hasNull && nonNull.size() == 1) {
+          return "?" + nonNull.get(0);
+        }
+        return "union" + nonNull;
+      case RECORD:
+        return "record(" + s.getName() + ")";
+      case ARRAY:
+        return "array";
+      case MAP:
+        return "map";
+      default:
+        return s.getType().name().toLowerCase();
+    }
+  }
+
+  private static boolean schemaEquals(HoodieSchema a, HoodieSchema b) {
+    // Use Hudi's HoodieSchema equality, which respects type structure. Avoids relying on the more
+    // expensive toString-based comparison.
+    return Objects.equals(a, b);
+  }
+
+  // -------- inner types --------
+
+  private static final class SchemaDiff {
+    final List<String> added = new ArrayList<>();
+    final List<String> removed = new ArrayList<>();
+    final Map<String, TypeChange> typeChanges = new LinkedHashMap<>();
+
+    boolean isEmpty() {
+      return added.isEmpty() && removed.isEmpty() && typeChanges.isEmpty();
+    }
+  }
+
+  private static final class TypeChange {
+    final String oldType;
+    final String newType;
+
+    TypeChange(String oldType, String newType) {
+      this.oldType = oldType;
+      this.newType = newType;
+    }
+
+    @Override
+    public String toString() {
+      return oldType + "->" + newType;
+    }
+  }
+
+  private static final class Compatibility {
+    static final Compatibility COMPATIBLE = new Compatibility("COMPATIBLE", "");
+
+    final String label;
+    final String detail;
+
+    Compatibility(String label, String detail) {
+      this.label = label;
+      this.detail = detail;
+    }
+  }
+
+  /** Test-only accessor so unit tests can drive the diff logic without hitting SLF4J. */
+  static String renderDiffForTest(HoodieSchema previous, HoodieSchema current) {
+    SchemaDiff diff = computeTopLevelDiff(previous, current);
+    return "added=" + diff.added + ", removed=" + diff.removed + ", type_changes=" + diff.typeChanges;
+  }
+
+  /** Test-only accessor for compatibility classification. */
+  static String classifyForTest(HoodieSchema previous, HoodieSchema current) {
+    return classify(previous, current).label;
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -257,6 +257,15 @@ public class StreamSync implements Serializable, Closeable {
   private final SchemaSet processedSchema;
 
   /**
+   * Last source/target schemas the {@link SchemaChangeLogger} has emitted a diff against.
+   * Used purely for logging; the authoritative source-of-truth for "have we seen this schema
+   * before" is {@link #processedSchema}. These two fields capture the most-recent schema so that
+   * the logger can produce a per-field diff when a new schema is detected.
+   */
+  private transient HoodieSchema lastLoggedSourceSchema;
+  private transient HoodieSchema lastLoggedTargetSchema;
+
+  /**
    * DeltaSync will explicitly manage embedded timeline server so that they can be reused across Write Client
    * instantiations.
    */
@@ -545,11 +554,33 @@ public class StreamSync implements Serializable, Closeable {
       this.schemaProvider = inputBatch.getSchemaProvider();
       // Setup HoodieWriteClient and compaction now that we decided on schema
       setupWriteClient(inputBatch.getBatch(), metaClient);
+      // Log initial schema observation so the very first batch's schema is visible in the log
+      // even when no comparison is possible yet.
+      String providerClass = inputBatch.getSchemaProvider() == null
+          ? "unknown" : inputBatch.getSchemaProvider().getClass().getName();
+      SchemaChangeLogger.logIfChanged(
+          "Source", null, inputBatch.getSchemaProvider().getSourceHoodieSchema(), providerClass);
+      SchemaChangeLogger.logIfChanged(
+          "Target", null, inputBatch.getSchemaProvider().getTargetHoodieSchema(), providerClass);
+      this.lastLoggedSourceSchema = inputBatch.getSchemaProvider().getSourceHoodieSchema();
+      this.lastLoggedTargetSchema = inputBatch.getSchemaProvider().getTargetHoodieSchema();
     } else {
       HoodieSchema newSourceSchema = inputBatch.getSchemaProvider().getSourceHoodieSchema();
       HoodieSchema newTargetSchema = inputBatch.getSchemaProvider().getTargetHoodieSchema();
       if ((newSourceSchema != null && !processedSchema.isSchemaPresent(newSourceSchema))
           || (newTargetSchema != null && !processedSchema.isSchemaPresent(newTargetSchema))) {
+        // Log the per-field diff (and compatibility classification) BEFORE the existing summary
+        // line, so an operator scanning logs sees what changed without having to diff two big
+        // schema dumps by eye. The full schemas are only emitted on INCOMPATIBLE.
+        String providerClass = inputBatch.getSchemaProvider() == null
+          ? "unknown" : inputBatch.getSchemaProvider().getClass().getName();
+        SchemaChangeLogger.logIfChanged(
+            "Source", lastLoggedSourceSchema, newSourceSchema, providerClass);
+        SchemaChangeLogger.logIfChanged(
+            "Target", lastLoggedTargetSchema, newTargetSchema, providerClass);
+        this.lastLoggedSourceSchema = newSourceSchema;
+        this.lastLoggedTargetSchema = newTargetSchema;
+
         String sourceStr = newSourceSchema == null ? NULL_PLACEHOLDER : newSourceSchema.toString(true);
         String targetStr = newTargetSchema == null ? NULL_PLACEHOLDER : newTargetSchema.toString(true);
         LOG.info("Seeing new schema. Source: {}, Target: {}", sourceStr, targetStr);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestSchemaChangeLogger.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestSchemaChangeLogger.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.streamer;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the diff/classify logic in {@link SchemaChangeLogger} via the package-private test
+ * accessors. The logging side-effects themselves are not asserted (they go through SLF4J); only
+ * the structured diff string and the compatibility label.
+ */
+public class TestSchemaChangeLogger {
+
+  private static HoodieSchema parse(String json) {
+    return HoodieSchema.parse(json);
+  }
+
+  private static final String SCHEMA_OLD = "{"
+      + "\"type\":\"record\","
+      + "\"name\":\"Row\","
+      + "\"fields\":["
+      + "  {\"name\":\"id\",\"type\":\"long\"},"
+      + "  {\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+      + "  {\"name\":\"price\",\"type\":[\"null\",\"double\"],\"default\":null}"
+      + "]}";
+
+  private static final String SCHEMA_ADDED_NULLABLE_FIELD = "{"
+      + "\"type\":\"record\","
+      + "\"name\":\"Row\","
+      + "\"fields\":["
+      + "  {\"name\":\"id\",\"type\":\"long\"},"
+      + "  {\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+      + "  {\"name\":\"price\",\"type\":[\"null\",\"double\"],\"default\":null},"
+      + "  {\"name\":\"sku\",\"type\":[\"null\",\"string\"],\"default\":null}"
+      + "]}";
+
+  private static final String SCHEMA_REMOVED_FIELD = "{"
+      + "\"type\":\"record\","
+      + "\"name\":\"Row\","
+      + "\"fields\":["
+      + "  {\"name\":\"id\",\"type\":\"long\"},"
+      + "  {\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null}"
+      + "]}";
+
+  private static final String SCHEMA_TYPE_CHANGED = "{"
+      + "\"type\":\"record\","
+      + "\"name\":\"Row\","
+      + "\"fields\":["
+      + "  {\"name\":\"id\",\"type\":\"long\"},"
+      + "  {\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+      + "  {\"name\":\"price\",\"type\":[\"null\",{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":10,\"scale\":4}],\"default\":null}"
+      + "]}";
+
+  @Test
+  void compatibleAdditiveChangeIsClassifiedCompatible() {
+    HoodieSchema previous = parse(SCHEMA_OLD);
+    HoodieSchema current = parse(SCHEMA_ADDED_NULLABLE_FIELD);
+
+    String diff = SchemaChangeLogger.renderDiffForTest(previous, current);
+    assertTrue(diff.contains("sku"), "added field should appear in diff: " + diff);
+    assertTrue(diff.contains("removed=[]"), "no removed fields expected: " + diff);
+
+    assertEquals("COMPATIBLE", SchemaChangeLogger.classifyForTest(previous, current));
+  }
+
+  @Test
+  void typeChangeFromDoubleToDecimalIsClassifiedIncompatible() {
+    // Mirrors the ENG-40683 / catapult_period_stats scenario: a numeric column's type evolved
+    // from double to decimal. Avro's reader/writer rules consider this incompatible because a
+    // reader expecting decimal cannot decode bytes written as double.
+    HoodieSchema previous = parse(SCHEMA_OLD);
+    HoodieSchema current = parse(SCHEMA_TYPE_CHANGED);
+
+    String diff = SchemaChangeLogger.renderDiffForTest(previous, current);
+    assertTrue(diff.contains("price"), "price type change should appear in diff: " + diff);
+    assertTrue(diff.contains("type_changes={price="), "diff should record price's type change: " + diff);
+
+    assertEquals("INCOMPATIBLE", SchemaChangeLogger.classifyForTest(previous, current));
+  }
+
+  @Test
+  void removedFieldShowsInDiffAndIsIncompatible() {
+    HoodieSchema previous = parse(SCHEMA_OLD);
+    HoodieSchema current = parse(SCHEMA_REMOVED_FIELD);
+
+    String diff = SchemaChangeLogger.renderDiffForTest(previous, current);
+    assertTrue(diff.contains("removed=[price"), "diff should record price as removed: " + diff);
+    assertTrue(diff.contains("added=[]"), "no added fields expected: " + diff);
+    // Whether removal is incompatible depends on the field's reader-side default; for a nullable
+    // field with default null the reader can fill nulls. Either classification is acceptable; we
+    // only assert that the diff captures it.
+  }
+
+  @Test
+  void identicalSchemasProduceEmptyDiff() {
+    HoodieSchema previous = parse(SCHEMA_OLD);
+    HoodieSchema current = parse(SCHEMA_OLD);
+
+    String diff = SchemaChangeLogger.renderDiffForTest(previous, current);
+    assertEquals("added=[], removed=[], type_changes={}", diff);
+  }
+}


### PR DESCRIPTION
Adds a new utility, SchemaChangeLogger, called from StreamSync at the existing schema-detection point. When a SchemaProvider returns a schema different from the previous one, the logger emits a single INFO line naming the SchemaProvider class plus a per-field diff (added, removed, type-changed). For changes the Avro reader/writer compatibility checker flags as INCOMPATIBLE, an additional WARN line includes the full pre/post schemas so an operator has everything needed to investigate.

Motivation: when a schema-related write failure surfaces (AIOOBE, MatchError, or silent NULL columns — see ENG-40683, prod_cdc_sage_history, catapult_period_stats, Bswift incidents), the first oncall question is "did the customer change the schema, and was the change legal?". Today the only signal is a verbose dump of two large schemas in "Seeing new schema" — operators have to diff by eye. With this change the diff is precomputed and the compatibility classification is logged inline.

Comparison is shallow (top-level fields). For nested record evolution the diff records a top-level type change; the full schemas are still logged on INCOMPATIBLE so an operator can drill into nested differences. SchemaProvider class name is included so it's clear whether the schema came from FilebasedSchemaProvider, SchemaRegistryProvider, or another source.

The existing "Seeing new schema" log line is preserved unchanged for backward compatibility — anyone parsing it continues to work.

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
