### PR TITLE
fix(flink): Fix reflection ctor signature for AwsGlueCatalogSyncTool in HiveSyncContext

### DIFF
--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAwsGlueSyncTool.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAwsGlueSyncTool.java
@@ -21,9 +21,11 @@ package org.apache.hudi.aws.sync;
 import org.apache.hudi.aws.testutils.GlueTestUtil;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.sync.common.HoodieSyncTool;
 import org.apache.hudi.sync.common.util.SyncUtilHelpers;
 
+import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +40,7 @@ import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import static org.apache.hudi.aws.testutils.GlueTestUtil.getHadoopConf;
 import static org.apache.hudi.aws.testutils.GlueTestUtil.glueSyncProps;
@@ -103,6 +106,34 @@ class TestAwsGlueSyncTool {
           Option.empty());
       assertTrue(syncTool instanceof AwsGlueCatalogSyncTool);
       syncTool.close();
+    }
+  }
+
+  /**
+   * Verifies the 3-arg {@code (Properties, Configuration, Option)} reflection path used by Flink's
+   * {@code HiveSyncContext#hiveSyncTool()} can fully instantiate {@link AwsGlueCatalogSyncTool}.
+   */
+  @Test
+  void validateInitThroughHiveSyncContextReflectionSignature() throws Exception {
+    try (MockedStatic<GlueAsyncClient> mockedStatic = mockStatic(GlueAsyncClient.class);
+         MockedStatic<StsClient> mockedStsStatic = mockStatic(StsClient.class)) {
+      GlueAsyncClientBuilder builder = mock(GlueAsyncClientBuilder.class);
+      mockedStatic.when(GlueAsyncClient::builder).thenReturn(builder);
+      when(builder.credentialsProvider(any())).thenReturn(builder);
+      GlueAsyncClient mockClient = mock(GlueAsyncClient.class);
+      when(builder.build()).thenReturn(mockClient);
+      StsClient mockSts = mock(StsClient.class);
+      mockedStsStatic.when(StsClient::create).thenReturn(mockSts);
+      when(mockSts.getCallerIdentity(GetCallerIdentityRequest.builder().build()))
+          .thenReturn(GetCallerIdentityResponse.builder().account("").build());
+
+      Object syncTool = ReflectionUtils.loadClass(
+          AwsGlueCatalogSyncTool.class.getName(),
+          new Class<?>[] {Properties.class, Configuration.class, Option.class},
+          glueSyncProps, getHadoopConf(), Option.empty());
+      assertTrue(syncTool instanceof AwsGlueCatalogSyncTool,
+          "Reflection through the HiveSyncContext signature must yield an AwsGlueCatalogSyncTool instance");
+      ((AwsGlueCatalogSyncTool) syncTool).close();
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
@@ -19,6 +19,8 @@
 package org.apache.hudi.sink.utils;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
@@ -78,8 +80,8 @@ public class HiveSyncContext {
     HiveSyncMode syncMode = HiveSyncMode.of(props.getProperty(HIVE_SYNC_MODE.key()));
     if (syncMode == HiveSyncMode.GLUE) {
       return ((HiveSyncTool) ReflectionUtils.loadClass(AWS_GLUE_CATALOG_SYNC_TOOL_CLASS,
-          new Class<?>[] {Properties.class, org.apache.hadoop.conf.Configuration.class},
-          props, hiveConf));
+          new Class<?>[] {Properties.class, org.apache.hadoop.conf.Configuration.class, Option.class},
+          props, hiveConf, Option.<HoodieTableMetaClient>empty()));
     }
     return new HiveSyncTool(props, hiveConf);
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestHiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestHiveSyncContext.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.sink.utils;
 
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.hive.HiveSyncConfig;
 
@@ -65,5 +67,19 @@ public class TestHiveSyncContext {
     configuration3.setString(HiveSyncConfig.HIVE_CREATE_MANAGED_TABLE.key(), "true");
     Properties props3 = HiveSyncContext.buildSyncConfig(configuration3);
     assertTrue(Boolean.parseBoolean(props3.getProperty(HiveSyncConfig.HIVE_CREATE_MANAGED_TABLE.key(), "false")));
+  }
+
+  /**
+   * Pins the constructor signature {@link HiveSyncContext#hiveSyncTool()} relies on via reflection.
+   * End-to-end instantiation is covered in {@code hudi-aws}'s {@code TestAwsGlueSyncTool}.
+   */
+  @Test
+  void testAwsGlueSyncToolReflectionConstructorExists() {
+    assertTrue(
+        ReflectionUtils.hasConstructor(
+            HiveSyncContext.AWS_GLUE_CATALOG_SYNC_TOOL_CLASS,
+            new Class<?>[] {Properties.class, org.apache.hadoop.conf.Configuration.class, Option.class}),
+        "AwsGlueCatalogSyncTool must expose the constructor used by HiveSyncContext#hiveSyncTool() "
+            + "via reflection; otherwise Flink GLUE sync fails with NoSuchMethodException.");
   }
 }


### PR DESCRIPTION

### Describe the issue this Pull Request addresses

Closes #18673.

Flink GLUE sync fails at runtime with `NoSuchMethodException` because
`HiveSyncContext#hiveSyncTool()` loads `AwsGlueCatalogSyncTool` via
reflection using a 2-arg signature `(Properties, Configuration)`, while
the actual constructor is now 3-arg
`(Properties, Configuration, Option<HoodieTableMetaClient>)`.

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

- Align the reflection call in `HiveSyncContext#hiveSyncTool()` with the
  current `AwsGlueCatalogSyncTool` constructor: add `Option.class` to
  the parameter types and pass `Option.<HoodieTableMetaClient>empty()`.

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

No public API or user-facing change. 

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level
low

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update
none

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
