### PR TITLE
fix: remove the pk check for Flink append only table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/TimestampBasedAvroKeyGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/TimestampBasedAvroKeyGenerator.java
@@ -73,11 +73,11 @@ public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
   protected final boolean encodePartitionPath;
 
   public TimestampBasedAvroKeyGenerator(TypedProperties config) throws IOException {
-    this(config, config.getString(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), null),
+    this(config, config.getString(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key()),
         config.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()));
   }
 
-  TimestampBasedAvroKeyGenerator(TypedProperties config, String partitionPathField) throws IOException {
+  public TimestampBasedAvroKeyGenerator(TypedProperties config, String partitionPathField) throws IOException {
     this(config, null, partitionPathField);
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/TimestampBasedAvroKeyGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/TimestampBasedAvroKeyGenerator.java
@@ -73,7 +73,7 @@ public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
   protected final boolean encodePartitionPath;
 
   public TimestampBasedAvroKeyGenerator(TypedProperties config) throws IOException {
-    this(config, config.getString(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key()),
+    this(config, config.getString(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), null),
         config.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()));
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -156,8 +156,7 @@ public class OptionsResolver {
   }
 
   /**
-   * Return value of {@link FlinkOptions#RECORD_KEY_FIELD} if it was set,
-   * or throw exception otherwise.
+   * Return value of {@link FlinkOptions#RECORD_KEY_FIELD}, could be null if it is not set.
    */
   @Nullable
   public static String getRecordKeyStr(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -50,6 +50,8 @@ import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 
+import javax.annotation.Nullable;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -157,13 +159,31 @@ public class OptionsResolver {
    * Return value of {@link FlinkOptions#RECORD_KEY_FIELD} if it was set,
    * or throw exception otherwise.
    */
+  @Nullable
   public static String getRecordKeyStr(Configuration conf) {
+    return conf.get(FlinkOptions.RECORD_KEY_FIELD);
+  }
+
+  /**
+   * Return the record keys as an array.
+   */
+  public static String[] getRecordKeys(Configuration conf) {
     final String recordKeyStr = conf.get(FlinkOptions.RECORD_KEY_FIELD);
-    ValidationUtils.checkArgument(
-        recordKeyStr != null,
-        "Primary key definition is required, use either PRIMARY KEY syntax or option '"
-            + FlinkOptions.RECORD_KEY_FIELD.key() + "' to specify.");
-    return recordKeyStr;
+    if (StringUtils.isNullOrEmpty(recordKeyStr)) {
+      return new String[]{};
+    }
+    return recordKeyStr.split(",");
+  }
+
+  /**
+   * Return the bucket index keys as an array.
+   */
+  public static String[] getBucketIndexKeys(Configuration conf) {
+    final String indexKeyStr = conf.get(FlinkOptions.INDEX_KEY_FIELD);
+    if (StringUtils.isNullOrEmpty(indexKeyStr)) {
+      return new String[]{};
+    }
+    return indexKeyStr.split(",");
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/AutoRowDataKeyGen.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/AutoRowDataKeyGen.java
@@ -59,7 +59,7 @@ public class AutoRowDataKeyGen extends RowDataKeyGen {
     Option<TimestampBasedAvroKeyGenerator> keyGeneratorOpt = Option.empty();
     if (TimestampBasedAvroKeyGenerator.class.getName().equals(conf.get(FlinkOptions.KEYGEN_CLASS_NAME))) {
       try {
-        keyGeneratorOpt = Option.of(new TimestampBasedAvroKeyGenerator(StreamerUtil.flinkConf2TypedProperties(conf)));
+        keyGeneratorOpt = Option.of(new TimestampBasedAvroKeyGenerator(StreamerUtil.flinkConf2TypedProperties(conf), conf.get(FlinkOptions.PARTITION_PATH_FIELD)));
       } catch (IOException e) {
         throw new HoodieKeyException("Initialize TimestampBasedAvroKeyGenerator error", e);
       }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGens.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bulk/RowDataKeyGens.java
@@ -26,8 +26,6 @@ import org.apache.flink.table.types.logical.RowType;
 
 import javax.annotation.Nullable;
 
-import java.util.List;
-
 /**
  * Factory class for all kinds of {@link RowDataKeyGen}.
  */
@@ -37,8 +35,8 @@ public class RowDataKeyGens {
    * Creates {@link RowDataKeyGen} of corresponding type depending on table configuration.
    */
   public static RowDataKeyGen instance(Configuration conf, RowType rowType, @Nullable Integer taskId, @Nullable String instantTime) {
-    String recordKeys = OptionsResolver.getRecordKeyStr(conf);
-    if (hasRecordKey(recordKeys, rowType.getFieldNames())) {
+    String[] recordKeys = OptionsResolver.getRecordKeys(conf);
+    if (hasRecordKey(recordKeys)) {
       return RowDataKeyGen.instance(conf, rowType);
     } else {
       if (null == taskId || null == instantTime) {
@@ -59,8 +57,7 @@ public class RowDataKeyGens {
   /**
    * Checks whether user provides any record key.
    */
-  private static boolean hasRecordKey(String recordKeys, List<String> fieldNames) {
-    return recordKeys.split(",").length != 1
-        || fieldNames.contains(recordKeys);
+  private static boolean hasRecordKey(String[] recordKeys) {
+    return recordKeys.length > 0;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -173,7 +173,7 @@ public class Pipelines {
       if (conf.get(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT)) {
         final boolean isNeededSortInput = conf.get(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT_BY_RECORD_KEY);
         final String[] partitionFields = FilePathUtils.extractPartitionKeys(conf);
-        final String[] recordKeyFields = OptionsResolver.getRecordKeyStr(conf).split(",");
+        final String[] recordKeyFields = OptionsResolver.getRecordKeys(conf);
 
         // if sort input by record key is needed then add record keys to partition keys
         String[] sortFields = isNeededSortInput

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/prune/PrimaryKeyPruners.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/prune/PrimaryKeyPruners.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 public class PrimaryKeyPruners {
 
   public static Function<Integer, Integer> getBucketIdFunc(List<ResolvedExpression> hashKeyFilters, Configuration conf) {
-    List<String> pkFields = Arrays.asList(OptionsResolver.getRecordKeyStr(conf).split(","));
+    List<String> pkFields = Arrays.asList(OptionsResolver.getRecordKeys(conf));
     // step1: resolve the hash key values
     final boolean logicalTimestamp = OptionsResolver.isConsistentLogicalTimestampEnabled(conf);
     List<String> values = hashKeyFilters.stream()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -250,7 +250,11 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
   private void checkRecordKey(Configuration conf, ResolvedSchema schema) {
     List<String> fields = schema.getColumnNames();
     if (schema.getPrimaryKey().isEmpty()) {
-      String[] recordKeys = OptionsResolver.getRecordKeyStr(conf).split(",");
+      String[] recordKeys = OptionsResolver.getRecordKeys(conf);
+      if (recordKeys.length == 0) {
+        throw new HoodieValidationException("Primary key definition is required, use either PRIMARY KEY syntax or option '"
+            + FlinkOptions.RECORD_KEY_FIELD.key() + "' to specify.");
+      }
       Arrays.stream(recordKeys)
           .filter(field -> !fields.contains(field))
           .findAny()
@@ -303,7 +307,7 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
   private static void setupHoodieKeyOptions(Configuration conf, CatalogTable table) {
     List<String> pkColumns = table.getSchema().getPrimaryKey()
         .map(pk -> pk.getColumns()).orElse(Collections.emptyList());
-    if (pkColumns.size() > 0) {
+    if (!pkColumns.isEmpty()) {
       // the PRIMARY KEY syntax always has higher priority than option FlinkOptions#RECORD_KEY_FIELD
       String recordKey = String.join(",", pkColumns);
       conf.set(FlinkOptions.RECORD_KEY_FIELD, recordKey);
@@ -319,12 +323,15 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
         log.info("'{}' is not set, therefore '{}' value will be used as index key instead",
             FlinkOptions.INDEX_KEY_FIELD.key(),
             FlinkOptions.RECORD_KEY_FIELD.key());
-        conf.set(FlinkOptions.INDEX_KEY_FIELD, OptionsResolver.getRecordKeyStr(conf));
+        String recordKeyStr = OptionsResolver.getRecordKeyStr(conf);
+        if (StringUtils.nonEmpty(recordKeyStr)) {
+          conf.set(FlinkOptions.INDEX_KEY_FIELD, recordKeyStr);
+        }
       } else {
         Set<String> recordKeySet =
-            Arrays.stream(OptionsResolver.getRecordKeyStr(conf).split(",")).collect(Collectors.toSet());
+            Arrays.stream(OptionsResolver.getRecordKeys(conf)).collect(Collectors.toSet());
         Set<String> indexKeySet =
-            Arrays.stream(conf.get(FlinkOptions.INDEX_KEY_FIELD).split(",")).collect(Collectors.toSet());
+            Arrays.stream(OptionsResolver.getBucketIndexKeys(conf)).collect(Collectors.toSet());
         if (!recordKeySet.containsAll(indexKeySet)) {
           throw new HoodieValidationException(
               FlinkOptions.INDEX_KEY_FIELD + " should be a subset of or equal to the recordKey fields");
@@ -334,7 +341,7 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
 
     // tweak the key gen class if possible
     final String[] partitions = conf.get(FlinkOptions.PARTITION_PATH_FIELD).split(",");
-    final String[] pks = OptionsResolver.getRecordKeyStr(conf).split(",");
+    final String[] pks = OptionsResolver.getRecordKeys(conf);
     if (partitions.length == 1) {
       final String partitionField = partitions[0];
       if (partitionField.isEmpty()) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
@@ -314,6 +314,11 @@ public class HoodieCatalog extends AbstractCatalog {
     Configuration conf = Configuration.fromMap(options);
     conf.set(FlinkOptions.PATH, tablePathStr);
     ResolvedSchema resolvedSchema = resolvedTable.getResolvedSchema();
+    if (!resolvedSchema.getPrimaryKey().isPresent()
+        && !conf.containsKey(RECORD_KEY_FIELD.key())
+        && !OptionsResolver.isAppendMode(conf)) {
+      throw new CatalogException("Primary key definition is missing");
+    }
     final String avroSchema = HoodieSchemaConverter.convertToSchema(
         resolvedSchema.toPhysicalRowDataType().getLogicalType(),
         HoodieSchemaUtils.getRecordQualifiedName(tablePath.getObjectName())).toString();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieCatalog.java
@@ -314,9 +314,6 @@ public class HoodieCatalog extends AbstractCatalog {
     Configuration conf = Configuration.fromMap(options);
     conf.set(FlinkOptions.PATH, tablePathStr);
     ResolvedSchema resolvedSchema = resolvedTable.getResolvedSchema();
-    if (!resolvedSchema.getPrimaryKey().isPresent() && !conf.containsKey(RECORD_KEY_FIELD.key())) {
-      throw new CatalogException("Primary key definition is missing");
-    }
     final String avroSchema = HoodieSchemaConverter.convertToSchema(
         resolvedSchema.toPhysicalRowDataType().getLogicalType(),
         HoodieSchemaUtils.getRecordQualifiedName(tablePath.getObjectName())).toString();
@@ -350,7 +347,7 @@ public class HoodieCatalog extends AbstractCatalog {
       conf.set(FlinkOptions.PARTITION_PATH_FIELD, partitions);
       options.put(TableOptionProperties.PARTITION_COLUMNS, partitions);
 
-      final String[] pks = OptionsResolver.getRecordKeyStr(conf).split(",");
+      final String[] pks = OptionsResolver.getRecordKeys(conf);
       boolean complexHoodieKey = pks.length > 1 || resolvedTable.getPartitionKeys().size() > 1;
       StreamerUtil.checkKeygenGenerator(complexHoodieKey, conf);
     } else {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -514,7 +514,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
     if (catalogTable.isPartitioned() && !flinkConf.contains(FlinkOptions.PARTITION_PATH_FIELD)) {
       final String partitions = String.join(",", catalogTable.getPartitionKeys());
       flinkConf.set(FlinkOptions.PARTITION_PATH_FIELD, partitions);
-      final String[] pks = OptionsResolver.getRecordKeyStr(flinkConf).split(",");
+      final String[] pks = OptionsResolver.getRecordKeys(flinkConf);
       boolean complexHoodieKey = pks.length > 1 || catalogTable.getPartitionKeys().size() > 1;
       StreamerUtil.checkKeygenGenerator(complexHoodieKey, flinkConf);
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -840,7 +840,6 @@ public class StreamerUtil {
    *
    * @param conf             The Flink configuration
    * @param checkpointId     The checkpoint ID
-   * @param checkpointClient The checkpoint client (nullable)
    * @return Kafka offset checkpoint string in URL-encoded format for Hudi metadata,
    * e.g., "kafka_metadata%3Atopic-name%3A0:100;kafka_metadata%3Atopic-name%3A1:200"
    * where format is "kafka_metadata%3Atopic%3Apartition:offset" separated by semicolons.

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
@@ -31,8 +31,10 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -69,6 +71,31 @@ public class TestOptionsResolver {
     conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     assertFalse(OptionsResolver.isRecordLevelIndex(conf));
     assertFalse(OptionsResolver.isStreamingIndexWriteEnabled(conf));
+  }
+
+  @Test
+  void testGetRecordKeys() {
+    Configuration conf = new Configuration();
+    assertNull(OptionsResolver.getRecordKeyStr(conf));
+    assertArrayEquals(new String[]{}, OptionsResolver.getRecordKeys(conf));
+
+    conf.set(FlinkOptions.RECORD_KEY_FIELD, "");
+    assertArrayEquals(new String[]{}, OptionsResolver.getRecordKeys(conf));
+
+    conf.set(FlinkOptions.RECORD_KEY_FIELD, "uuid, name");
+    assertArrayEquals(new String[]{"uuid", " name"}, OptionsResolver.getRecordKeys(conf));
+  }
+
+  @Test
+  void testGetBucketIndexKeys() {
+    Configuration conf = new Configuration();
+    assertArrayEquals(new String[]{}, OptionsResolver.getBucketIndexKeys(conf));
+
+    conf.set(FlinkOptions.INDEX_KEY_FIELD, "");
+    assertArrayEquals(new String[]{}, OptionsResolver.getBucketIndexKeys(conf));
+
+    conf.set(FlinkOptions.INDEX_KEY_FIELD, "uuid, name");
+    assertArrayEquals(new String[]{"uuid", " name"}, OptionsResolver.getBucketIndexKeys(conf));
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestRowDataKeyGens.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bulk/TestRowDataKeyGens.java
@@ -226,7 +226,7 @@ public class TestRowDataKeyGens {
   @Test
   void testPrimaryKeylessWrite() {
     Configuration conf = TestConfigurations.getDefaultConf("path1");
-    conf.set(FlinkOptions.RECORD_KEY_FIELD, "");
+    conf.removeConfig(FlinkOptions.RECORD_KEY_FIELD);
     final RowData rowData1 = insertRow(StringData.fromString("id1"), StringData.fromString("Danny"), 23,
         TimestampData.fromEpochMillis(1), StringData.fromString("par1"));
     final int taskId = 3;
@@ -252,7 +252,7 @@ public class TestRowDataKeyGens {
     final String instantTime = "000001";
 
     Configuration conf = TestConfigurations.getDefaultConf("path1");
-    conf.set(FlinkOptions.RECORD_KEY_FIELD, "");
+    conf.removeConfig(FlinkOptions.RECORD_KEY_FIELD);
     conf.set(FlinkOptions.PARTITION_PATH_FIELD, "ts");
     conf.set(FlinkOptions.PARTITION_FORMAT, partitionFormat);
     HoodieTableFactory.setupTimestampKeygenOptions(conf, DataTypes.TIMESTAMP(3));
@@ -284,10 +284,21 @@ public class TestRowDataKeyGens {
   }
 
   @Test
-  void testAutoKeyGenRecordKey() {
+  void testAutoKeyGenRecordKeyWithEmptyRecordKeyField() {
     Configuration conf = TestConfigurations.getDefaultConf("path1");
-    // without record keys AutoRowDataKeyGen will be used, which expects taskId and instantTime parameters for instantiation
     conf.set(FlinkOptions.RECORD_KEY_FIELD, "");
+
+    int taskId = 1;
+    String instantTime = "20250716145212986";
+    final AutoRowDataKeyGen autoKeyGen = (AutoRowDataKeyGen) RowDataKeyGens.instance(conf, TestConfigurations.ROW_TYPE, taskId, instantTime);
+    assertThat(autoKeyGen.getRecordKey(TestData.DATA_SET_INSERT.get(0)), is(instantTime + "_" + taskId + "_0"));
+    assertThat(autoKeyGen.getRecordKey(TestData.DATA_SET_INSERT.get(1)), is(instantTime + "_" + taskId + "_1"));
+  }
+
+  @Test
+  void testAutoKeyGenRecordKeyWithoutDeclaringRecordKeyField() {
+    Configuration conf = TestConfigurations.getDefaultConf("path1");
+    conf.removeConfig(FlinkOptions.RECORD_KEY_FIELD);
 
     int taskId = 1;
     String instantTime = "20250716145212986";
@@ -300,7 +311,7 @@ public class TestRowDataKeyGens {
   void testAutoKeyGenNotAllowNulls() {
     Configuration conf = TestConfigurations.getDefaultConf("path1");
     // without record keys AutoRowDataKeyGen will be used, which expects taskId and instantTime parameters for instantiation
-    conf.set(FlinkOptions.RECORD_KEY_FIELD, "");
+    conf.removeConfig(FlinkOptions.RECORD_KEY_FIELD);
 
     HoodieValidationException exNullInstant =
         assertThrows(HoodieValidationException.class, () -> RowDataKeyGens.instance(conf, TestConfigurations.ROW_TYPE, 1, null));

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -1651,6 +1651,7 @@ public class ITTestHoodieDataSource {
         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
         .option(FlinkOptions.OPERATION, "insert")
         .option(FlinkOptions.INSERT_CLUSTER, clustering)
+        .option(FlinkOptions.RECORD_KEY_FIELD, clustering ? "uuid" : "")
         .end();
     tableEnv.executeSql(hoodieTableDDL);
 
@@ -3213,6 +3214,7 @@ public class ITTestHoodieDataSource {
         .option(FlinkOptions.OPERATION, "insert")
         .option(FlinkOptions.WRITE_BUFFER_MEMORY_TYPE, BufferMemoryType.MANAGED)
         .option(FlinkOptions.WRITE_BUFFER_TYPE, bufferType.name())
+        .option(FlinkOptions.RECORD_KEY_FIELD, "uuid")
         .end();
     streamTableEnv.executeSql(hoodieTableDDL);
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -21,6 +21,7 @@ package org.apache.hudi.table;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -31,7 +32,6 @@ import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.bucket.partition.PartitionBucketIndexUtils;
@@ -416,7 +416,6 @@ public class ITTestHoodieDataSource {
 
     String hoodieTableDDL = sql("t1")
         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
-        .options(getDefaultKeys())
         .option(FlinkOptions.OPERATION, "insert")
         .option(FlinkOptions.READ_AS_STREAMING, true)
         .option(FlinkOptions.CLUSTERING_SCHEDULE_ENABLED, true)
@@ -446,7 +445,6 @@ public class ITTestHoodieDataSource {
 
     String hoodieTableDDL = sql("t1")
         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
-        .options(getDefaultKeys())
         .option(FlinkOptions.OPERATION, "insert")
         .option(FlinkOptions.CLUSTERING_SCHEDULE_ENABLED, true)
         .option(FlinkOptions.CLUSTERING_ASYNC_ENABLED, true)
@@ -1651,7 +1649,6 @@ public class ITTestHoodieDataSource {
 
     String hoodieTableDDL = sql("hoodie_sink")
         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
-        .options(getDefaultKeys())
         .option(FlinkOptions.OPERATION, "insert")
         .option(FlinkOptions.INSERT_CLUSTER, clustering)
         .end();
@@ -3212,7 +3209,6 @@ public class ITTestHoodieDataSource {
 
     String hoodieTableDDL = sql("t1")
         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
-        .options(getDefaultKeys())
         .option(FlinkOptions.TABLE_TYPE, MERGE_ON_READ)
         .option(FlinkOptions.OPERATION, "insert")
         .option(FlinkOptions.WRITE_BUFFER_MEMORY_TYPE, BufferMemoryType.MANAGED)

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -193,6 +193,46 @@ public class TestHoodieTableFactory {
   }
 
   @Test
+  void testAppendOnlySinkWithoutRecordKey() {
+    Configuration appendOnlyConf = new Configuration();
+    appendOnlyConf.set(FlinkOptions.PATH, new File(tempFile, "append_only_without_record_key").getAbsolutePath());
+    appendOnlyConf.set(FlinkOptions.TABLE_NAME, "append_only_without_record_key");
+    appendOnlyConf.set(FlinkOptions.OPERATION, "insert");
+
+    ResolvedSchema schema = SchemaBuilder.instance()
+        .field("f0", DataTypes.INT())
+        .field("f1", DataTypes.VARCHAR(20))
+        .field("ts", DataTypes.TIMESTAMP(3))
+        .build();
+    MockContext context = MockContext.getInstance(appendOnlyConf, schema, "");
+
+    HoodieTableSink tableSink = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(context);
+    assertNull(tableSink.getConf().get(FlinkOptions.RECORD_KEY_FIELD));
+    assertThat(tableSink.getConf().get(FlinkOptions.ORDERING_FIELDS), is(FlinkOptions.NO_PRE_COMBINE));
+    assertThat(tableSink.getConf().get(FlinkOptions.KEYGEN_CLASS_NAME), is(NonpartitionedAvroKeyGenerator.class.getName()));
+  }
+
+  @Test
+  void testNonAppendSinkRequiresRecordKey() {
+    Configuration upsertConf = new Configuration();
+    upsertConf.set(FlinkOptions.PATH, new File(tempFile, "upsert_without_record_key").getAbsolutePath());
+    upsertConf.set(FlinkOptions.TABLE_NAME, "upsert_without_record_key");
+
+    ResolvedSchema schema = SchemaBuilder.instance()
+        .field("f0", DataTypes.INT())
+        .field("f1", DataTypes.VARCHAR(20))
+        .field("ts", DataTypes.TIMESTAMP(3))
+        .build();
+    MockContext context = MockContext.getInstance(upsertConf, schema, "");
+
+    HoodieValidationException exception = assertThrows(
+        HoodieValidationException.class,
+        () -> new HoodieTableFactory().createDynamicTableSink(context));
+    assertThat(exception.getMessage(), is("Primary key definition is required, use either PRIMARY KEY syntax or option '"
+        + FlinkOptions.RECORD_KEY_FIELD.key() + "' to specify."));
+  }
+
+  @Test
   void testIndexTypeCheck() {
     ResolvedSchema schema = SchemaBuilder.instance()
             .field("f0", DataTypes.INT().notNull())

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
@@ -361,6 +361,26 @@ public class TestHoodieCatalog extends BaseTestHoodieCatalog {
   }
 
   @Test
+  public void testCreateNonAppendTableWithoutRecordKey() {
+    ObjectPath tablePath = new ObjectPath(TEST_DEFAULT_DATABASE, "tb_non_append_without_record_key");
+    ResolvedSchema schemaWithoutPrimaryKey = new ResolvedSchema(
+        CREATE_COLUMNS,
+        Collections.emptyList(),
+        null);
+    ResolvedCatalogTable catalogTable = new ResolvedCatalogTable(
+        CatalogUtils.createCatalogTable(
+            Schema.newBuilder().fromResolvedSchema(schemaWithoutPrimaryKey).build(),
+            Arrays.asList("partition"),
+            EXPECTED_OPTIONS,
+            "test"),
+        schemaWithoutPrimaryKey
+    );
+
+    CatalogException exception = assertThrows(CatalogException.class, () -> catalog.createTable(tablePath, catalogTable, false));
+    assertEquals("Primary key definition is missing", exception.getMessage());
+  }
+
+  @Test
   void testCreateTableWithPartitionBucketIndex() throws TableAlreadyExistException, DatabaseNotExistException, IOException {
     String rule = "regex";
     String expressions = "\\d{4}-(06-(01|17|18)|11-(01|10|11)),256";

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
@@ -334,6 +334,33 @@ public class TestHoodieCatalog extends BaseTestHoodieCatalog {
   }
 
   @Test
+  public void testCreateAppendOnlyTableWithoutRecordKey() throws Exception {
+    ObjectPath tablePath = new ObjectPath(TEST_DEFAULT_DATABASE, "tb_append_only_without_record_key");
+    ResolvedSchema schemaWithoutPrimaryKey = new ResolvedSchema(
+        CREATE_COLUMNS,
+        Collections.emptyList(),
+        null);
+    Map<String, String> options = new HashMap<>(EXPECTED_OPTIONS);
+    options.put(FlinkOptions.OPERATION.key(), "insert");
+    ResolvedCatalogTable catalogTable = new ResolvedCatalogTable(
+        CatalogUtils.createCatalogTable(
+            Schema.newBuilder().fromResolvedSchema(schemaWithoutPrimaryKey).build(),
+            Arrays.asList("partition"),
+            options,
+            "test"),
+        schemaWithoutPrimaryKey
+    );
+
+    catalog.createTable(tablePath, catalogTable, false);
+
+    HoodieTableMetaClient metaClient = createMetaClient(
+        new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(new Configuration())),
+        catalog.inferTablePath(catalogPathStr, tablePath));
+    assertFalse(metaClient.getTableConfig().getRecordKeyFields().isPresent());
+    assertEquals(SimpleAvroKeyGenerator.class.getName(), metaClient.getTableConfig().getKeyGeneratorClassName());
+  }
+
+  @Test
   void testCreateTableWithPartitionBucketIndex() throws TableAlreadyExistException, DatabaseNotExistException, IOException {
     String rule = "regex";
     String expressions = "\\d{4}-(06-(01|17|18)|11-(01|10|11)),256";

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestConfigurations.java
@@ -241,11 +241,18 @@ public class TestConfigurations {
       String partitionField) {
     StringBuilder builder = new StringBuilder();
     builder.append("create table ").append(tableName).append("(\n");
-    for (String field : fields) {
-      builder.append("  ").append(field).append(",\n");
+    for (int i = 0; i < fields.size(); i++) {
+      builder.append("  ").append(fields.get(i));
+      if (i == fields.size() - 1 && pkField == null) {
+        builder.append(")\n");
+      } else {
+        builder.append(",\n");
+      }
     }
-    builder.append("  PRIMARY KEY(").append(pkField).append(") NOT ENFORCED\n")
-        .append(")\n");
+    if (pkField != null) {
+      builder.append("  PRIMARY KEY(").append(pkField).append(") NOT ENFORCED\n")
+          .append(")\n");
+    }
     if (havePartition) {
       builder.append("PARTITIONED BY (`").append(partitionField).append("`)\n");
     }
@@ -420,7 +427,7 @@ public class TestConfigurations {
     private final String tableName;
     private List<String> fields = new ArrayList<>();
     private boolean withPartition = true;
-    private String pkField = "uuid";
+    private String pkField = null;
     private String partitionField = "partition";
 
     public Sql(String tableName) {
@@ -464,8 +471,12 @@ public class TestConfigurations {
     }
 
     public String end() {
-      if (this.fields.size() == 0) {
+      if (this.fields.isEmpty()) {
         this.fields = FIELDS;
+      }
+      if (!"insert".equalsIgnoreCase(options.get(FlinkOptions.OPERATION.key())) && this.pkField == null) {
+        // assign default pk for upsert table
+        this.pkField = "uuid";
       }
       return TestConfigurations.getCreateHoodieTableDDL(this.tableName, this.fields, options,
           this.withPartition, this.pkField, this.partitionField);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fix the regression introduced by https://github.com/apache/hudi/pull/17994
Flink append-only ingestion currently requires a primary key or `hoodie.datasource.write.recordkey.field`, even though insert-only writes do not require record-key based update or deduplication semantics. This prevents valid append-only table definitions from being created through the Flink table factory and catalog paths.

This PR relaxes the primary-key requirement for append mode while preserving the existing validation for non-append writes. When no record key is declared, or the record-key option is empty, Flink uses auto-generated record keys for append-only ingestion.

There are no storage format changes and no breaking table format changes.

### Summary and Changelog

Append-only Flink ingestion can now create and write Hudi tables without declaring record keys, while upsert and other non-append write modes still require a primary key or record-key option.

- Updated `HoodieTableFactory` so record-key validation is skipped only for append mode and still enforced for non-append sinks.
- Added nullable record-key handling in `OptionsResolver`, including `getRecordKeys` and `getBucketIndexKeys`, with null and empty values resolving to no keys.
- Updated `RowDataKeyGens` so auto record-key generation is used when no record keys are resolved.
- Allowed `TimestampBasedAvroKeyGenerator` to be constructed without a record-key field by reading `hoodie.datasource.write.recordkey.field` with a nullable default.
- Updated Flink catalog paths (`HoodieCatalog`, `HoodieHiveCatalog`) and helper paths (`Pipelines`, `PrimaryKeyPruners`) to use the new record-key resolver behavior.
- Added `TestHoodieTableFactory` coverage for append-only sinks without record keys and for non-append sinks still requiring record keys.
- Added `TestHoodieCatalog` coverage for creating append-only catalog tables without primary keys.
- Added `TestOptionsResolver` coverage for nullable and empty record/index key resolution.
- Updated `TestRowDataKeyGens` coverage for keyless append writes, timestamp partition key generation without record keys, empty record-key auto key generation, and missing task/instant validation.
- Updated append-only datasource integration tests to omit default record-key options in append write scenarios.

### Impact

This changes Flink user-facing validation for append-only insert tables: users can omit both PRIMARY KEY syntax and `hoodie.datasource.write.recordkey.field` when `operation=insert`. Empty record-key and bucket-index-key options are resolved as no keys.

Non-append write modes continue to require a record key. Existing tables that already declare record keys continue to use those keys. There is no storage format change, table version change, or expected performance impact.

The affected area is Flink datasource ingestion, including table factory setup, catalog table creation, row-data key generation, and append-only test coverage.

### Risk Level

low

The change touches core Flink table setup and key-generation paths, so the main risk is accidentally relaxing record-key validation for non-append writes or changing empty option behavior unexpectedly. This is mitigated by targeted tests covering append-only keyless writes, non-append validation, resolver behavior, catalog creation, timestamp partition key generation, and auto key generation.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
