### PR TITLE
fix: #18691 Honor IF NOT EXISTS when creating indexes

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/HoodieSparkIndexClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/HoodieSparkIndexClient.java
@@ -167,9 +167,11 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
     String fullIndexName = indexType.equals(PARTITION_NAME_SECONDARY_INDEX)
         ? PARTITION_NAME_SECONDARY_INDEX_PREFIX + userIndexName
         : PARTITION_NAME_EXPRESSION_INDEX_PREFIX + userIndexName;
-    if (indexExists(metaClient, fullIndexName) && ignoreIfExists) {
-      log.info("Index {} already exists. Skipping creation.", userIndexName);
-      return;
+    if (indexExists(metaClient, fullIndexName)) {
+      if (ignoreIfExists) {
+        log.info("Index {} already exists. Skipping creation.", userIndexName);
+        return;
+      }
     }
 
     HoodieIndexDefinition indexDefinition = HoodieIndexUtils.getSecondaryOrExpressionIndexDefinition(metaClient, userIndexName, indexType, columns, options, tableProperties);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/HoodieSparkIndexClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/HoodieSparkIndexClient.java
@@ -63,8 +63,10 @@ import static org.apache.hudi.index.HoodieIndexUtils.indexExists;
 import static org.apache.hudi.index.HoodieIndexUtils.register;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault;
 
 @Slf4j
@@ -92,21 +94,31 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
   @Override
   public void create(HoodieTableMetaClient metaClient, String userIndexName, String indexType, Map<String, Map<String, String>> columns, Map<String, String> options,
                      Map<String, String> tableProperties) throws Exception {
+    create(metaClient, userIndexName, indexType, columns, options, tableProperties, false);
+  }
+
+  public void create(HoodieTableMetaClient metaClient, String userIndexName, String indexType, Map<String, Map<String, String>> columns, Map<String, String> options,
+                     Map<String, String> tableProperties, boolean ignoreIfExists) throws Exception {
     if (indexType.equals(PARTITION_NAME_SECONDARY_INDEX) || indexType.equals(PARTITION_NAME_BLOOM_FILTERS)
         || indexType.equals(PARTITION_NAME_COLUMN_STATS)) {
-      createExpressionOrSecondaryIndex(metaClient, userIndexName, indexType, columns, options, tableProperties);
+      createExpressionOrSecondaryIndex(metaClient, userIndexName, indexType, columns, options, tableProperties, ignoreIfExists);
     } else {
-      createRecordIndex(metaClient, userIndexName, indexType, options);
+      createRecordIndex(metaClient, userIndexName, indexType, options, ignoreIfExists);
     }
   }
 
-  private void createRecordIndex(HoodieTableMetaClient metaClient, String userIndexName, String indexType, Map<String, String> options) {
+  private void createRecordIndex(HoodieTableMetaClient metaClient, String userIndexName, String indexType, Map<String, String> options,
+                                 boolean ignoreIfExists) {
     if (!userIndexName.equals(PARTITION_NAME_RECORD_INDEX)) {
       throw new HoodieIndexException("Record index should be named as record_index");
     }
 
     String fullIndexName = PARTITION_NAME_RECORD_INDEX;
     if (indexExists(metaClient, fullIndexName)) {
+      if (ignoreIfExists) {
+        log.info("Index {} already exists. Skipping creation.", userIndexName);
+        return;
+      }
       throw new HoodieMetadataIndexException("Index already exists: " + userIndexName);
     }
 
@@ -150,7 +162,16 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
   }
 
   private void createExpressionOrSecondaryIndex(HoodieTableMetaClient metaClient, String userIndexName, String indexType,
-                                                Map<String, Map<String, String>> columns, Map<String, String> options, Map<String, String> tableProperties) throws Exception {
+                                                Map<String, Map<String, String>> columns, Map<String, String> options, Map<String, String> tableProperties,
+                                                boolean ignoreIfExists) throws Exception {
+    String fullIndexName = indexType.equals(PARTITION_NAME_SECONDARY_INDEX)
+        ? PARTITION_NAME_SECONDARY_INDEX_PREFIX + userIndexName
+        : PARTITION_NAME_EXPRESSION_INDEX_PREFIX + userIndexName;
+    if (indexExists(metaClient, fullIndexName) && ignoreIfExists) {
+      log.info("Index {} already exists. Skipping creation.", userIndexName);
+      return;
+    }
+
     HoodieIndexDefinition indexDefinition = HoodieIndexUtils.getSecondaryOrExpressionIndexDefinition(metaClient, userIndexName, indexType, columns, options, tableProperties);
     if (!metaClient.getTableConfig().getRelativeIndexDefinitionPath().isPresent()
         || !metaClient.getIndexForMetadataPartition(indexDefinition.getIndexName()).isPresent()) {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
@@ -62,11 +62,13 @@ case class CreateIndexCommand(table: CatalogTable,
         throw new HoodieIndexException("Column stats index without expression on any column can be created using datasource configs. " +
           "Please refer https://hudi.apache.org/docs/metadata for more info")
       }
-      new HoodieSparkIndexClient(sparkSession).create(metaClient, indexName, indexType, columnsMap, options.asJava, table.properties.asJava)
+      new HoodieSparkIndexClient(sparkSession)
+        .create(metaClient, indexName, indexType, columnsMap, options.asJava, table.properties.asJava, ignoreIfExists)
     } else if (indexName.equals(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX)) {
       ValidationUtils.checkArgument(CreateIndexCommand.matchesRecordKeys(columnsMap.keySet().asScala.toSet, metaClient.getTableConfig),
         "Input columns should match configured record key columns: " + metaClient.getTableConfig.getRecordKeyFieldProp)
-      new HoodieSparkIndexClient(sparkSession).create(metaClient, indexName, HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX, columnsMap, options.asJava, table.properties.asJava)
+      new HoodieSparkIndexClient(sparkSession)
+        .create(metaClient, indexName, HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX, columnsMap, options.asJava, table.properties.asJava, ignoreIfExists)
     } else if (StringUtils.isNullOrEmpty(indexType)) {
       val columnNames = columnsMap.keySet().asScala.toSet
       val derivedIndexType: String = if (CreateIndexCommand.matchesRecordKeys(columnNames, metaClient.getTableConfig)) {
@@ -74,7 +76,8 @@ case class CreateIndexCommand(table: CatalogTable,
       } else {
         HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX
       }
-      new HoodieSparkIndexClient(sparkSession).create(metaClient, indexName, derivedIndexType, columnsMap, options.asJava, table.properties.asJava)
+      new HoodieSparkIndexClient(sparkSession)
+        .create(metaClient, indexName, derivedIndexType, columnsMap, options.asJava, table.properties.asJava, ignoreIfExists)
     } else {
       throw new HoodieIndexException(String.format("%s is not supported", indexType))
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestIndexSyntax.scala
@@ -131,6 +131,10 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
         )
 
         spark.sql(s"create index record_index on $tableName (id)")
+        checkNestedException(s"create index record_index on $tableName (id)")(
+          "Index already exists: record_index"
+        )
+        spark.sql(s"create index if not exists record_index on $tableName (id)")
         spark.sql(s"drop index record_index on $tableName")
 
         // Test record index creation with using clause

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
@@ -128,6 +128,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
           checkException(s"create index idx_price on $tableName (price)")(
             "Index already exists: idx_price"
           )
+          spark.sql(s"create index if not exists idx_price on $tableName (price)")
 
           // Both indexes should be shown
           checkAnswer(s"show indexes from $tableName")(


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18691.

Spark SQL parses `IF NOT EXISTS` for `CREATE INDEX`, but the parsed flag was not propagated into the Spark index client. As a result, duplicate index creation still failed even when users explicitly requested idempotent behavior.

### Summary and Changelog

This pull request honors `IF NOT EXISTS` for Spark SQL `CREATE INDEX` statements.

Changes:
- Pass the parsed `ignoreIfExists` flag from Spark SQL `CREATE INDEX` commands into the Spark index client.
- Skip index creation when the index already exists and `IF NOT EXISTS` is used.
- Preserve the existing duplicate-index failure behavior when `IF NOT EXISTS` is not specified.

No code was copied from external sources.

### Impact

Low user-facing impact. This makes `CREATE INDEX IF NOT EXISTS` behave as expected for existing indexes while keeping the existing strict failure behavior for plain `CREATE INDEX`.

There is no public API change, storage format change, or expected performance impact.

### Risk Level

low

The change is scoped to Spark SQL index creation and preserves the existing non-`IF NOT EXISTS` failure path. Verification covered both syntax handling and secondary index behavior.

### Documentation Update

none

This fixes existing command semantics and does not add a new user-facing command, config, or API.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

Testing:
- `git diff --check`
- `mvn -pl hudi-spark-datasource/hudi-spark -am -Pspark3.5 -DskipTests -DskipITs -DskipUTs -DskipFTs -DskipDocker -Drat.skip=true -Dmaven.javadoc.skip=true install`
- `mvn -pl hudi-spark-datasource/hudi-spark -Pspark3.5 -DwildcardSuites=org.apache.spark.sql.hudi.feature.index.TestIndexSyntax -Drat.skip=true org.scalatest:scalatest-maven-plugin:2.2.0:test`
- `mvn -pl hudi-spark-datasource/hudi-spark -Pspark3.5 -DwildcardSuites=org.apache.spark.sql.hudi.feature.index.TestSecondaryIndex -Drat.skip=true org.scalatest:scalatest-maven-plugin:2.2.0:test`
