### PR TITLE
[HUDI-9624] Warn when event-time field is set without watermark tracking

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -46,6 +46,7 @@ import org.apache.hudi.common.fs.FileSystemRetryConfig;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodiePreWriteCleanerPolicy;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieRecordPayload;
@@ -3883,6 +3884,23 @@ public class HoodieWriteConfig extends HoodieConfig {
       checkArgument(ttlStatsMaxParallelism > 0,
           String.format("%s must be positive, but was %d",
               HoodieTTLConfig.STATS_MAX_PARALLELISM.key(), ttlStatsMaxParallelism));
+
+      validateEventTimeConfigs();
+    }
+
+    private void validateEventTimeConfigs() {
+      // Event-time field is configured but watermark tracking is off — the field
+      // will be ignored at commit time. Surface a hint so the user can opt in via
+      // TRACK_EVENT_TIME_WATERMARK.
+      String eventTimeFieldName = writeConfig.getString(HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY);
+      if (!StringUtils.isNullOrEmpty(eventTimeFieldName)
+          && !writeConfig.getBooleanOrDefault(TRACK_EVENT_TIME_WATERMARK)) {
+        log.warn("{}={} is configured but {}={}; event-time watermark metadata will not be tracked. "
+                + "Set {}=true to record event-time watermark in commit metadata.",
+            HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY, eventTimeFieldName,
+            TRACK_EVENT_TIME_WATERMARK.key(), writeConfig.getBooleanOrDefault(TRACK_EVENT_TIME_WATERMARK),
+            TRACK_EVENT_TIME_WATERMARK.key());
+      }
     }
 
     public HoodieWriteConfig build() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3999,6 +3999,20 @@ public class HoodieWriteConfig extends HoodieConfig {
                   + "Use %s=ALL or %s=NONE.",
               HoodieTableConfig.META_FIELDS_MODE.key(), metaFieldsMode, engineType,
               HoodieTableConfig.META_FIELDS_MODE.key(), HoodieTableConfig.META_FIELDS_MODE.key()));
+
+      warnIfEventTimeWatermarkNotTracked();
+    }
+
+    private void warnIfEventTimeWatermarkNotTracked() {
+      String eventTimeFieldName = writeConfig.getString(HoodiePayloadConfig.EVENT_TIME_FIELD);
+      boolean trackEventTimeWatermark = writeConfig.getBooleanOrDefault(TRACK_EVENT_TIME_WATERMARK);
+      if (!StringUtils.isNullOrEmpty(eventTimeFieldName) && !trackEventTimeWatermark) {
+        log.warn("{}={} is configured but {}={}; event-time watermark metadata will not be tracked. "
+                + "Set {}=true to record event-time watermark in commit metadata.",
+            HoodiePayloadConfig.EVENT_TIME_FIELD.key(), eventTimeFieldName,
+            TRACK_EVENT_TIME_WATERMARK.key(), trackEventTimeWatermark,
+            TRACK_EVENT_TIME_WATERMARK.key());
+      }
     }
 
     public HoodieWriteConfig build() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -42,6 +42,12 @@ import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -50,10 +56,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -984,5 +992,35 @@ public class TestHoodieWriteConfig {
         .withProperties(props)
         .build();
     assertEquals(customStrategy, writeConfig.getClusteringUpdatesStrategyClass());
+  }
+
+  @Test
+  public void testWarnsWhenEventTimeFieldSetWithoutWatermarkTracking() {
+    Properties props = new Properties();
+    props.setProperty(HoodiePayloadConfig.EVENT_TIME_FIELD.key(), "ts");
+    List<LogEvent> captured = new ArrayList<>();
+    AbstractAppender appender = new AbstractAppender(
+        "CaptureAppender", null, null, true, Property.EMPTY_ARRAY) {
+      @Override
+      public void append(LogEvent event) {
+        captured.add(event.toImmutable());
+      }
+    };
+    appender.start();
+    Logger logger = (Logger) LogManager.getLogger(HoodieWriteConfig.class);
+    logger.addAppender(appender);
+    try {
+      HoodieWriteConfig.newBuilder().withPath("/tmp").withProperties(props).build();
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
+    boolean foundHint = captured.stream()
+        .filter(e -> e.getLevel() == Level.WARN)
+        .map(e -> e.getMessage().getFormattedMessage())
+        .anyMatch(msg -> msg.contains(HoodiePayloadConfig.EVENT_TIME_FIELD.key())
+            && msg.contains(HoodieWriteConfig.TRACK_EVENT_TIME_WATERMARK.key()));
+    assertTrue(foundHint,
+        "Expected warning hint about TRACK_EVENT_TIME_WATERMARK when event-time field is set without tracking");
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -1015,12 +1015,12 @@ public class TestHoodieWriteConfig {
       logger.removeAppender(appender);
       appender.stop();
     }
-    boolean foundHint = captured.stream()
+    boolean warningFound = captured.stream()
         .filter(e -> e.getLevel() == Level.WARN)
         .map(e -> e.getMessage().getFormattedMessage())
         .anyMatch(msg -> msg.contains(HoodiePayloadConfig.EVENT_TIME_FIELD.key())
             && msg.contains(HoodieWriteConfig.TRACK_EVENT_TIME_WATERMARK.key()));
-    assertTrue(foundHint,
-        "Expected warning hint about TRACK_EVENT_TIME_WATERMARK when event-time field is set without tracking");
+    assertTrue(warningFound,
+        "Expected warning about TRACK_EVENT_TIME_WATERMARK when event-time field is set without tracking");
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodiePayloadProps;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -41,6 +42,12 @@ import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -49,10 +56,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -949,5 +958,36 @@ public class TestHoodieWriteConfig {
         .withProperties(props)
         .build();
     assertEquals(customStrategy, writeConfig.getClusteringUpdatesStrategyClass());
+  }
+
+  @Test
+  public void testWarnsWhenEventTimeFieldSetWithoutWatermarkTracking() {
+    Properties props = new Properties();
+    props.setProperty(HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY, "ts");
+    // hoodie.write.track.event.time.watermark is not set; default is false.
+    List<LogEvent> captured = new ArrayList<>();
+    AbstractAppender appender = new AbstractAppender(
+        "CaptureAppender", null, null, true, Property.EMPTY_ARRAY) {
+      @Override
+      public void append(LogEvent event) {
+        captured.add(event.toImmutable());
+      }
+    };
+    appender.start();
+    Logger logger = (Logger) LogManager.getLogger(HoodieWriteConfig.class);
+    logger.addAppender(appender);
+    try {
+      HoodieWriteConfig.newBuilder().withPath("/tmp").withProperties(props).build();
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
+    boolean foundHint = captured.stream()
+        .filter(e -> e.getLevel() == Level.WARN)
+        .map(e -> e.getMessage().getFormattedMessage())
+        .anyMatch(msg -> msg.contains(HoodiePayloadProps.PAYLOAD_EVENT_TIME_FIELD_PROP_KEY)
+            && msg.contains(HoodieWriteConfig.TRACK_EVENT_TIME_WATERMARK.key()));
+    assertTrue(foundHint,
+        "Expected warning hint about TRACK_EVENT_TIME_WATERMARK when event-time field is set without tracking");
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes https://github.com/apache/hudi/issues/17105. JIRA: https://issues.apache.org/jira/browse/HUDI-9624.

Before this change, setting `hoodie.payload.event.time.field` without enabling `hoodie.write.track.event.time.watermark` silently omitted watermark metadata from commits. The write config now warns that tracking is disabled and names the setting that enables it.

### Summary and Changelog

Write-config validation checks the existing event-time field and watermark tracking settings. When the field is non-empty and tracking is false, it emits one advisory warning. Commit metadata behavior and defaults are unchanged.

### Impact

Users with this configuration receive a warning when the write config is built. There is no public API, storage format, or performance change.

### Risk Level

Low. The condition reads two existing write-config properties.

### Documentation Update

None. This change adds no config and changes no default.

### Testing

```bash
mvn -pl hudi-client/hudi-client-common -am -DskipITs \
  -Dtest=TestHoodieWriteConfig#testWarnsWhenEventTimeFieldSetWithoutWatermarkTracking \
  -Dsurefire.failIfNoSpecifiedTests=false test
mvn -pl hudi-client/hudi-client-common -DskipTests checkstyle:check
```

<details>
<summary>Raw logs</summary>

Before, on upstream `master` with the regression test:
```text
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
AssertionFailedError: Expected warning hint about TRACK_EVENT_TIME_WATERMARK ... expected: <true> but was: <false>
BUILD FAILURE
```

After:
```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
You have 0 Checkstyle violations.
BUILD SUCCESS
```
</details>

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
