### PR TITLE
fix(flink): add Apache license header to muttley/README.md

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md
@@ -1,3 +1,20 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 # Internal Uber Components (Optional)
 
 This package contains integration with internal Uber services and is **optional** for Apache Hudi users.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

**Master is broken**: `apache-rat:check` fails on every new build with:

> Too many files with unapproved license: 1
> /home/runner/work/hudi/hudi/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md

This was introduced in #18394 (merged ~2026-05-10 02:10 UTC) which added the README without the standard Apache license header.

Example failing build: https://github.com/apache/hudi/actions/runs/25632749770/job/75239286191 (from PR #18405)

### Summary and Changelog

- Prepend the standard Apache 2.0 HTML-comment license header to `hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/README.md`. No content changes.

### Impact

**Public API Changes:** None.

**User-Facing Changes:** None — documentation file only, no behavior change.

**Performance Impact:** None.

**Build Impact:** Unblocks `apache-rat:check` on every module that runs from the parent reactor (currently red on master since #18394 merged). Restores green CI for all open PRs that need to be rebased / re-triggered after this lands.

**Verification:**

```
$ cd hudi-flink-datasource/hudi-flink
$ mvn -Pflink1.20 -Dscala-2.12 apache-rat:check
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 437 licenses.
[INFO] BUILD SUCCESS
```

### Risk Level

**Risk Level: none** — documentation header only, no code changes.

### Documentation Update

No user-facing documentation changes required. The modified file is an internal package README that already exists in master; this PR only adds the required Apache 2.0 license header so RAT compliance is satisfied.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (N/A — license-header fix)
- [x] Commits are signed and follow [conventions](https://www.conventionalcommits.org/)
- [x] All existing tests pass