### PR TITLE
feat(spark): Make Hudi's analyzed plans introspectable to lineage tooling

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -641,9 +641,15 @@ object HoodieIncrementalRelationIdentifier extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan =
     AnalysisHelper.allowInvokingTransformsInAnalyzer {
       plan transform {
-        case lr @ LogicalRelation(hfsr: HadoopFsRelation, _, None, _)
-            if isIncrementalOrCDC(hfsr.location) =>
-          val metaClient = hfsr.location.asInstanceOf[HoodieFileIndex].metaClient
+        // Type pattern + guard avoids destructuring `LogicalRelation`, whose case-class
+        // arity differs between Spark 3.x (4 args) and Spark 4.x (5 args). This rule
+        // lives in `hudi-spark`, which is compiled against every supported profile.
+        case lr: LogicalRelation
+            if lr.catalogTable.isEmpty
+              && lr.relation.isInstanceOf[HadoopFsRelation]
+              && isIncrementalOrCDC(lr.relation.asInstanceOf[HadoopFsRelation].location) =>
+          val fsRelation = lr.relation.asInstanceOf[HadoopFsRelation]
+          val metaClient = fsRelation.location.asInstanceOf[HoodieFileIndex].metaClient
           lr.copy(catalogTable = Some(buildCatalogTable(metaClient, lr.schema)))
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -17,20 +17,22 @@
 
 package org.apache.spark.sql.hudi.analysis
 
-import org.apache.hudi.{HoodieSchemaUtils, HoodieSparkUtils, SparkAdapterSupport}
+import org.apache.hudi.{HoodieFileIndex, HoodieIncrementalFileIndex, HoodieSchemaUtils, HoodieSparkUtils, SparkAdapterSupport}
+import org.apache.hudi.cdc.HoodieCDCFileIndex
+import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.{ReflectionUtils, ValidationUtils}
 import org.apache.hudi.common.util.ReflectionUtils.loadClass
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, HoodieCatalogTable}
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, HoodieCatalogTable}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSeq, Expression, GenericInternalRow}
 import org.apache.spark.sql.catalyst.optimizer.ReplaceExpressions
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.datasources.{CreateTable, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.{CreateTable, FileIndex, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{isMetaField, removeMetaFields}
 import org.apache.spark.sql.hudi.analysis.HoodieAnalysis.{sparkAdapter, MatchCreateIndex, MatchCreateTableLike, MatchDropIndex, MatchInsertIntoStatement, MatchMergeIntoTable, MatchRefreshIndex, MatchShowIndexes, ResolvesToHudiTable}
 import org.apache.spark.sql.hudi.blob.ReadBlobRule
@@ -39,6 +41,7 @@ import org.apache.spark.sql.hudi.command.HoodieLeafRunnableCommand.stripMetaFiel
 import org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand.alignQueryOutput
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
 import org.apache.spark.sql.hudi.command.procedures.{HoodieProcedures, Procedure, ProcedureArgs}
+import org.apache.spark.sql.types.StructType
 
 import java.util
 
@@ -127,7 +130,8 @@ object HoodieAnalysis extends SparkAdapterSupport {
       // NOTE: By default all commands are converted into corresponding Hudi implementations during
       //       "post-hoc resolution" phase
       session => ResolveImplementations(session),
-      session => HoodiePostAnalysisRule(session)
+      session => HoodiePostAnalysisRule(session),
+      _ => HoodieIncrementalRelationIdentifier
     )
 
     val postHocResolutionClass = "org.apache.spark.sql.hudi.analysis.PostAnalysisRule"
@@ -618,5 +622,50 @@ case class HoodiePostAnalysisRule(sparkSession: SparkSession) extends Rule[Logic
         }
       case _ => plan
     }
+  }
+}
+
+/**
+ * Stamps a synthesized [[CatalogTable]] (table name, base path, schema) onto path-based
+ * Hudi reads whose underlying file index is incremental or CDC. Without it, lineage and
+ * governance tooling sees `LogicalRelation.catalogTable = None` and falls back to the
+ * relation's class name as the dataset identifier -- useless for tracking which table
+ * an incremental query came from.
+ *
+ * Scope is intentionally limited to incremental and CDC reads:
+ *  - Catalog-registered reads already have `catalogTable` populated.
+ *  - Path-based snapshot reads have a working file-path-based fallback in existing
+ *    lineage tooling; changing their behavior is a separate decision.
+ */
+object HoodieIncrementalRelationIdentifier extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    AnalysisHelper.allowInvokingTransformsInAnalyzer {
+      plan transform {
+        case lr @ LogicalRelation(hfsr: HadoopFsRelation, _, None, _)
+            if isIncrementalOrCDC(hfsr.location) =>
+          val metaClient = hfsr.location.asInstanceOf[HoodieFileIndex].metaClient
+          lr.copy(catalogTable = Some(buildCatalogTable(metaClient, lr.schema)))
+      }
+    }
+
+  private def isIncrementalOrCDC(location: FileIndex): Boolean =
+    location.isInstanceOf[HoodieIncrementalFileIndex] ||
+      location.isInstanceOf[HoodieCDCFileIndex]
+
+  private def buildCatalogTable(
+      metaClient: HoodieTableMetaClient,
+      schema: StructType): CatalogTable = {
+    val tableConfig = metaClient.getTableConfig
+    // Falls back to Spark's `default` database when `hoodie.database.name` is unset --
+    // matches existing path-based DataFrame read behavior.
+    val dbName = Option(tableConfig.getDatabaseName).filter(_.nonEmpty)
+    CatalogTable(
+      identifier = TableIdentifier(tableConfig.getTableName, dbName),
+      tableType = CatalogTableType.EXTERNAL,
+      storage = CatalogStorageFormat.empty.copy(
+        locationUri = Some(metaClient.getBasePath.toUri)),
+      schema = schema,
+      provider = Some("hudi")
+    )
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -660,37 +660,53 @@ object HoodieIncrementalRelationIdentifier extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan =
     AnalysisHelper.allowInvokingTransformsInAnalyzer {
       plan transform {
-        // Type pattern + guard avoids destructuring `LogicalRelation`, whose case-class
-        // arity differs between Spark 3.x (4 args) and Spark 4.x (5 args). This rule
-        // lives in `hudi-spark`, which is compiled against every supported profile.
-        case lr: LogicalRelation
-            if lr.catalogTable.isEmpty
-              && lr.relation.isInstanceOf[HadoopFsRelation]
-              && isIncrementalOrCDC(lr.relation.asInstanceOf[HadoopFsRelation].location) =>
-          val fsRelation = lr.relation.asInstanceOf[HadoopFsRelation]
-          val metaClient = fsRelation.location.asInstanceOf[HoodieFileIndex].metaClient
-          lr.copy(catalogTable = Some(buildCatalogTable(metaClient, lr.schema)))
+        // Type pattern + nested match avoids destructuring `LogicalRelation`, whose
+        // case-class arity differs between Spark 3.x (4 args) and Spark 4.x (5 args). This
+        // rule lives in `hudi-spark`, which is compiled against every supported profile.
+        case lr: LogicalRelation if lr.catalogTable.isEmpty =>
+          lr.relation match {
+            case fsRelation: HadoopFsRelation =>
+              incrementalOrCDCIndex(fsRelation.location)
+                .flatMap(index => buildCatalogTable(index.metaClient, lr.schema))
+                .map(catalogTable => lr.copy(catalogTable = Some(catalogTable)))
+                .getOrElse(lr)
+            case _ => lr
+          }
       }
     }
 
-  private def isIncrementalOrCDC(location: FileIndex): Boolean =
-    location.isInstanceOf[HoodieIncrementalFileIndex] ||
-      location.isInstanceOf[HoodieCDCFileIndex]
+  /**
+   * Narrows a [[FileIndex]] to the incremental/CDC Hudi indexes this rule handles, or
+   * `None` for anything else. Both are [[HoodieFileIndex]] subclasses, so the widening is
+   * checked by the compiler rather than by an `asInstanceOf` that a future third index
+   * type could silently break.
+   */
+  private def incrementalOrCDCIndex(location: FileIndex): Option[HoodieFileIndex] =
+    location match {
+      case index: HoodieIncrementalFileIndex => Some(index)
+      case index: HoodieCDCFileIndex => Some(index)
+      case _ => None
+    }
 
   private def buildCatalogTable(
       metaClient: HoodieTableMetaClient,
-      schema: StructType): CatalogTable = {
+      schema: StructType): Option[CatalogTable] = {
     val tableConfig = metaClient.getTableConfig
-    // Falls back to Spark's `default` database when `hoodie.database.name` is unset --
-    // matches existing path-based DataFrame read behavior.
-    val dbName = Option(tableConfig.getDatabaseName).filter(_.nonEmpty)
-    CatalogTable(
-      identifier = TableIdentifier(tableConfig.getTableName, dbName),
-      tableType = CatalogTableType.EXTERNAL,
-      storage = CatalogStorageFormat.empty.copy(
-        locationUri = Some(metaClient.getBasePath.toUri)),
-      schema = schema,
-      provider = Some("hudi")
-    )
+    // `hoodie.table.name` is required for a valid Hudi table, but if it is somehow unset
+    // leave `catalogTable` as `None` -- the pre-existing behavior -- rather than synthesize
+    // a `TableIdentifier(null)` that would surface downstream as a garbage dataset name.
+    Option(tableConfig.getTableName).filter(_.nonEmpty).map { tableName =>
+      // Falls back to Spark's `default` database when `hoodie.database.name` is unset --
+      // matches existing path-based DataFrame read behavior.
+      val dbName = Option(tableConfig.getDatabaseName).filter(_.nonEmpty)
+      CatalogTable(
+        identifier = TableIdentifier(tableName, dbName),
+        tableType = CatalogTableType.EXTERNAL,
+        storage = CatalogStorageFormat.empty.copy(
+          locationUri = Some(metaClient.getBasePath.toUri)),
+        schema = schema,
+        provider = Some("hudi")
+      )
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -17,20 +17,22 @@
 
 package org.apache.spark.sql.hudi.analysis
 
-import org.apache.hudi.{HoodieSchemaUtils, HoodieSparkUtils, SparkAdapterSupport}
+import org.apache.hudi.{HoodieFileIndex, HoodieIncrementalFileIndex, HoodieSchemaUtils, HoodieSparkUtils, SparkAdapterSupport}
+import org.apache.hudi.cdc.HoodieCDCFileIndex
+import org.apache.hudi.common.table.HoodieTableMetaClient
 import org.apache.hudi.common.util.ReflectionUtils.loadClass
 import org.apache.hudi.common.util.ValidationUtils
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, HoodieCatalogTable}
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, HoodieCatalogTable}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSeq, Expression, GenericInternalRow}
 import org.apache.spark.sql.catalyst.optimizer.ReplaceExpressions
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.datasources.{CreateTable, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.{CreateTable, FileIndex, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils.{isMetaField, removeMetaFields}
 import org.apache.spark.sql.hudi.analysis.HoodieAnalysis.{sparkAdapter, MatchCreateIndex, MatchCreateTableLike, MatchDropIndex, MatchInsertIntoStatement, MatchMergeIntoTable, MatchRefreshIndex, MatchShowIndexes, ResolvesToHudiTable}
 import org.apache.spark.sql.hudi.blob.ReadBlobRule
@@ -39,6 +41,7 @@ import org.apache.spark.sql.hudi.command.HoodieLeafRunnableCommand.stripMetaFiel
 import org.apache.spark.sql.hudi.command.InsertIntoHoodieTableCommand.alignQueryOutput
 import org.apache.spark.sql.hudi.command.exception.HoodieAnalysisException
 import org.apache.spark.sql.hudi.command.procedures.{HoodieProcedures, Procedure, ProcedureArgs}
+import org.apache.spark.sql.types.StructType
 
 import java.util
 
@@ -126,7 +129,8 @@ object HoodieAnalysis extends SparkAdapterSupport {
       // NOTE: By default all commands are converted into corresponding Hudi implementations during
       //       "post-hoc resolution" phase
       session => ResolveImplementations(session),
-      session => HoodiePostAnalysisRule(session)
+      session => HoodiePostAnalysisRule(session),
+      _ => HoodieIncrementalRelationIdentifier
     )
 
     val postHocResolutionClass = "org.apache.spark.sql.hudi.analysis.PostAnalysisRule"
@@ -637,5 +641,50 @@ case class HoodiePostAnalysisRule(sparkSession: SparkSession) extends Rule[Logic
         }
       case _ => plan
     }
+  }
+}
+
+/**
+ * Stamps a synthesized [[CatalogTable]] (table name, base path, schema) onto path-based
+ * Hudi reads whose underlying file index is incremental or CDC. Without it, lineage and
+ * governance tooling sees `LogicalRelation.catalogTable = None` and falls back to the
+ * relation's class name as the dataset identifier -- useless for tracking which table
+ * an incremental query came from.
+ *
+ * Scope is intentionally limited to incremental and CDC reads:
+ *  - Catalog-registered reads already have `catalogTable` populated.
+ *  - Path-based snapshot reads have a working file-path-based fallback in existing
+ *    lineage tooling; changing their behavior is a separate decision.
+ */
+object HoodieIncrementalRelationIdentifier extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    AnalysisHelper.allowInvokingTransformsInAnalyzer {
+      plan transform {
+        case lr @ LogicalRelation(hfsr: HadoopFsRelation, _, None, _)
+            if isIncrementalOrCDC(hfsr.location) =>
+          val metaClient = hfsr.location.asInstanceOf[HoodieFileIndex].metaClient
+          lr.copy(catalogTable = Some(buildCatalogTable(metaClient, lr.schema)))
+      }
+    }
+
+  private def isIncrementalOrCDC(location: FileIndex): Boolean =
+    location.isInstanceOf[HoodieIncrementalFileIndex] ||
+      location.isInstanceOf[HoodieCDCFileIndex]
+
+  private def buildCatalogTable(
+      metaClient: HoodieTableMetaClient,
+      schema: StructType): CatalogTable = {
+    val tableConfig = metaClient.getTableConfig
+    // Falls back to Spark's `default` database when `hoodie.database.name` is unset --
+    // matches existing path-based DataFrame read behavior.
+    val dbName = Option(tableConfig.getDatabaseName).filter(_.nonEmpty)
+    CatalogTable(
+      identifier = TableIdentifier(tableConfig.getTableName, dbName),
+      tableType = CatalogTableType.EXTERNAL,
+      storage = CatalogStorageFormat.empty.copy(
+        locationUri = Some(metaClient.getBasePath.toUri)),
+      schema = schema,
+      provider = Some("hudi")
+    )
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -660,9 +660,15 @@ object HoodieIncrementalRelationIdentifier extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan =
     AnalysisHelper.allowInvokingTransformsInAnalyzer {
       plan transform {
-        case lr @ LogicalRelation(hfsr: HadoopFsRelation, _, None, _)
-            if isIncrementalOrCDC(hfsr.location) =>
-          val metaClient = hfsr.location.asInstanceOf[HoodieFileIndex].metaClient
+        // Type pattern + guard avoids destructuring `LogicalRelation`, whose case-class
+        // arity differs between Spark 3.x (4 args) and Spark 4.x (5 args). This rule
+        // lives in `hudi-spark`, which is compiled against every supported profile.
+        case lr: LogicalRelation
+            if lr.catalogTable.isEmpty
+              && lr.relation.isInstanceOf[HadoopFsRelation]
+              && isIncrementalOrCDC(lr.relation.asInstanceOf[HadoopFsRelation].location) =>
+          val fsRelation = lr.relation.asInstanceOf[HadoopFsRelation]
+          val metaClient = fsRelation.location.asInstanceOf[HoodieFileIndex].metaClient
           lr.copy(catalogTable = Some(buildCatalogTable(metaClient, lr.schema)))
       }
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodieIncrementalRelationIdentifier.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodieIncrementalRelationIdentifier.scala
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.analysis
+
+import org.apache.hudi.{HoodieFileIndex, HoodieIncrementalFileIndex, ScalaAssertionSupport}
+import org.apache.hudi.HoodieConversionUtils.toJavaOption
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.HoodieInstant
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+import org.apache.hudi.testutils.HoodieClientTestBase
+import org.apache.hudi.util.JFunction
+
+import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+import java.util.function.Consumer
+
+/**
+ * Verifies that [[HoodieIncrementalRelationIdentifier]] enriches path-based incremental
+ * reads (and only those), so that lineage tooling sees a real table identifier instead
+ * of falling back to the relation's class name.
+ */
+class TestHoodieIncrementalRelationIdentifier extends HoodieClientTestBase with ScalaAssertionSupport {
+
+  private var spark: SparkSession = _
+
+  @BeforeEach
+  override def setUp() {
+    setTableName("hoodie_incr_id_test")
+    initPath()
+    initSparkContexts()
+    spark = sqlContext.sparkSession
+  }
+
+  override def getSparkSessionExtensionsInjector: org.apache.hudi.common.util.Option[Consumer[SparkSessionExtensions]] =
+    toJavaOption(
+      Some(
+        JFunction.toJavaConsumer((receiver: SparkSessionExtensions) => new HoodieSparkSessionExtension().apply(receiver)))
+    )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("cow", "mor"))
+  def testPathBasedIncrementalReadGetsCatalogTable(tableType: String): Unit = {
+    val tablePath = s"$basePath/$tableName"
+    createAndPopulateTable(tableType, tablePath)
+
+    val firstInstant = firstCompletedInstantTime(tablePath)
+
+    val df = spark.read.format("hudi")
+      .option("hoodie.datasource.query.type", "incremental")
+      .option("hoodie.datasource.read.begin.instanttime", firstInstant)
+      .load(tablePath)
+
+    val analyzed = df.queryExecution.analyzed
+
+    val lrOpt = analyzed.collectFirst { case lr: LogicalRelation => lr }
+    assertTrue(lrOpt.isDefined,
+      s"Expected a LogicalRelation in analyzed plan, got:\n$analyzed")
+    val lr = lrOpt.get
+
+    // Sanity: confirm the path under test really exercises the incremental file index.
+    val location = lr.relation.asInstanceOf[HadoopFsRelation].location
+    assertTrue(location.isInstanceOf[HoodieIncrementalFileIndex],
+      s"Expected HoodieIncrementalFileIndex, got: ${location.getClass.getName}")
+
+    assertTrue(lr.catalogTable.isDefined,
+      s"Expected catalogTable to be populated by HoodieIncrementalRelationIdentifier, got None")
+
+    val ct = lr.catalogTable.get
+    assertEquals(tableName, ct.identifier.table,
+      s"Expected catalogTable identifier to use Hudi table name '$tableName', got '${ct.identifier.table}'")
+    assertEquals(Some("hudi"), ct.provider,
+      s"Expected provider 'hudi', got '${ct.provider}'")
+    assertTrue(ct.storage.locationUri.isDefined,
+      "Expected catalogTable.storage.locationUri to be populated from metaClient.getBasePath")
+    assertTrue(ct.schema.fields.nonEmpty,
+      "Expected catalogTable.schema to mirror the relation's resolved output schema")
+  }
+
+  @Test
+  def testCatalogRegisteredIncrementalReadIsNotMutated(): Unit = {
+    spark.sql(
+      s"""
+         |CREATE TABLE $tableName (
+         |  id int,
+         |  name string,
+         |  ts long
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$basePath/$tableName'
+         """.stripMargin)
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'a1', 1000)")
+
+    val analyzed = spark.sql(s"SELECT * FROM $tableName").queryExecution.analyzed
+    val lrOpt = analyzed.collectFirst { case lr: LogicalRelation => lr }
+    assertTrue(lrOpt.isDefined,
+      s"Expected a LogicalRelation in analyzed plan, got:\n$analyzed")
+    val lr = lrOpt.get
+
+    assertTrue(lr.catalogTable.isDefined, "Expected catalogTable from catalog registration")
+    assertEquals(tableName, lr.catalogTable.get.identifier.table)
+  }
+
+  @Test
+  def testSnapshotPathBasedReadIsNotEnriched(): Unit = {
+    val tablePath = s"$basePath/$tableName"
+    createAndPopulateTable("cow", tablePath)
+
+    val df = spark.read.format("hudi").load(tablePath)
+    val analyzed = df.queryExecution.analyzed
+
+    val lrOpt = analyzed.collectFirst { case lr: LogicalRelation => lr }
+    assertTrue(lrOpt.isDefined,
+      s"Expected a LogicalRelation in analyzed plan, got:\n$analyzed")
+    val lr = lrOpt.get
+
+    val location = lr.relation.asInstanceOf[HadoopFsRelation].location
+    assertFalse(location.isInstanceOf[HoodieIncrementalFileIndex],
+      s"Snapshot read should not produce a HoodieIncrementalFileIndex, got: ${location.getClass.getName}")
+    assertTrue(location.isInstanceOf[HoodieFileIndex],
+      s"Snapshot read should produce a HoodieFileIndex, got: ${location.getClass.getName}")
+    assertFalse(lr.catalogTable.isDefined,
+      "Snapshot path-based read must not be enriched by HoodieIncrementalRelationIdentifier")
+  }
+
+  // --- helpers ---
+
+  private def createAndPopulateTable(tableType: String, tablePath: String): Unit = {
+    spark.sql(
+      s"""
+         |CREATE TABLE $tableName (
+         |  id int,
+         |  name string,
+         |  price double,
+         |  ts long
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = '$tableType',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$tablePath'
+         """.stripMargin)
+    // Two commits so the incremental range is never empty.
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'a1', 10, 1000), (2, 'a2', 20, 2000)")
+    spark.sql(s"INSERT INTO $tableName VALUES (3, 'a3', 30, 3000)")
+  }
+
+  private def firstCompletedInstantTime(tablePath: String): String = {
+    val metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(tablePath)
+      .setConf(HadoopFSUtils.getStorageConf(spark.sparkContext.hadoopConfiguration)).build()
+    val instants: java.util.List[HoodieInstant] =
+      metaClient.getCommitsTimeline.filterCompletedInstants.getInstants
+    assertFalse(instants.isEmpty, s"Expected at least one completed instant at $tablePath")
+    instants.get(0).requestedTime
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodieIncrementalRelationIdentifier.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodieIncrementalRelationIdentifier.scala
@@ -98,7 +98,7 @@ class TestHoodieIncrementalRelationIdentifier extends HoodieClientTestBase with 
   }
 
   @Test
-  def testCatalogRegisteredIncrementalReadIsNotMutated(): Unit = {
+  def testCatalogRegisteredReadIsNotMutated(): Unit = {
     spark.sql(
       s"""
          |CREATE TABLE $tableName (

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestMergeIntoHoodieTableCommandInnerChildren.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestMergeIntoHoodieTableCommandInnerChildren.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.analysis
+
+import org.apache.hudi.HoodieConversionUtils.toJavaOption
+import org.apache.hudi.ScalaAssertionSupport
+import org.apache.hudi.testutils.HoodieClientTestBase
+import org.apache.hudi.util.JFunction
+
+import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.catalyst.plans.logical.MergeIntoTable
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+import org.apache.spark.sql.hudi.command.MergeIntoHoodieTableCommand
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+
+import java.util.function.Consumer
+
+/**
+ * Guards both the leaf-ness of [[MergeIntoHoodieTableCommand]] (Catalyst optimizer
+ * safety) and the new `innerChildren` exposure (lineage / EXPLAIN reachability).
+ */
+class TestMergeIntoHoodieTableCommandInnerChildren extends HoodieClientTestBase with ScalaAssertionSupport {
+
+  private var spark: SparkSession = _
+  private var sourceTableName: String = _
+
+  @BeforeEach
+  override def setUp() {
+    setTableName("hoodie_merge_target")
+    sourceTableName = "hoodie_merge_source"
+    initPath()
+    initSparkContexts()
+    spark = sqlContext.sparkSession
+  }
+
+  override def getSparkSessionExtensionsInjector: org.apache.hudi.common.util.Option[Consumer[SparkSessionExtensions]] =
+    toJavaOption(
+      Some(
+        JFunction.toJavaConsumer((receiver: SparkSessionExtensions) => new HoodieSparkSessionExtension().apply(receiver)))
+    )
+
+  @Test
+  def testMergeIntoExposesAnalyzedMergeIntoTableViaInnerChildren(): Unit = {
+    spark.sql(
+      s"""
+         |CREATE TABLE $tableName (
+         |  id int,
+         |  name string,
+         |  price double,
+         |  ts long
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$basePath/$tableName'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'a1', 10.0, 1000)")
+
+    spark.sql(s"CREATE OR REPLACE TEMPORARY VIEW $sourceTableName AS " +
+      s"SELECT 1 AS id, 'a1_updated' AS name, 99.0 AS price, 2000L AS ts " +
+      s"UNION ALL " +
+      s"SELECT 2, 'a2', 20.0, 2000L")
+
+    val mergeSql =
+      s"""
+         |MERGE INTO $tableName AS t
+         |USING $sourceTableName AS s
+         |ON t.id = s.id
+         |WHEN MATCHED THEN UPDATE SET t.name = s.name, t.price = s.price, t.ts = s.ts
+         |WHEN NOT MATCHED THEN INSERT (id, name, price, ts) VALUES (s.id, s.name, s.price, s.ts)
+         """.stripMargin
+
+    val analyzed = spark.sql(mergeSql).queryExecution.analyzed
+
+    val cmdOpt = analyzed.collectFirst { case c: MergeIntoHoodieTableCommand => c }
+    assertTrue(cmdOpt.isDefined,
+      s"Expected MergeIntoHoodieTableCommand in analyzed plan, got:\n$analyzed")
+    val cmd = cmdOpt.get
+
+    assertEquals(0, cmd.children.size,
+      s"MergeIntoHoodieTableCommand must remain a Catalyst leaf, got children: ${cmd.children}")
+
+    assertEquals(1, cmd.innerChildren.size,
+      s"Expected innerChildren to expose exactly one node (MergeIntoTable), got: ${cmd.innerChildren}")
+
+    val inner = cmd.innerChildren.head
+    assertTrue(inner.isInstanceOf[MergeIntoTable],
+      s"Expected innerChildren(0) to be MergeIntoTable, got: ${inner.getClass.getName}")
+
+    val mergeIntoTable = inner.asInstanceOf[MergeIntoTable]
+
+    val sourceLeaves = mergeIntoTable.sourceTable.collectLeaves()
+    assertTrue(sourceLeaves.nonEmpty,
+      s"Expected at least one leaf in source plan, got: ${mergeIntoTable.sourceTable}")
+
+    val targetLeaves = mergeIntoTable.targetTable.collectLeaves()
+    assertTrue(targetLeaves.exists(_.isInstanceOf[LogicalRelation]),
+      s"Expected target plan to contain a LogicalRelation, got: ${mergeIntoTable.targetTable}")
+
+    assertTrue(mergeIntoTable.mergeCondition != null, "Expected non-null mergeCondition")
+    assertEquals(1, mergeIntoTable.matchedActions.size,
+      s"Expected exactly one matched action, got: ${mergeIntoTable.matchedActions}")
+    assertEquals(1, mergeIntoTable.notMatchedActions.size,
+      s"Expected exactly one notMatched action, got: ${mergeIntoTable.notMatchedActions}")
+  }
+
+  @Test
+  def testExplainShowsSourceTableViaInnerChildren(): Unit = {
+    spark.sql(
+      s"""
+         |CREATE TABLE $tableName (
+         |  id int,
+         |  name string,
+         |  ts long
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$basePath/$tableName'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'a1', 1000)")
+
+    spark.sql(s"CREATE OR REPLACE TEMPORARY VIEW $sourceTableName AS " +
+      s"SELECT 1 AS id, 'a1_updated' AS name, 2000L AS ts")
+
+    val mergeSql =
+      s"""
+         |MERGE INTO $tableName AS t
+         |USING $sourceTableName AS s
+         |ON t.id = s.id
+         |WHEN MATCHED THEN UPDATE SET t.name = s.name, t.ts = s.ts
+         """.stripMargin
+
+    val explain = spark.sql(s"EXPLAIN $mergeSql").collect().map(_.getString(0)).mkString("\n")
+
+    assertTrue(explain.contains("MergeIntoHoodieTableCommand"),
+      s"Expected EXPLAIN output to contain MergeIntoHoodieTableCommand, got:\n$explain")
+    assertTrue(explain.contains(sourceTableName),
+      s"Expected EXPLAIN output to contain source view '$sourceTableName' via innerChildren, got:\n$explain")
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestMergeIntoHoodieTableCommandInnerChildren.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestMergeIntoHoodieTableCommandInnerChildren.scala
@@ -23,7 +23,8 @@ import org.apache.hudi.testutils.HoodieClientTestBase
 import org.apache.hudi.util.JFunction
 
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
-import org.apache.spark.sql.catalyst.plans.logical.MergeIntoTable
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{MergeIntoTable, UpdateAction}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.apache.spark.sql.hudi.command.MergeIntoHoodieTableCommand
@@ -122,6 +123,66 @@ class TestMergeIntoHoodieTableCommandInnerChildren extends HoodieClientTestBase 
       s"Expected exactly one matched action, got: ${mergeIntoTable.matchedActions}")
     assertEquals(1, mergeIntoTable.notMatchedActions.size,
       s"Expected exactly one notMatched action, got: ${mergeIntoTable.notMatchedActions}")
+  }
+
+  /**
+   * Pins *what* `innerChildren` exposes, not just its shape: the analyzed plan carrying the
+   * statement's assignments as written. A partial `UPDATE SET` must stay partial here. Hudi's
+   * expansion to the full target schema happens in `alignAssignments` and is serialized into
+   * the write config, never into a `MergeIntoTable`; substituting that expanded form here would
+   * report untouched columns as written (as `Literal(null)` on MOR). This is the tripwire.
+   */
+  @Test
+  def testInnerChildrenExposesUnalignedAssignments(): Unit = {
+    spark.sql(
+      s"""
+         |CREATE TABLE $tableName (
+         |  id int,
+         |  name string,
+         |  price double,
+         |  ts long
+         |) USING hudi
+         |TBLPROPERTIES (
+         |  type = 'cow',
+         |  primaryKey = 'id',
+         |  orderingFields = 'ts'
+         |)
+         |LOCATION '$basePath/$tableName'
+         """.stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName VALUES (1, 'a1', 10.0, 1000)")
+
+    spark.sql(s"CREATE OR REPLACE TEMPORARY VIEW $sourceTableName AS " +
+      s"SELECT 1 AS id, 'a1_updated' AS name, 99.0 AS price, 2000L AS ts")
+
+    // `price` is deliberately left out, so this stays a partial update. The ordering field
+    // (`ts`) must be assigned -- `checkUpdatingActions` rejects an update that omits it under
+    // event-time ordering -- so it is the target's `price` alone that distinguishes the
+    // statement's assignments from the full-schema aligned form.
+    val mergeSql =
+      s"""
+         |MERGE INTO $tableName AS t
+         |USING $sourceTableName AS s
+         |ON t.id = s.id
+         |WHEN MATCHED THEN UPDATE SET t.name = s.name, t.ts = s.ts
+         """.stripMargin
+
+    val analyzed = spark.sql(mergeSql).queryExecution.analyzed
+
+    val cmdOpt = analyzed.collectFirst { case c: MergeIntoHoodieTableCommand => c }
+    assertTrue(cmdOpt.isDefined,
+      s"Expected MergeIntoHoodieTableCommand in analyzed plan, got:\n$analyzed")
+
+    val mergeIntoTable = cmdOpt.get.innerChildren.head.asInstanceOf[MergeIntoTable]
+    val assignedColumns = mergeIntoTable.matchedActions.collect {
+      case update: UpdateAction => update.assignments
+    }.flatten.map(_.key).collect { case attr: Attribute => attr.name }.sorted
+
+    // Exactly the two columns the statement assigns -- not the four the aligned form carries.
+    assertEquals(Seq("name", "ts"), assignedColumns,
+      "innerChildren must expose the analyzed MergeIntoTable with the statement's own " +
+        "assignments, not Hudi's post-alignment expansion to the full target schema. " +
+        s"Got: $assignedColumns")
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BoundReference, EqualTo, Expression, Literal, NamedExpression, PredicateHelper}
 import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReference
-import org.apache.spark.sql.catalyst.plans.LeftOuter
+import org.apache.spark.sql.catalyst.plans.{LeftOuter, QueryPlan}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
@@ -112,6 +112,12 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
   with SparkAdapterSupport
   with ProvidesHoodieConfig
   with PredicateHelper {
+
+  // Required so that `HoodieLeafLike#children = Nil` (kept for Catalyst optimizer
+  // safety) does not also hide the source/target/merge-condition from EXPLAIN, lineage
+  // extractors, and other plan walkers. `innerChildren` is not traversed by `transform`
+  // or `mapChildren`.
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(mergeInto)
 
   private var sparkSession: SparkSession = _
 

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -117,6 +117,17 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
   // safety) does not also hide the source/target/merge-condition from EXPLAIN, lineage
   // extractors, and other plan walkers. `innerChildren` is not traversed by `transform`
   // or `mapChildren`.
+  //
+  // NOTE: this exposes the *analyzed* `MergeIntoTable`, carrying the statement's assignments
+  // exactly as written -- deliberately not a post-alignment plan. Hudi does expand partial
+  // `UPDATE SET` / `INSERT (...)` clauses to the full target schema, in `alignAssignments`,
+  // but that expansion is serialized into the write config (`PAYLOAD_*_CONDITION_AND_ASSIGNMENTS`)
+  // and never materialized as a `MergeIntoTable`. It also would not be a faithful description
+  // of the write if it were: the filler assignments are bound against the source-joined-target
+  // payload rather than the target alone, and under `ORIGINAL_VALUE` on a MOR table an untouched
+  // column is encoded as `Literal(null)` -- a plan walker would read that as "written as NULL"
+  // when it means "left alone". Consumers needing whole-row fidelity should fill in the
+  // unassigned target columns themselves.
   override def innerChildren: Seq[QueryPlan[_]] = Seq(mergeInto)
 
   private var sparkSession: SparkSession = _

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.catalog.HoodieCatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BoundReference, EqualTo, Expression, Literal, NamedExpression, PredicateHelper}
 import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReference
-import org.apache.spark.sql.catalyst.plans.LeftOuter
+import org.apache.spark.sql.catalyst.plans.{LeftOuter, QueryPlan}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils._
 import org.apache.spark.sql.hudi.ProvidesHoodieConfig
@@ -112,6 +112,12 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
   with SparkAdapterSupport
   with ProvidesHoodieConfig
   with PredicateHelper {
+
+  // Required so that `HoodieLeafLike#children = Nil` (kept for Catalyst optimizer
+  // safety) does not also hide the source/target/merge-condition from EXPLAIN, lineage
+  // extractors, and other plan walkers. `innerChildren` is not traversed by `transform`
+  // or `mapChildren`.
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(mergeInto)
 
   private var sparkSession: SparkSession = _
 

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
@@ -117,6 +117,17 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable) extends Hoodie
   // safety) does not also hide the source/target/merge-condition from EXPLAIN, lineage
   // extractors, and other plan walkers. `innerChildren` is not traversed by `transform`
   // or `mapChildren`.
+  //
+  // NOTE: this exposes the *analyzed* `MergeIntoTable`, carrying the statement's assignments
+  // exactly as written -- deliberately not a post-alignment plan. Hudi does expand partial
+  // `UPDATE SET` / `INSERT (...)` clauses to the full target schema, in `alignAssignments`,
+  // but that expansion is serialized into the write config (`PAYLOAD_*_CONDITION_AND_ASSIGNMENTS`)
+  // and never materialized as a `MergeIntoTable`. It also would not be a faithful description
+  // of the write if it were: the filler assignments are bound against the source-joined-target
+  // payload rather than the target alone, and under `ORIGINAL_VALUE` on a MOR table an untouched
+  // column is encoded as `Literal(null)` -- a plan walker would read that as "written as NULL"
+  // when it means "left alone". Consumers needing whole-row fidelity should fill in the
+  // unassigned target columns themselves.
   override def innerChildren: Seq[QueryPlan[_]] = Seq(mergeInto)
 
   private var sparkSession: SparkSession = _


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Plan walkers that derive column lineage (OpenLineage, Atlas, custom analyzer extensions) hit two dead ends on Hudi:

- **MERGE is opaque.** `MergeIntoHoodieTableCommand` is a `HoodieLeafRunnableCommand`, so `children = Nil` hides the source plan, target plan and merge condition. The other write commands moved to `DataWritingCommand`/`UnaryCommand` in #12772 and expose their query via `children`, leaving MERGE as the only gap on master.
- **Path-based incremental / CDC reads are anonymous.** `LogicalRelation.catalogTable` is `None`, so consumers fall back to the relation's class name as the dataset id, which collides across every incremental read in a job.

### Summary and Changelog

1. **`MergeIntoHoodieTableCommand.innerChildren`** returns `Seq(mergeInto)`. `children` stays `Nil`, so the optimizer still sees a leaf and `transform`/`mapChildren` never reach the inner plan, but EXPLAIN and plan walkers do.
2. **`HoodieIncrementalRelationIdentifier`**, a new post-hoc resolution rule, synthesizes a `CatalogTable` (name, base path, schema, `provider = "hudi"`) for `LogicalRelation`s over `HoodieIncrementalFileIndex` / `HoodieCDCFileIndex` that have no `catalogTable`. Metadata comes off the `HoodieTableMetaClient` the file index already holds, so no extra FS or metadata calls. Catalog-registered and snapshot reads are untouched -- snapshot reads already have a working path-based fallback in existing extractors, and widening scope to them is a separate call. `hoodie.database.name` falls back to `default`; an unset `hoodie.table.name` skips enrichment rather than building a `TableIdentifier(null)`.

Tracking issue: apache/hudi#18298

### Impact

`innerChildren` exposes the analyzed `MergeIntoTable`, with assignments exactly as written. This is the contract consumers will build on, so it's now stated in a comment at the override and pinned by a test.

### Risk Level

Low, with one interaction I'd like confirmed.

`innerChildren` is an additive override consumed only by EXPLAIN and opt-in plan walkers. The rule no-ops when `catalogTable` is already set. No write path, no public API, no config changes.

**Please sanity-check this one:** flipping `catalogTable` from `None` to `Some` makes incremental/CDC relations visible to code branching on `catalogTable.isDefined`. Walking the callers, the only read-path behavior change I found is in `Spark3/4HoodiePruneFileSourcePartitions`, where `lr.catalogTable.map(_.copy(stats = Some(CatalogStatistics(...))))` was previously a no-op for these relations. With partition-pruning filters present it now actually attaches pruned stats, so `computeStats` uses them instead of falling through to `relation.sizeInBytes`. That is arguably the rule's intent and brings incremental reads in line with catalog-registered ones, but it can shift join/broadcast decisions, so it should be a deliberate call rather than a side effect. Happy to narrow the rule if reviewers prefer. (Hudi's other `catalogTable.isDefined` checks are all on INSERT targets, which these reads can never be.)

### Documentation Update

None

### Test plan

Two new test classes, 7 tests, green locally under `-Pspark3.5` on JDK 11.

- `TestMergeIntoHoodieTableCommandInnerChildren` -- `innerChildren` carries the analyzed `MergeIntoTable` while `children` stays empty; a partial `UPDATE SET` stays partial (the tripwire if anyone swaps in an aligned plan; the other cases assign every column and so can't tell the two apart); EXPLAIN renders the merge source.
- `TestHoodieIncrementalRelationIdentifier` -- path-based incremental read gets the synthesized `CatalogTable` (cow and mor); catalog-registered and path-based snapshot reads are left unchanged.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable