### PR TITLE
fix(metadata): Exclude Variant/Blob/Vector from V1 column stats

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -724,7 +724,7 @@ public class HoodieIndexUtils {
       if (fieldSchema.getNonNullType().getType().isComplex()) {
         throw new HoodieMetadataIndexException(String.format(
             "Cannot create expression index '%s': Column '%s' has unsupported data type '%s'. "
-                + "Complex types (RECORD, ARRAY, MAP) are not supported for indexing. "
+                + "Complex types (RECORD, ARRAY, MAP, VARIANT, BLOB, VECTOR) are not supported for indexing. "
                 + "Please choose a column with a primitive data type.",
             userIndexName, columnName, fieldSchema.getType()));
       }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -2045,7 +2045,8 @@ public class HoodieTableMetadataUtil {
     // if record type is set and if its AVRO, MAP, ARRAY, RECORD and ENUM types are unsupported.
     if (recordType.isPresent() && recordType.get() == HoodieRecordType.AVRO) {
       return (type != HoodieSchemaType.RECORD && type != HoodieSchemaType.ARRAY && type != HoodieSchemaType.MAP
-          && type != HoodieSchemaType.ENUM && type != HoodieSchemaType.VARIANT);
+          && type != HoodieSchemaType.ENUM && type != HoodieSchemaType.VARIANT
+          && type != HoodieSchemaType.BLOB && type != HoodieSchemaType.VECTOR);
     }
     // if record Type is not set or if recordType is SPARK then we cannot support AVRO, MAP, ARRAY, RECORD, ENUM and FIXED and BYTES type as well.
     // HUDI-8585 will add support for BYTES and FIXED
@@ -2053,6 +2054,7 @@ public class HoodieTableMetadataUtil {
         && type != HoodieSchemaType.ENUM && type != HoodieSchemaType.BYTES && type != HoodieSchemaType.FIXED
         && type != HoodieSchemaType.DECIMAL // DECIMAL's underlying type is BYTES
         && type != HoodieSchemaType.BLOB
+        && type != HoodieSchemaType.VECTOR
         && type != HoodieSchemaType.VARIANT;
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -21,6 +21,7 @@ package org.apache.hudi.metadata;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
@@ -330,5 +331,25 @@ class TestHoodieTableMetadataUtil {
 
     assertFalse(HoodieTableMetadataUtil.isColumnTypeSupported(vectorSchema, Option.empty(), HoodieIndexVersion.V2));
     assertTrue(HoodieTableMetadataUtil.isColumnTypeSupported(stringSchema, Option.empty(), HoodieIndexVersion.V2));
+  }
+
+  @Test
+  void testVariantBlobVectorColumnsAreNotSupportedForV1ColumnStats() {
+    HoodieSchema variantSchema = HoodieSchema.createNullable(HoodieSchema.createVariant());
+    HoodieSchema blobSchema = HoodieSchema.createNullable(HoodieSchema.createBlob());
+    HoodieSchema vectorSchema = HoodieSchema.createNullable(HoodieSchema.createVector(128));
+    HoodieSchema stringSchema = HoodieSchema.createNullable(HoodieSchema.create(HoodieSchemaType.STRING));
+
+    for (HoodieRecordType recordType : new HoodieRecordType[] {HoodieRecordType.AVRO, HoodieRecordType.SPARK}) {
+      Option<HoodieRecordType> rt = Option.of(recordType);
+      assertFalse(HoodieTableMetadataUtil.isColumnTypeSupported(variantSchema, rt, HoodieIndexVersion.V1),
+          "VARIANT must be excluded from V1 column stats for record type " + recordType);
+      assertFalse(HoodieTableMetadataUtil.isColumnTypeSupported(blobSchema, rt, HoodieIndexVersion.V1),
+          "BLOB must be excluded from V1 column stats for record type " + recordType);
+      assertFalse(HoodieTableMetadataUtil.isColumnTypeSupported(vectorSchema, rt, HoodieIndexVersion.V1),
+          "VECTOR must be excluded from V1 column stats for record type " + recordType);
+      assertTrue(HoodieTableMetadataUtil.isColumnTypeSupported(stringSchema, rt, HoodieIndexVersion.V1),
+          "STRING should remain supported for record type " + recordType);
+    }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Variant, Blob, and Vector are recently added types. Index code (column stats, partition stats, bloom filters, expression-index column gating) was not taught about them. Stats on these columns are meaningless until proper support lands. Disable index population on these columns by default for now.

### Summary and Changelog

V2 already excluded all three types. The gaps were in V1, which is still active for:
- BLOOM_FILTERS (always V1)
- COLUMN_STATS / PARTITION_STATS / EXPRESSION_INDEX on table version 8

Changes:
- `HoodieTableMetadataUtil.isColumnTypeSupportedV1`:
  - AVRO branch now also excludes `BLOB` and `VECTOR`.
  - SPARK branch now also excludes `VECTOR` (`BLOB` and `VARIANT` were already excluded).
- `HoodieIndexUtils` expression-index error message now lists `VARIANT, BLOB, VECTOR` alongside `RECORD, ARRAY, MAP`. Behavior was already correct via `HoodieSchemaType.isComplex()`; only the message text was stale.
- `TestHoodieTableMetadataUtil`: new `testVariantBlobVectorColumnsAreNotSupportedForV1ColumnStats` covers all three types under both `AVRO` and `SPARK` record types in V1.

Note: `HoodieSchemaType.VECTOR.toAvroType()` is `FIXED`, but the V1 check switches on the `HoodieSchemaType` enum, so the existing `type != FIXED` does not catch `VECTOR`. It must be listed explicitly.

### Impact

User-facing: indexes silently skip Variant/Blob/Vector columns instead of indexing garbage. No on-disk format change. No public API change. Secondary index was already protected by its allow-list. Expression index was already blocked behaviorally; only its error wording changed.

### Risk Level

low

Single chokepoint (`isColumnTypeSupported`) feeds every column-list builder. V2 path is unchanged. V1 change strictly narrows the supported set; no previously-supported type is now rejected.

### Documentation Update

none

### Contributor's checklist

- [x] Read through contributor's guide
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
