### PR TITLE
fix: report renewed storage lock expiration metric

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -553,9 +553,10 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
           return true;
         case SUCCESS:
           // Only positive outcome
-          this.setLock(currentLock.getRight().get());
+          StorageLockFile renewedLock = currentLock.getRight().get();
+          this.setLock(renewedLock);
           hoodieLockMetrics.ifPresent(metrics -> metrics.updateLockExpirationDeadlineMetric(
-              (int) (oldExpirationMs - getCurrentEpochMs())));
+              (int) (renewedLock.getValidUntilMs() - getCurrentEpochMs())));
           logger.info("Owner {}: Lock renewal successful. The renewal completes {} ms before expiration for lock {}.",
               ownerId, oldExpirationMs - getCurrentEpochMs(), lockFilePath);
           recordAuditOperation(AuditOperationState.RENEW, acquisitionTimestamp);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -92,23 +92,28 @@ class TestStorageBasedLockProvider {
     when(mockHeartbeatManager.stopHeartbeat(true)).thenReturn(true);
     // Mock the readObject method to return Option.empty() to prevent NPE in audit service creation
     when(mockLockService.readObject(anyString(), anyBoolean())).thenReturn(Option.empty());
-    TypedProperties props = new TypedProperties();
-    props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
-    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
-    props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-default");
 
-    lockProvider = spy(new StorageBasedLockProvider(
-        ownerId,
-        props,
-        (a, b, c) -> mockHeartbeatManager,
-        (a, b, c) -> mockLockService,
-        mockLogger,
-        null));
+    lockProvider = createLockProviderWithMetrics(null);
   }
 
   @AfterEach
   void cleanupLockProvider() {
     lockProvider.close();
+  }
+
+  private StorageBasedLockProvider createLockProviderWithMetrics(HoodieLockMetrics lockMetrics) {
+    TypedProperties props = new TypedProperties();
+    props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
+    props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
+    props.put(BASE_PATH.key(), "gs://bucket/lake/db/tbl-default");
+
+    return spy(new StorageBasedLockProvider(
+        ownerId,
+        props,
+        (a, b, c) -> mockHeartbeatManager,
+        (a, b, c) -> mockLockService,
+        mockLogger,
+        lockMetrics));
   }
 
   @Test
@@ -514,6 +519,29 @@ class TestStorageBasedLockProvider {
     verify(mockLogger).info(
         eq("Owner {}: Lock renewal successful. The renewal completes {} ms before expiration for lock {}."),
         eq(this.ownerId), anyLong(), eq("gs://bucket/lake/db/tbl-default/.hoodie/.locks/table_lock.json"));
+  }
+
+  @Test
+  void testRenewLockUpdatesMetricWithRenewedExpirationDeadline() {
+    HoodieLockMetrics lockMetrics = mock(HoodieLockMetrics.class);
+    lockProvider.close();
+    lockProvider = createLockProviderWithMetrics(lockMetrics);
+
+    long currentEpochMs = 1000L;
+    long oldExpirationMs = currentEpochMs + 30L;
+    long renewedExpirationMs = currentEpochMs + DEFAULT_LOCK_VALIDITY_MS;
+    StorageLockFile lockFile = new StorageLockFile(
+        new StorageLockData(false, oldExpirationMs, ownerId), "v1");
+    doReturn(lockFile).when(lockProvider).getLock();
+    when(lockProvider.getCurrentEpochMs()).thenReturn(currentEpochMs);
+
+    StorageLockFile renewedLockFile = new StorageLockFile(
+        new StorageLockData(false, renewedExpirationMs, ownerId), "v2");
+    when(mockLockService.tryUpsertLockFile(any(), eq(Option.of(lockFile))))
+        .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(renewedLockFile)));
+
+    assertTrue(lockProvider.renewLock());
+    verify(lockMetrics).updateLockExpirationDeadlineMetric(DEFAULT_LOCK_VALIDITY_MS);
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -93,7 +93,7 @@ class TestStorageBasedLockProvider {
     // Mock the readObject method to return Option.empty() to prevent NPE in audit service creation
     when(mockLockService.readObject(anyString(), anyBoolean())).thenReturn(Option.empty());
 
-    lockProvider = createLockProviderWithMetrics(null);
+    lockProvider = createLockProvider(null);
   }
 
   @AfterEach
@@ -101,7 +101,7 @@ class TestStorageBasedLockProvider {
     lockProvider.close();
   }
 
-  private StorageBasedLockProvider createLockProviderWithMetrics(HoodieLockMetrics lockMetrics) {
+  private StorageBasedLockProvider createLockProvider(HoodieLockMetrics metrics) {
     TypedProperties props = new TypedProperties();
     props.put(StorageBasedLockConfig.VALIDITY_TIMEOUT_SECONDS.key(), "10");
     props.put(StorageBasedLockConfig.RENEW_INTERVAL_SECS.key(), "1");
@@ -113,7 +113,7 @@ class TestStorageBasedLockProvider {
         (a, b, c) -> mockHeartbeatManager,
         (a, b, c) -> mockLockService,
         mockLogger,
-        lockMetrics));
+        metrics));
   }
 
   @Test
@@ -525,7 +525,7 @@ class TestStorageBasedLockProvider {
   void testRenewLockUpdatesMetricWithRenewedExpirationDeadline() {
     HoodieLockMetrics lockMetrics = mock(HoodieLockMetrics.class);
     lockProvider.close();
-    lockProvider = createLockProviderWithMetrics(lockMetrics);
+    lockProvider = createLockProvider(lockMetrics);
 
     long currentEpochMs = 1000L;
     long oldExpirationMs = currentEpochMs + 30L;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -523,9 +523,9 @@ class TestStorageBasedLockProvider {
 
   @Test
   void testRenewLockUpdatesMetricWithRenewedExpirationDeadline() {
-    HoodieLockMetrics lockMetrics = mock(HoodieLockMetrics.class);
+    HoodieLockMetrics mockLockMetrics = mock(HoodieLockMetrics.class);
     lockProvider.close();
-    lockProvider = createLockProvider(lockMetrics);
+    lockProvider = createLockProvider(mockLockMetrics);
 
     long currentEpochMs = 1000L;
     long oldExpirationMs = currentEpochMs + 30L;
@@ -541,7 +541,7 @@ class TestStorageBasedLockProvider {
         .thenReturn(Pair.of(LockUpsertResult.SUCCESS, Option.of(renewedLockFile)));
 
     assertTrue(lockProvider.renewLock());
-    verify(lockMetrics).updateLockExpirationDeadlineMetric(DEFAULT_LOCK_VALIDITY_MS);
+    verify(mockLockMetrics).updateLockExpirationDeadlineMetric(DEFAULT_LOCK_VALIDITY_MS);
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18493.

### Summary and Changelog

StorageBasedLockProvider.renewLock now reports the renewed lock expiration deadline metric from the lock file returned by the successful conditional update instead of the previous lease's remaining time.

Added a regression test covering the renewal metric value.

Validation:

`mvn -pl hudi-client/hudi-client-common -am -Dtest=TestStorageBasedLockProvider#testRenewLockUpdatesMetricWithRenewedExpirationDeadline -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -DskipITs=true -DskipFTs=true test`

### Impact

Lock expiration metrics now reflect the active renewed lease after heartbeat renewal. There is no public API change.

### Risk Level

low. The change is limited to metrics emitted after successful storage lock renewal; lock renewal behavior and the existing old-expiration log message are unchanged.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable