### PR TITLE
fix: Honor SparkSession overrides for rebase mode and timezone in compaction tasks

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -57,6 +57,7 @@ import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.execution.datasources.DataSourceUtils;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetWriteSupport;
+import org.apache.spark.SparkEnv;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataType;
@@ -115,6 +116,11 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   private static final String MAP_REPEATED_NAME = "key_value";
   private static final String MAP_KEY_NAME = "key";
   private static final String MAP_VALUE_NAME = "value";
+
+  private static final String SESSION_LOCAL_TIME_ZONE_KEY = "spark.sql.session.timeZone";
+  private static final String PARQUET_METADATA_VERSION_KEY = "org.apache.spark.version";
+  private static final String PARQUET_METADATA_LEGACY_DATETIME_KEY = "org.apache.spark.legacyDateTime";
+  private static final String PARQUET_METADATA_TIME_ZONE_KEY = "org.apache.spark.timeZone";
 
   @Getter
   private final Configuration hadoopConf;
@@ -312,13 +318,49 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     return writers;
   }
 
+  /**
+   * Resolves the session-local timezone string. {@code SQLConf.get()} on a Spark
+   * executor task thread that is NOT inside a SQL execution context returns a
+   * fresh fallback {@code SQLConf} with default values — meaning the user's
+   * {@code spark.sql.session.timeZone} override on the SparkSession is invisible.
+   * This method falls back to {@code SparkEnv.get().conf()} (SparkConf is
+   * broadcast to every executor) so the override is honored in compaction-style
+   * code paths that dispatch via vanilla {@code parallelize().map()}.
+   *
+   * <p>Visible-for-testing: unit tests covering the SQLConf-not-propagated-to-executor
+   * behavior invoke this method directly from inside a Spark task closure without
+   * reflection.
+   */
+  public static String resolveSessionLocalTimeZone() {
+    // Resolution order:
+    //   1. SQLConf override (so `spark.conf.set("spark.sql.session.timeZone",
+    //      ...)` on the SparkSession takes effect on the driver and inside
+    //      Spark SQL execution contexts).
+    //   2. SparkConf (SparkEnv.get.conf) — broadcast to every executor at
+    //      startup, so the override is honored on executor tasks outside a SQL
+    //      execution context.
+    //   3. SQLConf.get.sessionLocalTimeZone — the JVM-default fallback.
+    String fromSqlConf = SQLConf.get().getConfString(SESSION_LOCAL_TIME_ZONE_KEY, null);
+    if (fromSqlConf != null) {
+      return fromSqlConf;
+    }
+    SparkEnv env = SparkEnv.get();
+    if (env != null) {
+      String fromSparkConf = env.conf().get(SESSION_LOCAL_TIME_ZONE_KEY, null);
+      if (fromSparkConf != null) {
+        return fromSparkConf;
+      }
+    }
+    return SQLConf.get().sessionLocalTimeZone();
+  }
+
   @Override
   public WriteContext init(Configuration configuration) {
     Map<String, String> metadata = new HashMap<>();
-    metadata.put("org.apache.spark.version", VersionUtils.shortVersion(HoodieSparkUtils.getSparkVersion()));
+    metadata.put(PARQUET_METADATA_VERSION_KEY, VersionUtils.shortVersion(HoodieSparkUtils.getSparkVersion()));
     if (SparkAdapterSupport$.MODULE$.sparkAdapter().isLegacyBehaviorPolicy(datetimeRebaseMode)) {
-      metadata.put("org.apache.spark.legacyDateTime", "");
-      metadata.put("org.apache.spark.timeZone", SQLConf.get().sessionLocalTimeZone());
+      metadata.put(PARQUET_METADATA_LEGACY_DATETIME_KEY, "");
+      metadata.put(PARQUET_METADATA_TIME_ZONE_KEY, resolveSessionLocalTimeZone());
     }
     String vectorMeta = HoodieSchema.buildVectorColumnsMetadataValue(schema);
     if (!vectorMeta.isEmpty()) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -118,8 +118,6 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   private static final String MAP_VALUE_NAME = "value";
 
   private static final String SESSION_LOCAL_TIME_ZONE_KEY = "spark.sql.session.timeZone";
-  private static final String PARQUET_METADATA_VERSION_KEY = "org.apache.spark.version";
-  private static final String PARQUET_METADATA_LEGACY_DATETIME_KEY = "org.apache.spark.legacyDateTime";
   private static final String PARQUET_METADATA_TIME_ZONE_KEY = "org.apache.spark.timeZone";
 
   @Getter
@@ -357,9 +355,9 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   @Override
   public WriteContext init(Configuration configuration) {
     Map<String, String> metadata = new HashMap<>();
-    metadata.put(PARQUET_METADATA_VERSION_KEY, VersionUtils.shortVersion(HoodieSparkUtils.getSparkVersion()));
+    metadata.put("org.apache.spark.version", VersionUtils.shortVersion(HoodieSparkUtils.getSparkVersion()));
     if (SparkAdapterSupport$.MODULE$.sparkAdapter().isLegacyBehaviorPolicy(datetimeRebaseMode)) {
-      metadata.put(PARQUET_METADATA_LEGACY_DATETIME_KEY, "");
+      metadata.put("org.apache.spark.legacyDateTime", "");
       metadata.put(PARQUET_METADATA_TIME_ZONE_KEY, resolveSessionLocalTimeZone());
     }
     String vectorMeta = HoodieSchema.buildVectorColumnsMetadataValue(schema);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
@@ -31,12 +31,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Coverage for {@link HoodieRowParquetWriteSupport#resolveSessionLocalTimeZone()}.
  */
-public class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
+class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
 
   private static final String SESSION_LOCAL_TIME_ZONE_KEY = "spark.sql.session.timeZone";
 
   @Test
-  public void testResolveSessionLocalTimeZoneWithoutOverride() {
+  void testResolveSessionLocalTimeZoneWithoutOverride() {
     String expected = TimeZone.getDefault().getID();
 
     // Driver thread.
@@ -56,7 +56,7 @@ public class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
   }
 
   @Test
-  public void testResolveSessionLocalTimeZoneWithSqlConfOverride() {
+  void testResolveSessionLocalTimeZoneWithSqlConfOverride() {
     // Pick a non-JVM-default zone so we can distinguish "fix worked" from
     // "fell back to JVM default".
     String jvmDefault = TimeZone.getDefault().getID();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Coverage for {@link HoodieRowParquetWriteSupport#resolveSessionLocalTimeZone()}.
@@ -75,6 +76,45 @@ class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
           "helper did not return the SQLConf override on the driver");
     } finally {
       sqlContext.sparkSession().conf().unset(SESSION_LOCAL_TIME_ZONE_KEY);
+    }
+  }
+
+  /**
+   * SparkConf branch: when the override lives in SparkConf (broadcast to every
+   * executor) but is absent from the current thread's SQLConf, the helper
+   * must return it via {@code SparkEnv.get.conf}. Mirrors a compaction task
+   * thread that is outside any SQL execution context — exactly the
+   * production scenario the fix targets.
+   */
+  @Test
+  void testResolveSessionLocalTimeZoneWithSparkConfOverride() {
+    String jvmDefault = TimeZone.getDefault().getID();
+    String customTz = "Asia/Tokyo".equals(jvmDefault) ? "Pacific/Auckland" : "Asia/Tokyo";
+    assertNotEquals(customTz, jvmDefault,
+        "test setup is fragile if customTz matches the JVM default");
+
+    // Inject the key into SparkConf and remove it from the SparkSession's
+    // SQLConf so only the SparkEnv branch can satisfy the lookup.
+    jsc.sc().conf().set(SESSION_LOCAL_TIME_ZONE_KEY, customTz);
+    sqlContext.sparkSession().conf().unset(SESSION_LOCAL_TIME_ZONE_KEY);
+    try {
+      // Driver: SQLConf branch returns null → SparkEnv branch returns customTz.
+      assertEquals(customTz, HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone(),
+          "driver helper should fall back to SparkEnv when SQLConf is unset");
+
+      // Executor task threads: SQLConf.get returns the fallback default (no
+      // override), so the SparkEnv branch is the only one that can satisfy
+      // the lookup. SparkEnv is shared by driver and executors in local mode.
+      List<String> seen = jsc.parallelize(Arrays.asList(1, 2, 3, 4), 4)
+          .map(i -> HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone())
+          .collect();
+      for (int i = 0; i < seen.size(); i++) {
+        assertEquals(customTz, seen.get(i),
+            "executor task #" + i + " should resolve to SparkConf override '"
+                + customTz + "', got '" + seen.get(i) + "'");
+      }
+    } finally {
+      jsc.sc().conf().remove(SESSION_LOCAL_TIME_ZONE_KEY);
     }
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
@@ -30,6 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Coverage for {@link HoodieRowParquetWriteSupport#resolveSessionLocalTimeZone()}.
+ * The full {@code init()} method is exercised end-to-end by integration tests in
+ * {@code hudi-spark-datasource/hudi-spark} (e.g. {@code TestHoodieInternalRowParquetWriter},
+ * {@code TestSparkAdapterRebaseModePropagation}). Constructing the write support
+ * directly from this module is not feasible because it requires a Spark
+ * adapter (e.g. {@code Spark3_5Adapter}) that is not on the test classpath
+ * here — the adapters live in sibling modules that depend on this one.
  */
 class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage.row;
+
+import org.apache.hudi.testutils.HoodieClientTestBase;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Coverage for {@link HoodieRowParquetWriteSupport#resolveSessionLocalTimeZone()}:
+ * the helper must return the SQLConf default (JVM default timezone) when no
+ * override is set on the SparkSession or SparkConf, both on the driver and
+ * inside Spark task closures.
+ */
+public class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
+
+  @Test
+  public void testResolveSessionLocalTimeZoneWithoutOverride() {
+    String expected = TimeZone.getDefault().getID();
+
+    // Driver thread.
+    assertEquals(expected, HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone(),
+        "driver-side helper did not return the JVM default timezone");
+
+    // Executor task threads via vanilla parallelize().map() — outside any
+    // Spark SQL execution context — exercise the SparkEnv-fallback branch.
+    List<String> seen = jsc.parallelize(Arrays.asList(1, 2, 3, 4), 4)
+        .map(i -> HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone())
+        .collect();
+    for (int i = 0; i < seen.size(); i++) {
+      assertEquals(expected, seen.get(i),
+          "executor task #" + i + " resolved sessionLocalTimeZone to '" + seen.get(i)
+              + "' with no overrides; expected the JVM default ('" + expected + "')");
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupport.java
@@ -29,12 +29,11 @@ import java.util.TimeZone;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Coverage for {@link HoodieRowParquetWriteSupport#resolveSessionLocalTimeZone()}:
- * the helper must return the SQLConf default (JVM default timezone) when no
- * override is set on the SparkSession or SparkConf, both on the driver and
- * inside Spark task closures.
+ * Coverage for {@link HoodieRowParquetWriteSupport#resolveSessionLocalTimeZone()}.
  */
 public class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
+
+  private static final String SESSION_LOCAL_TIME_ZONE_KEY = "spark.sql.session.timeZone";
 
   @Test
   public void testResolveSessionLocalTimeZoneWithoutOverride() {
@@ -53,6 +52,23 @@ public class TestHoodieRowParquetWriteSupport extends HoodieClientTestBase {
       assertEquals(expected, seen.get(i),
           "executor task #" + i + " resolved sessionLocalTimeZone to '" + seen.get(i)
               + "' with no overrides; expected the JVM default ('" + expected + "')");
+    }
+  }
+
+  @Test
+  public void testResolveSessionLocalTimeZoneWithSqlConfOverride() {
+    // Pick a non-JVM-default zone so we can distinguish "fix worked" from
+    // "fell back to JVM default".
+    String jvmDefault = TimeZone.getDefault().getID();
+    String customTz = "Asia/Tokyo".equals(jvmDefault) ? "Pacific/Auckland" : "Asia/Tokyo";
+
+    sqlContext.sparkSession().conf().set(SESSION_LOCAL_TIME_ZONE_KEY, customTz);
+    try {
+      // Driver SQLConf carries the override; helper must return it via the first branch.
+      assertEquals(customTz, HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone(),
+          "helper did not return the SQLConf override on the driver");
+    } finally {
+      sqlContext.sparkSession().conf().unset(SESSION_LOCAL_TIME_ZONE_KEY);
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkAdapterRebaseModeDefault.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkAdapterRebaseModeDefault.scala
@@ -20,6 +20,7 @@ import org.apache.hudi.util.JFunction
 
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+import org.apache.spark.sql.internal.SQLConf
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.assertEquals
 
@@ -50,10 +51,16 @@ class TestSparkAdapterRebaseModeDefault extends HoodieSparkClientTestBase {
     cleanupFileSystem()
   }
 
-  /** Adapter falls through to the ConfigEntry default (`EXCEPTION`). */
+  /**
+   * Adapter falls through to the ConfigEntry default. The default differs by
+   * Spark version (EXCEPTION on 3.x, CORRECTED on 4.1+), so we read it
+   * dynamically from SQLConf.
+   */
   @Test
   def testRebaseModeDefaultsToConfigEntryDefault(): Unit = {
-    assertEquals("EXCEPTION",
+    val expected = SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE).toString
+
+    assertEquals(expected,
       SparkAdapterSupport.sparkAdapter.getDateTimeRebaseMode().toString,
       "driver-side adapter did not return the ConfigEntry default")
 
@@ -62,9 +69,9 @@ class TestSparkAdapterRebaseModeDefault extends HoodieSparkClientTestBase {
     }.collect()
 
     seenOnExecutor.zipWithIndex.foreach { case (mode, i) =>
-      assertEquals("EXCEPTION", mode,
+      assertEquals(expected, mode,
         s"executor task #$i resolved rebase mode to '$mode' with no overrides set; " +
-          "expected the ConfigEntry default (EXCEPTION).")
+          s"expected the ConfigEntry default ('$expected').")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkAdapterRebaseModeDefault.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkAdapterRebaseModeDefault.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.HoodieConversionUtils.toJavaOption
+import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.io.storage.row.HoodieRowParquetWriteSupport
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.util.JFunction
+
+import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.assertEquals
+
+import java.util.function.Consumer
+
+/**
+ * Regression: with no override on SparkSession or SparkConf, the resolution
+ * chain falls through to the documented defaults (driver and executor).
+ */
+class TestSparkAdapterRebaseModeDefault extends HoodieSparkClientTestBase {
+
+  var spark: SparkSession = _
+
+  override def getSparkSessionExtensionsInjector: HOption[Consumer[SparkSessionExtensions]] =
+    toJavaOption(Some(JFunction.toJavaConsumer((rcv: SparkSessionExtensions) =>
+      new HoodieSparkSessionExtension().apply(rcv))))
+
+  @BeforeEach override def setUp(): Unit = {
+    // Deliberately set no rebase or timezone overrides in extraConf; the
+    // session is created with whatever defaults Spark ships with.
+    initPath()
+    initSparkContexts()
+    spark = sqlContext.sparkSession
+  }
+
+  @AfterEach override def tearDown(): Unit = {
+    cleanupSparkContexts()
+    cleanupFileSystem()
+  }
+
+  /** Adapter falls through to the ConfigEntry default (`EXCEPTION`). */
+  @Test
+  def testRebaseModeDefaultsToConfigEntryDefault(): Unit = {
+    assertEquals("EXCEPTION",
+      SparkAdapterSupport.sparkAdapter.getDateTimeRebaseMode().toString,
+      "driver-side adapter did not return the ConfigEntry default")
+
+    val seenOnExecutor: Array[String] = spark.sparkContext.parallelize(1 to 4, 4).map { _ =>
+      SparkAdapterSupport.sparkAdapter.getDateTimeRebaseMode().toString
+    }.collect()
+
+    seenOnExecutor.zipWithIndex.foreach { case (mode, i) =>
+      assertEquals("EXCEPTION", mode,
+        s"executor task #$i resolved rebase mode to '$mode' with no overrides set; " +
+          "expected the ConfigEntry default (EXCEPTION).")
+    }
+  }
+
+  /** Timezone helper falls through to SQLConf's session-local timezone (JVM default). */
+  @Test
+  def testSessionLocalTimeZoneDefaultsToJvmDefault(): Unit = {
+    val expected = java.util.TimeZone.getDefault.getID
+
+    assertEquals(expected,
+      HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone(),
+      "driver-side helper did not return the JVM default timezone")
+
+    val seen: Array[String] = spark.sparkContext.parallelize(1 to 4, 4).map { _ =>
+      HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone()
+    }.collect()
+
+    seen.zipWithIndex.foreach { case (tz, i) =>
+      assertEquals(expected, tz,
+        s"executor task #$i resolved sessionLocalTimeZone to '$tz' with no overrides; " +
+          s"expected the JVM default ('$expected').")
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkAdapterRebaseModePropagation.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkAdapterRebaseModePropagation.scala
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.HoodieConversionUtils.toJavaOption
+import org.apache.hudi.SparkAdapterSupport
+import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.io.storage.row.HoodieRowParquetWriteSupport
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.util.JFunction
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertTrue}
+
+import java.util.function.Consumer
+
+/**
+ * Asserts that user-set rebase mode and session timezone are visible to Spark
+ * executor tasks even when the task runs outside a Spark SQL execution context
+ * (e.g. compaction dispatched via vanilla `JavaSparkContext.parallelize().map()`).
+ * Each test fails without the SparkEnv.get.conf fallback in `getDateTimeRebaseMode`
+ * and `HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone`.
+ */
+class TestSparkAdapterRebaseModePropagation extends HoodieSparkClientTestBase {
+
+  var spark: SparkSession = _
+
+  override def getSparkSessionExtensionsInjector: HOption[Consumer[SparkSessionExtensions]] =
+    toJavaOption(Some(JFunction.toJavaConsumer((rcv: SparkSessionExtensions) =>
+      new HoodieSparkSessionExtension().apply(rcv))))
+
+  // Use a non-default timezone so we can prove that the user override is what
+  // the executor sees, not the JVM default that any fresh SQLConf would return.
+  // We pick whichever of two unrelated zones isn't the JVM default, so the test
+  // works on any developer's machine (or CI box).
+  private val customTimeZone: String = {
+    val jvmDefault = java.util.TimeZone.getDefault.getID
+    if (jvmDefault == "Asia/Tokyo") "Pacific/Auckland" else "Asia/Tokyo"
+  }
+
+  @BeforeEach override def setUp(): Unit = {
+    // LEGACY rebase + a non-default session timezone in SparkConf (broadcast to
+    // all executors) AND propagated into the driver SparkSession's SQLConf at
+    // startup.
+    extraConf.put("spark.sql.parquet.datetimeRebaseModeInWrite", "LEGACY")
+    extraConf.put("spark.sql.parquet.datetimeRebaseModeInRead", "LEGACY")
+    extraConf.put("spark.sql.parquet.int96RebaseModeInWrite", "LEGACY")
+    extraConf.put("spark.sql.parquet.int96RebaseModeInRead", "LEGACY")
+    extraConf.put("spark.sql.session.timeZone", customTimeZone)
+
+    initPath()
+    initSparkContexts()
+    spark = sqlContext.sparkSession
+  }
+
+  @AfterEach override def tearDown(): Unit = {
+    cleanupSparkContexts()
+    cleanupFileSystem()
+  }
+
+  @Test
+  def testRebaseModeReachesExecutorTask(): Unit = {
+    // Sanity check #1: SparkConf carries LEGACY (so SparkEnv.get.conf
+    // on the executor will see it after the fix).
+    assertEquals(
+      "LEGACY",
+      spark.sparkContext.getConf.get("spark.sql.parquet.datetimeRebaseModeInWrite"),
+      "SparkConf does not carry LEGACY — extraConf setup failed"
+    )
+
+    // Sanity check #2: Driver session's SQLConf has LEGACY.
+    assertEquals(
+      "LEGACY",
+      spark.conf.get("spark.sql.parquet.datetimeRebaseModeInWrite"),
+      "driver SparkSession SQLConf does not see LEGACY"
+    )
+
+    // Sanity check #3: The Hudi adapter, called from the driver, returns LEGACY.
+    val driverMode = SparkAdapterSupport.sparkAdapter.getDateTimeRebaseMode().toString
+    assertEquals(
+      "LEGACY", driverMode,
+      s"adapter on driver returned $driverMode — expected LEGACY"
+    )
+
+    // Now the actual bug check: ask the adapter on EXECUTOR task threads.
+    // We use raw RDD.map (NOT Dataset.map) so we are NOT inside a Spark SQL
+    // execution context — Spark will not auto-propagate SQLConf for us.
+    // This mirrors HoodieCompactor.compact:146's `context.parallelize(...).map(...)`.
+    val seenOnExecutor: Array[String] = spark.sparkContext.parallelize(1 to 4, 4).map { _ =>
+      SparkAdapterSupport.sparkAdapter.getDateTimeRebaseMode().toString
+    }.collect()
+
+    seenOnExecutor.zipWithIndex.foreach { case (mode, i) =>
+      assertEquals(
+        "LEGACY", mode,
+        s"executor task #$i resolved rebase mode to '$mode' despite the driver " +
+          "session being LEGACY and SparkConf carrying LEGACY. This is the " +
+          "SQLConf-not-propagated-to-executor bug. " +
+          "Fix: have the adapter's getDateTimeRebaseMode() fall back to " +
+          "SparkEnv.get.conf when SQLConf.get does not have the override."
+      )
+    }
+  }
+
+  /**
+   * Verifies the *mechanism* the fix relies on: SparkConf IS broadcast to every
+   * executor and is reachable via SparkEnv.get.conf inside a task closure.
+   * If this assertion ever fails, the adapter fallback's premise is broken.
+   */
+  @Test
+  def testSparkConfIsVisibleOnExecutorViaSparkEnv(): Unit = {
+    val key = "spark.sql.parquet.datetimeRebaseModeInWrite"
+    val seen: Array[String] = spark.sparkContext.parallelize(1 to 4, 4).map { _ =>
+      Option(SparkEnv.get).map(_.conf.get(key, "<absent>")).getOrElse("<no SparkEnv>")
+    }.collect()
+    seen.zipWithIndex.foreach { case (v, i) =>
+      assertEquals(
+        "LEGACY", v,
+        s"task #$i could not read $key from SparkEnv.get.conf; got '$v'. " +
+          "If this fails, the adapter SparkEnv fallback path is unreachable on this Spark version."
+      )
+    }
+  }
+
+  /**
+   * Parallel hole: HoodieRowParquetWriteSupport.init() reads
+   * `SQLConf.get().sessionLocalTimeZone()` to record the table's timezone
+   * metadata when LEGACY rebase is in effect. With the same SQLConf-on-executor
+   * bug, that read returned the JVM default timezone — not the user's
+   * `spark.sql.session.timeZone` override — when called from a compaction task.
+   *
+   * The fix: HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone() falls
+   * back to SparkEnv.get.conf when SQLConf.get is the default. This test
+   * exercises that helper directly from an executor task closure to confirm.
+   */
+  @Test
+  def testSessionLocalTimeZoneReachesExecutorTask(): Unit = {
+    // Sanity: customTimeZone is set on the driver session.
+    assertEquals(customTimeZone, spark.conf.get("spark.sql.session.timeZone"))
+    assertNotEquals(customTimeZone, java.util.TimeZone.getDefault.getID,
+      "test setup is fragile: customTimeZone matches the JVM default, so we " +
+        "cannot distinguish 'fix worked' from 'fell back to JVM default'")
+
+    // Sanity: helper returns the override when called on the driver thread.
+    assertEquals(customTimeZone, HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone())
+
+    // Bug check: helper returns the override when called from an executor task,
+    // not the JVM default.
+    val seen: Array[String] = spark.sparkContext.parallelize(1 to 4, 4).map { _ =>
+      HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone()
+    }.collect()
+    seen.zipWithIndex.foreach { case (tz, i) =>
+      assertEquals(
+        customTimeZone, tz,
+        s"executor task #$i resolved sessionLocalTimeZone to '$tz', not the " +
+          s"user override '$customTimeZone'. Same SQLConf-not-propagated bug " +
+          "as the rebase mode read. Fix: use SparkEnv.get.conf as a fallback."
+      )
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkAdapterRebaseModePropagation.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkAdapterRebaseModePropagation.scala
@@ -27,11 +27,9 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertTr
 import java.util.function.Consumer
 
 /**
- * Asserts that user-set rebase mode and session timezone are visible to Spark
- * executor tasks even when the task runs outside a Spark SQL execution context
- * (e.g. compaction dispatched via vanilla `JavaSparkContext.parallelize().map()`).
- * Each test fails without the SparkEnv.get.conf fallback in `getDateTimeRebaseMode`
- * and `HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone`.
+ * User-set rebase mode and session timezone must reach Spark executor tasks
+ * dispatched outside a SQL execution context. Each test fails without the
+ * SparkEnv.get.conf fallback.
  */
 class TestSparkAdapterRebaseModePropagation extends HoodieSparkClientTestBase {
 
@@ -51,9 +49,9 @@ class TestSparkAdapterRebaseModePropagation extends HoodieSparkClientTestBase {
   }
 
   @BeforeEach override def setUp(): Unit = {
-    // LEGACY rebase + a non-default session timezone in SparkConf (broadcast to
-    // all executors) AND propagated into the driver SparkSession's SQLConf at
-    // startup.
+    // Customer-style config: LEGACY rebase + a non-default session timezone in
+    // SparkConf (broadcast to all executors) AND propagated into the driver
+    // SparkSession's SQLConf at startup.
     extraConf.put("spark.sql.parquet.datetimeRebaseModeInWrite", "LEGACY")
     extraConf.put("spark.sql.parquet.datetimeRebaseModeInRead", "LEGACY")
     extraConf.put("spark.sql.parquet.int96RebaseModeInWrite", "LEGACY")
@@ -114,11 +112,7 @@ class TestSparkAdapterRebaseModePropagation extends HoodieSparkClientTestBase {
     }
   }
 
-  /**
-   * Verifies the *mechanism* the fix relies on: SparkConf IS broadcast to every
-   * executor and is reachable via SparkEnv.get.conf inside a task closure.
-   * If this assertion ever fails, the adapter fallback's premise is broken.
-   */
+  /** SparkConf must be reachable on executor task threads via SparkEnv.get.conf. */
   @Test
   def testSparkConfIsVisibleOnExecutorViaSparkEnv(): Unit = {
     val key = "spark.sql.parquet.datetimeRebaseModeInWrite"
@@ -134,17 +128,7 @@ class TestSparkAdapterRebaseModePropagation extends HoodieSparkClientTestBase {
     }
   }
 
-  /**
-   * Parallel hole: HoodieRowParquetWriteSupport.init() reads
-   * `SQLConf.get().sessionLocalTimeZone()` to record the table's timezone
-   * metadata when LEGACY rebase is in effect. With the same SQLConf-on-executor
-   * bug, that read returned the JVM default timezone — not the user's
-   * `spark.sql.session.timeZone` override — when called from a compaction task.
-   *
-   * The fix: HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone() falls
-   * back to SparkEnv.get.conf when SQLConf.get is the default. This test
-   * exercises that helper directly from an executor task closure to confirm.
-   */
+  /** Same shape as the rebase-mode test, for `HoodieRowParquetWriteSupport.resolveSessionLocalTimeZone`. */
   @Test
   def testSessionLocalTimeZoneReachesExecutorTask(): Unit = {
     // Sanity: customTimeZone is set on the driver session.

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
@@ -180,9 +180,9 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
     // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
-    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
-    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
+    val fromSqlConf = Option(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE, null))
+    val fromSparkConf = Option(SparkEnv.get)
+      .flatMap(env => Option(env.conf.get(SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key, null)))
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
@@ -182,7 +182,7 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
     // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
     val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
     val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).map(_.conf.get(key, null)).filter(_ != null)
+    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.storage.StorageConfiguration
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.schema.MessageType
+import org.apache.spark.SparkEnv
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.avro._
@@ -178,7 +179,13 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
 
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
-    LegacyBehaviorPolicy.withName(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE))
+    // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
+    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
+    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
+    val fromSparkConf = Option(SparkEnv.get).map(_.conf.get(key, null)).filter(_ != null)
+    LegacyBehaviorPolicy.withName(
+      fromSqlConf.orElse(fromSparkConf)
+        .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))
   }
 
   override def isLegacyBehaviorPolicy(value: Object): Boolean = {

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.storage.StorageConfiguration
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.schema.MessageType
+import org.apache.spark.SparkEnv
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.avro._
@@ -178,7 +179,13 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
   }
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
-    LegacyBehaviorPolicy.withName(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE))
+    // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
+    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
+    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
+    val fromSparkConf = Option(SparkEnv.get).map(_.conf.get(key, null)).filter(_ != null)
+    LegacyBehaviorPolicy.withName(
+      fromSqlConf.orElse(fromSparkConf)
+        .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))
   }
 
   override def isLegacyBehaviorPolicy(value: Object): Boolean = {

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
@@ -182,7 +182,7 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
     // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
     val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
     val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).map(_.conf.get(key, null)).filter(_ != null)
+    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
@@ -180,9 +180,9 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
     // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
-    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
-    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
+    val fromSqlConf = Option(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE, null))
+    val fromSparkConf = Option(SparkEnv.get)
+      .flatMap(env => Option(env.conf.get(SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key, null)))
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -205,7 +205,7 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
     //   3. The ConfigEntry's own default.
     val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
     val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).map(_.conf.get(key, null)).filter(_ != null)
+    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -23,6 +23,7 @@ import org.apache.hudi.storage.StorageConfiguration
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.schema.MessageType
+import org.apache.spark.SparkEnv
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.avro._
@@ -193,7 +194,21 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
   }
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
-    LegacyBehaviorPolicy.withName(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE))
+    // Resolution order:
+    //   1. SQLConf override (so `spark.conf.set(...)` on the SparkSession takes
+    //      effect on the driver and inside Spark SQL execution contexts).
+    //   2. SparkConf (SparkEnv.get.conf) — broadcast to every executor at
+    //      startup, so user-set `spark.sql.parquet.datetimeRebaseModeInWrite`
+    //      is honored on executor tasks outside a SQL execution context (e.g.
+    //      compaction dispatched via vanilla
+    //      `JavaSparkContext.parallelize(...).map(...)`).
+    //   3. The ConfigEntry's own default.
+    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
+    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
+    val fromSparkConf = Option(SparkEnv.get).map(_.conf.get(key, null)).filter(_ != null)
+    LegacyBehaviorPolicy.withName(
+      fromSqlConf.orElse(fromSparkConf)
+        .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))
   }
 
   override def isLegacyBehaviorPolicy(value: Object): Boolean = {

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -203,9 +203,9 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
     //      compaction dispatched via vanilla
     //      `JavaSparkContext.parallelize(...).map(...)`).
     //   3. The ConfigEntry's own default.
-    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
-    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
+    val fromSqlConf = Option(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE, null))
+    val fromSparkConf = Option(SparkEnv.get)
+      .flatMap(env => Option(env.conf.get(SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key, null)))
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkEnv
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.avro._
@@ -223,7 +224,13 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
   }
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
-    LegacyBehaviorPolicy.withName(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE))
+    // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
+    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
+    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
+    val fromSparkConf = Option(SparkEnv.get).map(_.conf.get(key, null)).filter(_ != null)
+    LegacyBehaviorPolicy.withName(
+      fromSqlConf.orElse(fromSparkConf)
+        .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))
   }
 
   override def isLegacyBehaviorPolicy(value: Object): Boolean = {

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -225,9 +225,9 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
     // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
-    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
-    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
+    val fromSqlConf = Option(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE, null))
+    val fromSparkConf = Option(SparkEnv.get)
+      .flatMap(env => Option(env.conf.get(SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key, null)))
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -227,7 +227,7 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
     // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
     val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
     val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).map(_.conf.get(key, null)).filter(_ != null)
+    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
     LegacyBehaviorPolicy.withName(
       fromSqlConf.orElse(fromSparkConf)
         .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)))

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -227,12 +227,14 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
   }
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
-    // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
-    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
-    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
-    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
-    fromSqlConf.orElse(fromSparkConf)
+    // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale. In Spark 4.1
+    // the ConfigEntry returns LegacyBehaviorPolicy.Value directly, so the
+    // SparkConf string is parsed via withName before the orElse chain.
+    val fromSqlConf = Option(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE, null))
+    val fromSparkConf = Option(SparkEnv.get)
+      .flatMap(env => Option(env.conf.get(SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key, null)))
       .map(LegacyBehaviorPolicy.withName)
+    fromSqlConf.orElse(fromSparkConf)
       .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE))
   }
 

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_1Adapter.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkEnv
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.avro._
@@ -226,7 +227,13 @@ class Spark4_1Adapter extends BaseSpark4Adapter {
   }
 
   override def getDateTimeRebaseMode(): LegacyBehaviorPolicy.Value = {
-    SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)
+    // See Spark3_5Adapter.getDateTimeRebaseMode for the rationale.
+    val key = SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key
+    val fromSqlConf = Option(SQLConf.get.getConfString(key, null))
+    val fromSparkConf = Option(SparkEnv.get).flatMap(env => Option(env.conf.get(key, null)))
+    fromSqlConf.orElse(fromSparkConf)
+      .map(LegacyBehaviorPolicy.withName)
+      .getOrElse(SQLConf.get.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE))
   }
 
   override def isLegacyBehaviorPolicy(value: Object): Boolean = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When MOR compaction runs outside a Spark SQL execution context (for example, a standalone compaction runner that dispatches per-file-group work via `JavaSparkContext.parallelize(...).map(...)`), `SQLConf.get` on the executor task thread returns a fresh fallback `SQLConf` with default values rather than the user's SparkSession overrides. As a result, `Spark{3_3,3_4,3_5,4_0}Adapter.getDateTimeRebaseMode()` resolves to `EXCEPTION` even when the user has set `spark.sql.parquet.datetimeRebaseModeInWrite=LEGACY`, producing `SparkUpgradeException [INCONSISTENT_BEHAVIOR_CROSS_VERSION.WRITE_ANCIENT_DATETIME]` during compaction of MOR tables containing pre-1900 timestamps (a common Oracle DATE sentinel pattern). The same gap affects `HoodieRowParquetWriteSupport.init()`'s `sessionLocalTimeZone` read when LEGACY rebase metadata is being recorded.

### Summary and Changelog

This change resolves the value in three steps:

1. **SQLConf override** — catches values set via `spark.conf.set(...)` on the SparkSession (and any task thread that IS inside a Spark SQL execution context, where Spark already propagated SQLConf for us).
2. **SparkConf via `SparkEnv.get.conf`** — catches values set in SparkConf at startup. SparkConf is broadcast to every executor, so user overrides reach tasks dispatched outside any SQL execution context.
3. **The `ConfigEntry`'s own default** (or `SQLConf.sessionLocalTimeZone` for the timezone helper).

The inline-compaction-via-`df.write` path was already correct because Spark's SQL execution wrapper had already populated the task thread's SQLConf. No call-site changes; the fix is localized to the adapter read and a small helper in `HoodieRowParquetWriteSupport`.

- `Spark{3_3,3_4,3_5,4_0}Adapter.getDateTimeRebaseMode()`: SQLConf → SparkConf → ConfigEntry default.
- `HoodieRowParquetWriteSupport`: extracted Parquet metadata key strings as named constants; new `resolveSessionLocalTimeZone()` helper applies the same resolution order; called from `init()` when LEGACY rebase metadata is being recorded.

New tests: `TestSparkAdapterRebaseModePropagation` (3 methods)
- rebase mode reaches executor task threads under `parallelize().map()`,
- SparkConf is reachable on executors via `SparkEnv.get.conf` (mechanism check),
- `sessionLocalTimeZone` reaches executor task threads.

Each test fails without the fix.

### Impact

User-facing: users who set `spark.sql.parquet.datetimeRebaseModeInWrite` (or `spark.sql.session.timeZone`) on the SparkSession — at startup via SparkConf or at runtime via `spark.conf.set(...)` — will have the override honored by Hudi compaction tasks dispatched outside a Spark SQL execution context. No behavior change for callers already inside a SQL execution context, and no change to default behavior when no override is set.

### Risk Level

Low. The SparkConf fallback only fires when `SQLConf.get` does not have the key set; SparkConf is the canonical broadcast source for cluster-wide configuration. No call-site or API changes.

### Documentation Update

None required — fix preserves the documented behavior of the underlying Spark configs.

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable