### PR TITLE
feat: Add ClusteringGroupWriter SPI for pluggable clustering writes

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/ClusteringGroupWriteContext.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/ClusteringGroupWriteContext.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.clustering.run.strategy;
+
+import org.apache.hudi.avro.model.HoodieClusteringGroup;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Immutable parameter bundle passed to a {@link ClusteringGroupWriter} for a single
+ * clustering group. Wraps the inputs the SPI needs (clustering group, strategy params,
+ * instant time, executor, schema, table, write config) so the SPI signature can grow
+ * without breaking implementers.
+ */
+public final class ClusteringGroupWriteContext {
+
+  private final HoodieClusteringGroup clusteringGroup;
+  private final Map<String, String> strategyParams;
+  private final boolean shouldPreserveHoodieMetadata;
+  private final String instantTime;
+  private final ExecutorService clusteringExecutorService;
+  private final HoodieSchema schema;
+  private final HoodieTable table;
+  private final HoodieWriteConfig writeConfig;
+
+  private ClusteringGroupWriteContext(Builder b) {
+    this.clusteringGroup = Objects.requireNonNull(b.clusteringGroup, "clusteringGroup");
+    this.strategyParams = b.strategyParams != null
+        ? Collections.unmodifiableMap(b.strategyParams)
+        : Collections.emptyMap();
+    this.shouldPreserveHoodieMetadata = b.shouldPreserveHoodieMetadata;
+    this.instantTime = Objects.requireNonNull(b.instantTime, "instantTime");
+    this.clusteringExecutorService =
+        Objects.requireNonNull(b.clusteringExecutorService, "clusteringExecutorService");
+    this.schema = Objects.requireNonNull(b.schema, "schema");
+    this.table = Objects.requireNonNull(b.table, "table");
+    this.writeConfig = Objects.requireNonNull(b.writeConfig, "writeConfig");
+  }
+
+  public HoodieClusteringGroup getClusteringGroup() {
+    return clusteringGroup;
+  }
+
+  public Map<String, String> getStrategyParams() {
+    return strategyParams;
+  }
+
+  public boolean shouldPreserveHoodieMetadata() {
+    return shouldPreserveHoodieMetadata;
+  }
+
+  public String getInstantTime() {
+    return instantTime;
+  }
+
+  public ExecutorService getClusteringExecutorService() {
+    return clusteringExecutorService;
+  }
+
+  public HoodieSchema getSchema() {
+    return schema;
+  }
+
+  public HoodieTable getTable() {
+    return table;
+  }
+
+  public HoodieWriteConfig getWriteConfig() {
+    return writeConfig;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private HoodieClusteringGroup clusteringGroup;
+    private Map<String, String> strategyParams;
+    private boolean shouldPreserveHoodieMetadata;
+    private String instantTime;
+    private ExecutorService clusteringExecutorService;
+    private HoodieSchema schema;
+    private HoodieTable table;
+    private HoodieWriteConfig writeConfig;
+
+    public Builder clusteringGroup(HoodieClusteringGroup v) {
+      this.clusteringGroup = v;
+      return this;
+    }
+
+    public Builder strategyParams(Map<String, String> v) {
+      this.strategyParams = v;
+      return this;
+    }
+
+    public Builder shouldPreserveHoodieMetadata(boolean v) {
+      this.shouldPreserveHoodieMetadata = v;
+      return this;
+    }
+
+    public Builder instantTime(String v) {
+      this.instantTime = v;
+      return this;
+    }
+
+    public Builder clusteringExecutorService(ExecutorService v) {
+      this.clusteringExecutorService = v;
+      return this;
+    }
+
+    public Builder schema(HoodieSchema v) {
+      this.schema = v;
+      return this;
+    }
+
+    public Builder table(HoodieTable v) {
+      this.table = v;
+      return this;
+    }
+
+    public Builder writeConfig(HoodieWriteConfig v) {
+      this.writeConfig = v;
+      return this;
+    }
+
+    public ClusteringGroupWriteContext build() {
+      return new ClusteringGroupWriteContext(this);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/ClusteringGroupWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/ClusteringGroupWriter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.clustering.run.strategy;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.util.Option;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * SPI for an external writer that can perform the write phase of clustering for a single
+ * input group end-to-end (scan, sort, write) and return the resulting {@link WriteStatus}es.
+ * Implementations are discovered via {@link java.util.ServiceLoader} from the runtime classpath.
+ *
+ * <p>{@link SparkSortAndSizeExecutionStrategy} consults the registered writer (if any) before
+ * falling back to the default Spark scan + sort + bulk-insert path. A writer that cannot
+ * serve a particular group (for example, MOR groups with delta log files) returns
+ * {@link Option#empty()} so the caller falls back per-group rather than per-plan.
+ *
+ * <p>The single argument is a {@link ClusteringGroupWriteContext} parameter object so the
+ * SPI can grow without breaking implementers when more inputs become necessary.
+ */
+public interface ClusteringGroupWriter {
+
+  /**
+   * Write a single clustering input group asynchronously and return a future of the
+   * resulting {@link WriteStatus}es. Returns {@link Option#empty()} when this writer cannot
+   * serve the group; the caller will then run the default path.
+   */
+  Option<CompletableFuture<HoodieData<WriteStatus>>> runClusteringForGroupAsync(
+      ClusteringGroupWriteContext context);
+
+  /**
+   * Identifier used in logs to indicate which writer implementation is loaded.
+   */
+  String name();
+
+  /**
+   * Whether delegation should run. Lets a provider self-gate via its own configuration without
+   * leaking that configuration into the Hudi strategy. Returning {@code false} skips delegation
+   * and falls through to the default Spark path.
+   */
+  default boolean isEnabled() {
+    return true;
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/ClusteringGroupWriterRegistry.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/ClusteringGroupWriterRegistry.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.clustering.run.strategy;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Cached lookup for the {@link ClusteringGroupWriter} provider on the runtime classpath.
+ * Resolved once per JVM via {@link ServiceLoader}; absence of a provider yields {@link Option#empty()}
+ * and lets {@link SparkSortAndSizeExecutionStrategy} run its default path with no penalty.
+ */
+public final class ClusteringGroupWriterRegistry {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusteringGroupWriterRegistry.class);
+
+  private static final Option<ClusteringGroupWriter> INSTANCE = loadFirst();
+
+  /** Test-only override slot. AtomicReference is the documented thread-safe type. */
+  private static final AtomicReference<Option<ClusteringGroupWriter>> OVERRIDE = new AtomicReference<>();
+
+  private ClusteringGroupWriterRegistry() {
+  }
+
+  public static Option<ClusteringGroupWriter> get() {
+    Option<ClusteringGroupWriter> current = OVERRIDE.get();
+    return current != null ? current : INSTANCE;
+  }
+
+  @VisibleForTesting
+  static void setOverrideForTesting(Option<ClusteringGroupWriter> writer) {
+    OVERRIDE.set(writer);
+  }
+
+  private static Option<ClusteringGroupWriter> loadFirst() {
+    try {
+      Iterator<ClusteringGroupWriter> it =
+          ServiceLoader.load(ClusteringGroupWriter.class, ClusteringGroupWriterRegistry.class.getClassLoader())
+              .iterator();
+      if (it.hasNext()) {
+        ClusteringGroupWriter writer = it.next();
+        LOG.info("Loaded clustering group writer: {} ({})", writer.name(), writer.getClass().getName());
+        return Option.of(writer);
+      }
+    } catch (ServiceConfigurationError | RuntimeException t) {
+      LOG.warn("Failed to load ClusteringGroupWriter via ServiceLoader; using default clustering path.", t);
+    }
+    return Option.empty();
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/MultipleSparkJobExecutionStrategy.java
@@ -106,7 +106,10 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
         Math.min(clusteringPlan.getInputGroups().size(), writeConfig.getClusteringMaxParallelism()),
         new CustomizedThreadFactory("clustering-job-group", true));
     try {
-      boolean canUseRowWriter = getWriteConfig().getBooleanOrDefault("hoodie.datasource.write.row.writer.enable", true);
+      // shouldForceRowWriter() opts in for subclasses that require the Row path (e.g. when
+      // delegating to a ClusteringGroupWriter SPI provider that operates on Datasets only).
+      boolean canUseRowWriter = shouldForceRowWriter()
+          || getWriteConfig().getBooleanOrDefault("hoodie.datasource.write.row.writer.enable", true);
       // execute clustering for each group async and collect WriteStatus
       Stream<HoodieData<WriteStatus>> writeStatusesStream = FutureUtils.allOf(
               clusteringPlan.getInputGroups().stream()
@@ -217,6 +220,18 @@ public abstract class MultipleSparkJobExecutionStrategy<T>
     }).orElseGet(() -> isRowPartitioner
         ? BulkInsertInternalPartitionerWithRowsFactory.get(getWriteConfig(), getHoodieTable().isPartitioned(), true)
         : BulkInsertInternalPartitionerFactory.get(getHoodieTable(), getWriteConfig(), true));
+  }
+
+  /**
+   * Hook for subclasses to force the Row write path regardless of {@code
+   * hoodie.datasource.write.row.writer.enable}. Default returns {@code false} so existing
+   * behavior is unchanged. Subclasses delegating to a {@link ClusteringGroupWriter} that only
+   * supports the Dataset pipeline override this to return {@code true} when delegation is
+   * active. The standard Row-writer compatibility check (decimal + list/map handling) still
+   * gates whether the path is actually taken.
+   */
+  protected boolean shouldForceRowWriter() {
+    return false;
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SparkSortAndSizeExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SparkSortAndSizeExecutionStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.client.clustering.run.strategy;
 
 import org.apache.hudi.HoodieDatasetBulkInsertHelper;
+import org.apache.hudi.avro.model.HoodieClusteringGroup;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.data.HoodieData;
@@ -26,6 +27,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.io.CreateHandleFactory;
 import org.apache.hudi.table.BulkInsertPartitioner;
@@ -38,20 +40,127 @@ import org.apache.spark.sql.Row;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Clustering Strategy based on following.
  * 1) Spark execution engine.
  * 2) Uses bulk_insert to write data into new files.
+ *
+ * <p>When a {@link ClusteringGroupWriter} provider is registered on the runtime classpath
+ * and reports {@link ClusteringGroupWriter#isEnabled()}, this strategy delegates each input
+ * group to the writer. The Row path is forced (subject to the standard Row-writer
+ * compatibility check) so the writer always sees the Dataset-based pipeline. Per-group
+ * fallback to the default Spark path happens whenever the writer returns
+ * {@link Option#empty()}.
  */
 @Slf4j
 public class SparkSortAndSizeExecutionStrategy<T>
     extends MultipleSparkJobExecutionStrategy<T> {
 
+  /** Lazily initialized; write config schema is constant for a given strategy instance. */
+  private final AtomicReference<HoodieSchema> cachedSchema = new AtomicReference<>();
+
   public SparkSortAndSizeExecutionStrategy(HoodieTable table,
                                            HoodieEngineContext engineContext,
                                            HoodieWriteConfig writeConfig) {
     super(table, engineContext, writeConfig);
+  }
+
+  @Override
+  protected boolean shouldForceRowWriter() {
+    Option<ClusteringGroupWriter> writer = ClusteringGroupWriterRegistry.get();
+    return writer.isPresent() && writer.get().isEnabled();
+  }
+
+  @Override
+  protected CompletableFuture<HoodieData<WriteStatus>> runClusteringForGroupAsyncAsRow(
+      HoodieClusteringGroup clusteringGroup,
+      Map<String, String> strategyParams,
+      boolean shouldPreserveHoodieMetadata,
+      String instantTime,
+      ExecutorService clusteringExecutorService) {
+    Option<CompletableFuture<HoodieData<WriteStatus>>> delegated = tryDelegateToGroupWriter(
+        clusteringGroup, strategyParams, shouldPreserveHoodieMetadata, instantTime, clusteringExecutorService);
+    if (delegated.isPresent()) {
+      return delegated.get();
+    }
+    return runSuperRunClusteringForGroupAsyncAsRow(
+        clusteringGroup, strategyParams, shouldPreserveHoodieMetadata, instantTime, clusteringExecutorService);
+  }
+
+  /**
+   * Indirection over {@code super.runClusteringForGroupAsyncAsRow} so unit tests can
+   * verify the fallback contract without bootstrapping a real {@link HoodieTable}. Tests
+   * override only this method; the production {@code runClusteringForGroupAsyncAsRow}
+   * routing logic is exercised unchanged.
+   */
+  CompletableFuture<HoodieData<WriteStatus>> runSuperRunClusteringForGroupAsyncAsRow(
+      HoodieClusteringGroup clusteringGroup,
+      Map<String, String> strategyParams,
+      boolean shouldPreserveHoodieMetadata,
+      String instantTime,
+      ExecutorService clusteringExecutorService) {
+    return super.runClusteringForGroupAsyncAsRow(
+        clusteringGroup, strategyParams, shouldPreserveHoodieMetadata, instantTime, clusteringExecutorService);
+  }
+
+  /**
+   * Routing for the {@link ClusteringGroupWriter} SPI. Returns the writer's future when a
+   * writer is registered, reports enabled, AND can serve the group. Returns
+   * {@link Option#empty()} otherwise so the caller falls back to the default path.
+   *
+   * <p>Package-private so tests can exercise the routing logic directly without needing a
+   * real {@link HoodieTable} to drive {@code super.runClusteringForGroupAsyncAsRow}.
+   */
+  Option<CompletableFuture<HoodieData<WriteStatus>>> tryDelegateToGroupWriter(
+      HoodieClusteringGroup clusteringGroup,
+      Map<String, String> strategyParams,
+      boolean shouldPreserveHoodieMetadata,
+      String instantTime,
+      ExecutorService clusteringExecutorService) {
+    Option<ClusteringGroupWriter> writerOpt = ClusteringGroupWriterRegistry.get();
+    if (!writerOpt.isPresent() || !writerOpt.get().isEnabled()) {
+      return Option.empty();
+    }
+    ClusteringGroupWriter writer = writerOpt.get();
+    log.info("Delegating clustering group (firstFileId={}, instant={}) to ClusteringGroupWriter '{}'",
+        firstFileGroupId(clusteringGroup), instantTime, writer.name());
+    ClusteringGroupWriteContext context = ClusteringGroupWriteContext.builder()
+        .clusteringGroup(clusteringGroup)
+        .strategyParams(strategyParams)
+        .shouldPreserveHoodieMetadata(shouldPreserveHoodieMetadata)
+        .instantTime(instantTime)
+        .clusteringExecutorService(clusteringExecutorService)
+        .schema(getCachedSchema())
+        .table(getHoodieTable())
+        .writeConfig(getWriteConfig())
+        .build();
+    Option<CompletableFuture<HoodieData<WriteStatus>>> result = writer.runClusteringForGroupAsync(context);
+    if (!result.isPresent()) {
+      log.info("ClusteringGroupWriter '{}' declined to serve group (firstFileId={}, instant={}); "
+              + "falling back to the default Spark bulk-insert path.",
+          writer.name(), firstFileGroupId(clusteringGroup), instantTime);
+    }
+    return result;
+  }
+
+  private static String firstFileGroupId(HoodieClusteringGroup clusteringGroup) {
+    if (clusteringGroup.getSlices() == null || clusteringGroup.getSlices().isEmpty()) {
+      return "<empty-group>";
+    }
+    return clusteringGroup.getSlices().get(0).getFileId();
+  }
+
+  private HoodieSchema getCachedSchema() {
+    HoodieSchema local = cachedSchema.get();
+    if (local != null) {
+      return local;
+    }
+    HoodieSchema parsed = HoodieSchema.parse(getWriteConfig().getSchema());
+    return cachedSchema.compareAndSet(null, parsed) ? parsed : cachedSchema.get();
   }
 
   @Override


### PR DESCRIPTION
### Change Logs

Adds a `ServiceLoader`-based SPI that lets an external writer perform the write phase of clustering for a single input group end-to-end (scan, sort, write) and return the resulting `WriteStatus`es. Default behavior is unchanged when no provider is on the classpath -- the registry resolves to `Option.empty()` and `SparkSortAndSizeExecutionStrategy` runs its existing path.

**New types:**

- `ClusteringGroupWriter` -- the SPI. Single async entry point `runClusteringForGroupAsync(ClusteringGroupWriteContext)` returning `Option<CompletableFuture<HoodieData<WriteStatus>>>`. Returning `Option.empty()` declines the group; the caller then falls back to the default per-group. `isEnabled()` defaults to `true` and lets a provider self-gate via its own configuration without leaking it into Hudi.
- `ClusteringGroupWriteContext` -- immutable parameter bundle (clustering group, strategy params, instant time, executor, schema, table, write config). Builder-shaped so the SPI signature can grow without breaking implementers.
- `ClusteringGroupWriterRegistry` -- one `ServiceLoader` resolve per JVM, cached. `Option.empty()` when no provider is registered, plus a test-only override slot guarded by `AtomicReference`.

**Strategy hooks:**

- `MultipleSparkJobExecutionStrategy` -- new protected `shouldForceRowWriter()` (default `false`), `OR`-ed into the existing `canUseRowWriter` check. Subclasses delegating to a Dataset-only external writer override this to opt into the Row path. The standard Row-writer compatibility check still gates whether the path is actually taken.
- `SparkSortAndSizeExecutionStrategy` -- `shouldForceRowWriter()` returns `true` iff a writer is registered and reports `isEnabled()`. `runClusteringForGroupAsyncAsRow` consults the SPI first; on absent / disabled writer, or when the writer returns `Option.empty()`, falls through to `super.runClusteringForGroupAsyncAsRow` per group.

### Impact

No user-facing behavior change without a provider. With a provider:
- Each clustering group is delegated to the writer end-to-end (scan, sort, write). Hudi keeps ownership of plan generation, instant management, and the replace-commit; only the per-group write phase is pluggable.
- Per-group fallback (rather than per-plan) lets a provider decline a single group it cannot serve (for example, MOR groups with delta log files) without disabling acceleration for the whole table.

### Risk level

low

The SPI is opt-in (provider must be on the classpath and report `isEnabled()`). The registry returns `Option.empty()` when no provider is registered, which short-circuits before any new code runs in the existing path. The `shouldForceRowWriter()` hook is `false` by default.

### Documentation Update

N/A -- internal SPI for downstream integrators; no user-facing docs change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
