### PR TITLE
docs(rfc): Add RFC-104 to unify schema evolution on schema-on-read

### DIFF
--- a/rfc/rfc-104/rfc-104.md
+++ b/rfc/rfc-104/rfc-104.md
@@ -1,0 +1,190 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# RFC-104: Unify schema evolution on schema-on-read
+
+## Proposers
+
+- @voonhous
+
+## Approvers
+
+- @<TBD>
+- @<TBD>
+
+## Abstract
+
+Hudi today supports two parallel schema-evolution paths:
+
+1. **Schema-on-read** — gated by `hoodie.schema.on.read.enable=true`. Hudi tracks schema changes itself in `.hoodie/.schema/<instant>.schema_commit` using a versioned, field-ID-based `InternalSchema`. Supports add, drop, rename, and type-promote without rewriting data files.
+2. **Schema-on-write** (the default) — relies on Spark/Avro to reconcile schemas implicitly during the write. No Hudi-side schema metadata is produced. Effectively limited to add-column and Avro-compatible type promotions; rename and drop are not safely supported.
+
+Two paths impose costs on both sides of the system. Users have to learn which knob produces which behavior and discover that the default path silently fails to track renames and drops. Developers maintain parallel branches in every write entry point (`if (schemaOnReadEnabled) ... else ...`) and a large Avro-based reconciliation surface (`HoodieAvroUtils.rewriteRecordWithNewSchema` and friends, referenced from ~74 files) whose semantics are weaker than the schema-on-read alternative.
+
+This RFC proposes:
+
+- **End state**: schema-on-read is the only schema evolution path. The schema-on-write code path is removed.
+- **Mechanism**: a staged migration — close engine gaps under all four supported readers (Spark, Flink, Hive MR, Trino), make schema-on-read silently correct as a non-default in 1.x, lazy-bootstrap an `InternalSchema` for legacy tables on first write under the new default, then delete the schema-on-write branches in the next major (2.0).
+- **Scope boundary**: this RFC removes the *schema-evolution semantics* layered on top of Avro. It does not remove Avro as a serialization format. The broader Avro removal is addressed by RFC-46, RFC-87, and RFC-99 — RFC-104 stacks on those without re-litigating their scope.
+
+## Background
+
+> **Code references**: this RFC names classes and methods rather than file/line locations, since line numbers go stale quickly. Symbol references survive line shifts and are stable to grep against any branch. Where the RFC was drafted against a specific snapshot, the master commit at the time of writing is recorded in the PR that introduced the RFC.
+
+### The two paths today
+
+Configuration entry point — `HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE` (the `hoodie.schema.on.read.enable` config, default `false`):
+
+```
+hoodie.schema.on.read.enable = false  // default
+```
+
+The two paths diverge at well-defined points in the write pipeline:
+
+- **Write client**: `BaseHoodieWriteClient#commit` invokes `BaseHoodieWriteClient#saveInternalSchema` when schema-on-read is enabled. That method reconciles incoming and previous `InternalSchema` via `AvroSchemaEvolutionUtils.reconcileSchema`, persists schema history via `FileBasedInternalSchemaStorageManager#persistHistorySchemaStr`, and stamps `SerDeHelper.LATEST_SCHEMA` into commit metadata. When schema-on-read is disabled, only `SCHEMA_KEY` (Avro schema string) is set; no Hudi-side schema metadata is produced.
+- **Spark writer**: `HoodieSchemaUtils#deduceWriterSchema` is the entry; it dispatches to `deduceWriterSchemaWithReconcile` or `deduceWriterSchemaWithoutReconcile` based on `shouldReconcileSchema` and on whether an `InternalSchema` was injected upstream by `HoodieSparkSqlWriter`.
+- **Write handle**: in the `HoodieWriteHandle` constructor, `schemaOnReadEnabled = !isNullOrEmpty(config.getInternalSchema())`. Many downstream branches hang off this flag.
+- **Reader**: `HoodieFileGroupReader` plus `FileGroupReaderSchemaHandler` consume `Option<InternalSchema>` if present and project records by field ID via `InternalSchemaMerger`; otherwise they fall back to Avro projection.
+
+Schema-on-read uses a versioned `InternalSchema` tree (`org.apache.hudi.internal.schema.InternalSchema`) where each field has a stable integer ID. Renames are name-only changes preserving the ID; drops are tombstones. Field-ID projection at read time fills missing columns with nulls and applies safe type promotions per `SchemaChangeUtils`.
+
+### Where schema-on-read does not yet work
+
+| Area                              | Current state                                              | Notes                                                                                     |
+|-----------------------------------|------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| Spark write + read                | Full support                                               | Reference implementation.                                                                 |
+| Flink writer                      | Partial                                                    | RFC-87 in progress.                                                                       |
+| Hadoop / Hive MR FileGroup reader | Disabled when `SCHEMA_EVOLUTION_ENABLE=true`               | `HoodieInputFormatUtils` in the `hudi-hadoop-mr` module.                                  |
+| Trino plugin                      | Not aware of `.hoodie/.schema/`                            | No references to `SCHEMA_EVOLUTION_ENABLE` anywhere under the `hudi-trino-plugin` module. |
+| HFile base files                  | Schema evolution unsupported                               | `TestHoodieHFileReaderWriter` has `@Disabled` evolved-schema tests.                       |
+| Metadata table / column stats     | Explicit TODO disabling features when schema-on-read is on | `HoodieMetadataConfig`.                                                                   |
+
+### Surface area to remove
+
+- The `HoodieAvroUtils#rewriteRecordWithNewSchema` family plus `HoodieAvroUtils#reconcileSchemas` — referenced from a wide range of call sites across writers, log readers, merge handles, the Hive reader, and HiveSync. Many of these uses are *serialization* (still needed for Hive serde and similar); this RFC removes only the *evolution semantics* uses.
+- `if (schemaOnReadEnabled)` / `!isNullOrEmpty(internalSchema)` branches across the write client, write handle, and Spark writer (the `schemaOnReadEnabled` field on `HoodieWriteHandle` and its propagation through subclasses).
+- Configs subsumed by the unified path: `hoodie.write.schema.allow.auto.evolution.column.drop`, `hoodie.avro.schema.validate`, `hoodie.datasource.write.reconcile.schema` (already deprecated in 0.14.1).
+
+### Relationship with related RFCs
+
+- **RFC-33** (completed) introduced `InternalSchema` and the schema-on-read read/write semantics. RFC-104 builds on RFC-33 by making it the only path.
+- **RFC-46** (completed) decoupled the record-merge API from Avro. RFC-104 is the schema-side counterpart: it removes the Avro-based *schema-evolution* semantics, leaving Avro as a pure serialization format on the way out.
+- **RFC-78** (in progress, 1.0 migration) defines the upgrade contract for legacy tables. RFC-104's lazy-bootstrap behavior plugs into the same upgrade machinery.
+- **RFC-87** (in progress, Flink Avro elimination in writer) is a hard prerequisite for closing the Flink-writer engine gap.
+- **RFC-88** (under review, new schema/datatype/expression abstractions) and **RFC-99** (under review, Hudi type-system redesign) target the long-term replacement of `InternalSchema`'s in-memory shape with an Arrow-based type system.
+
+**Layering decision**: RFC-104 keeps `InternalSchema` as the on-disk schema-evolution format under `.hoodie/.schema/`. RFC-99 evolves the in-memory representation later. RFC-104 must not lock in Avro-shaped serialization choices in `InternalSchema` that RFC-99 would then have to undo.
+
+## Implementation
+
+The migration is split into three orthogonal workstreams. They can run in parallel; the default flip and the deletion are sequenced after all three are green.
+
+### Workstream A — Engine parity
+
+All four reader/writer paths must read and write through `InternalSchema` before the default flips.
+
+1. **Spark** — already supported; tighten test coverage to also exercise schema-on-read CI for the full suite, not just schema-evolution tests.
+2. **Flink writer** — track and land RFC-87. Wire `OptionsResolver` and `InternalSchemaManager` into the post-RFC-87 `HoodieFlinkInternalRow` write path so the writer can reconcile and persist `InternalSchema` exactly as the Spark client does.
+3. **Hive MR reader** — close the input-format gap. Wire `FileGroupReaderSchemaHandler` into the path used by `HoodieInputFormatUtils`. The recent BLOB/ArrayWritable fixes (commits `07a7410452`, `7c2c56ec31`) opened up this module and are a useful template for how to thread the Hudi reader through the legacy Hive serde.
+4. **Trino plugin** — net-new work. The plugin must read `.hoodie/.schema/` and project Parquet/ORC records by field ID. Two concrete options are:
+   - Reuse the Spark `FileGroupReaderSchemaHandler` semantics by extracting the field-ID projection logic into an engine-neutral helper in `hudi-common` and consuming it from the Trino plugin.
+   - Re-implement field-ID projection inside the Trino plugin against Trino's native page-source API, mirroring (but not sharing) the Spark code.
+   The RFC discussion must pick one before Trino implementation starts. **Open question**.
+5. **HFile base files** — HFile lacks any schema-evolution support and one disabled test in `TestHoodieHFileReaderWriter` documents this. Two options:
+   - Add field-ID projection on the HFile reader.
+   - Formally exclude HFile base files from schema evolution and surface a clear runtime error when the user tries to evolve a schema on an HFile-base table.
+   The RFC discussion must pick one. **Open question**.
+
+### Workstream B — Metadata table and indexes
+
+The metadata table currently disables some functionality when schema-on-read is on (the `HoodieMetadataConfig` TODO). Before the default flip:
+
+- Audit the column-stats index against schema-on-read tables with renamed and dropped columns. Stats must continue to be queryable (and possibly invalidated) when a column's name changes or a column is dropped.
+- Audit record index and secondary index for the same scenarios.
+- Add metadata-table integration tests that mutate schema (add/drop/rename) and assert that all indexes remain consistent with the latest table schema and that point lookups continue to work.
+
+### Workstream C — Lazy bootstrap
+
+For tables created before the default flip, schema-on-read history does not exist. On the first write under the new default:
+
+1. Resolve the latest commit's Avro schema via `TableSchemaResolver`.
+2. Synthesize an `InternalSchema` from it via `InternalSchemaConverter` (Avro → InternalSchema).
+3. Persist via `FileBasedInternalSchemaStorageManager#persistHistorySchemaStr` (the same path the schema-on-read writer already uses).
+
+Rules:
+
+- Bootstrap is lazy: a read on a legacy table without schema history continues to use Avro projection until the next write.
+- Bootstrap is one-shot: subsequent commits write incremental `InternalSchema` versions normally.
+- Bootstrap discards no data; field IDs are assigned freshly on bootstrap. **Pre-bootstrap rename and drop history is not recoverable** — schema-on-write never tracked it. The RFC's release notes must state this explicitly.
+- Bootstrap reuses `AvroSchemaEvolutionUtils.reconcileSchema` and `InternalSchemaConverter`; no new conversion logic is introduced.
+
+### Deletion targets (for the 2.0 cut)
+
+Inventory of what gets removed once schema-on-read is the only path:
+
+- `if (schemaOnReadEnabled)` / `!isNullOrEmpty(internalSchema)` branches in:
+  - `BaseHoodieWriteClient#commit` and `BaseHoodieWriteClient#saveInternalSchema` (the schema-on-read leg becomes unconditional; the schema-on-write leg is removed)
+  - The `schemaOnReadEnabled` field on `HoodieWriteHandle` and every conditional that consumes it in subclasses
+  - `HoodieSparkSqlWriter` and `HoodieSchemaUtils#deduceWriterSchema` (collapse `deduceWriterSchemaWithReconcile` and `deduceWriterSchemaWithoutReconcile` into a single path)
+- The Avro-based schema-evolution overloads of `HoodieAvroUtils#rewriteRecordWithNewSchema`. Keep only the serialization-compatibility uses (Hive serde and similar); the *evolution* logic lives entirely in `SchemaChangeUtils` plus `FileGroupReaderSchemaHandler`.
+- Config `hoodie.schema.on.read.enable` becomes a no-op. **Open question**: keep as no-op for one major after 2.0, or remove immediately.
+
+## Rollout/Adoption Plan
+
+### Stage 1 — Close gaps, default still off (1–2 minor releases of 1.x)
+
+- Land Workstreams A, B, C above.
+- Add a deprecation warning when `hoodie.schema.on.read.enable=false` is explicitly set; default remains `false`.
+- Schema-on-read CI runs the full test suite, not just schema-evolution tests, on every PR.
+
+### Stage 2 — Flip the default (one minor release of 1.x)
+
+- Default `hoodie.schema.on.read.enable=true`.
+- Existing tables auto-bootstrap on first write (Workstream C).
+- Soak for one full minor-release cycle before Stage 3 is allowed to merge. Any schema-on-read regression during the soak is release-blocking.
+
+### Stage 3 — Delete schema-on-write code (2.0)
+
+- Remove the deletion targets listed above.
+- Update the user-facing docs to describe a single schema-evolution model.
+- Deprecated configs (`hoodie.write.schema.allow.auto.evolution.column.drop`, `hoodie.avro.schema.validate`, `hoodie.datasource.write.reconcile.schema`) are removed or re-implemented as `InternalSchema`-aware checks.
+
+### User impact
+
+- **Existing schema-on-read users**: no impact; their tables continue to work.
+- **Existing schema-on-write users**: from Stage 2, their next write triggers a one-time bootstrap. They gain support for safe drops, renames, and richer type promotion. They lose nothing in terms of data; they do not retroactively recover rename/drop history they never had.
+- **Engine integrators outside Spark/Flink/Hive/Trino**: third-party readers that only consume the Avro schema in commit metadata will continue to work for add-column scenarios; they need to adopt field-ID projection from `.hoodie/.schema/` to support drops and renames. The RFC ships a checklist for this.
+
+### Discussion items the RFC must resolve before Stage 1
+
+These are the explicit open questions the community must close in review:
+
+1. Trino field-ID projection ownership: shared helper in `hudi-common` vs. plugin-local re-implementation.
+2. HFile schema evolution: add support vs. formally exclude.
+3. `hoodie.schema.on.read.enable` lifetime after 2.0: keep as no-op for one major vs. remove immediately.
+4. Whether deprecation warnings ride with a 1.x minor or wait for 2.0 release notes.
+
+## Test Plan
+
+The RFC is testable by running the full Hudi test suite under both the legacy default (`hoodie.schema.on.read.enable=false`, removed in Stage 3) and the new default (`true`, on by default in Stage 2). Specific additions:
+
+- **Default-on suite**: re-run existing tests including `TestHiveTableSchemaEvolution`, Flink `ITTestSchemaEvolution` / `ITTestSchemaEvolutionBySQL`, MOR/COW round-trips, clustering, compaction, metadata-table tests, and bulk_insert under `SCHEMA_EVOLUTION_ENABLE=true`. Failures are the gating signal for whether Stage 2 is ready.
+- **Lazy-bootstrap test**: write a table with the legacy writer (no `.hoodie/.schema/`); upgrade to a build with the new default; verify that the next write produces a `.hoodie/.schema/<instant>.schema_commit` file and that subsequent reads use field-ID projection.
+- **Cross-engine read-after-write matrix**: Spark writes a table that goes through add → rename → drop → type-promote in its history. All of Spark, Flink, Hive MR, and Trino must read the resulting table and reconcile to the latest schema. This is the Stage 1 exit criterion for Workstream A.
+- **Metadata-table consistency**: with column-stats / record index / secondary index enabled, schema-on-read add/rename/drop sequences must leave indexes queryable and consistent with the latest schema. Stage 1 exit criterion for Workstream B.
+- **Backward compatibility**: a 0.x-written table must be readable under the new default and must bootstrap transparently on first write. No operator action permitted in this test.
+- **Deletion validation (Stage 3)**: after the schema-on-write branches are removed, the `if (schemaOnReadEnabled)` grep over the codebase must return no hits in production code (test fixtures may keep them).


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Hudi today supports two parallel schema-evolution paths, schema-on-read (gated by `hoodie.schema.on.read.enable=true`, backed by `InternalSchema` under `.hoodie/.schema/`) and the default schema-on-write path that relies on Spark/Avro to reconcile schemas implicitly. 

The dual paths are confusing for users (the default silently fails to track renames and drops) and force every write entry point in the code to branch on `schemaOnReadEnabled`. With the broader push to break Hudi's hard dependency on Avro (RFC-46, RFC-87, RFC-99), the schema-evolution layer is the natural next consolidation.

This PR proposes RFC-104 to unify on schema-on-read.

### Summary and Changelog

Adds RFC-104, "Unify schema evolution on schema-on-read." No production code changes.

- `rfc/rfc-104/rfc-104.md`: new RFC. Covers the staged migration: close engine gaps (Spark, Flink writer via RFC-87, Hive MR reader, Trino plugin), resolve metadata-table interactions, lazy-bootstrap an `InternalSchema` for legacy tables on first write under the new default, then delete the schema-on-write branches in 2.0. Lists four open questions for community discussion (Trino projection ownership, HFile schema-evolution decision, post-2.0 lifetime of `hoodie.schema.on.read.enable`, deprecation-warning timing).

### Impact

None at this stage: RFC only, no behavior change. The eventual implementation will be a 2.0 breaking change (schema-on-write path removed, default flipped). 

The RFC explicitly notes that pre-bootstrap rename/drop history is unrecoverable for legacy tables, since schema-on-write never tracked it.

### Risk Level

None

### Documentation Update

None, the RFC itself is the documentation. User-facing docs and the Hudi website will be updated when the implementation lands.

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
