### PR TITLE
test(hadoop-mr): enable rollback case in HoodieRealtimeRecordReader.testReader

### DIFF
--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.hadoop.realtime;
 
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.avro.model.HoodieRollbackPlan;
 import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
@@ -213,8 +214,8 @@ public class TestHoodieRealtimeRecordReader {
     List<Pair<String, Integer>> logVersionsWithAction = new ArrayList<>();
     logVersionsWithAction.add(Pair.of(HoodieTimeline.DELTA_COMMIT_ACTION, 1));
     logVersionsWithAction.add(Pair.of(HoodieTimeline.DELTA_COMMIT_ACTION, 2));
-    // TODO: HUDI-154 Once Hive 2.x PR (PR-674) is merged, enable this change
-    // logVersionsWithAction.add(Pair.of(HoodieTimeline.ROLLBACK_ACTION, 3));
+    logVersionsWithAction.add(Pair.of(HoodieTimeline.ROLLBACK_ACTION, 3));
+    
     FileSlice fileSlice =
         new FileSlice(partitioned ? HadoopFSUtils.getRelativePartitionPath(new Path(basePath.toString()),
             new Path(partitionDir.getAbsolutePath())) : "default", baseInstant, "fileid0");
@@ -243,7 +244,11 @@ public class TestHoodieRealtimeRecordReader {
         long size = writer.getCurrentSize();
         writer.close();
         assertTrue(size > 0, "block - size should be > 0");
-        FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
+        if (action.equals(HoodieTimeline.ROLLBACK_ACTION)) {
+          FileCreateUtilsLegacy.createRequestedRollbackFile(basePath.toString(), instantTime, new HoodieRollbackPlan());
+        } else {
+          FileCreateUtilsLegacy.createDeltaCommit(COMMIT_METADATA_SER_DE, basePath.toString(), instantTime, commitMetadata);
+        }
 
         // create a split with baseFile (parquet file written earlier) and new log file(s)
         fileSlice.addLogFile(writer.getLogFile());
@@ -251,7 +256,7 @@ public class TestHoodieRealtimeRecordReader {
             new FileSplit(new Path(partitionDir + "/fileid0_1-0-1_" + baseInstant + ".parquet"), 0, 1, baseJobConf),
             basePath.toUri().toString(), fileSlice.getLogFiles().sorted(HoodieLogFile.getLogFileComparator())
             .collect(Collectors.toList()),
-            instantTime,
+            latestInstant,
             false,
             Option.empty());
 

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
@@ -232,7 +232,7 @@ public class TestHoodieRealtimeRecordReader {
 
         HoodieLogFormat.Writer writer;
         if (action.equals(HoodieTimeline.ROLLBACK_ACTION)) {
-          writer = InputFormatTestUtil.writeRollback(partitionDir, storage, "fileid0", baseInstant,
+          writer = InputFormatTestUtil.writeRollback(partitionDir, storage, "fileid0", instantTime,
               instantTime,
               String.valueOf(baseInstantTs + logVersion - 1), logVersion);
         } else {
@@ -256,7 +256,7 @@ public class TestHoodieRealtimeRecordReader {
             new FileSplit(new Path(partitionDir + "/fileid0_1-0-1_" + baseInstant + ".parquet"), 0, 1, baseJobConf),
             basePath.toUri().toString(), fileSlice.getLogFiles().sorted(HoodieLogFile.getLogFileComparator())
             .collect(Collectors.toList()),
-            latestInstant,
+            instantTime,
             false,
             Option.empty());
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #14486 

Enables the rollback case in `TestHoodieRealtimeRecordReader.testReader` and removes the TODO comment added in PR-674:
```java
// TODO: HUDI-154 Once Hive 2.x PR (PR-674) is merged, enable this change
// logVersionsWithAction.add(Pair.of(HoodieTimeline.ROLLBACK_ACTION, 3));
```

JIRA: https://issues.apache.org/jira/browse/HUDI-154

### Summary and Changelog

Uncomments and fixes the rollback test case in `TestHoodieRealtimeRecordReader.testReader`.

Three changes were made to enable the rollback case:
1. Uncommented `logVersionsWithAction.add(Pair.of(HoodieTimeline.ROLLBACK_ACTION, 3))` 
   to enable the rollback iteration.
2. Added proper rollback timeline entry using `createRequestedRollbackFile` instead of 
   `createDeltaCommit` for the rollback action, so the timeline correctly records the rollback.
3. `HoodieRealtimeFileSplit` was constructed with `latestInstant` (the last valid commit) 
   instead of `instantTime` (the rollback instant), so the reader correctly stops at the 
   last valid commit.

### Impact

None. Test-only change with no public API or user-facing impact.

### Risk Level

None. Test-only change.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
