### PR TITLE
[MINOR] CatalogBackedTableMetadata: fall back to FileSystemBackedTableMetadata when table not in catalog

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/metadata/CatalogBackedTableMetadata.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/metadata/CatalogBackedTableMetadata.scala
@@ -29,6 +29,8 @@ import org.apache.hudi.util.PartitionPathFilterUtil
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.catalog.CatalogTablePartition
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.internal.SQLConf
@@ -52,19 +54,35 @@ class CatalogBackedTableMetadata(engineContext: HoodieEngineContext,
       tableConfig.getDatabaseName
     }
   private lazy val tableIdentifier = TableIdentifier(catalogTableName, Some(catalogDatabaseName))
-  private lazy val catalogTable = sparkSession.sessionState.catalog.getTableMetadata(tableIdentifier)
 
-  private def isPartitionedTable: Boolean = {
-    catalogTable.partitionColumnNames.nonEmpty
+  // Lookup the table in Spark's session catalog. If the table isn't registered there
+  // (e.g. spark.read.format("hudi").load(path) on a path created via HoodieTableMetaClient
+  // without a CREATE TABLE), return None and the override methods below fall through to
+  // the parent FileSystemBackedTableMetadata implementation.
+  private lazy val catalogTable: Option[CatalogTable] = {
+    try {
+      Some(sparkSession.sessionState.catalog.getTableMetadata(tableIdentifier))
+    } catch {
+      case _: NoSuchTableException | _: NoSuchDatabaseException =>
+        logWarning(s"Table $tableIdentifier not found in Spark session catalog; falling " +
+          s"back to filesystem-backed partition listing for $datasetBasePath. To suppress " +
+          "this fallback, register the table or set " +
+          "hoodie.datasource.read.file.index.list.partitions.from.catalog=false.")
+        None
+    }
   }
 
-  private def shouldUseCatalogPartitions: Boolean = {
-    isPartitionedTable && catalogTable.tracksPartitionsInCatalog
-  }
+  private def isPartitionedTable: Boolean =
+    catalogTable.exists(_.partitionColumnNames.nonEmpty)
+
+  private def shouldUseCatalogPartitions: Boolean =
+    catalogTable.exists(t => t.partitionColumnNames.nonEmpty && t.tracksPartitionsInCatalog)
 
   override def getAllPartitionPaths():
   util.List[String] =
-    if (!isPartitionedTable) {
+    if (catalogTable.isEmpty) {
+      super.getAllPartitionPaths()
+    } else if (!isPartitionedTable) {
       util.Collections.emptyList()
     } else if (shouldUseCatalogPartitions) {
       sparkSession.sessionState.catalog.externalCatalog
@@ -79,7 +97,9 @@ class CatalogBackedTableMetadata(engineContext: HoodieEngineContext,
 
   override def getPartitionPathWithPathPrefixes(relativePathPrefixes: util.List[String]):
   util.List[String] =
-    if (!isPartitionedTable) {
+    if (catalogTable.isEmpty) {
+      super.getPartitionPathWithPathPrefixes(relativePathPrefixes)
+    } else if (!isPartitionedTable) {
       util.Collections.emptyList()
     } else if (shouldUseCatalogPartitions) {
       filterPartitionsBasedOnRelativePathPrefixes(relativePathPrefixes,
@@ -94,7 +114,9 @@ class CatalogBackedTableMetadata(engineContext: HoodieEngineContext,
                                                                    pushedExpr: org.apache.hudi.expression.Expression,
                                                                    partitionPredicateExpressions: util.List[Object]):
   util.List[String] = {
-    if (!isPartitionedTable) {
+    if (catalogTable.isEmpty) {
+      super.getPartitionPathWithPathPrefixUsingFilterExpression(relativePathPrefix, partitionFields, pushedExpr)
+    } else if (!isPartitionedTable) {
       util.Collections.emptyList()
     } else if (shouldUseCatalogPartitions) {
       val partitionPredicateExpressionSeq = partitionPredicateExpressions.asScala.map(_.asInstanceOf[Expression]).toSeq


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18656

`CatalogBackedTableMetadata` (added in #18265) calls `sparkSession.sessionState.catalog.getTableMetadata(tableIdentifier)` unconditionally. When the table isn't registered in Spark's session catalog — e.g. `spark.read.format("hudi").load(path)` on a path created via `HoodieTableMetaClient.newTableBuilder().initTable(...)` without a `CREATE TABLE` — this throws `NoSuchTableException` and the read fails before any partition listing can run. `spark.read.format("hudi").load(path)` is a documented Hudi API and must work without catalog registration.

### Summary and Changelog

Wrap the catalog lookup in a try/catch that handles `NoSuchTableException` and `NoSuchDatabaseException`, returning `Option[CatalogTable]`. Each override method (`getAllPartitionPaths`, `getPartitionPathWithPathPrefixes`, `getPartitionPathWithPathPrefixUsingFilterExpression`) now checks `catalogTable.isEmpty` and falls through to the parent `FileSystemBackedTableMetadata` implementation when the table isn't registered, instead of throwing.

A warning is logged once per metadata instance so operators can spot the fallback in audit logs and either register the table or set `hoodie.datasource.read.file.index.list.partitions.from.catalog=false`.

Files changed:
- `hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/metadata/CatalogBackedTableMetadata.scala` — change `catalogTable` to `Option[CatalogTable]`, add fallthrough in three override methods.

### Impact

Unblocks `spark.read.format("hudi").load(path)` for any Hudi table, registered or not, when `list.partitions.from.catalog=true` (the new opt-in path from #18265 that's now the default in some downstream distros).

No behavior change when the table IS in the catalog — that path is preserved bit for bit. The warning fires only when the lookup fails.

### Risk Level

low

Single-class change adding a try/catch and an `isEmpty` check in three methods. The dropped exception path was already an unrecoverable error for callers (`spark.read.format(hudi).load(path)` had no recourse), so widening it to a fallback can only improve behavior.

### Documentation Update

none — the fallback restores expected behavior of an existing public API.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
