### PR TITLE
feat: support customized metrics reporter

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/config/metrics/HoodieMetricsConfig.java
@@ -73,7 +73,10 @@ public class HoodieMetricsConfig extends HoodieConfig {
       .defaultValue("")
       .markAdvanced()
       .sinceVersion("0.6.0")
-      .withDocumentation("");
+      .withDocumentation("Fully qualified class name of a custom MetricsReporter implementation. "
+          + "The class must extend MetricsReporter and support one of these constructors (tried in order): "
+          + "(Properties, MetricRegistry), (HoodieMetricsConfig, MetricRegistry), or no-arg. "
+          + "Set reporter.type=CUSTOM or leave it unset when using this option.");
 
   public static final ConfigProperty<String> METRICS_REPORTER_PREFIX = ConfigProperty
       .key(METRIC_PREFIX + ".reporter.metricsname.prefix")

--- a/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.metrics.custom.CustomizableMetricsReporter;
 import org.apache.hudi.metrics.datadog.DatadogMetricsReporter;
 import org.apache.hudi.metrics.m3.M3MetricsReporter;
 import org.apache.hudi.metrics.prometheus.PrometheusReporter;
@@ -41,18 +40,6 @@ import java.util.Properties;
 public class MetricsReporterFactory {
 
   public static Option<MetricsReporter> createReporter(HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
-    String reporterClassName = metricsConfig.getMetricReporterClassName();
-
-    if (!StringUtils.isNullOrEmpty(reporterClassName)) {
-      Object instance = ReflectionUtils.loadClass(
-          reporterClassName, new Class<?>[] {Properties.class, MetricRegistry.class}, metricsConfig.getProps(), registry);
-      if (!(instance instanceof CustomizableMetricsReporter)) {
-        throw new HoodieException(metricsConfig.getMetricReporterClassName()
-            + " is not a subclass of CustomizableMetricsReporter");
-      }
-      return Option.of((MetricsReporter) instance);
-    }
-
     MetricsReporterType type = metricsConfig.getMetricsReporterType();
     MetricsReporter reporter = null;
     if (type == null) {
@@ -93,10 +80,35 @@ public class MetricsReporterFactory {
       case SLF4J:
         reporter = new Slf4jMetricsReporter(registry);
         break;
+      case CUSTOM:
+        String reporterClassName = metricsConfig.getMetricReporterClassName();
+        if (!StringUtils.isNullOrEmpty(reporterClassName)) {
+          return Option.of(loadCustomReporter(reporterClassName, metricsConfig, registry));
+        } else {
+          throw new HoodieException(MetricsReporterType.CUSTOM + " reporter type requires "
+                  + HoodieMetricsConfig.METRICS_REPORTER_CLASS_NAME.key() + " to be set");
+        }
       default:
         log.error("Reporter type[" + type + "] is not supported.");
         break;
     }
     return Option.ofNullable(reporter);
+  }
+
+  private static MetricsReporter loadCustomReporter(String className, HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
+    Object instance;
+    if (ReflectionUtils.hasConstructor(className, new Class<?>[] {Properties.class, MetricRegistry.class})) {
+      instance = ReflectionUtils.loadClass(className,
+          new Class<?>[] {Properties.class, MetricRegistry.class}, metricsConfig.getProps(), registry);
+    } else if (ReflectionUtils.hasConstructor(className, new Class<?>[] {HoodieMetricsConfig.class, MetricRegistry.class})) {
+      instance = ReflectionUtils.loadClass(className,
+          new Class<?>[] {HoodieMetricsConfig.class, MetricRegistry.class}, metricsConfig, registry);
+    } else {
+      instance = ReflectionUtils.loadClass(className);
+    }
+    if (!(instance instanceof MetricsReporter)) {
+      throw new HoodieException(className + " is not a subclass of MetricsReporter");
+    }
+    return (MetricsReporter) instance;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterType.java
@@ -22,5 +22,5 @@ package org.apache.hudi.metrics;
  * Types of the reporter supported, hudi also supports user defined reporter.
  */
 public enum MetricsReporterType {
-  GRAPHITE, INMEMORY, JMX, DATADOG, CONSOLE, PROMETHEUS_PUSHGATEWAY, PROMETHEUS, CLOUDWATCH, M3, SLF4J
+  GRAPHITE, INMEMORY, JMX, DATADOG, CONSOLE, PROMETHEUS_PUSHGATEWAY, PROMETHEUS, CLOUDWATCH, M3, SLF4J, CUSTOM
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
@@ -96,23 +96,60 @@ class TestMetricsReporterFactory {
 
   @Test
   void metricsReporterFactoryShouldReturnUserDefinedReporter() {
-    when(metricsConfig.getMetricReporterClassName()).thenReturn(DummyMetricsReporter.class.getName());
-
     TypedProperties props = new TypedProperties();
     props.setProperty("testKey", "testValue");
 
-    when(metricsConfig.getProps()).thenReturn(props);
-    MetricsReporter reporter = MetricsReporterFactory.createReporter(metricsConfig, registry).get();
+    HoodieMetricsConfig config = HoodieMetricsConfig.newBuilder()
+        .fromProperties(props)
+        .withReporterType(MetricsReporterType.CUSTOM.name())
+        .withReporterClass(DummyMetricsReporter.class.getName())
+        .build();
+
+    MetricsReporter reporter = MetricsReporterFactory.createReporter(config, registry).get();
     assertTrue(reporter instanceof CustomizableMetricsReporter);
-    assertEquals(props, ((DummyMetricsReporter) reporter).getProps());
+    assertEquals("testValue", ((DummyMetricsReporter) reporter).getProps().getProperty("testKey"));
     assertEquals(registry, ((DummyMetricsReporter) reporter).getRegistry());
   }
 
   @Test
   void metricsReporterFactoryShouldThrowExceptionWhenMetricsReporterClassIsIllegal() {
-    when(metricsConfig.getMetricReporterClassName()).thenReturn(IllegalTestMetricsReporter.class.getName());
-    when(metricsConfig.getProps()).thenReturn(new TypedProperties());
-    assertThrows(HoodieException.class, () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
+    HoodieMetricsConfig config = HoodieMetricsConfig.newBuilder()
+        .withReporterType(MetricsReporterType.CUSTOM.name())
+        .withReporterClass(IllegalTestMetricsReporter.class.getName())
+        .build();
+    assertThrows(HoodieException.class, () -> MetricsReporterFactory.createReporter(config, registry));
+  }
+
+  @Test
+  void customTypeWithoutClassNameThrows() {
+    HoodieMetricsConfig config = HoodieMetricsConfig.newBuilder()
+        .withReporterType(MetricsReporterType.CUSTOM.name())
+        .build();
+    HoodieException ex = assertThrows(HoodieException.class,
+        () -> MetricsReporterFactory.createReporter(config, registry));
+    assertTrue(ex.getMessage().contains(HoodieMetricsConfig.METRICS_REPORTER_CLASS_NAME.key()));
+  }
+
+  @Test
+  void customReporterWithConfigConstructorIsLoaded() {
+    HoodieMetricsConfig config = HoodieMetricsConfig.newBuilder()
+        .withReporterType(MetricsReporterType.CUSTOM.name())
+        .withReporterClass(ConfigConstructorReporter.class.getName())
+        .build();
+    MetricsReporter reporter = MetricsReporterFactory.createReporter(config, registry).get();
+    assertTrue(reporter instanceof ConfigConstructorReporter);
+    assertSame(config, ((ConfigConstructorReporter) reporter).getConfig());
+    assertSame(registry, ((ConfigConstructorReporter) reporter).getRegistry());
+  }
+
+  @Test
+  void customReporterWithNoArgConstructorIsLoaded() {
+    HoodieMetricsConfig config = HoodieMetricsConfig.newBuilder()
+            .withReporterType(MetricsReporterType.CUSTOM.name())
+            .withReporterClass(NoArgConstructorReporter.class.getName())
+        .build();
+    MetricsReporter reporter = MetricsReporterFactory.createReporter(config, registry).get();
+    assertTrue(reporter instanceof NoArgConstructorReporter);
   }
 
   public static class DummyMetricsReporter extends CustomizableMetricsReporter {
@@ -140,6 +177,54 @@ class TestMetricsReporterFactory {
   public static class IllegalTestMetricsReporter {
 
     public IllegalTestMetricsReporter(Properties props, MetricRegistry registry) {
+    }
+  }
+
+  /** Uses the (HoodieMetricsConfig, MetricRegistry) constructor — no Properties constructor. */
+  public static class ConfigConstructorReporter extends MetricsReporter {
+
+    private final HoodieMetricsConfig config;
+    private final MetricRegistry registry;
+
+    public ConfigConstructorReporter(HoodieMetricsConfig config, MetricRegistry registry) {
+      this.config = config;
+      this.registry = registry;
+    }
+
+    public HoodieMetricsConfig getConfig() {
+      return config;
+    }
+
+    public MetricRegistry getRegistry() {
+      return registry;
+    }
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void report() {
+    }
+
+    @Override
+    public void stop() {
+    }
+  }
+
+  /** Uses no-arg constructor — no Properties or HoodieMetricsConfig constructor. */
+  public static class NoArgConstructorReporter extends MetricsReporter {
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void report() {
+    }
+
+    @Override
+    public void stop() {
     }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Add Custom reporter type for Hudi users to customize any metrics reporter for internal infra requirement

### Summary and Changelog

1. Add CUSTOM MetricsReporterType
2. Change MetricsReporterFactory to load custom reporter defined in config with reflection 
3. Add test cases for TestMetricsReporterFactory to cover the change


### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
