### PR TITLE
docs: add batch vector search demo + notebook for RFC-102

### DIFF
--- a/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/README.md
+++ b/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/README.md
@@ -25,18 +25,20 @@ the Oxford-IIIT Pet dataset:
 2. **BLOB type (INLINE)** — image bytes are written as a Hudi BLOB struct
    tagged with `hudi_type = "BLOB"`.
 3. **Vector search** — cosine similarity top-K via the
-   `hudi_vector_search` SQL table-valued function, backed by Lance files.
+   `hudi_vector_search` and `hudi_vector_search_batch` SQL table-valued
+   functions, backed by Lance files.
 
-## Three variants
+## Four variants
 
-The folder ships three scripts — each focused on a specific Hudi feature.
+The folder ships four scripts — each focused on a specific Hudi feature.
 Run them independently or in sequence for a full walkthrough.
 
 | File | Feature focus | Surface | Best for |
 |---|---|---|---|
 | [`hudi_blob_reader_demo.py`](hudi_blob_reader_demo.py) | **OUT_OF_LINE BLOBs + `read_blob()`** — Hudi table stores references to bytes living in a separate container file; `read_blob()` resolves them on demand | Spark SQL | Showing the "lakehouse that references unstructured data without copying" story — tiny Hudi table, bytes elsewhere |
-| [`hudi_sql_vector_blob_demo.py`](hudi_sql_vector_blob_demo.py) | **INLINE BLOBs + VECTOR + `hudi_vector_search`** — bytes embedded in the Hudi base files, cosine similarity search via the TVF | Spark SQL — `CREATE TABLE ... (embedding VECTOR(N), image_bytes BLOB, ...) USING hudi`, `named_struct('type','INLINE', ...)`, `hudi_vector_search(...)` | Live demos; SQL-first users; showing the Hudi 1.2.0 DDL/DML surface the way it's documented |
+| [`hudi_sql_vector_blob_demo.py`](hudi_sql_vector_blob_demo.py) | **INLINE BLOBs + VECTOR + `hudi_vector_search`** — bytes embedded in the Hudi base files, single-query cosine similarity search via the TVF | Spark SQL — `CREATE TABLE ... (embedding VECTOR(N), image_bytes BLOB, ...) USING hudi`, `named_struct('type','INLINE', ...)`, `hudi_vector_search(...)` | Live demos; SQL-first users; showing the Hudi 1.2.0 DDL/DML surface the way it's documented |
 | [`hudi_dataframe_vector_blob_demo.py`](hudi_dataframe_vector_blob_demo.py) | Same as the SQL demo, but via DataFrame | Python DataFrame API — `spark.createDataFrame(rows, explicit_schema)` with `containsNull=False` and `hudi_type` metadata declared upfront, then `df.write.format("hudi").save(path)` | Library-style integration; seeing how the Python DataFrame API composes the VECTOR/BLOB logical types under the hood |
+| [`hudi_vector_search_batch_demo.py`](hudi_vector_search_batch_demo.py) | **`hudi_vector_search_batch` certification** — table-to-table batch KNN (RFC-102), 1000-row corpus × 20-row query table, with a **numpy ground-truth oracle** that fails the run if the TVF disagrees | Spark SQL — `hudi_vector_search_batch('<corpus>', 'embedding', '<queries>', 'embedding', k, 'cosine')` | Certifying batch-mode correctness at non-trivial scale; broadcast + window-rank machinery under load |
 
 All three share the same venv, jars, and env vars. They write to different
 table paths (`/tmp/hudi_blob_reader_{format}_pets` vs `/tmp/hudi_sql_{format}_pets`
@@ -64,6 +66,7 @@ on Parquet, flip one config flag in the DDL.
 | [`notebooks/01_blob_reader.ipynb`](notebooks/01_blob_reader.ipynb) | supplemental: OUT_OF_LINE deep-dive | [`hudi_blob_reader_demo.py`](hudi_blob_reader_demo.py) | `BASE_FILE_FORMAT`, `BLOB_MODE`, `INLINE_READ_MODE`, `N_SAMPLES` |
 | [`notebooks/02_sql_vector_search.ipynb`](notebooks/02_sql_vector_search.ipynb) | supplemental: SQL DDL deep-dive | [`hudi_sql_vector_blob_demo.py`](hudi_sql_vector_blob_demo.py) | `BASE_FILE_FORMAT`, `N_SAMPLES` |
 | [`notebooks/03_dataframe_vector_search.ipynb`](notebooks/03_dataframe_vector_search.ipynb) | supplemental: DataFrame API | [`hudi_dataframe_vector_blob_demo.py`](hudi_dataframe_vector_blob_demo.py) | `BASE_FILE_FORMAT`, `N_SAMPLES` |
+| [`notebooks/04_vector_search_batch.ipynb`](notebooks/04_vector_search_batch.ipynb) | supplemental: batch TVF certification (numpy oracle) | [`hudi_vector_search_batch_demo.py`](hudi_vector_search_batch_demo.py) | `BASE_FILE_FORMAT`, `N_CORPUS`, `N_QUERIES`, `TOP_K` |
 
 See [`notebooks/README.md`](notebooks/README.md) for setup details.
 
@@ -160,6 +163,24 @@ export HUDI_LANCE_DEMO_N=1000
 python hudi_dataframe_vector_blob_demo.py        # or hudi_sql_vector_blob_demo.py
 ```
 
+### Run the batch vector search certification
+
+```bash
+# Defaults: 1000-row corpus × 20-row queries × top-k=5, against the corpus.
+HUDI_BASE_FILE_FORMAT=parquet python hudi_vector_search_batch_demo.py
+```
+
+The run ends with a numpy ground-truth oracle that compares the TVF's
+top-K per query against a locally computed cosine distance matrix. A
+successful run ends with `CERTIFIED ✓` and writes
+`outputs/hudi_vector_search_batch_<format>_results.png` (one row per query,
+showing its top-K matches).
+
+Knobs:
+- `HUDI_BATCH_N_CORPUS` (default `1000`)
+- `HUDI_BATCH_N_QUERIES` (default `20`)
+- `HUDI_BATCH_TOP_K` (default `5`)
+
 ### Run the same demo against Parquet base files
 
 The Hudi VECTOR + BLOB + vector search path is format-agnostic — flip the
@@ -197,6 +218,9 @@ etc.) with similarity scores in the 0.3–0.5 range at N=100, tighter at N=1000.
 | `HUDI_BLOB_MODE` | `out_of_line` | Blob reader demo only. Set to `inline` to embed PNG bytes directly in the Hudi table (no external container file) |
 | `HUDI_INLINE_READ_MODE` | `content` | Blob reader demo only, and only meaningful when `HUDI_BLOB_MODE=inline`. Set to `descriptor` to make `image_bytes.data` come back null and force `read_blob()` to materialize bytes lazily. |
 | `HUDI_LANCE_DEMO_N` | `1000` (`100` for blob reader) | Number of images to sample |
+| `HUDI_BATCH_N_CORPUS` | `1000` | Batch demo only — corpus row count |
+| `HUDI_BATCH_N_QUERIES` | `20` | Batch demo only — query table row count |
+| `HUDI_BATCH_TOP_K` | `5` | Batch demo only — top-K per query |
 | `PYSPARK_DRIVER_MEMORY` | `4g` | Driver JVM heap — bump to `8g`+ for N≥2000 |
 | `HUDI_LANCE_DEMO_OUTDIR` | `./outputs` | Where query/top-K PNGs land |
 

--- a/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/hudi_vector_search_batch_demo.py
+++ b/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/hudi_vector_search_batch_demo.py
@@ -1,0 +1,713 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Hudi BATCH vector search demo — certifies `hudi_vector_search_batch` at non-
+trivial scale against a numpy ground-truth oracle.
+
+Sibling to `hudi_sql_vector_blob_demo.py` (single-query). Same dataset, same
+embedding model, same Hudi DDL — but the search step is the **table-to-table**
+batch TVF described in RFC-102:
+
+  SELECT *
+  FROM hudi_vector_search_batch(
+      'pets_batch_corpus_<format>',  'embedding',
+      'pets_batch_queries_<format>', 'embedding',
+      k, 'cosine')
+
+Flow:
+  1. Load N_CORPUS + N_QUERIES Oxford-IIIT Pet images.
+  2. Generate L2-normalized embeddings with `mobilenetv3_small_100`.
+  3. Split into corpus (N_CORPUS) + held-out queries (N_QUERIES).
+  4. Stage both via PyArrow, write each to its own Hudi table.
+  5. Run `hudi_vector_search_batch` and collect results.
+  6. **Oracle validation:** compute the cosine distance matrix in numpy from
+     the same embeddings and assert the TVF's top-k per query matches.
+  7. Render a result panel (one row per query showing its top-k matches).
+
+Env vars:
+  HUDI_BUNDLE_JAR         (defaults to ~/Downloads/hudi-spark3.5-bundle_2.12-1.2.0-rc1.jar)
+  HUDI_BASE_FILE_FORMAT   (default 'lance'; set to 'parquet' to use Parquet)
+  LANCE_BUNDLE_JAR        (defaults to ~/Downloads/lance-spark-bundle-3.5_2.12-0.4.0.jar; only used when HUDI_BASE_FILE_FORMAT=lance)
+  HUDI_BATCH_N_CORPUS     (default 1000; rows in the corpus Hudi table)
+  HUDI_BATCH_N_QUERIES    (default 20;   rows in the query Hudi table)
+  HUDI_BATCH_TOP_K        (default 5)
+  PYSPARK_DRIVER_MEMORY   (default '4g')
+  HUDI_LANCE_DEMO_OUTDIR  (default './outputs')
+"""
+
+import io
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# MUST run before any `pyspark` import — local-mode driver heap is fixed at
+# JVM launch time and cannot be raised via SparkSession.config() later.
+_driver_mem = os.getenv("PYSPARK_DRIVER_MEMORY", "4g")
+os.environ.setdefault(
+    "PYSPARK_SUBMIT_ARGS",
+    f"--driver-memory {_driver_mem} --conf spark.driver.maxResultSize=2g pyspark-shell",
+)
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import torch
+import timm
+from sklearn.preprocessing import normalize
+from PIL import Image
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+from torchvision.datasets import OxfordIIITPet  # noqa: E402
+
+from pyspark.sql import SparkSession
+
+
+# ======================================================
+# CONFIGURATION
+# ======================================================
+
+_file_format = os.getenv("HUDI_BASE_FILE_FORMAT", "lance").lower()
+if _file_format not in ("lance", "parquet"):
+    sys.exit(f"ERROR: HUDI_BASE_FILE_FORMAT must be 'lance' or 'parquet', got '{_file_format}'")
+
+CONFIG = {
+    "dataset": "OxfordIIITPet",
+    "base_file_format": _file_format,
+    "corpus_table_path": f"/tmp/hudi_batch_corpus_{_file_format}_pets",
+    "corpus_table_name": f"pets_batch_corpus_{_file_format}",
+    "queries_table_path": f"/tmp/hudi_batch_queries_{_file_format}_pets",
+    "queries_table_name": f"pets_batch_queries_{_file_format}",
+    "n_corpus": int(os.getenv("HUDI_BATCH_N_CORPUS", "1000")),
+    "n_queries": int(os.getenv("HUDI_BATCH_N_QUERIES", "20")),
+    "top_k": int(os.getenv("HUDI_BATCH_TOP_K", "5")),
+    "embedding_model": "mobilenetv3_small_100",
+    "output_dir": os.getenv("HUDI_LANCE_DEMO_OUTDIR", "./outputs"),
+    "panel_filename": f"hudi_vector_search_batch_{_file_format}_results.png",
+    "log_level": "ERROR",
+    "hide_progress": True,
+    # Oracle tolerance: cosine distance computed on L2-normalized float32 vectors
+    # in numpy vs JVM-side DenseVector(Double) UDF. Float32 → Float64 widening +
+    # different summation orders allow ~1e-5 deltas.
+    "oracle_distance_tol": 1e-5,
+}
+
+BLOB_REFERENCE_CAST = (
+    "struct<external_path:string,offset:bigint,length:bigint,managed:boolean>"
+)
+
+
+# ======================================================
+# UTILITIES
+# ======================================================
+
+def ensure_dir(p: Path) -> None:
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def wipe_prior_state() -> None:
+    """
+    Remove this script's prior table dirs and staging Parquets so re-runs are
+    idempotent. `DROP TABLE IF EXISTS` (run inside `create_hudi_table_sql`) only
+    removes the catalog entry — the data dir and `.hoodie/` timeline at
+    LOCATION persist, so a re-run would query stale rows alongside fresh ones
+    and the oracle would (correctly) flag the mismatch.
+    """
+    targets = [
+        CONFIG["corpus_table_path"],
+        CONFIG["queries_table_path"],
+        f"/tmp/staging_pets_batch_corpus_{CONFIG['base_file_format']}.parquet",
+        f"/tmp/staging_pets_batch_queries_{CONFIG['base_file_format']}.parquet",
+    ]
+    for t in targets:
+        p = Path(t)
+        if p.is_dir():
+            shutil.rmtree(p, ignore_errors=True)
+        elif p.is_file():
+            p.unlink(missing_ok=True)
+    # Catalog warehouse from prior runs in this cwd.
+    shutil.rmtree("spark-warehouse", ignore_errors=True)
+
+
+def save_png_bytes(img_bytes: bytes, path: Path) -> None:
+    ensure_dir(path.parent)
+    with open(path, "wb") as f:
+        f.write(img_bytes)
+
+
+def default_hudi_bundle_jar() -> str:
+    return str(Path.home() / "Downloads" / "hudi-spark3.5-bundle_2.12-1.2.0-rc1.jar")
+
+
+def default_lance_bundle_jar() -> str:
+    return str(Path.home() / "Downloads" / "lance-spark-bundle-3.5_2.12-0.4.0.jar")
+
+
+def resolve_jars() -> str:
+    hudi_jar = os.getenv("HUDI_BUNDLE_JAR", default_hudi_bundle_jar())
+    if not Path(hudi_jar).is_file():
+        sys.exit(
+            f"ERROR: HUDI_BUNDLE_JAR does not exist at {hudi_jar}\n"
+            "Download the Apache 1.2.0-rc1 staging jar with:\n"
+            "  curl -L -o ~/Downloads/hudi-spark3.5-bundle_2.12-1.2.0-rc1.jar \\\n"
+            "    https://repository.apache.org/content/repositories/orgapachehudi-1176/org/apache/hudi/hudi-spark3.5-bundle_2.12/1.2.0-rc1/hudi-spark3.5-bundle_2.12-1.2.0-rc1.jar\n"
+            "or set HUDI_BUNDLE_JAR=/abs/path/to/locally-built.jar."
+        )
+    if CONFIG["base_file_format"] != "lance":
+        return hudi_jar
+    lance_jar = os.getenv("LANCE_BUNDLE_JAR", default_lance_bundle_jar())
+    if not Path(lance_jar).is_file():
+        sys.exit(
+            f"ERROR: LANCE_BUNDLE_JAR does not exist at {lance_jar}\n"
+            "Download the Lance 0.4.0 bundle from Maven Central with:\n"
+            "  curl -L -o ~/Downloads/lance-spark-bundle-3.5_2.12-0.4.0.jar \\\n"
+            "    https://repo1.maven.org/maven2/com/lancedb/lance-spark-bundle-3.5_2.12/0.4.0/lance-spark-bundle-3.5_2.12-0.4.0.jar\n"
+            "or set LANCE_BUNDLE_JAR=/abs/path/to/jar."
+        )
+    return f"{hudi_jar},{lance_jar}"
+
+
+# ======================================================
+# 1. SPARK SESSION SETUP
+# ======================================================
+
+def create_spark() -> SparkSession:
+    jars = resolve_jars()
+    builder = (
+        SparkSession.builder.appName("Hudi-Vector-Search-Batch-Demo")
+        .config("spark.jars", jars)
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        .config(
+            "spark.sql.extensions",
+            "org.apache.spark.sql.hudi.HoodieSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.hudi.catalog.HoodieCatalog",
+        )
+        .config("spark.sql.session.timeZone", "UTC")
+        .config("hoodie.read.blob.inline.mode", "CONTENT")
+        .config("spark.default.parallelism", "2")
+        .config("spark.sql.shuffle.partitions", "2")
+    )
+    if CONFIG.get("hide_progress", True):
+        builder = builder.config("spark.ui.showConsoleProgress", "false")
+    spark = builder.getOrCreate()
+    spark.sparkContext.setLogLevel(CONFIG.get("log_level", "ERROR"))
+    return spark
+
+
+# ======================================================
+# 2. LOAD DATASET (Oxford-IIIT Pet)
+# ======================================================
+
+def load_dataset(n_samples):
+    print(f"Loading dataset: Oxford-IIIT Pet ({n_samples} samples)...")
+    root = os.path.expanduser("~/.cache/torchvision")
+    ds = OxfordIIITPet(root=root, split="trainval", download=True)
+    class_names = ds.classes
+
+    rng = np.random.default_rng()
+    n = min(n_samples, len(ds))
+    indices = rng.choice(len(ds), size=n, replace=False)
+
+    data = []
+    for idx in indices:
+        img, label = ds[int(idx)]
+        img = img.convert("RGB")
+        bio = io.BytesIO()
+        img.save(bio, format="PNG")
+        img_bytes = bio.getvalue()
+        w, h = img.size
+        category = class_names[label] if isinstance(class_names, list) else str(label)
+        safe_category = category.replace("/", "_")
+        data.append(
+            {
+                "image_id": f"pets_{int(idx):06d}",
+                "category": category,
+                "category_sanitized": safe_category,
+                "label": int(label),
+                "description": f"{category} from Oxford-IIIT Pet",
+                "image_bytes_raw": img_bytes,
+                "width": int(w),
+                "height": int(h),
+            }
+        )
+    print(f"✓ Loaded {len(data)} images")
+    return data, class_names
+
+
+# ======================================================
+# 3. EMBEDDING MODEL (timm)
+# ======================================================
+
+def create_embedding_model():
+    print(f"Loading embedding model: {CONFIG['embedding_model']}...")
+    model = timm.create_model(CONFIG["embedding_model"], pretrained=True, num_classes=0)
+    model.eval()
+    data_config = timm.data.resolve_model_data_config(model)
+    transform = timm.data.create_transform(**data_config, is_training=False)
+    print("✓ Model loaded")
+    return model, transform
+
+
+def generate_embeddings(data, model, transform):
+    print(f"Generating embeddings for {len(data)} images...")
+    images = []
+    for item in data:
+        img = Image.open(io.BytesIO(item["image_bytes_raw"])).convert("RGB")
+        images.append(transform(img))
+    batch = torch.stack(images)
+    with torch.no_grad():
+        feats = model(batch).detach().cpu().numpy()
+    feats = normalize(feats)
+    for i, item in enumerate(data):
+        item["embedding"] = feats[i].tolist()
+    print(f"✓ Generated embeddings (dimension: {feats.shape[1]})")
+    return data, int(feats.shape[1])
+
+
+# ======================================================
+# 4. SPLIT corpus + queries
+# ======================================================
+
+def split_corpus_and_queries(data):
+    """
+    First N_CORPUS rows → corpus, last N_QUERIES rows → queries. Order is
+    already randomized by `load_dataset`'s `rng.choice(replace=False)`, so a
+    simple slice gives two disjoint subsets.
+
+    We hold both subsets in Python so the oracle (Step 7) can recompute the
+    distance matrix from the exact same embeddings that were written to Hudi.
+    """
+    n_corpus = CONFIG["n_corpus"]
+    n_queries = CONFIG["n_queries"]
+    if len(data) < n_corpus + n_queries:
+        sys.exit(
+            f"ERROR: requested n_corpus={n_corpus} + n_queries={n_queries}={n_corpus + n_queries} "
+            f"rows but dataset returned only {len(data)}"
+        )
+    corpus = data[:n_corpus]
+    queries = data[n_corpus : n_corpus + n_queries]
+
+    # Sanity: image_ids must be disjoint (no row appears in both tables).
+    corpus_ids = {r["image_id"] for r in corpus}
+    query_ids = {r["image_id"] for r in queries}
+    assert corpus_ids.isdisjoint(query_ids), "corpus and queries overlap"
+    print(f"✓ Split: {len(corpus)} corpus rows, {len(queries)} query rows (disjoint)")
+    return corpus, queries
+
+
+# ======================================================
+# 5. STAGE → PARQUET → TEMP VIEW (PyArrow, bypassing PythonRDD)
+# ======================================================
+
+def stage_to_parquet_with_pyarrow(data, embedding_dim: int, staging_path: str) -> None:
+    arrow_schema = pa.schema(
+        [
+            pa.field("image_id", pa.string(), nullable=False),
+            pa.field("category", pa.string(), nullable=False),
+            pa.field("category_sanitized", pa.string(), nullable=False),
+            pa.field("label", pa.int32(), nullable=False),
+            pa.field("description", pa.string(), nullable=True),
+            pa.field("image_bytes_raw", pa.binary(), nullable=False),
+            pa.field("width", pa.int32(), nullable=False),
+            pa.field("height", pa.int32(), nullable=False),
+            pa.field(
+                "embedding",
+                pa.list_(
+                    pa.field("element", pa.float32(), nullable=False),
+                    list_size=embedding_dim,
+                ),
+                nullable=False,
+            ),
+        ]
+    )
+    columns = {
+        "image_id": [d["image_id"] for d in data],
+        "category": [d["category"] for d in data],
+        "category_sanitized": [d["category_sanitized"] for d in data],
+        "label": [int(d["label"]) for d in data],
+        "description": [d.get("description") for d in data],
+        "image_bytes_raw": [d["image_bytes_raw"] for d in data],
+        "width": [int(d["width"]) for d in data],
+        "height": [int(d["height"]) for d in data],
+        "embedding": [d["embedding"] for d in data],
+    }
+    pq.write_table(pa.table(columns, schema=arrow_schema), staging_path)
+
+
+def register_staging_view(spark, data, embedding_dim, view_name, staging_path):
+    print(f"Staging Python data → Parquet at {staging_path} (PyArrow, no Spark)...")
+    stage_to_parquet_with_pyarrow(data, embedding_dim, staging_path)
+    spark.read.parquet(staging_path).createOrReplaceTempView(view_name)
+    print(f"✓ Registered Spark temp view: {view_name}")
+
+
+# ======================================================
+# 6. CREATE TABLE + INSERT — SQL  (run twice: corpus + queries)
+# ======================================================
+
+def create_hudi_table_sql(spark, embedding_dim, table_name, table_path):
+    print(f"\nDDL: CREATE TABLE {table_name} ...  [{CONFIG['base_file_format']} base files]")
+    spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+    ddl = f"""
+        CREATE TABLE {table_name} (
+            image_id            STRING,
+            category            STRING,
+            category_sanitized  STRING,
+            label               INT,
+            description         STRING,
+            image_bytes         BLOB           COMMENT 'Pet image bytes (INLINE)',
+            width               INT,
+            height              INT,
+            embedding           VECTOR({embedding_dim})
+                                               COMMENT 'Image embedding for ANN search'
+        ) USING hudi
+        PARTITIONED BY (category_sanitized)
+        LOCATION '{table_path}'
+        TBLPROPERTIES (
+            primaryKey = 'image_id',
+            preCombineField = 'image_id',
+            type = 'cow',
+            'hoodie.table.base.file.format' = '{CONFIG['base_file_format']}',
+            'hoodie.write.record.merge.custom.implementation.classes' = 'org.apache.hudi.DefaultSparkRecordMerger'
+        )
+    """
+    spark.sql(ddl)
+    print(f"✓ Created table {table_name} at {table_path}")
+
+
+def insert_into_hudi_sql(spark, table_name, staging_view):
+    print(f"\nDML: INSERT INTO {table_name} SELECT ... FROM {staging_view}")
+    insert = f"""
+        INSERT INTO {table_name}
+        SELECT
+            image_id,
+            category,
+            category_sanitized,
+            label,
+            description,
+            named_struct(
+                'type',      'INLINE',
+                'data',      image_bytes_raw,
+                'reference', cast(null as {BLOB_REFERENCE_CAST})
+            ) AS image_bytes,
+            width,
+            height,
+            embedding
+        FROM {staging_view}
+    """
+    spark.sql(insert)
+    count = spark.sql(f"SELECT COUNT(image_id) AS c FROM {table_name}").collect()[0]["c"]
+    print(f"✓ Inserted {count} records into {table_name}")
+
+
+# ======================================================
+# 7. BATCH SEARCH — `hudi_vector_search_batch` TVF
+# ======================================================
+
+def run_batch_search_sql(spark):
+    """
+    Run the batch TVF. Both tables share column names ({image_id, category,
+    category_sanitized, label, description, image_bytes, width, height,
+    embedding}), so every non-embedding column on the query side gets the
+    `_hudi_query_` prefix per HoodieVectorSearchPlanBuilder.scala (the
+    clashing-column rename path is automatically exercised).
+    """
+    k = CONFIG["top_k"]
+    corpus = CONFIG["corpus_table_name"]
+    queries = CONFIG["queries_table_name"]
+    print(f"\nDQL: hudi_vector_search_batch(corpus={corpus}, queries={queries}, k={k}, cosine)")
+    sql = f"""
+        SELECT
+            image_id              AS corpus_image_id,
+            category              AS corpus_category,
+            image_bytes           AS corpus_image_bytes,
+            _hudi_query_image_id  AS query_image_id,
+            _hudi_query_category  AS query_category,
+            _hudi_distance,
+            _hudi_query_index
+        FROM hudi_vector_search_batch(
+            '{corpus}',
+            'embedding',
+            '{queries}',
+            'embedding',
+            {k},
+            'cosine'
+        )
+        ORDER BY _hudi_query_index, _hudi_distance
+    """
+    print(sql.strip())
+    rows = spark.sql(sql).collect()
+    print(f"✓ TVF returned {len(rows)} rows ({CONFIG['n_queries']} queries × {k} matches)")
+    return rows
+
+
+# ======================================================
+# 8. ORACLE VALIDATION (numpy) — the certification step
+# ======================================================
+
+def oracle_validate_with_numpy(corpus, queries, tvf_rows, k):
+    """
+    Re-derive top-k from the exact same Python-side embeddings and confirm the
+    TVF agrees. This is the load-bearing assertion of the script — if it
+    passes, batch mode is correct on this dataset; if it fails, the TVF and
+    numpy disagree and the script exits non-zero.
+
+    Cosine distance via L2-normalized dot product: `dist = 1 - sim`. Embeddings
+    are already L2-normalized by `generate_embeddings` (sklearn.preprocessing
+    .normalize), so no re-normalization is needed here.
+    """
+    print("\n" + "-" * 80)
+    print("ORACLE: numpy ground-truth vs TVF result")
+    print("-" * 80)
+
+    corpus_embs = np.asarray([r["embedding"] for r in corpus], dtype=np.float32)
+    query_embs = np.asarray([r["embedding"] for r in queries], dtype=np.float32)
+    corpus_ids = np.asarray([r["image_id"] for r in corpus])
+    query_ids = np.asarray([r["image_id"] for r in queries])
+
+    # 1 - similarity; shape (n_corpus, n_queries). Use float64 to match the
+    # JVM-side DenseVector(Double) arithmetic.
+    sim = corpus_embs.astype(np.float64) @ query_embs.astype(np.float64).T
+    dist = 1.0 - sim
+    # Cosine distance is bounded in [0, 2]; clamp to align with the JVM-side
+    # clamp at VectorDistanceUtils (FP rounding can push slightly outside).
+    dist = np.clip(dist, 0.0, 2.0)
+
+    # Group TVF rows by query_image_id (stable, content-addressed) — _hudi_query_index
+    # is an opaque grouping ID generated by monotonically_increasing_id(), not a
+    # contiguous index, so we key by the actual query image id.
+    tvf_by_query = {}
+    for r in tvf_rows:
+        tvf_by_query.setdefault(r["query_image_id"], []).append(r)
+
+    if set(tvf_by_query.keys()) != set(query_ids.tolist()):
+        missing = set(query_ids.tolist()) - set(tvf_by_query.keys())
+        extra = set(tvf_by_query.keys()) - set(query_ids.tolist())
+        sys.exit(
+            f"ORACLE FAILED: query-id sets disagree. "
+            f"missing from TVF: {sorted(missing)[:5]}, "
+            f"unexpected in TVF: {sorted(extra)[:5]}"
+        )
+
+    max_distance_delta = 0.0
+    matches = 0
+    for j, qid in enumerate(query_ids):
+        # numpy top-k by ascending distance (stable sort for tie reproducibility).
+        order = np.argsort(dist[:, j], kind="stable")[:k]
+        expected_ids = corpus_ids[order].tolist()
+        expected_dists = dist[order, j].tolist()
+
+        # TVF rows already ORDER BY _hudi_query_index, _hudi_distance — pick by
+        # query id and they're in ascending-distance order within the group.
+        tvf_rows_for_q = tvf_by_query[qid]
+        if len(tvf_rows_for_q) != k:
+            sys.exit(
+                f"ORACLE FAILED: query {qid} returned {len(tvf_rows_for_q)} rows, expected {k}"
+            )
+        tvf_ids = [r["corpus_image_id"] for r in tvf_rows_for_q]
+        tvf_dists = [float(r["_hudi_distance"]) for r in tvf_rows_for_q]
+
+        # ID-set must match exactly. Order may differ across ties (which is OK
+        # because numpy and the JVM may break ties differently), so we compare
+        # as multisets first, then verify per-rank distance agreement.
+        if sorted(tvf_ids) != sorted(expected_ids):
+            sys.exit(
+                f"ORACLE FAILED for query {qid}:\n"
+                f"  expected ids: {expected_ids}\n"
+                f"  tvf ids     : {tvf_ids}\n"
+                f"  expected dist: {expected_dists}\n"
+                f"  tvf dist     : {tvf_dists}"
+            )
+
+        # Position-wise distance check is tolerant to tied-distance reordering:
+        # since both lists are sorted ascending, the i-th distance must agree
+        # regardless of which id sits at position i.
+        tol = CONFIG["oracle_distance_tol"]
+        for i, (ed, td) in enumerate(zip(expected_dists, tvf_dists)):
+            delta = abs(ed - td)
+            max_distance_delta = max(max_distance_delta, delta)
+            if delta > tol:
+                sys.exit(
+                    f"ORACLE FAILED for query {qid} rank {i}: "
+                    f"expected dist={ed:.8f}, tvf dist={td:.8f}, delta={delta:.2e} > {tol:.0e}"
+                )
+        matches += 1
+
+    print(f"✓ {matches}/{len(query_ids)} queries match numpy ground truth")
+    print(f"  Max per-rank distance delta: {max_distance_delta:.2e} (tol {CONFIG['oracle_distance_tol']:.0e})")
+    return max_distance_delta
+
+
+# ======================================================
+# 9. VISUALIZATION (panel of all queries × top-k)
+# ======================================================
+
+def visualize_batch_panel(queries, tvf_rows):
+    """
+    One row per query: query image on the left, then the top-k matches with
+    distance overlays. Saved as a single PNG so the user can scroll/open and
+    eyeball that the matches are visually plausible (same breed / similar
+    breed). The numpy oracle is the load-bearing correctness check; this is
+    sanity.
+    """
+    print("\nRendering result panel...")
+    out_dir = Path(CONFIG["output_dir"])
+    ensure_dir(out_dir)
+
+    by_query = {}
+    for r in tvf_rows:
+        by_query.setdefault(r["query_image_id"], []).append(r)
+
+    k = CONFIG["top_k"]
+    n = len(queries)
+    fig, axes = plt.subplots(n, k + 1, figsize=(2.0 * (k + 1), 2.2 * n))
+    if n == 1:
+        axes = np.array([axes])
+
+    for row_idx, q in enumerate(queries):
+        # Column 0: query image
+        ax = axes[row_idx, 0]
+        ax.imshow(Image.open(io.BytesIO(q["image_bytes_raw"])).convert("RGB"))
+        ax.set_title(f"QUERY\n{q['category']}", fontsize=8, fontweight="bold")
+        ax.axis("off")
+
+        # Columns 1..k: top-k matches
+        matches = by_query.get(q["image_id"], [])
+        for col_idx in range(k):
+            ax = axes[row_idx, col_idx + 1]
+            if col_idx < len(matches):
+                m = matches[col_idx]
+                blob = m["corpus_image_bytes"]
+                inline = blob["data"] if blob is not None else None
+                if inline is not None:
+                    ax.imshow(Image.open(io.BytesIO(bytes(inline))).convert("RGB"))
+                ax.set_title(
+                    f"{m['corpus_category']}\nd={float(m['_hudi_distance']):.3f}",
+                    fontsize=7,
+                )
+            ax.axis("off")
+
+    plt.tight_layout()
+    panel_path = out_dir / CONFIG["panel_filename"]
+    plt.savefig(str(panel_path), dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    print(f"✓ Panel: {panel_path.resolve()}")
+    return str(panel_path.resolve())
+
+
+# ======================================================
+# MAIN
+# ======================================================
+
+def main():
+    fmt = CONFIG["base_file_format"].upper()
+    print("\n" + "=" * 80)
+    print(f"HUDI BATCH VECTOR SEARCH DEMO  [base file format: {fmt}]")
+    print("Oxford-IIIT Pet — table-to-table KNN via hudi_vector_search_batch")
+    print("=" * 80)
+    print(f"  n_corpus         : {CONFIG['n_corpus']}")
+    print(f"  n_queries        : {CONFIG['n_queries']}")
+    print(f"  top_k            : {CONFIG['top_k']}")
+    print(f"  embedding_model  : {CONFIG['embedding_model']}")
+    print(f"  base_file_format : {CONFIG['base_file_format']}")
+    print(f"  corpus path      : {CONFIG['corpus_table_path']}")
+    print(f"  queries path     : {CONFIG['queries_table_path']}")
+    print("=" * 80 + "\n")
+
+    wipe_prior_state()
+    spark = create_spark()
+
+    # 1-3. Load dataset + generate embeddings for everyone in one pass.
+    total = CONFIG["n_corpus"] + CONFIG["n_queries"]
+    data, _ = load_dataset(total)
+    model, transform = create_embedding_model()
+    data, embedding_dim = generate_embeddings(data, model, transform)
+
+    # 4. Split.
+    corpus, queries = split_corpus_and_queries(data)
+
+    # 5-6. Stage + write both Hudi tables.
+    register_staging_view(
+        spark, corpus, embedding_dim, "staging_corpus",
+        f"/tmp/staging_pets_batch_corpus_{CONFIG['base_file_format']}.parquet",
+    )
+    create_hudi_table_sql(
+        spark, embedding_dim, CONFIG["corpus_table_name"], CONFIG["corpus_table_path"]
+    )
+    insert_into_hudi_sql(spark, CONFIG["corpus_table_name"], "staging_corpus")
+
+    register_staging_view(
+        spark, queries, embedding_dim, "staging_queries",
+        f"/tmp/staging_pets_batch_queries_{CONFIG['base_file_format']}.parquet",
+    )
+    create_hudi_table_sql(
+        spark, embedding_dim, CONFIG["queries_table_name"], CONFIG["queries_table_path"]
+    )
+    insert_into_hudi_sql(spark, CONFIG["queries_table_name"], "staging_queries")
+
+    # 7. Batch search.
+    tvf_rows = run_batch_search_sql(spark)
+
+    # Schema-level coverage: the prefix-renaming code path at
+    # HoodieVectorSearchPlanBuilder.scala:305-310 should produce
+    # `_hudi_query_image_id` / `_hudi_query_category` / `_hudi_query_index`
+    # in the select list. Assert they're present.
+    expected_cols = {
+        "corpus_image_id", "corpus_category", "corpus_image_bytes",
+        "query_image_id", "query_category",
+        "_hudi_distance", "_hudi_query_index",
+    }
+    actual_cols = set(tvf_rows[0].asDict().keys()) if tvf_rows else set()
+    assert expected_cols.issubset(actual_cols), (
+        f"unexpected TVF schema: missing {expected_cols - actual_cols}, "
+        f"got {actual_cols}"
+    )
+
+    # 8. Oracle validation — the certification step.
+    max_delta = oracle_validate_with_numpy(corpus, queries, tvf_rows, CONFIG["top_k"])
+
+    # 9. Visualization.
+    panel = visualize_batch_panel(queries, tvf_rows)
+
+    print("\n" + "=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+    print(f"✓ Dataset:        {CONFIG['dataset']}")
+    print(f"✓ Corpus:         {CONFIG['n_corpus']} rows @ {CONFIG['corpus_table_path']}")
+    print(f"✓ Queries:        {CONFIG['n_queries']} rows @ {CONFIG['queries_table_path']}")
+    print(f"✓ Model:          {CONFIG['embedding_model']} (dim={embedding_dim})")
+    print(f"✓ Base format:    {CONFIG['base_file_format']}")
+    print(f"✓ TVF rows:       {len(tvf_rows)} ({CONFIG['n_queries']}×{CONFIG['top_k']})")
+    print(f"✓ Oracle delta:   max {max_delta:.2e} (tol {CONFIG['oracle_distance_tol']:.0e})")
+    print(f"✓ Panel:          {panel}")
+    print("=" * 80)
+    print("CERTIFIED ✓  hudi_vector_search_batch matches numpy ground truth")
+    print("=" * 80 + "\n")
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/notebooks/04_vector_search_batch.ipynb
+++ b/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/notebooks/04_vector_search_batch.ipynb
@@ -1,0 +1,782 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!--\n",
+    "  Licensed to the Apache Software Foundation (ASF) under one or more\n",
+    "  contributor license agreements.  See the NOTICE file distributed with\n",
+    "  this work for additional information regarding copyright ownership.\n",
+    "  The ASF licenses this file to You under the Apache License, Version 2.0\n",
+    "  (the \"License\"); you may not use this file except in compliance with\n",
+    "  the License.  You may obtain a copy of the License at\n",
+    "\n",
+    "       http://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    "  Unless required by applicable law or agreed to in writing, software\n",
+    "  distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "  See the License for the specific language governing permissions and\n",
+    "  limitations under the License.\n",
+    "-->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hudi Batch Vector Search \u2014 Certification Demo\n",
+    "\n",
+    "Certifies the `hudi_vector_search_batch` TVF (RFC-102) at non-trivial scale\n",
+    "against a **numpy ground-truth oracle**.\n",
+    "\n",
+    "Sibling to [`02_sql_vector_search.ipynb`](02_sql_vector_search.ipynb), which\n",
+    "runs the **single-query** TVF on one query vector. This notebook runs the\n",
+    "**table-to-table** form: for each row in a query table, find the top-K\n",
+    "nearest rows in a corpus table.\n",
+    "\n",
+    "```sql\n",
+    "SELECT *\n",
+    "FROM hudi_vector_search_batch(\n",
+    "    'pets_batch_corpus_<format>',  'embedding',\n",
+    "    'pets_batch_queries_<format>', 'embedding',\n",
+    "    k, 'cosine')\n",
+    "```\n",
+    "\n",
+    "Flow:\n",
+    "\n",
+    "1. Load `N_CORPUS + N_QUERIES` Oxford-IIIT Pet images.\n",
+    "2. Generate L2-normalized embeddings (`mobilenetv3_small_100`).\n",
+    "3. Split into corpus + held-out queries (disjoint).\n",
+    "4. Write each as its own Hudi table (`VECTOR(1024)`, `BLOB`).\n",
+    "5. Run `hudi_vector_search_batch` \u2014 collect to driver.\n",
+    "6. **Oracle**: recompute the cosine distance matrix in numpy from the same\n",
+    "   embeddings; assert TVF's top-K per query matches.\n",
+    "7. Render a panel: one row per query \u00d7 its top-K matches.\n",
+    "\n",
+    "Mirrors [`hudi_vector_search_batch_demo.py`](../hudi_vector_search_batch_demo.py)\n",
+    "cell-for-cell. The `.py` is the source of truth; this notebook is for live\n",
+    "walkthroughs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Toggles\n",
+    "\n",
+    "| Variable | Effect |\n",
+    "|---|---|\n",
+    "| `BASE_FILE_FORMAT` | `\"parquet\"` or `\"lance\"` \u2014 flips Hudi's base file format. |\n",
+    "| `N_CORPUS`         | Corpus row count (Hudi table the search reads against). |\n",
+    "| `N_QUERIES`        | Query row count (Hudi table whose rows are searched for). |\n",
+    "| `TOP_K`            | Nearest neighbors returned per query. |\n",
+    "| `EMBEDDING_MODEL`  | `timm` backbone \u2014 default `mobilenetv3_small_100` (1024-d). |\n",
+    "\n",
+    "A `1000 \u00d7 20 \u00d7 k=5` run produces a 20,000-row cross-join intermediate inside\n",
+    "`buildBatchQueryPlan` \u2014 large enough to exercise the broadcast + window-rank\n",
+    "machinery while still completing in under a minute on the default 4 GB driver\n",
+    "heap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ===== EDIT THESE =====\n",
+    "BASE_FILE_FORMAT = \"parquet\"   # \"parquet\" or \"lance\"\n",
+    "N_CORPUS         = 1000\n",
+    "N_QUERIES        = 20\n",
+    "TOP_K            = 5\n",
+    "EMBEDDING_MODEL  = \"mobilenetv3_small_100\"\n",
+    "\n",
+    "assert BASE_FILE_FORMAT in {\"parquet\", \"lance\"}\n",
+    "assert N_QUERIES >= 1 and N_CORPUS >= TOP_K"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Pre-flight cleanup\n",
+    "\n",
+    "Wipe `/tmp/` paths and `spark-warehouse/` so each run is idempotent. `DROP\n",
+    "TABLE IF EXISTS` only removes the catalog entry; the data dir and `.hoodie/`\n",
+    "timeline at `LOCATION` persist across runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "\n",
+    "for pattern in [\n",
+    "    \"/tmp/hudi_batch_*_pets\",\n",
+    "    \"/tmp/staging_pets_batch_*.parquet\",\n",
+    "]:\n",
+    "    for p in Path(\"/\").glob(pattern.lstrip(\"/\")):\n",
+    "        if p.is_dir():\n",
+    "            shutil.rmtree(p, ignore_errors=True)\n",
+    "        elif p.is_file():\n",
+    "            p.unlink(missing_ok=True)\n",
+    "\n",
+    "shutil.rmtree(\"spark-warehouse\", ignore_errors=True)\n",
+    "print(\"\u2713 Wiped /tmp/hudi_batch_*_pets, staging Parquet, spark-warehouse\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Pre-JVM env (driver heap)\n",
+    "\n",
+    "PySpark local-mode bakes the driver heap into the JVM at launch \u2014 by the\n",
+    "time `pyspark` is imported it can't be raised via `SparkSession.config(...)`.\n",
+    "Set it here, before any other imports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "DRIVER_MEMORY = \"4g\"   # bump to \"8g\" for N_CORPUS >= 5000\n",
+    "\n",
+    "os.environ.setdefault(\n",
+    "    \"PYSPARK_SUBMIT_ARGS\",\n",
+    "    f\"--driver-memory {DRIVER_MEMORY} --conf spark.driver.maxResultSize=2g pyspark-shell\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "import torch\n",
+    "import timm\n",
+    "from sklearn.preprocessing import normalize\n",
+    "from PIL import Image\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from torchvision.datasets import OxfordIIITPet\n",
+    "from pyspark.sql import SparkSession"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Configuration (derived from toggles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CONFIG = {\n",
+    "    \"dataset\": \"OxfordIIITPet\",\n",
+    "    \"base_file_format\": BASE_FILE_FORMAT,\n",
+    "    \"corpus_table_path\": f\"/tmp/hudi_batch_corpus_{BASE_FILE_FORMAT}_pets\",\n",
+    "    \"corpus_table_name\": f\"pets_batch_corpus_{BASE_FILE_FORMAT}\",\n",
+    "    \"queries_table_path\": f\"/tmp/hudi_batch_queries_{BASE_FILE_FORMAT}_pets\",\n",
+    "    \"queries_table_name\": f\"pets_batch_queries_{BASE_FILE_FORMAT}\",\n",
+    "    \"n_corpus\": N_CORPUS,\n",
+    "    \"n_queries\": N_QUERIES,\n",
+    "    \"top_k\": TOP_K,\n",
+    "    \"embedding_model\": EMBEDDING_MODEL,\n",
+    "    \"output_dir\": \"./outputs\",\n",
+    "    \"panel_filename\": f\"hudi_vector_search_batch_{BASE_FILE_FORMAT}_results.png\",\n",
+    "    \"oracle_distance_tol\": 1e-5,\n",
+    "}\n",
+    "\n",
+    "BLOB_REFERENCE_CAST = \"struct<external_path:string,offset:bigint,length:bigint,managed:boolean>\"\n",
+    "\n",
+    "for k, v in CONFIG.items():\n",
+    "    print(f\"  {k:22s}: {v}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Resolve Hudi (and optionally Lance) jars\n",
+    "\n",
+    "Defaults to `~/Downloads/`. Set `HUDI_BUNDLE_JAR` and/or `LANCE_BUNDLE_JAR`\n",
+    "*before launching jupyter* if the jars live elsewhere."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def default_hudi_bundle_jar() -> str:\n",
+    "    return str(Path.home() / \"Downloads\" / \"hudi-spark3.5-bundle_2.12-1.2.0-rc1.jar\")\n",
+    "\n",
+    "def default_lance_bundle_jar() -> str:\n",
+    "    return str(Path.home() / \"Downloads\" / \"lance-spark-bundle-3.5_2.12-0.4.0.jar\")\n",
+    "\n",
+    "def resolve_jars(base_file_format: str) -> str:\n",
+    "    hudi_jar = os.getenv(\"HUDI_BUNDLE_JAR\", default_hudi_bundle_jar())\n",
+    "    if not Path(hudi_jar).is_file():\n",
+    "        sys.exit(f\"ERROR: HUDI_BUNDLE_JAR does not exist at {hudi_jar}\")\n",
+    "    if base_file_format != \"lance\":\n",
+    "        return hudi_jar\n",
+    "    lance_jar = os.getenv(\"LANCE_BUNDLE_JAR\", default_lance_bundle_jar())\n",
+    "    if not Path(lance_jar).is_file():\n",
+    "        sys.exit(f\"ERROR: LANCE_BUNDLE_JAR does not exist at {lance_jar}\")\n",
+    "    return f\"{hudi_jar},{lance_jar}\"\n",
+    "\n",
+    "jars = resolve_jars(CONFIG[\"base_file_format\"])\n",
+    "print(f\"\u2713 Jars: {jars}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Spark session\n",
+    "\n",
+    "Same four Hudi-mandatory configs as the other demos: Kryo serializer,\n",
+    "`HoodieSparkSessionExtension` (registers `hudi_vector_search_batch` and the\n",
+    "`VECTOR(N)`/`BLOB` type parsers), and `HoodieCatalog`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark = (\n",
+    "    SparkSession.builder\n",
+    "    .appName(\"Hudi-Vector-Search-Batch-Demo\")\n",
+    "    .config(\"spark.jars\", jars)\n",
+    "    .config(\"spark.serializer\", \"org.apache.spark.serializer.KryoSerializer\")\n",
+    "    .config(\"spark.sql.extensions\", \"org.apache.spark.sql.hudi.HoodieSparkSessionExtension\")\n",
+    "    .config(\"spark.sql.catalog.spark_catalog\", \"org.apache.spark.sql.hudi.catalog.HoodieCatalog\")\n",
+    "    .config(\"spark.sql.session.timeZone\", \"UTC\")\n",
+    "    .config(\"hoodie.read.blob.inline.mode\", \"CONTENT\")\n",
+    "    .config(\"spark.default.parallelism\", \"2\")\n",
+    "    .config(\"spark.sql.shuffle.partitions\", \"2\")\n",
+    "    .config(\"spark.ui.showConsoleProgress\", \"false\")\n",
+    "    .getOrCreate()\n",
+    ")\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")\n",
+    "print(\"\u2713 Spark session ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Load Oxford-IIIT Pet\n",
+    "\n",
+    "Load `N_CORPUS + N_QUERIES` images in one pass. We hold them in Python so\n",
+    "the oracle (cell 16) can recompute the distance matrix from the exact same\n",
+    "embeddings that were written to Hudi."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Loading dataset: Oxford-IIIT Pet ({CONFIG['n_corpus'] + CONFIG['n_queries']} samples)...\")\n",
+    "root = os.path.expanduser(\"~/.cache/torchvision\")\n",
+    "ds = OxfordIIITPet(root=root, split=\"trainval\", download=True)\n",
+    "class_names = ds.classes\n",
+    "\n",
+    "rng = np.random.default_rng()\n",
+    "total = CONFIG['n_corpus'] + CONFIG['n_queries']\n",
+    "indices = rng.choice(len(ds), size=min(total, len(ds)), replace=False)\n",
+    "\n",
+    "data = []\n",
+    "for idx in indices:\n",
+    "    img, label = ds[int(idx)]\n",
+    "    img = img.convert(\"RGB\")\n",
+    "    bio = io.BytesIO()\n",
+    "    img.save(bio, format=\"PNG\")\n",
+    "    img_bytes = bio.getvalue()\n",
+    "    w, h = img.size\n",
+    "    category = class_names[label] if isinstance(class_names, list) else str(label)\n",
+    "    data.append({\n",
+    "        \"image_id\": f\"pets_{int(idx):06d}\",\n",
+    "        \"category\": category,\n",
+    "        \"category_sanitized\": category.replace(\"/\", \"_\"),\n",
+    "        \"label\": int(label),\n",
+    "        \"description\": f\"{category} from Oxford-IIIT Pet\",\n",
+    "        \"image_bytes_raw\": img_bytes,\n",
+    "        \"width\": int(w),\n",
+    "        \"height\": int(h),\n",
+    "    })\n",
+    "print(f\"\u2713 Loaded {len(data)} images\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Generate embeddings (timm)\n",
+    "\n",
+    "`num_classes=0` strips the classifier head so `model(x)` returns feature\n",
+    "vectors. `sklearn.preprocessing.normalize` L2-normalizes each embedding \u2014\n",
+    "cosine distance is then `1 - dot_product`, which the oracle exploits in\n",
+    "cell 16."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Loading embedding model: {CONFIG['embedding_model']}...\")\n",
+    "model = timm.create_model(CONFIG[\"embedding_model\"], pretrained=True, num_classes=0)\n",
+    "model.eval()\n",
+    "data_config = timm.data.resolve_model_data_config(model)\n",
+    "transform = timm.data.create_transform(**data_config, is_training=False)\n",
+    "\n",
+    "print(f\"Generating embeddings for {len(data)} images...\")\n",
+    "images = [transform(Image.open(io.BytesIO(item[\"image_bytes_raw\"])).convert(\"RGB\")) for item in data]\n",
+    "batch = torch.stack(images)\n",
+    "with torch.no_grad():\n",
+    "    feats = model(batch).detach().cpu().numpy()\n",
+    "feats = normalize(feats)\n",
+    "for i, item in enumerate(data):\n",
+    "    item[\"embedding\"] = feats[i].tolist()\n",
+    "embedding_dim = int(feats.shape[1])\n",
+    "print(f\"\u2713 Generated embeddings (dimension: {embedding_dim})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Split into corpus + queries\n",
+    "\n",
+    "First `N_CORPUS` \u2192 corpus, last `N_QUERIES` \u2192 queries. Order is randomized\n",
+    "by `rng.choice(replace=False)`, so a simple slice gives disjoint subsets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corpus = data[:CONFIG[\"n_corpus\"]]\n",
+    "queries = data[CONFIG[\"n_corpus\"]:CONFIG[\"n_corpus\"] + CONFIG[\"n_queries\"]]\n",
+    "assert {r[\"image_id\"] for r in corpus}.isdisjoint({r[\"image_id\"] for r in queries})\n",
+    "print(f\"\u2713 Split: {len(corpus)} corpus rows, {len(queries)} query rows (disjoint)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 11. Stage \u2192 Parquet \u2192 Spark temp views (PyArrow, no PythonRDD)\n",
+    "\n",
+    "Both subsets get a Parquet staging file + a Spark temp view. Bypassing\n",
+    "`spark.createDataFrame(list_of_rows)` avoids `PythonRDD` socket traffic, which\n",
+    "matters at scale (see parent [`README.md`](../README.md) \"Why we stage\n",
+    "through Parquet\")."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stage_to_parquet(rows, embedding_dim, path):\n",
+    "    schema = pa.schema([\n",
+    "        pa.field(\"image_id\", pa.string(), nullable=False),\n",
+    "        pa.field(\"category\", pa.string(), nullable=False),\n",
+    "        pa.field(\"category_sanitized\", pa.string(), nullable=False),\n",
+    "        pa.field(\"label\", pa.int32(), nullable=False),\n",
+    "        pa.field(\"description\", pa.string(), nullable=True),\n",
+    "        pa.field(\"image_bytes_raw\", pa.binary(), nullable=False),\n",
+    "        pa.field(\"width\", pa.int32(), nullable=False),\n",
+    "        pa.field(\"height\", pa.int32(), nullable=False),\n",
+    "        pa.field(\"embedding\",\n",
+    "                 pa.list_(pa.field(\"element\", pa.float32(), nullable=False), list_size=embedding_dim),\n",
+    "                 nullable=False),\n",
+    "    ])\n",
+    "    cols = {f.name: [r[f.name] if f.name != \"image_bytes_raw\" else r[\"image_bytes_raw\"] for r in rows]\n",
+    "            for f in schema}\n",
+    "    pq.write_table(pa.table(cols, schema=schema), path)\n",
+    "\n",
+    "corpus_parquet = f\"/tmp/staging_pets_batch_corpus_{BASE_FILE_FORMAT}.parquet\"\n",
+    "queries_parquet = f\"/tmp/staging_pets_batch_queries_{BASE_FILE_FORMAT}.parquet\"\n",
+    "\n",
+    "stage_to_parquet(corpus, embedding_dim, corpus_parquet)\n",
+    "spark.read.parquet(corpus_parquet).createOrReplaceTempView(\"staging_corpus\")\n",
+    "print(f\"\u2713 staging_corpus view registered ({corpus_parquet})\")\n",
+    "\n",
+    "stage_to_parquet(queries, embedding_dim, queries_parquet)\n",
+    "spark.read.parquet(queries_parquet).createOrReplaceTempView(\"staging_queries\")\n",
+    "print(f\"\u2713 staging_queries view registered ({queries_parquet})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 12. CREATE TABLE \u2014 corpus + queries\n",
+    "\n",
+    "Identical DDL for both tables. The two share schema by design \u2014 this also\n",
+    "exercises the clashing-column rename path in\n",
+    "`HoodieVectorSearchPlanBuilder.buildBatchQueryPlan` (the query side's\n",
+    "`image_id` / `category` / `image_bytes` get the `_hudi_query_` prefix in\n",
+    "the TVF result)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_table(name, path):\n",
+    "    spark.sql(f\"DROP TABLE IF EXISTS {name}\")\n",
+    "    spark.sql(f\"\"\"\n",
+    "        CREATE TABLE {name} (\n",
+    "            image_id            STRING,\n",
+    "            category            STRING,\n",
+    "            category_sanitized  STRING,\n",
+    "            label               INT,\n",
+    "            description         STRING,\n",
+    "            image_bytes         BLOB           COMMENT 'Pet image bytes (INLINE)',\n",
+    "            width               INT,\n",
+    "            height              INT,\n",
+    "            embedding           VECTOR({embedding_dim})\n",
+    "                                               COMMENT 'Image embedding for ANN search'\n",
+    "        ) USING hudi\n",
+    "        PARTITIONED BY (category_sanitized)\n",
+    "        LOCATION '{path}'\n",
+    "        TBLPROPERTIES (\n",
+    "            primaryKey = 'image_id',\n",
+    "            preCombineField = 'image_id',\n",
+    "            type = 'cow',\n",
+    "            'hoodie.table.base.file.format' = '{BASE_FILE_FORMAT}',\n",
+    "            'hoodie.write.record.merge.custom.implementation.classes' = 'org.apache.hudi.DefaultSparkRecordMerger'\n",
+    "        )\n",
+    "    \"\"\")\n",
+    "    print(f\"\u2713 Created table {name} at {path}\")\n",
+    "\n",
+    "create_table(CONFIG[\"corpus_table_name\"],  CONFIG[\"corpus_table_path\"])\n",
+    "create_table(CONFIG[\"queries_table_name\"], CONFIG[\"queries_table_path\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 13. INSERT INTO \u2014 corpus + queries\n",
+    "\n",
+    "`named_struct('type', 'INLINE', 'data', <bytes>, 'reference', null)` is the\n",
+    "canonical shape for a Hudi BLOB INLINE value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def insert_from(view, table):\n",
+    "    spark.sql(f\"\"\"\n",
+    "        INSERT INTO {table}\n",
+    "        SELECT\n",
+    "            image_id, category, category_sanitized, label, description,\n",
+    "            named_struct(\n",
+    "                'type',      'INLINE',\n",
+    "                'data',      image_bytes_raw,\n",
+    "                'reference', cast(null as {BLOB_REFERENCE_CAST})\n",
+    "            ) AS image_bytes,\n",
+    "            width, height, embedding\n",
+    "        FROM {view}\n",
+    "    \"\"\")\n",
+    "    c = spark.sql(f\"SELECT COUNT(image_id) AS c FROM {table}\").collect()[0][\"c\"]\n",
+    "    print(f\"\u2713 Inserted {c} rows into {table}\")\n",
+    "\n",
+    "insert_from(\"staging_corpus\",  CONFIG[\"corpus_table_name\"])\n",
+    "insert_from(\"staging_queries\", CONFIG[\"queries_table_name\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 14. Batch search \u2014 `hudi_vector_search_batch` TVF\n",
+    "\n",
+    "This is the line being certified. Both tables share column names, so every\n",
+    "non-embedding column from the query side gets the `_hudi_query_` prefix in\n",
+    "the output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sql = f\"\"\"\n",
+    "    SELECT\n",
+    "        image_id              AS corpus_image_id,\n",
+    "        category              AS corpus_category,\n",
+    "        image_bytes           AS corpus_image_bytes,\n",
+    "        _hudi_query_image_id  AS query_image_id,\n",
+    "        _hudi_query_category  AS query_category,\n",
+    "        _hudi_distance,\n",
+    "        _hudi_query_index\n",
+    "    FROM hudi_vector_search_batch(\n",
+    "        '{CONFIG[\"corpus_table_name\"]}',\n",
+    "        'embedding',\n",
+    "        '{CONFIG[\"queries_table_name\"]}',\n",
+    "        'embedding',\n",
+    "        {CONFIG[\"top_k\"]},\n",
+    "        'cosine'\n",
+    "    )\n",
+    "    ORDER BY _hudi_query_index, _hudi_distance\n",
+    "\"\"\"\n",
+    "print(sql.strip())\n",
+    "\n",
+    "tvf_rows = spark.sql(sql).collect()\n",
+    "print(f\"\\n\u2713 TVF returned {len(tvf_rows)} rows ({CONFIG['n_queries']} queries \u00d7 {CONFIG['top_k']} matches)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 15. Schema sanity check\n",
+    "\n",
+    "Confirm the prefix-rename code path produced the expected `_hudi_query_*`\n",
+    "columns. The renaming logic lives at\n",
+    "[`HoodieVectorSearchPlanBuilder.scala:305-310`](../../../../../../../hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieVectorSearchPlanBuilder.scala)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected = {\"corpus_image_id\", \"corpus_category\", \"corpus_image_bytes\",\n",
+    "            \"query_image_id\", \"query_category\", \"_hudi_distance\", \"_hudi_query_index\"}\n",
+    "actual = set(tvf_rows[0].asDict().keys()) if tvf_rows else set()\n",
+    "assert expected.issubset(actual), f\"missing {expected - actual}; got {actual}\"\n",
+    "print(f\"\u2713 TVF output columns: {sorted(actual)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 16. Oracle validation \u2014 numpy ground truth\n",
+    "\n",
+    "This is the load-bearing assertion of the notebook. We recompute cosine\n",
+    "distances from the same Python-side embeddings in numpy and assert the TVF\n",
+    "returns the same top-K per query (as a multiset, with per-rank distances\n",
+    "within `1e-5`). Position-wise comparison is multiset-based because tied\n",
+    "distances can be ordered differently by numpy and the JVM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corpus_embs = np.asarray([r[\"embedding\"] for r in corpus], dtype=np.float32)\n",
+    "query_embs  = np.asarray([r[\"embedding\"] for r in queries], dtype=np.float32)\n",
+    "corpus_ids  = np.asarray([r[\"image_id\"]  for r in corpus])\n",
+    "query_ids   = np.asarray([r[\"image_id\"]  for r in queries])\n",
+    "\n",
+    "# Use float64 to match the JVM-side DenseVector(Double) arithmetic, then clamp\n",
+    "# to [0, 2] like VectorDistanceUtils.\n",
+    "sim = corpus_embs.astype(np.float64) @ query_embs.astype(np.float64).T\n",
+    "dist = np.clip(1.0 - sim, 0.0, 2.0)\n",
+    "\n",
+    "tvf_by_query = {}\n",
+    "for r in tvf_rows:\n",
+    "    tvf_by_query.setdefault(r[\"query_image_id\"], []).append(r)\n",
+    "\n",
+    "assert set(tvf_by_query.keys()) == set(query_ids.tolist()), \"query id sets disagree\"\n",
+    "\n",
+    "k = CONFIG[\"top_k\"]\n",
+    "tol = CONFIG[\"oracle_distance_tol\"]\n",
+    "max_delta = 0.0\n",
+    "matches = 0\n",
+    "for j, qid in enumerate(query_ids):\n",
+    "    order = np.argsort(dist[:, j], kind=\"stable\")[:k]\n",
+    "    expected_ids   = corpus_ids[order].tolist()\n",
+    "    expected_dists = dist[order, j].tolist()\n",
+    "\n",
+    "    tvf_for_q = tvf_by_query[qid]\n",
+    "    assert len(tvf_for_q) == k, f\"query {qid}: got {len(tvf_for_q)} rows, expected {k}\"\n",
+    "    tvf_ids   = [r[\"corpus_image_id\"] for r in tvf_for_q]\n",
+    "    tvf_dists = [float(r[\"_hudi_distance\"]) for r in tvf_for_q]\n",
+    "\n",
+    "    assert sorted(tvf_ids) == sorted(expected_ids), (\n",
+    "        f\"query {qid}:\\n  expected ids: {expected_ids}\\n  tvf ids     : {tvf_ids}\")\n",
+    "    for i, (ed, td) in enumerate(zip(expected_dists, tvf_dists)):\n",
+    "        delta = abs(ed - td)\n",
+    "        max_delta = max(max_delta, delta)\n",
+    "        assert delta <= tol, f\"query {qid} rank {i}: delta {delta:.2e} > tol {tol:.0e}\"\n",
+    "    matches += 1\n",
+    "\n",
+    "print(f\"\u2713 ORACLE: {matches}/{len(query_ids)} queries match numpy ground truth\")\n",
+    "print(f\"  Max per-rank distance delta: {max_delta:.2e} (tol {tol:.0e})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 17. Render result panel\n",
+    "\n",
+    "One row per query: query image on the left, then top-K matches with cosine\n",
+    "distance overlays. The numpy oracle (cell 16) is the load-bearing\n",
+    "correctness check \u2014 this panel is for eyeball sanity (same-breed / similar-breed)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_dir = Path(CONFIG[\"output_dir\"])\n",
+    "out_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "by_query = {}\n",
+    "for r in tvf_rows:\n",
+    "    by_query.setdefault(r[\"query_image_id\"], []).append(r)\n",
+    "\n",
+    "k = CONFIG[\"top_k\"]\n",
+    "n = len(queries)\n",
+    "fig, axes = plt.subplots(n, k + 1, figsize=(2.0 * (k + 1), 2.2 * n))\n",
+    "if n == 1:\n",
+    "    axes = np.array([axes])\n",
+    "\n",
+    "for row_idx, q in enumerate(queries):\n",
+    "    ax = axes[row_idx, 0]\n",
+    "    ax.imshow(Image.open(io.BytesIO(q[\"image_bytes_raw\"])).convert(\"RGB\"))\n",
+    "    ax.set_title(f\"QUERY\\n{q['category']}\", fontsize=8, fontweight=\"bold\")\n",
+    "    ax.axis(\"off\")\n",
+    "    matches = by_query.get(q[\"image_id\"], [])\n",
+    "    for col_idx in range(k):\n",
+    "        ax = axes[row_idx, col_idx + 1]\n",
+    "        if col_idx < len(matches):\n",
+    "            m = matches[col_idx]\n",
+    "            inline = m[\"corpus_image_bytes\"][\"data\"] if m[\"corpus_image_bytes\"] is not None else None\n",
+    "            if inline is not None:\n",
+    "                ax.imshow(Image.open(io.BytesIO(bytes(inline))).convert(\"RGB\"))\n",
+    "            ax.set_title(f\"{m['corpus_category']}\\nd={float(m['_hudi_distance']):.3f}\", fontsize=7)\n",
+    "        ax.axis(\"off\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "panel_path = out_dir / CONFIG[\"panel_filename\"]\n",
+    "plt.savefig(str(panel_path), dpi=120, bbox_inches=\"tight\")\n",
+    "plt.show()\n",
+    "print(f\"\u2713 Panel saved: {panel_path.resolve()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 18. Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"=\" * 80)\n",
+    "print(f\"\u2713 Corpus:       {CONFIG['n_corpus']} rows @ {CONFIG['corpus_table_path']}\")\n",
+    "print(f\"\u2713 Queries:      {CONFIG['n_queries']} rows @ {CONFIG['queries_table_path']}\")\n",
+    "print(f\"\u2713 Embeddings:   {CONFIG['embedding_model']} (dim={embedding_dim})\")\n",
+    "print(f\"\u2713 Base format:  {CONFIG['base_file_format']}\")\n",
+    "print(f\"\u2713 TVF rows:     {len(tvf_rows)} ({CONFIG['n_queries']}\u00d7{CONFIG['top_k']})\")\n",
+    "print(f\"\u2713 Oracle delta: max {max_delta:.2e} (tol {tol:.0e})\")\n",
+    "print(f\"\u2713 Panel:        {panel_path.resolve()}\")\n",
+    "print(\"=\" * 80)\n",
+    "print(\"CERTIFIED \u2713  hudi_vector_search_batch matches numpy ground truth\")\n",
+    "print(\"=\" * 80)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 19. Stop Spark (optional)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.stop()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/notebooks/README.md
+++ b/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/notebooks/README.md
@@ -130,6 +130,29 @@ BASE_FILE_FORMAT  = "parquet"      # "parquet" or "lance"
 N_SAMPLES         = 256
 ```
 
+### `04_vector_search_batch.ipynb` — supplemental: batch TVF certification
+
+Exercises **`hudi_vector_search_batch`** (RFC-102) — the table-to-table form
+of vector search. Builds two Hudi tables (corpus + queries) and asserts the
+TVF's top-K per query matches a **numpy ground-truth oracle** that recomputes
+the cosine distance matrix from the same embeddings. The notebook prints
+`CERTIFIED ✓` on success or fails the cell loudly on the first divergence.
+
+Toggle variables:
+
+```python
+BASE_FILE_FORMAT = "parquet"   # "parquet" or "lance"
+N_CORPUS         = 1000         # corpus row count
+N_QUERIES        = 20           # query table row count
+TOP_K            = 5
+EMBEDDING_MODEL  = "mobilenetv3_small_100"
+```
+
+A `1000 × 20 × k=5` run produces a 20,000-row cross-join intermediate inside
+`BruteForceSearchAlgorithm.buildBatchQueryPlan`, large enough to exercise
+the broadcast + window-rank machinery while still completing in under a
+minute on a 4 GB driver heap.
+
 ## How toggles work
 
 Each notebook starts with a small **toggles cell** containing plain Python

--- a/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/run_demos.sh
+++ b/hudi-examples/hudi-examples-spark/src/test/python/vector_blob_demo/run_demos.sh
@@ -32,8 +32,10 @@ cd "$(dirname "$0")"
 # then end up with offsets past EOF, causing file boundary errors during read.
 clean() {
   rm -rf /tmp/hudi_*_pets \
+         /tmp/hudi_batch_*_pets \
          /tmp/pets_blob_container.bin \
          /tmp/staging_pets_*.parquet \
+         /tmp/staging_pets_batch_*.parquet \
          spark-warehouse
 }
 
@@ -67,6 +69,11 @@ run "sql / lance"                                  HUDI_BASE_FILE_FORMAT=lance  
 run "dataframe / parquet"                          HUDI_BASE_FILE_FORMAT=parquet python hudi_dataframe_vector_blob_demo.py
 [[ "${SKIP_LANCE:-0}" != "1" ]] && \
 run "dataframe / lance"                            HUDI_BASE_FILE_FORMAT=lance   python hudi_dataframe_vector_blob_demo.py
+
+# batch vector search certification: format only; oracle check asserts correctness
+run "batch / parquet"                              HUDI_BASE_FILE_FORMAT=parquet python hudi_vector_search_batch_demo.py
+[[ "${SKIP_LANCE:-0}" != "1" ]] && \
+run "batch / lance"                                HUDI_BASE_FILE_FORMAT=lance   python hudi_vector_search_batch_demo.py
 
 echo
 echo "All combinations finished."


### PR DESCRIPTION
## Summary
- Adds the fourth variant to the existing `vector_blob_demo/` family: a reproducible end-to-end certification of `hudi_vector_search_batch` (RFC-102) on a 1000-row corpus × 20-row query Hudi table.
- Result is asserted against a numpy ground-truth cosine distance matrix to within 1e-5 — script exits non-zero on any divergence.
- Ships both a standalone `.py` (canonical, scriptable, hooks into `run_demos.sh`) and a mirroring `.ipynb` notebook for live walkthroughs.

## Test plan
- [x] Smoke test: 100 × 5, k=3, parquet → `CERTIFIED ✓`, max delta 7.22e-08
- [x] Full: 1000 × 20, k=5, parquet → `CERTIFIED ✓`, max delta 1.22e-07
- [ ] Lance run (`HUDI_BASE_FILE_FORMAT=lance python hudi_vector_search_batch_demo.py`)
- [ ] Notebook Run All renders the panel + prints `CERTIFIED ✓`

🤖 Generated with [Claude Code](https://claude.com/claude-code)