### PR TITLE
fix: #18496 Respect configured record type when filtering index keys

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -246,13 +247,23 @@ public class HoodieIndexUtils {
   public static Collection<Pair<String, Long>> filterKeysFromFile(StoragePath filePath,
                                                                   Set<String> candidateRecordKeys,
                                                                   HoodieStorage storage) throws HoodieIndexException {
+    return filterKeysFromFile(filePath, candidateRecordKeys, storage, HoodieRecordType.AVRO);
+  }
+
+  public static Collection<Pair<String, Long>> filterKeysFromFile(StoragePath filePath,
+                                                                  Set<String> candidateRecordKeys,
+                                                                  HoodieStorage storage,
+                                                                  HoodieRecordType fallbackRecordType)
+      throws HoodieIndexException {
     checkArgument(FSUtils.isBaseFile(filePath));
     if (candidateRecordKeys.isEmpty()) {
       return Collections.emptyList();
     }
     log.info("Going to filter {} keys from file {}", candidateRecordKeys.size(), filePath);
+    HoodieRecordType recordType = HoodieFileFormat.resolveRecordTypeForExtension(
+        FSUtils.getFileExtension(filePath.toString()), fallbackRecordType);
     try (HoodieFileReader fileReader = HoodieIOFactory.getIOFactory(storage)
-        .getReaderFactory(HoodieRecordType.AVRO)
+        .getReaderFactory(recordType)
         .getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, filePath)) {
       // Load all rowKeys from the file, to double-confirm
       HoodieTimer timer = HoodieTimer.start();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyLookupHandle.java
@@ -96,7 +96,8 @@ public class HoodieKeyLookupHandle<T, I, K, O> extends HoodieReadHandle<T, I, K,
 
     HoodieBaseFile baseFile = getLatestBaseFile();
     Collection<Pair<String, Long>> matchingKeysAndPositions = HoodieIndexUtils.filterKeysFromFile(
-        baseFile.getStoragePath(), candidateRecordKeys, hoodieTable.getStorage());
+        baseFile.getStoragePath(), candidateRecordKeys, hoodieTable.getStorage(),
+        config.getRecordMerger().getRecordType());
     log.info("Total records ({}), bloom filter candidates ({})/fp({}), actual matches ({})", totalKeysChecked,
             candidateRecordKeys.size(), candidateRecordKeys.size() - matchingKeysAndPositions.size(), matchingKeysAndPositions.size());
     return new HoodieKeyLookupResult(partitionPathFileIDPair.getRight(), partitionPathFileIDPair.getLeft(),

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieFileProbingFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieFileProbingFunction.java
@@ -20,6 +20,7 @@ package org.apache.hudi.index.bloom;
 
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -58,11 +59,14 @@ public class HoodieFileProbingFunction implements
 
   private final Broadcast<HoodieTableFileSystemView> baseFileOnlyViewBroadcast;
   private final StorageConfiguration<?> storageConf;
+  private final HoodieRecord.HoodieRecordType recordType;
 
   public HoodieFileProbingFunction(Broadcast<HoodieTableFileSystemView> baseFileOnlyViewBroadcast,
-                                   StorageConfiguration<?> storageConf) {
+                                   StorageConfiguration<?> storageConf,
+                                   HoodieRecord.HoodieRecordType recordType) {
     this.baseFileOnlyViewBroadcast = baseFileOnlyViewBroadcast;
     this.storageConf = storageConf;
+    this.recordType = recordType;
   }
 
   @Override
@@ -138,7 +142,8 @@ public class HoodieFileProbingFunction implements
 
             final HoodieBaseFile dataFile = fileIDBaseFileMap.get(fileId);
             Collection<Pair<String, Long>> matchingKeysAndPositions = HoodieIndexUtils.filterKeysFromFile(
-                dataFile.getStoragePath(), candidateRecordKeys, HoodieStorageUtils.getStorage(dataFile.getStoragePath(), storageConf));
+                dataFile.getStoragePath(), candidateRecordKeys,
+                HoodieStorageUtils.getStorage(dataFile.getStoragePath(), storageConf), recordType);
 
             log.debug(
                 "Bloom filter candidates ({}) / false positives ({}), actual matches ({})",

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
@@ -157,7 +157,8 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
           .mapPartitionsToPair(new HoodieMetadataBloomFilterProbingFunction(baseFileOnlyViewBroadcast, hoodieTable))
           // Second, we use [[HoodieFileProbingFunction]] to open actual file and check whether it
           // contains the records with candidate keys that were filtered in by the Bloom Filter
-          .mapPartitions(new HoodieFileProbingFunction(baseFileOnlyViewBroadcast, storageConf), true);
+          .mapPartitions(new HoodieFileProbingFunction(
+              baseFileOnlyViewBroadcast, storageConf, config.getRecordMerger().getRecordType()), true);
 
     } else if (config.useBloomIndexBucketizedChecking()) {
       Map<HoodieFileGroupId, Long> comparisonsPerFileGroup = computeComparisonsPerFileGroup(

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -74,13 +74,35 @@ public enum HoodieFileFormat {
     return extension;
   }
 
+  public boolean requiresSparkRecordType() {
+    return this == LANCE;
+  }
+
+  public HoodieRecord.HoodieRecordType resolveRecordType(HoodieRecord.HoodieRecordType fallback) {
+    return requiresSparkRecordType() ? HoodieRecord.HoodieRecordType.SPARK : fallback;
+  }
+
+  public static HoodieRecord.HoodieRecordType resolveRecordTypeForExtension(
+      String extension, HoodieRecord.HoodieRecordType fallback) {
+    HoodieFileFormat format = fromFileExtensionOrNull(extension);
+    return format == null ? fallback : format.resolveRecordType(fallback);
+  }
+
   public static HoodieFileFormat fromFileExtension(String extension) {
+    HoodieFileFormat format = fromFileExtensionOrNull(extension);
+    if (format != null) {
+      return format;
+    }
+    throw new IllegalArgumentException("Unknown file extension :" + extension);
+  }
+
+  public static HoodieFileFormat fromFileExtensionOrNull(String extension) {
     for (HoodieFileFormat format : HoodieFileFormat.values()) {
       if (format.getFileExtension().equals(extension)) {
         return format;
       }
     }
-    throw new IllegalArgumentException("Unknown file extension :" + extension);
+    return null;
   }
 
   public static HoodieFileFormat getValue(String fileFormat) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileFormat.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieFileFormat.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.AVRO;
+import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.FLINK;
+import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.SPARK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestHoodieFileFormat {
+
+  @Test
+  void testResolveRecordType() {
+    assertFalse(HoodieFileFormat.PARQUET.requiresSparkRecordType());
+    assertFalse(HoodieFileFormat.ORC.requiresSparkRecordType());
+    assertFalse(HoodieFileFormat.HFILE.requiresSparkRecordType());
+    assertTrue(HoodieFileFormat.LANCE.requiresSparkRecordType());
+
+    assertEquals(SPARK, HoodieFileFormat.PARQUET.resolveRecordType(SPARK));
+    assertEquals(FLINK, HoodieFileFormat.ORC.resolveRecordType(FLINK));
+    assertEquals(AVRO, HoodieFileFormat.HFILE.resolveRecordType(AVRO));
+    assertEquals(SPARK, HoodieFileFormat.LANCE.resolveRecordType(AVRO));
+  }
+
+  @Test
+  void testResolveRecordTypeForExtension() {
+    assertEquals(SPARK, HoodieFileFormat.resolveRecordTypeForExtension(".parquet", SPARK));
+    assertEquals(FLINK, HoodieFileFormat.resolveRecordTypeForExtension(".orc", FLINK));
+    assertEquals(SPARK, HoodieFileFormat.resolveRecordTypeForExtension(".lance", AVRO));
+    assertEquals(AVRO, HoodieFileFormat.resolveRecordTypeForExtension(".unknown", AVRO));
+    assertNull(HoodieFileFormat.fromFileExtensionOrNull(".unknown"));
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18496

### Summary and Changelog

- Adds file-format record type resolution so formats that require Spark readers can override the configured fallback.
- Threads the configured record merger type into index key filtering paths instead of always using AVRO readers.
- Adds unit coverage for record type resolution by file format and extension.

### Impact

Keeps index key filtering consistent with the configured record merger type while preserving the existing AVRO fallback for existing callers.

### Risk level

Low. The previous filterKeysFromFile signature still defaults to AVRO, and format-specific overrides are limited to the file format resolution helper.

### Test Plan

- git diff --check
- mvn -pl hudi-common -DskipITs -Dcheckstyle.skip -DfailIfNoTests=false -Dtest=TestHoodieFileFormat test
- mvn -pl hudi-client/hudi-client-common,hudi-client/hudi-spark-client -am -DskipTests -DskipITs compile