### PR TITLE
feat(flink): expose metadata table metrics to Flink operators

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 public abstract class BaseTableMetadata extends AbstractHoodieTableMetadata {
 
   protected final HoodieTableMetaClient dataMetaClient;
+  @Getter
   protected final Option<HoodieMetadataMetrics> metrics;
   @Getter
   protected final HoodieMetadataConfig metadataConfig;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkMetricsUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkMetricsUtils.java
@@ -21,49 +21,104 @@ package org.apache.hudi.metrics;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
 /**
  * Utils for Flink metrics registration.
  */
 public class FlinkMetricsUtils {
 
+  /**
+   * Registers metadata table metrics with Flink for the first time.
+   * Use the three-argument overload when the metadata table may be reloaded, to avoid
+   * duplicate gauge registration.
+   */
   public static void registerMetadataTableMetrics(HoodieBackedTableMetadata metadataTable, MetricGroup metricGroup) {
+    registerMetadataTableMetrics(metadataTable, metricGroup, null);
+  }
+
+  /**
+   * Registers or updates metadata table metrics in Flink's metric group.
+   *
+   * <p>On the first call ({@code handles} is {@code null} or empty) each metric name is
+   * registered once with Flink as a gauge whose value is read through an
+   * {@link AtomicReference}.  On subsequent calls the references are swapped to point at
+   * the new metric objects from the reloaded metadata table, so Flink never sees a
+   * duplicate registration.
+   *
+   * @param metadataTable the (possibly reloaded) metadata table
+   * @param metricGroup   Flink metric group to register gauges into
+   * @param handles       map returned by a previous call, or {@code null} for the first call
+   * @return updated handles map; pass it back on the next invocation
+   */
+  public static Map<String, AtomicReference<Supplier<Object>>> registerMetadataTableMetrics(
+      HoodieBackedTableMetadata metadataTable,
+      MetricGroup metricGroup,
+      Map<String, AtomicReference<Supplier<Object>>> handles) {
+
+    Map<String, AtomicReference<Supplier<Object>>> result = handles != null ? handles : new HashMap<>();
     if (metadataTable == null) {
-      return;
+      return result;
     }
 
-    // metrics is Option.empty() when metrics are disabled
     metadataTable.getMetrics().ifPresent(m -> {
       m.registry().getGauges().forEach((name, gauge) ->
-          metricGroup.gauge(name, gauge::getValue));
+          bindMetric(result, metricGroup, name, () -> gauge.getValue()));
       m.registry().getCounters().forEach((name, counter) ->
-          metricGroup.gauge(name, counter::getCount));
+          bindMetric(result, metricGroup, name, () -> counter.getCount()));
       m.registry().getMeters().forEach((name, meter) -> {
-        metricGroup.gauge(name + ".count", meter::getCount);
-        metricGroup.gauge(name + ".meanRate", meter::getMeanRate);
-        metricGroup.gauge(name + ".1minRate", meter::getOneMinuteRate);
-        metricGroup.gauge(name + ".5minRate", meter::getFiveMinuteRate);
-        metricGroup.gauge(name + ".15minRate", meter::getFifteenMinuteRate);
+        bindMetric(result, metricGroup, name + ".count", () -> meter.getCount());
+        bindMetric(result, metricGroup, name + ".meanRate", () -> meter.getMeanRate());
+        bindMetric(result, metricGroup, name + ".1minRate", () -> meter.getOneMinuteRate());
+        bindMetric(result, metricGroup, name + ".5minRate", () -> meter.getFiveMinuteRate());
+        bindMetric(result, metricGroup, name + ".15minRate", () -> meter.getFifteenMinuteRate());
       });
       m.registry().getHistograms().forEach((name, histogram) -> {
-        metricGroup.gauge(name + ".count", histogram::getCount);
-        metricGroup.gauge(name + ".mean", () -> histogram.getSnapshot().getMean());
-        metricGroup.gauge(name + ".min", () -> histogram.getSnapshot().getMin());
-        metricGroup.gauge(name + ".max", () -> histogram.getSnapshot().getMax());
-        metricGroup.gauge(name + ".p75", () -> histogram.getSnapshot().get75thPercentile());
-        metricGroup.gauge(name + ".p95", () -> histogram.getSnapshot().get95thPercentile());
-        metricGroup.gauge(name + ".p99", () -> histogram.getSnapshot().get99thPercentile());
+        bindMetric(result, metricGroup, name + ".count", () -> histogram.getCount());
+        bindMetric(result, metricGroup, name + ".mean", () -> histogram.getSnapshot().getMean());
+        bindMetric(result, metricGroup, name + ".min", () -> histogram.getSnapshot().getMin());
+        bindMetric(result, metricGroup, name + ".max", () -> histogram.getSnapshot().getMax());
+        bindMetric(result, metricGroup, name + ".p75", () -> histogram.getSnapshot().get75thPercentile());
+        bindMetric(result, metricGroup, name + ".p95", () -> histogram.getSnapshot().get95thPercentile());
+        bindMetric(result, metricGroup, name + ".p99", () -> histogram.getSnapshot().get99thPercentile());
       });
       m.registry().getTimers().forEach((name, timer) -> {
-        metricGroup.gauge(name + ".count", timer::getCount);
-        metricGroup.gauge(name + ".meanRate", timer::getMeanRate);
-        metricGroup.gauge(name + ".1minRate", timer::getOneMinuteRate);
-        metricGroup.gauge(name + ".5minRate", timer::getFiveMinuteRate);
-        metricGroup.gauge(name + ".15minRate", timer::getFifteenMinuteRate);
-        metricGroup.gauge(name + ".mean", () -> timer.getSnapshot().getMean());
-        metricGroup.gauge(name + ".p75", () -> timer.getSnapshot().get75thPercentile());
-        metricGroup.gauge(name + ".p95", () -> timer.getSnapshot().get95thPercentile());
-        metricGroup.gauge(name + ".p99", () -> timer.getSnapshot().get99thPercentile());
+        bindMetric(result, metricGroup, name + ".count", () -> timer.getCount());
+        bindMetric(result, metricGroup, name + ".meanRate", () -> timer.getMeanRate());
+        bindMetric(result, metricGroup, name + ".1minRate", () -> timer.getOneMinuteRate());
+        bindMetric(result, metricGroup, name + ".5minRate", () -> timer.getFiveMinuteRate());
+        bindMetric(result, metricGroup, name + ".15minRate", () -> timer.getFifteenMinuteRate());
+        bindMetric(result, metricGroup, name + ".mean", () -> timer.getSnapshot().getMean());
+        bindMetric(result, metricGroup, name + ".p75", () -> timer.getSnapshot().get75thPercentile());
+        bindMetric(result, metricGroup, name + ".p95", () -> timer.getSnapshot().get95thPercentile());
+        bindMetric(result, metricGroup, name + ".p99", () -> timer.getSnapshot().get99thPercentile());
       });
     });
+
+    return result;
+  }
+
+  /**
+   * Registers a Flink gauge for {@code name} the first time it is seen, or updates the
+   * supplier reference when the metric is already registered.
+   */
+  private static void bindMetric(
+      Map<String, AtomicReference<Supplier<Object>>> handles,
+      MetricGroup metricGroup,
+      String name,
+      Supplier<Object> supplier) {
+
+    AtomicReference<Supplier<Object>> ref = handles.get(name);
+    if (ref == null) {
+      ref = new AtomicReference<>(supplier);
+      handles.put(name, ref);
+      AtomicReference<Supplier<Object>> capturedRef = ref;
+      metricGroup.gauge(name, () -> capturedRef.get().get());
+    } else {
+      ref.set(supplier);
+    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkMetricsUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkMetricsUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+
+/**
+ * Utils for Flink metrics registration.
+ */
+public class FlinkMetricsUtils {
+
+  public static void registerMetadataTableMetrics(HoodieBackedTableMetadata metadataTable, MetricGroup metricGroup) {
+    if (metadataTable == null) {
+      return;
+    }
+
+    // metrics is Option.empty() when metrics are disabled
+    metadataTable.getMetrics().ifPresent(m -> {
+      m.registry().getGauges().forEach((name, gauge) ->
+          metricGroup.gauge(name, gauge::getValue));
+      m.registry().getCounters().forEach((name, counter) ->
+          metricGroup.gauge(name, counter::getCount));
+      m.registry().getMeters().forEach((name, meter) -> {
+        metricGroup.gauge(name + ".count", meter::getCount);
+        metricGroup.gauge(name + ".meanRate", meter::getMeanRate);
+        metricGroup.gauge(name + ".1minRate", meter::getOneMinuteRate);
+        metricGroup.gauge(name + ".5minRate", meter::getFiveMinuteRate);
+        metricGroup.gauge(name + ".15minRate", meter::getFifteenMinuteRate);
+      });
+      m.registry().getHistograms().forEach((name, histogram) -> {
+        metricGroup.gauge(name + ".count", histogram::getCount);
+        metricGroup.gauge(name + ".mean", () -> histogram.getSnapshot().getMean());
+        metricGroup.gauge(name + ".min", () -> histogram.getSnapshot().getMin());
+        metricGroup.gauge(name + ".max", () -> histogram.getSnapshot().getMax());
+        metricGroup.gauge(name + ".p75", () -> histogram.getSnapshot().get75thPercentile());
+        metricGroup.gauge(name + ".p95", () -> histogram.getSnapshot().get95thPercentile());
+        metricGroup.gauge(name + ".p99", () -> histogram.getSnapshot().get99thPercentile());
+      });
+      m.registry().getTimers().forEach((name, timer) -> {
+        metricGroup.gauge(name + ".count", timer::getCount);
+        metricGroup.gauge(name + ".meanRate", timer::getMeanRate);
+        metricGroup.gauge(name + ".1minRate", timer::getOneMinuteRate);
+        metricGroup.gauge(name + ".5minRate", timer::getFiveMinuteRate);
+        metricGroup.gauge(name + ".15minRate", timer::getFifteenMinuteRate);
+        metricGroup.gauge(name + ".mean", () -> timer.getSnapshot().getMean());
+        metricGroup.gauge(name + ".p75", () -> timer.getSnapshot().get75thPercentile());
+        metricGroup.gauge(name + ".p95", () -> timer.getSnapshot().get95thPercentile());
+        metricGroup.gauge(name + ".p99", () -> timer.getSnapshot().get99thPercentile());
+      });
+    });
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bootstrap/RLIBootstrapOperator.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metrics.FlinkMetricsUtils;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.RuntimeContextUtils;
 
@@ -62,14 +63,12 @@ public class RLIBootstrapOperator
   @Override
   public void initializeState(StateInitializationContext context) throws Exception {
     loadedCnt = 0;
-    HoodieTableMetaClient metaClient = StreamerUtil.createMetaClient(conf);
-    this.metadataTable = (HoodieBackedTableMetadata) metaClient.getTableFormat().getMetadataFactory().create(
-        HoodieFlinkEngineContext.DEFAULT,
-        metaClient.getStorage(),
-        StreamerUtil.metadataConfig(conf),
-        conf.get(FlinkOptions.PATH));
+    HoodieTableMetaClient metaClient = createMetaClient();
+    this.metadataTable = createMetadataTable(metaClient);
+
     // Load RLI records
     preLoadRLIRecords();
+    FlinkMetricsUtils.registerMetadataTableMetrics(metadataTable, getMetricGroup());
   }
 
   @Override
@@ -81,6 +80,18 @@ public class RLIBootstrapOperator
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------
+
+  protected HoodieTableMetaClient createMetaClient() {
+    return StreamerUtil.createMetaClient(conf);
+  }
+
+  protected HoodieBackedTableMetadata createMetadataTable(HoodieTableMetaClient metaClient) {
+    return (HoodieBackedTableMetadata) metaClient.getTableFormat().getMetadataFactory().create(
+        HoodieFlinkEngineContext.DEFAULT,
+        metaClient.getStorage(),
+        StreamerUtil.metadataConfig(conf),
+        conf.get(FlinkOptions.PATH));
+  }
 
   private void preLoadRLIRecords() {
     int taskID = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -45,6 +45,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 /**
  * An implementation of {@link IndexBackend} based on the record level index in metadata table.
@@ -57,6 +59,8 @@ public class RecordLevelIndexBackend implements MinibatchIndexBackend {
   private final Configuration conf;
   private final HoodieTableMetaClient metaClient;
   private HoodieTableMetadata metadataTable;
+  private MetricGroup metricGroup;
+  private Map<String, AtomicReference<Supplier<Object>>> metricsHandles;
 
   public RecordLevelIndexBackend(Configuration conf, long initCheckpointId) {
     this.metaClient = StreamerUtil.createMetaClient(conf);
@@ -121,6 +125,7 @@ public class RecordLevelIndexBackend implements MinibatchIndexBackend {
     recordIndexCache.markAsEvictable(inflightInstants.keySet().stream().min(Long::compareTo).orElse(completedCheckpointID));
     this.metaClient.reloadActiveTimeline();
     reloadMetadataTable();
+    registerMetricsInternal();
   }
 
   private void reloadMetadataTable() {
@@ -146,8 +151,14 @@ public class RecordLevelIndexBackend implements MinibatchIndexBackend {
 
   @Override
   public void registerMetrics(MetricGroup metricGroup) {
+    this.metricGroup = metricGroup;
+    registerMetricsInternal();
+  }
+
+  private void registerMetricsInternal() {
     if (metadataTable instanceof HoodieBackedTableMetadata) {
-      FlinkMetricsUtils.registerMetadataTableMetrics((HoodieBackedTableMetadata) metadataTable, metricGroup);
+      this.metricsHandles = FlinkMetricsUtils.registerMetadataTableMetrics(
+          (HoodieBackedTableMetadata) metadataTable, metricGroup, this.metricsHandles);
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.sink.partitioner.index;
 
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.data.HoodiePairData;
@@ -28,7 +29,9 @@ import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metrics.FlinkMetricsUtils;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.util.StreamerUtil;
 
@@ -138,6 +141,13 @@ public class RecordLevelIndexBackend implements MinibatchIndexBackend {
       this.metadataTable.close();
     } catch (Exception e) {
       throw new HoodieException("Exception happened during close metadata table.", e);
+    }
+  }
+
+  @Override
+  public void registerMetrics(MetricGroup metricGroup) {
+    if (metadataTable instanceof HoodieBackedTableMetadata) {
+      FlinkMetricsUtils.registerMetadataTableMetrics((HoodieBackedTableMetadata) metadataTable, metricGroup);
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkMetricsUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkMetricsUtils.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieMetadataMetrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestFlinkMetricsUtils {
+
+  // -------------------------------------------------------------------------
+  //  Null guard
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testNullTableIsNoOp() {
+    MetricGroup metricGroup = mock(MetricGroup.class);
+    FlinkMetricsUtils.registerMetadataTableMetrics(null, metricGroup);
+    verify(metricGroup, never()).gauge(any(), any());
+  }
+
+  // -------------------------------------------------------------------------
+  //  Counter
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testCounterBridgedAsGauge() {
+    MetricRegistry dropwizard = new MetricRegistry();
+    com.codahale.metrics.Counter counter = dropwizard.counter("hits");
+    counter.inc(7);
+
+    Map<String, Gauge<?>> captured = new HashMap<>();
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(dropwizard), trackingGroup(captured));
+
+    assertNotNull(captured.get("hits"), "counter 'hits' should be registered as a Flink gauge");
+    assertEquals(7L, captured.get("hits").getValue());
+
+    counter.inc(3);
+    assertEquals(10L, captured.get("hits").getValue(), "gauge should reflect live counter value");
+  }
+
+  // -------------------------------------------------------------------------
+  //  Meter
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testMeterBridgesAllFiveRates() {
+    MetricRegistry dropwizard = new MetricRegistry();
+    dropwizard.meter("writes");
+
+    Map<String, Gauge<?>> captured = new HashMap<>();
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(dropwizard), trackingGroup(captured));
+
+    assertNotNull(captured.get("writes.count"), "count");
+    assertNotNull(captured.get("writes.meanRate"), "meanRate");
+    assertNotNull(captured.get("writes.1minRate"), "1minRate");
+    assertNotNull(captured.get("writes.5minRate"), "5minRate");
+    assertNotNull(captured.get("writes.15minRate"), "15minRate");
+    assertEquals(5, captured.size());
+  }
+
+  @Test
+  void testMeterCountGaugeLive() {
+    MetricRegistry dropwizard = new MetricRegistry();
+    Meter meter = dropwizard.meter("events");
+
+    Map<String, Gauge<?>> captured = new HashMap<>();
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(dropwizard), trackingGroup(captured));
+
+    meter.mark(5);
+    assertEquals(5L, captured.get("events.count").getValue());
+    meter.mark(3);
+    assertEquals(8L, captured.get("events.count").getValue());
+  }
+
+  // -------------------------------------------------------------------------
+  //  Histogram
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testHistogramBridgesAllSevenStats() {
+    MetricRegistry dropwizard = new MetricRegistry();
+    dropwizard.register("latency", new Histogram(new ExponentiallyDecayingReservoir()));
+
+    Map<String, Gauge<?>> captured = new HashMap<>();
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(dropwizard), trackingGroup(captured));
+
+    assertNotNull(captured.get("latency.count"), "count");
+    assertNotNull(captured.get("latency.mean"), "mean");
+    assertNotNull(captured.get("latency.min"), "min");
+    assertNotNull(captured.get("latency.max"), "max");
+    assertNotNull(captured.get("latency.p75"), "p75");
+    assertNotNull(captured.get("latency.p95"), "p95");
+    assertNotNull(captured.get("latency.p99"), "p99");
+    assertEquals(7, captured.size());
+  }
+
+  @Test
+  void testHistogramStatsReflectRecordedValues() {
+    MetricRegistry dropwizard = new MetricRegistry();
+    Histogram histogram = dropwizard.register("size", new Histogram(new ExponentiallyDecayingReservoir()));
+    for (int i = 1; i <= 100; i++) {
+      histogram.update(i);
+    }
+
+    Map<String, Gauge<?>> captured = new HashMap<>();
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(dropwizard), trackingGroup(captured));
+
+    assertEquals(100L, captured.get("size.count").getValue());
+    assertEquals(1L, captured.get("size.min").getValue());
+    assertEquals(100L, captured.get("size.max").getValue());
+  }
+
+  // -------------------------------------------------------------------------
+  //  Timer
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testTimerBridgesAllNineStats() {
+    MetricRegistry dropwizard = new MetricRegistry();
+    dropwizard.register("rpc", new Timer());
+
+    Map<String, Gauge<?>> captured = new HashMap<>();
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(dropwizard), trackingGroup(captured));
+
+    // Rate metrics (same set as Meter)
+    assertNotNull(captured.get("rpc.count"), "count");
+    assertNotNull(captured.get("rpc.meanRate"), "meanRate");
+    assertNotNull(captured.get("rpc.1minRate"), "1minRate");
+    assertNotNull(captured.get("rpc.5minRate"), "5minRate");
+    assertNotNull(captured.get("rpc.15minRate"), "15minRate");
+    // Snapshot metrics
+    assertNotNull(captured.get("rpc.mean"), "mean");
+    assertNotNull(captured.get("rpc.p75"), "p75");
+    assertNotNull(captured.get("rpc.p95"), "p95");
+    assertNotNull(captured.get("rpc.p99"), "p99");
+    assertEquals(9, captured.size());
+  }
+
+  @Test
+  void testTimerAndMeterExposeTheSameRateGauges() {
+    MetricRegistry meterRegistry = new MetricRegistry();
+    meterRegistry.meter("op");
+
+    MetricRegistry timerRegistry = new MetricRegistry();
+    timerRegistry.register("op", new Timer());
+
+    Map<String, Gauge<?>> meterGauges = new HashMap<>();
+    Map<String, Gauge<?>> timerGauges = new HashMap<>();
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(meterRegistry), trackingGroup(meterGauges));
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(timerRegistry), trackingGroup(timerGauges));
+
+    // Every rate key that Meter exposes must also appear in Timer
+    for (String rateKey : new String[]{"op.count", "op.meanRate", "op.1minRate", "op.5minRate", "op.15minRate"}) {
+      assertNotNull(meterGauges.get(rateKey), "meter missing " + rateKey);
+      assertNotNull(timerGauges.get(rateKey), "timer missing " + rateKey);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  //  Helpers
+  // -------------------------------------------------------------------------
+
+  private static HoodieBackedTableMetadata tableWith(MetricRegistry dropwizard) {
+    HoodieMetadataMetrics mockMetrics = mock(HoodieMetadataMetrics.class);
+    when(mockMetrics.registry()).thenReturn(dropwizard);
+
+    HoodieBackedTableMetadata mockTable = mock(HoodieBackedTableMetadata.class);
+    when(mockTable.getMetrics()).thenReturn(Option.of(mockMetrics));
+    return mockTable;
+  }
+
+  private static MetricGroup trackingGroup(Map<String, Gauge<?>> captured) {
+    MetricGroup group = mock(MetricGroup.class);
+    doAnswer(inv -> {
+      captured.put(inv.getArgument(0), inv.getArgument(1));
+      return null;
+    }).when(group).gauge(any(String.class), any());
+    return group;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkMetricsUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkMetricsUtils.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -192,6 +194,35 @@ class TestFlinkMetricsUtils {
       assertNotNull(meterGauges.get(rateKey), "meter missing " + rateKey);
       assertNotNull(timerGauges.get(rateKey), "timer missing " + rateKey);
     }
+  }
+
+  // -------------------------------------------------------------------------
+  //  Re-registration (replaceable gauges)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testReregistrationUpdatesGaugeWithoutDuplicateRegistration() {
+    MetricRegistry dropwizard1 = new MetricRegistry();
+    com.codahale.metrics.Counter counter1 = dropwizard1.counter("hits");
+    counter1.inc(5);
+
+    MetricRegistry dropwizard2 = new MetricRegistry();
+    com.codahale.metrics.Counter counter2 = dropwizard2.counter("hits");
+    counter2.inc(99);
+
+    Map<String, Gauge<?>> captured = new HashMap<>();
+    MetricGroup group = trackingGroup(captured);
+
+    // First registration
+    Map<String, AtomicReference<Supplier<Object>>> handles =
+        FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(dropwizard1), group, null);
+    assertEquals(5L, captured.get("hits").getValue(), "should read from first table");
+    assertEquals(1, captured.size(), "gauge registered once");
+
+    // Second registration with a reloaded table — must not register a new gauge
+    FlinkMetricsUtils.registerMetadataTableMetrics(tableWith(dropwizard2), group, handles);
+    assertEquals(99L, captured.get("hits").getValue(), "should now read from second table");
+    assertEquals(1, captured.size(), "no duplicate gauge registered");
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
@@ -28,6 +28,7 @@ import org.apache.hudi.utils.TestData;
 import org.apache.hudi.utils.TestUtils;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.MetricGroup;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -185,6 +189,16 @@ public class TestRecordLevelIndexBackend {
       assertEquals("par1", recordLevelIndexBackend.get("id2_0").getPartitionPath());
       assertEquals("par1", recordLevelIndexBackend.get("id3_0").getPartitionPath());
       assertEquals("par1", recordLevelIndexBackend.get("id4_0").getPartitionPath());
+    }
+  }
+
+  @Test
+  void testRegisterMetricsIsNoOpWhenMetricsDisabled() throws Exception {
+    // Default test config has metadata metrics disabled; registerMetrics() should not register any gauges.
+    try (RecordLevelIndexBackend backend = new RecordLevelIndexBackend(conf, -1)) {
+      MetricGroup metricGroup = mock(MetricGroup.class);
+      backend.registerMetrics(metricGroup);
+      verify(metricGroup, never()).gauge(any(), any());
     }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
Expose metadata table metrics to Flink in RLIBootstrapOperator

### Summary and Changelog

1. Register metrics defined in metadataTable with Flink metrics group in RLIBootstrapOperator
2. Add test cases for RLIBootstrapOperator

### Impact

None

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
