### PR TITLE
fix(variant): align Spark 4.1 MOR merge with PushVariantIntoScan and restore Spark 4.0 reads

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -187,10 +187,17 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
                 String.valueOf(storage.getConf().getBoolean(SQLConf.PARQUET_RECORD_FILTER_ENABLED().key(), sqlConf.parquetRecordFilterEnabled())));
           });
     }
-    ParquetReader<InternalRow> reader = ParquetReader.builder(new HoodieParquetReadSupport(Option$.MODULE$.empty(), true, true,
-                rebaseDateSpec,
-                SparkAdapterSupport$.MODULE$.sparkAdapter().getRebaseSpec("LEGACY"), messageSchema),
-            new Path(path.toUri()))
+    // Build the ReadSupport via the SparkAdapter so version-specific subclasses (e.g.
+    // Spark40HoodieParquetReadSupport, which reorders variant group fields to [value, metadata]
+    // for Spark 4.0's ParquetUnshreddedVariantConverter) are picked up. Constructing the base
+    // class directly here would skip the variant reorder and produce MALFORMED_VARIANT for
+    // parquet log blocks containing variant columns on Spark 4.0.
+    HoodieParquetReadSupport readSupport = SparkAdapterSupport$.MODULE$.sparkAdapter().createParquetReadSupport(
+        Option$.MODULE$.empty(), true, true,
+        rebaseDateSpec,
+        SparkAdapterSupport$.MODULE$.sparkAdapter().getRebaseSpec("LEGACY"),
+        messageSchema);
+    ParquetReader<InternalRow> reader = ParquetReader.builder(readSupport, new Path(path.toUri()))
         .withConf(storage.getConf().unwrapAs(Configuration.class))
         .build();
     UnsafeProjection projection = evolution.generateUnsafeProjection();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -192,7 +192,6 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
     HoodieParquetReadSupport readSupport = SparkAdapterSupport$.MODULE$.sparkAdapter().createParquetReadSupport(
         Option$.MODULE$.empty(), true, true,
         rebaseDateSpec,
-        SparkAdapterSupport$.MODULE$.sparkAdapter().getRebaseSpec("LEGACY"),
         messageSchema);
     ParquetReader<InternalRow> reader = ParquetReader.builder(readSupport, new Path(path.toUri()))
         .withConf(storage.getConf().unwrapAs(Configuration.class))

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -187,11 +187,8 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
                 String.valueOf(storage.getConf().getBoolean(SQLConf.PARQUET_RECORD_FILTER_ENABLED().key(), sqlConf.parquetRecordFilterEnabled())));
           });
     }
-    // Build the ReadSupport via the SparkAdapter so version-specific subclasses (e.g.
-    // Spark40HoodieParquetReadSupport, which reorders variant group fields to [value, metadata]
-    // for Spark 4.0's ParquetUnshreddedVariantConverter) are picked up. Constructing the base
-    // class directly here would skip the variant reorder and produce MALFORMED_VARIANT for
-    // parquet log blocks containing variant columns on Spark 4.0.
+    // Via SparkAdapter so Spark 4.0 picks up its variant-reordering ReadSupport subclass
+    // (#18334); constructing the base class here would MALFORMED_VARIANT on Spark 4.0.
     HoodieParquetReadSupport readSupport = SparkAdapterSupport$.MODULE$.sparkAdapter().createParquetReadSupport(
         Option$.MODULE$.empty(), true, true,
         rebaseDateSpec,

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -84,17 +84,10 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
   private lazy val morFilters = filters.filter(filterIsSafeForPrimaryKey(_, recordKeyFields)) ++ requiredFilters
   private lazy val allFilters = filters ++ requiredFilters
 
-  // Engine-neutral hook used by FileGroupRecordBuffer to align log-block records with the
-  // PushVariantIntoScan-projected variant shape before they reach the merger.
-  //
-  // The data block carries v as a real VariantType plus Hudi's merger metadata columns
-  // (_hoodie_record_key for key-based merge, _tmp_metadata_row_index for position-based).
-  // The downstream merger reads those metadata columns by ordinal to look records up. So the
-  // projector must preserve every field of the data-block schema and only rewrite variant
-  // fields into their PushVariantIntoScan struct shape — projecting down to the bare required
-  // schema (id,name,v,ts) drops _hoodie_record_key / _tmp_metadata_row_index and the merger
-  // then reads garbage offsets, surfacing as a SIGBUS-translated InternalError in
-  // FileScanRDD.hasNext during the next shuffle's RangePartitioner sample.
+  // Aligns log-block records with the PushVariantIntoScan-projected variant shape before
+  // they reach the merger. Preserves merger metadata cols (_hoodie_record_key,
+  // _tmp_metadata_row_index) which the merger reads by ordinal — projecting down to the
+  // bare required schema would drop them and the merger would read garbage offsets.
   override def getLogBlockRecordProjection(
       dataBlockSchema: HoodieSchema): HOption[JFunction[InternalRow, InternalRow]] = {
     val needsProjection = sparkRequiredSchema.exists(_.fields.exists(f => f.dataType match {
@@ -106,9 +99,6 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     }
     val req = sparkRequiredSchema.get
     val dataStruct = HoodieInternalRowUtils.getCachedSchema(dataBlockSchema)
-    // Build the projector's target schema from dataStruct, replacing each variant field with
-    // the PushVariantIntoScan-projected struct shape from the required schema. Non-variant
-    // fields (including merger metadata cols absent from the required schema) pass through.
     val targetFields = dataStruct.fields.map { df =>
       SparkFileFormatInternalRowReaderContext.findFieldByName(req, df.name).map(_.dataType) match {
         case Some(projStruct: StructType) if sparkAdapter.isVariantProjectionStruct(projStruct) =>
@@ -119,9 +109,8 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     val targetStruct = StructType(targetFields)
     sparkAdapter.buildVariantProjector(dataStruct, targetStruct) match {
       case Some(p) => HOption.of(new JFunction[InternalRow, InternalRow] {
-        // buildVariantProjector returns an UnsafeProjection whose `apply` reuses a single
-        // UnsafeRow buffer. The merge path stores these rows into ExternalSpillableMap, so we
-        // must copy before the next invocation overwrites the buffer.
+        // .copy() because the buffer stores rows into ExternalSpillableMap and
+        // UnsafeProjection reuses a single output buffer.
         override def apply(r: InternalRow): InternalRow = p(r).copy()
       })
       case None => HOption.empty[JFunction[InternalRow, InternalRow]]()
@@ -138,18 +127,10 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     if (hasRowIndexField) {
       assert(getRecordContext.supportsParquetRowIndex())
     }
-    // The function-arg requiredSchema is the engine's *augmented* required schema — Hudi's
-    // schema handler has already added the merger's metadata columns (_hoodie_record_key for
-    // key-based merge, _tmp_metadata_row_index for position-based) to the user-requested
-    // fields. Start from that so the parquet read includes those columns (the merger needs
-    // them to extract record keys / positions from base rows).
-    //
-    // Then overlay variant projection metadata from sparkRequiredSchema: when Spark 4.1's
-    // PushVariantIntoScan rewrote a variant column into struct<0:..> with VariantMetadata,
-    // parquet-mr can do that projection natively — but only if the field carries the
-    // VariantMetadata. The augmented HoodieSchema-derived struct loses that metadata
-    // (HoodieSparkSchemaConverters collapses the projected struct back to VariantType), so
-    // we copy the projected struct shape from sparkRequiredSchema where it exists.
+    // Use the engine's augmented requiredSchema (includes merger metadata cols the merger
+    // reads from base rows), but overlay the projected variant shape from sparkRequiredSchema
+    // so parquet-mr's PushVariantIntoScan kicks in (HoodieSchema collapses the projected
+    // struct back to VariantType, dropping the VariantMetadata parquet-mr looks for).
     val structType = sparkRequiredSchema match {
       case Some(sparkReq) =>
         val augmentedStruct = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
@@ -182,9 +163,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     val (readSchema, readFilters) = getSchemaAndFiltersForRead(parquetReadStructType, hasRowIndexField)
     if (FSUtils.isLogFile(filePath)) {
       // NOTE: now only primary key based filtering is supported for log files
-      // Records come out with v as VARIANT (the parquet log block's native shape). Variant
-      // alignment to PushVariantIntoScan's projected struct shape happens later in the
-      // FileGroupRecordBuffer via getLogBlockRecordProjection.
+      // Variant alignment happens later via getLogBlockRecordProjection in the merge buffer.
       new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
         .asInstanceOf[HoodieSparkParquetReader].getUnsafeRowIterator(requiredSchema, readFilters.asJava)
         .asInstanceOf[ClosableIterator[InternalRow]]
@@ -360,12 +339,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
 }
 
 object SparkFileFormatInternalRowReaderContext {
-  /**
-   * Look up a field by name on a Spark StructType, honoring the session's
-   * `spark.sql.caseSensitive` setting. Used when overlaying variant projection metadata from
-   * the Spark required schema onto the Hudi-derived data schema, where the two schemas may
-   * have arrived through different name-resolution paths.
-   */
+  /** Look up a field by name, honoring `spark.sql.caseSensitive`. */
   private[hudi] def findFieldByName(schema: StructType, name: String): Option[StructField] = {
     if (SQLConf.get.caseSensitiveAnalysis) {
       schema.fields.find(_.name == name)

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.{HoodieFileFormat, HoodieRecord}
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
+import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, CloseableMappingIterator, Pair => HPair}
 import org.apache.hudi.io.storage.{HoodieSparkFileReaderFactory, HoodieSparkParquetReader, VectorConversionUtils}
@@ -42,6 +43,8 @@ import org.apache.spark.sql.hudi.SparkAdapter
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{ArrayType, ByteType, DoubleType, FloatType, LongType, MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
+
+import java.util.function.{Function => JFunction}
 
 import scala.collection.JavaConverters._
 
@@ -80,17 +83,50 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
   private lazy val morFilters = filters.filter(filterIsSafeForPrimaryKey(_, recordKeyFields)) ++ requiredFilters
   private lazy val allFilters = filters ++ requiredFilters
 
-  // Per Spark 4.1's PushVariantIntoScan: when the Catalyst-rewritten required schema contains
-  // variant projection structs (each child carries VariantMetadata), we need to align log-file
-  // rows (which carry the full variant) to the projected struct shape before they reach the
-  // merger. Base files use parquet-mr's native variant projection via the Spark required schema
-  // we'll prefer below. Returns None on Spark <4.1 or for non-variant queries (fast path).
-  private lazy val variantLogProjector: Option[InternalRow => InternalRow] =
-    for {
-      d <- sparkDataSchema
-      r <- sparkRequiredSchema
-      p <- sparkAdapter.buildVariantProjector(d, r)
-    } yield p
+  // Engine-neutral hook used by FileGroupRecordBuffer to align log-block records with the
+  // PushVariantIntoScan-projected variant shape before they reach the merger.
+  //
+  // The data block carries v as a real VariantType plus Hudi's merger metadata columns
+  // (_hoodie_record_key for key-based merge, _tmp_metadata_row_index for position-based).
+  // The downstream merger reads those metadata columns by ordinal to look records up. So the
+  // projector must preserve every field of the data-block schema and only rewrite variant
+  // fields into their PushVariantIntoScan struct shape — projecting down to the bare required
+  // schema (id,name,v,ts) drops _hoodie_record_key / _tmp_metadata_row_index and the merger
+  // then reads garbage offsets, surfacing as a SIGBUS-translated InternalError in
+  // FileScanRDD.hasNext during the next shuffle's RangePartitioner sample.
+  override def getLogBlockRecordProjection(
+      dataBlockSchema: HoodieSchema): HOption[JFunction[InternalRow, InternalRow]] = {
+    val needsProjection = sparkRequiredSchema.exists(_.fields.exists(f => f.dataType match {
+      case st: StructType => sparkAdapter.isVariantProjectionStruct(st)
+      case _ => false
+    }))
+    if (!needsProjection) {
+      return HOption.empty[JFunction[InternalRow, InternalRow]]()
+    }
+    val req = sparkRequiredSchema.get
+    val dataStruct = HoodieInternalRowUtils.getCachedSchema(dataBlockSchema)
+    // Build the projector's target schema from dataStruct, replacing each variant field with
+    // the PushVariantIntoScan-projected struct shape from the required schema. Non-variant
+    // fields (including merger metadata cols absent from the required schema) pass through.
+    val targetFields = dataStruct.fields.map { df =>
+      val reqField = req.fields.find(_.name == df.name)
+      reqField.map(_.dataType) match {
+        case Some(projStruct: StructType) if sparkAdapter.isVariantProjectionStruct(projStruct) =>
+          df.copy(dataType = projStruct)
+        case _ => df
+      }
+    }
+    val targetStruct = StructType(targetFields)
+    sparkAdapter.buildVariantProjector(dataStruct, targetStruct) match {
+      case Some(p) => HOption.of(new JFunction[InternalRow, InternalRow] {
+        // buildVariantProjector returns an UnsafeProjection whose `apply` reuses a single
+        // UnsafeRow buffer. The merge path stores these rows into ExternalSpillableMap, so we
+        // must copy before the next invocation overwrites the buffer.
+        override def apply(r: InternalRow): InternalRow = p(r).copy()
+      })
+      case None => HOption.empty[JFunction[InternalRow, InternalRow]]()
+    }
+  }
 
   override def getFileRecordIterator(filePath: StoragePath,
                                      start: Long,
@@ -102,10 +138,30 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     if (hasRowIndexField) {
       assert(getRecordContext.supportsParquetRowIndex())
     }
-    // Prefer the original Spark required schema when present (carries Spark 4.1
-    // VariantMetadata that parquet-mr needs to do variant projection natively); fall back
-    // to the HoodieSchema-derived StructType otherwise.
-    val structType = sparkRequiredSchema.getOrElse(HoodieInternalRowUtils.getCachedSchema(requiredSchema))
+    // The function-arg requiredSchema is the engine's *augmented* required schema — Hudi's
+    // schema handler has already added the merger's metadata columns (_hoodie_record_key for
+    // key-based merge, _tmp_metadata_row_index for position-based) to the user-requested
+    // fields. Start from that so the parquet read includes those columns (the merger needs
+    // them to extract record keys / positions from base rows).
+    //
+    // Then overlay variant projection metadata from sparkRequiredSchema: when Spark 4.1's
+    // PushVariantIntoScan rewrote a variant column into struct<0:..> with VariantMetadata,
+    // parquet-mr can do that projection natively — but only if the field carries the
+    // VariantMetadata. The augmented HoodieSchema-derived struct loses that metadata
+    // (HoodieSparkSchemaConverters collapses the projected struct back to VariantType), so
+    // we copy the projected struct shape from sparkRequiredSchema where it exists.
+    val structType = sparkRequiredSchema match {
+      case Some(sparkReq) =>
+        val augmentedStruct = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
+        StructType(augmentedStruct.fields.map { f =>
+          sparkReq.fields.find(_.name == f.name).map(_.dataType) match {
+            case Some(projStruct: StructType) if sparkAdapter.isVariantProjectionStruct(projStruct) =>
+              f.copy(dataType = projStruct)
+            case _ => f
+          }
+        })
+      case None => HoodieInternalRowUtils.getCachedSchema(requiredSchema)
+    }
 
     // Parquet stores VECTOR as FIXED_LEN_BYTE_ARRAY, so the reader needs BinaryType
     // and we decode back to ArrayType below. Lance returns ArrayType natively, so skip
@@ -126,15 +182,12 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     val (readSchema, readFilters) = getSchemaAndFiltersForRead(parquetReadStructType, hasRowIndexField)
     if (FSUtils.isLogFile(filePath)) {
       // NOTE: now only primary key based filtering is supported for log files
-      val rawLogIter = new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
+      // Records come out with v as VARIANT (the parquet log block's native shape). Variant
+      // alignment to PushVariantIntoScan's projected struct shape happens later in the
+      // FileGroupRecordBuffer via getLogBlockRecordProjection.
+      new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
         .asInstanceOf[HoodieSparkParquetReader].getUnsafeRowIterator(requiredSchema, readFilters.asJava)
         .asInstanceOf[ClosableIterator[InternalRow]]
-      // Spark 4.1 PushVariantIntoScan: log records carry the full variant; project per-row
-      // to the requested struct shape so they align with the base file's already-projected rows.
-      variantLogProjector match {
-        case Some(project) => SparkFileFormatInternalRowReaderContext.mappedClosable(rawLogIter, project)
-        case None => rawLogIter
-      }
     } else {
       // partition value is empty because the spark parquet reader will append the partition columns to
       // each row if they are given. That is the only usage of the partition values in the reader.

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -66,7 +66,6 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
                                               requiredFilters: Seq[Filter],
                                               storageConfiguration: StorageConfiguration[_],
                                               tableConfig: HoodieTableConfig,
-                                              sparkDataSchema: Option[StructType] = None,
                                               sparkRequiredSchema: Option[StructType] = None)
   extends BaseSparkInternalRowReaderContext(storageConfiguration, tableConfig, SparkFileFormatInternalRecordContext.apply(tableConfig)) {
 
@@ -76,7 +75,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
            requiredFilters: Seq[Filter],
            storageConfiguration: StorageConfiguration[_],
            tableConfig: HoodieTableConfig) =
-    this(baseFileReader, filters, requiredFilters, storageConfiguration, tableConfig, None, None)
+    this(baseFileReader, filters, requiredFilters, storageConfiguration, tableConfig, None)
 
   lazy val sparkAdapter: SparkAdapter = SparkAdapterSupport.sparkAdapter
   private lazy val recordKeyFields = Option(tableConfig.getRecordKeyFields.orElse(null)).map(_.map(_.toLowerCase).toSet).getOrElse(Set.empty)

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -28,7 +28,7 @@ import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
 import org.apache.hudi.common.util.ValidationUtils.checkState
-import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, Pair => HPair}
+import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, CloseableMappingIterator, Pair => HPair}
 import org.apache.hudi.io.storage.{HoodieSparkFileReaderFactory, HoodieSparkParquetReader, VectorConversionUtils}
 import org.apache.hudi.storage.{HoodieStorage, StorageConfiguration, StoragePath}
 import org.apache.hudi.util.CloseableInternalRowIterator
@@ -61,13 +61,36 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
                                               filters: Seq[Filter],
                                               requiredFilters: Seq[Filter],
                                               storageConfiguration: StorageConfiguration[_],
-                                              tableConfig: HoodieTableConfig)
+                                              tableConfig: HoodieTableConfig,
+                                              sparkDataSchema: Option[StructType] = None,
+                                              sparkRequiredSchema: Option[StructType] = None)
   extends BaseSparkInternalRowReaderContext(storageConfiguration, tableConfig, SparkFileFormatInternalRecordContext.apply(tableConfig)) {
+
+  // Java-friendly auxiliary constructor (Scala default args don't generate matching Java overloads).
+  def this(baseFileReader: SparkColumnarFileReader,
+           filters: Seq[Filter],
+           requiredFilters: Seq[Filter],
+           storageConfiguration: StorageConfiguration[_],
+           tableConfig: HoodieTableConfig) =
+    this(baseFileReader, filters, requiredFilters, storageConfiguration, tableConfig, None, None)
+
   lazy val sparkAdapter: SparkAdapter = SparkAdapterSupport.sparkAdapter
   private lazy val recordKeyFields = Option(tableConfig.getRecordKeyFields.orElse(null)).map(_.map(_.toLowerCase).toSet).getOrElse(Set.empty)
   private lazy val bootstrapSafeFilters: Seq[Filter] = filters.filter(filterIsSafeForBootstrap) ++ requiredFilters
   private lazy val morFilters = filters.filter(filterIsSafeForPrimaryKey(_, recordKeyFields)) ++ requiredFilters
   private lazy val allFilters = filters ++ requiredFilters
+
+  // Per Spark 4.1's PushVariantIntoScan: when the Catalyst-rewritten required schema contains
+  // variant projection structs (each child carries VariantMetadata), we need to align log-file
+  // rows (which carry the full variant) to the projected struct shape before they reach the
+  // merger. Base files use parquet-mr's native variant projection via the Spark required schema
+  // we'll prefer below. Returns None on Spark <4.1 or for non-variant queries (fast path).
+  private lazy val variantLogProjector: Option[InternalRow => InternalRow] =
+    for {
+      d <- sparkDataSchema
+      r <- sparkRequiredSchema
+      p <- sparkAdapter.buildVariantProjector(d, r)
+    } yield p
 
   override def getFileRecordIterator(filePath: StoragePath,
                                      start: Long,
@@ -79,7 +102,10 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     if (hasRowIndexField) {
       assert(getRecordContext.supportsParquetRowIndex())
     }
-    val structType = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
+    // Prefer the original Spark required schema when present (carries Spark 4.1
+    // VariantMetadata that parquet-mr needs to do variant projection natively); fall back
+    // to the HoodieSchema-derived StructType otherwise.
+    val structType = sparkRequiredSchema.getOrElse(HoodieInternalRowUtils.getCachedSchema(requiredSchema))
 
     // Parquet stores VECTOR as FIXED_LEN_BYTE_ARRAY, so the reader needs BinaryType
     // and we decode back to ArrayType below. Lance returns ArrayType natively, so skip
@@ -100,8 +126,15 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     val (readSchema, readFilters) = getSchemaAndFiltersForRead(parquetReadStructType, hasRowIndexField)
     if (FSUtils.isLogFile(filePath)) {
       // NOTE: now only primary key based filtering is supported for log files
-      new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
-        .asInstanceOf[HoodieSparkParquetReader].getUnsafeRowIterator(requiredSchema, readFilters.asJava).asInstanceOf[ClosableIterator[InternalRow]]
+      val rawLogIter = new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
+        .asInstanceOf[HoodieSparkParquetReader].getUnsafeRowIterator(requiredSchema, readFilters.asJava)
+        .asInstanceOf[ClosableIterator[InternalRow]]
+      // Spark 4.1 PushVariantIntoScan: log records carry the full variant; project per-row
+      // to the requested struct shape so they align with the base file's already-projected rows.
+      variantLogProjector match {
+        case Some(project) => SparkFileFormatInternalRowReaderContext.mappedClosable(rawLogIter, project)
+        case None => rawLogIter
+      }
     } else {
       // partition value is empty because the spark parquet reader will append the partition columns to
       // each row if they are given. That is the only usage of the partition values in the reader.
@@ -274,6 +307,12 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
 }
 
 object SparkFileFormatInternalRowReaderContext {
+  /** Wrap a closable iterator with a per-row transform, preserving close semantics. */
+  def mappedClosable(it: ClosableIterator[InternalRow],
+                     transform: InternalRow => InternalRow): ClosableIterator[InternalRow] = {
+    new CloseableMappingIterator[InternalRow, InternalRow](it, (r: InternalRow) => transform(r))
+  }
+
   // From "namedExpressions.scala": Used to construct to record position field metadata.
   private val FILE_SOURCE_GENERATED_METADATA_COL_ATTR_KEY = "__file_source_generated_metadata_col"
   private val FILE_SOURCE_METADATA_COL_ATTR_KEY = "__file_source_metadata_col"

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -29,7 +29,7 @@ import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.common.util.ValidationUtils.checkState
-import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, CloseableMappingIterator, Pair => HPair}
+import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, Pair => HPair}
 import org.apache.hudi.io.storage.{HoodieSparkFileReaderFactory, HoodieSparkParquetReader, VectorConversionUtils}
 import org.apache.hudi.storage.{HoodieStorage, StorageConfiguration, StoragePath}
 import org.apache.hudi.util.CloseableInternalRowIterator
@@ -39,6 +39,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{JoinedRow, UnsafeProjection}
 import org.apache.spark.sql.execution.datasources.{PartitionedFile, SparkColumnarFileReader}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.hudi.SparkAdapter
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{ArrayType, ByteType, DoubleType, FloatType, LongType, MetadataBuilder, StructField, StructType}
@@ -109,8 +110,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     // the PushVariantIntoScan-projected struct shape from the required schema. Non-variant
     // fields (including merger metadata cols absent from the required schema) pass through.
     val targetFields = dataStruct.fields.map { df =>
-      val reqField = req.fields.find(_.name == df.name)
-      reqField.map(_.dataType) match {
+      SparkFileFormatInternalRowReaderContext.findFieldByName(req, df.name).map(_.dataType) match {
         case Some(projStruct: StructType) if sparkAdapter.isVariantProjectionStruct(projStruct) =>
           df.copy(dataType = projStruct)
         case _ => df
@@ -154,7 +154,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
       case Some(sparkReq) =>
         val augmentedStruct = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
         StructType(augmentedStruct.fields.map { f =>
-          sparkReq.fields.find(_.name == f.name).map(_.dataType) match {
+          SparkFileFormatInternalRowReaderContext.findFieldByName(sparkReq, f.name).map(_.dataType) match {
             case Some(projStruct: StructType) if sparkAdapter.isVariantProjectionStruct(projStruct) =>
               f.copy(dataType = projStruct)
             case _ => f
@@ -360,10 +360,18 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
 }
 
 object SparkFileFormatInternalRowReaderContext {
-  /** Wrap a closable iterator with a per-row transform, preserving close semantics. */
-  def mappedClosable(it: ClosableIterator[InternalRow],
-                     transform: InternalRow => InternalRow): ClosableIterator[InternalRow] = {
-    new CloseableMappingIterator[InternalRow, InternalRow](it, (r: InternalRow) => transform(r))
+  /**
+   * Look up a field by name on a Spark StructType, honoring the session's
+   * `spark.sql.caseSensitive` setting. Used when overlaying variant projection metadata from
+   * the Spark required schema onto the Hudi-derived data schema, where the two schemas may
+   * have arrived through different name-resolution paths.
+   */
+  private[hudi] def findFieldByName(schema: StructType, name: String): Option[StructField] = {
+    if (SQLConf.get.caseSensitiveAnalysis) {
+      schema.fields.find(_.name == name)
+    } else {
+      schema.fields.find(_.name.equalsIgnoreCase(name))
+    }
   }
 
   // From "namedExpressions.scala": Used to construct to record position field metadata.

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -84,6 +84,18 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
   private lazy val morFilters = filters.filter(filterIsSafeForPrimaryKey(_, recordKeyFields)) ++ requiredFilters
   private lazy val allFilters = filters ++ requiredFilters
 
+  // For each field of `target`, replace its dataType with the matching field's projected
+  // variant struct from `source` (when present). Non-matching fields pass through.
+  private def overlayVariantProjections(target: StructType, source: StructType): StructType = {
+    StructType(target.fields.map { f =>
+      SparkFileFormatInternalRowReaderContext.findFieldByName(source, f.name).map(_.dataType) match {
+        case Some(projStruct: StructType) if sparkAdapter.isVariantProjectionStruct(projStruct) =>
+          f.copy(dataType = projStruct)
+        case _ => f
+      }
+    })
+  }
+
   // Aligns log-block records with the PushVariantIntoScan-projected variant shape before
   // they reach the merger. Preserves merger metadata cols (_hoodie_record_key,
   // _tmp_metadata_row_index) which the merger reads by ordinal — projecting down to the
@@ -99,14 +111,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     }
     val req = sparkRequiredSchema.get
     val dataStruct = HoodieInternalRowUtils.getCachedSchema(dataBlockSchema)
-    val targetFields = dataStruct.fields.map { df =>
-      SparkFileFormatInternalRowReaderContext.findFieldByName(req, df.name).map(_.dataType) match {
-        case Some(projStruct: StructType) if sparkAdapter.isVariantProjectionStruct(projStruct) =>
-          df.copy(dataType = projStruct)
-        case _ => df
-      }
-    }
-    val targetStruct = StructType(targetFields)
+    val targetStruct = overlayVariantProjections(dataStruct, req)
     sparkAdapter.buildVariantProjector(dataStruct, targetStruct) match {
       case Some(p) => HOption.of(new JFunction[InternalRow, InternalRow] {
         // .copy() because the buffer stores rows into ExternalSpillableMap and
@@ -132,15 +137,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     // so parquet-mr's PushVariantIntoScan kicks in (HoodieSchema collapses the projected
     // struct back to VariantType, dropping the VariantMetadata parquet-mr looks for).
     val structType = sparkRequiredSchema match {
-      case Some(sparkReq) =>
-        val augmentedStruct = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
-        StructType(augmentedStruct.fields.map { f =>
-          SparkFileFormatInternalRowReaderContext.findFieldByName(sparkReq, f.name).map(_.dataType) match {
-            case Some(projStruct: StructType) if sparkAdapter.isVariantProjectionStruct(projStruct) =>
-              f.copy(dataType = projStruct)
-            case _ => f
-          }
-        })
+      case Some(sparkReq) => overlayVariantProjections(HoodieInternalRowUtils.getCachedSchema(requiredSchema), sparkReq)
       case None => HoodieInternalRowUtils.getCachedSchema(requiredSchema)
     }
 

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -190,13 +190,9 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
         isCanonicalVariantStruct(variantStruct) =>
         HoodieSchema.createVariant(recordName, nameSpace, null)
 
-      // Spark 4.1's PushVariantIntoScan rule rewrites a Variant column on the read schema to a
-      // struct of pushed-down extractions (each child carries VariantMetadata). The Spark
-      // requiredSchema with this metadata still flows through to parquet-mr unchanged, which does
-      // the projection natively. For Hudi's internal HoodieSchema we represent it as a regular
-      // unshredded Variant — the schema handler/merger then aligns with the table's stored
-      // `v: Variant` data schema, and the projected struct shape is preserved by Spark's parquet
-      // reader at row-construction time.
+      // PushVariantIntoScan (Spark 4.1+) rewrites Variant to a struct of extractions; map
+      // it back to a regular HoodieSchema Variant. parquet-mr does the projection natively
+      // from the Spark required schema's VariantMetadata.
       case projectedVariant: StructType if isSparkVariantProjectionStruct(projectedVariant) =>
         HoodieSchema.createVariant(recordName, nameSpace, null)
 
@@ -525,18 +521,9 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
   }
 
   /**
-   * Detects a Spark 4.1 PushVariantIntoScan-projected struct. The check defers to the
-   * version-specific SparkAdapter, but most schemas can be cleared without that detour:
-   *
-   *   1. Spark < 4.1 — PushVariantIntoScan does not exist.
-   *   2. No field carries any non-empty Spark Metadata — the projection always tags every
-   *      field with VariantMetadata, so an empty-metadata struct is definitively not one.
-   *
-   * Both short-circuits matter for shared-module unit tests (e.g. `hudi-spark-common`'s
-   * `TestHoodieSparkSchemaUtils`) whose runtime classpath does not include any
-   * `SparkXAdapter`: forcing `SparkAdapterSupport.sparkAdapter` to resolve there raises
-   * `ClassNotFoundException` on every StructType conversion. The try/catch is a
-   * belt-and-suspenders fallback for any other environment that hits the same gap.
+   * Detects a Spark 4.1 PushVariantIntoScan-projected struct. Short-circuits before consulting
+   * the version-specific SparkAdapter so shared-module unit tests (whose classpath lacks any
+   * SparkXAdapter) don't trigger an adapter-load failure on plain StructType conversions.
    */
   private def isSparkVariantProjectionStruct(st: StructType): Boolean = {
     if (!HoodieSparkUtils.gteqSpark4_1) return false

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -27,6 +27,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.Decimal.minBytesForPrecision
+import org.slf4j.{Logger, LoggerFactory}
 
 import java.util.Locale
 
@@ -47,6 +48,8 @@ import scala.collection.JavaConverters._
  */
 @DeveloperApi
 object HoodieSparkSchemaConverters extends SparkAdapterSupport {
+
+  private val LOG: Logger = LoggerFactory.getLogger(getClass)
 
   /**
    * Internal wrapper for SQL data type and nullability.
@@ -190,8 +193,26 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
         isCanonicalVariantStruct(variantStruct) =>
         HoodieSchema.createVariant(recordName, nameSpace, null)
 
+      // Spark 4.1's PushVariantIntoScan rule rewrites a Variant column on the read schema to a
+      // struct of pushed-down extractions (each child carries VariantMetadata). The Spark
+      // requiredSchema with this metadata still flows through to parquet-mr unchanged, which does
+      // the projection natively. For Hudi's internal HoodieSchema we represent it as a regular
+      // unshredded Variant — the schema handler/merger then aligns with the table's stored
+      // `v: Variant` data schema, and the projected struct shape is preserved by Spark's parquet
+      // reader at row-construction time.
+      case projectedVariant: StructType if sparkAdapter.isVariantProjectionStruct(projectedVariant) =>
+        HoodieSchema.createVariant(recordName, nameSpace, null)
+
       case st: StructType =>
         val childNameSpace = if (nameSpace != "") s"$nameSpace.$recordName" else recordName
+        val typeMetaTag = if (metadata.contains(HoodieSchema.TYPE_METADATA_FIELD)) {
+          metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)
+        } else "<none>"
+        LOG.warn(
+          s"toHoodieTypeNested entering generic StructType branch: depth=$depth, " +
+            s"recordName=$recordName, nameSpace=$nameSpace, typeMetaTag=$typeMetaTag, " +
+            s"isVariantType=${sparkAdapter.isVariantType(st)}, " +
+            s"fields=${st.fields.map(f => s"${f.name}:${f.dataType.simpleString}").mkString("[", ",", "]")}")
 
         // Check if this might be a union (using heuristic like Avro converter)
         if (canBeUnion(st)) {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -18,7 +18,7 @@
 
 package org.apache.spark.sql.avro
 
-import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.{HoodieSparkUtils, SparkAdapterSupport}
 import org.apache.hudi.common.schema.{HoodieJsonProperties, HoodieSchema, HoodieSchemaField, HoodieSchemaType}
 import org.apache.hudi.common.schema.HoodieSchema.TimePrecision
 import org.apache.hudi.internal.schema.HoodieSchemaException
@@ -27,7 +27,6 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.Decimal.minBytesForPrecision
-import org.slf4j.{Logger, LoggerFactory}
 
 import java.util.Locale
 
@@ -48,8 +47,6 @@ import scala.collection.JavaConverters._
  */
 @DeveloperApi
 object HoodieSparkSchemaConverters extends SparkAdapterSupport {
-
-  private val LOG: Logger = LoggerFactory.getLogger(getClass)
 
   /**
    * Internal wrapper for SQL data type and nullability.
@@ -200,19 +197,11 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
       // unshredded Variant — the schema handler/merger then aligns with the table's stored
       // `v: Variant` data schema, and the projected struct shape is preserved by Spark's parquet
       // reader at row-construction time.
-      case projectedVariant: StructType if sparkAdapter.isVariantProjectionStruct(projectedVariant) =>
+      case projectedVariant: StructType if isSparkVariantProjectionStruct(projectedVariant) =>
         HoodieSchema.createVariant(recordName, nameSpace, null)
 
       case st: StructType =>
         val childNameSpace = if (nameSpace != "") s"$nameSpace.$recordName" else recordName
-        val typeMetaTag = if (metadata.contains(HoodieSchema.TYPE_METADATA_FIELD)) {
-          metadata.getString(HoodieSchema.TYPE_METADATA_FIELD)
-        } else "<none>"
-        LOG.warn(
-          s"toHoodieTypeNested entering generic StructType branch: depth=$depth, " +
-            s"recordName=$recordName, nameSpace=$nameSpace, typeMetaTag=$typeMetaTag, " +
-            s"isVariantType=${sparkAdapter.isVariantType(st)}, " +
-            s"fields=${st.fields.map(f => s"${f.name}:${f.dataType.simpleString}").mkString("[", ",", "]")}")
 
         // Check if this might be a union (using heuristic like Avro converter)
         if (canBeUnion(st)) {
@@ -533,6 +522,27 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
       st.forall { f =>
         f.name.matches("member\\d+") && f.nullable
       }
+  }
+
+  /**
+   * Detects a Spark 4.1 PushVariantIntoScan-projected struct. The check defers to the
+   * version-specific SparkAdapter, but most schemas can be cleared without that detour:
+   *
+   *   1. Spark < 4.1 — PushVariantIntoScan does not exist.
+   *   2. No field carries any non-empty Spark Metadata — the projection always tags every
+   *      field with VariantMetadata, so an empty-metadata struct is definitively not one.
+   *
+   * Both short-circuits matter for shared-module unit tests (e.g. `hudi-spark-common`'s
+   * `TestHoodieSparkSchemaUtils`) whose runtime classpath does not include any
+   * `SparkXAdapter`: forcing `SparkAdapterSupport.sparkAdapter` to resolve there raises
+   * `ClassNotFoundException` on every StructType conversion. The try/catch is a
+   * belt-and-suspenders fallback for any other environment that hits the same gap.
+   */
+  private def isSparkVariantProjectionStruct(st: StructType): Boolean = {
+    if (!HoodieSparkUtils.gteqSpark4_1) return false
+    if (!st.fields.exists(_.metadata != Metadata.empty)) return false
+    try sparkAdapter.isVariantProjectionStruct(st)
+    catch { case _: NoClassDefFoundError | _: ClassNotFoundException => false }
   }
 
   private def sparkTypeForVectorElementType(

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/avro/HoodieSparkSchemaConverters.scala
@@ -527,7 +527,7 @@ object HoodieSparkSchemaConverters extends SparkAdapterSupport {
    */
   private def isSparkVariantProjectionStruct(st: StructType): Boolean = {
     if (!HoodieSparkUtils.gteqSpark4_1) return false
-    if (!st.fields.exists(_.metadata != Metadata.empty)) return false
+    if (st.fields.forall(_.metadata == Metadata.empty)) return false
     try sparkAdapter.isVariantProjectionStruct(st)
     catch { case _: NoClassDefFoundError | _: ClassNotFoundException => false }
   }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieParquetReadSupport.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieParquetReadSupport.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.common.util.ValidationUtils
 
 import org.apache.parquet.hadoop.api.InitContext
 import org.apache.parquet.hadoop.api.ReadSupport.ReadContext
-import org.apache.parquet.schema.{GroupType, MessageType, PrimitiveType, SchemaRepair, Type, Types}
+import org.apache.parquet.schema.{GroupType, MessageType, SchemaRepair, Type, Types}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 
 import java.time.ZoneId
@@ -50,15 +50,7 @@ class HoodieParquetReadSupport(
       readContext.getRequestedSchema
     }
     val trimmedParquetSchema = HoodieParquetReadSupport.trimParquetSchema(requestedParquetSchema, context.getFileSchema)
-    // TODO: Remove this workaround once Spark is bumped to 4.1+, which reads variant fields by
-    //  name via SPARK-54410. Spark 4.0.x's ParquetUnshreddedVariantConverter builds its converters
-    //  array in hardcoded [value, metadata] order, then indexes by schema position. If the Parquet
-    //  schema has [metadata, value] order (per spec), the positional mismatch causes
-    //  MALFORMED_VARIANT. Workaround: reorder variant group fields to [value, metadata] in the
-    //  requested schema. parquet-mr reconciles requested vs file schema by field name, so bytes
-    //  flow correctly. This is tracked in issue #18334
-    val reorderedSchema = HoodieParquetReadSupport.reorderVariantFields(trimmedParquetSchema)
-    new ReadContext(reorderedSchema, readContext.getReadSupportMetadata)
+    new ReadContext(trimmedParquetSchema, readContext.getReadSupportMetadata)
   }
 }
 
@@ -81,42 +73,6 @@ object HoodieParquetReadSupport {
       }
     }).filter(_.isDefined).map(_.get).toArray[Type]
     Types.buildMessage().addFields(trimmedFields: _*).named(requestedSchema.getName)
-  }
-
-  /**
-   * Reorders variant group fields in the requested schema so that "value" precedes "metadata".
-   * This works around Spark 4.0.x's ParquetUnshreddedVariantConverter, which builds its
-   * converters array in hardcoded [value, metadata] order and indexes by schema position.
-   * parquet-mr reconciles the requested schema against the file schema by field name,
-   * so the correct bytes still flow to the correct converters regardless of file order.
-   */
-  def reorderVariantFields(schema: MessageType): MessageType = {
-    val reordered = schema.getFields.asScala.map(reorderVariantType).toArray[Type]
-    Types.buildMessage().addFields(reordered: _*).named(schema.getName)
-  }
-
-  private def reorderVariantType(t: Type): Type = {
-    t match {
-      case group: GroupType if isVariantGroup(group) =>
-        // Rebuild with [value, metadata] order for Spark compatibility
-        val valueField = group.getType("value")
-        val metadataField = group.getType("metadata")
-        group.withNewFields(java.util.Arrays.asList(valueField, metadataField))
-      case group: GroupType =>
-        // Recurse into nested groups
-        val children = group.getFields.asScala.map(reorderVariantType).asJava
-        group.withNewFields(children)
-      case _ => t
-    }
-  }
-
-  private def isVariantGroup(group: GroupType): Boolean = {
-    group.containsField("value") &&
-      group.containsField("metadata") &&
-      group.getType("value").isPrimitive &&
-      group.getType("metadata").isPrimitive &&
-      group.getType("value").asPrimitiveType().getPrimitiveTypeName == PrimitiveType.PrimitiveTypeName.BINARY &&
-      group.getType("metadata").asPrimitiveType().getPrimitiveTypeName == PrimitiveType.PrimitiveTypeName.BINARY
   }
 
   private def trimParquetType(requestedType: Type, fileType: Type): Option[Type] = {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -243,12 +243,8 @@ trait SparkAdapter extends Serializable {
                             hadoopConf: Configuration): Option[SparkColumnarFileReader]
 
   /**
-   * Builds the [[HoodieParquetReadSupport]] used by parquet-mr to materialize Spark
-   * [[org.apache.spark.sql.catalyst.InternalRow]]s. Spark 4.0 must override this to return its
-   * variant-aware subclass which reorders variant group fields to [value, metadata] — the order
-   * Spark 4.0's ParquetUnshreddedVariantConverter indexes its converters array against. Without
-   * the reorder the converters consume each other's bytes and Variant.<init> raises
-   * MALFORMED_VARIANT during read.
+   * Build the [[HoodieParquetReadSupport]] for a parquet read. Spark 4.0 overrides to return
+   * its variant-aware subclass (variant group field reorder for the positional converter).
    */
   def createParquetReadSupport(convertTz: Option[java.time.ZoneId],
                                enableVectorizedReader: Boolean,

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters}
+import org.apache.spark.sql.execution.datasources.parquet.{HoodieParquetReadSupport, ParquetFileFormat, ParquetFilters}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.parser.HoodieExtendedParserInterface
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
@@ -241,6 +241,25 @@ trait SparkAdapter extends Serializable {
                             sqlConf: SQLConf,
                             options: Map[String, String],
                             hadoopConf: Configuration): Option[SparkColumnarFileReader]
+
+  /**
+   * Builds the [[HoodieParquetReadSupport]] used by parquet-mr to materialize Spark
+   * [[org.apache.spark.sql.catalyst.InternalRow]]s. Spark 4.0 must override this to return its
+   * variant-aware subclass which reorders variant group fields to [value, metadata] — the order
+   * Spark 4.0's ParquetUnshreddedVariantConverter indexes its converters array against. Without
+   * the reorder the converters consume each other's bytes and Variant.<init> raises
+   * MALFORMED_VARIANT during read.
+   */
+  def createParquetReadSupport(convertTz: Option[java.time.ZoneId],
+                               enableVectorizedReader: Boolean,
+                               enableTimestampFieldRepair: Boolean,
+                               datetimeRebaseSpec: org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec,
+                               int96RebaseSpec: org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec,
+                               tableSchemaOpt: org.apache.hudi.common.util.Option[org.apache.parquet.schema.MessageType])
+      : HoodieParquetReadSupport = {
+    new HoodieParquetReadSupport(convertTz, enableVectorizedReader, enableTimestampFieldRepair,
+      datetimeRebaseSpec, int96RebaseSpec, tableSchemaOpt)
+  }
 
   /**
    * use new qe execute

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -467,6 +467,28 @@ trait SparkAdapter extends Serializable {
   def isVariantShreddingStruct(structType: StructType): Boolean
 
   /**
+   * Checks if a StructType is the result of Spark 4.1's PushVariantIntoScan rewriting — i.e.,
+   * every child field carries `VariantMetadata` describing a pushed-down variant extraction.
+   *
+   * Returns false on Spark versions earlier than 4.1 (the rewriting only happens there).
+   */
+  def isVariantProjectionStruct(structType: StructType): Boolean = false
+
+  /**
+   * If `sparkRequiredSchema` contains any field that's a Spark 4.1 variant projection struct
+   * (i.e., the same-named field in `sparkDataSchema` is `VariantType`), returns a row
+   * transformer that takes an InternalRow in the data-schema shape (with full variants) and
+   * produces an InternalRow in the required-schema shape (with each variant column projected
+   * to its requested struct via VariantGet).
+   *
+   * Used on the MOR log-file path: log records carry the full variant on disk, but the merger
+   * expects rows aligned to the post-PushVariantIntoScan required schema. Returns None when
+   * there's nothing to project (cheap fast-path for Spark < 4.1 and for non-variant queries).
+   */
+  def buildVariantProjector(sparkDataSchema: StructType,
+                            sparkRequiredSchema: StructType): Option[InternalRow => InternalRow] = None
+
+  /**
    * Generates a shredded Variant schema and marks it with write shredding metadata.
    *
    * For Spark 4.x, this uses SparkShreddingUtils to generate the schema and add metadata.

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
+import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.storage.StorageConfiguration
 
 import org.apache.hadoop.conf.Configuration
@@ -245,16 +246,16 @@ trait SparkAdapter extends Serializable {
   /**
    * Build the [[HoodieParquetReadSupport]] for a parquet read. Spark 4.0 overrides to return
    * its variant-aware subclass (variant group field reorder for the positional converter).
+   * int96 rebase mode is fixed to LEGACY (Hudi convention for timestamp compatibility).
    */
   def createParquetReadSupport(convertTz: Option[java.time.ZoneId],
                                enableVectorizedReader: Boolean,
                                enableTimestampFieldRepair: Boolean,
-                               datetimeRebaseSpec: org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec,
-                               int96RebaseSpec: org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec,
-                               tableSchemaOpt: org.apache.hudi.common.util.Option[org.apache.parquet.schema.MessageType])
+                               datetimeRebaseSpec: RebaseSpec,
+                               tableSchemaOpt: HOption[MessageType])
       : HoodieParquetReadSupport = {
     new HoodieParquetReadSupport(convertTz, enableVectorizedReader, enableTimestampFieldRepair,
-      datetimeRebaseSpec, int96RebaseSpec, tableSchemaOpt)
+      datetimeRebaseSpec, getRebaseSpec("LEGACY"), tableSchemaOpt)
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/TestHoodieParquetReadSupport.scala
+++ b/hudi-client/hudi-spark-client/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/TestHoodieParquetReadSupport.scala
@@ -113,38 +113,4 @@ class TestHoodieParquetReadSupport {
         .named("required")
     Assertions.assertEquals(expectedSchema, trimmedSchema)
   }
-
-  /**
-   * Validate that reorderVariantFields does not treat groups as variant when the value/metadata
-   * fields fail the type checks in isVariantGroup. Each sub-group exercises a different false
-   * branch of the short-circuit && chain (lines 116-119).
-   */
-  @Test
-  def testReorderVariantFields_nonVariantGroupsUnchanged(): Unit = {
-    val schema = Types.buildMessage()
-      // value is non-primitive → line 116 false
-      .addField(Types.requiredGroup()
-        .addField(Types.requiredGroup().addField(Types.required(PrimitiveTypeName.INT32).named("x")).named("value"))
-        .addField(Types.required(PrimitiveTypeName.BINARY).named("metadata"))
-        .named("g1"))
-      // value is primitive, metadata is non-primitive → line 117 false
-      .addField(Types.requiredGroup()
-        .addField(Types.required(PrimitiveTypeName.BINARY).named("value"))
-        .addField(Types.requiredGroup().addField(Types.required(PrimitiveTypeName.INT32).named("x")).named("metadata"))
-        .named("g2"))
-      // both primitive but non-BINARY → line 118 false
-      .addField(Types.requiredGroup()
-        .addField(Types.required(PrimitiveTypeName.INT32).named("value"))
-        .addField(Types.required(PrimitiveTypeName.INT32).named("metadata"))
-        .named("g3"))
-      // value is BINARY, metadata is non-BINARY primitive → line 119 false
-      .addField(Types.requiredGroup()
-        .addField(Types.required(PrimitiveTypeName.BINARY).named("value"))
-        .addField(Types.required(PrimitiveTypeName.INT32).named("metadata"))
-        .named("g4"))
-      .named("test")
-
-    val result = HoodieParquetReadSupport.reorderVariantFields(schema)
-    Assertions.assertEquals(schema, result)
-  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -57,6 +57,8 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificRecordBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -101,6 +103,8 @@ import static org.apache.hudi.common.util.ValidationUtils.checkState;
  * Helper class to do common stuff across Avro.
  */
 public class HoodieAvroUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieAvroUtils.class);
 
   public static final String AVRO_VERSION = Schema.class.getPackage().getImplementationVersion();
 
@@ -261,7 +265,12 @@ public class HoodieAvroUtils {
    * @return a new Schema.Field with properly formatted default value for Avro 1.12.0+ compatibility
    */
   public static Schema.Field createNewSchemaField(String name, Schema schema, String doc, Object defaultValue) {
-    return new Schema.Field(name, schema, doc, convertDefaultValueForAvroCompatibility(defaultValue));
+    try {
+      return new Schema.Field(name, schema, doc, convertDefaultValueForAvroCompatibility(defaultValue));
+    } catch (RuntimeException e) {
+      LOG.error("Failed to create Avro Schema.Field name='{}' schema={} doc='{}'", name, schema, doc, e);
+      throw e;
+    }
   }
 
   /**
@@ -285,7 +294,12 @@ public class HoodieAvroUtils {
    * @return a new Schema.Field with properly formatted default value for Avro 1.12.0+ compatibility
    */
   public static Schema.Field createNewSchemaField(String name, Schema schema, String doc, Object defaultValue, Order order) {
-    return new Schema.Field(name, schema, doc, convertDefaultValueForAvroCompatibility(defaultValue), order);
+    try {
+      return new Schema.Field(name, schema, doc, convertDefaultValueForAvroCompatibility(defaultValue), order);
+    } catch (RuntimeException e) {
+      LOG.error("Failed to create Avro Schema.Field name='{}' schema={} doc='{}' order={}", name, schema, doc, order, e);
+      throw e;
+    }
   }
 
   private static Schema removeFields(Schema schema, Set<String> fieldsToRemove) {

--- a/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/HoodieAvroUtils.java
@@ -57,8 +57,6 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificRecordBase;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -103,8 +101,6 @@ import static org.apache.hudi.common.util.ValidationUtils.checkState;
  * Helper class to do common stuff across Avro.
  */
 public class HoodieAvroUtils {
-
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieAvroUtils.class);
 
   public static final String AVRO_VERSION = Schema.class.getPackage().getImplementationVersion();
 
@@ -265,12 +261,7 @@ public class HoodieAvroUtils {
    * @return a new Schema.Field with properly formatted default value for Avro 1.12.0+ compatibility
    */
   public static Schema.Field createNewSchemaField(String name, Schema schema, String doc, Object defaultValue) {
-    try {
-      return new Schema.Field(name, schema, doc, convertDefaultValueForAvroCompatibility(defaultValue));
-    } catch (RuntimeException e) {
-      LOG.error("Failed to create Avro Schema.Field name='{}' schema={} doc='{}'", name, schema, doc, e);
-      throw e;
-    }
+    return new Schema.Field(name, schema, doc, convertDefaultValueForAvroCompatibility(defaultValue));
   }
 
   /**
@@ -294,12 +285,7 @@ public class HoodieAvroUtils {
    * @return a new Schema.Field with properly formatted default value for Avro 1.12.0+ compatibility
    */
   public static Schema.Field createNewSchemaField(String name, Schema schema, String doc, Object defaultValue, Order order) {
-    try {
-      return new Schema.Field(name, schema, doc, convertDefaultValueForAvroCompatibility(defaultValue), order);
-    } catch (RuntimeException e) {
-      LOG.error("Failed to create Avro Schema.Field name='{}' schema={} doc='{}' order={}", name, schema, doc, order, e);
-      throw e;
-    }
+    return new Schema.Field(name, schema, doc, convertDefaultValueForAvroCompatibility(defaultValue), order);
   }
 
   private static Schema removeFields(Schema schema, Set<String> fieldsToRemove) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -56,6 +56,7 @@ import org.apache.hudi.storage.StoragePathInfo;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_DEPRECATED_WRITE_CONFIG_KEY;
 import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_WRITE_CONFIG_KEY;
@@ -382,6 +383,23 @@ public abstract class HoodieReaderContext<T> {
                                                             ClosableIterator<T> dataFileIterator,
                                                             HoodieSchema dataRequiredSchema,
                                                             List<Pair<String, Object>> requiredPartitionFieldAndValues);
+
+  /**
+   * Per-row transformer applied to records emerging from a log data block before they reach the
+   * merger. Engines that need to align log-block records to a projected required schema (e.g.
+   * Spark 4.1's PushVariantIntoScan, which projects variant columns into a synthetic struct shape
+   * at scan time) override this; the default is no projection.
+   *
+   * <p>When this returns a non-empty {@link Option}, the produced records must match the required
+   * (projected) schema, and {@code FileGroupRecordBuffer} will use that required schema as the
+   * downstream {@code BufferedRecords} schema in place of {@code dataBlock.getSchema()}.
+   *
+   * @param dataBlockSchema the schema actually carried by the log data block
+   * @return per-row transformer; {@code Option.empty()} means no projection is needed
+   */
+  public Option<Function<T, T>> getLogBlockRecordProjection(HoodieSchema dataBlockSchema) {
+    return Option.empty();
+  }
 
   public Option<Pair<String, String>> getPayloadClasses(TypedProperties props) {
     return getRecordMerger().map(merger -> {

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -385,17 +385,9 @@ public abstract class HoodieReaderContext<T> {
                                                             List<Pair<String, Object>> requiredPartitionFieldAndValues);
 
   /**
-   * Per-row transformer applied to records emerging from a log data block before they reach the
-   * merger. Engines that need to align log-block records to a projected required schema (e.g.
-   * Spark 4.1's PushVariantIntoScan, which projects variant columns into a synthetic struct shape
-   * at scan time) override this; the default is no projection.
-   *
-   * <p>When this returns a non-empty {@link Option}, the produced records must match the required
-   * (projected) schema, and {@code FileGroupRecordBuffer} will use that required schema as the
-   * downstream {@code BufferedRecords} schema in place of {@code dataBlock.getSchema()}.
-   *
-   * @param dataBlockSchema the schema actually carried by the log data block
-   * @return per-row transformer; {@code Option.empty()} means no projection is needed
+   * Optional per-row transformer applied to log-block records before they reach the merger.
+   * Engines override this to align records with a projected read schema (e.g. Spark 4.1's
+   * PushVariantIntoScan). Default is no projection.
    */
   public Option<Function<T, T>> getLogBlockRecordProjection(HoodieSchema dataBlockSchema) {
     return Option.empty();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
@@ -199,8 +199,8 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
       } else {
         blockRecordsIterator = dataBlock.getEngineRecordIterator(readerContext);
       }
-      Pair<Function<T, T>, HoodieSchema> projected = getProjectedTransformer(dataBlock);
-      return Pair.of(new CloseableMappingIterator<>(blockRecordsIterator, projected.getLeft()), projected.getRight());
+      Pair<Function<T, T>, HoodieSchema> projectedTransformer = getProjectedTransformer(dataBlock);
+      return Pair.of(new CloseableMappingIterator<>(blockRecordsIterator, projectedTransformer.getLeft()), projectedTransformer.getRight());
     } catch (IOException e) {
       throw new HoodieIOException("Failed to deser records from log files ", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
@@ -199,9 +199,8 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
       } else {
         blockRecordsIterator = dataBlock.getEngineRecordIterator(readerContext);
       }
-      Pair<Function<T, T>, HoodieSchema> schemaTransformerWithEvolvedSchema = getSchemaTransformerWithEvolvedSchema(dataBlock);
-      return Pair.of(new CloseableMappingIterator<>(
-          blockRecordsIterator, schemaTransformerWithEvolvedSchema.getLeft()), schemaTransformerWithEvolvedSchema.getRight());
+      Pair<Function<T, T>, HoodieSchema> projected = getProjectedTransformer(dataBlock);
+      return Pair.of(new CloseableMappingIterator<>(blockRecordsIterator, projected.getLeft()), projected.getRight());
     } catch (IOException e) {
       throw new HoodieIOException("Failed to deser records from log files ", e);
     }
@@ -279,6 +278,33 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
 
     HoodieSchema evolvedSchema = schemaEvolutionTransformerOpt.map(Pair::getRight).orElseGet(dataBlock::getSchema);
     return Pair.of(transformer, evolvedSchema);
+  }
+
+  /**
+   * Combines the schema-evolution transformer with the engine's optional log-block record
+   * projection. When the engine provides a projection (currently only Spark 4.1's
+   * PushVariantIntoScan path), it is composed *after* the evolution transformer.
+   *
+   * <p>The returned schema is the evolved data-block schema, not {@code readerSchema}: the
+   * Spark 4.1 projector rewrites variant fields in place but preserves every other field of
+   * the data-block schema, including the merger metadata columns ({@code _hoodie_record_key},
+   * {@code _tmp_metadata_row_index}) that the merger needs to look records up by ordinal.
+   * Returning {@code readerSchema} (the bare projected required schema) would tell the buffer
+   * the records are 4 fields wide while the actual rows still carry the metadata columns,
+   * causing the merger to read off the end of the row.
+   *
+   * <p>Composition order: schema-evolution first, then variant projection. Reasoning: the
+   * evolution transformer rewrites the on-disk Avro/Hudi schema into the shape the engine
+   * projector was built against; reversing the order would feed a not-yet-evolved row to the
+   * projector and corrupt field ordinals.
+   */
+  protected Pair<Function<T, T>, HoodieSchema> getProjectedTransformer(HoodieDataBlock dataBlock) {
+    Pair<Function<T, T>, HoodieSchema> evolved = getSchemaTransformerWithEvolvedSchema(dataBlock);
+    Option<Function<T, T>> logProjOpt = readerContext.getLogBlockRecordProjection(evolved.getRight());
+    if (!logProjOpt.isPresent()) {
+      return evolved;
+    }
+    return Pair.of(evolved.getLeft().andThen(logProjOpt.get()), evolved.getRight());
   }
 
   private static class LogRecordIterator<T> implements ClosableIterator<BufferedRecord<T>> {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
@@ -297,9 +297,18 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
    * evolution transformer rewrites the on-disk Avro/Hudi schema into the shape the engine
    * projector was built against; reversing the order would feed a not-yet-evolved row to the
    * projector and corrupt field ordinals.
+   *
+   * <p>Skip the projection when a custom payload class is configured: {@code PayloadUpdateProcessor}
+   * round-trips the row through {@code convertToAvroRecord(record, recordSchema)} and the schema
+   * still describes variant fields as {@code VariantType}, so feeding it a row whose variant
+   * column has been rewritten into the projected struct shape would corrupt the avro record.
+   * Standard mergers only touch metadata cols by ordinal and are unaffected.
    */
   protected Pair<Function<T, T>, HoodieSchema> getProjectedTransformer(HoodieDataBlock dataBlock) {
     Pair<Function<T, T>, HoodieSchema> evolved = getSchemaTransformerWithEvolvedSchema(dataBlock);
+    if (payloadClasses.isPresent()) {
+      return evolved;
+    }
     Option<Function<T, T>> logProjOpt = readerContext.getLogBlockRecordProjection(evolved.getRight());
     if (!logProjOpt.isPresent()) {
       return evolved;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
@@ -281,28 +281,14 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
   }
 
   /**
-   * Combines the schema-evolution transformer with the engine's optional log-block record
-   * projection. When the engine provides a projection (currently only Spark 4.1's
-   * PushVariantIntoScan path), it is composed *after* the evolution transformer.
+   * Composes schema evolution then the engine's optional log-block record projection
+   * (currently only Spark 4.1's PushVariantIntoScan). Returns the evolved data-block schema
+   * — the projector preserves field shape, only rewriting variant fields, so merger
+   * metadata cols (read by ordinal) stay intact.
    *
-   * <p>The returned schema is the evolved data-block schema, not {@code readerSchema}: the
-   * Spark 4.1 projector rewrites variant fields in place but preserves every other field of
-   * the data-block schema, including the merger metadata columns ({@code _hoodie_record_key},
-   * {@code _tmp_metadata_row_index}) that the merger needs to look records up by ordinal.
-   * Returning {@code readerSchema} (the bare projected required schema) would tell the buffer
-   * the records are 4 fields wide while the actual rows still carry the metadata columns,
-   * causing the merger to read off the end of the row.
-   *
-   * <p>Composition order: schema-evolution first, then variant projection. Reasoning: the
-   * evolution transformer rewrites the on-disk Avro/Hudi schema into the shape the engine
-   * projector was built against; reversing the order would feed a not-yet-evolved row to the
-   * projector and corrupt field ordinals.
-   *
-   * <p>Skip the projection when a custom payload class is configured: {@code PayloadUpdateProcessor}
-   * round-trips the row through {@code convertToAvroRecord(record, recordSchema)} and the schema
-   * still describes variant fields as {@code VariantType}, so feeding it a row whose variant
-   * column has been rewritten into the projected struct shape would corrupt the avro record.
-   * Standard mergers only touch metadata cols by ordinal and are unaffected.
+   * <p>Skipped when a custom payload class is configured: {@code PayloadUpdateProcessor}
+   * round-trips through {@code convertToAvroRecord} against a schema that still types
+   * variant fields as {@code VariantType}, which would mis-decode rewritten rows.
    */
   protected Pair<Function<T, T>, HoodieSchema> getProjectedTransformer(HoodieDataBlock dataBlock) {
     Pair<Function<T, T>, HoodieSchema> evolved = getSchemaTransformerWithEvolvedSchema(dataBlock);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
@@ -126,9 +126,9 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
           partialUpdateModeOpt);
     }
 
-    Pair<Function<T, T>, HoodieSchema> schemaTransformerWithEvolvedSchema = getProjectedTransformer(dataBlock);
+    Pair<Function<T, T>, HoodieSchema> projectedTransformer = getProjectedTransformer(dataBlock);
 
-    HoodieSchema schema = HoodieSchemaCache.intern(schemaTransformerWithEvolvedSchema.getRight());
+    HoodieSchema schema = HoodieSchemaCache.intern(projectedTransformer.getRight());
 
     // TODO: Return an iterator that can generate sequence number with the record.
     //       Then we can hide this logic into data block.
@@ -144,9 +144,9 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
         }
 
         long recordPosition = recordPositions.get(recordIndex++);
-        T evolvedNextRecord = schemaTransformerWithEvolvedSchema.getLeft().apply(nextRecord);
-        boolean isDelete = readerContext.getRecordContext().isDeleteRecord(evolvedNextRecord, deleteContext);
-        BufferedRecord<T> bufferedRecord = BufferedRecords.fromEngineRecord(evolvedNextRecord, schema, readerContext.getRecordContext(), orderingFieldNames, isDelete);
+        T projectedNextRecord = projectedTransformer.getLeft().apply(nextRecord);
+        boolean isDelete = readerContext.getRecordContext().isDeleteRecord(projectedNextRecord, deleteContext);
+        BufferedRecord<T> bufferedRecord = BufferedRecords.fromEngineRecord(projectedNextRecord, schema, readerContext.getRecordContext(), orderingFieldNames, isDelete);
         processNextDataRecord(bufferedRecord, recordPosition);
       }
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
@@ -126,7 +126,7 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
           partialUpdateModeOpt);
     }
 
-    Pair<Function<T, T>, HoodieSchema> schemaTransformerWithEvolvedSchema = getSchemaTransformerWithEvolvedSchema(dataBlock);
+    Pair<Function<T, T>, HoodieSchema> schemaTransformerWithEvolvedSchema = getProjectedTransformer(dataBlock);
 
     HoodieSchema schema = HoodieSchemaCache.intern(schemaTransformerWithEvolvedSchema.getRight());
 

--- a/hudi-hadoop-common/src/main/java/org/apache/parquet/avro/AvroSchemaConverterWithTimestampNTZ.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/parquet/avro/AvroSchemaConverterWithTimestampNTZ.java
@@ -478,7 +478,14 @@ public class AvroSchemaConverterWithTimestampNTZ extends HoodieAvroParquetSchema
           public java.util.Optional<HoodieSchema> visit(LogicalTypeAnnotation.EnumLogicalTypeAnnotation enumLogicalType) {
             return java.util.Optional.of(HoodieSchema.create(HoodieSchemaType.STRING));
           }
-        }).orElseThrow(() -> new UnsupportedOperationException("Cannot convert Parquet type " + parquetType));
+        }).orElseGet(() ->
+          // The visitor has no handler for newer logical type annotations (e.g., parquet 1.16.0+'s
+          // VariantLogicalTypeAnnotation, which is not available on the default parquet version
+          // hudi-hadoop-common compiles against). When the group still has fields, fall back to
+          // treating it as a record — this is the right thing for the variant binary group
+          // (`metadata`, `value`) we write, since Hudi reads variant columns through the record
+          // path elsewhere.
+          convertFields(parquetGroupType.getName(), parquetGroupType.getFields(), names));
       } else {
         // if no original type then it's a record
         return convertFields(parquetGroupType.getName(), parquetGroupType.getFields(), names);

--- a/hudi-hadoop-common/src/main/java/org/apache/parquet/avro/AvroSchemaConverterWithTimestampNTZ.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/parquet/avro/AvroSchemaConverterWithTimestampNTZ.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.schema.ConversionPatterns;
@@ -77,6 +78,7 @@ import static org.apache.parquet.schema.Type.Repetition.REPEATED;
  * This was taken from parquet-java 1.13.1 AvroSchemaConverter and modified
  * to support local timestamp types by copying a few methods from 1.14.0 AvroSchemaConverter.
  */
+@Slf4j
 @SuppressWarnings("all")
 public class AvroSchemaConverterWithTimestampNTZ extends HoodieAvroParquetSchemaConverter {
 
@@ -478,14 +480,14 @@ public class AvroSchemaConverterWithTimestampNTZ extends HoodieAvroParquetSchema
           public java.util.Optional<HoodieSchema> visit(LogicalTypeAnnotation.EnumLogicalTypeAnnotation enumLogicalType) {
             return java.util.Optional.of(HoodieSchema.create(HoodieSchemaType.STRING));
           }
-        }).orElseGet(() ->
-          // The visitor has no handler for newer logical type annotations (e.g., parquet 1.16.0+'s
-          // VariantLogicalTypeAnnotation, which is not available on the default parquet version
-          // hudi-hadoop-common compiles against). When the group still has fields, fall back to
-          // treating it as a record — this is the right thing for the variant binary group
-          // (`metadata`, `value`) we write, since Hudi reads variant columns through the record
-          // path elsewhere.
-          convertFields(parquetGroupType.getName(), parquetGroupType.getFields(), names));
+        }).orElseGet(() -> {
+          // Unrecognized annotation (e.g., parquet 1.16.0+ VariantLogicalTypeAnnotation, not
+          // available on the parquet version we compile against). Fall back to record
+          // conversion, correct for the variant binary group (`metadata`, `value`) we write.
+          log.debug("Unrecognized parquet LogicalTypeAnnotation '{}' on group '{}', falling back to record conversion",
+              logicalTypeAnnotation, parquetGroupType.getName());
+          return convertFields(parquetGroupType.getName(), parquetGroupType.getFields(), names);
+        });
       } else {
         // if no original type then it's a record
         return convertFields(parquetGroupType.getName(), parquetGroupType.getFields(), names);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -161,17 +161,8 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       supportReturningBatch = false
       false
     } else if (HoodieSparkUtils.gteqSpark4_1 && schema.fields.exists(f => sparkAdapter.isVariantType(f.dataType))) {
-      // #18605: Spark 4.1's vectorized parquet reader path produces UnsafeRow encodings for
-      // VariantType columns that crash during shuffle copy under Hudi's pipeline (JVM SIGBUS
-      // in StubRoutines::forward_copy_longs / UnsafeRow.copy when the row is sampled by
-      // RangePartitioner). Force row-based reading; row-based reads route through Spark's
-      // ParquetReadSupport which materializes VariantType correctly via
-      // ParquetUnshreddedVariantConverter. Restoring vectorized perf needs a separate fix to
-      // how Hudi's pipeline encodes variant columns into UnsafeRow.
-      //
-      // Gated on Spark 4.1+: Spark 4.0's vectorized variant path reads correctly under Hudi
-      // (variant byte ordering is handled by Spark40HoodieParquetReadSupport in the row-based
-      // path; the vectorized path doesn't have the same UnsafeRow shuffle-copy issue).
+      // #18605: Spark 4.1's vectorized variant read produces UnsafeRow encodings that SIGBUS
+      // during RangePartitioner sampling. Force row-based reads. Spark 4.0 unaffected.
       supportVectorizedRead = false
       supportReturningBatch = false
       false

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -303,7 +303,7 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
             case Some(fileSlice) if !isCount && (requiredSchema.nonEmpty || fileSlice.getLogFiles.findAny().isPresent) =>
               val readerContext = new SparkFileFormatInternalRowReaderContext(
                 fileGroupBaseFileReader.value, filters, requiredFilters, storageConf, metaClient.getTableConfig,
-                sparkDataSchema = Some(dataStructType), sparkRequiredSchema = Some(requiredSchema))
+                sparkRequiredSchema = Some(requiredSchema))
               readerContext.setEnableLogicalTimestampFieldRepair(storageConf.getBoolean(ENABLE_LOGICAL_TIMESTAMP_REPAIR, true))
               val props = metaClient.getTableConfig.getProps
               options.foreach(kv => props.setProperty(kv._1, kv._2))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -160,7 +160,7 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       supportVectorizedRead = false
       supportReturningBatch = false
       false
-    } else if (schema.fields.exists(f => sparkAdapter.isVariantType(f.dataType))) {
+    } else if (HoodieSparkUtils.gteqSpark4_1 && schema.fields.exists(f => sparkAdapter.isVariantType(f.dataType))) {
       // #18605: Spark 4.1's vectorized parquet reader path produces UnsafeRow encodings for
       // VariantType columns that crash during shuffle copy under Hudi's pipeline (JVM SIGBUS
       // in StubRoutines::forward_copy_longs / UnsafeRow.copy when the row is sampled by
@@ -168,6 +168,10 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       // ParquetReadSupport which materializes VariantType correctly via
       // ParquetUnshreddedVariantConverter. Restoring vectorized perf needs a separate fix to
       // how Hudi's pipeline encodes variant columns into UnsafeRow.
+      //
+      // Gated on Spark 4.1+: Spark 4.0's vectorized variant path reads correctly under Hudi
+      // (variant byte ordering is handled by Spark40HoodieParquetReadSupport in the row-based
+      // path; the vectorized path doesn't have the same UnsafeRow shuffle-copy issue).
       supportVectorizedRead = false
       supportReturningBatch = false
       false
@@ -193,7 +197,7 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       }
       supportVectorizedRead = !isIncremental && !isBootstrap && supportBatch
       supportReturningBatch = !isMOR && supportVectorizedRead
-      logInfo(s"supportReturningBatch: $supportReturningBatch, supportVectorizedRead: $supportVectorizedRead, isIncremental: $isIncremental, " +
+      logDebug(s"supportReturningBatch: $supportReturningBatch, supportVectorizedRead: $supportVectorizedRead, isIncremental: $isIncremental, " +
         s"isBootstrap: $isBootstrap, superSupportBatch: $supportBatch")
       supportReturningBatch
     }
@@ -242,7 +246,7 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     val superSplitable = super.isSplitable(sparkSession, options, path)
     val isLance = hoodieFileFormat == HoodieFileFormat.LANCE
     val splitable = !isMOR && !isIncremental && !isBootstrap && !isLance && superSplitable
-    logInfo(s"isSplitable: $splitable, super.isSplitable: $superSplitable, isMOR: $isMOR, isIncremental: $isIncremental, isBootstrap: $isBootstrap")
+    logDebug(s"isSplitable: $splitable, super.isSplitable: $superSplitable, isMOR: $isMOR, isIncremental: $isIncremental, isBootstrap: $isBootstrap")
     splitable
   }
 
@@ -253,10 +257,6 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
                                               filters: Seq[Filter],
                                               options: Map[String, String],
                                               hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
-    logInfo(s"buildReaderWithPartitionValues entry: tableName=$sanitizedTableName, " +
-      s"dataStructType=${dataStructType.simpleString}, " +
-      s"requiredSchema=${requiredSchema.simpleString}, " +
-      s"partitionSchema=${partitionSchema.simpleString}")
     val outputSchema = StructType(requiredSchema.fields ++ partitionSchema.fields)
     val isCount = requiredSchema.isEmpty && !isMOR && !isIncremental
     val augmentedStorageConf = new HadoopStorageConfiguration(hadoopConf).getInline
@@ -275,12 +275,8 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     exclusionFields.add("op")
     partitionSchema.fields.foreach(f => exclusionFields.add(f.name))
     val requestedStructType = StructType(requiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
-    logInfo(s"Converting requested struct to Hoodie schema: tableName=$sanitizedTableName, " +
-      s"fields=${requestedStructType.fieldNames.mkString("[", ",", "]")}")
     val requestedSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(requestedStructType, sanitizedTableName), exclusionFields)
     val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
-    logInfo(s"Converting data struct to Hoodie schema: tableName=$sanitizedTableName, " +
-      s"fields=${dataStructTypeWithMandatoryPartitionFields.fieldNames.mkString("[", ",", "]")}")
     val dataSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(dataStructTypeWithMandatoryPartitionFields, sanitizedTableName), exclusionFields)
 
     spark.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", supportVectorizedRead.toString)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -160,6 +160,17 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       supportVectorizedRead = false
       supportReturningBatch = false
       false
+    } else if (schema.fields.exists(f => sparkAdapter.isVariantType(f.dataType))) {
+      // #18605: Spark 4.1's vectorized parquet reader path produces UnsafeRow encodings for
+      // VariantType columns that crash during shuffle copy under Hudi's pipeline (JVM SIGBUS
+      // in StubRoutines::forward_copy_longs / UnsafeRow.copy when the row is sampled by
+      // RangePartitioner). Force row-based reading; row-based reads route through Spark's
+      // ParquetReadSupport which materializes VariantType correctly via
+      // ParquetUnshreddedVariantConverter. Restoring vectorized perf needs a separate fix to
+      // how Hudi's pipeline encodes variant columns into UnsafeRow.
+      supportVectorizedRead = false
+      supportReturningBatch = false
+      false
     } else {
       val conf = sparkSession.sessionState.conf
       val parquetBatchSupported = ParquetUtils.isBatchReadSupportedForSchema(conf, schema) && supportBatchWithTableSchema

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -151,6 +151,15 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       supportVectorizedRead = false
       supportReturningBatch = false
       false
+    } else if (schema.fields.exists(f => f.dataType.isInstanceOf[StructType]
+        && sparkAdapter.isVariantProjectionStruct(f.dataType.asInstanceOf[StructType]))) {
+      // Spark 4.1's PushVariantIntoScan rewrites a variant column to a struct of pushed-down
+      // extractions. The Spark vectorized parquet reader treats this as a nested type change
+      // (data column is VariantType, required is a struct) and refuses to read in vectorized
+      // mode (ParquetSchemaEvolutionUtils throws). Force row-based reading on this path.
+      supportVectorizedRead = false
+      supportReturningBatch = false
+      false
     } else {
       val conf = sparkSession.sessionState.conf
       val parquetBatchSupported = ParquetUtils.isBatchReadSupportedForSchema(conf, schema) && supportBatchWithTableSchema
@@ -233,6 +242,10 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
                                               filters: Seq[Filter],
                                               options: Map[String, String],
                                               hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+    logInfo(s"buildReaderWithPartitionValues entry: tableName=$sanitizedTableName, " +
+      s"dataStructType=${dataStructType.simpleString}, " +
+      s"requiredSchema=${requiredSchema.simpleString}, " +
+      s"partitionSchema=${partitionSchema.simpleString}")
     val outputSchema = StructType(requiredSchema.fields ++ partitionSchema.fields)
     val isCount = requiredSchema.isEmpty && !isMOR && !isIncremental
     val augmentedStorageConf = new HadoopStorageConfiguration(hadoopConf).getInline
@@ -251,8 +264,12 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     exclusionFields.add("op")
     partitionSchema.fields.foreach(f => exclusionFields.add(f.name))
     val requestedStructType = StructType(requiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
+    logInfo(s"Converting requested struct to Hoodie schema: tableName=$sanitizedTableName, " +
+      s"fields=${requestedStructType.fieldNames.mkString("[", ",", "]")}")
     val requestedSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(requestedStructType, sanitizedTableName), exclusionFields)
     val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
+    logInfo(s"Converting data struct to Hoodie schema: tableName=$sanitizedTableName, " +
+      s"fields=${dataStructTypeWithMandatoryPartitionFields.fieldNames.mkString("[", ",", "]")}")
     val dataSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(dataStructTypeWithMandatoryPartitionFields, sanitizedTableName), exclusionFields)
 
     spark.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", supportVectorizedRead.toString)
@@ -286,7 +303,9 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
             .getSparkPartitionedFileUtils.getPathFromPartitionedFile(file))
           fileSliceMapping.getSlice(fileGroupName) match {
             case Some(fileSlice) if !isCount && (requiredSchema.nonEmpty || fileSlice.getLogFiles.findAny().isPresent) =>
-              val readerContext = new SparkFileFormatInternalRowReaderContext(fileGroupBaseFileReader.value, filters, requiredFilters, storageConf, metaClient.getTableConfig)
+              val readerContext = new SparkFileFormatInternalRowReaderContext(
+                fileGroupBaseFileReader.value, filters, requiredFilters, storageConf, metaClient.getTableConfig,
+                sparkDataSchema = Some(dataStructType), sparkRequiredSchema = Some(requiredSchema))
               readerContext.setEnableLogicalTimestampFieldRepair(storageConf.getBoolean(ENABLE_LOGICAL_TIMESTAMP_REPAIR, true))
               val props = metaClient.getTableConfig.getProps
               options.foreach(kv => props.setProperty(kv._1, kv._2))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -38,10 +38,14 @@ import org.scalatest.{Canceled, Outcome}
 
 class TestVariantDataType extends HoodieSparkSqlTestBase {
 
-  // TODO(#18605): Re-enable after fixing JVM SIGSEGV crash on Spark 4.1
+  // TODO(#18605): Re-enable on Spark 4.1 once the JVM SIGBUS during shuffle of variant
+  //  UnsafeRows in the MERGE INTO path is resolved. Read paths (post-insert/update/delete
+  //  selects via cast(v as string)) and the schema conversion for Spark 4.1's
+  //  PushVariantIntoScan rewriting are working — the remaining blocker is purely the
+  //  merge-into shuffle crash.
   override def withFixture(test: NoArgTest): Outcome = {
     if (HoodieSparkUtils.gteqSpark4_1) {
-      Canceled("Disabled on Spark 4.1 due to JVM SIGSEGV crash in variant data type tests")
+      Canceled("Disabled on Spark 4.1 due to JVM SIGBUS in MERGE INTO shuffle (#18605)")
     } else {
       super.withFixture(test)
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -38,14 +38,15 @@ import org.scalatest.{Canceled, Outcome}
 
 class TestVariantDataType extends HoodieSparkSqlTestBase {
 
-  // TODO(#18605): Re-enable on Spark 4.1 once the JVM SIGBUS during shuffle of variant
+  // TODO(#18605): Re-enable on Spark 4.1 once the flaky JVM SIGBUS during shuffle of variant
   //  UnsafeRows in the MERGE INTO path is resolved. Read paths (post-insert/update/delete
   //  selects via cast(v as string)) and the schema conversion for Spark 4.1's
-  //  PushVariantIntoScan rewriting are working — the remaining blocker is purely the
-  //  merge-into shuffle crash.
+  //  PushVariantIntoScan rewriting are working; only MERGE INTO is still flaky — the variant
+  //  UnsafeRow encoding produces nondeterministic shuffle copy faults regardless of vectorized
+  //  vs row-based reading.
   override def withFixture(test: NoArgTest): Outcome = {
     if (HoodieSparkUtils.gteqSpark4_1) {
-      Canceled("Disabled on Spark 4.1 due to JVM SIGBUS in MERGE INTO shuffle (#18605)")
+      Canceled("Disabled on Spark 4.1 due to flaky JVM SIGBUS in MERGE INTO shuffle (#18605)")
     } else {
       super.withFixture(test)
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -33,24 +33,9 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable
 import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, LongType, MapType, MetadataBuilder, StringType, StructField, StructType}
-import org.scalatest.{Canceled, Outcome}
 
 
 class TestVariantDataType extends HoodieSparkSqlTestBase {
-
-  // TODO(#18605): Re-enable on Spark 4.1 once the flaky JVM SIGBUS during shuffle of variant
-  //  UnsafeRows in the MERGE INTO path is resolved. Read paths (post-insert/update/delete
-  //  selects via cast(v as string)) and the schema conversion for Spark 4.1's
-  //  PushVariantIntoScan rewriting are working; only MERGE INTO is still flaky — the variant
-  //  UnsafeRow encoding produces nondeterministic shuffle copy faults regardless of vectorized
-  //  vs row-based reading.
-  override def withFixture(test: NoArgTest): Outcome = {
-    if (HoodieSparkUtils.gteqSpark4_1) {
-      Canceled("Disabled on Spark 4.1 due to flaky JVM SIGBUS in MERGE INTO shuffle (#18605)")
-    } else {
-      super.withFixture(test)
-    }
-  }
 
   test(s"Test Table with Variant Data Type") {
     // Variant type is only supported in Spark 4.0+

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.common.util.JsonUtils
 import org.apache.hudi.spark.internal.ReflectUtil
 import org.apache.hudi.storage.StorageConfiguration
 
-import org.apache.parquet.schema.{MessageType, PrimitiveType, Type, Types}
+import org.apache.parquet.schema.{GroupType, MessageType, PrimitiveType, Type, Types}
 import org.apache.parquet.schema.Type.Repetition
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.internal.Logging
@@ -198,6 +198,14 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
     (requiredType, fileType) match {
       case (_: VariantType, s: StructType) if isVariantPhysicalSchema(s) => Some(true)
       case (s: StructType, _: VariantType) if isVariantPhysicalSchema(s) => Some(true)
+      // Spark 4.1's PushVariantIntoScan rewrites a `v: VariantType` column into a
+      // pushed-down projection struct (each child carries `VariantMetadata`). When the file
+      // stores `v` as a real Variant, the projection struct is NOT a type change — parquet-mr
+      // reads the variant natively and projects per-row using the field metadata. Treat the
+      // pair as compatible so Hudi's schema-change machinery doesn't rewrite the requested
+      // schema back to `VariantType` (which would lose the projection metadata).
+      case (s: StructType, _: VariantType) if isVariantProjectionStruct(s) => Some(true)
+      case (_: VariantType, s: StructType) if isVariantProjectionStruct(s) => Some(true)
       case _ => None // Not a VariantType comparison, use default logic
     }
   }
@@ -245,12 +253,15 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
     // VariantType is always stored in Parquet as a struct with separate value and metadata binary fields.
     // This matches how the HoodieRowParquetWriteSupport writes variant data.
     // Note: We intentionally omit 'typed_value' for shredded variants as this writer only accesses raw binary blobs.
-    // TODO: use `.as(LogicalTypeAnnotation.variantType())` after parquet-java version is bumped to 1.16.0
-    Types.buildGroup(repetition)
+    // The variant LogicalTypeAnnotation is applied via applyVariantLogicalType, Spark 4.0 (parquet 1.15.2)
+    // is a no-op since the annotation only exists in parquet 1.16.0+; Spark 4.1 overrides to apply it.
+    val builder = Types.buildGroup(repetition)
       .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, Repetition.REQUIRED).named(HoodieSchema.Variant.VARIANT_METADATA_FIELD))
       .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, valueRepetition).named(HoodieSchema.Variant.VARIANT_VALUE_FIELD))
-      .named(fieldName)
+    applyVariantLogicalType(builder).named(fieldName)
   }
+
+  protected def applyVariantLogicalType(builder: Types.GroupBuilder[GroupType]): Types.GroupBuilder[GroupType] = builder
 
   override def isVariantShreddingStruct(structType: StructType): Boolean = {
     SparkShreddingUtils.isVariantShreddingStruct(structType)

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -195,6 +195,18 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
     Spark40ParquetReader.build(vectorized, sqlConf, options, hadoopConf)
   }
 
+  override def createParquetReadSupport(convertTz: Option[java.time.ZoneId],
+                                        enableVectorizedReader: Boolean,
+                                        enableTimestampFieldRepair: Boolean,
+                                        datetimeRebaseSpec: org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec,
+                                        int96RebaseSpec: org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec,
+                                        tableSchemaOpt: org.apache.hudi.common.util.Option[org.apache.parquet.schema.MessageType])
+      : org.apache.spark.sql.execution.datasources.parquet.HoodieParquetReadSupport = {
+    new org.apache.spark.sql.execution.datasources.parquet.Spark40HoodieParquetReadSupport(
+      convertTz, enableVectorizedReader, enableTimestampFieldRepair,
+      datetimeRebaseSpec, int96RebaseSpec, tableSchemaOpt)
+  }
+
   /**
    * TODO
    *

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -22,8 +22,10 @@ import org.apache.hudi.client.model.{HoodieInternalRow, Spark40HoodieInternalRow
 import org.apache.hudi.common.model.FileSlice
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
+import org.apache.hudi.common.util.{Option => HOption}
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.schema.MessageType
 import org.apache.spark.SparkEnv
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
@@ -37,11 +39,12 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
+import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.orc.Spark40OrcReader
-import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, Spark40LegacyHoodieParquetFileFormat, Spark40ParquetReader}
+import org.apache.spark.sql.execution.datasources.parquet.{HoodieParquetReadSupport, ParquetFileFormat, Spark40HoodieParquetReadSupport, Spark40LegacyHoodieParquetFileFormat, Spark40ParquetReader}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.hudi.HoodieMemoryStream
@@ -198,13 +201,12 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
   override def createParquetReadSupport(convertTz: Option[java.time.ZoneId],
                                         enableVectorizedReader: Boolean,
                                         enableTimestampFieldRepair: Boolean,
-                                        datetimeRebaseSpec: org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec,
-                                        int96RebaseSpec: org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec,
-                                        tableSchemaOpt: org.apache.hudi.common.util.Option[org.apache.parquet.schema.MessageType])
-      : org.apache.spark.sql.execution.datasources.parquet.HoodieParquetReadSupport = {
-    new org.apache.spark.sql.execution.datasources.parquet.Spark40HoodieParquetReadSupport(
+                                        datetimeRebaseSpec: RebaseSpec,
+                                        tableSchemaOpt: HOption[MessageType])
+      : HoodieParquetReadSupport = {
+    new Spark40HoodieParquetReadSupport(
       convertTz, enableVectorizedReader, enableTimestampFieldRepair,
-      datetimeRebaseSpec, int96RebaseSpec, tableSchemaOpt)
+      datetimeRebaseSpec, getRebaseSpec("LEGACY"), tableSchemaOpt)
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40HoodieParquetReadSupport.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40HoodieParquetReadSupport.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.parquet.hadoop.api.InitContext
+import org.apache.parquet.hadoop.api.ReadSupport.ReadContext
+import org.apache.parquet.schema.{GroupType, MessageType, PrimitiveType, Type, Types}
+import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
+
+import java.time.ZoneId
+
+import scala.collection.JavaConverters._
+
+// TODO: Delete this file when the hudi-spark4.0.x module is removed. Spark 4.1+ reads
+//  variant fields by name via SPARK-54410, so the reorder workaround below is no longer
+//  needed there. Spark 4.0.x's ParquetUnshreddedVariantConverter builds its converters
+//  array in hardcoded [value, metadata] order, then indexes by schema position. If the
+//  Parquet schema has [metadata, value] order (per spec), the positional mismatch causes
+//  MALFORMED_VARIANT. Workaround: reorder variant group fields to [value, metadata] in
+//  the requested schema. parquet-mr reconciles requested vs file schema by field name,
+//  so bytes flow correctly. Tracked in issue #18334.
+class Spark40HoodieParquetReadSupport(
+                                       convertTz: Option[ZoneId],
+                                       enableVectorizedReader: Boolean,
+                                       enableTimestampFieldRepair: Boolean,
+                                       datetimeRebaseSpec: RebaseSpec,
+                                       int96RebaseSpec: RebaseSpec,
+                                       tableSchemaOpt: org.apache.hudi.common.util.Option[org.apache.parquet.schema.MessageType] = org.apache.hudi.common.util.Option.empty())
+  extends HoodieParquetReadSupport(
+    convertTz, enableVectorizedReader, enableTimestampFieldRepair,
+    datetimeRebaseSpec, int96RebaseSpec, tableSchemaOpt) {
+
+  override def init(context: InitContext): ReadContext = {
+    val baseContext = super.init(context)
+    val reorderedSchema = Spark40HoodieParquetReadSupport.reorderVariantFields(
+      baseContext.getRequestedSchema)
+    new ReadContext(reorderedSchema, baseContext.getReadSupportMetadata)
+  }
+}
+
+object Spark40HoodieParquetReadSupport {
+  /**
+   * Reorders variant group fields in the requested schema so that "value" precedes "metadata".
+   * This works around Spark 4.0.x's ParquetUnshreddedVariantConverter, which builds its
+   * converters array in hardcoded [value, metadata] order and indexes by schema position.
+   * parquet-mr reconciles the requested schema against the file schema by field name,
+   * so the correct bytes still flow to the correct converters regardless of file order.
+   */
+  def reorderVariantFields(schema: MessageType): MessageType = {
+    val reordered = schema.getFields.asScala.map(reorderVariantType).toArray[Type]
+    Types.buildMessage().addFields(reordered: _*).named(schema.getName)
+  }
+
+  private def reorderVariantType(t: Type): Type = {
+    t match {
+      case group: GroupType if isVariantGroup(group) =>
+        // Rebuild with [value, metadata] order for Spark compatibility
+        val valueField = group.getType("value")
+        val metadataField = group.getType("metadata")
+        group.withNewFields(java.util.Arrays.asList(valueField, metadataField))
+      case group: GroupType =>
+        // Recurse into nested groups
+        val children = group.getFields.asScala.map(reorderVariantType).asJava
+        group.withNewFields(children)
+      case _ => t
+    }
+  }
+
+  private def isVariantGroup(group: GroupType): Boolean = {
+    group.containsField("value") &&
+      group.containsField("metadata") &&
+      group.getType("value").isPrimitive &&
+      group.getType("metadata").isPrimitive &&
+      group.getType("value").asPrimitiveType().getPrimitiveTypeName == PrimitiveType.PrimitiveTypeName.BINARY &&
+      group.getType("metadata").asPrimitiveType().getPrimitiveTypeName == PrimitiveType.PrimitiveTypeName.BINARY
+  }
+}

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40HoodieParquetReadSupport.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40HoodieParquetReadSupport.scala
@@ -19,10 +19,13 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
+import org.apache.hudi.common.util.{Option => HOption}
+
 import org.apache.parquet.hadoop.api.InitContext
 import org.apache.parquet.hadoop.api.ReadSupport.ReadContext
 import org.apache.parquet.schema.{GroupType, MessageType, PrimitiveType, Type, Types}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
+import org.apache.spark.sql.types.{StructType, VariantType}
 
 import java.time.ZoneId
 
@@ -42,15 +45,21 @@ class Spark40HoodieParquetReadSupport(
                                        enableTimestampFieldRepair: Boolean,
                                        datetimeRebaseSpec: RebaseSpec,
                                        int96RebaseSpec: RebaseSpec,
-                                       tableSchemaOpt: org.apache.hudi.common.util.Option[org.apache.parquet.schema.MessageType] = org.apache.hudi.common.util.Option.empty())
+                                       tableSchemaOpt: HOption[MessageType] = HOption.empty())
   extends HoodieParquetReadSupport(
     convertTz, enableVectorizedReader, enableTimestampFieldRepair,
     datetimeRebaseSpec, int96RebaseSpec, tableSchemaOpt) {
 
   override def init(context: InitContext): ReadContext = {
     val baseContext = super.init(context)
+    // Resolve the Spark catalyst requested schema so the reorder is gated on
+    // VariantType — a user struct that happens to be <value: binary, metadata: binary>
+    // shouldn't be silently reshuffled.
+    val sparkRequestedSchema = Option(context.getConfiguration.get(
+      ParquetReadSupport.SPARK_ROW_REQUESTED_SCHEMA))
+      .map(StructType.fromString)
     val reorderedSchema = Spark40HoodieParquetReadSupport.reorderVariantFields(
-      baseContext.getRequestedSchema)
+      baseContext.getRequestedSchema, sparkRequestedSchema)
     new ReadContext(reorderedSchema, baseContext.getReadSupportMetadata)
   }
 }
@@ -62,9 +71,21 @@ object Spark40HoodieParquetReadSupport {
    * converters array in hardcoded [value, metadata] order and indexes by schema position.
    * parquet-mr reconciles the requested schema against the file schema by field name,
    * so the correct bytes still flow to the correct converters regardless of file order.
+   *
+   * When a Spark catalyst schema is supplied, reorder only the top-level fields that are
+   * actually typed `VariantType` in catalyst; this prevents reshuffling a user-defined
+   * `struct<value: binary, metadata: binary>` that happens to match the parquet shape.
    */
-  def reorderVariantFields(schema: MessageType): MessageType = {
-    val reordered = schema.getFields.asScala.map(reorderVariantType).toArray[Type]
+  def reorderVariantFields(schema: MessageType, sparkSchema: Option[StructType] = None): MessageType = {
+    val variantFieldNames: Set[String] = sparkSchema match {
+      case Some(s) => s.fields.collect { case f if f.dataType.isInstanceOf[VariantType] => f.name }.toSet
+      case None => null
+    }
+    val reordered = schema.getFields.asScala.map { f =>
+      if (variantFieldNames == null || variantFieldNames.contains(f.getName)) {
+        reorderVariantType(f)
+      } else f
+    }.toArray[Type]
     Types.buildMessage().addFields(reordered: _*).named(schema.getName)
   }
 

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40LegacyHoodieParquetFileFormat.scala
@@ -329,12 +329,8 @@ class Spark40LegacyHoodieParquetFileFormat(private val shouldAppendPartitionValu
         }
       } else {
         logDebug(s"Falling back to parquet-mr")
-        // Use the Spark 4.0 subclass: it overrides init to reorder variant group fields to
-        // [value, metadata] so Spark 4.0's ParquetUnshreddedVariantConverter (which indexes its
-        // converters array by position assuming that order) reads the correct bytes for each
-        // converter. The base HoodieParquetReadSupport no longer applies this reorder (#18334
-        // moved it into the version-specific subclass), so wiring the base class here would
-        // produce MALFORMED_VARIANT for variant columns.
+        // Spark40 subclass reorders variant group fields to [value, metadata] for Spark 4.0's
+        // positional variant converter (#18334); base class no longer applies the reorder.
         val readSupport = new Spark40HoodieParquetReadSupport(
           convertTz,
           enableVectorizedReader = false,

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40LegacyHoodieParquetFileFormat.scala
@@ -329,7 +329,13 @@ class Spark40LegacyHoodieParquetFileFormat(private val shouldAppendPartitionValu
         }
       } else {
         logDebug(s"Falling back to parquet-mr")
-        val readSupport = new HoodieParquetReadSupport(
+        // Use the Spark 4.0 subclass: it overrides init to reorder variant group fields to
+        // [value, metadata] so Spark 4.0's ParquetUnshreddedVariantConverter (which indexes its
+        // converters array by position assuming that order) reads the correct bytes for each
+        // converter. The base HoodieParquetReadSupport no longer applies this reorder (#18334
+        // moved it into the version-specific subclass), so wiring the base class here would
+        // produce MALFORMED_VARIANT for variant columns.
+        val readSupport = new Spark40HoodieParquetReadSupport(
           convertTz,
           enableVectorizedReader = false,
           enableTimestampFieldRepair = true,

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40ParquetReader.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40ParquetReader.scala
@@ -206,7 +206,7 @@ class Spark40ParquetReader(enableVectorizedReader: Boolean,
       }
     } else {
       // ParquetRecordReader returns InternalRow
-      val readSupport = new HoodieParquetReadSupport(
+      val readSupport = new Spark40HoodieParquetReadSupport(
         convertTz,
         enableVectorizedReader = false,
         enableLogicalTimestampRepair,

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/TestSpark40HoodieParquetReadSupport.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/TestSpark40HoodieParquetReadSupport.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+import org.apache.parquet.schema.Types
+import org.junit.jupiter.api.{Assertions, Test}
+
+class TestSpark40HoodieParquetReadSupport {
+
+  /**
+   * Validate that reorderVariantFields does not treat groups as variant when the value/metadata
+   * fields fail the type checks in isVariantGroup. Each sub-group exercises a different false
+   * branch of the short-circuit && chain.
+   */
+  @Test
+  def testReorderVariantFieldsNonVariantGroupsUnchanged(): Unit = {
+    val schema = Types.buildMessage()
+      // value is non-primitive
+      .addField(Types.requiredGroup()
+        .addField(Types.requiredGroup().addField(Types.required(PrimitiveTypeName.INT32).named("x")).named("value"))
+        .addField(Types.required(PrimitiveTypeName.BINARY).named("metadata"))
+        .named("g1"))
+      // value is primitive, metadata is non-primitive
+      .addField(Types.requiredGroup()
+        .addField(Types.required(PrimitiveTypeName.BINARY).named("value"))
+        .addField(Types.requiredGroup().addField(Types.required(PrimitiveTypeName.INT32).named("x")).named("metadata"))
+        .named("g2"))
+      // both primitive but non-BINARY
+      .addField(Types.requiredGroup()
+        .addField(Types.required(PrimitiveTypeName.INT32).named("value"))
+        .addField(Types.required(PrimitiveTypeName.INT32).named("metadata"))
+        .named("g3"))
+      // value is BINARY, metadata is non-BINARY primitive
+      .addField(Types.requiredGroup()
+        .addField(Types.required(PrimitiveTypeName.BINARY).named("value"))
+        .addField(Types.required(PrimitiveTypeName.INT32).named("metadata"))
+        .named("g4"))
+      .named("test")
+
+    val result = Spark40HoodieParquetReadSupport.reorderVariantFields(schema)
+    Assertions.assertEquals(schema, result)
+  }
+}

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -262,11 +262,8 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
     if (!sparkRequiredSchema.fields.exists(f => VariantMetadata.isVariantStruct(f.dataType))) {
       None
     } else {
-      // Resolve required-schema field name to (index, field) in sparkDataSchema. Both schemas
-      // come from the same source (PushVariantIntoScan output overlaid on the data-block
-      // schema), so a missing field is a programming error in the caller, surface it with
-      // both schemas in the message rather than the bare IllegalArgumentException
-      // sparkDataSchema.fieldIndex would throw.
+      // Surface mismatched schemas with both field lists rather than Spark's bare
+      // IllegalArgumentException from fieldIndex.
       def lookupDataField(name: String): (Int, StructField) = {
         val idx = sparkDataSchema.getFieldIndex(name).getOrElse(
           throw new IllegalStateException(
@@ -275,15 +272,10 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
               s"data=${sparkDataSchema.fieldNames.mkString("[", ",", "]")}"))
         (idx, sparkDataSchema.fields(idx))
       }
-      // For each required-schema field, build either a passthrough BoundReference (non-variant)
-      // or a CreateNamedStruct of VariantGet expressions (variant projection).
       val exprs: Array[Expression] = sparkRequiredSchema.fields.map { rf =>
         rf.dataType match {
           case projectedStruct: StructType if VariantMetadata.isVariantStruct(projectedStruct) =>
             val (dataIdx, dataField) = lookupDataField(rf.name)
-            // We only handle the case where the data column is VariantType — i.e., the table's
-            // stored shape for `v` is a real variant. (If it weren't, PushVariantIntoScan
-            // wouldn't have produced this projection.)
             require(isVariantType(dataField.dataType),
               s"Expected VariantType for field '${rf.name}' in data schema, got ${dataField.dataType}")
             val variantRef: Expression = BoundReference(dataIdx, dataField.dataType, dataField.nullable)
@@ -306,14 +298,12 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
     }
   }
 
-  // NOTE: We previously overrode `applyVariantLogicalType` to apply
-  // `LogicalTypeAnnotation.variantType((byte) 1)` (matching Spark's own
-  // SparkToParquetSchemaConverter on parquet 1.16.0). It compiles, but the resulting
-  // `VARIANT(1)`-annotated group is incompatible with Hudi's Java Avro reader path
-  // (HoodieAvroParquetReader → AvroSchemaConverterWithTimestampNTZ) used for MOR merge updates,
-  // and triggers downstream JVM crashes during variant binary copies. Until Hudi's Avro reader
-  // path understands the annotation (or migrates to the Spark reader), keep the unannotated
-  // 2-binary-field group from BaseSpark4Adapter so writes are readable by every internal path.
+  // We intentionally don't override applyVariantLogicalType to apply
+  // LogicalTypeAnnotation.variantType((byte) 1) here (parquet 1.16+ /
+  // SparkToParquetSchemaConverter style). AvroSchemaConverterWithTimestampNTZ now tolerates
+  // unknown annotations via record-conversion fallback, but writing the annotated group has
+  // not been validated end-to-end through MOR merge updates. Keep the unannotated
+  // 2-binary-field group from BaseSpark4Adapter until that is verified.
 
   override def createMemoryStream[T: Encoder](id: Int, sparkSession: SparkSession): HoodieMemoryStream[T] = {
     // In Spark 4.1, MemoryStream is in org.apache.spark.sql.execution.streaming.runtime package

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.schema.{GroupType, LogicalTypeAnnotation, Types}
 import org.apache.spark.SparkEnv
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
@@ -298,12 +299,11 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
     }
   }
 
-  // We intentionally don't override applyVariantLogicalType to apply
-  // LogicalTypeAnnotation.variantType((byte) 1) here (parquet 1.16+ /
-  // SparkToParquetSchemaConverter style). AvroSchemaConverterWithTimestampNTZ now tolerates
-  // unknown annotations via record-conversion fallback, but writing the annotated group has
-  // not been validated end-to-end through MOR merge updates. Keep the unannotated
-  // 2-binary-field group from BaseSpark4Adapter until that is verified.
+  // Apply LogicalTypeAnnotation.variantType((byte) 1) to the variant group, matching parquet 1.16+'s
+  // SparkToParquetSchemaConverter convention.
+  override protected def applyVariantLogicalType(builder: Types.GroupBuilder[GroupType]): Types.GroupBuilder[GroupType] = {
+    builder.as(LogicalTypeAnnotation.variantType(1.toByte))
+  }
 
   override def createMemoryStream[T: Encoder](id: Int, sparkSession: SparkSession): HoodieMemoryStream[T] = {
     // In Spark 4.1, MemoryStream is in org.apache.spark.sql.execution.streaming.runtime package

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -31,11 +31,13 @@ import org.apache.spark.sql.avro._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, ResolvedTable}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, CreateNamedStruct, Expression, Literal, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.variant.VariantGet
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
@@ -249,6 +251,58 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
   override def getRebaseSpec(policy: String): RebaseDateTime.RebaseSpec = {
     RebaseDateTime.RebaseSpec(LegacyBehaviorPolicy.withName(policy))
   }
+
+  override def isVariantProjectionStruct(structType: StructType): Boolean = {
+    VariantMetadata.isVariantStruct(structType)
+  }
+
+  override def buildVariantProjector(sparkDataSchema: StructType,
+                                     sparkRequiredSchema: StructType): Option[InternalRow => InternalRow] = {
+    // Quick check: any required field a variant projection struct?
+    if (!sparkRequiredSchema.fields.exists(f => VariantMetadata.isVariantStruct(f.dataType))) {
+      None
+    } else {
+      // For each required-schema field, build either a passthrough BoundReference (non-variant)
+      // or a CreateNamedStruct of VariantGet expressions (variant projection).
+      val exprs: Array[Expression] = sparkRequiredSchema.fields.zipWithIndex.map { case (rf, _) =>
+        rf.dataType match {
+          case projectedStruct: StructType if VariantMetadata.isVariantStruct(projectedStruct) =>
+            val dataIdx = sparkDataSchema.fieldIndex(rf.name)
+            val dataField = sparkDataSchema.fields(dataIdx)
+            // We only handle the case where the data column is VariantType — i.e., the table's
+            // stored shape for `v` is a real variant. (If it weren't, PushVariantIntoScan
+            // wouldn't have produced this projection.)
+            require(isVariantType(dataField.dataType),
+              s"Expected VariantType for field '${rf.name}' in data schema, got ${dataField.dataType}")
+            val variantRef: Expression = BoundReference(dataIdx, dataField.dataType, dataField.nullable)
+            val childExprs: Seq[Expression] = projectedStruct.fields.toSeq.flatMap { child =>
+              val vm = VariantMetadata.fromMetadata(child.metadata)
+              val pathLit = Literal(UTF8String.fromString(vm.path), DataTypes.StringType)
+              val tz: Option[String] = Option(vm.timeZoneId)
+              val variantGet: Expression = VariantGet(variantRef, pathLit, child.dataType, vm.failOnError, tz)
+              Seq(Literal(UTF8String.fromString(child.name), DataTypes.StringType), variantGet)
+            }
+            CreateNamedStruct(childExprs)
+          case _ =>
+            val dataIdx = sparkDataSchema.fieldIndex(rf.name)
+            val dataField = sparkDataSchema.fields(dataIdx)
+            BoundReference(dataIdx, dataField.dataType, dataField.nullable)
+        }
+      }
+
+      val projection = UnsafeProjection.create(exprs.toIndexedSeq, DataTypeUtils.toAttributes(sparkDataSchema))
+      Some(row => projection(row))
+    }
+  }
+
+  // NOTE: We previously overrode `applyVariantLogicalType` to apply
+  // `LogicalTypeAnnotation.variantType((byte) 1)` (matching Spark's own
+  // SparkToParquetSchemaConverter on parquet 1.16.0). It compiles, but the resulting
+  // `VARIANT(1)`-annotated group is incompatible with Hudi's Java Avro reader path
+  // (HoodieAvroParquetReader → AvroSchemaConverterWithTimestampNTZ) used for MOR merge updates,
+  // and triggers downstream JVM crashes during variant binary copies. Until Hudi's Avro reader
+  // path understands the annotation (or migrates to the Spark reader), keep the unannotated
+  // 2-binary-field group from BaseSpark4Adapter so writes are readable by every internal path.
 
   override def createMemoryStream[T: Encoder](id: Int, sparkSession: SparkSession): HoodieMemoryStream[T] = {
     // In Spark 4.1, MemoryStream is in org.apache.spark.sql.execution.streaming.runtime package

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -51,7 +51,7 @@ import org.apache.spark.sql.hudi.analysis.TableValuedFunctions
 import org.apache.spark.sql.hudi.blob.{BatchedBlobReaderStrategy, ScalarFunctions}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.parser.{HoodieExtendedParserInterface, HoodieSpark4_1ExtendedSqlParser}
-import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructType}
+import org.apache.spark.sql.types.{DataType, DataTypes, Metadata, MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatchRow
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StorageLevel._
@@ -262,13 +262,25 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
     if (!sparkRequiredSchema.fields.exists(f => VariantMetadata.isVariantStruct(f.dataType))) {
       None
     } else {
+      // Resolve required-schema field name to (index, field) in sparkDataSchema. Both schemas
+      // come from the same source (PushVariantIntoScan output overlaid on the data-block
+      // schema), so a missing field is a programming error in the caller, surface it with
+      // both schemas in the message rather than the bare IllegalArgumentException
+      // sparkDataSchema.fieldIndex would throw.
+      def lookupDataField(name: String): (Int, StructField) = {
+        val idx = sparkDataSchema.getFieldIndex(name).getOrElse(
+          throw new IllegalStateException(
+            s"Required field '$name' is absent from sparkDataSchema; " +
+              s"required=${sparkRequiredSchema.fieldNames.mkString("[", ",", "]")}, " +
+              s"data=${sparkDataSchema.fieldNames.mkString("[", ",", "]")}"))
+        (idx, sparkDataSchema.fields(idx))
+      }
       // For each required-schema field, build either a passthrough BoundReference (non-variant)
       // or a CreateNamedStruct of VariantGet expressions (variant projection).
-      val exprs: Array[Expression] = sparkRequiredSchema.fields.zipWithIndex.map { case (rf, _) =>
+      val exprs: Array[Expression] = sparkRequiredSchema.fields.map { rf =>
         rf.dataType match {
           case projectedStruct: StructType if VariantMetadata.isVariantStruct(projectedStruct) =>
-            val dataIdx = sparkDataSchema.fieldIndex(rf.name)
-            val dataField = sparkDataSchema.fields(dataIdx)
+            val (dataIdx, dataField) = lookupDataField(rf.name)
             // We only handle the case where the data column is VariantType — i.e., the table's
             // stored shape for `v` is a real variant. (If it weren't, PushVariantIntoScan
             // wouldn't have produced this projection.)
@@ -284,8 +296,7 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
             }
             CreateNamedStruct(childExprs)
           case _ =>
-            val dataIdx = sparkDataSchema.fieldIndex(rf.name)
-            val dataField = sparkDataSchema.fields(dataIdx)
+            val (dataIdx, dataField) = lookupDataField(rf.name)
             BoundReference(dataIdx, dataField.dataType, dataField.nullable)
         }
       }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes: #18605
Closes: #18334

`TestVariantDataType` was previously skipped on Spark 4.1 because the MOR merge path crashed with a JVM SIGBUS during `UnsafeRow.copy` (translated to `java.lang.InternalError: a fault occurred in a recent unsafe memory access` with `-XX:+UnlockDiagnosticVMOptions -XX:+PreserveFramePointer`). While investigating that, two adjacent Spark 4.0 variant-read regressions and a shared-module unit-test classpath fragility surfaced; this PR fixes all three so variant + MOR works end-to-end on both Spark 4.0 and Spark 4.1.

### Summary and Changelog

Re-enables `TestVariantDataType` on Spark 4.1 (`Seq("cow", "mor")`) and fixes the three latent variant-read issues uncovered while investigating #18605:

**1. Spark 4.1 MOR merge — log records misaligned with PushVariantIntoScan**

Spark 4.1's `PushVariantIntoScan` Catalyst rule rewrites a Variant column on the read schema into `struct<0:..>` with `VariantMetadata`. Base files use parquet-mr's native projection from that metadata, but log-block records reach the merger carrying the full variant, so the merger combines mismatched-shape rows. The resulting `UnsafeRow` has a malformed size header that survives the read pipeline and overruns memory the first time something calls `UnsafeRow.copy()` (in our case, `RangePartitioner` sampling).

- `HoodieReaderContext.getLogBlockRecordProjection`: new engine-neutral hook (default no-op) that returns a per-row transformer aligning log-block records to the engine's projected read schema.
- `FileGroupRecordBuffer.getProjectedTransformer`: composes schema evolution with the new hook. Returns the evolved data-block schema (not `readerSchema`) because the projector preserves field shape and the merger reads metadata cols (`_hoodie_record_key`, `_tmp_metadata_row_index`) by ordinal. Skipped when a custom payload class is configured (`PayloadUpdateProcessor.handleNonDeletes`'s `convertToAvroRecord` would mis-decode a row whose variant has been rewritten).
- `PositionBasedFileGroupRecordBuffer.processDataBlock` routes through the new helper.
- `Spark4_1Adapter.buildVariantProjector`: builds a `VariantGet`-driven `UnsafeProjection` from the data-block schema to the projected required schema (the existing implementation, kept).
- `SparkFileFormatInternalRowReaderContext.getLogBlockRecordProjection` overrides the new hook for Spark 4.1, building a target schema that preserves every field of the data-block schema and only rewrites variant fields into their `PushVariantIntoScan` struct shape.
- `SparkFileFormatInternalRowReaderContext.getFileRecordIterator` builds the base-file read schema from the engine's *augmented* `requiredSchema` (so `_hoodie_record_key` is read for the merger's key extraction) and overlays the projected variant struct shape from `sparkRequiredSchema` (so parquet-mr still does the native variant projection). Drops the now-redundant lazy `variantLogProjector` from the log-file path; the merge buffer's hook handles it.
- `HoodieFileGroupReaderBasedFileFormat.supportBatch` disables vectorized reads when a `VariantType` field is in the schema — Spark 4.1's vectorized variant path produces UnsafeRow encodings that crash during shuffle copy. Gated on `gteqSpark4_1` so Spark 4.0 keeps vectorized variant reads.

**2. Spark 4.0 — `MALFORMED_VARIANT` on legacy file format and log-block reads**

#18334 moved the `[value, metadata]` variant field reorder out of the shared `HoodieParquetReadSupport` and into the version-specific `Spark40HoodieParquetReadSupport`, but two consumers still constructed the base class directly. With no reorder, parquet-mr hands `[metadata, value]` bytes to Spark 4.0's positional `ParquetUnshreddedVariantConverter` and `Variant.<init>` raises `MALFORMED_VARIANT`.

- `Spark40LegacyHoodieParquetFileFormat`: switch the parquet-mr fallback branch to `Spark40HoodieParquetReadSupport`. Affects the legacy file-format read path on Spark 4.0.
- `HoodieSparkParquetReader` (shared, used for parquet log-block reads on every Spark version): route through a new `SparkAdapter.createParquetReadSupport` factory. Default returns the base class; `Spark4_0Adapter` overrides to return the Spark40 subclass. Other Spark versions are unchanged.

**3. Shared-module unit test classpath fragility**

`TestHoodieSparkSchemaUtils` (in `hudi-spark-common`) was failing with `ClassNotFoundException` for `Spark{3_5,4_1}Adapter` after the PushVariantIntoScan support lande: every StructType conversion was forcing `SparkAdapterSupport.sparkAdapter` to resolve a version-specific adapter class that isn't on `hudi-spark-common`'s test classpath.

- `HoodieSparkSchemaConverters.toHoodieTypeNested` hoists the variant-projection guard into a `isSparkVariantProjectionStruct` helper that short-circuits on Spark < 4.1 and on structs whose fields carry no Spark `Metadata` (PushVariantIntoScan always tags every field with `VariantMetadata`, so empty-metadata structs are definitively not projections). Belt-and-suspenders try/catch around the adapter lookup for any other environment that hits the gap. Drops a debug `LOG.warn` left over from the #18605 investigation.

**Misc**

- `HoodieAvroUtils.createNewSchemaField`: drop the diagnostic `try/catch + LOG.error` left over from the #18605 investigation, along with the now-unused slf4j Logger imports and `LOG` field.
- `HoodieFileGroupReaderBasedFileFormat`: demote four `logInfo` debug calls (entry log + per-conversion logs + `isSplitable` summary) to `logDebug`. They fire on every reader build and would flood production logs at INFO.
- `Spark4_1Adapter.buildVariantProjector`: replace bare `sparkDataSchema.fieldIndex(...)` calls with a `lookupDataField` helper that raises an `IllegalStateException` naming both schemas, so future projector mismatches are easier to triage than Spark's bare `IllegalArgumentException`. Drop the unused `.zipWithIndex`.
- `SparkFileFormatInternalRowReaderContext`: new `findFieldByName` helper honoring `spark.sql.caseSensitive` for the variant-projection field lookups, replacing exact `==` matches.
- `AvroSchemaConverterWithTimestampNTZ`: `LOG.debug` line when a group's `LogicalTypeAnnotation` is unrecognized and we fall back to record conversion. Right for the variant binary group we write; the log is so a future unrecognized annotation that *isn't* a record doesn't fail silently.

### Impact

User-facing impact:

- Variant + MOR queries (insert / update / delete / merge into / select with `cast(v as string)`) now work on Spark 4.1.
- Spark 4.0 variant reads via the legacy file format and parquet log blocks no longer raise `MALFORMED_VARIANT`.
- `TestHoodieSparkSchemaUtils` runs on shared modules without a version-specific adapter on the classpath.

Performance:

- Spark 4.1 with `VariantType` fields is forced row-based on the file group reader path; vectorized variant reads need a separate fix to Hudi's UnsafeRow encoding (out of scope for this PR).
- Spark 4.0 unchanged — the new gate (`gteqSpark4_1`) avoids degrading it to row-based.
- Custom-payload tables with variant on Spark 4.1 skip the merge-path variant projection (degrades to the same correctness path the rest of the merge pipeline gives that combo, no crash). No effect on standard mergers.

### Risk Level

Medium.

The changes touch the engine-neutral merge buffer (`FileGroupRecordBuffer`, `PositionBasedFileGroupRecordBuffer`) and the shared `HoodieReaderContext` API. New behavior is gated:

- The new `getLogBlockRecordProjection` hook defaults to `Option.empty()`; non-Spark engines (Avro, Flink, Lance) and Spark versions other than 4.1 see no behavior change in the buffer.
- The base-file read schema augmentation in `SparkFileFormatInternalRowReaderContext.getFileRecordIterator` is a cross-version change but only modifies what columns are read, not how the merger interprets them — the merger's key extraction was already expecting metadata cols, this just makes them actually arrive in the base record.
- The Spark 4.0 ReadSupport rewiring is a subclass swap, no API change.

Verification:

- `TestVariantDataType` passes end-to-end on Spark 4.1 (cow + mor iterations: insert, update, delete, merge into, all cast(v as string) selects).
- `TestVariantDataType` continues to pass on Spark 4.0.
- `TestHoodieSparkSchemaUtils` passes on Spark 3.5 and Spark 4.1 profiles.

### Documentation Update

None.

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
