### PR TITLE
feat(blob): RFC-100: Clarify inline vs out-of-line blob read behavior

### DIFF
--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -174,7 +174,7 @@ Lance's native blob encoding stores blobs in a way that already exposes a `(file
   └──────────────────────────────────────────────────────────────────┘
 
   ┌──────────────────────────────────────────────────────────────────┐
-  │  SELECT *  (returns Blob struct as-is)                           │
+  │  SELECT col  (returns Blob struct as-is)                         │
   │       │                                                          │
   │       ▼                                                          │
   │  storage = OUT_OF_LINE  ─────────────► data=NULL, reference=set  │

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -128,6 +128,67 @@ For Spark SQL we will provide a function that the user can leverage to materiali
 SELECT id, url, read_blob(image_blob) as image_bytes FROM my_table;
 ```
 
+#### Read Modes: `read_blob` vs. `SELECT *`
+
+`read_blob(<blob_column>)` is the canonical, universal API for materializing raw blob bytes in a query. It always returns the underlying `bytes` regardless of:
+- Storage strategy (`INLINE` vs `OUT_OF_LINE`)
+- Base file format (Parquet, Lance, …)
+- Any reader-side config such as `hoodie.read.blob.inline.mode`
+
+Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *`) returns the underlying `Blob` struct as-is. The contents of that struct depend on the storage strategy, the file format, and the read mode, as summarized below.
+
+**Reader Configuration**
+
+- `hoodie.read.blob.inline.mode` — values `CONTENT` (default) | `DESCRIPTOR`.
+  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field.
+  - `DESCRIPTOR`: the engine returns an `OUT_OF_LINE`-shaped descriptor in the `reference` field where the underlying file format supports it (Lance today), enabling lazy byte materialization via `read_blob`. For file formats without a native descriptor for inline payloads (Parquet), both `data` and `reference` are returned `NULL`, and the caller must use `read_blob` to retrieve bytes.
+  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting.
+
+**Behavior matrix**
+
+| Access pattern   | Storage      | File format | `hoodie.read.blob.inline.mode` | `data` field | `reference` field            | Raw bytes available?                              |
+|------------------|--------------|-------------|--------------------------------|--------------|------------------------------|---------------------------------------------------|
+| `read_blob(col)` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
+| `read_blob(col)` | INLINE       | Lance       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
+| `read_blob(col)` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
+| `SELECT *`       | INLINE       | Parquet     | `CONTENT` (default)            | bytes        | NULL                         | Yes — via `data`                                  |
+| `SELECT *`       | INLINE       | Parquet     | `DESCRIPTOR`                   | **NULL**     | **NULL**                     | No — must call `read_blob`                        |
+| `SELECT *`       | INLINE       | Lance       | `CONTENT` (default)            | bytes        | NULL                         | Yes — via `data`                                  |
+| `SELECT *`       | INLINE       | Lance       | `DESCRIPTOR`                   | NULL         | populated (Lance blob enc.)  | No — descriptor visible; use `read_blob` for bytes|
+| `SELECT *`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
+
+**Why Parquet and Lance differ in `DESCRIPTOR` mode**
+
+Lance's native blob encoding stores blobs in a way that already exposes a `(file, offset, length)` descriptor cheaply, so `DESCRIPTOR` mode surfaces it directly in the `reference` field — effectively letting INLINE blobs be read with the same deferred-materialization path used for OUT_OF_LINE references. Parquet has no equivalent native descriptor for an inline byte array, so both fields are `NULL` in `DESCRIPTOR` mode and the caller must use `read_blob` to materialize bytes.
+
+**Visual**
+
+```
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  read_blob(col)        ── universal, always materializes bytes ──│
+  │       │                                                          │
+  │       ▼                                                          │
+  │  ┌─────────────┐    INLINE ───► read inline payload              │
+  │  │ Hudi reader │ ──┤                                             │
+  │  └─────────────┘    OUT_OF_LINE ► follow reference → read bytes  │
+  └──────────────────────────────────────────────────────────────────┘
+
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  SELECT *  (returns Blob struct as-is)                           │
+  │       │                                                          │
+  │       ▼                                                          │
+  │  storage = OUT_OF_LINE  ─────────────► data=NULL, reference=set  │
+  │                                                                  │
+  │  storage = INLINE,                                               │
+  │   inline.mode = CONTENT (default) ───► data=<bytes>, ref=NULL    │
+  │                                                                  │
+  │  storage = INLINE,                                               │
+  │   inline.mode = DESCRIPTOR                                       │
+  │     ├─ Parquet  ─────────────────────► data=NULL, ref=NULL       │
+  │     └─ Lance    ─────────────────────► data=NULL, ref=set        │
+  └──────────────────────────────────────────────────────────────────┘
+```
+
 ### 3. Writer
 #### Phase 1: External Blob Support
 The writer will be updated to support writing blob data as out-of-line references. 

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -148,14 +148,14 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 
 | Access pattern   | Storage      | File format | `hoodie.read.blob.inline.mode` | `data` field | `reference` field            | Raw bytes available?                              |
 |------------------|--------------|-------------|--------------------------------|--------------|------------------------------|---------------------------------------------------|
-| `read_blob(col)` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
-| `read_blob(col)` | INLINE       | Lance       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
-| `read_blob(col)` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
-| `SELECT *`       | INLINE       | Parquet     | `CONTENT` (default)            | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT *`       | INLINE       | Parquet     | `DESCRIPTOR`                   | **NULL**     | **NULL**                     | No — must call `read_blob`                        |
-| `SELECT *`       | INLINE       | Lance       | `CONTENT` (default)            | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT *`       | INLINE       | Lance       | `DESCRIPTOR`                   | NULL         | populated (Lance blob enc.)  | No — descriptor visible; use `read_blob` for bytes|
-| `SELECT *`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
+| `SELECT read_blob(col) FROM table` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
+| `SELECT read_blob(col) FROM table` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
+| `SELECT col FROM table`       | INLINE       | Parquet     | `CONTENT` (default)            | bytes        | NULL                         | Yes — via `data`                                  |
+| `SELECT col FROM table`       | INLINE       | Parquet     | `DESCRIPTOR`                   | **NULL**     | **NULL**                     | No — must call `read_blob`                        |
+| `SELECT col FROM table`       | INLINE       | Lance       | `CONTENT` (default)            | bytes        | NULL                         | Yes — via `data`                                  |
+| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR`                   | NULL         | populated (Lance blob enc.)  | No — descriptor visible; use `read_blob` for bytes|
+| `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
 
 **Why Parquet and Lance differ in `DESCRIPTOR` mode**
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

RFC-100's current Reader section describes the high-level intent (lazy loading, `read_blob`) but does not specify what users see for each combination of storage strategy, file format, and read mode. The Parquet vs. Lance difference under `DESCRIPTOR` mode is especially non-obvious. This PR is a doc-only clarification to RFC-100 — no code changes.

### Summary and Changelog

Adds a new **Read Modes** subsection to RFC-100 that clarifies how blob columns are returned to the caller, so engineers and users can quickly tell which path materializes bytes vs. which returns a descriptor.

Specifically, this PR documents:

- `read_blob(<blob_column>)` is the **universal, canonical API** for materializing raw blob bytes. It always returns bytes regardless of:
  - Storage strategy (`INLINE` vs `OUT_OF_LINE`)
  - Base file format (Parquet, Lance, …)
  - Any reader-side config such as `hoodie.read.blob.inline.mode`
- The existing reader config `hoodie.read.blob.inline.mode` (defined in `HoodieReaderConfig.java`, values `CONTENT` (default) | `DESCRIPTOR`) and how it interacts with `SELECT *`:
  - `CONTENT`: inline bytes are eagerly materialized into the struct's `data` field.
  - `DESCRIPTOR`: engine returns an `OUT_OF_LINE`-shaped descriptor in `reference` where the underlying file format supports it (Lance today). For formats with no native inline descriptor (Parquet), both `data` and `reference` are `NULL` and the caller must use `read_blob`.
- For `OUT_OF_LINE` storage the `inline.read.mode` config is irrelevant — `SELECT *` always returns a populated `reference` and `NULL` `data`.

The new subsection includes a behavior matrix table and an ASCII diagram of the two read paths.

Changelog:
- `rfc/rfc-100/rfc-100.md`: new **Read Modes: `read_blob` vs. `SELECT *`** subsection inserted after the existing `read_blob` SQL example, before the "3. Writer" heading.

### Impact

Doc-only change to RFC-100. No public API, user-facing behavior, or performance impact.

### Risk Level

none

### Documentation Update

This PR is itself an RFC documentation update. No website or other doc changes needed — `hoodie.read.blob.inline.mode` already exists in `HoodieReaderConfig.java`; this PR only documents its interaction with `SELECT *` and `read_blob` in the RFC.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (N/A — doc-only change)