### PR TITLE
feat(flink): Support reading VECTOR columns from Parquet and Avro format

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/AvroToRowDataConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/AvroToRowDataConverters.java
@@ -19,6 +19,9 @@
 package org.apache.hudi.util;
 
 import org.apache.hudi.adapter.DataTypeAdapter;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -57,6 +60,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 /**
  * Tool class used to convert from Avro {@link GenericRecord} to {@link RowData}.
@@ -78,16 +82,55 @@ public class AvroToRowDataConverters {
   // -------------------------------------------------------------------------------------
   // Runtime Converters
   // -------------------------------------------------------------------------------------
+
+  /**
+   * Creates a row converter from the Flink row type using UTC timezone conversion.
+   *
+   * <p>Note that this RowType-only path cannot recover Hoodie-specific logical type metadata
+   * that is not represented in Flink's {@link RowType}.
+   */
   public static AvroToRowDataConverter createRowConverter(RowType rowType) {
     return createRowConverter(rowType, true);
   }
 
+  /**
+   * Creates a row converter from the Flink row type.
+   *
+   * <p>Note that this RowType-only path cannot recover Hoodie-specific logical type metadata
+   * that is not represented in Flink's {@link RowType}.
+   */
   public static AvroToRowDataConverter createRowConverter(RowType rowType, boolean utcTimezone) {
-    final AvroToRowDataConverter[] fieldConverters =
-        rowType.getFields().stream()
-            .map(RowType.RowField::getType)
-            .map(type -> AvroToRowDataConverters.createNullableConverter(type, utcTimezone))
-            .toArray(AvroToRowDataConverter[]::new);
+    return createRowConverter(HoodieSchemaConverter.convertToSchema(rowType), rowType, utcTimezone);
+  }
+
+  /**
+   * Creates a row converter using only the Flink row type.
+   *
+   * <p>This converter cannot recover Hoodie-specific logical type metadata from {@link RowType}.
+   * Use {@link #createRowConverter(HoodieSchema, RowType, boolean)} when a Hoodie schema is
+   * available, especially for VECTOR columns.
+   */
+  public static AvroToRowDataConverter createRowConverter(HoodieSchema hoodieSchema) {
+    return createRowConverter(hoodieSchema, (RowType) HoodieSchemaConverter.convertToDataType(hoodieSchema).getLogicalType(), true);
+  }
+
+  /**
+   * Creates a row converter using both Hoodie schema metadata and the target Flink row type.
+   */
+  public static AvroToRowDataConverter createRowConverter(HoodieSchema schema, RowType rowType, boolean utcTimezone) {
+    HoodieSchema recordSchema = schema.getNonNullType();
+    if (recordSchema.getType() == HoodieSchemaType.UNION) {
+      // getNonNullType() unwraps simple nullable unions only. Complex unions can still reach
+      // here when their Flink representation is a ROW, for example fields inside
+      // ColumnStatsSchemas.METADATA_SCHEMA. In that case the RowType already captures the
+      // target Flink shape, so use the first union branch only as the positional Hoodie schema
+      // template for building nested field converters.
+      recordSchema = recordSchema.getTypes().get(0);
+    }
+    final List<HoodieSchemaField> fields = recordSchema.getFields();
+    final AvroToRowDataConverter[] fieldConverters = IntStream.range(0, rowType.getFieldCount())
+        .mapToObj(i -> createNullableConverter(fields.get(i).schema(), rowType.getTypeAt(i), utcTimezone))
+        .toArray(AvroToRowDataConverter[]::new);
     final int arity = rowType.getFieldCount();
 
     return avroObject -> {
@@ -103,8 +146,11 @@ public class AvroToRowDataConverters {
   /**
    * Creates a runtime converter which is null safe.
    */
-  private static AvroToRowDataConverter createNullableConverter(LogicalType type, boolean utcTimezone) {
-    final AvroToRowDataConverter converter = createConverter(type, utcTimezone);
+  private static AvroToRowDataConverter createNullableConverter(
+      HoodieSchema schema,
+      LogicalType type,
+      boolean utcTimezone) {
+    final AvroToRowDataConverter converter = createConverter(schema, type, utcTimezone);
     return avroObject -> {
       if (avroObject == null) {
         return null;
@@ -117,6 +163,19 @@ public class AvroToRowDataConverters {
    * Creates a runtime converter which assuming input object is not null.
    */
   public static AvroToRowDataConverter createConverter(LogicalType type, boolean utcTimezone) {
+    return createConverter(HoodieSchemaConverter.convertToSchema(type), type, utcTimezone);
+  }
+
+  /**
+   * Creates a runtime converter with both Hoodie schema and Flink logical type information.
+   *
+   * <p>The recursive converter construction keeps these two type views together: Flink
+   * {@link LogicalType} decides the target RowData representation, while {@link HoodieSchema}
+   * carries Hoodie-specific logical metadata such as VECTOR dimension and element type.
+   */
+  private static AvroToRowDataConverter createConverter(HoodieSchema schema, LogicalType type, boolean utcTimezone) {
+    HoodieSchema nonNullSchema = schema.getNonNullType();
+
     switch (type.getTypeRoot()) {
       case NULL:
         return avroObject -> null;
@@ -143,25 +202,36 @@ public class AvroToRowDataConverters {
         return createTimestampConverter(((TimestampType) type).getPrecision(), utcTimezone);
       case CHAR:
       case VARCHAR:
-        return avroObject -> avroObject instanceof Utf8 ? StringData.fromBytes(((Utf8) avroObject).getBytes()) : StringData.fromString(avroObject.toString());
+        return avroObject -> avroObject instanceof Utf8
+            ? StringData.fromBytes(((Utf8) avroObject).getBytes())
+            : StringData.fromString(avroObject.toString());
       case BINARY:
       case VARBINARY:
         return AvroToRowDataConverters::convertToBytes;
       case DECIMAL:
         return createDecimalConverter((DecimalType) type);
       case ARRAY:
-        return createArrayConverter((ArrayType) type, utcTimezone);
+        if (nonNullSchema.getType() == HoodieSchemaType.VECTOR) {
+          HoodieSchema.Vector vectorSchema = (HoodieSchema.Vector) nonNullSchema;
+          VectorConversionUtils.validateVectorLogicalType(vectorSchema, type);
+          return createVectorConverter(vectorSchema);
+        }
+        return createArrayConverter(nonNullSchema.getElementType(), (ArrayType) type, utcTimezone);
       case ROW:
-        return createRowConverter((RowType) type, utcTimezone);
+        return createRowConverter(nonNullSchema, (RowType) type, utcTimezone);
       case MAP:
       case MULTISET:
-        return createMapConverter(type, utcTimezone);
+        return createMapConverter(nonNullSchema.getValueType(), type, utcTimezone);
       default:
         if (DataTypeAdapter.isVariantType(type)) {
           return createVariantConverter();
         }
         throw new UnsupportedOperationException("Unsupported type: " + type);
     }
+  }
+
+  private static AvroToRowDataConverter createVectorConverter(HoodieSchema.Vector vectorSchema) {
+    return avroObject -> VectorConversionUtils.createVectorArrayData(convertToBytes(avroObject), vectorSchema);
   }
 
   private static AvroToRowDataConverter createDecimalConverter(DecimalType decimalType) {
@@ -182,9 +252,12 @@ public class AvroToRowDataConverters {
     };
   }
 
-  private static AvroToRowDataConverter createArrayConverter(ArrayType arrayType, boolean utcTimezone) {
+  private static AvroToRowDataConverter createArrayConverter(
+      HoodieSchema elementSchema,
+      ArrayType arrayType,
+      boolean utcTimezone) {
     final AvroToRowDataConverter elementConverter =
-        createNullableConverter(arrayType.getElementType(), utcTimezone);
+        createNullableConverter(elementSchema, arrayType.getElementType(), utcTimezone);
     final Class<?> elementClass =
         LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
 
@@ -199,11 +272,14 @@ public class AvroToRowDataConverters {
     };
   }
 
-  private static AvroToRowDataConverter createMapConverter(LogicalType type, boolean utcTimezone) {
+  private static AvroToRowDataConverter createMapConverter(
+      HoodieSchema valueSchema,
+      LogicalType type,
+      boolean utcTimezone) {
     final AvroToRowDataConverter keyConverter =
         createConverter(DataTypes.STRING().getLogicalType(), utcTimezone);
     final AvroToRowDataConverter valueConverter =
-        createNullableConverter(HoodieSchemaConverter.extractValueTypeToMap(type), utcTimezone);
+        createNullableConverter(valueSchema, HoodieSchemaConverter.extractValueTypeToMap(type), utcTimezone);
 
     return avroObject -> {
       final Map<?, ?> map = (Map<?, ?>) avroObject;

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/AvroToRowDataConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/AvroToRowDataConverters.java
@@ -104,11 +104,7 @@ public class AvroToRowDataConverters {
   }
 
   /**
-   * Creates a row converter using only the Flink row type.
-   *
-   * <p>This converter cannot recover Hoodie-specific logical type metadata from {@link RowType}.
-   * Use {@link #createRowConverter(HoodieSchema, RowType, boolean)} when a Hoodie schema is
-   * available, especially for VECTOR columns.
+   * Creates a row converter using Hoodie schema.
    */
   public static AvroToRowDataConverter createRowConverter(HoodieSchema hoodieSchema) {
     return createRowConverter(hoodieSchema, (RowType) HoodieSchemaConverter.convertToDataType(hoodieSchema).getLogicalType(), true);

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataQueryContexts.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataQueryContexts.java
@@ -67,7 +67,7 @@ public class RowDataQueryContexts {
         contextMap.put(rowFields[i].getName(), FieldQueryContext.create(fieldType, fieldGetter, utcTimezone));
       }
       RowDataToAvroConverter rowDataToAvroConverter = RowDataToAvroConverters.createConverter(rowType, utcTimezone);
-      AvroToRowDataConverter avroToRowDataConverter = AvroToRowDataConverters.createRowConverter(rowType, utcTimezone);
+      AvroToRowDataConverter avroToRowDataConverter = AvroToRowDataConverters.createRowConverter(schema, rowType, utcTimezone);
       return RowDataQueryContext.create(dataType, contextMap, fieldGetters, rowDataToAvroConverter, avroToRowDataConverter);
     });
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/VectorConversionUtils.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/VectorConversionUtils.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.util.HoodieVectorUtils;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
+import org.apache.hudi.exception.SchemaCompatibilityException;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities for reading Hoodie VECTOR columns into Flink {@link RowData}.
+ *
+ * <p>VECTOR columns are stored as fixed-length bytes in parquet/log files. The Flink reader
+ * reads those physical bytes first and then decodes them into Flink array data according to
+ * the vector element type declared in {@link HoodieSchema.Vector}.
+ */
+public final class VectorConversionUtils {
+
+  private VectorConversionUtils() {
+  }
+
+  /**
+   * Detects VECTOR columns in the selected read projection.
+   *
+   * <p>The returned map is keyed by the projected field ordinal, not the ordinal in the full
+   * table schema. This matches the ordinal layout of the {@link RowData} emitted by the reader.
+   *
+   * @param fullFieldNames field names in the full query/table row type
+   * @param selectedFields ordinals selected from {@code fullFieldNames}
+   * @param tableSchema    hoodie table schema containing logical VECTOR type metadata
+   * @return projected ordinal to vector schema information
+   */
+  public static Map<Integer, HoodieSchema.Vector> detectVectorColumns(
+      String[] fullFieldNames,
+      int[] selectedFields,
+      HoodieSchema tableSchema) {
+    Map<String, HoodieSchema.Vector> vectorFields = getVectorFields(tableSchema);
+    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = new LinkedHashMap<>();
+    for (int i = 0; i < selectedFields.length; i++) {
+      HoodieSchema.Vector vector = vectorFields.get(fullFieldNames[selectedFields[i]].toLowerCase(Locale.ROOT));
+      if (vector != null) {
+        vectorColumnInfo.put(i, vector);
+      }
+    }
+    return vectorColumnInfo;
+  }
+
+  /**
+   * Rewrites VECTOR fields in a requested row data type to BYTES for parquet reads.
+   *
+   * <p>Parquet stores VECTOR values as fixed-length byte arrays. This method keeps the requested
+   * row shape unchanged, but asks the physical parquet reader to materialize VECTOR columns as
+   * bytes. The resulting rows should be passed through
+   * {@link #wrapVectorColumnIterator(ClosableIterator, RowType, Map)} to decode the bytes into
+   * array data.
+   *
+   * @param dataType         requested row data type
+   * @param requestedSchema  requested Hudi schema
+   * @param vectorColumnInfo projected VECTOR column metadata
+   * @return row data type to use for the physical parquet read
+   */
+  public static DataType getParquetReadDataType(
+      DataType dataType,
+      HoodieSchema requestedSchema,
+      Map<Integer, HoodieSchema.Vector> vectorColumnInfo) {
+    if (vectorColumnInfo.isEmpty()) {
+      return dataType;
+    }
+
+    RowType rowType = (RowType) dataType.getLogicalType();
+    List<RowType.RowField> readFields = new ArrayList<>(rowType.getFields().size());
+    for (RowType.RowField field : rowType.getFields()) {
+      readFields.add(field.copy());
+    }
+    for (Integer requestedOrdinal : vectorColumnInfo.keySet()) {
+      String fieldName = requestedSchema.getFields().get(requestedOrdinal).name();
+      int fieldOrdinal = rowType.getFieldIndex(fieldName);
+      if (fieldOrdinal >= 0) {
+        RowType.RowField field = readFields.get(fieldOrdinal);
+        readFields.set(fieldOrdinal, newRowField(field, bytesType(field.getType())));
+      }
+    }
+    return DataTypes.of(new RowType(rowType.isNullable(), readFields));
+  }
+
+  /**
+   * Rewrites VECTOR field types in the full field type array to BYTES for parquet reads.
+   *
+   * <p>This variant is used by copy-on-write input format code paths that keep the full field
+   * type array and apply projection separately.
+   *
+   * @param fullFieldNames field names in the full query/table row type
+   * @param fullFieldTypes field types corresponding to {@code fullFieldNames}
+   * @param tableSchema    hoodie table schema containing logical VECTOR type metadata
+   * @return field types to use for the physical parquet read
+   */
+  public static DataType[] getParquetReadFieldTypes(
+      String[] fullFieldNames,
+      DataType[] fullFieldTypes,
+      HoodieSchema tableSchema) {
+    Map<String, HoodieSchema.Vector> vectorFields = getVectorFields(tableSchema);
+    if (vectorFields.isEmpty()) {
+      return fullFieldTypes;
+    }
+    DataType[] readFieldTypes = Arrays.copyOf(fullFieldTypes, fullFieldTypes.length);
+    for (int i = 0; i < fullFieldNames.length; i++) {
+      if (vectorFields.containsKey(fullFieldNames[i].toLowerCase(Locale.ROOT))) {
+        readFieldTypes[i] = DataTypes.of(bytesType(fullFieldTypes[i].getLogicalType()));
+      }
+    }
+    return readFieldTypes;
+  }
+
+  /**
+   * Wraps a row iterator and decodes VECTOR byte values into Flink array values.
+   *
+   * <p>{@code rowType} must describe the physical rows emitted by {@code rowDataItr}, where VECTOR
+   * columns have already been read as BYTES. Non-vector fields are copied with type-aware Flink
+   * field getters to preserve their original representation.
+   *
+   * @param rowDataItr       physical row iterator
+   * @param rowType          row type of the physical rows emitted by {@code rowDataItr}
+   * @param vectorColumnInfo projected VECTOR column metadata keyed by row ordinal
+   * @return iterator emitting rows with VECTOR columns decoded as arrays
+   */
+  public static ClosableIterator<RowData> wrapVectorColumnIterator(
+      ClosableIterator<RowData> rowDataItr,
+      RowType rowType,
+      Map<Integer, HoodieSchema.Vector> vectorColumnInfo) {
+    RowData.FieldGetter[] fieldGetters = createFieldGetters(rowType);
+    return new CloseableMappingIterator<>(
+        rowDataItr, rowData -> convertVectorColumns(rowData, fieldGetters, vectorColumnInfo));
+  }
+
+  /**
+   * Wraps a projected row iterator and decodes VECTOR byte values into Flink array values.
+   *
+   * <p>The selected physical row type is derived from {@code fullFieldTypes} and
+   * {@code selectedFields}, then delegated to {@link #wrapVectorColumnIterator(ClosableIterator, RowType, Map)}.
+   *
+   * @param rowDataItr       physical row iterator
+   * @param fullFieldTypes   field types before projection
+   * @param selectedFields   ordinals selected from {@code fullFieldTypes}
+   * @param vectorColumnInfo projected VECTOR column metadata keyed by row ordinal
+   * @return iterator emitting rows with VECTOR columns decoded as arrays
+   */
+  public static ClosableIterator<RowData> wrapVectorColumnIterator(
+      ClosableIterator<RowData> rowDataItr,
+      DataType[] fullFieldTypes,
+      int[] selectedFields,
+      Map<Integer, HoodieSchema.Vector> vectorColumnInfo) {
+    return wrapVectorColumnIterator(rowDataItr, createRowType(fullFieldTypes, selectedFields), vectorColumnInfo);
+  }
+
+  /**
+   * Returns VECTOR fields keyed by lower-cased field name.
+   */
+  private static Map<String, HoodieSchema.Vector> getVectorFields(HoodieSchema tableSchema) {
+    return tableSchema.getFields().stream()
+        .filter(field -> field.schema().getNonNullType().getType() == HoodieSchemaType.VECTOR)
+        .collect(Collectors.toMap(
+            field -> field.name().toLowerCase(Locale.ROOT),
+            field -> (HoodieSchema.Vector) field.schema().getNonNullType()));
+  }
+
+  /**
+   * Creates a BYTES logical type while preserving the original nullability.
+   */
+  private static LogicalType bytesType(LogicalType originalType) {
+    return DataTypes.BYTES().getLogicalType().copy(originalType.isNullable());
+  }
+
+  /**
+   * Creates a row field with a replacement logical type while preserving metadata.
+   */
+  private static RowType.RowField newRowField(RowType.RowField field, LogicalType type) {
+    return field.getDescription()
+        .map(description -> new RowType.RowField(field.getName(), type, description))
+        .orElseGet(() -> new RowType.RowField(field.getName(), type));
+  }
+
+  /**
+   * Converts VECTOR columns in one row from physical bytes to Flink array data.
+   */
+  private static RowData convertVectorColumns(
+      RowData rowData,
+      RowData.FieldGetter[] fieldGetters,
+      Map<Integer, HoodieSchema.Vector> vectorColumnInfo) {
+    GenericRowData converted = new GenericRowData(rowData.getArity());
+    converted.setRowKind(rowData.getRowKind());
+    for (int i = 0; i < rowData.getArity(); i++) {
+      if (rowData.isNullAt(i)) {
+        converted.setField(i, null);
+      } else if (vectorColumnInfo.containsKey(i)) {
+        converted.setField(i, createVectorArrayData(rowData.getBinary(i), vectorColumnInfo.get(i)));
+      } else {
+        converted.setField(i, fieldGetters[i].getFieldOrNull(rowData));
+      }
+    }
+    return converted;
+  }
+
+  /**
+   * Creates type-aware field getters for the physical row type.
+   */
+  private static RowData.FieldGetter[] createFieldGetters(RowType rowType) {
+    RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[rowType.getFieldCount()];
+    for (int i = 0; i < fieldGetters.length; i++) {
+      fieldGetters[i] = RowData.createFieldGetter(rowType.getTypeAt(i), i);
+    }
+    return fieldGetters;
+  }
+
+  /**
+   * Builds a projected row type from full field types and selected ordinals.
+   */
+  private static RowType createRowType(DataType[] fullFieldTypes, int[] selectedFields) {
+    List<RowType.RowField> rowFields = new ArrayList<>(selectedFields.length);
+    for (int i = 0; i < selectedFields.length; i++) {
+      rowFields.add(new RowType.RowField(String.valueOf(i), fullFieldTypes[selectedFields[i]].getLogicalType()));
+    }
+    return new RowType(rowFields);
+  }
+
+  /**
+   * Wraps a decoded primitive vector array as Flink array data.
+   */
+  public static GenericArrayData createVectorArrayData(byte[] bytes, HoodieSchema.Vector vectorSchema) {
+    Object vectorArray = HoodieVectorUtils.decodeVectorBytes(bytes, vectorSchema);
+    if (vectorArray instanceof float[]) {
+      return new GenericArrayData((float[]) vectorArray);
+    } else if (vectorArray instanceof double[]) {
+      return new GenericArrayData((double[]) vectorArray);
+    } else if (vectorArray instanceof byte[]) {
+      return new GenericArrayData((byte[]) vectorArray);
+    }
+    throw new UnsupportedOperationException("Unsupported decoded vector array type: " + vectorArray.getClass());
+  }
+
+  public static void validateVectorLogicalType(HoodieSchema.Vector vectorSchema, LogicalType type) {
+    LogicalTypeRoot elementTypeRoot = ((ArrayType) type).getElementType().getTypeRoot();
+    LogicalTypeRoot expectedElementTypeRoot = expectedVectorElementTypeRoot(vectorSchema.getVectorElementType());
+    if (elementTypeRoot != expectedElementTypeRoot) {
+      throw new SchemaCompatibilityException(
+          "VECTOR element type "
+              + vectorSchema.getVectorElementType()
+              + " must be converted to Flink ARRAY<"
+              + expectedElementTypeRoot
+              + ">, but got ARRAY<"
+              + elementTypeRoot
+              + ">.");
+    }
+  }
+
+  private static LogicalTypeRoot expectedVectorElementTypeRoot(HoodieSchema.Vector.VectorElementType elementType) {
+    switch (elementType) {
+      case FLOAT:
+        return LogicalTypeRoot.FLOAT;
+      case DOUBLE:
+        return LogicalTypeRoot.DOUBLE;
+      case INT8:
+        return LogicalTypeRoot.TINYINT;
+      default:
+        throw new UnsupportedOperationException("Unsupported VECTOR element type: " + elementType);
+    }
+  }
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/VectorConversionUtils.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/VectorConversionUtils.java
@@ -259,7 +259,7 @@ public final class VectorConversionUtils {
   }
 
   /**
-   * Wraps a decoded primitive vector array as Flink array data.
+   * Decodes raw vector bytes and wraps the decoded primitive vector array as Flink array data.
    */
   public static GenericArrayData createVectorArrayData(byte[] bytes, HoodieSchema.Vector vectorSchema) {
     Object vectorArray = HoodieVectorUtils.decodeVectorBytes(bytes, vectorSchema);
@@ -273,6 +273,13 @@ public final class VectorConversionUtils {
     throw new UnsupportedOperationException("Unsupported decoded vector array type: " + vectorArray.getClass());
   }
 
+  /**
+   * Validates that a Flink ARRAY logical type uses the element type required by the VECTOR schema.
+   *
+   * @param vectorSchema VECTOR schema defining the expected element type
+   * @param type         Flink ARRAY logical type to validate
+   * @throws SchemaCompatibilityException if the ARRAY element type does not match the VECTOR element type
+   */
   public static void validateVectorLogicalType(HoodieSchema.Vector vectorSchema, LogicalType type) {
     LogicalTypeRoot elementTypeRoot = ((ArrayType) type).getElementType().getTypeRoot();
     LogicalTypeRoot expectedElementTypeRoot = expectedVectorElementTypeRoot(vectorSchema.getVectorElementType());

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestAvroToRowDataConverters.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestAvroToRowDataConverters.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.RowData;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestAvroToRowDataConverters {
+
+  @Test
+  public void testConvertVectorFixedBytesToArrays() {
+    HoodieSchema floatVector = HoodieSchema.createVector(2);
+    HoodieSchema doubleVector = HoodieSchema.createVector(2, HoodieSchema.Vector.VectorElementType.DOUBLE);
+    HoodieSchema int8Vector = HoodieSchema.createVector(3, HoodieSchema.Vector.VectorElementType.INT8);
+    HoodieSchema schema = HoodieSchema.createRecord("VectorRecord", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)),
+        HoodieSchemaField.of("float_vec", floatVector),
+        HoodieSchemaField.of("double_vec", doubleVector),
+        HoodieSchemaField.of("int8_vec", int8Vector)));
+
+    GenericData.Record record = new GenericData.Record(schema.toAvroSchema());
+    record.put("id", 1);
+    record.put("float_vec", new GenericData.Fixed(floatVector.toAvroSchema(), vectorBytes(new float[] {1.0f, 2.5f})));
+    record.put("double_vec", new GenericData.Fixed(doubleVector.toAvroSchema(), vectorBytes(new double[] {3.0d, 4.5d})));
+    record.put("int8_vec", new GenericData.Fixed(int8Vector.toAvroSchema(), new byte[] {1, 2, 3}));
+
+    RowData rowData = (RowData) RowDataQueryContexts.fromSchema(schema).getAvroToRowDataConverter().convert(record);
+
+    assertEquals(1, rowData.getInt(0));
+    ArrayData floatArray = rowData.getArray(1);
+    assertEquals(2, floatArray.size());
+    assertEquals(1.0f, floatArray.getFloat(0), 0.0f);
+    assertEquals(2.5f, floatArray.getFloat(1), 0.0f);
+    ArrayData doubleArray = rowData.getArray(2);
+    assertEquals(2, doubleArray.size());
+    assertEquals(3.0d, doubleArray.getDouble(0), 0.0d);
+    assertEquals(4.5d, doubleArray.getDouble(1), 0.0d);
+    ArrayData int8Array = rowData.getArray(3);
+    assertEquals(3, int8Array.size());
+    assertEquals((byte) 1, int8Array.getByte(0));
+    assertEquals((byte) 2, int8Array.getByte(1));
+    assertEquals((byte) 3, int8Array.getByte(2));
+  }
+
+  @Test
+  public void testConvertNullableVector() {
+    HoodieSchema nullableVector = HoodieSchema.createNullable(HoodieSchema.createVector(2));
+    HoodieSchema schema = HoodieSchema.createRecord("NullableVectorRecord", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)),
+        HoodieSchemaField.of("embedding", nullableVector)));
+
+    GenericData.Record record = new GenericData.Record(schema.toAvroSchema());
+    record.put("id", 1);
+    record.put("embedding", null);
+
+    RowData rowData = (RowData) RowDataQueryContexts.fromSchema(schema).getAvroToRowDataConverter().convert(record);
+
+    assertEquals(1, rowData.getInt(0));
+    assertTrue(rowData.isNullAt(1));
+  }
+
+  @Test
+  public void testConvertVectorWithWrongByteLengthFails() {
+    HoodieSchema vector = HoodieSchema.createVector(2);
+    HoodieSchema schema = HoodieSchema.createRecord("InvalidVectorRecord", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)),
+        HoodieSchemaField.of("embedding", vector)));
+
+    GenericData.Record record = new GenericData.Record(schema.toAvroSchema());
+    record.put("id", 1);
+    record.put("embedding", ByteBuffer.wrap(new byte[] {1, 2, 3}));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> RowDataQueryContexts.fromSchema(schema).getAvroToRowDataConverter().convert(record));
+  }
+
+  private static byte[] vectorBytes(float[] values) {
+    ByteBuffer buffer = ByteBuffer.allocate(values.length * Float.BYTES)
+        .order(HoodieSchema.VectorLogicalType.VECTOR_BYTE_ORDER);
+    for (float value : values) {
+      buffer.putFloat(value);
+    }
+    return buffer.array();
+  }
+
+  private static byte[] vectorBytes(double[] values) {
+    ByteBuffer buffer = ByteBuffer.allocate(values.length * Double.BYTES)
+        .order(HoodieSchema.VectorLogicalType.VECTOR_BYTE_ORDER);
+    for (double value : values) {
+      buffer.putDouble(value);
+    }
+    return buffer.array();
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.FileFormatUtils;
+import org.apache.hudi.common.util.HoodieVectorUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ParquetReaderIterator;
 import org.apache.hudi.common.util.ParquetUtils;
@@ -146,7 +147,7 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
     StructType structSchema = HoodieInternalRowUtils.getCachedSchema(nonNullSchema);
 
     // Detect vector columns: ordinal → Vector schema
-    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = VectorConversionUtils.detectVectorColumns(nonNullSchema);
+    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = HoodieVectorUtils.detectVectorColumns(nonNullSchema);
 
     // For vector columns, replace ArrayType(FloatType) with BinaryType in the read schema
     // so SparkBasicSchemaEvolution sees matching types (file has FIXED_LEN_BYTE_ARRAY → BinaryType)

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
@@ -19,8 +19,8 @@
 package org.apache.hudi.io.storage;
 
 import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.util.HoodieVectorUtils;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
@@ -36,14 +36,10 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.LanceArrowUtils;
 
-import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-
-import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 
 /**
  * Shared utility methods for vector column handling during Parquet read/write.
@@ -56,28 +52,6 @@ import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 public final class VectorConversionUtils {
 
   private VectorConversionUtils() {
-  }
-
-  /**
-   * Detects VECTOR columns in a HoodieSchema record and returns a map of field ordinal
-   * to the corresponding {@link HoodieSchema.Vector} schema.
-   *
-   * @param schema a HoodieSchema of type RECORD (or null)
-   * @return map from field index to Vector schema; empty map if schema is null or has no vectors
-   */
-  public static Map<Integer, HoodieSchema.Vector> detectVectorColumns(HoodieSchema schema) {
-    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = new LinkedHashMap<>();
-    if (schema == null) {
-      return vectorColumnInfo;
-    }
-    List<HoodieSchemaField> fields = schema.getFields();
-    for (int i = 0; i < fields.size(); i++) {
-      HoodieSchema fieldSchema = fields.get(i).schema().getNonNullType();
-      if (fieldSchema.getType() == HoodieSchemaType.VECTOR) {
-        vectorColumnInfo.put(i, (HoodieSchema.Vector) fieldSchema);
-      }
-    }
-    return vectorColumnInfo;
   }
 
   /**
@@ -179,33 +153,12 @@ public final class VectorConversionUtils {
    */
   public static ArrayData convertBinaryToVectorArray(byte[] bytes, int dim,
                                                      HoodieSchema.Vector.VectorElementType elemType) {
-    int expectedSize = dim * elemType.getElementSize();
-    checkArgument(bytes.length == expectedSize,
-        "Vector byte array length mismatch: expected " + expectedSize + " but got " + bytes.length);
-    ByteBuffer buffer = ByteBuffer.wrap(bytes).order(HoodieSchema.VectorLogicalType.VECTOR_BYTE_ORDER);
-    switch (elemType) {
-      case FLOAT:
-        float[] floats = new float[dim];
-        for (int j = 0; j < dim; j++) {
-          floats[j] = buffer.getFloat();
-        }
-        return new GenericArrayData(floats);
-      case DOUBLE:
-        double[] doubles = new double[dim];
-        for (int j = 0; j < dim; j++) {
-          doubles[j] = buffer.getDouble();
-        }
-        return new GenericArrayData(doubles);
-      case INT8:
-        byte[] int8s = new byte[dim];
-        buffer.get(int8s);
-        // Use UnsafeArrayData to avoid boxing each byte into a Byte object.
-        // GenericArrayData(byte[]) would box every element into Object[].
-        return UnsafeArrayData.fromPrimitiveArray(int8s);
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported vector element type: " + elemType);
+    Object decoded = HoodieVectorUtils.decodeVectorBytes(bytes, dim, elemType);
+    if (decoded instanceof byte[]) {
+      // Use UnsafeArrayData to avoid boxing each byte into a Byte object.
+      return UnsafeArrayData.fromPrimitiveArray((byte[]) decoded);
     }
+    return new GenericArrayData(decoded);
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.{HoodieFileFormat, HoodieRecord}
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
+import org.apache.hudi.common.util.HoodieVectorUtils
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, Pair => HPair}
@@ -385,11 +386,11 @@ object SparkFileFormatInternalRowReaderContext {
 
   /**
    * Detects VECTOR columns from HoodieSchema.
-   * Delegates to [[VectorConversionUtils.detectVectorColumns]].
+   * Delegates to [[HoodieVectorUtils.detectVectorColumns]].
    * @return Map of ordinal to Vector schema for VECTOR fields.
    */
   private[hudi] def detectVectorColumns(schema: HoodieSchema): Map[Int, HoodieSchema.Vector] = {
-    VectorConversionUtils.detectVectorColumns(schema).asScala.map { case (k, v) => (k.intValue(), v) }.toMap
+    HoodieVectorUtils.detectVectorColumns(schema).asScala.map { case (k, v) => (k.intValue(), v) }.toMap
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieVectorUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieVectorUtils.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Utilities for decoding Hudi VECTOR fixed-bytes payloads.
+ * Utilities for decoding Hoodie VECTOR fixed-bytes payloads.
  */
 public final class HoodieVectorUtils {
 
@@ -62,7 +62,7 @@ public final class HoodieVectorUtils {
    *
    * @param bytes        raw bytes read from Parquet
    * @param vectorSchema vector schema
-   * @return an ArrayData containing the decoded float[], double[], or byte[] array
+   * @return the decoded float[], double[], or byte[] array
    * @throws IllegalArgumentException if byte array length doesn't match expected size
    */
   public static Object decodeVectorBytes(byte[] bytes, HoodieSchema.Vector vectorSchema) {
@@ -75,7 +75,7 @@ public final class HoodieVectorUtils {
    * @param bytes    raw bytes read from Parquet
    * @param dim      vector dimension (number of elements)
    * @param elemType element type (FLOAT, DOUBLE, or INT8)
-   * @return an ArrayData containing the decoded float[], double[], or byte[] array
+   * @return the decoded float[], double[], or byte[] array
    * @throws IllegalArgumentException if byte array length doesn't match expected size
    */
   public static Object decodeVectorBytes(

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieVectorUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieVectorUtils.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utilities for decoding Hudi VECTOR fixed-bytes payloads.
+ */
+public final class HoodieVectorUtils {
+
+  private HoodieVectorUtils() {
+  }
+
+  /**
+   * Detects VECTOR columns in a HoodieSchema record and returns a map of field ordinal
+   * to the corresponding {@link HoodieSchema.Vector} schema.
+   *
+   * @param schema a HoodieSchema of type RECORD (or null)
+   * @return map from field index to Vector schema; empty map if schema is null or has no vectors
+   */
+  public static Map<Integer, HoodieSchema.Vector> detectVectorColumns(HoodieSchema schema) {
+    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = new LinkedHashMap<>();
+    if (schema == null) {
+      return vectorColumnInfo;
+    }
+    List<HoodieSchemaField> fields = schema.getFields();
+    for (int i = 0; i < fields.size(); i++) {
+      HoodieSchema fieldSchema = fields.get(i).schema().getNonNullType();
+      if (fieldSchema.getType() == HoodieSchemaType.VECTOR) {
+        vectorColumnInfo.put(i, (HoodieSchema.Vector) fieldSchema);
+      }
+    }
+    return vectorColumnInfo;
+  }
+
+  /**
+   * Converts binary bytes from a FIXED_LEN_BYTE_ARRAY Parquet column back to a typed array.
+   *
+   * @param bytes        raw bytes read from Parquet
+   * @param vectorSchema vector schema
+   * @return an ArrayData containing the decoded float[], double[], or byte[] array
+   * @throws IllegalArgumentException if byte array length doesn't match expected size
+   */
+  public static Object decodeVectorBytes(byte[] bytes, HoodieSchema.Vector vectorSchema) {
+    return decodeVectorBytes(bytes, vectorSchema.getDimension(), vectorSchema.getVectorElementType());
+  }
+
+  /**
+   * Converts binary bytes from a FIXED_LEN_BYTE_ARRAY Parquet column back to a typed array.
+   *
+   * @param bytes    raw bytes read from Parquet
+   * @param dim      vector dimension (number of elements)
+   * @param elemType element type (FLOAT, DOUBLE, or INT8)
+   * @return an ArrayData containing the decoded float[], double[], or byte[] array
+   * @throws IllegalArgumentException if byte array length doesn't match expected size
+   */
+  public static Object decodeVectorBytes(
+      byte[] bytes,
+      int dim,
+      HoodieSchema.Vector.VectorElementType elemType) {
+    int expectedSize = dim * elemType.getElementSize();
+    ValidationUtils.checkArgument(bytes.length == expectedSize,
+        "Vector byte array length mismatch: expected " + expectedSize + " but got " + bytes.length);
+    ByteBuffer buffer = ByteBuffer.wrap(bytes).order(HoodieSchema.VectorLogicalType.VECTOR_BYTE_ORDER);
+    switch (elemType) {
+      case FLOAT:
+        float[] floats = new float[dim];
+        for (int i = 0; i < dim; i++) {
+          floats[i] = buffer.getFloat();
+        }
+        return floats;
+      case DOUBLE:
+        double[] doubles = new double[dim];
+        for (int i = 0; i < dim; i++) {
+          doubles[i] = buffer.getDouble();
+        }
+        return doubles;
+      case INT8:
+        byte[] int8s = new byte[dim];
+        buffer.get(int8s);
+        return int8s;
+      default:
+        throw new UnsupportedOperationException("Unsupported vector element type: " + elemType);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ColumnStatsSchemas.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/ColumnStatsSchemas.java
@@ -35,7 +35,8 @@ public class ColumnStatsSchemas {
   // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------
-  public static final DataType METADATA_DATA_TYPE = getMetadataDataType();
+  public static final HoodieSchema METADATA_SCHEMA = HoodieSchema.fromAvroSchema(HoodieMetadataRecord.SCHEMA$);
+  public static final DataType METADATA_DATA_TYPE = HoodieSchemaConverter.convertToDataType(METADATA_SCHEMA);
   public static final DataType COL_STATS_DATA_TYPE = getColStatsDataType();
   public static final int[] COL_STATS_TARGET_POS = getColStatsTargetPos();
 
@@ -52,10 +53,6 @@ public class ColumnStatsSchemas {
   public static final int ORD_NULL_CNT = 3;
   public static final int ORD_VAL_CNT = 4;
   public static final int ORD_COL_NAME = 5;
-
-  private static DataType getMetadataDataType() {
-    return HoodieSchemaConverter.convertToDataType(HoodieSchema.fromAvroSchema(HoodieMetadataRecord.SCHEMA$));
-  }
 
   private static DataType getColStatsDataType() {
     int pos = HoodieMetadataRecord.SCHEMA$.getField(HoodieMetadataPayload.SCHEMA_FIELD_ID_COLUMN_STATS).pos();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FileStatsIndex.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/stats/FileStatsIndex.java
@@ -64,7 +64,7 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
 import static org.apache.hudi.source.stats.ColumnStatsSchemas.COL_STATS_DATA_TYPE;
 import static org.apache.hudi.source.stats.ColumnStatsSchemas.COL_STATS_TARGET_POS;
-import static org.apache.hudi.source.stats.ColumnStatsSchemas.METADATA_DATA_TYPE;
+import static org.apache.hudi.source.stats.ColumnStatsSchemas.METADATA_SCHEMA;
 import static org.apache.hudi.source.stats.ColumnStatsSchemas.ORD_COL_NAME;
 import static org.apache.hudi.source.stats.ColumnStatsSchemas.ORD_FILE_NAME;
 import static org.apache.hudi.source.stats.ColumnStatsSchemas.ORD_MAX_VAL;
@@ -404,7 +404,7 @@ public class FileStatsIndex implements ColumnStatsIndex {
             HoodieListData.lazy(rawKeys), getIndexPartitionName(), false);
 
     org.apache.hudi.util.AvroToRowDataConverters.AvroToRowDataConverter converter =
-        AvroToRowDataConverters.createRowConverter((RowType) METADATA_DATA_TYPE.getLogicalType());
+        AvroToRowDataConverters.createRowConverter(METADATA_SCHEMA);
     List<RowData> rows = records.collectAsList().stream().parallel().map(record -> {
           // schema and props are ignored for generating metadata record from the payload
           // instead, the underlying file system, or bloom filter, or columns stats metadata (part of payload) are directly used

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -308,7 +308,7 @@ public class HoodieTableSource extends FileIndexReader implements
             rowType,
             requiredRowType,
             tableSchema.toString(),
-            HoodieSchemaConverter.convertToSchema(requiredRowType).toString(),
+            DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableSchema).toString(),
             new ArrayList<>());
     boolean emitDelete = tableType == HoodieTableType.MERGE_ON_READ && context.isStreaming();
     if (conf.get(FlinkOptions.CDC_ENABLED)) {
@@ -324,7 +324,7 @@ public class HoodieTableSource extends FileIndexReader implements
       splitReaderFunction = new HoodieSplitReaderFunction(
           conf,
           tableSchema,
-          HoodieSchemaConverter.convertToSchema(requiredRowType),
+          DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableSchema),
           internalSchemaManager,
           conf.get(FlinkOptions.MERGE_TYPE),
           predicates,
@@ -535,12 +535,12 @@ public class HoodieTableSource extends FileIndexReader implements
             return mergeOnReadInputFormat(rowType, requiredRowType, tableSchema,
                 rowDataType, inputSplits, false);
           case COPY_ON_WRITE:
-            return baseFileOnlyInputFormat();
+            return baseFileOnlyInputFormat(tableSchema);
           default:
             throw new HoodieException("Unexpected table type: " + this.conf.get(FlinkOptions.TABLE_TYPE));
         }
       case FlinkOptions.QUERY_TYPE_READ_OPTIMIZED:
-        return baseFileOnlyInputFormat();
+        return baseFileOnlyInputFormat(tableSchema);
       case FlinkOptions.QUERY_TYPE_INCREMENTAL:
         IncrementalInputSplits incrementalInputSplits = IncrementalInputSplits.builder()
             .conf(conf)
@@ -613,7 +613,7 @@ public class HoodieTableSource extends FileIndexReader implements
         rowType,
         requiredRowType,
         tableSchema.toString(),
-        HoodieSchemaConverter.convertToSchema(requiredRowType).toString(),
+        DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableSchema).toString(),
         inputSplits);
     return CdcInputFormat.builder()
         .config(this.conf)
@@ -638,7 +638,7 @@ public class HoodieTableSource extends FileIndexReader implements
         rowType,
         requiredRowType,
         tableAvroSchema.toString(),
-        HoodieSchemaConverter.convertToSchema(requiredRowType).toString(),
+        DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableAvroSchema).toString(),
         inputSplits);
     return MergeOnReadInputFormat.builder()
         .config(this.conf)
@@ -653,7 +653,7 @@ public class HoodieTableSource extends FileIndexReader implements
         .build();
   }
 
-  private InputFormat<RowData, ?> baseFileOnlyInputFormat() {
+  private InputFormat<RowData, ?> baseFileOnlyInputFormat(HoodieSchema tableSchema) {
     final List<FileSlice> fileSlices = getBaseFileOnlyFileSlices(metaClient);
     if (fileSlices.isEmpty()) {
       return InputFormats.EMPTY_INPUT_FORMAT;
@@ -678,7 +678,8 @@ public class HoodieTableSource extends FileIndexReader implements
         this.limit == NO_LIMIT_CONSTANT ? Long.MAX_VALUE : this.limit, // ParquetInputFormat always uses the limit value
         getParquetConf(this.conf, this.hadoopConf.unwrap()),
         this.conf.get(FlinkOptions.READ_UTC_TIMEZONE),
-        this.internalSchemaManager
+        this.internalSchemaManager,
+        tableSchema
     );
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -300,6 +300,7 @@ public class HoodieTableSource extends FileIndexReader implements
     final DataType rowDataType = HoodieSchemaConverter.convertToDataType(tableSchema);
     final RowType rowType = (RowType) rowDataType.getLogicalType();
     final RowType requiredRowType = (RowType) getProducedDataType().notNull().getLogicalType();
+    final HoodieSchema requiredHoodieSchema = DataTypeUtils.toHoodieSchema(requiredRowType, tableSchema);
 
     HoodieScanContext context = createHoodieScanContext(rowType);
     final HoodieTableType tableType = HoodieTableType.valueOf(this.conf.get(FlinkOptions.TABLE_TYPE));
@@ -308,7 +309,7 @@ public class HoodieTableSource extends FileIndexReader implements
             rowType,
             requiredRowType,
             tableSchema.toString(),
-            DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableSchema).toString(),
+            requiredHoodieSchema.toString(),
             new ArrayList<>());
     boolean emitDelete = tableType == HoodieTableType.MERGE_ON_READ && context.isStreaming();
     if (conf.get(FlinkOptions.CDC_ENABLED)) {
@@ -324,7 +325,7 @@ public class HoodieTableSource extends FileIndexReader implements
       splitReaderFunction = new HoodieSplitReaderFunction(
           conf,
           tableSchema,
-          DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableSchema),
+          requiredHoodieSchema,
           internalSchemaManager,
           conf.get(FlinkOptions.MERGE_TYPE),
           predicates,
@@ -613,7 +614,7 @@ public class HoodieTableSource extends FileIndexReader implements
         rowType,
         requiredRowType,
         tableSchema.toString(),
-        DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableSchema).toString(),
+        DataTypeUtils.toHoodieSchema(requiredRowType, tableSchema).toString(),
         inputSplits);
     return CdcInputFormat.builder()
         .config(this.conf)
@@ -638,7 +639,7 @@ public class HoodieTableSource extends FileIndexReader implements
         rowType,
         requiredRowType,
         tableAvroSchema.toString(),
-        DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableAvroSchema).toString(),
+        DataTypeUtils.toHoodieSchema(requiredRowType, tableAvroSchema).toString(),
         inputSplits);
     return MergeOnReadInputFormat.builder()
         .config(this.conf)

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataParquetReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/HoodieRowDataParquetReader.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.util.HoodieVectorUtils;
 import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
@@ -35,6 +36,7 @@ import org.apache.hudi.source.ExpressionPredicates.Predicate;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.HoodieSchemaConverter;
+import org.apache.hudi.util.VectorConversionUtils;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
@@ -46,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -100,7 +103,15 @@ public class HoodieRowDataParquetReader implements HoodieFileReader<RowData>  {
       DataType dataType,
       HoodieSchema requestedSchema,
       List<Predicate> predicates) throws IOException {
-    return RecordIterators.getParquetRecordIterator(storage.getConf(), internalSchemaManager, dataType, requestedSchema, path, predicates);
+    Map<Integer, HoodieSchema.Vector> vectorColumnInfo = HoodieVectorUtils.detectVectorColumns(requestedSchema);
+    ClosableIterator<RowData> rowDataItr = RecordIterators.getParquetRecordIterator(
+        storage.getConf(), internalSchemaManager, VectorConversionUtils.getParquetReadDataType(dataType, requestedSchema, vectorColumnInfo),
+        requestedSchema, path, predicates);
+    if (vectorColumnInfo.isEmpty()) {
+      return rowDataItr;
+    }
+    RowType requestedRowType = HoodieSchemaConverter.convertToRowType(requestedSchema);
+    return VectorConversionUtils.wrapVectorColumnIterator(rowDataItr, requestedRowType, vectorColumnInfo);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
@@ -389,7 +389,7 @@ public final class CdcIterators {
       this.requiredSchema = requiredSchema;
       this.requiredPos = computeRequiredPos(tableSchema, requiredSchema);
       this.recordBuilder = new GenericRecordBuilder(requiredSchema.getAvroSchema());
-      this.avroToRowDataConverter = AvroToRowDataConverters.createRowConverter(requiredRowType);
+      this.avroToRowDataConverter = AvroToRowDataConverters.createRowConverter(requiredSchema, requiredRowType, true);
 
       StoragePath hadoopTablePath = new StoragePath(tablePath);
       HoodieStorage storage = HoodieStorageUtils.getStorage(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table.format.cow;
 
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
@@ -26,6 +27,7 @@ import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
+import org.apache.hudi.util.VectorConversionUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.io.FileInputFormat;
@@ -49,6 +51,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -70,7 +73,9 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
 
   private final String[] fullFieldNames;
   private final DataType[] fullFieldTypes;
+  private final DataType[] readFieldTypes;
   private final int[] selectedFields;
+  private final Map<Integer, HoodieSchema.Vector> vectorColumnInfo;
   private final String partDefaultName;
   private final String partPathField;
   private final boolean hiveStylePartitioning;
@@ -101,7 +106,8 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
       long limit,
       Configuration conf,
       boolean utcTimestamp,
-      InternalSchemaManager internalSchemaManager) {
+      InternalSchemaManager internalSchemaManager,
+      HoodieSchema tableSchema) {
     super.setFilePaths(paths);
     this.predicates = predicates;
     this.limit = limit;
@@ -110,7 +116,9 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     this.hiveStylePartitioning = hiveStylePartitioning;
     this.fullFieldNames = fullFieldNames;
     this.fullFieldTypes = fullFieldTypes;
+    this.readFieldTypes = VectorConversionUtils.getParquetReadFieldTypes(fullFieldNames, fullFieldTypes, tableSchema);
     this.selectedFields = selectedFields;
+    this.vectorColumnInfo = VectorConversionUtils.detectVectorColumns(fullFieldNames, selectedFields, tableSchema);
     this.conf = new SerializableConfiguration(conf);
     this.utcTimestamp = utcTimestamp;
     this.internalSchemaManager = internalSchemaManager;
@@ -129,13 +137,14 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
           this.partPathField,
           this.hiveStylePartitioning
       );
-      this.itr = RecordIterators.getParquetRecordIterator(
+
+      ClosableIterator<RowData> rowDataItr = RecordIterators.getParquetRecordIterator(
           internalSchemaManager,
           utcTimestamp,
           true,
           conf.conf(),
           fullFieldNames,
-          fullFieldTypes,
+          readFieldTypes,
           partObjects,
           selectedFields,
           2048,
@@ -143,6 +152,7 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
           fileSplit.getStart(),
           fileSplit.getLength(),
           predicates);
+      this.itr = vectorColumnInfo.isEmpty() ? rowDataItr : VectorConversionUtils.wrapVectorColumnIterator(rowDataItr, fullFieldTypes, selectedFields, vectorColumnInfo);
     }
     this.currentReadCount = 0L;
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/DataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/DataTypeUtils.java
@@ -19,6 +19,10 @@
 package org.apache.hudi.util;
 
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.exception.HoodieCatalogException;
 
 import org.apache.flink.table.api.DataTypes;
@@ -118,6 +122,48 @@ public class DataTypeUtils {
   public static int[] projectOrdinals(RowType rowType, RowType producedRowType) {
     List<String> fieldNames = rowType.getFieldNames();
     return producedRowType.getFieldNames().stream().mapToInt(fieldNames::indexOf).toArray();
+  }
+
+  /**
+   * Creates a hoodie schema from a Flink row type with logical metadata from the table schema.
+   *
+   * <p>When a field is a hoodie specific logical type in {@code tableSchema}, this method
+   * reuses the table schema field to preserve logical metadata that cannot be recovered from Flink
+   * {@link RowType}, for example VECTOR element type and dimension. Other fields are taken from the
+   * schema converted from {@code rowType}, so the returned schema follows the row type's field order
+   * while retaining hoodie-specific logical metadata where needed.
+   *
+   * @param rowType     Flink row type to convert
+   * @param tableSchema source table schema with hoodie logical type metadata
+   * @return hoodie schema matching the row type field order
+   */
+  public static HoodieSchema toHoodieSchemaWithLogicalMetadata(RowType rowType, HoodieSchema tableSchema) {
+    HoodieSchema convertedSchema = HoodieSchemaConverter.convertToSchema(rowType);
+    List<HoodieSchemaField> schemaFields = new ArrayList<>(rowType.getFieldCount());
+
+    for (String fieldName : rowType.getFieldNames()) {
+      HoodieSchemaField tableField = tableSchema.getField(fieldName).orElse(null);
+      HoodieSchemaField field = tableField != null && useTableSchemaField(tableField)
+          ? tableField : convertedSchema.getField(fieldName).get();
+      schemaFields.add(HoodieSchemaUtils.createNewSchemaField(field));
+    }
+
+    return HoodieSchema.createRecord(
+        tableSchema.getName(),
+        tableSchema.getNamespace().orElse(null),
+        tableSchema.getDoc().orElse(null),
+        schemaFields);
+  }
+
+  /**
+   * Returns whether the converted schema should reuse the field from the table schema.
+   *
+   * <p>Only types whose logical metadata cannot be fully reconstructed from Flink
+   * {@link RowType} are reused from the table schema.
+   */
+  private static boolean useTableSchemaField(HoodieSchemaField field) {
+    HoodieSchemaType fieldType = field.schema().getNonNullType().getType();
+    return fieldType == HoodieSchemaType.VECTOR;
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/DataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/DataTypeUtils.java
@@ -137,7 +137,7 @@ public class DataTypeUtils {
    * @param tableSchema source table schema with hoodie logical type metadata
    * @return hoodie schema matching the row type field order
    */
-  public static HoodieSchema toHoodieSchemaWithLogicalMetadata(RowType rowType, HoodieSchema tableSchema) {
+  public static HoodieSchema toHoodieSchema(RowType rowType, HoodieSchema tableSchema) {
     HoodieSchema convertedSchema = HoodieSchemaConverter.convertToSchema(rowType);
     List<HoodieSchemaField> schemaFields = new ArrayList<>(rowType.getFieldCount());
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestVectorCrossEngineCompatibility.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestVectorCrossEngineCompatibility.java
@@ -31,11 +31,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.List;
 
 import static org.apache.hudi.utils.TestData.assertRowsEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Integration test for cross-engine compatibility - verifying that Flink can read tables with VECTOR columns written by Spark.
@@ -69,33 +70,76 @@ public class ITTestVectorCrossEngineCompatibility {
 
   @ParameterizedTest
   @EnumSource(value = HoodieTableType.class)
-  public void testValidationVectorColumnsFromCOWTable(HoodieTableType tableType) throws Exception {
-    // Validate exception will be thrown when reading VECTOR columns from a table with VECTOR columns
-    Path cowTargetDir = tempDir.resolve("table");
+  public void testReadVectorColumnsFromTable(HoodieTableType tableType) throws Exception {
+    Path tableTargetDir = tempDir.resolve("table");
     String resourceName = tableType == HoodieTableType.MERGE_ON_READ ? "vector_mor" : "vector_cow";
-    HoodieTestUtils.extractZipToDirectory(String.format("vector_cross_engine_validation/%s.zip", resourceName), cowTargetDir, getClass());
-    String cowPath = cowTargetDir.resolve(resourceName).toString();
+    HoodieTestUtils.extractZipToDirectory(String.format("vector_cross_engine_validation/%s.zip", resourceName), tableTargetDir, getClass());
+    String tablePath = tableTargetDir.resolve(resourceName).toString();
     TableEnvironment tableEnv = TestTableEnvs.getBatchTableEnv();
-    createTable(tableEnv, cowPath, tableType.name());
+    createTable(tableEnv, tablePath, tableType.name());
 
-    // ValidationException expects to be thrown
-    assertThrows(RuntimeException.class,
-        () -> CollectionUtil.iteratorToList(tableEnv.executeSql("select * from vector_table").collect()),
-        "Unexpected type exception. Primitive type: FIXED_LEN_BYTE_ARRAY. Field type: FLOAT. Field name: embedding1");
+    List<Row> rows = CollectionUtil.iteratorToList(tableEnv.executeSql("select * from vector_table order by id").collect());
+    assertEquals(2, rows.size());
+    assertEquals(1L, rows.get(0).getField(0));
+    assertEquals("doc-1", rows.get(0).getField(1));
+    assertEquals(1000L, rows.get(0).getField(5));
+    assertEquals(2L, rows.get(1).getField(0));
+    assertEquals("doc-2", rows.get(1).getField(1));
+    assertEquals(2000L, rows.get(1).getField(5));
+    for (Row row : rows) {
+      assertFloatVector(row.getField(2), 0.1f);
+      assertDoubleVector(row.getField(3), 0.2d);
+      assertByteVector(row.getField(4), (byte) 3);
+    }
   }
 
   @ParameterizedTest
   @EnumSource(value = HoodieTableType.class)
   public void testReadNonVectorColumnsFromCOWTable(HoodieTableType tableType) throws Exception {
     // Test that Flink can read non-VECTOR columns from a table with VECTOR columns
-    Path cowTargetDir = tempDir.resolve("table");
+    Path tableTargetDir = tempDir.resolve("table");
     String resourceName = tableType == HoodieTableType.MERGE_ON_READ ? "vector_mor" : "vector_cow";
-    HoodieTestUtils.extractZipToDirectory(String.format("vector_cross_engine_validation/%s.zip", resourceName), cowTargetDir, getClass());
-    String cowPath = cowTargetDir.resolve(resourceName).toString();
+    HoodieTestUtils.extractZipToDirectory(String.format("vector_cross_engine_validation/%s.zip", resourceName), tableTargetDir, getClass());
+    String tablePath = tableTargetDir.resolve(resourceName).toString();
     TableEnvironment tableEnv = TestTableEnvs.getBatchTableEnv();
-    createTable(tableEnv, cowPath, tableType.name());
+    createTable(tableEnv, tablePath, tableType.name());
 
     List<Row> rows = CollectionUtil.iteratorToList(tableEnv.executeSql("select id, name, ts from vector_table").collect());
     assertRowsEquals(rows, "[+I[1, doc-1, 1000], +I[2, doc-2, 2000]]");
+  }
+
+  private static int arrayLength(Object value) {
+    if (value instanceof List) {
+      return ((List<?>) value).size();
+    }
+    return Array.getLength(value);
+  }
+
+  private static Object arrayValue(Object value, int index) {
+    if (value instanceof List) {
+      return ((List<?>) value).get(index);
+    }
+    return Array.get(value, index);
+  }
+
+  private static void assertFloatVector(Object value, float expected) {
+    assertEquals(128, arrayLength(value));
+    for (int i = 0; i < 128; i++) {
+      assertEquals(expected, ((Number) arrayValue(value, i)).floatValue(), 0.00001f);
+    }
+  }
+
+  private static void assertDoubleVector(Object value, double expected) {
+    assertEquals(128, arrayLength(value));
+    for (int i = 0; i < 128; i++) {
+      assertEquals(expected, ((Number) arrayValue(value, i)).doubleValue(), 0.0000001d);
+    }
+  }
+
+  private static void assertByteVector(Object value, byte expected) {
+    assertEquals(128, arrayLength(value));
+    for (int i = 0; i < 128; i++) {
+      assertEquals(expected, ((Number) arrayValue(value, i)).byteValue());
+    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.util;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.logical.RowType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Tests for {@link DataTypeUtils}.
+ */
+public class TestDataTypeUtils {
+
+  @Test
+  public void testToHoodieSchemaWithLogicalMetadata() {
+    HoodieSchema tableSchema = HoodieSchema.createRecord(
+        "test_record",
+        null,
+        null,
+        Arrays.asList(
+            HoodieSchemaField.of("amount", HoodieSchema.create(HoodieSchemaType.LONG)),
+            HoodieSchemaField.of("embedding", HoodieSchema.createVector(
+                128, HoodieSchema.Vector.VectorElementType.DOUBLE)),
+            HoodieSchemaField.of("payload", HoodieSchema.createVariant())));
+
+    RowType requiredRowType = (RowType) DataTypes.ROW(
+        DataTypes.FIELD("amount", DataTypes.INT().nullable()),
+        DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT().notNull()).notNull()),
+        DataTypes.FIELD("payload", DataTypes.ROW(
+            DataTypes.FIELD("value", DataTypes.BYTES().notNull()),
+            DataTypes.FIELD("metadata", DataTypes.BYTES().notNull())).notNull()),
+        DataTypes.FIELD("missing", DataTypes.STRING().nullable()))
+        .notNull()
+        .getLogicalType();
+
+    HoodieSchema requiredSchema = DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableSchema);
+
+    assertEquals(Arrays.asList("amount", "embedding", "payload", "missing"),
+        Arrays.asList(
+            requiredSchema.getFields().get(0).name(),
+            requiredSchema.getFields().get(1).name(),
+            requiredSchema.getFields().get(2).name(),
+            requiredSchema.getFields().get(3).name()));
+    assertEquals(HoodieSchemaType.UNION, requiredSchema.getField("amount").get().schema().getType());
+    assertEquals(HoodieSchemaType.INT, requiredSchema.getField("amount").get().schema().getNonNullType().getType());
+
+    HoodieSchema embeddingSchema = requiredSchema.getField("embedding").get().schema().getNonNullType();
+    assertEquals(HoodieSchemaType.VECTOR, embeddingSchema.getType());
+    assertInstanceOf(HoodieSchema.Vector.class, embeddingSchema);
+    assertEquals(128, ((HoodieSchema.Vector) embeddingSchema).getDimension());
+    assertEquals(HoodieSchema.Vector.VectorElementType.DOUBLE,
+        ((HoodieSchema.Vector) embeddingSchema).getVectorElementType());
+
+    assertEquals(HoodieSchemaType.RECORD,
+        requiredSchema.getField("payload").get().schema().getNonNullType().getType());
+    assertEquals(HoodieSchemaType.STRING,
+        requiredSchema.getField("missing").get().schema().getNonNullType().getType());
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/util/TestDataTypeUtils.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 public class TestDataTypeUtils {
 
   @Test
-  public void testToHoodieSchemaWithLogicalMetadata() {
+  public void testToHoodieSchema() {
     HoodieSchema tableSchema = HoodieSchema.createRecord(
         "test_record",
         null,
@@ -58,7 +58,7 @@ public class TestDataTypeUtils {
         .notNull()
         .getLogicalType();
 
-    HoodieSchema requiredSchema = DataTypeUtils.toHoodieSchemaWithLogicalMetadata(requiredRowType, tableSchema);
+    HoodieSchema requiredSchema = DataTypeUtils.toHoodieSchema(requiredRowType, tableSchema);
 
     assertEquals(Arrays.asList("amount", "embedding", "payload", "missing"),
         Arrays.asList(

--- a/hudi-flink-datasource/hudi-flink1.17.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.17.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -365,7 +365,15 @@ public class ParquetSplitReaderUtil {
       case VARCHAR:
       case BINARY:
       case VARBINARY:
-        return new BytesColumnReader(descriptor, pageReader);
+        switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+          case BINARY:
+            return new BytesColumnReader(descriptor, pageReader);
+          case FIXED_LEN_BYTE_ARRAY:
+            return new FixedLenBytesColumnReader(
+                descriptor, pageReader);
+          default:
+            throw new AssertionError();
+        }
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
@@ -496,7 +504,9 @@ public class ParquetSplitReaderUtil {
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY
+                || typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -435,7 +435,14 @@ public class ParquetSplitReaderUtil {
       case VARCHAR:
       case BINARY:
       case VARBINARY:
-        return new BytesColumnReader(descriptor, pageReader);
+        switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+          case BINARY:
+            return new BytesColumnReader(descriptor, pageReader);
+          case FIXED_LEN_BYTE_ARRAY:
+            return new FixedLenBytesColumnReader(descriptor, pageReader);
+          default:
+            throw new AssertionError();
+        }
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
@@ -537,7 +544,8 @@ public class ParquetSplitReaderUtil {
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY,
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY
+                || typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
             getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:

--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -435,7 +435,14 @@ public class ParquetSplitReaderUtil {
       case VARCHAR:
       case BINARY:
       case VARBINARY:
-        return new BytesColumnReader(descriptor, pageReader);
+        switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+          case BINARY:
+            return new BytesColumnReader(descriptor, pageReader);
+          case FIXED_LEN_BYTE_ARRAY:
+            return new FixedLenBytesColumnReader(descriptor, pageReader);
+          default:
+            throw new AssertionError();
+        }
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
@@ -537,7 +544,8 @@ public class ParquetSplitReaderUtil {
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY,
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY
+                || typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
             getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:

--- a/hudi-flink-datasource/hudi-flink1.20.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink1.20.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -380,7 +380,14 @@ public class ParquetSplitReaderUtil {
       case VARCHAR:
       case BINARY:
       case VARBINARY:
-        return new BytesColumnReader(descriptor, pageReader);
+        switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+          case BINARY:
+            return new BytesColumnReader(descriptor, pageReader);
+          case FIXED_LEN_BYTE_ARRAY:
+            return new FixedLenBytesColumnReader(descriptor, pageReader);
+          default:
+            throw new AssertionError();
+        }
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
@@ -556,7 +563,9 @@ public class ParquetSplitReaderUtil {
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY
+                || typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/hudi-flink-datasource/hudi-flink2.0.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink2.0.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -380,7 +380,14 @@ public class ParquetSplitReaderUtil {
       case VARCHAR:
       case BINARY:
       case VARBINARY:
-        return new BytesColumnReader(descriptor, pageReader);
+        switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+          case BINARY:
+            return new BytesColumnReader(descriptor, pageReader);
+          case FIXED_LEN_BYTE_ARRAY:
+            return new FixedLenBytesColumnReader(descriptor, pageReader);
+          default:
+            throw new AssertionError();
+        }
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
@@ -556,7 +563,9 @@ public class ParquetSplitReaderUtil {
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY
+                || typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/hudi-flink-datasource/hudi-flink2.1.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
+++ b/hudi-flink-datasource/hudi-flink2.1.x/src/main/java/org/apache/hudi/table/format/cow/ParquetSplitReaderUtil.java
@@ -392,7 +392,14 @@ public class ParquetSplitReaderUtil {
       case VARCHAR:
       case BINARY:
       case VARBINARY:
-        return new BytesColumnReader(descriptor, pageReader);
+        switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+          case BINARY:
+            return new BytesColumnReader(descriptor, pageReader);
+          case FIXED_LEN_BYTE_ARRAY:
+            return new FixedLenBytesColumnReader(descriptor, pageReader);
+          default:
+            throw new AssertionError();
+        }
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
@@ -582,7 +589,9 @@ public class ParquetSplitReaderUtil {
       case BINARY:
       case VARBINARY:
         checkArgument(
-            typeName == PrimitiveType.PrimitiveTypeName.BINARY, getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
+            typeName == PrimitiveType.PrimitiveTypeName.BINARY
+                || typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+            getPrimitiveTypeCheckFailureMessage(typeName, fieldType));
         return new HeapBytesVector(batchSize);
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes https://github.com/apache/hudi/issues/18863.

Flink reader paths could convert VECTOR columns at the schema/type level, but could not reliably read VECTOR values from Avro log records or Parquet base files. VECTOR is physically stored as fixed-length bytes, so readers need to materialize the physical bytes first and then decode them back into `ARRAY<FLOAT>`, `ARRAY<DOUBLE>`, or `ARRAY<TINYINT>`.

This PR adds Flink-side VECTOR read support for both Avro and Parquet paths, and shares the low-level vector byte decoding logic with Spark to keep cross-engine behavior consistent.

### Summary and Changelog
- Adds HoodieSchema-aware conversion in `AvroToRowDataConverters` so Avro log reads can decode VECTOR fixed bytes into Flink `ArrayData`, including nullable vectors and byte-length validation.
- Adds Flink `VectorConversionUtils` to detect projected VECTOR columns, rewrite Parquet read types to bytes, and wrap `RowData` iterators to decode vector bytes back into arrays.
- Updates `HoodieRowDataParquetReader` and `CopyOnWriteInputFormat` to read VECTOR columns as physical bytes and apply vector decoding after Parquet materialization.
- Updates all version-specific Flink `ParquetSplitReaderUtil` implementations to accept `FIXED_LEN_BYTE_ARRAY` for binary/varbinary reads and use `FixedLenBytesColumnReader`.
- Adds `HoodieVectorUtils` in `hudi-common` for shared VECTOR detection and fixed-byte decoding, and refactors Spark vector conversion to reuse it.
- Preserves Hoodie logical metadata in projected required schemas via `DataTypeUtils.createRequiredSchema`, including fallback handling for requested fields missing from the table schema.
- Extends vector test coverage with `TestAvroToRowDataConverters` and updates `ITTestVectorCrossEngineCompatibility` to validate actual FLOAT, DOUBLE, and INT8 vector contents for both COW and MOR tables.

### Impact

Flink can now read VECTOR columns from Avro log records and Parquet base files, including Spark-written vector tables.

### Risk Level
Medium. 
The change touches Flink reader paths, Parquet split utilities across multiple Flink versions, and shared Spark vector conversion; added unit and integration coverage mitigates the main VECTOR read scenarios.


<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
