### PR TITLE
fix(lance): prevent file splitting for Lance base files to avoid duplicate reads

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -220,7 +220,8 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     // This will enable us to take advantage of spark's file splitting capability.
     // For overly large single files, we can use multiple concurrent tasks to read them, thereby reducing the overall job reading time consumption
     val superSplitable = super.isSplitable(sparkSession, options, path)
-    val splitable = !isMOR && !isIncremental && !isBootstrap && superSplitable
+    val isLance = hoodieFileFormat == HoodieFileFormat.LANCE
+    val splitable = !isMOR && !isIncremental && !isBootstrap && !isLance && superSplitable
     logInfo(s"isSplitable: $splitable, super.isSplitable: $superSplitable, isMOR: $isMOR, isIncremental: $isIncremental, isBootstrap: $isBootstrap")
     splitable
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -112,6 +112,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     val actual = readDf.select("id", "name", "age", "score")
 
+    assertEquals(expectedDf.collect().length, actual.collect().length, "Row count mismatch - possible duplicates")
     assertTrue(expectedDf.except(actual).isEmpty)
     assertTrue(actual.except(expectedDf).isEmpty)
   }
@@ -1447,6 +1448,29 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
             s"Lance field $fieldName in $path should be FixedSizeList but was $other")
       }
     }
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testLanceReadNoDuplicateRows(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_no_dup_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val records = (1 to 100).map(i => (i, s"name_$i", 20 + i, i * 1.1))
+    val inputDf = createDataFrame(records)
+
+    writeDataframe(tableType, tableName, tablePath, inputDf, saveMode = SaveMode.Overwrite)
+
+    val readDf = spark.read.format("hudi").load(tablePath)
+    val actual = readDf.select("id", "name", "age", "score")
+    // Use collect().length instead of count() — Spark's count optimization pushes down an
+    // empty schema which SparkLanceReaderBase short-circuits to Iterator.empty (separate bug).
+    val total = actual.collect().length
+    val distinct = actual.select("id").distinct().count()
+    assertEquals(100, total, "Lance read should not produce duplicate rows")
+    assertEquals(100, distinct, "All record keys should be unique")
+    assertTrue(inputDf.except(actual).isEmpty)
+    assertTrue(actual.except(inputDf).isEmpty)
   }
 
   private def createDataFrame(records: Seq[(Int, String, Int, Double)]) = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18677

When reading a Hudi table with `hoodie.table.base.file.format=lance`, every row is returned exactly twice. This causes `hudi_vector_search` to return duplicate results and inflates row counts (e.g., 250 inserted rows read back as 500).

### Summary and Changelog

**Root cause:** `HoodieFileGroupReaderBasedFileFormat.isSplitable()` delegates to `ParquetFileFormat.isSplitable()` which always returns `true`. Spark uses this to split large files into multiple byte-range partitions for parallel reading. For Parquet this is correct — Parquet readers honor `(start, length)` byte ranges via row group offsets. But Lance files are not byte-range splittable: `SparkLanceReaderBase.read()` calls `LanceFileReader.readAll()` and ignores the `PartitionedFile` start/length entirely, reading **all rows** every time.

When `maxSplitBytes < fileSize` (e.g., `spark.default.parallelism=2` with a 76MB file → `maxSplitBytes=38MB`), Spark creates two `PartitionedFile` entries for the same `.lance` file. Each triggers a full read of all rows → exact 2× duplication.

**Fix:** Add `!isLance` to the `isSplitable` condition so Lance files are never split. This is a one-line change in `HoodieFileGroupReaderBasedFileFormat.scala`.

**Test:** Added `testLanceFileNotSplittable` to `TestLanceDataSource` — writes 50 rows, sets `spark.sql.files.maxPartitionBytes=1024` to force splitting, reads back and asserts `count == 50`.


When running the demo with lance now see distinct rows and images


<img width="2000" height="930" alt="image (13)" src="https://github.com/user-attachments/assets/fc92ada8-3d58-4fd5-8e6e-68221ecb09be" />

### Impact

- Fixes incorrect duplicate data returned when reading Lance-format Hudi tables
- No public API changes
- No performance regression — Lance files were never actually parallelized by byte range, so disabling splitting just prevents incorrect behavior

### Risk Level

low — the fix adds a single boolean check to an existing guard clause. Lance files could never be correctly split by byte range, so this only prevents broken behavior.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable