### PR TITLE
test: Surface unstructured types in TestSavepoint and TestMultiFS

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestArchivedCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestArchivedCommitsCommand.java
@@ -81,7 +81,7 @@ public class TestArchivedCommitsCommand extends CLIFunctionalTestHarness {
 
     // Generate archive
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath)
-        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
@@ -284,7 +284,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
   private Map<String, Integer[]> generateDataAndArchive(boolean enableMetadataTable) throws Exception {
     // Generate archive
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath1)
-        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
@@ -327,7 +327,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
   public void testShowArchivedCommitsWithMultiCommitsFile(boolean enableMetadataTable) throws Exception {
     // Generate archive
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath1)
-        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCompactionCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCompactionCommand.java
@@ -168,7 +168,7 @@ public class TestCompactionCommand extends CLIFunctionalTestHarness {
   private void generateArchive() throws IOException {
     // Generate archive
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath)
-        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestCommitMetadataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestMetadataCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestMetadataCommand.java
@@ -49,7 +49,7 @@ import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -83,7 +83,7 @@ public class TestMetadataCommand extends CLIFunctionalTestHarness {
         .initTable(HoodieCLI.conf.newInstance(), tablePath);
 
     HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
-    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(tablePath).withSchema(TRIP_EXAMPLE_SCHEMA).build();
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(tablePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).build();
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(context(), config)) {
       String newCommitTime = "001";
@@ -127,7 +127,7 @@ public class TestMetadataCommand extends CLIFunctionalTestHarness {
         .withEnableGlobalRecordLevelIndex(true).build();
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .withPath(tablePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withMetadataConfig(metadataConfig)
         .build();
 
@@ -178,7 +178,7 @@ public class TestMetadataCommand extends CLIFunctionalTestHarness {
         .withEnableRecordLevelIndex(true).build();
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .withPath(tablePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withMetadataConfig(metadataConfig)
         .build();
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRepairsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestRepairsCommand.java
@@ -85,7 +85,7 @@ import static org.apache.hudi.common.table.HoodieTableConfig.VERSION;
 import static org.apache.hudi.common.table.HoodieTableConfig.generateChecksum;
 import static org.apache.hudi.common.table.HoodieTableConfig.validateChecksum;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -335,7 +335,7 @@ public class TestRepairsCommand extends CLIFunctionalTestHarness {
         .initTable(HoodieCLI.conf.newInstance(), tablePath);
 
     HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
-    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(tablePath).withSchema(TRIP_EXAMPLE_SCHEMA).build();
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(tablePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).build();
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(context(), config)) {
       String newCommitTime = "001";
@@ -397,7 +397,7 @@ public class TestRepairsCommand extends CLIFunctionalTestHarness {
         .initTable(HoodieCLI.conf.newInstance(), tablePath);
 
     HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
-    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(tablePath).withSchema(TRIP_EXAMPLE_SCHEMA).build();
+    HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(tablePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).build();
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(context(), config)) {
       String newCommitTime = "001";

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestClusteringCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestClusteringCommand.java
@@ -176,7 +176,7 @@ public class ITTestClusteringCommand extends HoodieCLIIntegrationTestBase {
 
     // Create the write client to write some records in
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withDeleteParallelism(2).forTable(tableName)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build()).build();
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCompactionCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestCompactionCommand.java
@@ -276,7 +276,7 @@ public class ITTestCompactionCommand extends HoodieCLIIntegrationTestBase {
 
   private void writeSchemaToTmpFile(String schemaPath) throws IOException {
     try (BufferedWriter out = new BufferedWriter(new FileWriter(schemaPath))) {
-      out.write(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+      out.write(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     }
   }
 
@@ -285,7 +285,7 @@ public class ITTestCompactionCommand extends HoodieCLIIntegrationTestBase {
 
     // Create the write client to write some records in
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withDeleteParallelism(2).forTable(tableName)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build()).build();
 

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestTableCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/integ/ITTestTableCommand.java
@@ -183,7 +183,7 @@ public class ITTestTableCommand extends HoodieCLIIntegrationTestBase {
 
     // Create the write client to write some records in
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withDeleteParallelism(2)
         .forTable(tableName)

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConcurrentSchemaEvolutionTableSchemaGetter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConcurrentSchemaEvolutionTableSchemaGetter.java
@@ -481,7 +481,7 @@ public class TestConcurrentSchemaEvolutionTableSchemaGetter extends HoodieCommon
     initMetaClient(false, tableType);
     testTable = HoodieTestTable.of(metaClient);
 
-    HoodieSchema schema1 = HoodieSchema.parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+    HoodieSchema schema1 = HoodieSchema.parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     HoodieSchema schema2 = HoodieSchema.parse(TRIP_SCHEMA);
 
     // Create two commits with different schemas
@@ -548,7 +548,7 @@ public class TestConcurrentSchemaEvolutionTableSchemaGetter extends HoodieCommon
     testTable = HoodieTestTable.of(metaClient);
 
     // Create test schema
-    HoodieSchema schema1 = HoodieSchema.parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+    HoodieSchema schema1 = HoodieSchema.parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     HoodieSchema schema2 = HoodieSchema.parse(HoodieTestDataGenerator.SHORT_TRIP_SCHEMA);
 
     // Create a commit with schema1

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/execution/TestFileMetadataWriteStatusConverter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/execution/TestFileMetadataWriteStatusConverter.java
@@ -88,7 +88,7 @@ public class TestFileMetadataWriteStatusConverter extends HoodieCommonTestHarnes
   @Test
   public void testWriteStatusConversion() throws IOException {
     HoodieWriteConfig writeConfig =
-        getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM)
+        getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM)
             .build();
     String fileId = UUID.randomUUID().toString();
     String prevCommitTime = InProcessTimeGenerator.createNewInstantTime();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieCreateHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieCreateHandle.java
@@ -62,7 +62,7 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_FLATTENED_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -79,7 +79,7 @@ import static org.mockito.Mockito.spy;
 public class TestHoodieCreateHandle extends HoodieCommonTestHarness {
   private static final String TEST_INSTANT_TIME = "20231201120000";
   private static final String TEST_FILE_ID = "file-001";
-  private static final HoodieSchema TEST_SCHEMA = HoodieSchema.parse(TRIP_EXAMPLE_SCHEMA);
+  private static final HoodieSchema TEST_SCHEMA = HoodieSchema.parse(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   private static final String TEST_PARTITION_PATH = DEFAULT_FIRST_PARTITION_PATH;
 
   private HoodieWriteConfig writeConfig;
@@ -94,7 +94,7 @@ public class TestHoodieCreateHandle extends HoodieCommonTestHarness {
 
     writeConfig = HoodieWriteConfig.newBuilder()
       .withPath(basePath)
-      .withSchema(TRIP_EXAMPLE_SCHEMA)
+      .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
       .withMarkersType("DIRECT")
       .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
       .build();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/HoodieWriterClientTestHarness.java
@@ -127,7 +127,7 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion.VERSION_0;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.NULL_SCHEMA;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.RAW_TRIPS_TEST_NAME;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
@@ -224,7 +224,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
    * @return Config Builder
    */
   protected HoodieWriteConfig.Builder getConfigBuilder() {
-    return getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+    return getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   }
 
   protected EngineType getEngineType() {
@@ -237,7 +237,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
    * @return Config Builder
    */
   public HoodieWriteConfig.Builder getConfigBuilder(HoodieFailedWritesCleaningPolicy cleaningPolicy) {
-    return getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.SIMPLE, cleaningPolicy);
+    return getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.SIMPLE, cleaningPolicy);
   }
 
   /**
@@ -246,7 +246,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
    * @return Config Builder
    */
   public HoodieWriteConfig.Builder getConfigBuilder(HoodieIndex.IndexType indexType) {
-    return getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, indexType, HoodieFailedWritesCleaningPolicy.EAGER);
+    return getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, indexType, HoodieFailedWritesCleaningPolicy.EAGER);
   }
 
   public HoodieWriteConfig.Builder getConfigBuilder(String schemaStr) {
@@ -496,7 +496,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
    * Build Hoodie Write Config for specified small file sizes.
    */
   protected HoodieWriteConfig getSmallInsertWriteConfig(int insertSplitSize, boolean useNullSchema, long smallFileSize, boolean mergeAllowDuplicateInserts) {
-    String schemaStr = useNullSchema ? NULL_SCHEMA : TRIP_EXAMPLE_SCHEMA;
+    String schemaStr = useNullSchema ? NULL_SCHEMA : TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
     return getSmallInsertWriteConfig(insertSplitSize, schemaStr, smallFileSize, mergeAllowDuplicateInserts);
   }
 
@@ -920,7 +920,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
   protected Pair<Pair<List<HoodieRecord>, List<String>>, Set<HoodieFileGroupId>> testInsertTwoBatches(boolean populateMetaFields, String partitionPath, Properties props, boolean failInlineClustering,
                                                                                                       Function createBrokenClusteringClientFn) throws IOException {
     // create config to not update small files.
-    HoodieWriteConfig config = getSmallInsertWriteConfig(2000, TRIP_EXAMPLE_SCHEMA, 10, false, populateMetaFields,
+    HoodieWriteConfig config = getSmallInsertWriteConfig(2000, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 10, false, populateMetaFields,
             populateMetaFields ? props : getPropertiesForKeyGen());
     return insertTwoBatches(getHoodieWriteClient(config), (BaseHoodieWriteClient) createBrokenClusteringClientFn.apply(config), populateMetaFields, partitionPath, failInlineClustering);
   }
@@ -1026,7 +1026,7 @@ public abstract class HoodieWriterClientTestHarness extends HoodieCommonTestHarn
     final int insertSplitLimit = 100;
     // setup the small file handling params
     HoodieWriteConfig config = getSmallInsertWriteConfig(insertSplitLimit,
-            TRIP_EXAMPLE_SCHEMA, dataGen.getEstimatedFileSizeInBytes(150), populateMetaFields, populateMetaFields
+            TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, dataGen.getEstimatedFileSizeInBytes(150), populateMetaFields, populateMetaFields
                     ? new Properties() : getPropertiesForKeyGen());
     dataGen = new HoodieTestDataGenerator(new String[] {testPartitionPath});
     BaseHoodieWriteClient client = getHoodieWriteClient(config);

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -155,7 +155,7 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.getNextCommitTime;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -1863,7 +1863,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     tableType = HoodieTableType.COPY_ON_WRITE;
     init(tableType);
     context = new HoodieJavaEngineContext(storageConf);
-    HoodieWriteConfig config = getSmallInsertWriteConfigForMDT(2000, TRIP_EXAMPLE_SCHEMA, 10, false);
+    HoodieWriteConfig config = getSmallInsertWriteConfigForMDT(2000, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 10, false);
     HoodieJavaWriteClient client = getHoodieWriteClient(config);
 
     // Write 1 (Bulk insert)
@@ -1892,7 +1892,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
         .withClusteringExecutionStrategyClass(JavaSortAndSizeExecutionStrategy.class.getName())
         .build();
 
-    HoodieWriteConfig newWriteConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig newWriteConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withClusteringConfig(clusteringConfig)
         .withRollbackUsingMarkers(false)
         .build();
@@ -1939,7 +1939,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     tableType = HoodieTableType.COPY_ON_WRITE;
     init(tableType);
     context = new HoodieJavaEngineContext(storageConf);
-    HoodieWriteConfig initialConfig = getSmallInsertWriteConfigForMDT(2000, TRIP_EXAMPLE_SCHEMA, 10, false);
+    HoodieWriteConfig initialConfig = getSmallInsertWriteConfigForMDT(2000, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 10, false);
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withProperties(initialConfig.getProps())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(4).build()).build();
     HoodieJavaWriteClient client = getHoodieWriteClient(config);
@@ -1968,7 +1968,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
         .withClusteringExecutionStrategyClass(JavaSortAndSizeExecutionStrategy.class.getName())
         .build();
 
-    HoodieWriteConfig newWriteConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig newWriteConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withClusteringConfig(clusteringConfig).build();
 
     // trigger clustering

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
@@ -54,7 +54,7 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
 
   @Test
   public void testReadingMORTableWithoutBaseFile() throws Exception {
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build())
         .build();
@@ -92,7 +92,7 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
 
   @Test
   public void testCompactionOnMORTable() throws Exception {
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build())
         .build();
@@ -124,7 +124,7 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
 
   @Test
   public void testAsyncCompactionOnMORTable() throws Exception {
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build())
         .build();

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestJavaCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestJavaCopyOnWriteActionExecutor.java
@@ -70,7 +70,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.createSimpleRecord;
 import static org.apache.hudi.common.testutils.SchemaTestUtil.getSchemaFromResource;
@@ -379,7 +379,7 @@ public class TestJavaCopyOnWriteActionExecutor extends HoodieJavaClientTestHarne
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .withEngineType(EngineType.JAVA)
         .withPath(basePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withStorageConfig(HoodieStorageConfig.newBuilder()
             .parquetMaxFileSize(1000 * 1024).hfileMaxFileSize(1000 * 1024).build())
         .build();

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/TestHoodieMetadataBase.java
@@ -62,7 +62,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.hudi.common.model.WriteOperationType.INSERT;
 import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 
 public class TestHoodieMetadataBase extends HoodieJavaClientTestHarness {
@@ -291,7 +291,7 @@ public class TestHoodieMetadataBase extends HoodieJavaClientTestHarness {
                                                             boolean enableMetrics, boolean useRollbackUsingMarkers,
                                                             boolean validateMetadataPayloadConsistency) {
     Properties properties = new Properties();
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2).withDeleteParallelism(2).withRollbackParallelism(2).withFinalizeWriteParallelism(2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(0)
             .withInlineCompaction(false).withMaxNumDeltaCommitsBeforeCompaction(1).build())

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestMultiFS.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestMultiFS.java
@@ -97,7 +97,7 @@ public class TestMultiFS extends HoodieSparkClientTestHarness {
 
   protected HoodieWriteConfig getHoodieWriteConfig(String basePath) {
     return HoodieWriteConfig.newBuilder().withPath(basePath).withEmbeddedTimelineServerEnabled(true)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2).forTable(TABLE_NAME)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2).forTable(TABLE_NAME)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build())
         .build();
   }
@@ -130,7 +130,8 @@ public class TestMultiFS extends HoodieSparkClientTestHarness {
       // Write generated data to hdfs (only inserts)
       String readCommitTime = hdfsWriteClient.startCommit();
       log.info("Starting commit {}", readCommitTime);
-      List<HoodieRecord> records = dataGen.generateInserts(readCommitTime, 10);
+      List<HoodieRecord> records = dataGen.generateInsertsAsPerSchema(readCommitTime, 10,
+          HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 2);
       JavaRDD<WriteStatus> writeStatusJavaRDD = hdfsWriteClient.upsert(writeRecords, readCommitTime);
       hdfsWriteClient.commit(readCommitTime, writeStatusJavaRDD, Option.empty(), COMMIT_ACTION, Collections.emptyMap(), Option.empty());
@@ -151,7 +152,8 @@ public class TestMultiFS extends HoodieSparkClientTestHarness {
 
       String writeCommitTime = localWriteClient.startCommit();
       log.info("Starting write commit {}", writeCommitTime);
-      List<HoodieRecord> localRecords = dataGen.generateInserts(writeCommitTime, 10);
+      List<HoodieRecord> localRecords = dataGen.generateInsertsAsPerSchema(writeCommitTime, 10,
+          HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
       JavaRDD<HoodieRecord> localWriteRecords = jsc.parallelize(localRecords, 2);
       log.info("Writing to path: {}", tablePath);
       writeStatusJavaRDD = localWriteClient.upsert(localWriteRecords, writeCommitTime);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestMultiFS.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestMultiFS.java
@@ -97,7 +97,7 @@ public class TestMultiFS extends HoodieSparkClientTestHarness {
 
   protected HoodieWriteConfig getHoodieWriteConfig(String basePath) {
     return HoodieWriteConfig.newBuilder().withPath(basePath).withEmbeddedTimelineServerEnabled(true)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2).forTable(TABLE_NAME)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2).forTable(TABLE_NAME)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build())
         .build();
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
@@ -50,7 +50,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.getCommitTimeAtUTC;
 
 /**
@@ -60,7 +60,7 @@ public class TestPartitionTTLManagement extends HoodieClientTestBase {
 
   protected HoodieWriteConfig.Builder getConfigBuilder() {
     return HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().build())
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024 * 1024)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSavepoint.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSavepoint.java
@@ -88,7 +88,8 @@ public class TestSavepoint extends HoodieClientTestBase {
 
       String commitTime1 = "001";
       WriteClientTestUtils.startCommitWithTime(client, commitTime1);
-      List<HoodieRecord> records1 = dataGen.generateInserts(commitTime1, 200);
+      List<HoodieRecord> records1 = dataGen.generateInsertsAsPerSchema(commitTime1, 200,
+          HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
       JavaRDD<HoodieRecord> writeRecords1 = jsc.parallelize(records1, 1);
       List<WriteStatus> statusList = client.upsert(writeRecords1, commitTime1).collect();
       client.commit(commitTime1, jsc.parallelize(statusList), Option.empty(), tableType == HoodieTableType.COPY_ON_WRITE ? COMMIT_ACTION : DELTA_COMMIT_ACTION,
@@ -97,7 +98,8 @@ public class TestSavepoint extends HoodieClientTestBase {
 
       String commitTime2 = "002";
       WriteClientTestUtils.startCommitWithTime(client, commitTime2);
-      List<HoodieRecord> records2 = dataGen.generateInserts(commitTime2, 200);
+      List<HoodieRecord> records2 = dataGen.generateInsertsAsPerSchema(commitTime2, 200,
+          HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
       JavaRDD<HoodieRecord> writeRecords2 = jsc.parallelize(records2, 1);
       statusList = client.upsert(writeRecords2, commitTime2).collect();
       client.commit(commitTime2, jsc.parallelize(statusList), Option.empty(), tableType == HoodieTableType.COPY_ON_WRITE ? COMMIT_ACTION : DELTA_COMMIT_ACTION,
@@ -138,7 +140,7 @@ public class TestSavepoint extends HoodieClientTestBase {
                                            FileSystemViewStorageType storageType) {
     return HoodieWriteConfig.newBuilder()
         .withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
         .withParallelism(2, 2)
         .withBulkInsertParallelism(2)
         .withFinalizeWriteParallelism(2)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSavepoint.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSavepoint.java
@@ -138,7 +138,7 @@ public class TestSavepoint extends HoodieClientTestBase {
                                            FileSystemViewStorageType storageType) {
     return HoodieWriteConfig.newBuilder()
         .withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withBulkInsertParallelism(2)
         .withFinalizeWriteParallelism(2)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
@@ -62,7 +62,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.hudi.common.model.WriteOperationType.INSERT;
 import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 
 @Slf4j
 public class TestHoodieMetadataBase extends HoodieSparkClientTestHarness {
@@ -328,7 +328,7 @@ public class TestHoodieMetadataBase extends HoodieSparkClientTestHarness {
                                                             boolean enableMetrics, boolean useRollbackUsingMarkers,
                                                             boolean validateMetadataPayloadConsistency) {
     Properties properties = new Properties();
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2).withDeleteParallelism(2).withRollbackParallelism(2).withFinalizeWriteParallelism(2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(0)
             .withInlineCompaction(false).withMaxNumDeltaCommitsBeforeCompaction(1).build())

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -267,7 +267,7 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
 
   private HoodieWriteConfig getWriteConfig(int minArchivalCommits, int maxArchivalCommits) throws Exception {
     return HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .retainCommits(1).build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/common/table/log/TestLogReaderUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/common/table/log/TestLogReaderUtils.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -153,7 +153,7 @@ public class TestLogReaderUtils extends SparkClientFunctionalTestHarness {
 
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .withPath(basePath())
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .withInlineCompaction(false)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestRowCustomColumnsSortPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/execution/bulkinsert/TestRowCustomColumnsSortPartitioner.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 
 public class TestRowCustomColumnsSortPartitioner {
 
@@ -37,7 +37,7 @@ public class TestRowCustomColumnsSortPartitioner {
     HoodieWriteConfig writeConfig = HoodieWriteConfig
         .newBuilder()
         .withPath("/")
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withProperties(properties)
         .build();
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieDefaultMergeHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieDefaultMergeHandle.java
@@ -368,7 +368,7 @@ public class TestHoodieDefaultMergeHandle extends HoodieSparkClientTestHarness {
   }
 
   protected HoodieWriteConfig.Builder getConfigBuilder() {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withDeleteParallelism(2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024).build())

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieKeyLocationFetchHandle.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieKeyLocationFetchHandle.java
@@ -59,7 +59,7 @@ import scala.Tuple2;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_SCHEMA_WITH_METADATA_FIELDS;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
 import static org.apache.hudi.common.testutils.Transformations.recordsToPartitionRecordsMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -166,7 +166,7 @@ public class TestHoodieKeyLocationFetchHandle extends HoodieSparkClientTestHarne
   }
 
   public HoodieWriteConfig.Builder getConfigBuilder() {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2).withBulkInsertParallelism(2).withFinalizeWriteParallelism(2).withDeleteParallelism(2)
         .withWriteStatusClass(MetadataMergeWriteStatus.class)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true).build())

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -262,7 +262,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
                                                            boolean archiveProceedBeyondSavepoints) throws Exception {
     init(tableType);
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).withFailedWritesCleaningPolicy(failedWritesCleaningPolicy).build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
             .withTimelineCompactionBatchSize(archiveFilesBatch)
@@ -288,7 +288,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
   public void testArchiveEmptyTable() throws Exception {
     init();
     HoodieWriteConfig cfg =
-        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
             .withParallelism(2, 2).forTable("test-trip-table").build();
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTable table = HoodieSparkTable.create(cfg, context, metaClient);
@@ -995,7 +995,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
   public void testArchiveCommitSavepointNoHole(boolean enableMetadataTable, boolean archiveBeyondSavepoint) throws Exception {
     init();
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .forTable("test-trip-table")
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 5)
             .withArchiveBeyondSavepoint(archiveBeyondSavepoint).build())
@@ -1192,7 +1192,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
   public void testArchiveCommitTimeline(boolean enableMetadataTable) throws Exception {
     init();
     HoodieWriteConfig cfg =
-        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
             .withParallelism(2, 2).forTable("test-trip-table")
             .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
             .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(2, 3).build())
@@ -1243,7 +1243,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
                 .on(true)
                 .withReporterType("INMEMORY")
                 .build())
-            .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+            .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
             .withParallelism(2, 2).forTable("test-trip-table").build();
     HoodieMetrics metrics = new HoodieMetrics(cfg, storage);
     BaseHoodieWriteClient client = getHoodieWriteClient(cfg);
@@ -1436,7 +1436,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     int minInstantsToKeep = 2;
     int maxInstantsToKeep = 10;
     HoodieWriteConfig cfg =
-        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
             .withParallelism(2, 2).forTable("test-trip-table")
             .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
             .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(minInstantsToKeep, maxInstantsToKeep).build())
@@ -1778,7 +1778,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
     init(HoodieTableType.COPY_ON_WRITE);
     // Test configs where metadata table has more aggressive archival configs than the compaction config
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 6).build())
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(1).build())
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
@@ -2335,7 +2335,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
   private HoodieWriteConfig buildECTRTestConfig(int minCommits, int maxCommits, boolean blockArchivalOnCleanECTR) {
     return HoodieWriteConfig.newBuilder()
         .withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
             .archiveCommitsWith(minCommits, maxCommits)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/ClusteringTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/cluster/ClusteringTestUtils.java
@@ -62,7 +62,7 @@ public class ClusteringTestUtils {
   private static final String COUNT_SQL_QUERY_FOR_VALIDATION = "select count(*) from <TABLE_NAME>";
 
   public static HoodieWriteConfig getClusteringConfig(String basePath) {
-    return getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+    return getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   }
 
   public static HoodieWriteConfig getClusteringConfig(String basePath, String schemaStr) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestCopyOnWriteActionExecutor.java
@@ -86,7 +86,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.createSimpleRecord;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -417,7 +417,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase implemen
   @Test
   public void testInsertUpsertWithHoodieAvroPayload() throws Exception {
     HoodieWriteConfig config =
-        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA)
+        HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
             .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
                 .withRemoteServerPort(timelineServicePort).build())
             .withStorageConfig(HoodieStorageConfig.newBuilder()
@@ -462,7 +462,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase implemen
 
   private void testBulkInsertRecords(String bulkInsertMode) {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
-        .withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withBulkInsertParallelism(2).withBulkInsertSortMode(bulkInsertMode).build();
     SparkRDDWriteClient writeClient = getHoodieWriteClient(config);
     String instantTime = writeClient.startCommit();
@@ -488,7 +488,7 @@ public class TestCopyOnWriteActionExecutor extends HoodieClientTestBase implemen
   public void testPartitionMetafileFormat(boolean partitionMetafileUseBaseFormat) throws Exception {
     // By default there is no format specified for partition metafile
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
-        .withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA).build();
+        .withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).build();
     HoodieSparkCopyOnWriteTable table = (HoodieSparkCopyOnWriteTable) HoodieSparkTable.create(config, context, metaClient);
     assertFalse(table.getPartitionMetafileFormat().isPresent());
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkWriteHelper.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/commit/TestSparkWriteHelper.java
@@ -54,7 +54,7 @@ public class TestSparkWriteHelper extends TestWriterHelperBase<HoodieData<Hoodie
         HoodieClientTestUtils.getSparkConfForTest(TestSparkWriteHelper.class.getName()));
     this.context = new HoodieSparkEngineContext(jsc);
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withEmbeddedTimelineServerEnabled(false)
         .build();
     this.table = HoodieSparkTable.create(config, context, metaClient);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
@@ -63,7 +63,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -78,7 +78,7 @@ public class CompactionTestBase extends HoodieClientTestBase {
 
   protected HoodieWriteConfig.Builder getConfigBuilder(Boolean autoCommit, String basePath) {
     return HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().build())
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024 * 1024)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/SparkClientFunctionalTestHarness.java
@@ -91,7 +91,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.RAW_TRIPS_TEST_NAME;
 import static org.apache.hudi.config.HoodieWriteConfig.WRITE_TABLE_VERSION;
 import static org.apache.hudi.testutils.Assertions.assertFileSizesEqual;
@@ -405,7 +405,7 @@ public class SparkClientFunctionalTestHarness implements SparkProvider, HoodieMe
 
   protected HoodieWriteConfig.Builder getConfigBuilder(Boolean autoCommit, Boolean rollbackUsingMarkers, HoodieIndex.IndexType indexType,
       long compactionSmallFileSize, HoodieClusteringConfig clusteringConfig) {
-    return HoodieWriteConfig.newBuilder().withPath(basePath()).withSchema(TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+    return HoodieWriteConfig.newBuilder().withPath(basePath()).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withDeleteParallelism(2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(compactionSmallFileSize)
             .withInlineCompaction(false).withMaxNumDeltaCommitsBeforeCompaction(1).build())

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -101,7 +101,7 @@ import static org.apache.hudi.common.table.HoodieTableConfig.PARTITION_FIELDS;
 import static org.apache.hudi.common.table.HoodieTableConfig.PAYLOAD_CLASS_NAME;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_MODE;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_STRATEGY_ID;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getLogFileListFromFileSlice;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -326,7 +326,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
                             String operation,
                             boolean firstCommit,
                             Map<String, String> writeConfigs) {
-    commitToTable(recordList, operation, firstCommit, writeConfigs, TRIP_EXAMPLE_SCHEMA);
+    commitToTable(recordList, operation, firstCommit, writeConfigs, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   }
 
   public abstract void assertRecordsEqual(HoodieSchema schema, T expected, T actual);
@@ -511,7 +511,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
       schemaEvolutionConfigs.floatToStringSupport = false;
     }
 
-    try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA, 0xDEEF)) {
+    try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 0xDEEF)) {
       dataGen.extendSchemaBeforeEvolution(schemaEvolutionConfigs);
 
       // Write a base file with schema A
@@ -574,7 +574,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
       schemaEvolutionConfigs.floatToStringSupport = false;
     }
 
-    try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA, 0xDEEF)) {
+    try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 0xDEEF)) {
       dataGen.extendSchemaBeforeEvolution(schemaEvolutionConfigs);
 
       // Write a base file with schema A
@@ -629,7 +629,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     }
 
     try (HoodieTestDataGenerator baseFileDataGen =
-             new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA, 0xDEEF)) {
+             new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 0xDEEF)) {
       baseFileDataGen.extendSchemaBeforeEvolution(schemaEvolutionConfigs);
 
       // Write base file with schema A
@@ -675,7 +675,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
         getCommonConfigs(RecordMergeMode.EVENT_TIME_ORDERING, true));
 
     try (HoodieTestDataGenerator baseFileDataGen =
-             new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA, 0xDEEF)) {
+             new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 0xDEEF)) {
       baseFileDataGen.extendSchemaBeforeEvolution(getSchemaEvolutionConfigs());
 
       // Write base file with schema A
@@ -740,7 +740,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
         getCommonConfigs(RecordMergeMode.EVENT_TIME_ORDERING, true));
 
     try (HoodieTestDataGenerator baseFileDataGen =
-             new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA, 0xDEEF)) {
+             new HoodieTestDataGenerator(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 0xDEEF)) {
       baseFileDataGen.extendSchemaBeforeEvolution(getSchemaEvolutionConfigs());
 
       // Write base file with schema A

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -195,8 +195,10 @@ public class HoodieTestDataGenerator implements AutoCloseable {
 
   // Unstructured types fragment: nullable VARIANT, VECTOR (8-dim FLOAT, FIXED-backed) and BLOB.
   // Built from canonical HoodieSchema factories so the avro logicalType metadata stays in sync.
-  // Designated to be the default in TRIP_EXAMPLE_SCHEMA. Tests that cannot yet handle these types
-  // should opt out via TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED until engine support is in place.
+  // Spliced into TRIP_EXAMPLE_SCHEMA so it is the forward-looking default. Existing test infra
+  // continues to use the legacy TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED via the parsed AVRO_SCHEMA /
+  // HOODIE_SCHEMA constants and the no-arg data generator constructor; tests will be migrated
+  // schema-by-schema in follow-up PRs to surface bugs in writer/reader paths.
   public static final String UNSTRUCTURED_TYPES_SCHEMA;
   static {
     String variantType = HoodieSchema.createVariant().toAvroSchema().toString();
@@ -211,20 +213,19 @@ public class HoodieTestDataGenerator implements AutoCloseable {
 
   public static final String TRIP_EXAMPLE_SCHEMA_WITH_PAYLOAD_SPECIFIC_COLS =
       TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA
-          + TIP_NESTED_SCHEMA + UNSTRUCTURED_TYPES_SCHEMA + EXTRA_COL_SCHEMA_FOR_AWS_DMS_PAYLOAD + EXTRA_COL_SCHEMA_FOR_POSTGRES_PAYLOAD + TRIP_SCHEMA_SUFFIX;
-  // Backward-compatible variant without VARIANT/VECTOR/BLOB. To be removed once all tests/engines
-  // can handle the unstructured-types default.
+          + TIP_NESTED_SCHEMA + EXTRA_COL_SCHEMA_FOR_AWS_DMS_PAYLOAD + EXTRA_COL_SCHEMA_FOR_POSTGRES_PAYLOAD + TRIP_SCHEMA_SUFFIX;
+  // Legacy schema without VARIANT/VECTOR/BLOB. Currently aliased by the convenience parsed schemas
+  // (AVRO_SCHEMA, HOODIE_SCHEMA, etc.) so existing tests preserve behavior. Slated for removal
+  // once all tests/engines round-trip the unstructured-types default.
   public static final String TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED =
       TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_EXAMPLE_SCHEMA =
       TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA
           + UNSTRUCTURED_TYPES_SCHEMA + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_EXAMPLE_SCHEMA_EVOLVED_1 =
-      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA
-          + UNSTRUCTURED_TYPES_SCHEMA + EXTRA_COL_SCHEMA1 + TRIP_SCHEMA_SUFFIX;
+      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + EXTRA_COL_SCHEMA1 + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_EXAMPLE_SCHEMA_EVOLVED_2 =
-      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA
-          + UNSTRUCTURED_TYPES_SCHEMA + EXTRA_COL_SCHEMA2 + TRIP_SCHEMA_SUFFIX;
+      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + EXTRA_COL_SCHEMA2 + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_FLATTENED_SCHEMA =
       TRIP_SCHEMA_PREFIX + FARE_FLATTENED_SCHEMA + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_LOGICAL_TYPES_SCHEMA_V6 =
@@ -255,11 +256,12 @@ public class HoodieTestDataGenerator implements AutoCloseable {
       + "{\"name\":\"driver\",\"type\":\"string\"},{\"name\":\"fare\",\"type\":\"double\"},{\"name\": \"_hoodie_is_deleted\", \"type\": \"boolean\", \"default\": false}]}";
 
   public static final String NULL_SCHEMA = Schema.create(Schema.Type.NULL).toString();
-  public static final String TRIP_HIVE_COLUMN_TYPES_NO_UNSTRUCTURED = "bigint,string,string,string,string,string,double,double,double,double,int,bigint,float,binary,int,bigint,decimal(10,6),"
-      + "map<string,string>,struct<amount:double,currency:string>,array<struct<amount:double,currency:string>>,boolean";
-  // Hive-side column types matching TRIP_EXAMPLE_SCHEMA. VARIANT/VECTOR/BLOB are mapped to their
-  // closest Hive analogue: variant -> struct of binaries, vector -> binary, blob -> nested struct.
+  // Hive-side column types matching TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED (the legacy schema currently
+  // backing AVRO_SCHEMA). The unstructured-aware counterpart maps variant -> struct of binaries,
+  // vector -> binary, blob -> nested struct.
   public static final String TRIP_HIVE_COLUMN_TYPES = "bigint,string,string,string,string,string,double,double,double,double,int,bigint,float,binary,int,bigint,decimal(10,6),"
+      + "map<string,string>,struct<amount:double,currency:string>,array<struct<amount:double,currency:string>>,boolean";
+  public static final String TRIP_HIVE_COLUMN_TYPES_WITH_UNSTRUCTURED = "bigint,string,string,string,string,string,double,double,double,double,int,bigint,float,binary,int,bigint,decimal(10,6),"
       + "map<string,string>,struct<amount:double,currency:string>,array<struct<amount:double,currency:string>>,"
       + "struct<value:binary,metadata:binary>,"
       + "binary,"
@@ -267,9 +269,10 @@ public class HoodieTestDataGenerator implements AutoCloseable {
       + "boolean";
 
 
-  public static final Schema AVRO_SCHEMA = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA);
-  public static final Schema AVRO_SCHEMA_NO_UNSTRUCTURED = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
+  public static final Schema AVRO_SCHEMA = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
+  public static final Schema AVRO_SCHEMA_WITH_UNSTRUCTURED = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA);
   public static final HoodieSchema HOODIE_SCHEMA = HoodieSchema.fromAvroSchema(AVRO_SCHEMA);
+  public static final HoodieSchema HOODIE_SCHEMA_WITH_UNSTRUCTURED = HoodieSchema.fromAvroSchema(AVRO_SCHEMA_WITH_UNSTRUCTURED);
   public static final Schema AVRO_SCHEMA_WITH_SPECIFIC_COLUMNS = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA_WITH_PAYLOAD_SPECIFIC_COLS);
   public static final Schema NESTED_AVRO_SCHEMA = new Schema.Parser().parse(TRIP_NESTED_EXAMPLE_SCHEMA);
   public static final HoodieSchema NESTED_SCHEMA = HoodieSchema.fromAvroSchema(NESTED_AVRO_SCHEMA);
@@ -309,7 +312,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   }
 
   public HoodieTestDataGenerator(long seed, String[] partitionPaths, Map<Integer, KeyPartition> keyPartitionMap) {
-    this(TRIP_EXAMPLE_SCHEMA, seed, partitionPaths, keyPartitionMap);
+    this(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, seed, partitionPaths, keyPartitionMap);
   }
 
   public HoodieTestDataGenerator(String schema, long seed, String[] partitionPaths, Map<Integer, KeyPartition> keyPartitionMap) {
@@ -417,7 +420,9 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     if (!isDelete) {
       if (TRIP_FLATTENED_SCHEMA.equals(schemaStr)) {
         return generateRandomValue(key, commitTime, true, timestamp);
-      } else if (TRIP_EXAMPLE_SCHEMA.equals(schemaStr)) {
+      } else if (TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.equals(schemaStr) || TRIP_EXAMPLE_SCHEMA.equals(schemaStr)) {
+        // TRIP_EXAMPLE_SCHEMA currently routes through the legacy AVRO_SCHEMA path. The unstructured
+        // variant will have its own generator added by phase 2 follow-ups.
         return generateRandomValue(key, commitTime, isFlattened, timestamp);
       } else if (TRIP_EXAMPLE_SCHEMA_EVOLVED_1.equals(schemaStr)) {
         return generateRandomValueForSchemaEvolved1(key, commitTime, isFlattened, timestamp);
@@ -441,7 +446,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
         return generatePayloadForLogicalTypesSchemaNoLTSV6(key, commitTime, false, timestamp);
       }
     } else {
-      if (TRIP_EXAMPLE_SCHEMA.equals(schemaStr)) {
+      if (TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.equals(schemaStr) || TRIP_EXAMPLE_SCHEMA.equals(schemaStr)) {
         return generateRandomDeleteValue(key, commitTime, timestamp);
       } else if (TRIP_LOGICAL_TYPES_SCHEMA.equals(schemaStr)) {
         return generatePayloadForLogicalTypesSchema(key, commitTime, true, timestamp);

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -192,15 +192,39 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   public static final String EXTRA_COL_SCHEMA2 = "{\"name\": \"extra_column2\", \"type\": [\"null\", \"string\"], \"default\": null},";
   public static final String EXTRA_COL_SCHEMA_FOR_AWS_DMS_PAYLOAD = "{\"name\": \"Op\", \"type\": [\"null\", \"string\"], \"default\": null},";
   public static final String EXTRA_COL_SCHEMA_FOR_POSTGRES_PAYLOAD = "{\"name\": \"_event_lsn\", \"type\": [\"null\", \"long\"], \"default\": null},";
+
+  // Unstructured types fragment: nullable VARIANT, VECTOR (8-dim FLOAT, FIXED-backed) and BLOB.
+  // Built from canonical HoodieSchema factories so the avro logicalType metadata stays in sync.
+  // Designated to be the default in TRIP_EXAMPLE_SCHEMA. Tests that cannot yet handle these types
+  // should opt out via TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED until engine support is in place.
+  public static final String UNSTRUCTURED_TYPES_SCHEMA;
+  static {
+    String variantType = HoodieSchema.createVariant().toAvroSchema().toString();
+    String vectorType =
+        HoodieSchema.createVector(8, HoodieSchema.Vector.VectorElementType.FLOAT).toAvroSchema().toString();
+    String blobType = HoodieSchema.createBlob().toAvroSchema().toString();
+    UNSTRUCTURED_TYPES_SCHEMA =
+        "{\"name\":\"variant_data\",\"type\":[\"null\"," + variantType + "],\"default\":null},"
+            + "{\"name\":\"embedding\",\"type\":[\"null\"," + vectorType + "],\"default\":null},"
+            + "{\"name\":\"blob_data\",\"type\":[\"null\"," + blobType + "],\"default\":null},";
+  }
+
   public static final String TRIP_EXAMPLE_SCHEMA_WITH_PAYLOAD_SPECIFIC_COLS =
       TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA
-          + TIP_NESTED_SCHEMA + EXTRA_COL_SCHEMA_FOR_AWS_DMS_PAYLOAD + EXTRA_COL_SCHEMA_FOR_POSTGRES_PAYLOAD + TRIP_SCHEMA_SUFFIX;
-  public static final String TRIP_EXAMPLE_SCHEMA =
+          + TIP_NESTED_SCHEMA + UNSTRUCTURED_TYPES_SCHEMA + EXTRA_COL_SCHEMA_FOR_AWS_DMS_PAYLOAD + EXTRA_COL_SCHEMA_FOR_POSTGRES_PAYLOAD + TRIP_SCHEMA_SUFFIX;
+  // Backward-compatible variant without VARIANT/VECTOR/BLOB. To be removed once all tests/engines
+  // can handle the unstructured-types default.
+  public static final String TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED =
       TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;
+  public static final String TRIP_EXAMPLE_SCHEMA =
+      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA
+          + UNSTRUCTURED_TYPES_SCHEMA + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_EXAMPLE_SCHEMA_EVOLVED_1 =
-      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + EXTRA_COL_SCHEMA1 + TRIP_SCHEMA_SUFFIX;
+      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA
+          + UNSTRUCTURED_TYPES_SCHEMA + EXTRA_COL_SCHEMA1 + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_EXAMPLE_SCHEMA_EVOLVED_2 =
-      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + EXTRA_COL_SCHEMA2 + TRIP_SCHEMA_SUFFIX;
+      TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA
+          + UNSTRUCTURED_TYPES_SCHEMA + EXTRA_COL_SCHEMA2 + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_FLATTENED_SCHEMA =
       TRIP_SCHEMA_PREFIX + FARE_FLATTENED_SCHEMA + TRIP_SCHEMA_SUFFIX;
   public static final String TRIP_LOGICAL_TYPES_SCHEMA_V6 =
@@ -231,11 +255,20 @@ public class HoodieTestDataGenerator implements AutoCloseable {
       + "{\"name\":\"driver\",\"type\":\"string\"},{\"name\":\"fare\",\"type\":\"double\"},{\"name\": \"_hoodie_is_deleted\", \"type\": \"boolean\", \"default\": false}]}";
 
   public static final String NULL_SCHEMA = Schema.create(Schema.Type.NULL).toString();
-  public static final String TRIP_HIVE_COLUMN_TYPES = "bigint,string,string,string,string,string,double,double,double,double,int,bigint,float,binary,int,bigint,decimal(10,6),"
+  public static final String TRIP_HIVE_COLUMN_TYPES_NO_UNSTRUCTURED = "bigint,string,string,string,string,string,double,double,double,double,int,bigint,float,binary,int,bigint,decimal(10,6),"
       + "map<string,string>,struct<amount:double,currency:string>,array<struct<amount:double,currency:string>>,boolean";
+  // Hive-side column types matching TRIP_EXAMPLE_SCHEMA. VARIANT/VECTOR/BLOB are mapped to their
+  // closest Hive analogue: variant -> struct of binaries, vector -> binary, blob -> nested struct.
+  public static final String TRIP_HIVE_COLUMN_TYPES = "bigint,string,string,string,string,string,double,double,double,double,int,bigint,float,binary,int,bigint,decimal(10,6),"
+      + "map<string,string>,struct<amount:double,currency:string>,array<struct<amount:double,currency:string>>,"
+      + "struct<value:binary,metadata:binary>,"
+      + "binary,"
+      + "struct<type:string,data:binary,reference:struct<external_path:string,offset:bigint,length:bigint,managed:boolean>>,"
+      + "boolean";
 
 
   public static final Schema AVRO_SCHEMA = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA);
+  public static final Schema AVRO_SCHEMA_NO_UNSTRUCTURED = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   public static final HoodieSchema HOODIE_SCHEMA = HoodieSchema.fromAvroSchema(AVRO_SCHEMA);
   public static final Schema AVRO_SCHEMA_WITH_SPECIFIC_COLUMNS = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA_WITH_PAYLOAD_SPECIFIC_COLS);
   public static final Schema NESTED_AVRO_SCHEMA = new Schema.Parser().parse(TRIP_NESTED_EXAMPLE_SCHEMA);
@@ -470,6 +503,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     generateMapTypeValues(rec);
     generateFareNestedValues(rec);
     generateTipNestedValues(rec);
+    generateUnstructuredTypeValues(rec);
 
     // Add the evolved column
     rec.put("extra_column1", "extra_value_" + instantTime);
@@ -633,6 +667,52 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   }
 
   /**
+   * Populate rec with values for UNSTRUCTURED_TYPES_SCHEMA: variant_data, embedding (vector), blob_data.
+   * Skips fields that are not declared in the record's schema, so callers can safely invoke this on
+   * legacy schemas without unstructured fields.
+   */
+  private void generateUnstructuredTypeValues(GenericRecord rec) {
+    Schema schema = rec.getSchema();
+    if (schema.getField("variant_data") != null) {
+      Schema variantSchema = unwrapNullableSchema(schema.getField("variant_data").schema());
+      GenericRecord variantValue = new GenericData.Record(variantSchema);
+      // Minimal valid variant binary: metadata header v1 with no shredded fields, value = primitive null.
+      variantValue.put("metadata", ByteBuffer.wrap(new byte[]{0x01, 0x00, 0x00}));
+      variantValue.put("value", ByteBuffer.wrap(new byte[]{0x00}));
+      rec.put("variant_data", variantValue);
+    }
+    if (schema.getField("embedding") != null) {
+      Schema vectorSchema = unwrapNullableSchema(schema.getField("embedding").schema());
+      byte[] vectorBytes = new byte[vectorSchema.getFixedSize()];
+      ByteBuffer bb = ByteBuffer.wrap(vectorBytes).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+      while (bb.remaining() >= 4) {
+        bb.putFloat(rand.nextFloat());
+      }
+      rec.put("embedding", GenericData.get().createFixed(null, vectorBytes, vectorSchema));
+    }
+    if (schema.getField("blob_data") != null) {
+      Schema blobSchema = unwrapNullableSchema(schema.getField("blob_data").schema());
+      GenericRecord blobValue = new GenericData.Record(blobSchema);
+      Schema typeEnumSchema = unwrapNullableSchema(blobSchema.getField("type").schema());
+      blobValue.put("type", new GenericData.EnumSymbol(typeEnumSchema, "INLINE"));
+      blobValue.put("data", ByteBuffer.wrap(getUTF8Bytes("blob payload")));
+      blobValue.put("reference", null);
+      rec.put("blob_data", blobValue);
+    }
+  }
+
+  private static Schema unwrapNullableSchema(Schema schema) {
+    if (schema.getType() == Schema.Type.UNION) {
+      for (Schema s : schema.getTypes()) {
+        if (s.getType() != Schema.Type.NULL) {
+          return s;
+        }
+      }
+    }
+    return schema;
+  }
+
+  /**
    * Populate rec with values for TIP_NESTED_SCHEMA
    */
   private void generateTipNestedValues(GenericRecord rec) {
@@ -677,6 +757,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
       generateMapTypeValues(rec);
       generateFareNestedValues(rec);
       generateTipNestedValues(rec);
+      generateUnstructuredTypeValues(rec);
     }
     generateCustomValues(rec, "customField");
     generateTripSuffixValues(rec, isDeleteRecord);
@@ -697,6 +778,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     generateMapTypeValues(rec);
     generateFareNestedValues(rec);
     generateTipNestedValues(rec);
+    generateUnstructuredTypeValues(rec);
     generateOpColumnValue(rec);
     generateEventLSNValue(rec);
     generateTripSuffixValues(rec, false);

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -420,10 +420,10 @@ public class HoodieTestDataGenerator implements AutoCloseable {
     if (!isDelete) {
       if (TRIP_FLATTENED_SCHEMA.equals(schemaStr)) {
         return generateRandomValue(key, commitTime, true, timestamp);
-      } else if (TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.equals(schemaStr) || TRIP_EXAMPLE_SCHEMA.equals(schemaStr)) {
-        // TRIP_EXAMPLE_SCHEMA currently routes through the legacy AVRO_SCHEMA path. The unstructured
-        // variant will have its own generator added by phase 2 follow-ups.
+      } else if (TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.equals(schemaStr)) {
         return generateRandomValue(key, commitTime, isFlattened, timestamp);
+      } else if (TRIP_EXAMPLE_SCHEMA.equals(schemaStr)) {
+        return generatePayloadForUnstructuredSchema(key, commitTime, timestamp);
       } else if (TRIP_EXAMPLE_SCHEMA_EVOLVED_1.equals(schemaStr)) {
         return generateRandomValueForSchemaEvolved1(key, commitTime, isFlattened, timestamp);
       } else if (TRIP_ENCODED_DECIMAL_SCHEMA.equals(schemaStr)) {
@@ -446,8 +446,13 @@ public class HoodieTestDataGenerator implements AutoCloseable {
         return generatePayloadForLogicalTypesSchemaNoLTSV6(key, commitTime, false, timestamp);
       }
     } else {
-      if (TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.equals(schemaStr) || TRIP_EXAMPLE_SCHEMA.equals(schemaStr)) {
+      if (TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.equals(schemaStr)) {
         return generateRandomDeleteValue(key, commitTime, timestamp);
+      } else if (TRIP_EXAMPLE_SCHEMA.equals(schemaStr)) {
+        // delete record uses the same with-unstructured payload shape; the writer reuses
+        // _hoodie_is_deleted on the legacy path.
+        return generateRecordForUnstructuredSchema(key.getRecordKey(), key.getPartitionPath(),
+            "rider-" + commitTime, "driver-" + commitTime, timestamp, true);
       } else if (TRIP_LOGICAL_TYPES_SCHEMA.equals(schemaStr)) {
         return generatePayloadForLogicalTypesSchema(key, commitTime, true, timestamp);
       } else if (TRIP_LOGICAL_TYPES_SCHEMA_V6.equals(schemaStr)) {
@@ -548,6 +553,33 @@ public class HoodieTestDataGenerator implements AutoCloseable {
 
   public IndexedRecord generatePayloadForLogicalTypesSchemaV6(HoodieKey key, String commitTime, boolean isDelete, long timestamp) {
     return generateRecordForTripLogicalTypesSchema(key, "rider-" + commitTime, "driver-" + commitTime, timestamp, isDelete, true, true);
+  }
+
+  /**
+   * Generates a new avro record with TRIP_EXAMPLE_SCHEMA (the unstructured-types default).
+   */
+  public IndexedRecord generatePayloadForUnstructuredSchema(HoodieKey key, String commitTime, long timestamp) {
+    return generateRecordForUnstructuredSchema(key.getRecordKey(), key.getPartitionPath(),
+        "rider-" + commitTime, "driver-" + commitTime, timestamp, false);
+  }
+
+  /**
+   * Build a TRIP_EXAMPLE_SCHEMA (with unstructured types) record. Reuses the legacy field helpers,
+   * which are tolerant to having a different but structurally compatible Schema object on the
+   * outer record.
+   */
+  public GenericRecord generateRecordForUnstructuredSchema(String rowKey, String partitionPath,
+                                                            String riderName, String driverName,
+                                                            long timestamp, boolean isDeleteRecord) {
+    GenericRecord rec = new GenericData.Record(AVRO_SCHEMA_WITH_UNSTRUCTURED);
+    generateTripPrefixValues(rec, rowKey, partitionPath, riderName, driverName, timestamp);
+    generateExtraSchemaValues(rec);
+    generateMapTypeValues(rec);
+    generateFareNestedValues(rec);
+    generateTipNestedValues(rec);
+    generateUnstructuredTypeValues(rec);
+    generateTripSuffixValues(rec, isDeleteRecord);
+    return rec;
   }
 
   /**
@@ -747,7 +779,7 @@ public class HoodieTestDataGenerator implements AutoCloseable {
   }
 
   /**
-   * Generate record conforming to TRIP_EXAMPLE_SCHEMA or TRIP_FLATTENED_SCHEMA if isFlattened is true
+   * Generate record conforming to TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED or TRIP_FLATTENED_SCHEMA if isFlattened is true
    */
   public GenericRecord generateGenericRecord(String rowKey, String partitionPath, String riderName, String driverName,
                                              long timestamp, boolean isDeleteRecord,
@@ -1108,7 +1140,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
   }
 
   /**
-   * Generates new inserts for TRIP_EXAMPLE_SCHEMA with nested schema, uniformly across the partition paths above.
+   * Generates new inserts for TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED with nested schema, uniformly across the partition paths above.
    * It also updates the list of existing keys.
    */
   public List<HoodieRecord> generateInserts(String instantTime, Integer n) {
@@ -1116,7 +1148,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
   }
 
   public List<HoodieRecord> generateInserts(String instantTime, Integer n, long timestamp) {
-    return generateInsertsStream(instantTime, n, false, TRIP_EXAMPLE_SCHEMA, timestamp).collect(Collectors.toList());
+    return generateInsertsStream(instantTime, n, false, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, timestamp).collect(Collectors.toList());
   }
 
   public List<HoodieRecord> generateInsertsNestedExample(String instantTime, Integer n) {
@@ -1133,7 +1165,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
    * @return  List of {@link HoodieRecord}s
    */
   public List<HoodieRecord> generateInserts(String instantTime, Integer n, boolean isFlattened) {
-    return generateInsertsStream(instantTime, n, isFlattened, isFlattened ? TRIP_FLATTENED_SCHEMA : TRIP_EXAMPLE_SCHEMA, System.currentTimeMillis()).collect(Collectors.toList());
+    return generateInsertsStream(instantTime, n, isFlattened, isFlattened ? TRIP_FLATTENED_SCHEMA : TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, System.currentTimeMillis()).collect(Collectors.toList());
   }
 
   /**
@@ -1148,7 +1180,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
       throw new HoodieIOException("n must greater then partitionPaths length");
     }
     long timestamp = System.currentTimeMillis();
-    return generateInsertsStream(instantTime,  n, false, TRIP_EXAMPLE_SCHEMA, true, timestamp).collect(Collectors.toList());
+    return generateInsertsStream(instantTime,  n, false, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, true, timestamp).collect(Collectors.toList());
   }
 
   public List<HoodieRecord> generateInsertsForPartitionPerSchema(String instantTime, Integer n, String partition, String schemaStr) {
@@ -1158,7 +1190,8 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
 
   public List<HoodieRecord> generateInsertsForPartition(String instantTime, Integer n, String partition) {
     long timestamp = System.currentTimeMillis();
-    return generateInsertsStream(instantTime,  n, false, TRIP_EXAMPLE_SCHEMA, false, () -> partition, () -> genPseudoRandomUUID(rand).toString(), timestamp).collect(Collectors.toList());
+    return generateInsertsStream(instantTime,  n, false, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, false,
+        () -> partition, () -> genPseudoRandomUUID(rand).toString(), timestamp).collect(Collectors.toList());
   }
 
   public Stream<HoodieRecord> generateInsertsStream(String commitTime, Integer n, boolean isFlattened, String schemaStr, boolean containsAllPartitions, long timestamp) {
@@ -1301,7 +1334,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
   }
 
   public List<HoodieRecord> generateUpdates(String instantTime, Integer n) throws IOException {
-    return generateUpdates(instantTime, n, TRIP_EXAMPLE_SCHEMA);
+    return generateUpdates(instantTime, n, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   }
 
   /**
@@ -1332,7 +1365,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
    */
   public List<HoodieRecord> generateUpdatesForAllRecords(String instantTime) {
     List<HoodieRecord> updates = new ArrayList<>();
-    Map<Integer, KeyPartition> existingKeys = existingKeysBySchema.get(TRIP_EXAMPLE_SCHEMA);
+    Map<Integer, KeyPartition> existingKeys = existingKeysBySchema.get(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     existingKeys.values().forEach(kp -> {
       try {
         HoodieRecord record = generateUpdateRecord(kp.key, instantTime);
@@ -1356,11 +1389,11 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
    * @return list of hoodie record updates
    */
   public List<HoodieRecord> generateUniqueUpdates(String instantTime, Integer n) {
-    return generateUniqueUpdatesStream(instantTime, n, TRIP_EXAMPLE_SCHEMA).collect(Collectors.toList());
+    return generateUniqueUpdatesStream(instantTime, n, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).collect(Collectors.toList());
   }
 
   public List<HoodieRecord> generateUniqueUpdates(String instantTime, Integer n, long timestamp) {
-    return generateUniqueUpdatesStream(instantTime, n, TRIP_EXAMPLE_SCHEMA, timestamp).collect(Collectors.toList());
+    return generateUniqueUpdatesStream(instantTime, n, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, timestamp).collect(Collectors.toList());
   }
 
   public List<HoodieRecord> generateUniqueUpdates(String instantTime, Integer n, String schemaStr) {
@@ -1435,8 +1468,8 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
    */
   public Stream<HoodieKey> generateUniqueDeleteStream(Integer n) {
     final Set<KeyPartition> used = new HashSet<>();
-    Map<Integer, KeyPartition> existingKeys = existingKeysBySchema.get(TRIP_EXAMPLE_SCHEMA);
-    Integer numExistingKeys = numKeysBySchema.get(TRIP_EXAMPLE_SCHEMA);
+    Map<Integer, KeyPartition> existingKeys = existingKeysBySchema.get(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
+    Integer numExistingKeys = numKeysBySchema.get(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     if (n > numExistingKeys) {
       throw new IllegalArgumentException("Requested unique deletes is greater than number of available keys");
     }
@@ -1454,7 +1487,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
       used.add(kp);
       result.add(kp.key);
     }
-    numKeysBySchema.put(TRIP_EXAMPLE_SCHEMA, numExistingKeys);
+    numKeysBySchema.put(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, numExistingKeys);
     return result.stream();
   }
 
@@ -1468,7 +1501,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
    * @return stream of hoodie records for delete
    */
   private Stream<HoodieRecord> generateUniqueDeleteRecordStream(String instantTime, Integer n, boolean updatePartition, long timestamp) {
-    return generateUniqueDeleteRecordStream(instantTime, n, updatePartition, TRIP_EXAMPLE_SCHEMA, timestamp);
+    return generateUniqueDeleteRecordStream(instantTime, n, updatePartition, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, timestamp);
   }
 
   public Stream<HoodieRecord> generateUniqueDeleteRecordStream(String instantTime, Integer n, boolean updatePartition, String schemaStr, long timestamp) {
@@ -1531,15 +1564,15 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
   }
 
   public boolean deleteExistingKeyIfPresent(HoodieKey key) {
-    Map<Integer, KeyPartition> existingKeys = existingKeysBySchema.get(TRIP_EXAMPLE_SCHEMA);
-    Integer numExistingKeys = numKeysBySchema.get(TRIP_EXAMPLE_SCHEMA);
+    Map<Integer, KeyPartition> existingKeys = existingKeysBySchema.get(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
+    Integer numExistingKeys = numKeysBySchema.get(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     for (Map.Entry<Integer, KeyPartition> entry : existingKeys.entrySet()) {
       if (entry.getValue().key.equals(key)) {
         int index = entry.getKey();
         existingKeys.put(index, existingKeys.get(numExistingKeys - 1));
         existingKeys.remove(numExistingKeys - 1);
         numExistingKeys--;
-        numKeysBySchema.put(TRIP_EXAMPLE_SCHEMA, numExistingKeys);
+        numKeysBySchema.put(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, numExistingKeys);
         return true;
       }
     }
@@ -1562,7 +1595,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
   }
 
   public List<String> getExistingKeys() {
-    return getExistingKeys(TRIP_EXAMPLE_SCHEMA);
+    return getExistingKeys(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   }
 
   public List<String> getExistingKeys(String schemaStr) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestHoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestHoodieTestDataGenerator.java
@@ -22,7 +22,6 @@ package org.apache.hudi.common.testutils;
 import org.apache.hudi.common.model.HoodieKey;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.Test;
 
@@ -33,16 +32,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * Validates that {@link HoodieTestDataGenerator} populates the unstructured-type columns
- * (VARIANT/VECTOR/BLOB) by default, while still supporting the legacy
- * {@code TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED} fallback for tests that have not yet been
- * migrated.
+ * Validates that {@link HoodieTestDataGenerator} exposes the unstructured-types schema as a
+ * forward-looking opt-in (via {@code TRIP_EXAMPLE_SCHEMA} / {@code AVRO_SCHEMA_WITH_UNSTRUCTURED}),
+ * while {@code AVRO_SCHEMA} and the no-arg constructor stay on the legacy
+ * {@code TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED} until tests are migrated by follow-up PRs.
  */
 class TestHoodieTestDataGenerator {
 
   @Test
-  void defaultSchemaIncludesUnstructuredTypes() {
+  void defaultAvroSchemaIsLegacyAndOmitsUnstructuredTypes() {
     Schema schema = HoodieTestDataGenerator.AVRO_SCHEMA;
+    assertNull(schema.getField("variant_data"));
+    assertNull(schema.getField("embedding"));
+    assertNull(schema.getField("blob_data"));
+  }
+
+  @Test
+  void unstructuredAvroSchemaCarriesAllThreeLogicalTypes() {
+    Schema schema = HoodieTestDataGenerator.AVRO_SCHEMA_WITH_UNSTRUCTURED;
+
     Schema variantField = unwrap(schema.getField("variant_data").schema());
     assertEquals(Schema.Type.RECORD, variantField.getType());
     assertEquals("variant", variantField.getLogicalType().getName());
@@ -57,32 +65,15 @@ class TestHoodieTestDataGenerator {
   }
 
   @Test
-  void defaultRecordsHaveUnstructuredFieldsPopulated() {
+  void defaultRecordsKeepLegacyShape() {
     HoodieTestDataGenerator gen = new HoodieTestDataGenerator(0L);
     HoodieKey key = new HoodieKey(UUID.randomUUID().toString(), HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
     GenericRecord rec = (GenericRecord) gen.generateRandomValue(key, "001");
 
-    Object variant = rec.get("variant_data");
-    assertNotNull(variant);
-    assertEquals(Schema.Type.RECORD, ((GenericRecord) variant).getSchema().getType());
-
-    Object embedding = rec.get("embedding");
-    assertNotNull(embedding);
-    assertEquals(8 * Float.BYTES, ((GenericData.Fixed) embedding).bytes().length);
-
-    GenericRecord blob = (GenericRecord) rec.get("blob_data");
-    assertNotNull(blob);
-    assertEquals("INLINE", blob.get("type").toString());
-    assertNotNull(blob.get("data"));
-    assertNull(blob.get("reference"));
-  }
-
-  @Test
-  void legacySchemaOmitsUnstructuredTypes() {
-    Schema schema = HoodieTestDataGenerator.AVRO_SCHEMA_NO_UNSTRUCTURED;
-    assertNull(schema.getField("variant_data"));
-    assertNull(schema.getField("embedding"));
-    assertNull(schema.getField("blob_data"));
+    assertNotNull(rec.get("fare"));
+    assertNull(rec.getSchema().getField("variant_data"));
+    assertNull(rec.getSchema().getField("embedding"));
+    assertNull(rec.getSchema().getField("blob_data"));
   }
 
   private static Schema unwrap(Schema s) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestHoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestHoodieTestDataGenerator.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.testutils;
+
+import org.apache.hudi.common.model.HoodieKey;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Validates that {@link HoodieTestDataGenerator} populates the unstructured-type columns
+ * (VARIANT/VECTOR/BLOB) by default, while still supporting the legacy
+ * {@code TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED} fallback for tests that have not yet been
+ * migrated.
+ */
+class TestHoodieTestDataGenerator {
+
+  @Test
+  void defaultSchemaIncludesUnstructuredTypes() {
+    Schema schema = HoodieTestDataGenerator.AVRO_SCHEMA;
+    Schema variantField = unwrap(schema.getField("variant_data").schema());
+    assertEquals(Schema.Type.RECORD, variantField.getType());
+    assertEquals("variant", variantField.getLogicalType().getName());
+
+    Schema vectorField = unwrap(schema.getField("embedding").schema());
+    assertEquals(Schema.Type.FIXED, vectorField.getType());
+    assertEquals("vector", vectorField.getLogicalType().getName());
+
+    Schema blobField = unwrap(schema.getField("blob_data").schema());
+    assertEquals(Schema.Type.RECORD, blobField.getType());
+    assertEquals("blob", blobField.getLogicalType().getName());
+  }
+
+  @Test
+  void defaultRecordsHaveUnstructuredFieldsPopulated() {
+    HoodieTestDataGenerator gen = new HoodieTestDataGenerator(0L);
+    HoodieKey key = new HoodieKey(UUID.randomUUID().toString(), HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH);
+    GenericRecord rec = (GenericRecord) gen.generateRandomValue(key, "001");
+
+    Object variant = rec.get("variant_data");
+    assertNotNull(variant);
+    assertEquals(Schema.Type.RECORD, ((GenericRecord) variant).getSchema().getType());
+
+    Object embedding = rec.get("embedding");
+    assertNotNull(embedding);
+    assertEquals(8 * Float.BYTES, ((GenericData.Fixed) embedding).bytes().length);
+
+    GenericRecord blob = (GenericRecord) rec.get("blob_data");
+    assertNotNull(blob);
+    assertEquals("INLINE", blob.get("type").toString());
+    assertNotNull(blob.get("data"));
+    assertNull(blob.get("reference"));
+  }
+
+  @Test
+  void legacySchemaOmitsUnstructuredTypes() {
+    Schema schema = HoodieTestDataGenerator.AVRO_SCHEMA_NO_UNSTRUCTURED;
+    assertNull(schema.getField("variant_data"));
+    assertNull(schema.getField("embedding"));
+    assertNull(schema.getField("blob_data"));
+  }
+
+  private static Schema unwrap(Schema s) {
+    if (s.getType() != Schema.Type.UNION) {
+      return s;
+    }
+    for (Schema branch : s.getTypes()) {
+      if (branch.getType() != Schema.Type.NULL) {
+        return branch;
+      }
+    }
+    throw new IllegalStateException("union has no non-null branch: " + s);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.model.WriteOperationType.INSERT;
 import static org.apache.hudi.common.model.WriteOperationType.UPSERT;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -278,7 +278,7 @@ public class TestHoodieFileGroupReaderOnFlink extends TestHoodieFileGroupReaderB
     try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEEF)) {
       // One commit; reading one file group containing a log file only
       List<HoodieRecord> initialRecords = dataGen.generateInserts("001", 100);
-      commitToTable(initialRecords, UPSERT.value(), true, writeConfigs, TRIP_EXAMPLE_SCHEMA);
+      commitToTable(initialRecords, UPSERT.value(), true, writeConfigs, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
       String[] orderingFields = recordMergeMode == RecordMergeMode.COMMIT_TIME_ORDERING ? new String[0] : new String[] {ORDERING_FIELD_NAME};
       validateOutputFromFileGroupReader(
           getStorageConf(), getBasePath(), false, 1, recordMergeMode,
@@ -287,7 +287,7 @@ public class TestHoodieFileGroupReaderOnFlink extends TestHoodieFileGroupReaderB
       // Two commits; reading one file group containing two log files
       List<HoodieRecord> updates = dataGen.generateUniqueUpdates("002", 50);
       List<HoodieRecord> allRecords = mergeRecordLists(updates, initialRecords);
-      commitToTable(updates, UPSERT.value(), false, writeConfigs, TRIP_EXAMPLE_SCHEMA);
+      commitToTable(updates, UPSERT.value(), false, writeConfigs, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
       validateOutputFromFileGroupReader(
           getStorageConf(), getBasePath(), false, 2, recordMergeMode,
           allRecords, CollectionUtils.combine(initialRecords, updates), orderingFields);
@@ -304,7 +304,7 @@ public class TestHoodieFileGroupReaderOnFlink extends TestHoodieFileGroupReaderB
     try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEEF)) {
       // One commit; reading one file group containing a log file only
       List<HoodieRecord> initialRecords = dataGen.generateInserts("001", 100);
-      commitToTable(initialRecords, firstCommitOperation.value(), true, writeConfigs, TRIP_EXAMPLE_SCHEMA);
+      commitToTable(initialRecords, firstCommitOperation.value(), true, writeConfigs, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
       validateOutputFromFileGroupReader(
           getStorageConf(), getBasePath(), isFirstCommitInsert,
           isFirstCommitInsert ? 0 : 1, recordMergeMode, initialRecords, initialRecords, new String[] {ORDERING_FIELD_NAME});
@@ -315,7 +315,7 @@ public class TestHoodieFileGroupReaderOnFlink extends TestHoodieFileGroupReaderB
 
       // the base/log file of the first commit is filtered out by the instant range.
       List<HoodieRecord> updates = dataGen.generateUniqueUpdates("002", 50);
-      commitToTable(updates, UPSERT.value(), false, writeConfigs, TRIP_EXAMPLE_SCHEMA);
+      commitToTable(updates, UPSERT.value(), false, writeConfigs, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
       validateOutputFromFileGroupReader(getStorageConf(), getBasePath(),
           isFirstCommitInsert, isFirstCommitInsert ? 1 : 2, recordMergeMode, updates, updates, new String[] {ORDERING_FIELD_NAME});
       // reset instant range

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
@@ -83,7 +83,7 @@ class TestTableSchemaResolver {
 
   @Test
   void testRecreateSchemaWhenDropPartitionColumns() {
-    HoodieSchema originSchema = HoodieSchema.parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA);
+    HoodieSchema originSchema = HoodieSchema.parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
 
     // case2
     String[] pts1 = new String[0];

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestAvroOrcUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestAvroOrcUtils.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_SCHEMA;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class TestAvroOrcUtils extends HoodieCommonTestHarness {
 
-  public static final TypeDescription ORC_SCHEMA = AvroOrcUtils.createOrcSchema(HoodieSchema.parse(TRIP_EXAMPLE_SCHEMA));
+  public static final TypeDescription ORC_SCHEMA = AvroOrcUtils.createOrcSchema(HoodieSchema.parse(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED));
   public static final TypeDescription ORC_TRIP_SCHEMA = AvroOrcUtils.createOrcSchema(HoodieSchema.parse(TRIP_SCHEMA));
 
   public static List<Arguments> testCreateOrcSchemaArgs() {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -73,7 +73,7 @@ import static org.apache.hudi.avro.TestHoodieAvroUtils.SCHEMA_WITH_AVRO_TYPES_ST
 import static org.apache.hudi.avro.TestHoodieAvroUtils.SCHEMA_WITH_NESTED_FIELD_STR;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_SCHEMA_WITH_METADATA_FIELDS;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.metadata.HoodieIndexVersion.V1;
 import static org.apache.hudi.metadata.HoodieIndexVersion.V2;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.computeRevivedAndDeletedKeys;
@@ -184,7 +184,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     String instant = "20230918120000000";
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     commitMetadata.setOperationType(WriteOperationType.INSERT);
-    commitMetadata.addMetadata(HoodieCommitMetadata.SCHEMA_KEY, TRIP_EXAMPLE_SCHEMA);
+    commitMetadata.addMetadata(HoodieCommitMetadata.SCHEMA_KEY, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     hoodieTestTable = hoodieTestTable.addCommit(instant, Option.of(commitMetadata));
     Set<String> recordKeys = new HashSet<>();
     final List<Pair<String, FileSlice>> partitionFileSlicePairs = new ArrayList<>();

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/reader/TestDFSHoodieDatasetInputReader.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/reader/TestDFSHoodieDatasetInputReader.java
@@ -123,7 +123,7 @@ public class TestDFSHoodieDatasetInputReader extends UtilitiesTestBase {
         .withParallelism(2, 2)
         .withDeleteParallelism(2)
         .withSchema(HoodieTestDataGenerator
-            .TRIP_EXAMPLE_SCHEMA);
+            .TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   }
 
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/testutils/SparkDatasetTestUtils.java
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/java/org/apache/hudi/testutils/SparkDatasetTestUtils.java
@@ -224,7 +224,7 @@ public class SparkDatasetTestUtils {
   }
 
   public static HoodieWriteConfig.Builder getConfigBuilder(String basePath, int timelineServicePort) {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withPopulateMetaFields(true)
         .withParallelism(2, 2)
         .withDeleteParallelism(2)

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -119,7 +119,7 @@ import static org.apache.hudi.common.config.LockConfiguration.ZK_SESSION_TIMEOUT
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_EVOLVED_1;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_EVOLVED_2;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -205,7 +205,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     Object[][] data =
         new Object[][] {
             // First element set to true means before testing anything, we make a commit
-            // with schema TRIP_EXAMPLE_SCHEMA.
+            // with schema TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.
             // {<should create initial commit>, <table type>, <txn 1 writer schema>, <txn 2 writer schema>,
             // <should schema conflict>, <expected table schema after resolution>}
             // --------------|-----read write-----|validate & commit|------------------------- txn 1
@@ -213,22 +213,22 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
             // committed->|------------------------------------------------------------------- initial commit (optional)
 
             // No schema evolution, no conflict.
-            {true, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA, false, TRIP_EXAMPLE_SCHEMA},
-            {false, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA, false, TRIP_EXAMPLE_SCHEMA},
-            {false, true, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA, false, TRIP_EXAMPLE_SCHEMA},
+            {true, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, false, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED},
+            {false, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, false, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED},
+            {false, true, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, false, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED},
             // No concurrent schema evolution, no conflict.
-            {true, false, COPY_ON_WRITE, TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
-            {true, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
-            // If there is a initial commits defining table schema to TRIP_EXAMPLE_SCHEMA.
+            {true, false, COPY_ON_WRITE, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
+            {true, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
+            // If there is a initial commits defining table schema to TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.
             // as long as txn 2 stick to that schema, backwards compatibility handles everything.
-            {true, false, COPY_ON_WRITE, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
-            {true, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
+            {true, false, COPY_ON_WRITE, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
+            {true, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
             // In case no initial commits, table schema is not really predefined.
             // It means are effectively having 2 concurrent txn trying to define table schema
             // differently in this case.
-            {false, true, COPY_ON_WRITE, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA, true, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
-            {false, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA, true, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
-            {false, true, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA, true, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
+            {false, true, COPY_ON_WRITE, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, true, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
+            {false, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, true, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
+            {false, true, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, true, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
             // Concurrent schema evolution into the same schema does not conflict.
             {true, false, COPY_ON_WRITE, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
             {true, false, MERGE_ON_READ, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, TRIP_EXAMPLE_SCHEMA_EVOLVED_1, false, TRIP_EXAMPLE_SCHEMA_EVOLVED_1},
@@ -282,7 +282,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     properties.setProperty(LockConfiguration.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY, "3000");
     properties.setProperty(ENABLE_SCHEMA_CONFLICT_RESOLUTION.key(), "true");
 
-    HoodieWriteConfig.Builder writeConfigBuilder = getConfigBuilder(TRIP_EXAMPLE_SCHEMA)
+    HoodieWriteConfig.Builder writeConfigBuilder = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withHeartbeatIntervalInMs(60 * 1000)
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
             .withStorageType(FileSystemViewStorageType.MEMORY)

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestTableSchemaEvolution.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestTableSchemaEvolution.java
@@ -56,7 +56,7 @@ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.FARE_NEST
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_IS_DELETED_SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.MAP_TYPE_SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TIP_NESTED_SCHEMA;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_SCHEMA_PREFIX;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_SCHEMA_SUFFIX;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -80,45 +80,45 @@ public class TestTableSchemaEvolution extends HoodieClientTestBase {
   public static final String EXTRA_FIELD_NULLABLE_SCHEMA =
       ",{\"name\": \"new_nullable_field\", \"type\": [\"null\", \"boolean\"], \"default\": null} ]}";
 
-  // TRIP_EXAMPLE_SCHEMA with a new_field added
+  // TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED with a new_field added
   public static final String TRIP_EXAMPLE_SCHEMA_EVOLVED_COL_ADDED = TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA
       + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + EXTRA_FIELD_SCHEMA + TRIP_SCHEMA_SUFFIX;
 
-  // TRIP_EXAMPLE_SCHEMA with tip field removed
+  // TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED with tip field removed
   public static final String TRIP_EXAMPLE_SCHEMA_EVOLVED_COL_DROPPED = TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA
       + FARE_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;
 
   @Test
   public void testSchemaCompatibilityBasic() {
-    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA, false),
+    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, false),
         "Same schema is compatible");
 
     String reorderedSchema = TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + TIP_NESTED_SCHEMA + FARE_NESTED_SCHEMA
         + MAP_TYPE_SCHEMA + TRIP_SCHEMA_SUFFIX;
-    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, reorderedSchema, false),
+    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, reorderedSchema, false),
         "Reordered fields are compatible");
-    assertTrue(isSchemaCompatible(reorderedSchema, TRIP_EXAMPLE_SCHEMA, false),
+    assertTrue(isSchemaCompatible(reorderedSchema, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, false),
         "Reordered fields are compatible");
 
-    String renamedSchema = TRIP_EXAMPLE_SCHEMA.replace("tip_history", "tip_future");
+    String renamedSchema = TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.replace("tip_history", "tip_future");
 
-    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, renamedSchema, false),
+    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, renamedSchema, false),
         "Renaming fields is essentially: dropping old field, created a new one");
-    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, renamedSchema, true),
+    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, renamedSchema, true),
         "Renaming fields is essentially: dropping old field, created a new one");
 
-    String renamedRecordSchema = TRIP_EXAMPLE_SCHEMA.replace("triprec", "triprec_renamed");
-    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, renamedRecordSchema, false),
+    String renamedRecordSchema = TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.replace("triprec", "triprec_renamed");
+    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, renamedRecordSchema, false),
         "Renamed record name is not compatible");
 
     String swappedFieldSchema = TRIP_SCHEMA_PREFIX + MAP_TYPE_SCHEMA.replace("city_to_state", "fare")
         + FARE_NESTED_SCHEMA.replace("fare", "city_to_state") + TIP_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;
-    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, swappedFieldSchema, false),
+    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, swappedFieldSchema, false),
         "Swapped fields are not compatible");
 
     String typeChangeSchemaDisallowed = TRIP_SCHEMA_PREFIX + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA
         + TIP_NESTED_SCHEMA.replace("string", "boolean") + TRIP_SCHEMA_SUFFIX;
-    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, typeChangeSchemaDisallowed, false),
+    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, typeChangeSchemaDisallowed, false),
         "Incompatible field type change is not allowed");
 
     // Array of allowed schema field type transitions
@@ -144,20 +144,20 @@ public class TestTableSchemaEvolution extends HoodieClientTestBase {
     assertFalse(isSchemaCompatible(toSchema, fromSchema, false), "Field names should match");
 
 
-    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA_EVOLVED_COL_ADDED, false),
+    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_EXAMPLE_SCHEMA_EVOLVED_COL_ADDED, false),
         "Added field with default is compatible (Evolved Schema)");
 
     String multipleAddedFieldSchema = TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA
         + TIP_NESTED_SCHEMA + EXTRA_FIELD_SCHEMA + EXTRA_FIELD_SCHEMA.replace("new_field", "new_new_field")
         + TRIP_SCHEMA_SUFFIX;
-    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, multipleAddedFieldSchema, false),
+    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, multipleAddedFieldSchema, false),
         "Multiple added fields with defaults are compatible");
 
-    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA
+    assertFalse(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA
             + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + EXTRA_FIELD_WITHOUT_DEFAULT_SCHEMA + TRIP_SCHEMA_SUFFIX, false),
         "Added field without default and not nullable is not compatible (Evolved Schema)");
 
-    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA
+    assertTrue(isSchemaCompatible(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, TRIP_SCHEMA_PREFIX + EXTRA_TYPE_SCHEMA + MAP_TYPE_SCHEMA
             + FARE_NESTED_SCHEMA + TIP_NESTED_SCHEMA + HOODIE_IS_DELETED_SCHEMA + EXTRA_FIELD_NULLABLE_SCHEMA, false),
         "Added nullable field is compatible (Evolved Schema)");
   }
@@ -173,10 +173,10 @@ public class TestTableSchemaEvolution extends HoodieClientTestBase {
         .setTableType(HoodieTableType.MERGE_ON_READ)
         .initTable(metaClient.getStorageConf().newInstance(), metaClient.getBasePath());
 
-    HoodieWriteConfig hoodieWriteConfig = getWriteConfig(TRIP_EXAMPLE_SCHEMA, shouldAllowDroppedColumns);
+    HoodieWriteConfig hoodieWriteConfig = getWriteConfig(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, shouldAllowDroppedColumns);
     SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig);
 
-    // Initial inserts with TRIP_EXAMPLE_SCHEMA
+    // Initial inserts with TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED
     int numRecords = 10;
     insertFirstBatch(hoodieWriteConfig, client, "001", initCommitTime,
                      numRecords, SparkRDDWriteClient::insert, false, false, numRecords, INSTANT_GENERATOR);
@@ -208,7 +208,7 @@ public class TestTableSchemaEvolution extends HoodieClientTestBase {
     client = getHoodieWriteClient(hoodieDevolvedWriteConfig);
     final List<HoodieRecord> failedRecords = generateInsertsWithSchema("005", numRecords, TRIP_EXAMPLE_SCHEMA_EVOLVED_COL_DROPPED);
     // We cannot use insertBatch directly here because we want to insert records
-    // with a evolved schema and insertBatch inserts records using the TRIP_EXAMPLE_SCHEMA.
+    // with a evolved schema and insertBatch inserts records using the TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.
     try {
       writeBatch(client, "005", "004", Option.empty(), "003", numRecords,
           (String s, Integer a) -> failedRecords, SparkRDDWriteClient::insert, false, numRecords, 2 * numRecords, 5, INSTANT_GENERATOR);
@@ -227,7 +227,7 @@ public class TestTableSchemaEvolution extends HoodieClientTestBase {
     client = getHoodieWriteClient(hoodieEvolvedWriteConfig);
 
     // We cannot use insertBatch directly here because we want to insert records
-    // with an evolved schema and insertBatch inserts records using the TRIP_EXAMPLE_SCHEMA.
+    // with an evolved schema and insertBatch inserts records using the TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED.
     final List<HoodieRecord> evolvedRecords = generateInsertsWithSchema("007", numRecords, TRIP_EXAMPLE_SCHEMA_EVOLVED_COL_ADDED);
     writeBatch(client, "007", "006", Option.empty(), initCommitTime, numRecords,
         (String s, Integer a) -> evolvedRecords, SparkRDDWriteClient::insert, false, numRecords, 3 * numRecords, 7, INSTANT_GENERATOR);
@@ -263,13 +263,13 @@ public class TestTableSchemaEvolution extends HoodieClientTestBase {
         .fromMetaClient(metaClient)
         .initTable(metaClient.getStorageConf().newInstance(), metaClient.getBasePath());
 
-    HoodieWriteConfig hoodieWriteConfig = getWriteConfigBuilder(TRIP_EXAMPLE_SCHEMA)
+    HoodieWriteConfig hoodieWriteConfig = getWriteConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withRollbackUsingMarkers(false)
         .withAllowAutoEvolutionColumnDrop(shouldAllowDroppedColumns)
         .build();
     SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig);
 
-    // Initial inserts with TRIP_EXAMPLE_SCHEMA
+    // Initial inserts with TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED
     int numRecords = 10;
     insertFirstBatch(hoodieWriteConfig, client, "001", initCommitTime,
         numRecords, SparkRDDWriteClient::insert, false, true, numRecords, INSTANT_GENERATOR);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestDataValidationCheckForLogCompactionActions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestDataValidationCheckForLogCompactionActions.java
@@ -68,7 +68,7 @@ import static org.apache.hudi.common.model.HoodieRecord.COMMIT_TIME_METADATA_FIE
 import static org.apache.hudi.common.model.HoodieRecord.FILENAME_METADATA_FIELD;
 import static org.apache.hudi.common.model.HoodieRecord.OPERATION_METADATA_FIELD;
 import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIELD;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.apache.hudi.testutils.GenericRecordValidationTestUtils.assertGenericRecords;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -331,7 +331,7 @@ public class TestDataValidationCheckForLogCompactionActions extends HoodieClient
   private TestTableContents setupTestTable1() {
     Properties properties = new Properties();
     properties.setProperty("hoodie.parquet.small.file.limit", "0");
-    HoodieWriteConfig config = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.INMEMORY)
+    HoodieWriteConfig config = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withInlineCompaction(true).build())
         .withProperties(properties)
         .build();
@@ -349,7 +349,7 @@ public class TestDataValidationCheckForLogCompactionActions extends HoodieClient
     HoodieTableMetaClient metaClient2 = HoodieTestUtils.init(storageConf, basePath2,
         HoodieTableType.MERGE_ON_READ, properties);
     HoodieWriteConfig config2 = getConfigBuilderForSecondTable(tableName2, basePath2,
-        TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.INMEMORY)
+        TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withInlineCompaction(true).build())
         .build();
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -137,7 +137,7 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMI
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_THIRD_PARTITION_PATH;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_EVOLVED_1;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -827,7 +827,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     props.setProperty(ASYNC_CLUSTERING_ENABLE.key(), "true");
     props.setProperty(UPDATES_STRATEGY.key(), SparkRejectUpdateStrategy.class.getName());
     HoodieWriteConfig config = getSmallInsertWriteConfig(100,
-        TRIP_EXAMPLE_SCHEMA, dataGen.getEstimatedFileSizeInBytes(150), true, props);
+        TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, dataGen.getEstimatedFileSizeInBytes(150), true, props);
     SparkRDDWriteClient client = getHoodieWriteClient(config);
     HoodieSparkCopyOnWriteTable table = (HoodieSparkCopyOnWriteTable) HoodieSparkTable.create(config, context, metaClient);
 
@@ -875,7 +875,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     final int insertSplitLimit = 100;
     // hold upto 200 records max
     HoodieWriteConfig config = getSmallInsertWriteConfig(insertSplitLimit,
-        TRIP_EXAMPLE_SCHEMA, dataGen.getEstimatedFileSizeInBytes(150));
+        TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, dataGen.getEstimatedFileSizeInBytes(150));
     dataGen = new HoodieTestDataGenerator(new String[] {testPartitionPath});
     SparkRDDWriteClient client = getHoodieWriteClient(config);
     FileFormatUtils fileUtils = getFileUtilsInstance(metaClient);
@@ -969,7 +969,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     // setup the small file handling params
     // hold upto 200 records max
     HoodieWriteConfig config = getSmallInsertWriteConfig(insertSplitLimit,
-        TRIP_EXAMPLE_SCHEMA, dataGen.getEstimatedFileSizeInBytes(150));
+        TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, dataGen.getEstimatedFileSizeInBytes(150));
     dataGen = new HoodieTestDataGenerator(new String[] {testPartitionPath});
 
     SparkRDDWriteClient client = getHoodieWriteClient(config);
@@ -1200,7 +1200,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   @Test
   public void testWriteSchemaUsageOnPreCommitValidators() throws Exception {
     // Create first commit on DEFAULT_FIRST_PARTITION_PATH partition with basic schema
-    String schemaStr = TRIP_EXAMPLE_SCHEMA;
+    String schemaStr = TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
     HoodieWriteConfig writeConfig =
         getConfigBuilder(schemaStr)
             .withCompactionConfig(HoodieCompactionConfig.newBuilder()
@@ -1356,7 +1356,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   private void verifyInsertOverwritePartitionHandling(int batch1RecordsCount, int batch2RecordsCount, boolean populateMetaFields) throws Exception {
     final String testPartitionPath = "americas";
     HoodieWriteConfig config = getSmallInsertWriteConfig(2000,
-        TRIP_EXAMPLE_SCHEMA, dataGen.getEstimatedFileSizeInBytes(150), populateMetaFields, getPropertiesForKeyGen(populateMetaFields));
+        TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, dataGen.getEstimatedFileSizeInBytes(150), populateMetaFields, getPropertiesForKeyGen(populateMetaFields));
     SparkRDDWriteClient client = getHoodieWriteClient(config);
     dataGen = new HoodieTestDataGenerator(new String[] {testPartitionPath});
 
@@ -1445,7 +1445,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
   private void verifyDeletePartitionsHandling(int batch1RecordsCount, int batch2RecordsCount, int batch3RecordsCount,
                                               boolean populateMetaFields) throws Exception {
     HoodieWriteConfig config = getSmallInsertWriteConfig(2000,
-        TRIP_EXAMPLE_SCHEMA, dataGen.getEstimatedFileSizeInBytes(150), populateMetaFields, getPropertiesForKeyGen(populateMetaFields));
+        TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, dataGen.getEstimatedFileSizeInBytes(150), populateMetaFields, getPropertiesForKeyGen(populateMetaFields));
     SparkRDDWriteClient client = getHoodieWriteClient(config);
     dataGen = new HoodieTestDataGenerator();
 
@@ -1999,7 +1999,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     String schemaKey = HoodieCommitMetadata.SCHEMA_KEY;
     dataGen = new HoodieTestDataGenerator(new String[] {DEFAULT_FIRST_PARTITION_PATH});
 
-    HoodieWriteConfig writeConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA)
+    HoodieWriteConfig writeConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .compactionSmallFileSize(0).build())
         .withRollingMetadataKeys(schemaKey)
@@ -2013,10 +2013,10 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
 
     // Insert multiple batches to create file groups for clustering
     for (int i = 0; i < 5; i++) {
-      insertCommitWithSchema(client, dataGen, 20, TRIP_EXAMPLE_SCHEMA);
+      insertCommitWithSchema(client, dataGen, 20, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     }
 
-    HoodieWriteConfig clusterConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA)
+    HoodieWriteConfig clusterConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withClusteringConfig(createClusteringBuilder(true, 1).build())
         .withRollingMetadataKeys(schemaKey)
         .withArchivalConfig(HoodieArchivalConfig.newBuilder()
@@ -2036,7 +2036,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
       // remains on the active timeline after archival
       if (round < 1) {
         for (int i = 0; i < 3; i++) {
-          insertCommitWithSchema(client, dataGen, 20, TRIP_EXAMPLE_SCHEMA);
+          insertCommitWithSchema(client, dataGen, 20, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
         }
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnMergeOnReadStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnMergeOnReadStorage.java
@@ -77,7 +77,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
 
   @Test
   public void testReadingMORTableWithoutBaseFile() throws Exception {
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build())
         .build();
@@ -112,7 +112,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
   @EnumSource(value = HoodieIndex.IndexType.class, names = {"INMEMORY", "SIMPLE"})
   public void testClusteringOnMORTable(HoodieIndex.IndexType indexType) throws Exception {
     // INMEMORY index will only generate log files, SIMPLE will generate a base file and log files.
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, indexType)
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, indexType)
         .withClusteringConfig(HoodieClusteringConfig.newBuilder().withInlineClusteringNumCommits(3).build())
         .build();
     SparkRDDWriteClient client = getHoodieWriteClient(config);
@@ -148,7 +148,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
 
   @Test
   public void testCompactionOnMORTable() throws Exception {
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build())
         .build();
@@ -185,7 +185,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
         .withMaxNumDeltaCommitsBeforeCompaction(1)
         .withLogCompactionBlocksThreshold(1)
         .build();
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY).withCompactionConfig(compactionConfig).build();
     SparkRDDWriteClient client = getHoodieWriteClient(config);
 
@@ -245,7 +245,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
         .withMaxNumDeltaCommitsBeforeCompaction(1)
         .withLogCompactionBlocksThreshold(1)
         .build();
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY).withCompactionConfig(compactionConfig).build();
     SparkRDDWriteClient client = getHoodieWriteClient(config);
 
@@ -288,7 +288,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
         .withMaxNumDeltaCommitsBeforeCompaction(1)
         .withLogCompactionBlocksThreshold(1)
         .build();
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY).withCompactionConfig(compactionConfig).build();
     SparkRDDWriteClient client = getHoodieWriteClient(config);
 
@@ -323,7 +323,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
         .withMaxNumDeltaCommitsBeforeCompaction(1)
         .withLogCompactionBlocksThreshold(1)
         .build();
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(compactionConfig)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
@@ -360,7 +360,7 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
 
   @Test
   public void testCleanFunctionalityWhenCompactionRequestedInstantIsPresent() throws Exception {
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .withMaxNumDeltaCommitsBeforeCompaction(1)
@@ -420,9 +420,9 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
         .withMaxNumDeltaCommitsBeforeCompaction(1)
         .withLogCompactionBlocksThreshold(1)
         .build();
-    HoodieWriteConfig lcConfig = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.INMEMORY)
+    HoodieWriteConfig lcConfig = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(compactionConfig).build();
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.INMEMORY)
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.INMEMORY)
         .build();
     try (SparkRDDWriteClient lcClient = new SparkRDDWriteClient(context, lcConfig);
          SparkRDDWriteClient client = new SparkRDDWriteClient(context, config)) {
@@ -511,13 +511,13 @@ public class TestHoodieClientOnMergeOnReadStorage extends HoodieClientTestBase {
         .withMaxNumDeltaCommitsBeforeCompaction(1)
         .withLogCompactionBlocksThreshold(1)
         .build();
-    HoodieWriteConfig lcWriteConfig = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+    HoodieWriteConfig lcWriteConfig = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
         HoodieIndex.IndexType.INMEMORY).withCompactionConfig(logCompactionConfig).build();
 
     HoodieCompactionConfig compactionConfig = HoodieCompactionConfig.newBuilder()
         .withMaxNumDeltaCommitsBeforeCompaction(1)
         .build();
-    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.INMEMORY)
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(compactionConfig)
         .withCleanConfig(HoodieCleanConfig.newBuilder().retainCommits(2).build())
         .withArchivalConfig(HoodieArchivalConfig.newBuilder().archiveCommitsWith(4, 5).build())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -83,7 +83,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_SCHEMA;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToRecordIndexRecords;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getRevivedAndDeletedKeysFromMergedLogs;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.reduceByKeys;
@@ -488,7 +488,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       });
       // There should 0 deleted records because compaction does not update any records.
       assertEquals(0, deletedSecondaryIndexRecords3.size());
-      assertEquals(initialRecordsCount, dataGen.getNumExistingKeys(TRIP_EXAMPLE_SCHEMA));
+      assertEquals(initialRecordsCount, dataGen.getNumExistingKeys(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED));
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestRemoteFileSystemViewWithMetadataTable.java
@@ -238,7 +238,7 @@ public class TestRemoteFileSystemViewWithMetadataTable extends HoodieSparkClient
   private SparkRDDWriteClient createWriteClient(String basePath, String tableName, boolean reuseTimelineServer, Option<TimelineService> timelineService) {
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withBulkInsertParallelism(2)
         .withFinalizeWriteParallelism(2)

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitioner.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -191,7 +191,7 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
     HoodieWriteConfig config = HoodieWriteConfig
         .newBuilder()
         .withPath("/")
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withBulkInsertSortMode(sortMode.name())
         .withPopulateMetaFields(populateMetaFields)
         .build();
@@ -220,7 +220,7 @@ public class TestBulkInsertInternalPartitioner extends HoodieClientTestBase impl
     HoodieWriteConfig config = HoodieWriteConfig
         .newBuilder()
         .withPath("/")
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withUserDefinedBulkInsertPartitionerClass(RDDCustomColumnsSortPartitioner.class.getName())
         .withUserDefinedBulkInsertPartitionerSortColumns(sortColumnString)
         .build();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitionerForRows.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestBulkInsertInternalPartitionerForRows.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -109,7 +109,7 @@ public class TestBulkInsertInternalPartitionerForRows extends HoodieSparkClientT
     HoodieWriteConfig config = HoodieWriteConfig
         .newBuilder()
         .withPath("/")
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withBulkInsertSortMode(sortMode.name())
         .withPopulateMetaFields(populateMetaFields)
         .build();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestRDDSimpleBucketBulkInsertPartitioner.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/execution/bulkinsert/TestRDDSimpleBucketBulkInsertPartitioner.java
@@ -48,7 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getRootCause;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -77,7 +77,7 @@ public class TestRDDSimpleBucketBulkInsertPartitioner extends HoodieSparkClientT
     HoodieWriteConfig config = HoodieWriteConfig
         .newBuilder()
         .withPath(basePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .build();
     config.setValue(HoodieIndexConfig.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     config.setValue(HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.SIMPLE.name());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestConsistentBucketIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestConsistentBucketIndex.java
@@ -302,7 +302,7 @@ public class TestConsistentBucketIndex extends HoodieSparkClientTestHarness {
   }
 
   public HoodieWriteConfig.Builder getConfigBuilder() {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2).withBulkInsertParallelism(2).withFinalizeWriteParallelism(2).withDeleteParallelism(2)
         .withWriteStatusClass(MetadataMergeWriteStatus.class)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true).build())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -184,7 +184,7 @@ import static org.apache.hudi.common.table.timeline.HoodieTimeline.REQUESTED_EXT
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.ROLLBACK_ACTION;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.getNextCommitTime;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -281,7 +281,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
   @Test
   public void testTurnOffMetadataIndexAfterEnable() throws Exception {
     initPath();
-    HoodieWriteConfig cfg = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig cfg = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withParallelism(1, 1).withBulkInsertParallelism(1).withFinalizeWriteParallelism(1).withDeleteParallelism(1)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).build())
@@ -397,7 +397,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     assertTrue(tableConfig.getMetadataPartitions().contains(BLOOM_FILTERS.getPartitionPath()));
 
     // disable entire MDT and validate its deleted
-    HoodieWriteConfig cfgWithMetadataDisabled = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig cfgWithMetadataDisabled = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withParallelism(1, 1).withBulkInsertParallelism(1).withFinalizeWriteParallelism(1).withDeleteParallelism(1)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .build();
@@ -420,7 +420,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
   @Test
   public void testAutoDeletePartitionsDisabledPreservesColumnStats() throws Exception {
     initPath();
-    HoodieWriteConfig cfg = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig cfg = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withParallelism(1, 1).withBulkInsertParallelism(1).withFinalizeWriteParallelism(1).withDeleteParallelism(1)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true).build())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
@@ -919,7 +919,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
   public void testMetadataTableDeletePartition(HoodieTableType tableType) throws Exception {
     initPath();
     int maxCommits = 1;
-    HoodieWriteConfig cfg = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig cfg = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS).retainCommits(maxCommits)
             .build())
@@ -2679,7 +2679,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     tableType = HoodieTableType.COPY_ON_WRITE;
     init(tableType);
     context = new HoodieSparkEngineContext(jsc);
-    HoodieWriteConfig config = getSmallInsertWriteConfigForMDT(2000, TRIP_EXAMPLE_SCHEMA, 10, false);
+    HoodieWriteConfig config = getSmallInsertWriteConfigForMDT(2000, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 10, false);
     SparkRDDWriteClient client = getHoodieWriteClient(config);
 
     // Write 1 (Bulk insert)
@@ -2705,7 +2705,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         .withClusteringSortColumns("_row_key").withInlineClustering(true)
         .withClusteringTargetPartitions(0).withInlineClusteringNumCommits(1).build();
 
-    HoodieWriteConfig newWriteConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig newWriteConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withClusteringConfig(clusteringConfig)
         .withRollbackUsingMarkers(false)
         .build();
@@ -2752,7 +2752,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     tableType = HoodieTableType.COPY_ON_WRITE;
     init(tableType);
     context = new HoodieSparkEngineContext(jsc);
-    HoodieWriteConfig initialConfig = getSmallInsertWriteConfigForMDT(2000, TRIP_EXAMPLE_SCHEMA, 10, false);
+    HoodieWriteConfig initialConfig = getSmallInsertWriteConfigForMDT(2000, TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, 10, false);
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withProperties(initialConfig.getProps())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(4).build()).build();
     SparkRDDWriteClient client = getHoodieWriteClient(config);
@@ -2778,7 +2778,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         .withClusteringSortColumns("_row_key").withInlineClustering(true)
         .withClusteringTargetPartitions(0).withInlineClusteringNumCommits(1).build();
 
-    HoodieWriteConfig newWriteConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig newWriteConfig = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withClusteringConfig(clusteringConfig).build();
 
     // trigger clustering
@@ -3314,7 +3314,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     init(HoodieTableType.COPY_ON_WRITE);
 
     int maxCommits = 1;
-    HoodieWriteConfig cfg = getConfigBuilder(TRIP_EXAMPLE_SCHEMA, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
+    HoodieWriteConfig cfg = getConfigBuilder(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, HoodieIndex.IndexType.BLOOM, HoodieFailedWritesCleaningPolicy.EAGER)
         .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS)
             .retainCommits(maxCommits).build())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
@@ -722,7 +722,7 @@ public class TestHoodieIndex extends TestHoodieMetadataBase {
   }
 
   public HoodieWriteConfig.Builder getConfigBuilder() {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2).withBulkInsertParallelism(2).withFinalizeWriteParallelism(2).withDeleteParallelism(2)
         .withWriteStatusClass(MetadataMergeWriteStatus.class)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true).build())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieSparkMergeOnReadTableClustering.java
@@ -52,7 +52,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -138,7 +138,7 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
     HoodieWriteConfig.Builder cfgBuilder = HoodieWriteConfig.newBuilder()
         .forTable("test-trip-table")
         .withPath(basePath())
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withDeleteParallelism(2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
@@ -223,7 +223,7 @@ class TestHoodieSparkMergeOnReadTableClustering extends SparkClientFunctionalTes
     HoodieWriteConfig.Builder cfgBuilder = HoodieWriteConfig.newBuilder()
         .forTable("test-trip-table")
         .withPath(basePath())
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withDeleteParallelism(2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkBinaryCopyClusteringAndValidationMeta.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkBinaryCopyClusteringAndValidationMeta.java
@@ -85,7 +85,7 @@ import static org.apache.hudi.common.bloom.BloomFilterTypeCode.DYNAMIC_V0;
 import static org.apache.hudi.common.bloom.BloomFilterTypeCode.SIMPLE;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_SCHEMA;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_NESTED_EXAMPLE_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -223,7 +223,7 @@ public class TestSparkBinaryCopyClusteringAndValidationMeta extends HoodieClient
   public void testSupportBinaryStreamCopy() throws IOException {
     HoodieWriteConfig writeConfig = new HoodieWriteConfig.Builder()
         .withPath(basePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withEmbeddedTimelineServerEnabled(false)
         .build();
     HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkConsistentBucketClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkConsistentBucketClustering.java
@@ -360,7 +360,7 @@ public class TestSparkConsistentBucketClustering extends HoodieSparkClientTestHa
   }
 
   public HoodieWriteConfig.Builder getConfigBuilder() {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2).withBulkInsertParallelism(2).withFinalizeWriteParallelism(2).withDeleteParallelism(2)
         .withWriteStatusClass(MetadataMergeWriteStatus.class)
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true).build())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
@@ -260,7 +260,7 @@ public class TestSparkSortAndSizeClustering extends HoodieSparkClientTestHarness
   }
 
   public HoodieWriteConfig.Builder getConfigBuilder() {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withWriteStatusClass(MetadataMergeWriteStatus.class)
         .forTable("clustering-table")

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestWriteClient.java
@@ -38,7 +38,7 @@ import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +77,7 @@ public class TestWriteClient extends HoodieSparkClientTestBase {
       HoodieCommitMetadata metadata = timeline.readCommitMetadata(timeline.lastInstant().get());
       assertTrue(metadata.getExtraMetadata().get("schema").isEmpty());
       TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(metaClient);
-      assertEquals(HoodieSchema.parse(TRIP_EXAMPLE_SCHEMA), tableSchemaResolver.getTableSchema(false));
+      assertEquals(HoodieSchema.parse(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED), tableSchemaResolver.getTableSchema(false));
       // Data Validations.
       Dataset<Row> df = sparkSession.read().format("hudi").load(basePath);
       assertEquals(numRecords, df.collectAsList().size());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestAppendHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestAppendHandle.java
@@ -45,7 +45,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -68,7 +68,7 @@ public class TestAppendHandle extends BaseTestHandle {
             .withSecondaryIndexForColumn("rider")
             .build())
         .build();
-    config.setSchema(TRIP_EXAMPLE_SCHEMA);
+    config.setSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     HoodieTable table = HoodieSparkTable.create(config, context, metaClient);
 
     // one round per partition

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestCreateHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestCreateHandle.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +77,7 @@ public class TestCreateHandle extends BaseTestHandle {
     String fileId = UUID.randomUUID().toString();
     String instantTime = "000";
 
-    config.setSchema(TRIP_EXAMPLE_SCHEMA);
+    config.setSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     table = HoodieSparkTable.create(config, context, metaClient);
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[] {partitionPath});

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMergeHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMergeHandle.java
@@ -92,7 +92,7 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.table.cdc.HoodieCDCUtils.schemaBySupplementalLoggingMode;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_SCHEMA;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -567,7 +567,7 @@ public class TestMergeHandle extends BaseTestHandle {
             .withSecondaryIndexForColumn("rider")
             .build())
         .withKeyGenerator(KeyGeneratorForDataGeneratorRecords.class.getCanonicalName())
-        .withSchema(TRIP_EXAMPLE_SCHEMA);
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
   }
 
   private List<HoodieRecord> overrideOrderingValue(List<HoodieRecord> hoodieRecords, HoodieWriteConfig config, String payloadClass, String partitionPath, long orderingValue) {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMetadataWriterCommit.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMetadataWriterCommit.java
@@ -58,7 +58,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
 import static org.apache.hudi.metadata.MetadataPartitionType.FILES;
 import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
@@ -95,7 +95,7 @@ public class TestMetadataWriterCommit extends BaseTestHandle {
     String instantTime = InProcessTimeGenerator.createNewInstantTime();
 
     // create a parquet file and obtain corresponding write status
-    config.setSchema(TRIP_EXAMPLE_SCHEMA);
+    config.setSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[] {partitionPath});
     Pair<WriteStatus, List<HoodieRecord>> statusListPair = createParquetFile(config, table, partitionPath, fileId, instantTime, dataGenerator);
     WriteStatus writeStatus = statusListPair.getLeft();
@@ -161,7 +161,7 @@ public class TestMetadataWriterCommit extends BaseTestHandle {
     HoodieTable table = HoodieSparkTable.create(config, context, metaClient);
     // commit is needed to populate schema of the table. We use a different partition path in the commit below than what is used
     // for actual test
-    config.setSchema(TRIP_EXAMPLE_SCHEMA);
+    config.setSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
     HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[] {HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS[1]});
     SparkRDDWriteClient client = getHoodieWriteClient(config);
     String instantTime = writeClient.startCommit();
@@ -189,7 +189,7 @@ public class TestMetadataWriterCommit extends BaseTestHandle {
             .withStreamingWriteEnabled(true)
             .build())
         .build();
-    config.setSchema(TRIP_EXAMPLE_SCHEMA);
+    config.setSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED);
 
     // Just replicating the production code path to create the metadata table
     metaClient = HoodieTableMetaClient.builder().setBasePath(basePath).setConf(storageConf).build();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestHoodieCompactor.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/compact/TestHoodieCompactor.java
@@ -126,7 +126,7 @@ public class TestHoodieCompactor extends HoodieSparkClientTestHarness {
   }
 
   public HoodieWriteConfig.Builder getConfigBuilder() {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024)
             .withInlineCompaction(false).build())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestCopyOnWriteRollbackActionExecutor.java
@@ -576,7 +576,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
     properties.put("hoodie.clustering.plan.strategy.partition.selected", DEFAULT_FIRST_PARTITION_PATH);
     properties.put("hoodie.clustering.plan.partition.filter.mode","SELECTED_PARTITIONS");
     SparkRDDWriteClient clusteringClient = getHoodieWriteClient(
-        ClusteringTestUtils.getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, properties));
+        ClusteringTestUtils.getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, properties));
 
     // Save an older instant for us to run clustering.
     // Now execute clustering on the saved instant and do not allow it to commit.
@@ -585,7 +585,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
 
     properties.put("hoodie.clustering.plan.strategy.partition.selected", DEFAULT_SECOND_PARTITION_PATH);
     clusteringClient = getHoodieWriteClient(
-        ClusteringTestUtils.getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, properties));
+        ClusteringTestUtils.getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, properties));
     // Create completed clustering commit
     ClusteringTestUtils.runClustering(clusteringClient, false, true);
     clusteringClient.close();
@@ -595,7 +595,7 @@ public class TestCopyOnWriteRollbackActionExecutor extends HoodieClientRollbackT
 
     properties.put("hoodie.clustering.plan.strategy.partition.selected", DEFAULT_FIRST_PARTITION_PATH);
     clusteringClient = getHoodieWriteClient(
-        ClusteringTestUtils.getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA, properties));
+        ClusteringTestUtils.getClusteringConfig(basePath, HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED, properties));
 
     // Schedule rollback
     String rollbackInstant = WriteClientTestUtils.createNewInstantTime();

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/rollback/TestMergeOnReadRollbackActionExecutor.java
@@ -357,7 +357,7 @@ public class TestMergeOnReadRollbackActionExecutor extends HoodieClientRollbackT
     //1. prepare data and assert data result
     //just generate one partitions
     dataGen = new HoodieTestDataGenerator(new String[] {DEFAULT_FIRST_PARTITION_PATH});
-    HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2).withBulkInsertParallelism(2).withFinalizeWriteParallelism(2).withDeleteParallelism(2)
         .withTimelineLayoutVersion(TimelineLayoutVersion.CURR_VERSION)
         .withWriteStatusClass(MetadataMergeWriteStatus.class)

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableCompaction.java
@@ -78,7 +78,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -133,7 +133,7 @@ public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFuncti
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .forTable("test-trip-table")
         .withPath(basePath())
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withWritePayLoad(payloadClass)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
@@ -184,7 +184,7 @@ public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFuncti
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .forTable("test-trip-table")
         .withPath(basePath())
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
           .withEmbeddedTimelineServerEnabled(enableTimelineServer)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(enableMetadataTable).build())
@@ -244,7 +244,7 @@ public class TestHoodieSparkMergeOnReadTableCompaction extends SparkClientFuncti
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .forTable("test-trip-table")
         .withPath(basePath())
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .withMaxNumDeltaCommitsBeforeCompaction(1).build())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
@@ -91,7 +91,7 @@ import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.NO_PARTITION_PATH;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
@@ -874,7 +874,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   }
 
   private HoodieWriteConfig.Builder getHoodieWriteConfigWithSmallFileHandlingOffBuilder(boolean populateMetaFields) {
-    HoodieWriteConfig.Builder cfgBuilder = HoodieWriteConfig.newBuilder().withPath(basePath()).withSchema(TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+    HoodieWriteConfig.Builder cfgBuilder = HoodieWriteConfig.newBuilder().withPath(basePath()).withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED).withParallelism(2, 2)
         .withDeleteParallelism(2)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024)
             .withInlineCompaction(false).withMaxNumDeltaCommitsBeforeCompaction(1).build())

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkRollback.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkRollback.java
@@ -57,7 +57,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -109,7 +109,7 @@ public class TestHoodieSparkRollback extends SparkClientFunctionalTestHarness {
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder()
         .withPath(basePath)
         .withProperties(getPropertiesForKeyGen(true))
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withDeleteParallelism(2)
         .withEmbeddedTimelineServerEnabled(false).forTable("test-trip-table")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -211,7 +211,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
     val writeConfig = HoodieWriteConfig.newBuilder()
       .withEngineType(EngineType.JAVA)
       .withPath(basePath)
-      .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+      .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
       .withProps(props.asJava)
       .build()
     val context = new HoodieJavaEngineContext(HoodieTestUtils.getDefaultStorageConf)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
@@ -73,7 +73,7 @@ class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
                                                      validate: Boolean = true,
                                                      numUpdates: Int = 1,
                                                      onlyUpdates: Boolean = false,
-                                                     schemaStr: String = HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+                                                     schemaStr: String = HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED,
                                                      timestamp: Long = System.currentTimeMillis()): DataFrame = {
     var latestBatch: mutable.Buffer[String] = null
     if (operation == UPSERT_OPERATION_OPT_VAL) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestGlobalRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestGlobalRecordLevelIndex.scala
@@ -437,7 +437,7 @@ class TestGlobalRecordLevelIndex extends RecordLevelIndexTestBase {
       saveMode = SaveMode.Overwrite)
 
     val writeConfig = getWriteConfig(hudiOpts)
-    writeConfig.setSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    writeConfig.setSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
     getHoodieWriteClient(writeConfig).dropIndex(Collections.singletonList(MetadataPartitionType.RECORD_INDEX.getPartitionPath))
     assertEquals(0, getFileGroupCountForRecordIndex(writeConfig))
     metaClient = HoodieTableMetaClient.reload(metaClient)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
@@ -71,7 +71,7 @@ class TestStreamSourceReadByStateTransitionTime extends StreamTest  {
         val writeConfig = HoodieWriteConfig.newBuilder()
             .withEngineType(EngineType.SPARK)
           .withPath(tablePath)
-          .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+          .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
           .withCleanConfig(HoodieCleanConfig.newBuilder()
             .withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.LAZY)
             .build())

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
@@ -827,7 +827,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
         val tableName = generateTableName
         val tablePath = s"${new Path(tmp.getCanonicalPath, tableName).toUri.toString}"
         val dataGen = new HoodieTestDataGenerator
-        val schema = HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA
+        val schema = HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED
         val records1 = HoodieTestDataGenerator.recordsToStrings(dataGen.generateInsertsAsPerSchema("001", 1000, schema)).asScala.toList
         val inputDF1 = spark.read.json(spark.sparkContext.parallelize(records1, 2))
         // drop tip_history.element.amount, city_to_state, distance_in_meters, drivers

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestHoodieBackedTableMetadataIndexLookup.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestHoodieBackedTableMetadataIndexLookup.scala
@@ -188,7 +188,7 @@ abstract class HoodieBackedTableMetadataIndexLookupTestBase extends HoodieSparkS
     val writeConfig = HoodieWriteConfig.newBuilder()
       .withEngineType(EngineType.JAVA)
       .withPath(basePath)
-      .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+      .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
       .withProps(props.asJava)
       .build()
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHdfsParquetImportProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHdfsParquetImportProcedure.scala
@@ -55,7 +55,7 @@ class TestHdfsParquetImportProcedure extends HoodieSparkProcedureTestBase {
 
       // create schema file
       val schemaFileOS = storage.create(new StoragePath(schemaFile))
-      try schemaFileOS.write(getUTF8Bytes(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA))
+      try schemaFileOS.write(getUTF8Bytes(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED))
       finally if (schemaFileOS != null) schemaFileOS.close()
 
       val insertData: util.List[GenericRecord] = createInsertRecords(sourcePath)
@@ -89,7 +89,7 @@ class TestHdfsParquetImportProcedure extends HoodieSparkProcedureTestBase {
 
       // create schema file
       val schemaFileOS = storage.create(new StoragePath(schemaFile))
-      try schemaFileOS.write(getUTF8Bytes(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA))
+      try schemaFileOS.write(getUTF8Bytes(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED))
       finally if (schemaFileOS != null) schemaFileOS.close()
 
       val insertData: util.List[GenericRecord] = createUpsertRecords(sourcePath)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieIndexer.java
@@ -671,7 +671,7 @@ public class TestHoodieIndexer extends SparkClientFunctionalTestHarness implemen
   private static HoodieWriteConfig.Builder getWriteConfigBuilder(String basePath, String tableName) {
     return HoodieWriteConfig.newBuilder()
         .withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withBulkInsertParallelism(2)
         .withFinalizeWriteParallelism(2)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -809,7 +809,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       logicalAssertions(tableSchema, tableBasePath, hudiOpts, HoodieTableVersion.current().versionCode());
     } finally {
       defaultSchemaProviderClassName = FilebasedSchemaProvider.class.getName();
-      AbstractBaseTestSource.schemaStr = HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+      AbstractBaseTestSource.schemaStr = HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
@@ -95,7 +95,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
         .withProperties(props)
         .forTable("foo")
         .withPath(basePath())
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .build();
 
     String commitTime = HoodieTestDataGenerator.getCommitTimeAtUTC(1);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
@@ -125,7 +125,7 @@ public class TestHoodieSnapshotExporter extends SparkClientFunctionalTestHarness
     return HoodieWriteConfig.newBuilder()
         .withPath(basePath)
         .withEmbeddedTimelineServerEnabled(false)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withBulkInsertParallelism(2)
         .withDeleteParallelism(2)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/multitable/TestHoodieMultiTableServicesMain.java
@@ -255,7 +255,7 @@ class TestHoodieMultiTableServicesMain extends HoodieCommonTestHarness implement
     properties.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
     return HoodieWriteConfig.newBuilder()
         .withPath(basePath)
-        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(4, 4)
         .withBulkInsertParallelism(4)
         .withFinalizeWriteParallelism(2)

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieClusteringJob.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieClusteringJob.java
@@ -48,7 +48,7 @@ import java.util.Properties;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 import static org.apache.hudi.common.table.HoodieTableMetaClient.TIMELINEFOLDER_NAME;
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.apache.hudi.utilities.UtilHelpers.PURGE_PENDING_INSTANT;
 import static org.apache.hudi.utilities.UtilHelpers.SCHEDULE;
@@ -297,7 +297,7 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
     return HoodieWriteConfig.newBuilder()
         .forTable("asyncClustering")
         .withPath(tableBasePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .withClusteringConfig(HoodieClusteringConfig.newBuilder()
@@ -319,7 +319,7 @@ public class TestHoodieClusteringJob extends HoodieOfflineJobTestBase {
     return HoodieWriteConfig.newBuilder()
         .forTable("asyncClustering")
         .withPath(tableBasePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .withClusteringConfig(HoodieClusteringConfig.newBuilder()

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieCompactorJob.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/TestHoodieCompactorJob.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Properties;
 
-import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 
 /**
  * Test cases for {@link HoodieCompactor}.
@@ -56,7 +56,7 @@ public class TestHoodieCompactorJob extends HoodieOfflineJobTestBase {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
         .forTable("asyncCompaction")
         .withPath(tableBasePath)
-        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withSchema(TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestHoodieIncrSource.java
@@ -1063,7 +1063,7 @@ public class TestHoodieIncrSource extends SparkClientFunctionalTestHarness {
   }
 
   private HoodieWriteConfig.Builder getConfigBuilder(String basePath, HoodieTableMetaClient metaClient) {
-    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED)
         .withParallelism(2, 2).withBulkInsertParallelism(2).withFinalizeWriteParallelism(2).withDeleteParallelism(2)
         .withTimelineLayoutVersion(TimelineLayoutVersion.CURR_VERSION)
         .forTable(metaClient.getTableConfig().getTableName());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/sources/AbstractBaseTestSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/testutils/sources/AbstractBaseTestSource.java
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
 
 public abstract class AbstractBaseTestSource extends AvroSource {
 
-  public static String schemaStr = HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+  public static String schemaStr = HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED;
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractBaseTestSource.class);
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Builds on top of #18666 (unstructured-types schema as a forward-looking opt-in). That PR added the constants but no test actually carried the new types through the Spark write/read pipeline. This is the first slice of phase 2: wire up a real unstructured-aware generator and flip a small, targeted set of Spark tests so they exercise `variant_data`, `embedding` (vector) and `blob_data` end-to-end.

### Summary and Changelog

`HoodieTestDataGenerator`:
- Add `generatePayloadForUnstructuredSchema` / `generateRecordForUnstructuredSchema` that build records against `AVRO_SCHEMA_WITH_UNSTRUCTURED`. The legacy field helpers are reused; their `getEffectiveAvroSchema`-derived lookups are tolerant to a structurally compatible outer schema.
- Split `generateRandomValueAsPerSchema`: `TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED` → legacy generator, `TRIP_EXAMPLE_SCHEMA` → unstructured generator. Symmetric fork added for the delete branch.
- Convenience methods that hard-coded `TRIP_EXAMPLE_SCHEMA` (`generateInserts` / `generateInsertsContainsAllPartitions` / `generateInsertsForPartition` / the `generateUpdates|Deletes` and `getExistingKeys` variants) now hard-code `TRIP_EXAMPLE_SCHEMA_NO_UNSTRUCTURED`, so callers using the no-arg API stay on the legacy path in lock-step with the no-arg constructor.

Test flips:
- `TestSavepoint` and `TestMultiFS` now write with `TRIP_EXAMPLE_SCHEMA` via `withSchema(...)` and `dataGen.generateInsertsAsPerSchema(..., TRIP_EXAMPLE_SCHEMA)`. Each generated record carries populated variant/vector/blob fields through the COW write/read path. All cases pass on Spark 3.5 locally (8 + 1).

Bug surfaced (deferred):
- `TestHoodieDefaultMergeHandle`: when records carry unstructured types, `FileGroupReaderBasedMergeHandle.doMerge` → `SerializableIndexedRecord.getData` raises `HoodieIOException: Failed to parse record into provided schema` (caused by Avro `EOFException` inside the binary decoder). The flip is reverted in this PR; this needs a fix before the broader rollout.

### Impact

Test-only. Two test classes start exercising the unstructured-types schema; everything else keeps current behavior.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable