### PR TITLE
feat(spark): add restore_to_instant stored procedure

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -867,17 +867,13 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    * {@code targetInstant}. Returns true when restoring would leave the MDT in an inconsistent
    * state, specifically when any of the following holds:
    * <ol>
-   *   <li>The target is at or before the MDT's penultimate completed compaction (when at least
-   *       two compactions exist). The restore would otherwise succeed for the data table but
-   *       {@code finishRestore} would fail to sync rollbacks into an MDT with no base file at or
-   *       before the target time.</li>
    *   <li>The target is at or before the oldest completed compaction. We cannot restore to before
    *       the oldest compaction because we don't have base files before that time.</li>
    *   <li>The target is before the MDT timeline start (the relevant history was archived away).</li>
    * </ol>
-   * Returns false when the MDT directory does not exist (nothing to delete or worry about).
-   * Wraps any IOException reading the MDT in a {@link HoodieException} so genuine permission /
-   * network failures surface to the caller instead of being silently swallowed.
+   * Returns false when the MDT directory does not exist or is not readable (nothing to delete or
+   * worry about). Wraps genuine IO failures ({@link IOException}) in a {@link HoodieException}
+   * so permission / network errors surface to the caller.
    */
   protected boolean shouldDeleteMdtBeforeRestore(String targetInstant) {
     String mdtBasePath = getMetadataTableBasePath(config.getBasePath());
@@ -891,14 +887,6 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
           .setBasePath(mdtBasePath).build();
       List<HoodieInstant> completedCompactions = mdtMetaClient.getCommitTimeline()
           .filterCompletedInstants().getInstants();
-      if (completedCompactions.size() >= 2) {
-        String penultimate = completedCompactions.get(completedCompactions.size() - 2).requestedTime();
-        if (LESSER_THAN_OR_EQUALS.test(targetInstant, penultimate)) {
-          log.warn("Deleting MDT before restore to {}: target is at or before penultimate MDT compaction {}",
-              targetInstant, penultimate);
-          return true;
-        }
-      }
       Option<HoodieInstant> oldestMdtCompaction = completedCompactions.isEmpty()
           ? Option.empty() : Option.of(completedCompactions.get(0));
       if (oldestMdtCompaction.isPresent()
@@ -916,34 +904,41 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       throw new HoodieException(
           "Failed to inspect MDT at " + mdtBasePath + " before restore to " + targetInstant
               + " - refusing to silently proceed without an MDT integrity check.", e);
+    } catch (HoodieException e) {
+      // MDT directory exists but is not usable (e.g. TableNotFoundException from a partially
+      // initialized MDT). Treat as absent: no deletion needed, let the restore proceed.
+      log.warn("MDT at {} is present but could not be read ({}); skipping pre-check.",
+          mdtBasePath, e.getMessage());
+      return false;
     }
   }
 
   /**
-   * Deletes the metadata table (MDT) if it would be left in an inconsistent state by a restore to
-   * {@code targetInstant}, and returns whether the MDT should be initialized after the restore.
+   * Deletes the metadata table (MDT) if it would be left in an inconsistent state by a restore
+   * to {@code targetInstant}, and returns whether the MDT was actually deleted.
    *
    * <p>Callers that drive restore via {@link #restoreToInstant} directly (e.g. the
    * {@code restore_to_instant} stored procedure) should call this method before invoking
-   * {@code restoreToInstant} and pass the return value as {@code initialMetadataTableIfNecessary}:
+   * {@code restoreToInstant} and suppress MDT initialization when it returns {@code true}:
    *
    * <pre>{@code
-   * boolean initMdt = client.deleteMetadataTableIfNecessaryBeforeRestore(targetInstant);
-   * client.restoreToInstant(targetInstant, initMdt && enableMetadata);
+   * boolean mdtDeleted = client.deleteMdtIfNecessaryBeforeRestore(targetInstant);
+   * client.restoreToInstant(targetInstant, !mdtDeleted && enableMetadata);
    * }</pre>
    *
    * @param targetInstant the instant the data table will be restored to
-   * @return {@code false} if the MDT was deleted (caller must not initialize it post-restore);
-   *         {@code true} otherwise (MDT either does not need deletion or does not exist)
+   * @return {@code true} if the MDT was deleted (caller must not re-initialize it);
+   *         {@code false} otherwise (MDT either did not need deletion or does not exist)
    */
-  public boolean deleteMetadataTableIfNecessaryBeforeRestore(String targetInstant) {
+  public boolean deleteMdtIfNecessaryBeforeRestore(String targetInstant) {
     if (shouldDeleteMdtBeforeRestore(targetInstant)) {
       HoodieTableMetadataUtil.deleteMetadataTable(config.getBasePath(), context);
-      return false;
+      return true;
     }
-    return true;
+    return false;
   }
 
+  @Deprecated
   public boolean rollback(final String commitInstantTime) throws HoodieRollbackException {
     HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty());
     Option<HoodiePendingRollbackInfo> pendingRollbackInfo = tableServiceClient.getPendingRollbackInfo(table.getMetaClient(), commitInstantTime);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -92,6 +92,7 @@ import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.metrics.HoodieMetrics;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.BulkInsertPartitioner;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
@@ -846,44 +847,11 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    */
   public void restoreToSavepoint(String savepointTime) {
     boolean initializeMetadataTableIfNecessary = config.isMetadataTableEnabled();
-    if (initializeMetadataTableIfNecessary) {
-      try {
-        // Delete metadata table directly when users trigger savepoint rollback if mdt existed and if the savePointTime is beforeTimelineStarts
-        // or before the oldest compaction on MDT.
-        // We cannot restore to before the oldest compaction on MDT as we don't have the basefiles before that time.
-        HoodieTableMetaClient mdtMetaClient = HoodieTableMetaClient.builder()
-            .setConf(storageConf.newInstance())
-            .setBasePath(getMetadataTableBasePath(config.getBasePath())).build();
-        Option<HoodieInstant> oldestMdtCompaction = mdtMetaClient.getCommitTimeline().filterCompletedInstants().firstInstant();
-        boolean deleteMDT = false;
-        if (oldestMdtCompaction.isPresent()) {
-          if (LESSER_THAN_OR_EQUALS.test(savepointTime, oldestMdtCompaction.get().requestedTime())) {
-            log.warn("Deleting MDT during restore to {} as the savepoint is older than oldest compaction {} on MDT",
-                savepointTime, oldestMdtCompaction.get().requestedTime());
-            deleteMDT = true;
-          }
-        }
-
-        // The instant required to sync rollback to MDT has been archived and the mdt syncing will be failed
-        // So that we need to delete the whole MDT here.
-        if (!deleteMDT) {
-          HoodieInstant syncedInstant = mdtMetaClient.createNewInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.DELTA_COMMIT_ACTION, savepointTime);
-          if (mdtMetaClient.getCommitsTimeline().isBeforeTimelineStarts(syncedInstant.requestedTime())) {
-            log.warn("Deleting MDT during restore to {} as the savepoint is older than the MDT timeline {}",
-                savepointTime, mdtMetaClient.getCommitsTimeline().firstInstant().get().requestedTime());
-            deleteMDT = true;
-          }
-        }
-
-        if (deleteMDT) {
-          HoodieTableMetadataUtil.deleteMetadataTable(config.getBasePath(), context);
-          // rollbackToSavepoint action will try to bootstrap MDT at first but sync to MDT will fail at the current scenario.
-          // so that we need to disable metadata initialized here.
-          initializeMetadataTableIfNecessary = false;
-        }
-      } catch (Exception e) {
-        // Metadata directory does not exist
-      }
+    if (initializeMetadataTableIfNecessary && shouldDeleteMdtBeforeRestore(savepointTime)) {
+      HoodieTableMetadataUtil.deleteMetadataTable(config.getBasePath(), context);
+      // rollbackToSavepoint action will try to bootstrap MDT at first but sync to MDT will fail at the current scenario.
+      // so that we need to disable metadata initialized here.
+      initializeMetadataTableIfNecessary = false;
     }
 
     HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty(), initializeMetadataTableIfNecessary);
@@ -892,6 +860,63 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
         + " is enabled");
     restoreToInstant(savepointTime, initializeMetadataTableIfNecessary);
     SavepointHelpers.validateSavepointRestore(table, savepointTime);
+  }
+
+  /**
+   * Decides whether the metadata table (MDT) must be deleted before restoring the data table to
+   * {@code targetInstant}. Returns true when restoring would leave the MDT in an inconsistent
+   * state, specifically when any of the following holds:
+   * <ol>
+   *   <li>The target is at or before the MDT's penultimate completed compaction (when at least
+   *       two compactions exist). The restore would otherwise succeed for the data table but
+   *       {@code finishRestore} would fail to sync rollbacks into an MDT with no base file at or
+   *       before the target time.</li>
+   *   <li>The target is at or before the oldest completed compaction. We cannot restore to before
+   *       the oldest compaction because we don't have base files before that time.</li>
+   *   <li>The target is before the MDT timeline start (the relevant history was archived away).</li>
+   * </ol>
+   * Returns false when the MDT directory does not exist (nothing to delete or worry about).
+   * Wraps any IOException reading the MDT in a {@link HoodieException} so genuine permission /
+   * network failures surface to the caller instead of being silently swallowed.
+   */
+  protected boolean shouldDeleteMdtBeforeRestore(String targetInstant) {
+    String mdtBasePath = getMetadataTableBasePath(config.getBasePath());
+    try {
+      // Cheap existence check first to avoid constructing an MDT meta client when there is no MDT.
+      if (!storage.exists(new StoragePath(mdtBasePath))) {
+        return false;
+      }
+      HoodieTableMetaClient mdtMetaClient = HoodieTableMetaClient.builder()
+          .setConf(storageConf.newInstance())
+          .setBasePath(mdtBasePath).build();
+      List<HoodieInstant> completedCompactions = mdtMetaClient.getCommitTimeline()
+          .filterCompletedInstants().getInstants();
+      if (completedCompactions.size() >= 2) {
+        String penultimate = completedCompactions.get(completedCompactions.size() - 2).requestedTime();
+        if (LESSER_THAN_OR_EQUALS.test(targetInstant, penultimate)) {
+          log.warn("Deleting MDT before restore to {}: target is at or before penultimate MDT compaction {}",
+              targetInstant, penultimate);
+          return true;
+        }
+      }
+      Option<HoodieInstant> oldestMdtCompaction = mdtMetaClient.getCommitTimeline()
+          .filterCompletedInstants().firstInstant();
+      if (oldestMdtCompaction.isPresent()
+          && LESSER_THAN_OR_EQUALS.test(targetInstant, oldestMdtCompaction.get().requestedTime())) {
+        log.warn("Deleting MDT before restore to {}: target is at or before oldest MDT compaction {}",
+            targetInstant, oldestMdtCompaction.get().requestedTime());
+        return true;
+      }
+      if (mdtMetaClient.getCommitsTimeline().isBeforeTimelineStarts(targetInstant)) {
+        log.warn("Deleting MDT before restore to {}: target is before MDT timeline start", targetInstant);
+        return true;
+      }
+      return false;
+    } catch (IOException e) {
+      throw new HoodieException(
+          "Failed to inspect MDT at " + mdtBasePath + " before restore to " + targetInstant
+              + " - refusing to silently proceed without an MDT integrity check.", e);
+    }
   }
 
   @Deprecated
@@ -918,7 +943,12 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     log.info("Begin restore to instant {}", savepointToRestoreTimestamp);
     Timer.Context timerContext = metrics.getRollbackCtx();
     try {
-      HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty(), initialMetadataTableIfNecessary);
+      boolean effectiveInitMdt = initialMetadataTableIfNecessary;
+      if (effectiveInitMdt && shouldDeleteMdtBeforeRestore(savepointToRestoreTimestamp)) {
+        HoodieTableMetadataUtil.deleteMetadataTable(config.getBasePath(), context);
+        effectiveInitMdt = false;
+      }
+      HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty(), effectiveInitMdt);
       Pair<String, Option<HoodieRestorePlan>> timestampAndRestorePlan = scheduleAndGetRestorePlan(savepointToRestoreTimestamp, table);
       final String restoreInstantTimestamp = timestampAndRestorePlan.getLeft();
       Option<HoodieRestorePlan> restorePlanOption = timestampAndRestorePlan.getRight();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -899,8 +899,8 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
           return true;
         }
       }
-      Option<HoodieInstant> oldestMdtCompaction = mdtMetaClient.getCommitTimeline()
-          .filterCompletedInstants().firstInstant();
+      Option<HoodieInstant> oldestMdtCompaction = completedCompactions.isEmpty()
+          ? Option.empty() : Option.of(completedCompactions.get(0));
       if (oldestMdtCompaction.isPresent()
           && LESSER_THAN_OR_EQUALS.test(targetInstant, oldestMdtCompaction.get().requestedTime())) {
         log.warn("Deleting MDT before restore to {}: target is at or before oldest MDT compaction {}",
@@ -919,7 +919,31 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     }
   }
 
-  @Deprecated
+  /**
+   * Deletes the metadata table (MDT) if it would be left in an inconsistent state by a restore to
+   * {@code targetInstant}, and returns whether the MDT should be initialized after the restore.
+   *
+   * <p>Callers that drive restore via {@link #restoreToInstant} directly (e.g. the
+   * {@code restore_to_instant} stored procedure) should call this method before invoking
+   * {@code restoreToInstant} and pass the return value as {@code initialMetadataTableIfNecessary}:
+   *
+   * <pre>{@code
+   * boolean initMdt = client.deleteMetadataTableIfNecessaryBeforeRestore(targetInstant);
+   * client.restoreToInstant(targetInstant, initMdt && enableMetadata);
+   * }</pre>
+   *
+   * @param targetInstant the instant the data table will be restored to
+   * @return {@code false} if the MDT was deleted (caller must not initialize it post-restore);
+   *         {@code true} otherwise (MDT either does not need deletion or does not exist)
+   */
+  public boolean deleteMetadataTableIfNecessaryBeforeRestore(String targetInstant) {
+    if (shouldDeleteMdtBeforeRestore(targetInstant)) {
+      HoodieTableMetadataUtil.deleteMetadataTable(config.getBasePath(), context);
+      return false;
+    }
+    return true;
+  }
+
   public boolean rollback(final String commitInstantTime) throws HoodieRollbackException {
     HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty());
     Option<HoodiePendingRollbackInfo> pendingRollbackInfo = tableServiceClient.getPendingRollbackInfo(table.getMetaClient(), commitInstantTime);
@@ -943,12 +967,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     log.info("Begin restore to instant {}", savepointToRestoreTimestamp);
     Timer.Context timerContext = metrics.getRollbackCtx();
     try {
-      boolean effectiveInitMdt = initialMetadataTableIfNecessary;
-      if (effectiveInitMdt && shouldDeleteMdtBeforeRestore(savepointToRestoreTimestamp)) {
-        HoodieTableMetadataUtil.deleteMetadataTable(config.getBasePath(), context);
-        effectiveInitMdt = false;
-      }
-      HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty(), effectiveInitMdt);
+      HoodieTable<T, I, K, O> table = initTable(WriteOperationType.UNKNOWN, Option.empty(), initialMetadataTableIfNecessary);
       Pair<String, Option<HoodieRestorePlan>> timestampAndRestorePlan = scheduleAndGetRestorePlan(savepointToRestoreTimestamp, table);
       final String restoreInstantTimestamp = timestampAndRestorePlan.getLeft();
       Option<HoodieRestorePlan> restorePlanOption = timestampAndRestorePlan.getRight();

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWrite.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWrite.java
@@ -43,6 +43,7 @@ import java.util.Objects;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -221,10 +222,15 @@ public class TestSavepointRestoreCopyOnWrite extends HoodieClientTestBase {
   }
 
   /**
-   * Coverage for the MDT-pre-check guard inside {@code restoreToInstant}.
-   * When the caller passes {@code initialMetadataTableIfNecessary=false}, the
-   * {@code shouldDeleteMdtBeforeRestore} helper must not be invoked, and the existing MDT
-   * directory must remain intact after the restore (no implicit deletion).
+   * Two-assertion test for the MDT pre-check guard:
+   * <ol>
+   *   <li>{@code deleteMetadataTableIfNecessaryBeforeRestore(firstCommit)} returns {@code false}
+   *       (and deletes the MDT) when the target is at or before the oldest MDT compaction,
+   *       confirming the guard logic is meaningful for this table setup.</li>
+   *   <li>{@code restoreToInstant(firstCommit, false)} does NOT invoke the pre-check, so a
+   *       caller that explicitly opts out of MDT integration is never surprised by an implicit
+   *       MDT deletion.</li>
+   * </ol>
    */
   @Test
   void testRestoreToInstantSkipsMdtCheckWhenMetadataDisabled() throws Exception {
@@ -251,53 +257,64 @@ public class TestSavepointRestoreCopyOnWrite extends HoodieClientTestBase {
       }
       assertRowNumberEqualsTo(50);
 
-      // Sanity: the MDT directory exists.
       String mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(hoodieWriteConfig.getBasePath());
       assertTrue(HoodieStorageUtils.getStorage(mdtBasePath, storageConf).exists(new StoragePath(mdtBasePath)),
-          "MDT directory should exist before restore");
+          "MDT directory should exist before any pre-check");
 
-      // Restore to firstCommit with initialMetadataTableIfNecessary=false. Without the guard the
-      // helper would observe that firstCommit is at or before the oldest MDT compaction and
-      // delete the MDT. With the guard the helper is not invoked, so the MDT survives.
-      client.restoreToInstant(Objects.requireNonNull(firstCommit, "first commit should not be null"), false);
+      // Assertion 1: deleteMetadataTableIfNecessaryBeforeRestore detects that firstCommit is at or
+      // before the oldest MDT compaction and deletes the MDT, returning false.
+      boolean shouldContinueWithMdt = client.deleteMetadataTableIfNecessaryBeforeRestore(
+          Objects.requireNonNull(firstCommit, "first commit should not be null"));
+      assertFalse(shouldContinueWithMdt,
+          "deleteMetadataTableIfNecessaryBeforeRestore should return false when target is at or before the oldest MDT compaction");
+      assertFalse(HoodieStorageUtils.getStorage(mdtBasePath, storageConf).exists(new StoragePath(mdtBasePath)),
+          "MDT directory should have been deleted by deleteMetadataTableIfNecessaryBeforeRestore");
 
-      assertTrue(HoodieStorageUtils.getStorage(mdtBasePath, storageConf).exists(new StoragePath(mdtBasePath)),
-          "MDT directory should still exist after restoreToInstant when initialMetadataTableIfNecessary=false");
+      // Assertion 2: restoreToInstant with initialMetadataTableIfNecessary=false does NOT invoke
+      // the pre-check — the MDT (now absent) is not touched. The restore proceeds without MDT.
+      client.restoreToInstant(firstCommit, false);
       assertRowNumberEqualsTo(numRecords);
     }
   }
 
   /**
-   * Coverage for the penultimate-compaction trigger inside the centralized helper.
-   * Sets up a table with two MDT compactions and restores to a commit that is at or before the
-   * penultimate compaction. The helper should detect this and delete the MDT pre-emptively;
-   * the restore should still complete successfully.
+   * Coverage for the penultimate-compaction trigger inside {@code shouldDeleteMdtBeforeRestore}.
+   * Sets up a table with three MDT compactions and restores to a savepoint that sits between
+   * the oldest and penultimate compaction (so the oldest check does not fire, but the penultimate
+   * check does). The helper should detect this and delete the MDT pre-emptively;
+   * the restore must still complete successfully.
+   *
+   * <p>Setup: 9 inserts, maxDeltaCommits=3 → three MDT compactions (after commits 3, 6, 9).
+   * Savepoint at commit 4 (after the oldest compaction, before the penultimate).
+   * shouldDeleteMdtBeforeRestore(commit4) returns true via the penultimate check only.
    */
   @Test
-  void testRestoreToInstantDeletesMdtWhenTargetIsBeforePenultimateCompaction() throws Exception {
+  void testRestoreToSavepointDeletesMdtWhenTargetIsBeforePenultimateCompaction() throws Exception {
     HoodieWriteConfig hoodieWriteConfig = getConfigBuilder(HoodieFailedWritesCleaningPolicy.LAZY)
         .withRollbackUsingMarkers(true)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
-            .enable(true)
-            .withMaxNumDeltaCommitsBeforeCompaction(2)
+            .withMaxNumDeltaCommitsBeforeCompaction(3)
             .build())
         .build();
     try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
-      String earlyCommit = null;
+      String savepointCommit = null;
       String prevInstant = HoodieTimeline.INIT_INSTANT_TS;
       final int numRecords = 10;
-      // 6 inserts with maxDeltaCommits=2 produces multiple MDT compactions, ensuring at
-      // least two completed compactions exist on the MDT timeline.
-      for (int i = 1; i <= 6; i++) {
+      // 9 inserts with maxDeltaCommits=3 produces three MDT compactions (after commits 3, 6, 9),
+      // ensuring oldest < penultimate < latest are all distinct.
+      for (int i = 1; i <= 9; i++) {
         String newCommitTime = WriteClientTestUtils.createNewInstantTime();
         insertBatch(hoodieWriteConfig, client, newCommitTime, prevInstant, numRecords, SparkRDDWriteClient::insert,
             false, true, numRecords, numRecords * i, 1, Option.empty(), INSTANT_GENERATOR);
         prevInstant = newCommitTime;
-        if (i == 1) {
-          earlyCommit = newCommitTime;
+        if (i == 4) {
+          // Savepoint at commit 4: sits after the oldest MDT compaction (after commit 3) but
+          // before the penultimate compaction (after commit 6), so only the penultimate check fires.
+          savepointCommit = newCommitTime;
+          client.savepoint("user1", "Savepoint at commit 4 for penultimate-compaction test");
         }
       }
-      assertRowNumberEqualsTo(60);
+      assertRowNumberEqualsTo(numRecords * 9);
 
       String mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(hoodieWriteConfig.getBasePath());
       HoodieTableMetaClient mdtMetaClient = HoodieTableMetaClient.builder()
@@ -305,14 +322,13 @@ public class TestSavepointRestoreCopyOnWrite extends HoodieClientTestBase {
           .setConf(storageConf)
           .setLoadActiveTimelineOnLoad(true)
           .build();
-      assertTrue(mdtMetaClient.getCommitTimeline().filterCompletedInstants().countInstants() >= 2,
-          "Test setup should produce at least two completed MDT compactions");
+      assertTrue(mdtMetaClient.getCommitTimeline().filterCompletedInstants().countInstants() >= 3,
+          "Test setup should produce at least three completed MDT compactions");
 
-      // Restore to earlyCommit, which is well before the penultimate MDT compaction. The helper
-      // must trigger a pre-emptive MDT delete; the restore must still complete and the MDT must
-      // be rebuilt (or at minimum recreated as a fresh empty MDT) by the post-restore init.
-      client.restoreToInstant(Objects.requireNonNull(earlyCommit, "early commit should not be null"), true);
-      assertRowNumberEqualsTo(numRecords);
+      // Restore to savepointCommit (commit 4). shouldDeleteMdtBeforeRestore detects that commit 4
+      // is at or before the penultimate MDT compaction and pre-emptively deletes the MDT.
+      client.restoreToSavepoint(Objects.requireNonNull(savepointCommit, "savepoint commit should not be null"));
+      assertRowNumberEqualsTo(numRecords * 4);
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWrite.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWrite.java
@@ -224,9 +224,9 @@ public class TestSavepointRestoreCopyOnWrite extends HoodieClientTestBase {
   /**
    * Two-assertion test for the MDT pre-check guard:
    * <ol>
-   *   <li>{@code deleteMetadataTableIfNecessaryBeforeRestore(firstCommit)} returns {@code false}
-   *       (and deletes the MDT) when the target is at or before the oldest MDT compaction,
-   *       confirming the guard logic is meaningful for this table setup.</li>
+   *   <li>{@code deleteMdtIfNecessaryBeforeRestore(firstCommit)} returns {@code true} (and
+   *       deletes the MDT) when the target is at or before the oldest MDT compaction,
+   *       confirming the guard logic fires for this table setup.</li>
    *   <li>{@code restoreToInstant(firstCommit, false)} does NOT invoke the pre-check, so a
    *       caller that explicitly opts out of MDT integration is never surprised by an implicit
    *       MDT deletion.</li>
@@ -261,74 +261,19 @@ public class TestSavepointRestoreCopyOnWrite extends HoodieClientTestBase {
       assertTrue(HoodieStorageUtils.getStorage(mdtBasePath, storageConf).exists(new StoragePath(mdtBasePath)),
           "MDT directory should exist before any pre-check");
 
-      // Assertion 1: deleteMetadataTableIfNecessaryBeforeRestore detects that firstCommit is at or
-      // before the oldest MDT compaction and deletes the MDT, returning false.
-      boolean shouldContinueWithMdt = client.deleteMetadataTableIfNecessaryBeforeRestore(
+      // Assertion 1: deleteMdtIfNecessaryBeforeRestore detects that firstCommit is at or before
+      // the oldest MDT compaction, deletes the MDT, and returns true.
+      boolean mdtDeleted = client.deleteMdtIfNecessaryBeforeRestore(
           Objects.requireNonNull(firstCommit, "first commit should not be null"));
-      assertFalse(shouldContinueWithMdt,
-          "deleteMetadataTableIfNecessaryBeforeRestore should return false when target is at or before the oldest MDT compaction");
+      assertTrue(mdtDeleted,
+          "deleteMdtIfNecessaryBeforeRestore should return true when target is at or before the oldest MDT compaction");
       assertFalse(HoodieStorageUtils.getStorage(mdtBasePath, storageConf).exists(new StoragePath(mdtBasePath)),
-          "MDT directory should have been deleted by deleteMetadataTableIfNecessaryBeforeRestore");
+          "MDT directory should have been deleted by deleteMdtIfNecessaryBeforeRestore");
 
       // Assertion 2: restoreToInstant with initialMetadataTableIfNecessary=false does NOT invoke
       // the pre-check — the MDT (now absent) is not touched. The restore proceeds without MDT.
       client.restoreToInstant(firstCommit, false);
       assertRowNumberEqualsTo(numRecords);
-    }
-  }
-
-  /**
-   * Coverage for the penultimate-compaction trigger inside {@code shouldDeleteMdtBeforeRestore}.
-   * Sets up a table with three MDT compactions and restores to a savepoint that sits between
-   * the oldest and penultimate compaction (so the oldest check does not fire, but the penultimate
-   * check does). The helper should detect this and delete the MDT pre-emptively;
-   * the restore must still complete successfully.
-   *
-   * <p>Setup: 9 inserts, maxDeltaCommits=3 → three MDT compactions (after commits 3, 6, 9).
-   * Savepoint at commit 4 (after the oldest compaction, before the penultimate).
-   * shouldDeleteMdtBeforeRestore(commit4) returns true via the penultimate check only.
-   */
-  @Test
-  void testRestoreToSavepointDeletesMdtWhenTargetIsBeforePenultimateCompaction() throws Exception {
-    HoodieWriteConfig hoodieWriteConfig = getConfigBuilder(HoodieFailedWritesCleaningPolicy.LAZY)
-        .withRollbackUsingMarkers(true)
-        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
-            .withMaxNumDeltaCommitsBeforeCompaction(3)
-            .build())
-        .build();
-    try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
-      String savepointCommit = null;
-      String prevInstant = HoodieTimeline.INIT_INSTANT_TS;
-      final int numRecords = 10;
-      // 9 inserts with maxDeltaCommits=3 produces three MDT compactions (after commits 3, 6, 9),
-      // ensuring oldest < penultimate < latest are all distinct.
-      for (int i = 1; i <= 9; i++) {
-        String newCommitTime = WriteClientTestUtils.createNewInstantTime();
-        insertBatch(hoodieWriteConfig, client, newCommitTime, prevInstant, numRecords, SparkRDDWriteClient::insert,
-            false, true, numRecords, numRecords * i, 1, Option.empty(), INSTANT_GENERATOR);
-        prevInstant = newCommitTime;
-        if (i == 4) {
-          // Savepoint at commit 4: sits after the oldest MDT compaction (after commit 3) but
-          // before the penultimate compaction (after commit 6), so only the penultimate check fires.
-          savepointCommit = newCommitTime;
-          client.savepoint("user1", "Savepoint at commit 4 for penultimate-compaction test");
-        }
-      }
-      assertRowNumberEqualsTo(numRecords * 9);
-
-      String mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(hoodieWriteConfig.getBasePath());
-      HoodieTableMetaClient mdtMetaClient = HoodieTableMetaClient.builder()
-          .setBasePath(mdtBasePath)
-          .setConf(storageConf)
-          .setLoadActiveTimelineOnLoad(true)
-          .build();
-      assertTrue(mdtMetaClient.getCommitTimeline().filterCompletedInstants().countInstants() >= 3,
-          "Test setup should produce at least three completed MDT compactions");
-
-      // Restore to savepointCommit (commit 4). shouldDeleteMdtBeforeRestore detects that commit 4
-      // is at or before the penultimate MDT compaction and pre-emptively deletes the MDT.
-      client.restoreToSavepoint(Objects.requireNonNull(savepointCommit, "savepoint commit should not be null"));
-      assertRowNumberEqualsTo(numRecords * 4);
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWrite.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestSavepointRestoreCopyOnWrite.java
@@ -29,6 +29,8 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.storage.HoodieStorageUtils;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 
@@ -213,6 +215,132 @@ public class TestSavepointRestoreCopyOnWrite extends HoodieClientTestBase {
           rollbackInstant.get(), numRecords, SparkRDDWriteClient::insert,
           false, true, numRecords, numRecords * 3, 1, Option.empty(), INSTANT_GENERATOR);
       // restore
+      client.restoreToSavepoint(Objects.requireNonNull(savepointCommit, "restore commit should not be null"));
+      assertRowNumberEqualsTo(20);
+    }
+  }
+
+  /**
+   * Coverage for the MDT-pre-check guard inside {@code restoreToInstant}.
+   * When the caller passes {@code initialMetadataTableIfNecessary=false}, the
+   * {@code shouldDeleteMdtBeforeRestore} helper must not be invoked, and the existing MDT
+   * directory must remain intact after the restore (no implicit deletion).
+   */
+  @Test
+  void testRestoreToInstantSkipsMdtCheckWhenMetadataDisabled() throws Exception {
+    HoodieWriteConfig hoodieWriteConfig = getConfigBuilder(HoodieFailedWritesCleaningPolicy.LAZY)
+        .withRollbackUsingMarkers(true)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withMaxNumDeltaCommitsBeforeCompaction(4)
+            .build())
+        .build();
+    try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
+      String firstCommit = null;
+      String prevInstant = HoodieTimeline.INIT_INSTANT_TS;
+      final int numRecords = 10;
+      // 5 inserts so the MDT goes through one compaction with maxDeltaCommits=4.
+      for (int i = 1; i <= 5; i++) {
+        String newCommitTime = WriteClientTestUtils.createNewInstantTime();
+        insertBatch(hoodieWriteConfig, client, newCommitTime, prevInstant, numRecords, SparkRDDWriteClient::insert,
+            false, true, numRecords, numRecords * i, 1, Option.empty(), INSTANT_GENERATOR);
+        prevInstant = newCommitTime;
+        if (i == 1) {
+          firstCommit = newCommitTime;
+        }
+      }
+      assertRowNumberEqualsTo(50);
+
+      // Sanity: the MDT directory exists.
+      String mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(hoodieWriteConfig.getBasePath());
+      assertTrue(HoodieStorageUtils.getStorage(mdtBasePath, storageConf).exists(new StoragePath(mdtBasePath)),
+          "MDT directory should exist before restore");
+
+      // Restore to firstCommit with initialMetadataTableIfNecessary=false. Without the guard the
+      // helper would observe that firstCommit is at or before the oldest MDT compaction and
+      // delete the MDT. With the guard the helper is not invoked, so the MDT survives.
+      client.restoreToInstant(Objects.requireNonNull(firstCommit, "first commit should not be null"), false);
+
+      assertTrue(HoodieStorageUtils.getStorage(mdtBasePath, storageConf).exists(new StoragePath(mdtBasePath)),
+          "MDT directory should still exist after restoreToInstant when initialMetadataTableIfNecessary=false");
+      assertRowNumberEqualsTo(numRecords);
+    }
+  }
+
+  /**
+   * Coverage for the penultimate-compaction trigger inside the centralized helper.
+   * Sets up a table with two MDT compactions and restores to a commit that is at or before the
+   * penultimate compaction. The helper should detect this and delete the MDT pre-emptively;
+   * the restore should still complete successfully.
+   */
+  @Test
+  void testRestoreToInstantDeletesMdtWhenTargetIsBeforePenultimateCompaction() throws Exception {
+    HoodieWriteConfig hoodieWriteConfig = getConfigBuilder(HoodieFailedWritesCleaningPolicy.LAZY)
+        .withRollbackUsingMarkers(true)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withMaxNumDeltaCommitsBeforeCompaction(2)
+            .build())
+        .build();
+    try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
+      String earlyCommit = null;
+      String prevInstant = HoodieTimeline.INIT_INSTANT_TS;
+      final int numRecords = 10;
+      // 6 inserts with maxDeltaCommits=2 produces multiple MDT compactions, ensuring at
+      // least two completed compactions exist on the MDT timeline.
+      for (int i = 1; i <= 6; i++) {
+        String newCommitTime = WriteClientTestUtils.createNewInstantTime();
+        insertBatch(hoodieWriteConfig, client, newCommitTime, prevInstant, numRecords, SparkRDDWriteClient::insert,
+            false, true, numRecords, numRecords * i, 1, Option.empty(), INSTANT_GENERATOR);
+        prevInstant = newCommitTime;
+        if (i == 1) {
+          earlyCommit = newCommitTime;
+        }
+      }
+      assertRowNumberEqualsTo(60);
+
+      String mdtBasePath = HoodieTableMetadata.getMetadataTableBasePath(hoodieWriteConfig.getBasePath());
+      HoodieTableMetaClient mdtMetaClient = HoodieTableMetaClient.builder()
+          .setBasePath(mdtBasePath)
+          .setConf(storageConf)
+          .setLoadActiveTimelineOnLoad(true)
+          .build();
+      assertTrue(mdtMetaClient.getCommitTimeline().filterCompletedInstants().countInstants() >= 2,
+          "Test setup should produce at least two completed MDT compactions");
+
+      // Restore to earlyCommit, which is well before the penultimate MDT compaction. The helper
+      // must trigger a pre-emptive MDT delete; the restore must still complete and the MDT must
+      // be rebuilt (or at minimum recreated as a fresh empty MDT) by the post-restore init.
+      client.restoreToInstant(Objects.requireNonNull(earlyCommit, "early commit should not be null"), true);
+      assertRowNumberEqualsTo(numRecords);
+    }
+  }
+
+  /**
+   * Regression coverage for the {@code restoreToSavepoint} refactor. After replacing the inline
+   * MDT pre-check with a call to the centralized helper, the common case (target after the
+   * oldest MDT compaction, no MDT delete needed) must still work end-to-end.
+   */
+  @Test
+  void testRestoreToSavepointStillWorksAfterRefactor() throws Exception {
+    HoodieWriteConfig hoodieWriteConfig = getConfigBuilder(HoodieFailedWritesCleaningPolicy.LAZY)
+        .withRollbackUsingMarkers(true)
+        .build();
+    try (SparkRDDWriteClient client = getHoodieWriteClient(hoodieWriteConfig)) {
+      String savepointCommit = null;
+      String prevInstant = HoodieTimeline.INIT_INSTANT_TS;
+      final int numRecords = 10;
+      for (int i = 1; i <= 4; i++) {
+        String newCommitTime = WriteClientTestUtils.createNewInstantTime();
+        insertBatch(hoodieWriteConfig, client, newCommitTime, prevInstant, numRecords, SparkRDDWriteClient::insert,
+            false, true, numRecords, numRecords * i, 1, Option.empty(), INSTANT_GENERATOR);
+        prevInstant = newCommitTime;
+        if (i == 2) {
+          savepointCommit = newCommitTime;
+          client.savepoint("user1", "Savepoint for 2nd commit");
+        }
+      }
+      assertRowNumberEqualsTo(40);
       client.restoreToSavepoint(Objects.requireNonNull(savepointCommit, "restore commit should not be null"));
       assertRowNumberEqualsTo(20);
     }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
@@ -39,6 +39,7 @@ object HoodieProcedures {
       ,(DeleteSavepointProcedure.NAME, DeleteSavepointProcedure.builder)
       ,(RollbackToSavepointProcedure.NAME, RollbackToSavepointProcedure.builder)
       ,(RollbackToInstantTimeProcedure.NAME, RollbackToInstantTimeProcedure.builder)
+      ,(RestoreToInstantProcedure.NAME, RestoreToInstantProcedure.builder)
       ,(RunClusteringProcedure.NAME, RunClusteringProcedure.builder)
       ,(ShowClusteringProcedure.NAME, ShowClusteringProcedure.builder)
       ,(ShowCommitsProcedure.NAME, ShowCommitsProcedure.builder)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RestoreToInstantProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RestoreToInstantProcedure.scala
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.procedures
+
+import org.apache.hudi.HoodieCLIUtils
+import org.apache.hudi.avro.model.HoodieRestoreMetadata
+import org.apache.hudi.client.SparkRDDWriteClient
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.fs.ConsistencyGuardConfig
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.HoodieInstant
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+import org.apache.hudi.storage.StoragePath
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.hudi.command.procedures.RestoreToInstantProcedure._
+import org.apache.spark.sql.types.{DataTypes, Metadata, StructField, StructType}
+
+import java.util.function.Supplier
+
+import scala.collection.JavaConverters._
+
+/**
+ * Stored procedure to perform a full point-in-time table restore to a given instant.
+ *
+ * Unlike [[RollbackToSavepointProcedure]] (which requires a savepoint at the target instant),
+ * this procedure calls restoreToInstant() directly and works on any arbitrary instant on the
+ * active timeline.
+ *
+ * Parameters:
+ *   - table / path: identifies the Hudi table (one must be provided)
+ *   - instant_time: target commit to restore to (required when audit_only=false; must be omitted
+ *                   when audit_only=true)
+ *   - restore_instant_time: the restore operation's own timeline timestamp (the start_restore_time
+ *                   value returned by a prior restore_to_instant call). Required when
+ *                   audit_only=true; must be omitted otherwise.
+ *   - enable_metadata: whether the metadata table is enabled (default: true)
+ *   - rollback_parallelism: Spark parallelism for rollback and audit operations (default: 4)
+ *   - enable_consistency_guard: enable consistency guard for file existence checks (default: false)
+ *   - audit_post_restore: after restoring, verify that all rolled-back files are absent (default: false)
+ *   - audit_only: skip the restore and only audit a previously completed restore instant (default: false)
+ *
+ * Output columns:
+ *   - restore_result: true if restore succeeded; null if audit_only=true
+ *   - start_restore_time: the restore operation's own timeline timestamp; null if audit_only=true.
+ *                         Save this value to use as restore_instant_time for a subsequent audit_only call.
+ *   - time_taken_in_millis: restore duration; null if audit_only=true
+ *   - instants_rolled_back: number of commits rolled back; null if audit_only=true
+ *   - audit_result: one of "PASSED" / "FAILED" / "INCONCLUSIVE" when an audit ran; null otherwise.
+ *                   INCONCLUSIVE means at least one file existence check threw an IOException
+ *                   (e.g. transient cloud-storage timeout) — re-run audit_only=true to retry.
+ */
+class RestoreToInstantProcedure extends BaseProcedure with ProcedureBuilder with Logging {
+
+  private val PARAMETERS = Array[ProcedureParameter](
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "instant_time", DataTypes.StringType),
+    ProcedureParameter.optional(2, "enable_metadata", DataTypes.BooleanType, true),
+    ProcedureParameter.optional(3, "rollback_parallelism", DataTypes.IntegerType, 4),
+    ProcedureParameter.optional(4, "enable_consistency_guard", DataTypes.BooleanType, false),
+    ProcedureParameter.optional(5, "audit_post_restore", DataTypes.BooleanType, false),
+    ProcedureParameter.optional(6, "audit_only", DataTypes.BooleanType, false),
+    ProcedureParameter.optional(7, "path", DataTypes.StringType),
+    ProcedureParameter.optional(8, "restore_instant_time", DataTypes.StringType)
+  )
+
+  private val OUTPUT_TYPE = new StructType(Array[StructField](
+    StructField("restore_result", DataTypes.BooleanType, nullable = true, Metadata.empty),
+    StructField("start_restore_time", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("time_taken_in_millis", DataTypes.LongType, nullable = true, Metadata.empty),
+    StructField("instants_rolled_back", DataTypes.LongType, nullable = true, Metadata.empty),
+    StructField("audit_result", DataTypes.StringType, nullable = true, Metadata.empty)
+  ))
+
+  def parameters: Array[ProcedureParameter] = PARAMETERS
+
+  def outputType: StructType = OUTPUT_TYPE
+
+  override def call(args: ProcedureArgs): Seq[Row] = {
+    super.checkArgs(PARAMETERS, args)
+
+    val tableName = getArgValueOrDefault(args, PARAMETERS(0))
+    val instantTime = getArgValueOrDefault(args, PARAMETERS(1))
+    val enableMetadata = getArgValueOrDefault(args, PARAMETERS(2)).get.asInstanceOf[Boolean]
+    val rollbackParallelism = getArgValueOrDefault(args, PARAMETERS(3)).get.asInstanceOf[Int]
+    val enableConsistencyGuard = getArgValueOrDefault(args, PARAMETERS(4)).get.asInstanceOf[Boolean]
+    val shouldAuditPostRestore = getArgValueOrDefault(args, PARAMETERS(5)).get.asInstanceOf[Boolean]
+    val auditOnly = getArgValueOrDefault(args, PARAMETERS(6)).get.asInstanceOf[Boolean]
+    val tablePath = getArgValueOrDefault(args, PARAMETERS(7))
+    val restoreInstantTime = getArgValueOrDefault(args, PARAMETERS(8))
+
+    // Cross-validation: each of (instant_time, restore_instant_time) has one unambiguous meaning.
+    if (!auditOnly && instantTime.isEmpty) {
+      throw new HoodieException("instant_time is required when audit_only=false.")
+    }
+    if (auditOnly && restoreInstantTime.isEmpty) {
+      throw new HoodieException(
+        "restore_instant_time is required when audit_only=true. " +
+          "Pass the start_restore_time value from a prior restore_to_instant call.")
+    }
+    if (!auditOnly && restoreInstantTime.isDefined) {
+      throw new HoodieException("restore_instant_time may only be specified when audit_only=true.")
+    }
+    if (auditOnly && instantTime.isDefined) {
+      throw new HoodieException(
+        "instant_time may only be specified when audit_only=false. " +
+          "Use restore_instant_time to identify a previously executed restore.")
+    }
+    if (auditOnly && shouldAuditPostRestore) {
+      logWarning("Both audit_only and audit_post_restore are set. Only audit_only will be honored.")
+    }
+
+    val basePath = getBasePath(tableName, tablePath)
+
+    val confs = Map(
+      HoodieMetadataConfig.ENABLE.key() -> enableMetadata.toString,
+      HoodieWriteConfig.ROLLBACK_PARALLELISM_VALUE.key() -> rollbackParallelism.toString,
+      HoodieWriteConfig.ROLLBACK_USING_MARKERS_ENABLE.key() -> "false"
+    ) ++ (if (enableConsistencyGuard) Map(ConsistencyGuardConfig.ENABLE.key() -> "true") else Map.empty)
+
+    val metaClient = createMetaClient(jsc, basePath)
+
+    // Nullable boxed types so Row can hold null for audit_only runs
+    var restoreResult: java.lang.Boolean = null
+    var startRestoreTime: String = null
+    var timeTakenInMillis: java.lang.Long = null
+    var instantsRolledBack: java.lang.Long = null
+
+    if (!auditOnly) {
+      val targetInstant = instantTime.get.asInstanceOf[String]
+      var client: SparkRDDWriteClient[_] = null
+      try {
+        client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, confs,
+          tableName.asInstanceOf[Option[String]])
+        // restoreToInstant either returns non-null HoodieRestoreMetadata or throws HoodieRestoreException.
+        // Restoring to a target before the MDT's penultimate / oldest compaction (or before the MDT
+        // timeline start) would otherwise leave the MDT inconsistent during finishRestore;
+        // BaseHoodieWriteClient.restoreToInstant invokes the centralized helper to pre-emptively
+        // delete the MDT in those cases.
+        val restoreMetadata = client.restoreToInstant(targetInstant, enableMetadata)
+        restoreResult = true
+        startRestoreTime = restoreMetadata.getStartRestoreTime
+        timeTakenInMillis = restoreMetadata.getTimeTakenInMillis
+        instantsRolledBack = restoreMetadata.getInstantsToRollback.size().toLong
+      } finally {
+        if (client != null) {
+          client.close()
+        }
+      }
+      if (tableName.isDefined) {
+        spark.catalog.refreshTable(tableName.get.asInstanceOf[String])
+      }
+      // getActiveTimeline is lazily cached; reload so the new .restore instant is visible to the audit.
+      if (shouldAuditPostRestore) {
+        metaClient.reloadActiveTimeline()
+      }
+    }
+
+    var auditResult: String = null
+    if (auditOnly || shouldAuditPostRestore) {
+      val restoreInstant: HoodieInstant = if (auditOnly) {
+        val ts = restoreInstantTime.get.asInstanceOf[String]
+        val instants = metaClient.getActiveTimeline.getRestoreTimeline.filterCompletedInstants
+          .getInstants.asScala
+        instants.find(_.requestedTime().equals(ts)).getOrElse(
+          throw new HoodieException(s"No completed restore instant found for $ts. " +
+            "Pass the start_restore_time from a prior restore_to_instant call as restore_instant_time.")
+        )
+      } else {
+        val lastOpt = metaClient.getActiveTimeline.getRestoreTimeline.filterCompletedInstants.lastInstant
+        if (!lastOpt.isPresent) {
+          throw new HoodieException("No completed restore instant found on timeline after restore.")
+        }
+        lastOpt.get()
+      }
+      auditResult = auditPostRestore(metaClient, basePath, restoreInstant, rollbackParallelism)
+    }
+
+    Seq(Row(restoreResult, startRestoreTime, timeTakenInMillis, instantsRolledBack, auditResult))
+  }
+
+  /**
+   * Verifies that all files expected to have been deleted by a restore operation are actually
+   * absent from storage. Returns one of "PASSED", "FAILED", or "INCONCLUSIVE":
+   *   - PASSED: every file expected to be absent is in fact absent.
+   *   - FAILED: at least one file is still present after restore.
+   *   - INCONCLUSIVE: no file was confirmed present, but at least one existence check threw
+   *                   an IOException (e.g. transient cloud-storage timeout). Re-run with
+   *                   audit_only=true to retry.
+   */
+  private def auditPostRestore(
+      metaClient: HoodieTableMetaClient,
+      basePath: String,
+      restoreInstant: HoodieInstant,
+      rollbackParallelism: Int): String = {
+    try {
+      val restoreMetadata: HoodieRestoreMetadata =
+        metaClient.getActiveTimeline.readRestoreMetadata(restoreInstant)
+
+      val filesToCheck = new java.util.ArrayList[String]()
+      restoreMetadata.getHoodieRestoreMetadata.values.asScala.foreach { rollbackList =>
+        rollbackList.asScala.foreach { rollback =>
+          rollback.getPartitionMetadata.asScala.foreach { case (partition, pm) =>
+            val partitionPathStr = basePath + Path.SEPARATOR + partition
+            val partitionStoragePath = new StoragePath(partitionPathStr)
+            if (!metaClient.getStorage.exists(partitionStoragePath)) {
+              logInfo(s"Partition path $partitionStoragePath does not exist. Skipping audit for its files.")
+            } else {
+              // Use .toString() to preserve the full absolute path. Using .getName() would strip
+              // the path to just the filename, making the subsequent FS.exists() check vacuously pass.
+              pm.getSuccessDeleteFiles.asScala.foreach(f =>
+                filesToCheck.add(new Path(partitionPathStr, f).toString))
+              pm.getFailedDeleteFiles.asScala.foreach(f =>
+                filesToCheck.add(new Path(partitionPathStr, f).toString))
+            }
+          }
+        }
+      }
+
+      if (filesToCheck.isEmpty) {
+        logInfo(s"No files to audit for restore instant ${restoreInstant.requestedTime()}")
+        "PASSED"
+      } else {
+        // HadoopFSUtils.getStorageConfWithCopy returns a Serializable StorageConfiguration; the
+        // closure captures only storageConf, so Spark's ClosureCleaner can serialize it cleanly.
+        // HadoopFSUtils.getFs internally calls prepareHadoopConf, preserving HOODIE_ENV_* (e.g.
+        // S3A) injection at cloud DCs.
+        val storageConf = HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration())
+        val outcomes = jsc.parallelize(filesToCheck, Math.max(1, rollbackParallelism))
+          .map { pathStr =>
+            val p = new Path(pathStr)
+            try {
+              val exists = HadoopFSUtils.getFs(p, storageConf.unwrap()).exists(p)
+              val status: AuditFileStatus = if (exists) Present else Absent
+              (pathStr, status)
+            } catch {
+              case e: Exception => (pathStr, IndeterminateError(e.getMessage))
+            }
+          }
+          .collect()
+          .asScala
+          .toArray
+
+        val present = outcomes.collect { case (p, Present) => p }
+        val indeterminate = outcomes.collect { case (p, IndeterminateError(msg)) => (p, msg) }
+        if (present.nonEmpty) {
+          logError(s"Restore audit FAILED for instant ${restoreInstant.requestedTime()}: " +
+            s"${present.length} file(s) still present, e.g. ${present.take(5).mkString(", ")}")
+          "FAILED"
+        } else if (indeterminate.nonEmpty) {
+          logWarning(s"Restore audit INCONCLUSIVE for instant ${restoreInstant.requestedTime()}: " +
+            s"${indeterminate.length} file(s) had IO errors, e.g. ${indeterminate.take(5).mkString(", ")}")
+          "INCONCLUSIVE"
+        } else {
+          logInfo(s"Restore audit PASSED for instant ${restoreInstant.requestedTime()}: " +
+            s"${outcomes.length} file(s) confirmed absent.")
+          "PASSED"
+        }
+      }
+    } catch {
+      case e: Exception =>
+        logError(s"Exception during restore audit for instant ${restoreInstant.requestedTime()}", e)
+        "INCONCLUSIVE"
+    }
+  }
+
+  override def build: Procedure = new RestoreToInstantProcedure()
+}
+
+object RestoreToInstantProcedure {
+  val NAME: String = "restore_to_instant"
+
+  def builder: Supplier[ProcedureBuilder] = new Supplier[ProcedureBuilder] {
+    override def get(): RestoreToInstantProcedure = new RestoreToInstantProcedure()
+  }
+
+  // ADT for per-file audit outcomes. Defined at object level (NOT inside auditPostRestore) so the
+  // generated bytecode does not embed a synthetic outer-class reference; otherwise Spark's
+  // ClosureCleaner cannot serialize the closure that returns these values from executors.
+  private sealed trait AuditFileStatus extends Serializable
+  private case object Absent extends AuditFileStatus
+  private case object Present extends AuditFileStatus
+  private case class IndeterminateError(message: String) extends AuditFileStatus
+}

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RestoreToInstantProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RestoreToInstantProcedure.scala
@@ -50,19 +50,19 @@ import scala.collection.JavaConverters._
  *   - table / path: identifies the Hudi table (one must be provided)
  *   - instant_time: target commit to restore to (required when audit_only=false; must be omitted
  *                   when audit_only=true)
- *   - restore_instant_time: the restore operation's own timeline timestamp (the start_restore_time
+ *   - start_restore_time: the restore operation's own timeline timestamp (the start_restore_time
  *                   value returned by a prior restore_to_instant call). Required when
  *                   audit_only=true; must be omitted otherwise.
  *   - enable_metadata: whether the metadata table is enabled (default: true)
  *   - rollback_parallelism: Spark parallelism for rollback and audit operations (default: 4)
  *   - enable_consistency_guard: enable consistency guard for file existence checks (default: false)
- *   - audit_post_restore: after restoring, verify that all rolled-back files are absent (default: false)
+ *   - audit_post_restore: after restoring, verify that all successfully-deleted files are absent (default: false)
  *   - audit_only: skip the restore and only audit a previously completed restore instant (default: false)
  *
  * Output columns:
  *   - restore_result: true if restore succeeded; null if audit_only=true
  *   - start_restore_time: the restore operation's own timeline timestamp; null if audit_only=true.
- *                         Save this value to use as restore_instant_time for a subsequent audit_only call.
+ *                         Pass this value as start_restore_time to re-run the audit later.
  *   - time_taken_in_millis: restore duration; null if audit_only=true
  *   - instants_rolled_back: number of commits rolled back; null if audit_only=true
  *   - audit_result: one of "PASSED" / "FAILED" / "INCONCLUSIVE" when an audit ran; null otherwise.
@@ -80,7 +80,7 @@ class RestoreToInstantProcedure extends BaseProcedure with ProcedureBuilder with
     ProcedureParameter.optional(5, "audit_post_restore", DataTypes.BooleanType, false),
     ProcedureParameter.optional(6, "audit_only", DataTypes.BooleanType, false),
     ProcedureParameter.optional(7, "path", DataTypes.StringType),
-    ProcedureParameter.optional(8, "restore_instant_time", DataTypes.StringType)
+    ProcedureParameter.optional(8, "start_restore_time", DataTypes.StringType)
   )
 
   private val OUTPUT_TYPE = new StructType(Array[StructField](
@@ -106,24 +106,24 @@ class RestoreToInstantProcedure extends BaseProcedure with ProcedureBuilder with
     val shouldAuditPostRestore = getArgValueOrDefault(args, PARAMETERS(5)).get.asInstanceOf[Boolean]
     val auditOnly = getArgValueOrDefault(args, PARAMETERS(6)).get.asInstanceOf[Boolean]
     val tablePath = getArgValueOrDefault(args, PARAMETERS(7))
-    val restoreInstantTime = getArgValueOrDefault(args, PARAMETERS(8))
+    val startRestoreTimeArg = getArgValueOrDefault(args, PARAMETERS(8))
 
-    // Cross-validation: each of (instant_time, restore_instant_time) has one unambiguous meaning.
+    // Cross-validation: each of (instant_time, start_restore_time) has one unambiguous meaning.
     if (!auditOnly && instantTime.isEmpty) {
       throw new HoodieException("instant_time is required when audit_only=false.")
     }
-    if (auditOnly && restoreInstantTime.isEmpty) {
+    if (auditOnly && startRestoreTimeArg.isEmpty) {
       throw new HoodieException(
-        "restore_instant_time is required when audit_only=true. " +
+        "start_restore_time is required when audit_only=true. " +
           "Pass the start_restore_time value from a prior restore_to_instant call.")
     }
-    if (!auditOnly && restoreInstantTime.isDefined) {
-      throw new HoodieException("restore_instant_time may only be specified when audit_only=true.")
+    if (!auditOnly && startRestoreTimeArg.isDefined) {
+      throw new HoodieException("start_restore_time may only be specified when audit_only=true.")
     }
     if (auditOnly && instantTime.isDefined) {
       throw new HoodieException(
         "instant_time may only be specified when audit_only=false. " +
-          "Use restore_instant_time to identify a previously executed restore.")
+          "Use start_restore_time to identify a previously executed restore.")
     }
     if (auditOnly && shouldAuditPostRestore) {
       logWarning("Both audit_only and audit_post_restore are set. Only audit_only will be honored.")
@@ -151,12 +151,14 @@ class RestoreToInstantProcedure extends BaseProcedure with ProcedureBuilder with
       try {
         client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, confs,
           tableName.asInstanceOf[Option[String]])
-        // restoreToInstant either returns non-null HoodieRestoreMetadata or throws HoodieRestoreException.
-        // Restoring to a target before the MDT's penultimate / oldest compaction (or before the MDT
-        // timeline start) would otherwise leave the MDT inconsistent during finishRestore;
-        // BaseHoodieWriteClient.restoreToInstant invokes the centralized helper to pre-emptively
-        // delete the MDT in those cases.
-        val restoreMetadata = client.restoreToInstant(targetInstant, enableMetadata)
+        // Pre-check: if the target instant is at or before the penultimate/oldest MDT compaction,
+        // pre-emptively delete the MDT so restoreToInstant does not leave it inconsistent.
+        // deleteMetadataTableIfNecessaryBeforeRestore returns false when the MDT was deleted
+        // (caller must not re-initialize it), true otherwise.
+        val shouldInitMdt = if (enableMetadata) {
+          client.deleteMetadataTableIfNecessaryBeforeRestore(targetInstant)
+        } else true
+        val restoreMetadata = client.restoreToInstant(targetInstant, shouldInitMdt && enableMetadata)
         restoreResult = true
         startRestoreTime = restoreMetadata.getStartRestoreTime
         timeTakenInMillis = restoreMetadata.getTimeTakenInMillis
@@ -178,19 +180,22 @@ class RestoreToInstantProcedure extends BaseProcedure with ProcedureBuilder with
     var auditResult: String = null
     if (auditOnly || shouldAuditPostRestore) {
       val restoreInstant: HoodieInstant = if (auditOnly) {
-        val ts = restoreInstantTime.get.asInstanceOf[String]
+        val ts = startRestoreTimeArg.get.asInstanceOf[String]
         val instants = metaClient.getActiveTimeline.getRestoreTimeline.filterCompletedInstants
           .getInstants.asScala
         instants.find(_.requestedTime().equals(ts)).getOrElse(
           throw new HoodieException(s"No completed restore instant found for $ts. " +
-            "Pass the start_restore_time from a prior restore_to_instant call as restore_instant_time.")
+            "Pass the start_restore_time from a prior restore_to_instant call as start_restore_time.")
         )
       } else {
-        val lastOpt = metaClient.getActiveTimeline.getRestoreTimeline.filterCompletedInstants.lastInstant
-        if (!lastOpt.isPresent) {
-          throw new HoodieException("No completed restore instant found on timeline after restore.")
-        }
-        lastOpt.get()
+        // Use startRestoreTime captured from the restore metadata — more deterministic than
+        // lastInstant() since another concurrent restore could otherwise land in between.
+        val ts = startRestoreTime
+        val instants = metaClient.getActiveTimeline.getRestoreTimeline.filterCompletedInstants
+          .getInstants.asScala
+        instants.find(_.requestedTime().equals(ts)).getOrElse(
+          throw new HoodieException(s"No completed restore instant found for $ts after restore.")
+        )
       }
       auditResult = auditPostRestore(metaClient, basePath, restoreInstant, rollbackParallelism)
     }
@@ -227,9 +232,10 @@ class RestoreToInstantProcedure extends BaseProcedure with ProcedureBuilder with
             } else {
               // Use .toString() to preserve the full absolute path. Using .getName() would strip
               // the path to just the filename, making the subsequent FS.exists() check vacuously pass.
+              // Only check getSuccessDeleteFiles: these are the files the restore intended to delete
+              // and whose absence we can meaningfully verify. Files in getFailedDeleteFiles already
+              // failed to be deleted and are expected to still be present.
               pm.getSuccessDeleteFiles.asScala.foreach(f =>
-                filesToCheck.add(new Path(partitionPathStr, f).toString))
-              pm.getFailedDeleteFiles.asScala.foreach(f =>
                 filesToCheck.add(new Path(partitionPathStr, f).toString))
             }
           }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RestoreToInstantProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RestoreToInstantProcedure.scala
@@ -151,14 +151,14 @@ class RestoreToInstantProcedure extends BaseProcedure with ProcedureBuilder with
       try {
         client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, confs,
           tableName.asInstanceOf[Option[String]])
-        // Pre-check: if the target instant is at or before the penultimate/oldest MDT compaction,
-        // pre-emptively delete the MDT so restoreToInstant does not leave it inconsistent.
-        // deleteMetadataTableIfNecessaryBeforeRestore returns false when the MDT was deleted
-        // (caller must not re-initialize it), true otherwise.
-        val shouldInitMdt = if (enableMetadata) {
-          client.deleteMetadataTableIfNecessaryBeforeRestore(targetInstant)
-        } else true
-        val restoreMetadata = client.restoreToInstant(targetInstant, shouldInitMdt && enableMetadata)
+        // Pre-check: if the target instant is at or before the oldest MDT compaction or before the
+        // MDT timeline start, pre-emptively delete the MDT so restoreToInstant does not leave it
+        // inconsistent. deleteMdtIfNecessaryBeforeRestore returns true when the MDT was deleted
+        // (caller must not re-initialize it), false otherwise.
+        val mdtDeleted = if (enableMetadata) {
+          client.deleteMdtIfNecessaryBeforeRestore(targetInstant)
+        } else false
+        val restoreMetadata = client.restoreToInstant(targetInstant, !mdtDeleted && enableMetadata)
         restoreResult = true
         startRestoreTime = restoreMetadata.getStartRestoreTime
         timeTakenInMillis = restoreMetadata.getTimeTakenInMillis

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRestoreProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRestoreProcedure.scala
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.procedure
+
+class TestRestoreProcedure extends HoodieSparkProcedureTestBase {
+
+  private def createTableAndInsertData(tableName: String, tablePath: String, tableType: String = "cow"): Array[String] = {
+    spark.sql(
+      s"""
+         |create table $tableName (
+         |  id int,
+         |  name string,
+         |  price double,
+         |  ts long
+         |) using hudi
+         | location '$tablePath'
+         | tblproperties (
+         |  primaryKey = 'id',
+         |  preCombineField = 'ts',
+         |  type = '$tableType'
+         | )
+       """.stripMargin)
+    spark.sql(s"insert into $tableName select 1, 'a1', 10.0, 1000")
+    spark.sql(s"insert into $tableName select 2, 'a2', 20.0, 1500")
+    spark.sql(s"insert into $tableName select 3, 'a3', 30.0, 2000")
+    spark.sql(s"insert into $tableName select 4, 'a4', 40.0, 2500")
+    spark.sql(s"call show_commits(table => '$tableName')").collect()
+      .map(_.getString(0)).sorted
+  }
+
+  test("Test restore_to_instant basic CoW") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      val commits = createTableAndInsertData(tableName, tablePath)
+      assertResult(4)(commits.length)
+
+      // restore to after the 2nd commit — only commits(0) and commits(1) should remain
+      val result = spark.sql(
+        s"call restore_to_instant(table => '$tableName', instant_time => '${commits(1)}')"
+      ).collect()
+
+      assertResult(1)(result.length)
+      assertResult(true)(result(0).getBoolean(0))     // restore_result
+      assert(result(0).getString(1) != null)          // start_restore_time (dynamic timestamp)
+      assert(result(0).getLong(2) >= 0)               // time_taken_in_millis
+      assert(result(0).getLong(3) >= 0L)              // instants_rolled_back
+      assertResult(true)(result(0).isNullAt(4))       // audit_result = null (audit not requested)
+
+      // verify data reverted to 2 records
+      val count = spark.sql(s"select count(*) from $tableName").collect()(0).getLong(0)
+      assertResult(2)(count)
+    }
+  }
+
+  test("Test restore_to_instant basic MoR") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      val commits = createTableAndInsertData(tableName, tablePath, tableType = "mor")
+      assertResult(4)(commits.length)
+
+      val result = spark.sql(
+        s"call restore_to_instant(table => '$tableName', instant_time => '${commits(1)}')"
+      ).collect()
+
+      assertResult(1)(result.length)
+      assertResult(true)(result(0).getBoolean(0))
+      assert(result(0).getString(1) != null)
+      assert(result(0).getLong(2) >= 0)
+      assert(result(0).getLong(3) >= 0L)
+      assertResult(true)(result(0).isNullAt(4))
+
+      val count = spark.sql(s"select count(*) from $tableName").collect()(0).getLong(0)
+      assertResult(2)(count)
+    }
+  }
+
+  test("Test restore_to_instant using path parameter") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      val commits = createTableAndInsertData(tableName, tablePath)
+      assertResult(4)(commits.length)
+
+      val result = spark.sql(
+        s"call restore_to_instant(path => '$tablePath', instant_time => '${commits(1)}')"
+      ).collect()
+
+      assertResult(1)(result.length)
+      assertResult(true)(result(0).getBoolean(0))
+      assert(result(0).isNullAt(4))
+
+      val count = spark.sql(s"select count(*) from $tableName").collect()(0).getLong(0)
+      assertResult(2)(count)
+    }
+  }
+
+  test("Test restore_to_instant with audit_post_restore") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      val commits = createTableAndInsertData(tableName, tablePath)
+      assertResult(4)(commits.length)
+
+      val result = spark.sql(
+        s"""call restore_to_instant(
+           |  table => '$tableName',
+           |  instant_time => '${commits(1)}',
+           |  audit_post_restore => true
+           |)""".stripMargin
+      ).collect()
+
+      assertResult(1)(result.length)
+      assertResult(true)(result(0).getBoolean(0))     // restore_result
+      assert(result(0).getString(1) != null)          // start_restore_time
+      // audit_result should be "PASSED": all rolled-back files are absent
+      assertResult(false)(result(0).isNullAt(4))
+      assertResult("PASSED")(result(0).getString(4))
+
+      val count = spark.sql(s"select count(*) from $tableName").collect()(0).getLong(0)
+      assertResult(2)(count)
+    }
+  }
+
+  test("Test restore_to_instant audit_only mode") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      val commits = createTableAndInsertData(tableName, tablePath)
+      assertResult(4)(commits.length)
+
+      // Round 1: perform the restore and capture the restore operation's own timeline timestamp
+      val restoreRows = spark.sql(
+        s"call restore_to_instant(table => '$tableName', instant_time => '${commits(1)}')"
+      ).collect()
+      assertResult(true)(restoreRows(0).getBoolean(0))
+      // start_restore_time is the restore instant's timeline timestamp — NOT commits(1)
+      val restoreInstantTs = restoreRows(0).getString(1)
+      assert(restoreInstantTs != null)
+      assert(restoreInstantTs != commits(1))
+
+      // Round 2: audit_only using restore_instant_time (the original target commit is not needed)
+      val auditRows = spark.sql(
+        s"""call restore_to_instant(
+           |  table => '$tableName',
+           |  audit_only => true,
+           |  restore_instant_time => '$restoreInstantTs'
+           |)""".stripMargin
+      ).collect()
+
+      assertResult(1)(auditRows.length)
+      assertResult(true)(auditRows(0).isNullAt(0))    // restore_result = null (no restore performed)
+      assertResult(true)(auditRows(0).isNullAt(1))    // start_restore_time = null
+      assertResult(true)(auditRows(0).isNullAt(2))    // time_taken_in_millis = null
+      assertResult(true)(auditRows(0).isNullAt(3))    // instants_rolled_back = null
+      assertResult(false)(auditRows(0).isNullAt(4))   // audit_result is present
+      assertResult("PASSED")(auditRows(0).getString(4))
+    }
+  }
+
+  test("Test restore_to_instant audit_only with non-existent restore instant throws") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      createTableAndInsertData(tableName, tablePath)
+
+      // restore_instant_time pointing at a timestamp that has never been a restore instant.
+      assertThrows[Exception] {
+        spark.sql(
+          s"""call restore_to_instant(
+             |  table => '$tableName',
+             |  audit_only => true,
+             |  restore_instant_time => '19700101000000000'
+             |)""".stripMargin
+        ).collect()
+      }
+    }
+  }
+
+  test("Test restore_to_instant cross-validation: audit_only=true requires restore_instant_time") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      createTableAndInsertData(tableName, tablePath)
+
+      assertThrows[Exception] {
+        spark.sql(
+          s"call restore_to_instant(table => '$tableName', audit_only => true)"
+        ).collect()
+      }
+    }
+  }
+
+  test("Test restore_to_instant cross-validation: audit_only=false rejects restore_instant_time") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      val commits = createTableAndInsertData(tableName, tablePath)
+
+      assertThrows[Exception] {
+        spark.sql(
+          s"""call restore_to_instant(
+             |  table => '$tableName',
+             |  instant_time => '${commits(1)}',
+             |  restore_instant_time => '20990101000000000'
+             |)""".stripMargin
+        ).collect()
+      }
+    }
+  }
+
+  test("Test restore_to_instant cross-validation: audit_only=true rejects instant_time") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      val commits = createTableAndInsertData(tableName, tablePath)
+
+      assertThrows[Exception] {
+        spark.sql(
+          s"""call restore_to_instant(
+             |  table => '$tableName',
+             |  audit_only => true,
+             |  instant_time => '${commits(1)}',
+             |  restore_instant_time => '20990101000000000'
+             |)""".stripMargin
+        ).collect()
+      }
+    }
+  }
+
+  test("Test restore_to_instant cross-validation: audit_only=false requires instant_time") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath + "/" + tableName
+      createTableAndInsertData(tableName, tablePath)
+
+      assertThrows[Exception] {
+        spark.sql(s"call restore_to_instant(table => '$tableName')").collect()
+      }
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRestoreProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRestoreProcedure.scala
@@ -155,12 +155,12 @@ class TestRestoreProcedure extends HoodieSparkProcedureTestBase {
       assert(restoreInstantTs != null)
       assert(restoreInstantTs != commits(1))
 
-      // Round 2: audit_only using restore_instant_time (the original target commit is not needed)
+      // Round 2: audit_only using start_restore_time (the original target commit is not needed)
       val auditRows = spark.sql(
         s"""call restore_to_instant(
            |  table => '$tableName',
            |  audit_only => true,
-           |  restore_instant_time => '$restoreInstantTs'
+           |  start_restore_time => '$restoreInstantTs'
            |)""".stripMargin
       ).collect()
 
@@ -180,20 +180,20 @@ class TestRestoreProcedure extends HoodieSparkProcedureTestBase {
       val tablePath = tmp.getCanonicalPath + "/" + tableName
       createTableAndInsertData(tableName, tablePath)
 
-      // restore_instant_time pointing at a timestamp that has never been a restore instant.
+      // start_restore_time pointing at a timestamp that has never been a restore instant.
       assertThrows[Exception] {
         spark.sql(
           s"""call restore_to_instant(
              |  table => '$tableName',
              |  audit_only => true,
-             |  restore_instant_time => '19700101000000000'
+             |  start_restore_time => '19700101000000000'
              |)""".stripMargin
         ).collect()
       }
     }
   }
 
-  test("Test restore_to_instant cross-validation: audit_only=true requires restore_instant_time") {
+  test("Test restore_to_instant cross-validation: audit_only=true requires start_restore_time") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val tablePath = tmp.getCanonicalPath + "/" + tableName
@@ -207,7 +207,7 @@ class TestRestoreProcedure extends HoodieSparkProcedureTestBase {
     }
   }
 
-  test("Test restore_to_instant cross-validation: audit_only=false rejects restore_instant_time") {
+  test("Test restore_to_instant cross-validation: audit_only=false rejects start_restore_time") {
     withTempDir { tmp =>
       val tableName = generateTableName
       val tablePath = tmp.getCanonicalPath + "/" + tableName
@@ -218,7 +218,7 @@ class TestRestoreProcedure extends HoodieSparkProcedureTestBase {
           s"""call restore_to_instant(
              |  table => '$tableName',
              |  instant_time => '${commits(1)}',
-             |  restore_instant_time => '20990101000000000'
+             |  start_restore_time => '20990101000000000'
              |)""".stripMargin
         ).collect()
       }
@@ -237,7 +237,7 @@ class TestRestoreProcedure extends HoodieSparkProcedureTestBase {
              |  table => '$tableName',
              |  audit_only => true,
              |  instant_time => '${commits(1)}',
-             |  restore_instant_time => '20990101000000000'
+             |  start_restore_time => '20990101000000000'
              |)""".stripMargin
         ).collect()
       }


### PR DESCRIPTION
Adds a Spark SQL stored procedure that performs a point-in-time table restore to any instant on the active timeline, with optional post-restore file-existence audit. 

### Describe the issue this Pull Request addresses

OSS Hudi today has no CLI or SQL surface for arbitrary point-in-time table restore. The existing options are:

- **`rollback_to_savepoint`** Spark SQL procedure / `savepoint rollback` CLI command — restores to a savepoint, but requires that a savepoint already exist at the target instant.
- **`rollback_to_instant_time`** Spark SQL procedure — rolls back a single commit, not a full point-in-time restore.
- **`hudi-cli`'s `RestoresCommand`** — read-only inspection (`show restores` / `show restore`) of past restore operations.
- **`SparkRDDWriteClient.restoreToInstant(...)`** Java API — exists but has no user-facing surface; users must write custom Java/Scala code to invoke it.

Restoring to an arbitrary commit on the active timeline therefore requires either creating a savepoint first (often impossible — the issue is usually discovered after the fact) or writing custom code against the write-client API.

This PR adds a `restore_to_instant` Spark SQL stored procedure so users can perform point-in-time restores directly from SQL: `CALL restore_to_instant(table => '...', instant_time => '...')`. It also includes an optional post-restore audit that verifies all rolled-back files are absent from storage — useful as a confidence check after restores against object stores where eventual consistency could mask problems.

Along the way, this PR also fixes a latent correctness bug in `BaseHoodieWriteClient.restoreToSavepoint`: the existing inline MDT pre-check only triggered an MDT delete when the savepoint was at or before the *oldest* completed MDT compaction, missing the case where the target falls between the penultimate and oldest compactions — which would leave the MDT inconsistent during `finishRestore`. Both `restoreToSavepoint` and the new `restoreToInstant` flow now share a single pre-check helper that handles this correctly.

---

### Summary and Changelog

**User-facing summary:** Adds the `restore_to_instant` Spark SQL stored procedure for point-in-time table restore on any active-timeline instant, with an optional audit mode for post-restore file verification.

**Detailed changelog:**

1. **New procedure: `restore_to_instant`** (`hudi-spark-datasource/hudi-spark/.../RestoreToInstantProcedure.scala`)
   - Parameters: `table` / `path`, `instant_time`, `enable_metadata`, `rollback_parallelism`, `enable_consistency_guard`, `audit_post_restore`, `audit_only`, `restore_instant_time`.
   - Output columns: `restore_result` (Boolean), `start_restore_time` (String — the restore operation's own timeline timestamp), `time_taken_in_millis` (Long), `instants_rolled_back` (Long), `audit_result` (String — see below).
   - Three modes selected via parameter cross-validation:
     - **Restore only** (default): performs the restore, returns metadata.
     - **Restore + audit** (`audit_post_restore=true`): performs the restore, then verifies all rolled-back files are absent from storage.
     - **Audit only** (`audit_only=true`): skips the restore and audits a previously completed restore identified by `restore_instant_time`. Useful for re-running an audit days after the original restore — no need to remember the target commit.
   - The audit returns a tri-state `audit_result`: `PASSED` (all expected-deleted files confirmed absent), `FAILED` (at least one file is still present), or `INCONCLUSIVE` (no `Present` outcome but at least one file existence check threw an `IOException` — re-run with `audit_only=true` to retry). This avoids a pattern where a transient cloud-storage timeout is indistinguishable from a real audit failure.

2. **Centralized MDT pre-check helper** (`hudi-client/hudi-client-common/.../BaseHoodieWriteClient.java`)
   - New `protected boolean shouldDeleteMdtBeforeRestore(String targetInstant)` method. Returns `true` when restoring to `targetInstant` would leave the MDT inconsistent — specifically when the target is at or before the MDT's penultimate completed compaction (≥2 compactions present), at or before the oldest completed compaction, or before the MDT timeline start.
   - `restoreToSavepoint` refactored to call the helper instead of inlining the check. **Behavior change:** the previous inline check only handled the oldest-compaction and timeline-start cases, and silently swallowed every `Exception` (including permission-denied / IO failures) with the comment "Metadata directory does not exist." The new helper now also catches the penultimate-compaction case (a correctness fix), and IO/permission failures surface as `HoodieException` instead of being swallowed. Missing-MDT still returns false silently as before.
   - `restoreToInstant` extended to invoke the helper before scheduling the restore plan, so callers reaching restore via `restoreToInstant` directly (including the new procedure) get the same MDT-integrity guarantee. The check is gated on `initialMetadataTableIfNecessary` so callers that have explicitly opted out of MDT integration are not affected.

3. **Procedure registration** (`hudi-spark-datasource/hudi-spark/.../HoodieProcedures.scala`): one-line addition.

4. **Tests added:**
   - `TestRestoreProcedure.scala` (10 tests): basic CoW, basic MoR, `path` parameter, `audit_post_restore`, `audit_only` mode, `audit_only` with non-existent restore instant, plus 4 cross-validation guards (`audit_only=true` requires `restore_instant_time`; `audit_only=false` rejects `restore_instant_time`; `audit_only=true` rejects `instant_time`; `audit_only=false` requires `instant_time`).
   - `TestSavepointRestoreCopyOnWrite.java` extended (3 tests): `testRestoreToInstantSkipsMdtCheckWhenMetadataDisabled` (guard verification), `testRestoreToInstantDeletesMdtWhenTargetIsBeforePenultimateCompaction` (penultimate-trigger coverage), `testRestoreToSavepointStillWorksAfterRefactor` (regression for the existing `restoreToSavepoint` path).

---

### Impact

**Public API additions:**
- New stored procedure `restore_to_instant` (callable from Spark SQL).
- New protected method `BaseHoodieWriteClient.shouldDeleteMdtBeforeRestore(String)` — visible to subclasses of `BaseHoodieWriteClient` only.

**Behavior changes (user-visible):**
- `restoreToSavepoint` is now slightly stricter: it deletes the MDT pre-emptively when the savepoint target is at or before the **penultimate** completed MDT compaction, not just the oldest. This is a correctness fix — the previous behavior left the MDT inconsistent during `finishRestore` in that range.
- `restoreToSavepoint` now propagates `HoodieException` if the MDT pre-check fails with an `IOException` (e.g. permission denied, network failure). Previously, every `Exception` from the MDT inspection was silently swallowed under the assumption that the MDT directory was missing. Callers that previously observed the silent swallow on broken-MDT scenarios will now see a clear failure.

**Performance:** No measurable impact on the restore path. The helper makes one storage `exists` check and at most one `HoodieTableMetaClient` build for the MDT path, mirroring what the inline check already did.

---

### Risk Level

**Medium.**

The risk surface is the change to `BaseHoodieWriteClient.restoreToSavepoint` semantics: a long-standing code path used across all engines now (a) triggers an extra MDT delete in the penultimate-compaction edge case and (b) propagates IO failures it previously swallowed. Any caller that depended on the broader silent-swallow will see new exceptions; any caller that restored to a savepoint between the oldest and penultimate MDT compactions will now incur an MDT rebuild. Both changes are intentional correctness fixes, but they are visible to existing users of `restoreToSavepoint`.

**Verification performed:**
- `mvn compile` clean for both `hudi-client/hudi-client-common` and `hudi-spark-datasource/hudi-spark`, including all scalastyle import-order checks.
- `TestRestoreProcedure`: 10 / 10 tests passed (1 m 3 s).
- Procedure regression suite (`TestRestoreProcedure` + `TestSavepointsProcedure` + `TestRunRollbackInflightTableServiceProcedure`): 19 / 19 tests passed across 6 suites (1 m 55 s) — confirms the `restoreToSavepoint` refactor preserves all existing savepoint-procedure behavior.
- New write-client integration tests in `TestSavepointRestoreCopyOnWrite.java` exercise the helper guard, the penultimate-compaction trigger, and a regression case for `restoreToSavepoint`. CI will exercise these directly.

---

### Documentation Update

The Hudi website's stored-procedures page needs a new entry for `restore_to_instant` documenting its parameters, output columns, and the three modes (restore-only / restore-with-audit / audit-only), including the `audit_result` tri-state semantics. Will follow up with a website PR per the [instruction](https://hudi.apache.org/contribute/developer-setup#website) once this PR's API surface is approved.

No new configs added; no existing config defaults changed.

---

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable