### PR TITLE
fix(spark): catch HoodieSchemaNotFoundException in 3-arg DefaultSource.createRelation

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -140,12 +140,14 @@ class DefaultSource extends RelationProvider
     // HoodieSchemaNotFoundException and returns an EmptyRelation, but that catch is bypassed
     // on this path, so we mirror the same handling here. Preserve the caller-supplied schema
     // so subsequent query analysis (e.g. column resolution in WHERE clauses) sees the
-    // HMS-known columns even though the on-disk table is schemaless.
+    // HMS-known columns even though the on-disk table is schemaless. The 2-arg overload also
+    // re-enters this method with schema=null, so we must fall back to an empty StructType
+    // when schema is null to avoid an NPE in the 2-arg overload's relation.schema.isEmpty check.
     val relation = try {
       DefaultSource.createRelation(sqlContext, metaClient, schema, options.toMap)
     } catch {
       case _: HoodieSchemaNotFoundException =>
-        new EmptyRelation(sqlContext, schema)
+        new EmptyRelation(sqlContext, Option(schema).getOrElse(new StructType()))
     }
     log.info(s"Created relation ${relation.getClass.getSimpleName} with ${options.size} resolved options")
     relation

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -134,7 +134,19 @@ class DefaultSource extends RelationProvider
       parameters
     }
 
-    val relation = DefaultSource.createRelation(sqlContext, metaClient, schema, options.toMap)
+    // Spark's DataSource.resolveRelation() invokes this 3-arg overload directly via the
+    // SchemaRelationProvider path when a user-supplied schema is present (e.g.
+    // spark.read.schema(...).load(path)). The 2-arg overload catches
+    // HoodieSchemaNotFoundException and returns an EmptyRelation, but that catch is bypassed
+    // on this path, so we mirror the same handling here. Preserve the caller-supplied schema
+    // so subsequent query analysis (e.g. column resolution in WHERE clauses) sees the
+    // HMS-known columns even though the on-disk table is schemaless.
+    val relation = try {
+      DefaultSource.createRelation(sqlContext, metaClient, schema, options.toMap)
+    } catch {
+      case _: HoodieSchemaNotFoundException =>
+        new EmptyRelation(sqlContext, Option(schema).getOrElse(new StructType()))
+    }
     log.info(s"Created relation ${relation.getClass.getSimpleName} with ${options.size} resolved options")
     relation
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -145,7 +145,7 @@ class DefaultSource extends RelationProvider
       DefaultSource.createRelation(sqlContext, metaClient, schema, options.toMap)
     } catch {
       case _: HoodieSchemaNotFoundException =>
-        new EmptyRelation(sqlContext, Option(schema).getOrElse(new StructType()))
+        new EmptyRelation(sqlContext, schema)
     }
     log.info(s"Created relation ${relation.getClass.getSimpleName} with ${options.size} resolved options")
     relation

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -2214,6 +2214,40 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
     assertEquals(count, 0)
   }
 
+  @Test
+  def testReadOfAnEmptyTableWithUserSuppliedSchema(): Unit = {
+    val (writeOpts, _) = getWriterReaderOpts(HoodieRecordType.AVRO)
+
+    // Insert + then delete the only completed commit so the table has no resolvable schema.
+    val records = recordsToStrings(dataGen.generateInserts("000", 100)).asScala.toList
+    val inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+    inputDF.write.format("hudi")
+      .options(writeOpts)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val fileStatuses = storage.listDirectEntries(
+      new StoragePath(basePath + StoragePath.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME
+        + StoragePath.SEPARATOR + HoodieTableMetaClient.TIMELINEFOLDER_NAME),
+      new StoragePathFilter {
+        override def accept(path: StoragePath): Boolean = {
+          path.getName.endsWith(HoodieTimeline.COMMIT_ACTION)
+        }
+      })
+    storage.deleteFile(fileStatuses.get(0).getPath)
+
+    // spark.read.schema(...) triggers Spark's SchemaRelationProvider path which calls the
+    // 3-arg DefaultSource.createRelation overload directly. Without the catch on that
+    // overload, this would fail with HoodieSchemaNotFoundException.
+    val userSchema = inputDF.schema
+    val df = spark.read.schema(userSchema).format("hudi").load(basePath)
+    assertEquals(0, df.count())
+    // The caller-supplied schema must be preserved on the EmptyRelation so subsequent query
+    // analysis (e.g. column resolution) sees the user-known columns.
+    assertEquals(userSchema, df.schema)
+  }
+
   /**
    * Test incremental queries and time travel queries with event time ordering.
    *


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18668.

`org.apache.hudi.DefaultSource` has two read-side overloads of `createRelation`:

- The 2-arg overload `createRelation(sqlContext, parameters)` wraps its body in a `try { … } catch { case _: HoodieSchemaNotFoundException => new EmptyRelation(…) }`. This catch was added in [HUDI-7147 / #10689](https://github.com/apache/hudi/pull/10689) so that schema-less Hudi tables (no commits / commit metadata deleted / legacy schema-less layout) do not explode at query analysis time.
- The 3-arg overload `createRelation(sqlContext, optParams, schema)` calls `DefaultSource.createRelation(sqlContext, metaClient, schema, options.toMap)` directly, **without** the same catch.

Spark's `DataSource.resolveRelation()` chooses the overload based on whether a user-supplied schema is present:

```scala
case (dataSource: SchemaRelationProvider, Some(schema)) =>
  dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions, schema)
case (dataSource: RelationProvider, _) =>
  dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions)
```

So any read path that supplies a schema (e.g. `spark.read.schema(s).format("hudi").load(path)`, or HMS-catalog resolution that already knows the schema) bypasses the 2-arg catch and surfaces `HoodieSchemaNotFoundException` directly.

### Summary and Changelog

- **`DefaultSource.scala` (3-arg `createRelation`)**: mirror the existing 2-arg catch so `HoodieSchemaNotFoundException` resolves to `EmptyRelation` on this overload too. Adds an inline comment explaining why both overloads need the same catch.
- **`TestCOWDataSource.testReadOfAnEmptyTableWithUserSuppliedSchema`**: sibling of the existing `testReadOfAnEmptyTable` that asserts `spark.read.schema(userSchema).format("hudi").load(basePath).count() == 0` instead of throwing on a schema-less table.

### Impact

User-facing: a Hudi table whose schema is unresolvable will now return an empty relation when queried with a user-supplied schema, matching the existing no-schema-supplied behavior. No previously-successful path changes behavior — this only converts a previously-thrown exception into an empty result on the same exact failure condition.

### Risk Level

low — minimal scope (one try/catch mirroring existing logic), covered by a new unit test that mirrors an existing one.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)