### PR TITLE
feat(flink): add metrics for RLIBootstrapOperator

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkRLIBootstrapMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkRLIBootstrapMetrics.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * Metrics for {@link org.apache.hudi.sink.bootstrap.RLIBootstrapOperator}.
+ *
+ * <p>Exposes gauges that are updated once after the bootstrap loading completes.
+ */
+public class FlinkRLIBootstrapMetrics extends HoodieFlinkMetrics {
+
+  public static final String NUM_FILE_SLICES_PROCESSED = "rliBootstrap.numFileSlicesProcessed";
+  public static final String NUM_INDEX_RECORDS_EMITTED = "rliBootstrap.numIndexRecordsEmitted";
+  public static final String BOOTSTRAP_COST_MS = "rliBootstrap.bootstrapCostMs";
+  public static final String BOOTSTRAP_RECORD_PER_MS = "rliBootstrap.bootstrapRecordPerMs";
+
+  private long numFileSlicesProcessed;
+  private long numIndexRecordsEmitted;
+  private long bootstrapCostMs;
+
+  public FlinkRLIBootstrapMetrics(MetricGroup metricGroup) {
+    super(metricGroup);
+  }
+
+  @Override
+  public void registerMetrics() {
+    metricGroup.gauge(NUM_FILE_SLICES_PROCESSED, (Gauge<Long>) () -> numFileSlicesProcessed);
+    metricGroup.gauge(NUM_INDEX_RECORDS_EMITTED, (Gauge<Long>) () -> numIndexRecordsEmitted);
+    metricGroup.gauge(BOOTSTRAP_COST_MS, (Gauge<Long>) () -> bootstrapCostMs);
+    metricGroup.gauge(BOOTSTRAP_RECORD_PER_MS, (Gauge<Double>) this::getThroughput);
+  }
+
+  public void updateLoadResult(long numFileSlicesProcessed, long numIndexRecordsEmitted, long bootstrapCostMs) {
+    this.numFileSlicesProcessed = numFileSlicesProcessed;
+    this.numIndexRecordsEmitted = numIndexRecordsEmitted;
+    this.bootstrapCostMs = bootstrapCostMs;
+  }
+
+  private double getThroughput() {
+    return bootstrapCostMs > 0 ? (double) numIndexRecordsEmitted / bootstrapCostMs * 1000 : 0;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkRLIBootstrapMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkRLIBootstrapMetrics.java
@@ -56,6 +56,6 @@ public class FlinkRLIBootstrapMetrics extends HoodieFlinkMetrics {
   }
 
   private double getThroughput() {
-    return bootstrapCostMs > 0 ? (double) numIndexRecordsEmitted / bootstrapCostMs * 1000 : 0;
+    return bootstrapCostMs > 0 ? (double) numIndexRecordsEmitted / bootstrapCostMs : 0;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
@@ -82,6 +82,7 @@ public class RLIBootstrapOperator
         conf.get(FlinkOptions.PATH));
     // Load RLI records
     preLoadRLIRecords();
+    this.metrics.updateLoadResult(numFileSlicesProcessed, loadedCnt, bootstrapCostMs);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
@@ -82,7 +82,6 @@ public class RLIBootstrapOperator
         conf.get(FlinkOptions.PATH));
     // Load RLI records
     preLoadRLIRecords();
-    this.metrics.updateLoadResult(numFileSlicesProcessed, loadedCnt, bootstrapCostMs);
   }
 
   @Override
@@ -144,6 +143,11 @@ public class RLIBootstrapOperator
             location.getFileId(),
             String.valueOf(location.getInstantTime()))));
     loadedCnt += 1;
+
+    // update the metrics every 1000 records
+    if (loadedCnt % 1000 == 0) {
+      this.metrics.updateLoadResult(numFileSlicesProcessed, loadedCnt, bootstrapCostMs);
+    }
   }
 
   private void closeMetadataTable() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metrics.FlinkRLIBootstrapMetrics;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.RuntimeContextUtils;
 
@@ -54,9 +55,20 @@ public class RLIBootstrapOperator
 
   private transient HoodieBackedTableMetadata metadataTable;
   private transient long loadedCnt;
+  private transient long numFileSlicesProcessed;
+  private transient long bootstrapCostMs;
+  private transient FlinkRLIBootstrapMetrics metrics;
 
   public RLIBootstrapOperator(Configuration conf) {
     super(conf);
+  }
+
+  @Override
+  public void open() throws Exception {
+    super.open();
+    this.metrics = new FlinkRLIBootstrapMetrics(getRuntimeContext().getMetricGroup());
+    this.metrics.registerMetrics();
+    this.metrics.updateLoadResult(numFileSlicesProcessed, loadedCnt, bootstrapCostMs);
   }
 
   @Override
@@ -97,6 +109,7 @@ public class RLIBootstrapOperator
       }
       log.info("Subtask: {} will load record index records from file groups: {}, total file groups: {}.",
           taskID, filteredFileSlices.stream().map(FileSlice::getFileId).collect(Collectors.joining(",")), fileSlices.size());
+      numFileSlicesProcessed = filteredFileSlices.size();
       return filteredFileSlices;
     };
 
@@ -104,8 +117,8 @@ public class RLIBootstrapOperator
     long startTime = System.currentTimeMillis();
     HoodiePairData<String, HoodieRecordGlobalLocation> rliData = metadataTable.readRecordIndexLocations(fileSlicesFilter);
     rliData.forEach(locationPair -> emitIndexRecord(locationPair.getLeft(), locationPair.getRight()));
-    long costMs = System.currentTimeMillis() - startTime;
-    log.info("Finish loading RLI records, total records: {}, cost: {} ms, taskId = {}", loadedCnt, costMs, taskID);
+    bootstrapCostMs = System.currentTimeMillis() - startTime;
+    log.info("Finish loading RLI records, total records: {}, cost: {} ms, taskId = {}", loadedCnt, bootstrapCostMs, taskID);
 
     // Wait for other tasks to complete
     waitForBootstrapReady(taskID);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkRLIBootstrapMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkRLIBootstrapMetrics.java
@@ -119,7 +119,7 @@ class TestFlinkRLIBootstrapMetrics {
   void testThroughputIsRecordsPerSecond() {
     // 2000 records in 500 ms → 4000 records/sec
     metrics.updateLoadResult(4, 2000, 500);
-    assertEquals(4000.0, gaugeValue(BOOTSTRAP_RECORD_PER_MS));
+    assertEquals(4.0, gaugeValue(BOOTSTRAP_RECORD_PER_MS));
   }
 
   @Test
@@ -136,7 +136,7 @@ class TestFlinkRLIBootstrapMetrics {
     assertEquals(5L, (Long) gaugeValue(NUM_FILE_SLICES_PROCESSED));
     assertEquals(500L, (Long) gaugeValue(NUM_INDEX_RECORDS_EMITTED));
     assertEquals(250L, (Long) gaugeValue(BOOTSTRAP_COST_MS));
-    assertEquals(2000.0, gaugeValue(BOOTSTRAP_RECORD_PER_MS));
+    assertEquals(2.0, gaugeValue(BOOTSTRAP_RECORD_PER_MS));
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkRLIBootstrapMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkRLIBootstrapMetrics.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hudi.metrics.FlinkRLIBootstrapMetrics.BOOTSTRAP_COST_MS;
+import static org.apache.hudi.metrics.FlinkRLIBootstrapMetrics.BOOTSTRAP_RECORD_PER_MS;
+import static org.apache.hudi.metrics.FlinkRLIBootstrapMetrics.NUM_FILE_SLICES_PROCESSED;
+import static org.apache.hudi.metrics.FlinkRLIBootstrapMetrics.NUM_INDEX_RECORDS_EMITTED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Test cases for {@link FlinkRLIBootstrapMetrics}.
+ */
+class TestFlinkRLIBootstrapMetrics {
+
+  /** Subclass that captures registered gauges so tests can read their values. */
+  private static class CapturingMetricGroup extends UnregisteredMetricsGroup {
+    final Map<String, Gauge<?>> gauges = new HashMap<>();
+
+    @Override
+    public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+      gauges.put(name, gauge);
+      return gauge;
+    }
+  }
+
+  private CapturingMetricGroup metricGroup;
+  private FlinkRLIBootstrapMetrics metrics;
+
+  @BeforeEach
+  void setUp() {
+    metricGroup = new CapturingMetricGroup();
+    metrics = new FlinkRLIBootstrapMetrics(metricGroup);
+    metrics.registerMetrics();
+  }
+
+  // -------------------------------------------------------------------------
+  //  Metric name constants
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testMetricNameConstants() {
+    assertEquals("rliBootstrap.numFileSlicesProcessed", NUM_FILE_SLICES_PROCESSED);
+    assertEquals("rliBootstrap.numIndexRecordsEmitted", NUM_INDEX_RECORDS_EMITTED);
+    assertEquals("rliBootstrap.bootstrapCostMs", BOOTSTRAP_COST_MS);
+    assertEquals("rliBootstrap.bootstrapRecordPerMs", BOOTSTRAP_RECORD_PER_MS);
+  }
+
+  // -------------------------------------------------------------------------
+  //  Gauge registration
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testAllMetricsAreRegistered() {
+    assertEquals(4, metricGroup.gauges.size());
+    assertEquals(true, metricGroup.gauges.containsKey(NUM_FILE_SLICES_PROCESSED));
+    assertEquals(true, metricGroup.gauges.containsKey(NUM_INDEX_RECORDS_EMITTED));
+    assertEquals(true, metricGroup.gauges.containsKey(BOOTSTRAP_COST_MS));
+    assertEquals(true, metricGroup.gauges.containsKey(BOOTSTRAP_RECORD_PER_MS));
+  }
+
+  @Test
+  void testRegisterMetricsWithUnregisteredGroupDoesNotThrow() {
+    assertDoesNotThrow(() ->
+        new FlinkRLIBootstrapMetrics(new UnregisteredMetricsGroup()).registerMetrics());
+  }
+
+  // -------------------------------------------------------------------------
+  //  Initial values (before any update)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testInitialValuesAreZero() {
+    assertEquals(0L, (Long) gaugeValue(NUM_FILE_SLICES_PROCESSED));
+    assertEquals(0L, (Long) gaugeValue(NUM_INDEX_RECORDS_EMITTED));
+    assertEquals(0L, (Long) gaugeValue(BOOTSTRAP_COST_MS));
+    assertEquals(0.0, gaugeValue(BOOTSTRAP_RECORD_PER_MS));
+  }
+
+  // -------------------------------------------------------------------------
+  //  After updateLoadResult
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testUpdateLoadResultReflectsInGauges() {
+    metrics.updateLoadResult(8, 1000, 500);
+
+    assertEquals(8L, (Long) gaugeValue(NUM_FILE_SLICES_PROCESSED));
+    assertEquals(1000L, (Long) gaugeValue(NUM_INDEX_RECORDS_EMITTED));
+    assertEquals(500L, (Long) gaugeValue(BOOTSTRAP_COST_MS));
+  }
+
+  @Test
+  void testThroughputIsRecordsPerSecond() {
+    // 2000 records in 500 ms → 4000 records/sec
+    metrics.updateLoadResult(4, 2000, 500);
+    assertEquals(4000.0, gaugeValue(BOOTSTRAP_RECORD_PER_MS));
+  }
+
+  @Test
+  void testThroughputIsZeroWhenCostIsZero() {
+    metrics.updateLoadResult(3, 100, 0);
+    assertEquals(0.0, gaugeValue(BOOTSTRAP_RECORD_PER_MS));
+  }
+
+  @Test
+  void testGaugesReflectLatestUpdate() {
+    metrics.updateLoadResult(2, 200, 100);
+    metrics.updateLoadResult(5, 500, 250);
+
+    assertEquals(5L, (Long) gaugeValue(NUM_FILE_SLICES_PROCESSED));
+    assertEquals(500L, (Long) gaugeValue(NUM_INDEX_RECORDS_EMITTED));
+    assertEquals(250L, (Long) gaugeValue(BOOTSTRAP_COST_MS));
+    assertEquals(2000.0, gaugeValue(BOOTSTRAP_RECORD_PER_MS));
+  }
+
+  // -------------------------------------------------------------------------
+  //  Helper
+  // -------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private <T> T gaugeValue(String name) {
+    return (T) metricGroup.gauges.get(name).getValue();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bootstrap/TestRLIBootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bootstrap/TestRLIBootstrapOperator.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.bootstrap;
+
+import org.apache.hudi.adapter.CollectOutputAdapter;
+import org.apache.hudi.client.model.HoodieFlinkInternalRow;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.metrics.FlinkRLIBootstrapMetrics;
+import org.apache.hudi.sink.utils.MockStreamingRuntimeContext;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.metrics.FlinkRLIBootstrapMetrics.NUM_INDEX_RECORDS_EMITTED;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Unit tests for {@link RLIBootstrapOperator}.
+ */
+class TestRLIBootstrapOperator {
+
+  private RLIBootstrapOperator operator;
+  private CollectOutputAdapter<HoodieFlinkInternalRow> outputAdapter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    operator = spy(new RLIBootstrapOperator(new Configuration()));
+    MockStreamingRuntimeContext runtimeContext = new MockStreamingRuntimeContext(false, 4, 0);
+    doReturn(runtimeContext).when(operator).getRuntimeContext();
+
+    outputAdapter = new CollectOutputAdapter<>();
+    injectOutput(outputAdapter);
+    operator.open();
+  }
+
+  // -------------------------------------------------------------------------
+  //  shouldLoadBucket: round-robin partition assignment
+  // -------------------------------------------------------------------------
+
+  @ParameterizedTest
+  @CsvSource({
+      // Single-task: always loads every file group
+      "0, 1, 0, true",
+      "5, 1, 0, true",
+      "99, 1, 0, true",
+      // 4-way parallelism, correct task assignment
+      "0, 4, 0, true",
+      "1, 4, 1, true",
+      "2, 4, 2, true",
+      "3, 4, 3, true",
+      // Round-robin wraps correctly
+      "4, 4, 0, true",
+      "5, 4, 1, true",
+      "8, 4, 0, true",
+      // Wrong task does NOT load those file groups
+      "1, 4, 0, false",
+      "0, 4, 1, false",
+      "4, 4, 1, false",
+      // 3-way parallelism
+      "0, 3, 0, true",
+      "3, 3, 0, true",
+      "4, 3, 1, true",
+      "2, 3, 2, true",
+      "3, 3, 1, false",
+  })
+  void testShouldLoadBucket(int fileGroupIdx, int parallelism, int taskId, boolean expected) throws Exception {
+    Method m = RLIBootstrapOperator.class.getDeclaredMethod("shouldLoadBucket", int.class, int.class, int.class);
+    m.setAccessible(true);
+    assertEquals(expected, m.invoke(operator, fileGroupIdx, parallelism, taskId));
+  }
+
+  // -------------------------------------------------------------------------
+  //  emitIndexRecord: output and counter
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testEmitIndexRecordPopulatesAllFields() throws Exception {
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("2024/01", "20240101000000", "file-uuid-1");
+    invokeEmitIndexRecord("record-key-1", location);
+
+    List<HoodieFlinkInternalRow> records = outputAdapter.getRecords();
+    assertEquals(1, records.size());
+    HoodieFlinkInternalRow emitted = records.get(0);
+    assertEquals("record-key-1", emitted.getRecordKey());
+    assertEquals("2024/01", emitted.getPartitionPath());
+    assertEquals("file-uuid-1", emitted.getFileId());
+    assertEquals("20240101000000", emitted.getInstantTime());
+  }
+
+  @Test
+  void testEmitIndexRecordIncrementsOutputPerCall() throws Exception {
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("p1", "20240101", "f1");
+    invokeEmitIndexRecord("k1", location);
+    invokeEmitIndexRecord("k2", location);
+    invokeEmitIndexRecord("k3", location);
+
+    assertEquals(3, outputAdapter.getRecords().size());
+  }
+
+  @Test
+  void testEmitIndexRecordDoesNotThrowAt1000Boundary() throws Exception {
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("p1", "20240101", "f1");
+    // The 1000th record triggers a metrics update — verify it does not throw.
+    for (int i = 0; i < 1000; i++) {
+      invokeEmitIndexRecord("key-" + i, location);
+    }
+    assertEquals(1000, outputAdapter.getRecords().size());
+  }
+
+  @Test
+  void testEmitIndexRecordPreservesInsertionOrder() throws Exception {
+    HoodieRecordGlobalLocation loc1 = new HoodieRecordGlobalLocation("p1", "t1", "f1");
+    HoodieRecordGlobalLocation loc2 = new HoodieRecordGlobalLocation("p2", "t2", "f2");
+
+    invokeEmitIndexRecord("alpha", loc1);
+    invokeEmitIndexRecord("beta", loc2);
+
+    List<HoodieFlinkInternalRow> records = outputAdapter.getRecords();
+    assertEquals("alpha", records.get(0).getRecordKey());
+    assertEquals("f1", records.get(0).getFileId());
+    assertEquals("beta", records.get(1).getRecordKey());
+    assertEquals("f2", records.get(1).getFileId());
+  }
+
+  // -------------------------------------------------------------------------
+  //  processElement: pass-through
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testProcessElementPassesThrough() throws Exception {
+    HoodieFlinkInternalRow row = new HoodieFlinkInternalRow("k1", "p1", "f1", "t1");
+    operator.processElement(new StreamRecord<>(row));
+
+    assertEquals(1, outputAdapter.getRecords().size());
+    assertEquals("k1", outputAdapter.getRecords().get(0).getRecordKey());
+  }
+
+  @Test
+  void testProcessElementPreservesAllFields() throws Exception {
+    HoodieFlinkInternalRow row = new HoodieFlinkInternalRow("myKey", "myPartition", "myFile", "myInstant");
+    operator.processElement(new StreamRecord<>(row));
+
+    HoodieFlinkInternalRow out = outputAdapter.getRecords().get(0);
+    assertEquals("myKey", out.getRecordKey());
+    assertEquals("myPartition", out.getPartitionPath());
+    assertEquals("myFile", out.getFileId());
+    assertEquals("myInstant", out.getInstantTime());
+  }
+
+  // -------------------------------------------------------------------------
+  //  closeMetadataTable: null safety
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testCloseMetadataTableIsNullSafe() throws Exception {
+    // initializeState() was never called, so metadataTable is null.
+    Method m = RLIBootstrapOperator.class.getDeclaredMethod("closeMetadataTable");
+    m.setAccessible(true);
+    assertDoesNotThrow(() -> m.invoke(operator));
+  }
+
+  @Test
+  void testCloseMetadataTableIsIdempotent() throws Exception {
+    Method m = RLIBootstrapOperator.class.getDeclaredMethod("closeMetadataTable");
+    m.setAccessible(true);
+    assertDoesNotThrow(() -> {
+      m.invoke(operator);
+      m.invoke(operator);
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  //  Metrics registration
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testMetricsFieldIsInitializedAfterOpen() throws Exception {
+    Field metricsField = RLIBootstrapOperator.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    assertNotNull(metricsField.get(operator));
+  }
+
+  @Test
+  void testMetricsNotUpdatedBefore1000Records() throws Exception {
+    CapturingMetricGroup group = injectCapturingMetrics();
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("p", "t", "f");
+    for (int i = 0; i < 999; i++) {
+      invokeEmitIndexRecord("k-" + i, location);
+    }
+    assertEquals(0L, (Long) gaugeValue(group, NUM_INDEX_RECORDS_EMITTED));
+  }
+
+  @Test
+  void testMetricsUpdatedAt1000RecordBoundary() throws Exception {
+    CapturingMetricGroup group = injectCapturingMetrics();
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("p", "t", "f");
+    for (int i = 0; i < 1000; i++) {
+      invokeEmitIndexRecord("k-" + i, location);
+    }
+    assertEquals(1000L, (Long) gaugeValue(group, NUM_INDEX_RECORDS_EMITTED));
+  }
+
+  @Test
+  void testMetricsUpdatedAt2000RecordBoundary() throws Exception {
+    CapturingMetricGroup group = injectCapturingMetrics();
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("p", "t", "f");
+    for (int i = 0; i < 2000; i++) {
+      invokeEmitIndexRecord("k-" + i, location);
+    }
+    assertEquals(2000L, (Long) gaugeValue(group, NUM_INDEX_RECORDS_EMITTED));
+  }
+
+  @Test
+  void testMetricsGaugeReflectsLastMultipleOf1000() throws Exception {
+    CapturingMetricGroup group = injectCapturingMetrics();
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("p", "t", "f");
+    for (int i = 0; i < 1500; i++) {
+      invokeEmitIndexRecord("k-" + i, location);
+    }
+    // Updated at 1000, not again at 1500
+    assertEquals(1000L, (Long) gaugeValue(group, NUM_INDEX_RECORDS_EMITTED));
+  }
+
+  // -------------------------------------------------------------------------
+  //  Helpers
+  // -------------------------------------------------------------------------
+
+  private void invokeEmitIndexRecord(String recordKey, HoodieRecordGlobalLocation location) throws Exception {
+    Method m = RLIBootstrapOperator.class.getDeclaredMethod(
+        "emitIndexRecord", String.class, HoodieRecordGlobalLocation.class);
+    m.setAccessible(true);
+    m.invoke(operator, recordKey, location);
+  }
+
+  private void injectOutput(CollectOutputAdapter<HoodieFlinkInternalRow> output) throws Exception {
+    Field outputField = AbstractStreamOperator.class.getDeclaredField("output");
+    outputField.setAccessible(true);
+    outputField.set(operator, output);
+  }
+
+  private CapturingMetricGroup injectCapturingMetrics() throws Exception {
+    CapturingMetricGroup group = new CapturingMetricGroup();
+    FlinkRLIBootstrapMetrics capturingMetrics = new FlinkRLIBootstrapMetrics(group);
+    capturingMetrics.registerMetrics();
+    Field metricsField = RLIBootstrapOperator.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(operator, capturingMetrics);
+    return group;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T gaugeValue(CapturingMetricGroup group, String name) {
+    return (T) group.gauges.get(name).getValue();
+  }
+
+  private static class CapturingMetricGroup extends UnregisteredMetricsGroup {
+    final Map<String, Gauge<?>> gauges = new HashMap<>();
+
+    @Override
+    public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+      gauges.put(name, gauge);
+      return gauge;
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Add metrics for Flink RLI boot strap operator

### Summary and Changelog

1. Add FlinkRLIBootstrapMetrics for tracking basic metrics of RLIBootstrapOperator
2. Add test cases for FlinkRLIBootstrapMetrics

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
