### PR TITLE
fix(flink): add close function in AbstractStreamWriteFunction

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/common/AbstractStreamWriteFunction.java
@@ -176,6 +176,14 @@ public abstract class AbstractStreamWriteFunction<I>
     this.inputEnded = true;
   }
 
+  @Override
+  public void close() throws Exception {
+    if (this.writeClient != null) {
+      this.writeClient.close();
+    }
+    super.close();
+  }
+
   // -------------------------------------------------------------------------
   //  Getter/Setter
   // -------------------------------------------------------------------------


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Add close function in AbstractStreamWriteFunction to prevent orphan parquet file creation after rollback

### Summary and Changelog

1. Add close function in AbstractStreamWriteFunction to prevent orphan parquet file creation after rollback


### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
