### PR TITLE
feat(flink): Support bucket pruning for source V2

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieScanContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieScanContext.java
@@ -32,6 +32,7 @@ import org.apache.hudi.storage.StoragePath;
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.function.Function;
 
 /**
  * Hudi source scan context for finding completed commits for streaming and incremental read.
@@ -63,6 +64,8 @@ public class HoodieScanContext implements Serializable {
   private final PartitionPruners.PartitionPruner partitionPruner;
   // Column stats probe
   private final ColumnStatsProbe columnStatsProbe;
+  // Partition bucket id function for bucket pruning
+  private final Function<String, Integer> partitionBucketIdFunc;
   private final long limit;
 
   public Duration getScanInterval() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieSource.java
@@ -214,6 +214,7 @@ public class HoodieSource<T> extends FileIndexReader implements Source<T, Hoodie
         .metaClient(metaClient)
         .columnStatsProbe(scanContext.getColumnStatsProbe())
         .partitionPruner(scanContext.getPartitionPruner())
+        .partitionBucketIdFunc(scanContext.getPartitionBucketIdFunc())
         .build();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -354,6 +354,8 @@ public class HoodieTableSource extends FileIndexReader implements
         .maxPendingSplits(conf.get(FlinkOptions.READ_SPLITS_LIMIT))
         .partitionPruner(partitionPruner)
         .columnStatsProbe(columnStatsProbe)
+        .partitionBucketIdFunc(PartitionBucketIdFunc.create(this.dataBucketFunc,
+            this.metaClient, conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS)))
         .isStreaming(conf.get(FlinkOptions.READ_AS_STREAMING))
         .limit(limit)
         .build();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestHoodieSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestHoodieSource.java
@@ -26,6 +26,8 @@ import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.PartitionPathEncodeUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.source.prune.ColumnStatsProbe;
 import org.apache.hudi.source.prune.PartitionPruners;
 import org.apache.hudi.source.reader.HoodieRecordEmitter;
@@ -61,6 +63,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -265,6 +268,28 @@ public class TestHoodieSource {
   }
 
   @Test
+  public void testCreateBatchHoodieSplitsWithBucketPruner() throws Exception {
+    conf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.COPY_ON_WRITE.name());
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+    metaClient = StreamerUtil.createMetaClient(conf);
+
+    HoodieSource<RowData> source1 = createHoodieSourceWithPruner(conf, metaClient, null, null);
+    List<HoodieSourceSplit> fullSplits = source1.createBatchHoodieSplits();
+
+    int targetBucketId = 1;
+    String targetBucketIdStr = BucketIdentifier.bucketIdStr(targetBucketId);
+    HoodieSource<RowData> source = createHoodieSourceWithPruner(
+        conf, metaClient, null, null, partitionPath -> targetBucketId);
+    List<HoodieSourceSplit> prunedSplits = source.createBatchHoodieSplits();
+
+    assertTrue(prunedSplits.size() < fullSplits.size());
+    prunedSplits.forEach(split -> assertTrue(
+        split.getFileId().contains(targetBucketIdStr),
+        "Pruned split should belong to bucket " + targetBucketId));
+  }
+
+  @Test
   public void testGetOrBuildFileIndexInternal() throws Exception {
     metaClient = HoodieTestUtils.init(tempDir.getAbsolutePath(), HoodieTableType.COPY_ON_WRITE);
     conf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.COPY_ON_WRITE.name());
@@ -412,6 +437,15 @@ public class TestHoodieSource {
       HoodieTableMetaClient metaClient,
       PartitionPruners.PartitionPruner partitionPruner,
       ColumnStatsProbe columnStatsProbe) {
+    return createHoodieSourceWithPruner(conf, metaClient, partitionPruner, columnStatsProbe, null);
+  }
+
+  private HoodieSource<RowData> createHoodieSourceWithPruner(
+      Configuration conf,
+      HoodieTableMetaClient metaClient,
+      PartitionPruners.PartitionPruner partitionPruner,
+      ColumnStatsProbe columnStatsProbe,
+      Function<String, Integer> partitionBucketIdFunc) {
     RowType rowType = TestConfigurations.ROW_TYPE;
     HoodieScanContext scanContext = HoodieScanContext.builder()
         .conf(conf)
@@ -428,6 +462,7 @@ public class TestHoodieSource {
         .isStreaming(conf.get(FlinkOptions.READ_AS_STREAMING))
         .partitionPruner(partitionPruner)
         .columnStatsProbe(columnStatsProbe)
+        .partitionBucketIdFunc(partitionBucketIdFunc)
         .build();
     HoodieSchema schema = HoodieSchemaConverter.convertToSchema(rowType);
     HadoopStorageConfiguration hadoopConf = new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(conf));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink Source V2 builds its `FileIndex` from `HoodieScanContext`, but the scan context did not carry the partition-to-bucket lookup needed by bucket index pruning. As a result, bucket pruning information produced during filter pushdown in `HoodieTableSource` could not be applied when Source V2 created batch splits, fixes #18704 

### Summary and Changelog
- Added `partitionBucketIdFunc` to `HoodieScanContext` so Source V2 scan planning can carry bucket pruning state.

### Impact
* Enables bucket pruning for Flink Source V2 batch split generation when reading bucket-index tables.

### Risk Level
low

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
