### PR TITLE
fix(aws): implement writer-version update in Glue sync client

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.aws.sync;
 
+import org.apache.hudi.HoodieVersion;
 import org.apache.hudi.aws.credentials.HoodieAWSCredentialsProviderFactory;
 import org.apache.hudi.aws.sync.util.GluePartitionFilterGenerator;
 import org.apache.hudi.common.fs.FSUtils;
@@ -529,6 +530,21 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
         throw new HoodieGlueSyncException("Fail to update table comments " + tableId(databaseName, table.name()), e);
       }
       return true;
+    }
+  }
+
+  @Override
+  public void updateHoodieWriterVersion(String tableName) {
+    try {
+      updateTableParameters(
+          awsGlue,
+          databaseName,
+          tableName,
+          Collections.singletonMap(HoodieVersion.HOODIE_WRITER_VERSION, HoodieVersion.get()),
+          skipTableArchive);
+    } catch (Exception e) {
+      throw new HoodieGlueSyncException(String.format("Failed to update hudi writer major version %s for %s",
+          HoodieVersion.get(), tableName), e);
     }
   }
 

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -543,7 +543,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
           Collections.singletonMap(HoodieVersion.HOODIE_WRITER_VERSION, HoodieVersion.get()),
           skipTableArchive);
     } catch (Exception e) {
-      throw new HoodieGlueSyncException(String.format("Failed to update hudi writer major version %s for %s",
+      throw new HoodieGlueSyncException(String.format("Failed to update hudi writer version %s for %s",
           HoodieVersion.get(), tableName), e);
     }
   }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.aws.sync;
 
+import org.apache.hudi.HoodieVersion;
 import org.apache.hudi.aws.testutils.GlueTestUtil;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
@@ -772,6 +773,56 @@ class TestAWSGlueSyncClient {
     assertTrue(dbTagRequest.resourceArn().contains(dbName));
     assertEquals("SomeCenter", dbTagRequest.tagsToAdd().get("CostCenter"));
     assertEquals("Production", dbTagRequest.tagsToAdd().get("Environment"));
+  }
+
+  @Test
+  void testUpdateHoodieWriterVersion() throws ExecutionException, InterruptedException {
+    String tableName = "test";
+    List<Column> columns = Arrays.asList(
+        GlueTestUtil.getColumn("name", "string", "person's name"),
+        GlueTestUtil.getColumn("age", "int", "person's age"));
+    List<Column> partitionKeys = Collections.singletonList(
+        GlueTestUtil.getColumn("city", "string", "person's city"));
+    CompletableFuture<GetTableResponse> tableResponseFuture =
+        getTableWithDefaultProps(tableName, columns, partitionKeys);
+
+    CompletableFuture<UpdateTableResponse> mockUpdateTableResponse = Mockito.mock(CompletableFuture.class);
+    Mockito.when(mockUpdateTableResponse.get()).thenReturn(UpdateTableResponse.builder().build());
+    Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(tableResponseFuture);
+    Mockito.when(mockAwsGlue.updateTable(any(UpdateTableRequest.class))).thenReturn(mockUpdateTableResponse);
+
+    awsGlueSyncClient.updateHoodieWriterVersion(tableName);
+
+    // Capture the request to verify the writer-version parameter was set correctly
+    ArgumentCaptor<UpdateTableRequest> captor = ArgumentCaptor.forClass(UpdateTableRequest.class);
+    verify(mockAwsGlue, times(1)).updateTable(captor.capture());
+    UpdateTableRequest sent = captor.getValue();
+    assertEquals(
+        HoodieVersion.get(),
+        sent.tableInput().parameters().get(HoodieVersion.HOODIE_WRITER_VERSION),
+        "Writer version parameter should be set on the table");
+  }
+
+  @Test
+  void testUpdateHoodieWriterVersionThrowsGlueException() throws ExecutionException, InterruptedException {
+    String tableName = "test";
+    List<Column> columns = Collections.singletonList(
+        GlueTestUtil.getColumn("name", "string", "person's name"));
+    List<Column> partitionKeys = Collections.singletonList(
+        GlueTestUtil.getColumn("city", "string", "person's city"));
+    CompletableFuture<GetTableResponse> tableResponseFuture =
+        getTableWithDefaultProps(tableName, columns, partitionKeys);
+
+    CompletableFuture<UpdateTableResponse> mockUpdateTableResponse = Mockito.mock(CompletableFuture.class);
+    Mockito.when(mockUpdateTableResponse.get()).thenThrow(new InterruptedException());
+    Mockito.when(mockAwsGlue.getTable(any(GetTableRequest.class))).thenReturn(tableResponseFuture);
+    Mockito.when(mockAwsGlue.updateTable(any(UpdateTableRequest.class))).thenReturn(mockUpdateTableResponse);
+
+    HoodieGlueSyncException ex = assertThrows(
+        HoodieGlueSyncException.class,
+        () -> awsGlueSyncClient.updateHoodieWriterVersion(tableName));
+    assertTrue(ex.getMessage().contains(tableName), "exception message should mention the table");
+    assertTrue(ex.getMessage().contains(HoodieVersion.get()), "exception message should mention the writer version");
   }
 
   private CompletableFuture<GetTableResponse> getTableWithDefaultProps(String tableName, List<Column> columns, List<Column> partitionColumns) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

- AWSGlueCatalogSyncClient does not implement updateHoodieWriterVersion(), which was introduced as part of the metadata sync flow in Hudi 1.2.0. As a result, Glue sync fails with:
```
java.lang.UnsupportedOperationException 
at org.apache.hudi.sync.common.HoodieMetaSyncOperations.updateHoodieWriterVersion
```
- Glue sync works correctly in Hudi 1.1.1 but fails in 1.2.0-rc1/1.3.0-SNAPSHOT due to the newly introduced writer-version update call path.
- This PR implements updateHoodieWriterVersion() in AWSGlueCatalogSyncClient to properly update the Hudi writer version in Glue table parameters and avoid the runtime failure.

### Summary and Changelog

- This PR adds support for updating the Hudi writer version during AWS Glue sync operations.

Changes included:
- Implemented updateHoodieWriterVersion() in `AWSGlueCatalogSyncClient`

### Impact

- Fixes Glue sync failures in Hudi 1.2.x/1.3.0-SNAPSHOT when using AwsGlueCatalogSyncTool

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
