### PR TITLE
feat(flink): Support data skipping based on column stats for source V2

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieScanContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieScanContext.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.source;
 
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.source.prune.ColumnStatsProbe;
 import org.apache.hudi.source.prune.PartitionPruners;
 
 import lombok.AllArgsConstructor;
@@ -60,6 +61,8 @@ public class HoodieScanContext implements Serializable {
   private final boolean isStreaming;
   // Partition pruner
   private final PartitionPruners.PartitionPruner partitionPruner;
+  // Column stats probe
+  private final ColumnStatsProbe columnStatsProbe;
   private final long limit;
 
   public Duration getScanInterval() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieSource.java
@@ -212,6 +212,7 @@ public class HoodieSource<T> extends FileIndexReader implements Source<T, Hoodie
         .conf(this.scanContext.getConf())
         .rowType(scanContext.getRowType())
         .metaClient(metaClient)
+        .columnStatsProbe(scanContext.getColumnStatsProbe())
         .partitionPruner(scanContext.getPartitionPruner())
         .build();
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -353,6 +353,7 @@ public class HoodieTableSource extends FileIndexReader implements
         .maxCompactionMemoryInBytes(conf.get(FlinkOptions.COMPACTION_MAX_MEMORY))
         .maxPendingSplits(conf.get(FlinkOptions.READ_SPLITS_LIMIT))
         .partitionPruner(partitionPruner)
+        .columnStatsProbe(columnStatsProbe)
         .isStreaming(conf.get(FlinkOptions.READ_AS_STREAMING))
         .limit(limit)
         .build();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestHoodieSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestHoodieSource.java
@@ -36,6 +36,7 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.util.HoodieSchemaConverter;
+import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
 import org.apache.hudi.utils.TestData;
 
@@ -221,13 +222,12 @@ public class TestHoodieSource {
 
   @Test
   public void testCreateBatchHoodieSplitsWithColumnStatsPruner() throws Exception {
-    metaClient = HoodieTestUtils.init(tempDir.getAbsolutePath(), HoodieTableType.COPY_ON_WRITE);
     conf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.COPY_ON_WRITE.name());
     conf.set(FlinkOptions.READ_DATA_SKIPPING_ENABLED, true);
     conf.setString(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
 
     TestData.writeData(TestData.DATA_SET_INSERT, conf);
-    metaClient.reloadActiveTimeline();
+    metaClient = StreamerUtil.createMetaClient(conf);
 
     // Create column stats probe with uuid > 'id5' filter
     ColumnStatsProbe columnStatsProbe = ColumnStatsProbe.newInstance(Arrays.asList(
@@ -249,10 +249,19 @@ public class TestHoodieSource {
             .columnStatsProbe(columnStatsProbe)
             .build();
 
-    HoodieSource<RowData> source = createHoodieSourceWithPruner(conf, metaClient, partitionPruner);
-    List<HoodieSourceSplit> splits = source.createBatchHoodieSplits();
+    // get full splits
+    HoodieSource<RowData> source1 = createHoodieSourceWithPruner(conf, metaClient, null, null);
+    List<HoodieSourceSplit> fullSplits = source1.createBatchHoodieSplits();
 
-    assertNotNull(splits, "Splits should not be null with column stats pruner");
+    // pruned by partition stats
+    HoodieSource<RowData> source2 = createHoodieSourceWithPruner(conf, metaClient, partitionPruner, null);
+    List<HoodieSourceSplit> splits2 = source2.createBatchHoodieSplits();
+    assertTrue(splits2.size() < fullSplits.size());
+
+    // pruned by column stats
+    HoodieSource<RowData> source3 = createHoodieSourceWithPruner(conf, metaClient, null, columnStatsProbe);
+    List<HoodieSourceSplit> splits3 = source3.createBatchHoodieSplits();
+    assertTrue(splits3.size() < fullSplits.size());
   }
 
   @Test
@@ -395,6 +404,14 @@ public class TestHoodieSource {
       Configuration conf,
       HoodieTableMetaClient metaClient,
       PartitionPruners.PartitionPruner partitionPruner) {
+    return createHoodieSourceWithPruner(conf, metaClient, partitionPruner, null);
+  }
+
+  private HoodieSource<RowData> createHoodieSourceWithPruner(
+      Configuration conf,
+      HoodieTableMetaClient metaClient,
+      PartitionPruners.PartitionPruner partitionPruner,
+      ColumnStatsProbe columnStatsProbe) {
     RowType rowType = TestConfigurations.ROW_TYPE;
     HoodieScanContext scanContext = HoodieScanContext.builder()
         .conf(conf)
@@ -410,6 +427,7 @@ public class TestHoodieSource {
         .cdcEnabled(conf.get(FlinkOptions.CDC_ENABLED))
         .isStreaming(conf.get(FlinkOptions.READ_AS_STREAMING))
         .partitionPruner(partitionPruner)
+        .columnStatsProbe(columnStatsProbe)
         .build();
     HoodieSchema schema = HoodieSchemaConverter.convertToSchema(rowType);
     HadoopStorageConfiguration hadoopConf = new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(conf));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink Source V2 did not propagate the pushed-down `ColumnStatsProbe` into its `FileIndex`, so column stats based data skipping was not applied on the Source V2 path even when filter pushdown and data skipping were enabled.

This PR wires the existing column stats pruning context through Source V2 so it can use the same `FileStatsIndex` pruning path already available to the file index, fixes #18703 

### Summary and Changelog
- Added `ColumnStatsProbe` to `HoodieScanContext`.
- Passed `columnStatsProbe` from `HoodieTableSource` into the Source V2 scan context.
- Passed the scan context's `ColumnStatsProbe` into `FileIndex` from `HoodieSource.buildFileIndex()`.
- Updated `TestHoodieSource` coverage to validate Source V2 split pruning with partition stats and column stats paths.

### Impact

- Enables Source V2 to use existing column stats based file-level pruning when data skipping and metadata column stats are enabled.


### Risk Level
low
<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
