### PR TITLE
fix: filter EXTERNAL property in SparkCatalogMetaStoreClient.toCatalogTable

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/SparkCatalogMetaStoreClient.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hive/SparkCatalogMetaStoreClient.scala
@@ -311,8 +311,15 @@ class SparkCatalogMetaStoreClient(syncConfig: HiveSyncConfig)
     // table property keys may not start with 'spark.sql.'") because they are reserved for
     // Spark's internal use (provider, schema parts, create version). Spark re-derives and
     // writes these from the CatalogTable itself, so dropping them on the way in is safe.
+    //
+    // Also strip "EXTERNAL". HMSDDLExecutor.createTable sets both
+    // `tableType=EXTERNAL_TABLE` and `parameters[EXTERNAL]=TRUE`. Spark's
+    // HiveExternalCatalog.verifyTableProperties rejects "EXTERNAL" as a property key
+    // ("Cannot set or change the preserved property key: 'EXTERNAL'") because it controls
+    // table type via CatalogTableType instead. The tableType field below already encodes
+    // that information, so dropping the property is safe.
     val tableProperties = Option(table.getParameters).map(_.asScala.toMap).getOrElse(Map.empty)
-      .filterNot { case (k, _) => k.startsWith("spark.sql.") }
+      .filterNot { case (k, _) => k.startsWith("spark.sql.") || k == "EXTERNAL" }
 
     CatalogTable(
       identifier = TableIdentifier(tbl, Some(db)),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hive/TestSparkCatalogMetaStoreClient.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hive/TestSparkCatalogMetaStoreClient.scala
@@ -177,6 +177,32 @@ class TestSparkCatalogMetaStoreClient extends FunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("createTable accepts EXTERNAL=TRUE parameter (mirrors HMSDDLExecutor behavior)") {
+    withTempDir { tmp =>
+      val client = newClient()
+      val databaseName = generateName("db")
+      val tableName = generateName("tbl")
+
+      client.createDatabase(new Database(databaseName, "test database", new File(tmp, databaseName).toURI.toString, new util.HashMap[String, String]()))
+
+      // Hudi's HMSDDLExecutor.createTable sets BOTH `tableType=EXTERNAL_TABLE` and
+      // `parameters[EXTERNAL]=TRUE` on the Hive Table object. Spark's
+      // HiveExternalCatalog.verifyTableProperties rejects "EXTERNAL" as a property key
+      // unless we strip it in toCatalogTable. This test mirrors that real-world shape.
+      val createdTable = newTable(
+        databaseName,
+        tableName,
+        new File(tmp, tableName).toURI.toString,
+        Seq("id" -> "int", "name" -> "string"),
+        Seq("dt" -> "string"),
+        Map("EXTERNAL" -> "TRUE", "comment" -> "v1"))
+
+      client.createTable(createdTable)
+      assertTrue(client.tableExists(databaseName, tableName))
+      assertEquals("v1", client.getTable(databaseName, tableName).getParameters.get("comment"))
+    }
+  }
+
   private def newClient(): SparkCatalogMetaStoreClient = {
     SparkSession.setActiveSession(spark)
     SparkSession.setDefaultSession(spark)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Hudi's `HMSDDLExecutor.createTable` ([`HMSDDLExecutor.java#L128-L131`](https://github.com/apache/hudi/blob/master/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java#L128-L131)) sets BOTH of the following on the Hive `Table` object when the table is external:

```java
if (!syncConfig.getBoolean(HIVE_CREATE_MANAGED_TABLE)) {
  newTb.putToParameters("EXTERNAL", "TRUE");          // ← duplicate encoding
  newTb.setTableType(TableType.EXTERNAL_TABLE.toString());
}
```

When that `Table` flows through `SparkCatalogMetaStoreClient.createTable` → `toCatalogTable` → `HiveExternalCatalog.createTable`, `HiveExternalCatalog.verifyTableProperties` throws:

```
org.apache.spark.sql.AnalysisException: Cannot set or change the preserved property key: 'EXTERNAL'
  at org.apache.spark.sql.hive.HiveExternalCatalog.verifyTableProperties(HiveExternalCatalog.scala:147)
  ...
  at org.apache.spark.sql.hive.SparkCatalogMetaStoreClient.createTable(SparkCatalogMetaStoreClient.scala:59)
  at org.apache.hudi.hive.ddl.HMSDDLExecutor.createTable(HMSDDLExecutor.java:136)
```

Spark uses `CatalogTableType.EXTERNAL` on the `CatalogTable` itself to encode external-ness, and rejects `EXTERNAL=...` as a duplicate (and forbidden) encoding. So Hudi's normal `HMSDDLExecutor`-shaped `Table` cannot be created at all when `SparkCatalogMetaStoreClient` is in use (i.e. `hoodie.datasource.hive_sync.use_spark_catalog=true`), unless the user explicitly sets `HIVE_CREATE_MANAGED_TABLE=true`.

### Summary and Changelog

- **`SparkCatalogMetaStoreClient.toCatalogTable`**: extend the existing filter that strips `spark.sql.*` keys to also strip `EXTERNAL`. The `tableType` field below already maps `EXTERNAL_TABLE` → `CatalogTableType.EXTERNAL`, so dropping the redundant property is safe and avoids the `verifyTableProperties` rejection.
- **`TestSparkCatalogMetaStoreClient`**: add a regression test mirroring the real `HMSDDLExecutor` shape (`tableType=EXTERNAL_TABLE` AND `parameters[EXTERNAL]=TRUE`).

Same family as #18654 (filter `spark.sql.*`).

### Impact

Restores the ability to use `SparkCatalogMetaStoreClient` with the default Hive-sync codepath (external tables). No previously-successful path changes behavior — this only converts a previously-thrown exception into a successful create on the same exact input shape.

### Risk Level

low — one-line filter extension mirroring existing logic, covered by a new unit test.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)