### PR TITLE
feat(parquet): support configurable ZSTD compression level

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2436,6 +2436,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getString(HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_NAME);
   }
 
+  public int getParquetCompressionCodecZstdLevel() {
+    return getIntOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL);
+  }
+
   public boolean parquetDictionaryEnabled() {
     return getBoolean(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED);
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataFileWriterFactory.java
@@ -146,6 +146,7 @@ public class HoodieRowDataFileWriterFactory extends HoodieFileWriterFactory {
         config.getLongOrDefault(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE),
         new HadoopStorageConfiguration(writeSupport.getHadoopConf()),
         config.getDoubleOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_RATIO_FRACTION),
-        config.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED));
+        config.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED),
+        config.getIntOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL));
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataParquetOutputStreamWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataParquetOutputStreamWriter.java
@@ -47,6 +47,10 @@ public class HoodieRowDataParquetOutputStreamWriter implements HoodieRowDataFile
       HoodieRowDataParquetWriteSupport writeSupport,
       HoodieParquetConfig<HoodieRowDataParquetWriteSupport> parquetConfig) throws IOException {
     this.writeSupport = writeSupport;
+    Configuration hadoopConf = HoodieParquetConfig.applyZstdLevel(
+        parquetConfig.getStorageConf().unwrapAs(Configuration.class),
+        parquetConfig.getCompressionCodecName(),
+        parquetConfig.getZstdLevel());
     ParquetWriter.Builder parquetWriterbuilder = new ParquetWriter.Builder(
         new OutputStreamBackedOutputFile(outputStream)) {
       @Override
@@ -66,7 +70,7 @@ public class HoodieRowDataParquetOutputStreamWriter implements HoodieRowDataFile
     parquetWriterbuilder.withDictionaryPageSize(parquetConfig.getPageSize());
     parquetWriterbuilder.withDictionaryEncoding(parquetConfig.isDictionaryEnabled());
     parquetWriterbuilder.withWriterVersion(ParquetWriter.DEFAULT_WRITER_VERSION);
-    parquetWriterbuilder.withConf(parquetConfig.getStorageConf().unwrapAs(Configuration.class));
+    parquetWriterbuilder.withConf(hadoopConf);
     this.writer = parquetWriterbuilder.build();
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -74,7 +74,8 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
         hoodieConfig.getLongOrDefault(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE),
         (Configuration) storageConfiguration.unwrapAs(Configuration.class),
         hoodieConfig.getDoubleOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_RATIO_FRACTION),
-        hoodieConfig.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED));
+        hoodieConfig.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED),
+        hoodieConfig.getIntOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL));
     parquetConfig.getHadoopConf().addResource(writeSupport.getHadoopConf());
 
     return new HoodieSparkParquetWriter(path, parquetConfig, instantTime, taskContextSupplier, populateMetaFields);
@@ -95,7 +96,8 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
         config.getInt(HoodieStorageConfig.PARQUET_PAGE_SIZE),
         config.getLong(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE),
         writeSupport.getHadoopConf(), config.getDouble(HoodieStorageConfig.PARQUET_COMPRESSION_RATIO_FRACTION),
-        config.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED));
+        config.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED),
+        config.getIntOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL));
     parquetConfig.getHadoopConf().addResource(writeSupport.getHadoopConf());
     return new HoodieSparkParquetStreamWriter(new FSDataOutputStream(outputStream, null), parquetConfig);
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetStreamWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetStreamWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.io.storage;
 
+import org.apache.hudi.common.config.HoodieParquetConfig;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.io.storage.row.HoodieRowParquetConfig;
 import org.apache.hudi.io.storage.row.HoodieRowParquetWriteSupport;
@@ -42,6 +43,10 @@ public class HoodieSparkParquetStreamWriter implements HoodieSparkFileWriter, Au
   public HoodieSparkParquetStreamWriter(FSDataOutputStream outputStream,
       HoodieRowParquetConfig parquetConfig) throws IOException {
     this.writeSupport = parquetConfig.getWriteSupport();
+    Configuration hadoopConf = HoodieParquetConfig.applyZstdLevel(
+        parquetConfig.getHadoopConf(),
+        parquetConfig.getCompressionCodecName(),
+        parquetConfig.getZstdLevel());
     this.writer = new Builder<>(new OutputStreamBackedOutputFile(outputStream), writeSupport)
         .withWriteMode(ParquetFileWriter.Mode.CREATE)
         .withCompressionCodec(parquetConfig.getCompressionCodecName())
@@ -50,7 +55,7 @@ public class HoodieSparkParquetStreamWriter implements HoodieSparkFileWriter, Au
         .withDictionaryPageSize(parquetConfig.getPageSize())
         .withDictionaryEncoding(parquetConfig.isDictionaryEnabled())
         .withWriterVersion(ParquetWriter.DEFAULT_WRITER_VERSION)
-        .withConf(parquetConfig.getHadoopConf())
+        .withConf(hadoopConf)
         .build();
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
@@ -92,7 +92,8 @@ public class HoodieInternalRowFileWriterFactory {
             writeConfig.getParquetMaxFileSize(),
             new HadoopStorageConfiguration(writeSupport.getHadoopConf()),
             writeConfig.getParquetCompressionRatio(),
-            writeConfig.parquetDictionaryEnabled()
+            writeConfig.parquetDictionaryEnabled(),
+            writeConfig.getParquetCompressionCodecZstdLevel()
         ));
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetConfig.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetConfig.java
@@ -36,6 +36,13 @@ public class HoodieRowParquetConfig extends HoodieParquetConfig<HoodieRowParquet
         new HadoopStorageConfiguration(hadoopConf), compressionRatio, enableDictionary);
   }
 
+  public HoodieRowParquetConfig(HoodieRowParquetWriteSupport writeSupport, CompressionCodecName compressionCodecName,
+      int blockSize, int pageSize, long maxFileSize, Configuration hadoopConf,
+      double compressionRatio, boolean enableDictionary, int zstdLevel) {
+    super(writeSupport, compressionCodecName, blockSize, pageSize, maxFileSize,
+        new HadoopStorageConfiguration(hadoopConf), compressionRatio, enableDictionary, zstdLevel);
+  }
+
   public Configuration getHadoopConf() {
     return getStorageConf().unwrapAs(Configuration.class);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.config;
 
 import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.util.ValidationUtils;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -173,6 +174,16 @@ public class HoodieStorageConfig extends HoodieConfig {
       .key("hoodie.parquet.compression.codec")
       .defaultValue("gzip")
       .withDocumentation("Compression Codec for parquet files");
+
+  public static final ConfigProperty<String> PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL = ConfigProperty
+      .key("hoodie.parquet.compression.codec.zstd.level")
+      .defaultValue("3")
+      .markAdvanced()
+      .withDocumentation("ZSTD compression level for parquet base files. Valid range is -22 to 22; higher values "
+          + "trade CPU for better compression. Only takes effect when hoodie.parquet.compression.codec=zstd. "
+          + "Forwarded to parquet-mr as parquet.compression.codec.zstd.level, overriding any value set directly "
+          + "on the Hadoop Configuration. Note: not applied to parquet files produced by the clustering "
+          + "binary-copy path (HoodieParquetFileBinaryCopier), which preserves the source files' codec settings.");
 
   public static final ConfigProperty<Boolean> PARQUET_DICTIONARY_ENABLED = ConfigProperty
       .key("hoodie.parquet.dictionary.enabled")
@@ -521,6 +532,13 @@ public class HoodieStorageConfig extends HoodieConfig {
 
     public Builder parquetCompressionCodec(String parquetCompressionCodec) {
       storageConfig.setValue(PARQUET_COMPRESSION_CODEC_NAME, parquetCompressionCodec);
+      return this;
+    }
+
+    public Builder parquetCompressionCodecZstdLevel(int zstdLevel) {
+      ValidationUtils.checkArgument(zstdLevel >= -22 && zstdLevel <= 22,
+          "ZSTD compression level must be in the range [-22, 22], got: " + zstdLevel);
+      storageConfig.setValue(PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL, String.valueOf(zstdLevel));
       return this;
     }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieStorageConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieStorageConfig.java
@@ -29,8 +29,10 @@ import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_DYN
 import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_FPP_VALUE;
 import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_NUM_ENTRIES_VALUE;
 import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_TYPE;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestHoodieStorageConfig {
   @Test
@@ -73,5 +75,26 @@ public class TestHoodieStorageConfig {
     assertEquals(BLOOM_FILTER_NUM_ENTRIES_VALUE.defaultValue(), storageConfig.getString(BLOOM_FILTER_NUM_ENTRIES_VALUE));
     assertEquals(BLOOM_FILTER_FPP_VALUE.defaultValue(), storageConfig.getString(BLOOM_FILTER_FPP_VALUE));
     assertEquals(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES.defaultValue(), storageConfig.getString(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES));
+  }
+
+  @Test
+  void testParquetZstdLevelBuilderRoundTrip() {
+    HoodieStorageConfig storageConfig = HoodieStorageConfig.newBuilder()
+        .parquetCompressionCodecZstdLevel(15).build();
+    assertEquals(15, storageConfig.getInt(PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL));
+  }
+
+  @Test
+  void testParquetZstdLevelDefault() {
+    HoodieStorageConfig storageConfig = HoodieStorageConfig.newBuilder().build();
+    assertEquals("3", storageConfig.getString(PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL));
+  }
+
+  @Test
+  void testParquetZstdLevelOutOfRangeRejected() {
+    assertThrows(IllegalArgumentException.class,
+        () -> HoodieStorageConfig.newBuilder().parquetCompressionCodecZstdLevel(23));
+    assertThrows(IllegalArgumentException.class,
+        () -> HoodieStorageConfig.newBuilder().parquetCompressionCodecZstdLevel(-23));
   }
 }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/HoodieParquetConfig.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/HoodieParquetConfig.java
@@ -20,17 +20,22 @@ package org.apache.hudi.common.config;
 
 import org.apache.hudi.storage.StorageConfiguration;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 /**
  * Base ParquetConfig to hold config params for writing to Parquet.
  * @param <T>
  */
-@AllArgsConstructor
 @Getter
 public class HoodieParquetConfig<T> {
+
+  // Matches parquet-mr's ZstandardCodec default. See HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL.
+  public static final int DEFAULT_ZSTD_LEVEL = 3;
+
+  // parquet-mr ZstandardCodec reads this key off the Hadoop Configuration at write time.
+  public static final String PARQUET_COMPRESS_ZSTD_LEVEL = "parquet.compression.codec.zstd.level";
 
   private final T writeSupport;
   private final CompressionCodecName compressionCodecName;
@@ -40,4 +45,51 @@ public class HoodieParquetConfig<T> {
   private final StorageConfiguration<?> storageConf;
   private final double compressionRatio;
   private final boolean dictionaryEnabled;
+  private final int zstdLevel;
+
+  public HoodieParquetConfig(T writeSupport,
+                             CompressionCodecName compressionCodecName,
+                             int blockSize,
+                             int pageSize,
+                             long maxFileSize,
+                             StorageConfiguration<?> storageConf,
+                             double compressionRatio,
+                             boolean dictionaryEnabled) {
+    this(writeSupport, compressionCodecName, blockSize, pageSize, maxFileSize, storageConf,
+        compressionRatio, dictionaryEnabled, DEFAULT_ZSTD_LEVEL);
+  }
+
+  public HoodieParquetConfig(T writeSupport,
+                             CompressionCodecName compressionCodecName,
+                             int blockSize,
+                             int pageSize,
+                             long maxFileSize,
+                             StorageConfiguration<?> storageConf,
+                             double compressionRatio,
+                             boolean dictionaryEnabled,
+                             int zstdLevel) {
+    this.writeSupport = writeSupport;
+    this.compressionCodecName = compressionCodecName;
+    this.blockSize = blockSize;
+    this.pageSize = pageSize;
+    this.maxFileSize = maxFileSize;
+    this.storageConf = storageConf;
+    this.compressionRatio = compressionRatio;
+    this.dictionaryEnabled = dictionaryEnabled;
+    this.zstdLevel = zstdLevel;
+  }
+
+  /**
+   * Returns a Hadoop {@link Configuration} carrying the zstd compression level when {@code codec} is ZSTD.
+   * If the codec is not ZSTD, returns {@code conf} unchanged. Otherwise returns a defensive copy with the
+   * level stamped on it, so callers don't mutate the shared task-level Configuration.
+   */
+  public static Configuration applyZstdLevel(Configuration conf, CompressionCodecName codec, int zstdLevel) {
+    if (codec != CompressionCodecName.ZSTD) {
+      return conf;
+    }
+    Configuration copy = new Configuration(conf);
+    copy.setInt(PARQUET_COMPRESS_ZSTD_LEVEL, zstdLevel);
+    return copy;
+  }
 }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/hadoop/HoodieBaseParquetWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/hadoop/HoodieBaseParquetWriter.java
@@ -54,7 +54,10 @@ public abstract class HoodieBaseParquetWriter<R> implements Closeable {
 
   public HoodieBaseParquetWriter(StoragePath file,
                                  HoodieParquetConfig<? extends WriteSupport<R>> parquetConfig) throws IOException {
-    Configuration hadoopConf = parquetConfig.getStorageConf().unwrapAs(Configuration.class);
+    Configuration hadoopConf = HoodieParquetConfig.applyZstdLevel(
+        parquetConfig.getStorageConf().unwrapAs(Configuration.class),
+        parquetConfig.getCompressionCodecName(),
+        parquetConfig.getZstdLevel());
     ParquetWriter.Builder parquetWriterbuilder = new ParquetWriter.Builder(
         HoodieWrapperFileSystem.convertToHoodiePath(file, hadoopConf)) {
       @Override

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
@@ -85,7 +85,8 @@ public class HoodieAvroFileWriterFactory extends HoodieFileWriterFactory {
         hoodieConfig.getIntOrDefault(HoodieStorageConfig.PARQUET_PAGE_SIZE),
         hoodieConfig.getLongOrDefault(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE),
         storageConfiguration, hoodieConfig.getDoubleOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_RATIO_FRACTION),
-        hoodieConfig.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED));
+        hoodieConfig.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED),
+        hoodieConfig.getIntOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL));
     return new HoodieAvroParquetWriter(path, parquetConfig, instantTime, taskContextSupplier, populateMetaFields);
   }
 
@@ -102,7 +103,8 @@ public class HoodieAvroFileWriterFactory extends HoodieFileWriterFactory {
         config.getInt(HoodieStorageConfig.PARQUET_PAGE_SIZE),
         config.getLong(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE), // todo: 1024*1024*1024
         storage.getConf(), config.getDouble(HoodieStorageConfig.PARQUET_COMPRESSION_RATIO_FRACTION),
-        config.getBoolean(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED));
+        config.getBoolean(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED),
+        config.getIntOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_CODEC_ZSTD_LEVEL));
     return new HoodieParquetStreamWriter(new FSDataOutputStream(outputStream, null), parquetConfig);
   }
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieParquetStreamWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieParquetStreamWriter.java
@@ -49,6 +49,10 @@ public class HoodieParquetStreamWriter implements HoodieAvroFileWriter, AutoClos
   public HoodieParquetStreamWriter(FSDataOutputStream outputStream,
                                    HoodieParquetConfig<HoodieAvroWriteSupport> parquetConfig) throws IOException {
     this.writeSupport = parquetConfig.getWriteSupport();
+    Configuration hadoopConf = HoodieParquetConfig.applyZstdLevel(
+        parquetConfig.getStorageConf().unwrapAs(Configuration.class),
+        parquetConfig.getCompressionCodecName(),
+        parquetConfig.getZstdLevel());
     this.writer = new Builder<IndexedRecord>(new OutputStreamBackedOutputFile(outputStream), writeSupport)
         .withWriteMode(ParquetFileWriter.Mode.CREATE)
         .withCompressionCodec(parquetConfig.getCompressionCodecName())
@@ -57,7 +61,7 @@ public class HoodieParquetStreamWriter implements HoodieAvroFileWriter, AutoClos
         .withDictionaryPageSize(parquetConfig.getPageSize())
         .withDictionaryEncoding(parquetConfig.isDictionaryEnabled())
         .withWriterVersion(ParquetWriter.DEFAULT_WRITER_VERSION)
-        .withConf(parquetConfig.getStorageConf().unwrapAs(Configuration.class))
+        .withConf(hadoopConf)
         .build();
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/config/TestHoodieParquetConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/config/TestHoodieParquetConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.hudi.common.config.HoodieParquetConfig.PARQUET_COMPRESS_ZSTD_LEVEL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class TestHoodieParquetConfig {
+
+  @Test
+  void applyZstdLevelStampsClonedConfWhenCodecIsZstd() {
+    Configuration original = new Configuration(false);
+    Configuration result = HoodieParquetConfig.applyZstdLevel(original, CompressionCodecName.ZSTD, 10);
+
+    assertNotSame(original, result, "applyZstdLevel must not mutate the shared conf");
+    assertEquals(10, result.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+    assertNull(original.get(PARQUET_COMPRESS_ZSTD_LEVEL), "original conf must be untouched");
+  }
+
+  @Test
+  void applyZstdLevelReturnsOriginalForNonZstdCodec() {
+    Configuration original = new Configuration(false);
+    Configuration result = HoodieParquetConfig.applyZstdLevel(original, CompressionCodecName.GZIP, 10);
+
+    assertSame(original, result);
+    assertNull(original.get(PARQUET_COMPRESS_ZSTD_LEVEL),
+        "non-ZSTD codec must not stamp the zstd level on the conf");
+  }
+
+  @Test
+  void applyZstdLevelOverridesAnyPreexistingValue() {
+    Configuration original = new Configuration(false);
+    original.setInt(PARQUET_COMPRESS_ZSTD_LEVEL, 7);
+    Configuration result = HoodieParquetConfig.applyZstdLevel(original, CompressionCodecName.ZSTD, 22);
+
+    assertEquals(22, result.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1));
+    assertEquals(7, original.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, -1),
+        "original conf must be untouched even when it already had the key");
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Parquet base files written by Hudi use the parquet-mr ZSTD codec at its hard-coded default level (3). Users who want a higher compression ratio (or faster level for ingest) currently have to push `parquet.compression.codec.zstd.level` through raw Hadoop conf, which bypasses Hudi's config plumbing and isn't surfaced anywhere in `HoodieStorageConfig`.

### Summary and Changelog

- Added `hoodie.parquet.compression.codec.zstd.level` (default `3`, valid range `-22..22`, matching parquet-mr's `ZstandardCodec`).
- Threaded the level through `HoodieParquetConfig` (new field + backward-compatible 8-arg constructor preserved) and on to parquet-mr via `parquet.compression.codec.zstd.level` on a defensive `Configuration` copy, so the shared task-level conf isn't mutated.
- Wired the new setting through every parquet writer entry point: `HoodieAvroFileWriterFactory`, `HoodieSparkFileWriterFactory`, `HoodieRowDataFileWriterFactory`, `HoodieInternalRowFileWriterFactory`, `HoodieBaseParquetWriter`, `HoodieParquetStreamWriter`, `HoodieSparkParquetStreamWriter`, `HoodieRowDataParquetOutputStreamWriter`.
- Level is only stamped onto the conf when the active codec is `ZSTD` — non-ZSTD writes are unaffected.

Validation:

`mvn -pl hudi-hadoop-common -am -Dtest=TestHoodieParquetConfig,TestHoodieStorageConfig -DfailIfNoTests=false -DskipITs=true -DskipFTs=true test`

### Impact

New user-facing config only. No public API change — existing callers compile unchanged via the backward-compatible `HoodieParquetConfig` constructor that defaults the level to 3 (parquet-mr's existing default). Default behavior for existing tables is unchanged.

### Risk Level

low. The level is only applied when the codec is ZSTD, and only on a defensive Configuration copy. All other codecs and the existing default ZSTD level are unaffected.

### Documentation Update

The new config (`hoodie.parquet.compression.codec.zstd.level`) is declared with description and `withDocumentation` in `HoodieStorageConfig`, so it will be picked up by the auto-generated configurations page.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable