### PR TITLE
docs: add Spark 4.1 to support matrix in Spark quick start

### DIFF
--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -16,12 +16,13 @@ Hudi works with Spark 3.3 and above versions. You can follow instructions [here]
 
 ### Spark Support Matrix
 
-| Hudi   | Supported Spark versions                                 | Scala versions                                                | Java versions                   |
-|:-------|:---------------------------------------------------------|:--------------------------------------------------------------|:--------------------------------|
-| 1.1.x  | 4.0.x, 3.5.x (default build), 3.4.x, 3.3.x               | 2.13 (Spark 4.0), 2.12/2.13 (Spark 3.5), 2.12 (Spark 3.3-3.4) | 17+ (Spark 4.0), 8+ (Spark 3.x) |
-| 1.0.x  | 3.5.x (default build), 3.4.x, 3.3.x                      | 2.12/2.13 (Spark 3.5), 2.12 (Spark 3.3-3.4)                   | 8+                              |
-| 0.15.x | 3.5.x (default build), 3.4.x, 3.3.x, 3.2.x, 3.1.x, 3.0.x | 2.12/2.13 (Spark 3.5), 2.12                                   | 8+                              |
-| 0.14.x | 3.4.x (default build), 3.3.x, 3.2.x, 3.1.x, 3.0.x        | 2.12                                                          | 8+                              |
+| Hudi   | Supported Spark versions                                 | Scala versions                                                        | Java versions                       |
+|:-------|:---------------------------------------------------------|:----------------------------------------------------------------------|:------------------------------------|
+| 1.2.x  | 4.1.x, 4.0.x, 3.5.x (default build), 3.4.x, 3.3.x        | 2.13 (Spark 4.0/4.1), 2.12/2.13 (Spark 3.5), 2.12 (Spark 3.3-3.4)     | 17+ (Spark 4.0/4.1), 8+ (Spark 3.x) |
+| 1.1.x  | 4.0.x, 3.5.x (default build), 3.4.x, 3.3.x               | 2.13 (Spark 4.0), 2.12/2.13 (Spark 3.5), 2.12 (Spark 3.3-3.4)         | 17+ (Spark 4.0), 8+ (Spark 3.x)     |
+| 1.0.x  | 3.5.x (default build), 3.4.x, 3.3.x                      | 2.12/2.13 (Spark 3.5), 2.12 (Spark 3.3-3.4)                           | 8+                                  |
+| 0.15.x | 3.5.x (default build), 3.4.x, 3.3.x, 3.2.x, 3.1.x, 3.0.x | 2.12/2.13 (Spark 3.5), 2.12                                           | 8+                                  |
+| 0.14.x | 3.4.x (default build), 3.3.x, 3.2.x, 3.1.x, 3.0.x        | 2.12                                                                  | 8+                                  |
 
 :::note
 The *default build* Spark version indicates how we build `hudi-spark3-bundle`.
@@ -45,7 +46,7 @@ From the extracted directory run spark-shell with Hudi:
 
 
 ```shell
-# For Spark versions: 3.3 - 4.0
+# For Spark versions: 3.3 - 4.1
 export SPARK_VERSION=3.5
 export HUDI_VERSION=1.1.1
 # For Scala versions: 2.12/2.13
@@ -66,7 +67,7 @@ From the extracted directory run pyspark with Hudi:
 
 ```shell
 export PYSPARK_PYTHON=$(which python3)
-# For Spark versions: 3.3 - 4.0
+# For Spark versions: 3.3 - 4.1
 export SPARK_VERSION=3.5
 export HUDI_VERSION=1.1.1
 # For Scala versions: 2.12/2.13
@@ -87,7 +88,7 @@ Hudi support using Spark SQL to write and read data with the **HoodieSparkSessio
 From the extracted directory run Spark SQL with Hudi:
 
 ```shell
-# For Spark versions: 3.3 - 4.0
+# For Spark versions: 3.3 - 4.1
 export SPARK_VERSION=3.5
 export HUDI_VERSION=1.1.1
 # For Scala versions: 2.12/2.13

--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -46,9 +46,9 @@ From the extracted directory run spark-shell with Hudi:
 
 
 ```shell
-# For Spark versions: 3.3 - 4.0
+# For Spark versions: 3.3 - 4.1
 export SPARK_VERSION=3.5
-export HUDI_VERSION=1.1.1
+export HUDI_VERSION=1.2.0
 # For Scala versions: 2.12/2.13
 export SCALA_VERSION=2.13
 
@@ -67,9 +67,9 @@ From the extracted directory run pyspark with Hudi:
 
 ```shell
 export PYSPARK_PYTHON=$(which python3)
-# For Spark versions: 3.3 - 4.0
+# For Spark versions: 3.3 - 4.1
 export SPARK_VERSION=3.5
-export HUDI_VERSION=1.1.1
+export HUDI_VERSION=1.2.0
 # For Scala versions: 2.12/2.13
 export SCALA_VERSION=2.13
 
@@ -88,9 +88,9 @@ Hudi support using Spark SQL to write and read data with the **HoodieSparkSessio
 From the extracted directory run Spark SQL with Hudi:
 
 ```shell
-# For Spark versions: 3.3 - 4.0
+# For Spark versions: 3.3 - 4.1
 export SPARK_VERSION=3.5
-export HUDI_VERSION=1.1.1
+export HUDI_VERSION=1.2.0
 # For Scala versions: 2.12/2.13
 export SCALA_VERSION=2.13
 

--- a/website/docs/quick-start-guide.md
+++ b/website/docs/quick-start-guide.md
@@ -46,7 +46,7 @@ From the extracted directory run spark-shell with Hudi:
 
 
 ```shell
-# For Spark versions: 3.3 - 4.1
+# For Spark versions: 3.3 - 4.0
 export SPARK_VERSION=3.5
 export HUDI_VERSION=1.1.1
 # For Scala versions: 2.12/2.13
@@ -67,7 +67,7 @@ From the extracted directory run pyspark with Hudi:
 
 ```shell
 export PYSPARK_PYTHON=$(which python3)
-# For Spark versions: 3.3 - 4.1
+# For Spark versions: 3.3 - 4.0
 export SPARK_VERSION=3.5
 export HUDI_VERSION=1.1.1
 # For Scala versions: 2.12/2.13
@@ -88,7 +88,7 @@ Hudi support using Spark SQL to write and read data with the **HoodieSparkSessio
 From the extracted directory run Spark SQL with Hudi:
 
 ```shell
-# For Spark versions: 3.3 - 4.1
+# For Spark versions: 3.3 - 4.0
 export SPARK_VERSION=3.5
 export HUDI_VERSION=1.1.1
 # For Scala versions: 2.12/2.13


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Spark 4.1 support has landed in master via #17674, but the Spark quick start docs (`website/docs/quick-start-guide.md`) still show only up to Spark 4.0. Update the docs so users on the upcoming 1.2.x release can find Spark 4.1 listed.

### Summary and Changelog

- Add a `1.2.x` row to the Spark Support Matrix covering Spark 4.1.x (Scala 2.13, Java 17+) alongside Spark 4.0.x and 3.5/3.4/3.3.
- Update the spark-shell / pyspark / spark-sql command snippets from \`# For Spark versions: 3.3 - 4.0\` to \`# For Spark versions: 3.3 - 4.1\`.
- Download page and other release-specific docs will be updated when 1.2.0 ships.

### Impact

Docs only. No code or API changes.

### Risk Level

none

### Documentation Update

This PR is the documentation update.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable