### PR TITLE
feat(blob): default blob.inline.mode to DESCRIPTOR for Lance

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -107,13 +107,13 @@ public class HoodieReaderConfig extends HoodieConfig {
   public static final String BLOB_INLINE_READ_MODE_DESCRIPTOR = "DESCRIPTOR";
   public static final ConfigProperty<String> BLOB_INLINE_READ_MODE = ConfigProperty
       .key("hoodie.read.blob.inline.mode")
-      .defaultValue(BLOB_INLINE_READ_MODE_CONTENT)
+      .defaultValue(BLOB_INLINE_READ_MODE_DESCRIPTOR)
       .markAdvanced()
       .sinceVersion("1.2.0")
       .withValidValues(BLOB_INLINE_READ_MODE_CONTENT, BLOB_INLINE_READ_MODE_DESCRIPTOR)
       .withDocumentation("How Hudi interprets INLINE BLOB values on read. "
-          + "CONTENT (default) returns the raw inline bytes. "
-          + "DESCRIPTOR returns an OUT_OF_LINE-shaped reference pointing at the backing "
-          + "Lance file with the INLINE payload's position and size, so callers can defer "
-          + "the byte read via read_blob().");
+          + "DESCRIPTOR (default) returns an OUT_OF_LINE-shaped reference pointing at the "
+          + "backing Lance file with the INLINE payload's position and size, so callers can "
+          + "defer the byte read via read_blob(). "
+          + "CONTENT returns the raw inline bytes directly in the data field on every read.");
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieReaderConfig.java
@@ -114,6 +114,6 @@ public class HoodieReaderConfig extends HoodieConfig {
       .withDocumentation("How Hudi interprets INLINE BLOB values on read. "
           + "DESCRIPTOR (default) returns an OUT_OF_LINE-shaped reference pointing at the "
           + "backing Lance file with the INLINE payload's position and size, so callers can "
-          + "defer the byte read via read_blob(). "
+          + "skip the byte content read. "
           + "CONTENT returns the raw inline bytes directly in the data field on every read.");
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
@@ -210,11 +210,10 @@ class BatchedBlobReader(
             if (storageType == HoodieSchema.Blob.INLINE) {
               // INLINE + CONTENT: inline_data is populated; return bytes directly (1-hop).
               // INLINE + DESCRIPTOR: inline_data is null and the scan synthesized a
-              // reference pointing into the backing file's storage layout. We refuse to
-              // materialize bytes here — DESCRIPTOR is a metadata-only mode for INLINE
-              // rows, and the synthesized reference is an internal pointer, not
-              // user-facing storage info. Callers must switch to CONTENT mode or stop
-              // using read_blob() on INLINE columns under DESCRIPTOR.
+              // reference pointing into the backing file. Fall through to the same
+              // range-merged pread path used for OUT_OF_LINE rows — the synthesized
+              // reference is structurally identical to a user-supplied OUT_OF_LINE
+              // reference (external_path, offset, length, is_managed=true).
               if (!accessor.isNullAt(blobStruct, 1)) {
                 val bytes = accessor.getBytes(blobStruct, 1)
                 batch += RowInfo[R](
@@ -226,46 +225,11 @@ class BatchedBlobReader(
                   inlineBytes = Some(bytes)
                 )
               } else {
-                throw new IllegalStateException(
-                  s"read_blob() cannot materialize bytes for an INLINE blob under " +
-                    s"DESCRIPTOR mode (row $rowIndex). Under " +
-                    s"hoodie.read.blob.inline.mode=DESCRIPTOR, INLINE blobs will not return bytes via the 'data' subfield" +
-                    " and instead returns a 'reference' subfield containing metadata only." +
-                    s"In order to materialize bytes set hoodie.read.blob.inline.mode=CONTENT")
+                addRowInfoFromReference(row, blobStruct, batch)
               }
             } else if (storageType  == HoodieSchema.Blob.OUT_OF_LINE) {
               // Case 2 or 3: Out-of-line — get reference struct (field 2)
-              require(!accessor.isNullAt(blobStruct, 2), s"Out-of-line blob at row $rowIndex must set reference")
-              val referenceStruct = accessor.getStruct(blobStruct, 2, HoodieSchema.Blob.getReferenceFieldCount)
-              val filePath = accessor.getString(referenceStruct, 0)
-              require(filePath != null && filePath.nonEmpty, s"Blob reference must have non-empty external_path at row $rowIndex")
-              val offsetIsNull = accessor.isNullAt(referenceStruct, 1)
-              val lengthIsNull = accessor.isNullAt(referenceStruct, 2)
-              if (offsetIsNull && lengthIsNull) {
-                // Case 2: Whole-file read — no offset/length specified; sentinel length = -1
-                batch += RowInfo[R](
-                  originalRow = row,
-                  filePath = filePath,
-                  offset = 0,
-                  length = -1,
-                  index = rowIndex
-                )
-              } else if (offsetIsNull || lengthIsNull) {
-                throw new IllegalArgumentException(s"Blob reference for '$filePath' must set both offset and length, or neither")
-              } else {
-                // Case 3: Regular range read
-                val offset = accessor.getLong(referenceStruct, 1)
-                val length = accessor.getLong(referenceStruct, 2)
-                require(offset >= 0, s"Blob offset must be non-negative for '$filePath': $offset")
-                require(length >= 0, s"Blob length must be non-negative for '$filePath': $length")
-                batch += RowInfo[R](
-                  originalRow = row,
-                  filePath = filePath,
-                  offset = offset,
-                  length = length,
-                  index = rowIndex
-                )
-              }
+              addRowInfoFromReference(row, blobStruct, batch)
             } else {
               throw new IllegalArgumentException(s"Unsupported blob storage_type at row $rowIndex: $storageType")
             }
@@ -274,6 +238,55 @@ class BatchedBlobReader(
           }
         }
         batch.toSeq
+      }
+
+      /**
+       * Extract an external/synthesized reference (path/offset/length) from a blob
+       * struct's reference subfield (field 2) and append the corresponding RowInfo
+       * to the batch. Shared by two paths:
+       *   - OUT_OF_LINE rows: the user-supplied external reference.
+       *   - INLINE rows under DESCRIPTOR mode: the Lance-synthesized reference into
+       *     the backing .lance file. Structurally identical to OUT_OF_LINE, so the
+       *     same range-merged pread infrastructure materializes bytes via read_blob().
+       */
+      private def addRowInfoFromReference(
+          row: R,
+          blobStruct: R,
+          batch: ArrayBuffer[RowInfo[R]]): Unit = {
+        require(!accessor.isNullAt(blobStruct, 2),
+          s"Blob at row $rowIndex must set reference (got both inline_data=NULL and " +
+            s"reference=NULL — malformed row)")
+        val referenceStruct = accessor.getStruct(blobStruct, 2, HoodieSchema.Blob.getReferenceFieldCount)
+        val filePath = accessor.getString(referenceStruct, 0)
+        require(filePath != null && filePath.nonEmpty,
+          s"Blob reference must have non-empty external_path at row $rowIndex")
+        val offsetIsNull = accessor.isNullAt(referenceStruct, 1)
+        val lengthIsNull = accessor.isNullAt(referenceStruct, 2)
+        if (offsetIsNull && lengthIsNull) {
+          // Whole-file read — sentinel length = -1
+          batch += RowInfo[R](
+            originalRow = row,
+            filePath = filePath,
+            offset = 0,
+            length = -1,
+            index = rowIndex
+          )
+        } else if (offsetIsNull || lengthIsNull) {
+          throw new IllegalArgumentException(
+            s"Blob reference for '$filePath' must set both offset and length, or neither")
+        } else {
+          val offset = accessor.getLong(referenceStruct, 1)
+          val length = accessor.getLong(referenceStruct, 2)
+          require(offset >= 0, s"Blob offset must be non-negative for '$filePath': $offset")
+          require(length >= 0, s"Blob length must be non-negative for '$filePath': $length")
+          batch += RowInfo[R](
+            originalRow = row,
+            filePath = filePath,
+            offset = offset,
+            length = length,
+            index = rowIndex
+          )
+        }
       }
     }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
@@ -210,10 +210,11 @@ class BatchedBlobReader(
             if (storageType == HoodieSchema.Blob.INLINE) {
               // INLINE + CONTENT: inline_data is populated; return bytes directly (1-hop).
               // INLINE + DESCRIPTOR: inline_data is null and the scan synthesized a
-              // reference pointing into the backing file. Fall through to the same
-              // range-merged pread path used for OUT_OF_LINE rows — the synthesized
-              // reference is structurally identical to a user-supplied OUT_OF_LINE
-              // reference (external_path, offset, length, is_managed=true).
+              // reference pointing into the backing file's storage layout. We refuse to
+              // materialize bytes here — DESCRIPTOR is a metadata-only mode for INLINE
+              // rows, and the synthesized reference is an internal pointer, not
+              // user-facing storage info. Callers must switch to CONTENT mode or stop
+              // using read_blob() on INLINE columns under DESCRIPTOR.
               if (!accessor.isNullAt(blobStruct, 1)) {
                 val bytes = accessor.getBytes(blobStruct, 1)
                 batch += RowInfo[R](
@@ -225,11 +226,46 @@ class BatchedBlobReader(
                   inlineBytes = Some(bytes)
                 )
               } else {
-                addRowInfoFromReference(row, blobStruct, batch)
+                throw new IllegalStateException(
+                  s"read_blob() cannot materialize bytes for an INLINE blob under " +
+                    s"DESCRIPTOR mode (row $rowIndex). Under " +
+                    s"hoodie.read.blob.inline.mode=DESCRIPTOR, INLINE blobs will not return bytes via the 'data' subfield" +
+                    " and instead returns a 'reference' subfield containing metadata only." +
+                    s"In order to materialize bytes set hoodie.read.blob.inline.mode=CONTENT")
               }
             } else if (storageType  == HoodieSchema.Blob.OUT_OF_LINE) {
               // Case 2 or 3: Out-of-line — get reference struct (field 2)
-              addRowInfoFromReference(row, blobStruct, batch)
+              require(!accessor.isNullAt(blobStruct, 2), s"Out-of-line blob at row $rowIndex must set reference")
+              val referenceStruct = accessor.getStruct(blobStruct, 2, HoodieSchema.Blob.getReferenceFieldCount)
+              val filePath = accessor.getString(referenceStruct, 0)
+              require(filePath != null && filePath.nonEmpty, s"Blob reference must have non-empty external_path at row $rowIndex")
+              val offsetIsNull = accessor.isNullAt(referenceStruct, 1)
+              val lengthIsNull = accessor.isNullAt(referenceStruct, 2)
+              if (offsetIsNull && lengthIsNull) {
+                // Case 2: Whole-file read — no offset/length specified; sentinel length = -1
+                batch += RowInfo[R](
+                  originalRow = row,
+                  filePath = filePath,
+                  offset = 0,
+                  length = -1,
+                  index = rowIndex
+                )
+              } else if (offsetIsNull || lengthIsNull) {
+                throw new IllegalArgumentException(s"Blob reference for '$filePath' must set both offset and length, or neither")
+              } else {
+                // Case 3: Regular range read
+                val offset = accessor.getLong(referenceStruct, 1)
+                val length = accessor.getLong(referenceStruct, 2)
+                require(offset >= 0, s"Blob offset must be non-negative for '$filePath': $offset")
+                require(length >= 0, s"Blob length must be non-negative for '$filePath': $length")
+                batch += RowInfo[R](
+                  originalRow = row,
+                  filePath = filePath,
+                  offset = offset,
+                  length = length,
+                  index = rowIndex
+                )
+              }
             } else {
               throw new IllegalArgumentException(s"Unsupported blob storage_type at row $rowIndex: $storageType")
             }
@@ -238,55 +274,6 @@ class BatchedBlobReader(
           }
         }
         batch.toSeq
-      }
-
-      /**
-       * Extract an external/synthesized reference (path/offset/length) from a blob
-       * struct's reference subfield (field 2) and append the corresponding RowInfo
-       * to the batch. Shared by two paths:
-       *   - OUT_OF_LINE rows: the user-supplied external reference.
-       *   - INLINE rows under DESCRIPTOR mode: the Lance-synthesized reference into
-       *     the backing .lance file. Structurally identical to OUT_OF_LINE, so the
-       *     same range-merged pread infrastructure materializes bytes via read_blob().
-       */
-      private def addRowInfoFromReference(
-          row: R,
-          blobStruct: R,
-          batch: ArrayBuffer[RowInfo[R]]): Unit = {
-        require(!accessor.isNullAt(blobStruct, 2),
-          s"Blob at row $rowIndex must set reference (got both inline_data=NULL and " +
-            s"reference=NULL — malformed row)")
-        val referenceStruct = accessor.getStruct(blobStruct, 2, HoodieSchema.Blob.getReferenceFieldCount)
-        val filePath = accessor.getString(referenceStruct, 0)
-        require(filePath != null && filePath.nonEmpty,
-          s"Blob reference must have non-empty external_path at row $rowIndex")
-        val offsetIsNull = accessor.isNullAt(referenceStruct, 1)
-        val lengthIsNull = accessor.isNullAt(referenceStruct, 2)
-        if (offsetIsNull && lengthIsNull) {
-          // Whole-file read — sentinel length = -1
-          batch += RowInfo[R](
-            originalRow = row,
-            filePath = filePath,
-            offset = 0,
-            length = -1,
-            index = rowIndex
-          )
-        } else if (offsetIsNull || lengthIsNull) {
-          throw new IllegalArgumentException(
-            s"Blob reference for '$filePath' must set both offset and length, or neither")
-        } else {
-          val offset = accessor.getLong(referenceStruct, 1)
-          val length = accessor.getLong(referenceStruct, 2)
-          require(offset >= 0, s"Blob offset must be non-negative for '$filePath': $offset")
-          require(length >= 0, s"Blob length must be non-negative for '$filePath': $length")
-          batch += RowInfo[R](
-            originalRow = row,
-            filePath = filePath,
-            offset = offset,
-            length = length,
-            index = rowIndex
-          )
-        }
       }
     }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
@@ -229,10 +229,9 @@ class BatchedBlobReader(
                 throw new IllegalStateException(
                   s"read_blob() cannot materialize bytes for an INLINE blob under " +
                     s"DESCRIPTOR mode (row $rowIndex). Under " +
-                    s"hoodie.read.blob.inline.mode=DESCRIPTOR, INLINE blobs are returned " +
-                    s"as metadata-only (inline_data=NULL, synthesized reference). To read " +
-                    s"bytes, set hoodie.read.blob.inline.mode=CONTENT, or project " +
-                    s"col.data / col.reference.* directly instead of calling read_blob().")
+                    s"hoodie.read.blob.inline.mode=DESCRIPTOR, INLINE blobs will not return bytes via the 'data' subfield" +
+                    " and instead returns a 'reference' subfield containing metadata only." +
+                    s"In order to materialize bytes set hoodie.read.blob.inline.mode=CONTENT")
               }
             } else if (storageType  == HoodieSchema.Blob.OUT_OF_LINE) {
               // Case 2 or 3: Out-of-line — get reference struct (field 2)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
@@ -228,10 +228,10 @@ class BatchedBlobReader(
               } else {
                 throw new IllegalStateException(
                   s"read_blob() cannot materialize bytes for an INLINE blob under " +
-                    s"DESCRIPTOR mode (row $rowIndex). Under " +
-                    s"hoodie.read.blob.inline.mode=DESCRIPTOR, INLINE blobs will not return bytes via the 'data' subfield" +
-                    " and instead returns a 'reference' subfield containing metadata only." +
-                    s"In order to materialize bytes set hoodie.read.blob.inline.mode=CONTENT")
+                    s"DESCRIPTOR mode. Under hoodie.read.blob.inline.mode=DESCRIPTOR, " +
+                    s"INLINE blobs are returned as metadata-only (inline_data=NULL, " +
+                    s"synthesized reference). To read bytes, set " +
+                    s"hoodie.read.blob.inline.mode=CONTENT")
               }
             } else if (storageType  == HoodieSchema.Blob.OUT_OF_LINE) {
               // Case 2 or 3: Out-of-line — get reference struct (field 2)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
@@ -208,14 +208,14 @@ class BatchedBlobReader(
             // Dispatch based on storage_type (field 0)
             val storageType = accessor.getString(blobStruct, 0)
             if (storageType == HoodieSchema.Blob.INLINE) {
-              // INLINE rows can arrive in two shapes:
-              //  - CONTENT-mode read: inline_data populated with raw bytes (field 1).
-              //  - DESCRIPTOR-mode read: inline_data is null and the reference struct
-              //    (field 2) carries a synthetic positional pointer into the base file.
-              // read_blob() must return bytes in both cases, so we fall back to the
-              // descriptor's range read when inline_data is absent.
-              val inlineIsNull = accessor.isNullAt(blobStruct, 1)
-              if (!inlineIsNull) {
+              // INLINE + CONTENT: inline_data is populated; return bytes directly (1-hop).
+              // INLINE + DESCRIPTOR: inline_data is null and the scan synthesized a
+              // reference pointing into the backing file's storage layout. We refuse to
+              // materialize bytes here — DESCRIPTOR is a metadata-only mode for INLINE
+              // rows, and the synthesized reference is an internal pointer, not
+              // user-facing storage info. Callers must switch to CONTENT mode or stop
+              // using read_blob() on INLINE columns under DESCRIPTOR.
+              if (!accessor.isNullAt(blobStruct, 1)) {
                 val bytes = accessor.getBytes(blobStruct, 1)
                 batch += RowInfo[R](
                   originalRow = row,
@@ -226,25 +226,13 @@ class BatchedBlobReader(
                   inlineBytes = Some(bytes)
                 )
               } else {
-                require(!accessor.isNullAt(blobStruct, 2),
-                  s"INLINE blob at row $rowIndex has null inline_data and null reference; cannot resolve bytes")
-                val referenceStruct = accessor.getStruct(blobStruct, 2, HoodieSchema.Blob.getReferenceFieldCount)
-                val filePath = accessor.getString(referenceStruct, 0)
-                require(filePath != null && filePath.nonEmpty,
-                  s"INLINE blob descriptor at row $rowIndex must have non-empty external_path")
-                require(!accessor.isNullAt(referenceStruct, 1) && !accessor.isNullAt(referenceStruct, 2),
-                  s"INLINE blob descriptor at row $rowIndex must set both offset and length")
-                val offset = accessor.getLong(referenceStruct, 1)
-                val length = accessor.getLong(referenceStruct, 2)
-                require(offset >= 0, s"INLINE blob descriptor offset must be non-negative for '$filePath': $offset")
-                require(length >= 0, s"INLINE blob descriptor length must be non-negative for '$filePath': $length")
-                batch += RowInfo[R](
-                  originalRow = row,
-                  filePath = filePath,
-                  offset = offset,
-                  length = length,
-                  index = rowIndex
-                )
+                throw new IllegalStateException(
+                  s"read_blob() cannot materialize bytes for an INLINE blob under " +
+                    s"DESCRIPTOR mode (row $rowIndex). Under " +
+                    s"hoodie.read.blob.inline.mode=DESCRIPTOR, INLINE blobs are returned " +
+                    s"as metadata-only (inline_data=NULL, synthesized reference). To read " +
+                    s"bytes, set hoodie.read.blob.inline.mode=CONTENT, or project " +
+                    s"col.data / col.reference.* directly instead of calling read_blob().")
               }
             } else if (storageType  == HoodieSchema.Blob.OUT_OF_LINE) {
               // Case 2 or 3: Out-of-line — get reference struct (field 2)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/BatchedBlobReader.scala
@@ -208,16 +208,44 @@ class BatchedBlobReader(
             // Dispatch based on storage_type (field 0)
             val storageType = accessor.getString(blobStruct, 0)
             if (storageType == HoodieSchema.Blob.INLINE) {
-              // Case 1: Inline — bytes are in field 1
-              val bytes = accessor.getBytes(blobStruct, 1)
-              batch += RowInfo[R](
-                originalRow = row,
-                filePath = "",
-                offset = -1,
-                length = -1,
-                index = rowIndex,
-                inlineBytes = Some(bytes)
-              )
+              // INLINE rows can arrive in two shapes:
+              //  - CONTENT-mode read: inline_data populated with raw bytes (field 1).
+              //  - DESCRIPTOR-mode read: inline_data is null and the reference struct
+              //    (field 2) carries a synthetic positional pointer into the base file.
+              // read_blob() must return bytes in both cases, so we fall back to the
+              // descriptor's range read when inline_data is absent.
+              val inlineIsNull = accessor.isNullAt(blobStruct, 1)
+              if (!inlineIsNull) {
+                val bytes = accessor.getBytes(blobStruct, 1)
+                batch += RowInfo[R](
+                  originalRow = row,
+                  filePath = "",
+                  offset = -1,
+                  length = -1,
+                  index = rowIndex,
+                  inlineBytes = Some(bytes)
+                )
+              } else {
+                require(!accessor.isNullAt(blobStruct, 2),
+                  s"INLINE blob at row $rowIndex has null inline_data and null reference; cannot resolve bytes")
+                val referenceStruct = accessor.getStruct(blobStruct, 2, HoodieSchema.Blob.getReferenceFieldCount)
+                val filePath = accessor.getString(referenceStruct, 0)
+                require(filePath != null && filePath.nonEmpty,
+                  s"INLINE blob descriptor at row $rowIndex must have non-empty external_path")
+                require(!accessor.isNullAt(referenceStruct, 1) && !accessor.isNullAt(referenceStruct, 2),
+                  s"INLINE blob descriptor at row $rowIndex must set both offset and length")
+                val offset = accessor.getLong(referenceStruct, 1)
+                val length = accessor.getLong(referenceStruct, 2)
+                require(offset >= 0, s"INLINE blob descriptor offset must be non-negative for '$filePath': $offset")
+                require(length >= 0, s"INLINE blob descriptor length must be non-negative for '$filePath': $length")
+                batch += RowInfo[R](
+                  originalRow = row,
+                  filePath = filePath,
+                  offset = offset,
+                  length = length,
+                  index = rowIndex
+                )
+              }
             } else if (storageType  == HoodieSchema.Blob.OUT_OF_LINE) {
               // Case 2 or 3: Out-of-line — get reference struct (field 2)
               require(!accessor.isNullAt(blobStruct, 2), s"Out-of-line blob at row $rowIndex must set reference")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ReadBlobRule.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ReadBlobRule.scala
@@ -19,11 +19,14 @@
 
 package org.apache.spark.sql.hudi.blob
 
+import org.apache.hudi.common.config.HoodieReaderConfig
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 import scala.collection.mutable
@@ -46,6 +49,7 @@ case class ReadBlobRule(spark: SparkSession) extends Rule[LogicalPlan] {
       if containsReadBlobExpression(projectList)
         && containsReadBlobInExpression(condition)
         && !child.isInstanceOf[BatchedBlobRead] =>
+      rejectMixedBlobProjection(projectList, child)
       val projectBlobCols = extractAllBlobColumns(projectList)
       val filterBlobCols = extractBlobColumnsFromExpression(condition)
       val blobColumns = (projectBlobCols ++ filterBlobCols)
@@ -71,6 +75,7 @@ case class ReadBlobRule(spark: SparkSession) extends Rule[LogicalPlan] {
       if containsReadBlobExpression(projectList)
         && !child.isInstanceOf[BatchedBlobRead] =>
 
+      rejectMixedBlobProjection(projectList, child)
       val blobColumns = extractAllBlobColumns(projectList)
       val (wrappedPlan, blobToDataAttr) = wrapWithBlobReads(blobColumns, child)
       val newProjectList = transformNamedExpressions(projectList, blobToDataAttr)
@@ -169,5 +174,95 @@ case class ReadBlobRule(spark: SparkSession) extends Rule[LogicalPlan] {
       throw new IllegalStateException("read_blob() must be called on a direct column reference")
     case other =>
       other.mapChildren(replaceReadBlobExpression(_, blobToDataAttr))
+  }
+
+  /**
+   * Reject queries that mix `read_blob(blob_col)` with a direct projection of any blob
+   * column when the effective inline read mode resolves to DESCRIPTOR.
+   */
+  private def rejectMixedBlobProjection(
+      projectList: Seq[Expression],
+      child: LogicalPlan): Unit = {
+    val directBlobRefs = collectDirectBlobRefs(projectList)
+    val readBlobCols = extractAllBlobColumns(projectList)
+    if (directBlobRefs.nonEmpty && readBlobCols.nonEmpty && effectiveModeIsDescriptor(child)) {
+      val readBlobNames = readBlobCols.map(_.name).distinct.mkString(", ")
+      val directNames = directBlobRefs.map(_.name).distinct.mkString(", ")
+      throw new AnalysisException(
+        s"Cannot mix read_blob() with direct blob-column projection under " +
+          s"${HoodieReaderConfig.BLOB_INLINE_READ_MODE.key()}=" +
+          s"${HoodieReaderConfig.BLOB_INLINE_READ_MODE_DESCRIPTOR}. read_blob() is " +
+          s"called on [$readBlobNames] while [$directNames] is projected directly in " +
+          s"the same query. Either set " +
+          s"${HoodieReaderConfig.BLOB_INLINE_READ_MODE.key()}=" +
+          s"${HoodieReaderConfig.BLOB_INLINE_READ_MODE_CONTENT} (returns inline bytes " +
+          s"for all INLINE rows), or remove the direct blob-column projection from " +
+          s"this query.")
+    }
+  }
+
+  /**
+   * Collect all blob columns referenced directly (i.e. NOT inside a `read_blob()`) in
+   * the given expression list. A blob column is an `AttributeReference` whose dataType
+   * is the `BlobType` struct.
+   */
+  private def collectDirectBlobRefs(
+      expressions: Seq[Expression]): Seq[AttributeReference] = {
+    val seen = mutable.LinkedHashSet.empty[ExprId]
+    val result = ArrayBuffer.empty[AttributeReference]
+    expressions.foreach(walkDirectBlobRefs(_, seen, result))
+    result.toSeq
+  }
+
+  private def walkDirectBlobRefs(
+      expr: Expression,
+      seen: mutable.Set[ExprId],
+      result: ArrayBuffer[AttributeReference]): Unit = expr match {
+    // Skip subtrees rooted at read_blob() — its argument is wrapped, not direct.
+    case _: ReadBlobExpression =>
+    case attr: AttributeReference if isBlobAttr(attr) =>
+      if (seen.add(attr.exprId)) result += attr
+    case other =>
+      other.children.foreach(walkDirectBlobRefs(_, seen, result))
+  }
+
+  private def isBlobAttr(attr: AttributeReference): Boolean = attr.dataType match {
+    case struct: StructType =>
+      DataType.equalsIgnoreCaseAndNullability(struct, org.apache.spark.sql.types.BlobType.dataType)
+    case _ => false
+  }
+
+  /**
+   * Resolve the effective value of `hoodie.read.blob.inline.mode` at plan time and
+   * return true if it is DESCRIPTOR.
+   *
+   * Precedence (highest first): per-read DataFrame option on a `HadoopFsRelation` →
+   * Spark session conf → catalog-table property (when present) → default (DESCRIPTOR).
+   * The per-read option captures `.option("hoodie.read.blob.inline.mode", "CONTENT")`
+   * on `spark.read.format("hudi")`, which is the typical way users disable this check
+   * for a single query.
+   *
+   * Returns true (DESCRIPTOR) when no relation can be located — i.e., the rule prefers
+   * to fail noisily for an unrecognized relation shape rather than silently let a
+   * mixed projection through. The error message tells the user how to opt out.
+   */
+  private def effectiveModeIsDescriptor(plan: LogicalPlan): Boolean = {
+    val modeKey = HoodieReaderConfig.BLOB_INLINE_READ_MODE.key()
+    val maybeLr: Option[LogicalRelation] = plan.collectFirst { case lr: LogicalRelation => lr }
+    val relationOpt: Option[String] = maybeLr.flatMap { lr =>
+      lr.relation match {
+        case hfs: HadoopFsRelation => hfs.options.get(modeKey)
+        case _ => None
+      }
+    }
+    val tableProps: Map[String, String] = maybeLr
+      .flatMap(_.catalogTable)
+      .map(_.properties.toMap)
+      .getOrElse(Map.empty)
+    val effective = relationOpt
+      .orElse(spark.conf.getOption(modeKey))
+      .orElse(tableProps.get(modeKey))
+      .getOrElse(HoodieReaderConfig.BLOB_INLINE_READ_MODE.defaultValue())
+    effective.equalsIgnoreCase(HoodieReaderConfig.BLOB_INLINE_READ_MODE_DESCRIPTOR)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ReadBlobRule.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ReadBlobRule.scala
@@ -19,14 +19,11 @@
 
 package org.apache.spark.sql.hudi.blob
 
-import org.apache.hudi.common.config.HoodieReaderConfig
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 import scala.collection.mutable
@@ -49,7 +46,6 @@ case class ReadBlobRule(spark: SparkSession) extends Rule[LogicalPlan] {
       if containsReadBlobExpression(projectList)
         && containsReadBlobInExpression(condition)
         && !child.isInstanceOf[BatchedBlobRead] =>
-      rejectMixedBlobProjection(projectList, child)
       val projectBlobCols = extractAllBlobColumns(projectList)
       val filterBlobCols = extractBlobColumnsFromExpression(condition)
       val blobColumns = (projectBlobCols ++ filterBlobCols)
@@ -75,7 +71,6 @@ case class ReadBlobRule(spark: SparkSession) extends Rule[LogicalPlan] {
       if containsReadBlobExpression(projectList)
         && !child.isInstanceOf[BatchedBlobRead] =>
 
-      rejectMixedBlobProjection(projectList, child)
       val blobColumns = extractAllBlobColumns(projectList)
       val (wrappedPlan, blobToDataAttr) = wrapWithBlobReads(blobColumns, child)
       val newProjectList = transformNamedExpressions(projectList, blobToDataAttr)
@@ -174,95 +169,5 @@ case class ReadBlobRule(spark: SparkSession) extends Rule[LogicalPlan] {
       throw new IllegalStateException("read_blob() must be called on a direct column reference")
     case other =>
       other.mapChildren(replaceReadBlobExpression(_, blobToDataAttr))
-  }
-
-  /**
-   * Reject queries that mix `read_blob(blob_col)` with a direct projection of any blob
-   * column when the effective inline read mode resolves to DESCRIPTOR.
-   */
-  private def rejectMixedBlobProjection(
-      projectList: Seq[Expression],
-      child: LogicalPlan): Unit = {
-    val directBlobRefs = collectDirectBlobRefs(projectList)
-    val readBlobCols = extractAllBlobColumns(projectList)
-    if (directBlobRefs.nonEmpty && readBlobCols.nonEmpty && effectiveModeIsDescriptor(child)) {
-      val readBlobNames = readBlobCols.map(_.name).distinct.mkString(", ")
-      val directNames = directBlobRefs.map(_.name).distinct.mkString(", ")
-      throw new AnalysisException(
-        s"Cannot mix read_blob() with direct blob-column projection under " +
-          s"${HoodieReaderConfig.BLOB_INLINE_READ_MODE.key()}=" +
-          s"${HoodieReaderConfig.BLOB_INLINE_READ_MODE_DESCRIPTOR}. read_blob() is " +
-          s"called on [$readBlobNames] while [$directNames] is projected directly in " +
-          s"the same query. Either set " +
-          s"${HoodieReaderConfig.BLOB_INLINE_READ_MODE.key()}=" +
-          s"${HoodieReaderConfig.BLOB_INLINE_READ_MODE_CONTENT} (returns inline bytes " +
-          s"for all INLINE rows), or remove the direct blob-column projection from " +
-          s"this query.")
-    }
-  }
-
-  /**
-   * Collect all blob columns referenced directly (i.e. NOT inside a `read_blob()`) in
-   * the given expression list. A blob column is an `AttributeReference` whose dataType
-   * is the `BlobType` struct.
-   */
-  private def collectDirectBlobRefs(
-      expressions: Seq[Expression]): Seq[AttributeReference] = {
-    val seen = mutable.LinkedHashSet.empty[ExprId]
-    val result = ArrayBuffer.empty[AttributeReference]
-    expressions.foreach(walkDirectBlobRefs(_, seen, result))
-    result.toSeq
-  }
-
-  private def walkDirectBlobRefs(
-      expr: Expression,
-      seen: mutable.Set[ExprId],
-      result: ArrayBuffer[AttributeReference]): Unit = expr match {
-    // Skip subtrees rooted at read_blob() — its argument is wrapped, not direct.
-    case _: ReadBlobExpression =>
-    case attr: AttributeReference if isBlobAttr(attr) =>
-      if (seen.add(attr.exprId)) result += attr
-    case other =>
-      other.children.foreach(walkDirectBlobRefs(_, seen, result))
-  }
-
-  private def isBlobAttr(attr: AttributeReference): Boolean = attr.dataType match {
-    case struct: StructType =>
-      DataType.equalsIgnoreCaseAndNullability(struct, org.apache.spark.sql.types.BlobType.dataType)
-    case _ => false
-  }
-
-  /**
-   * Resolve the effective value of `hoodie.read.blob.inline.mode` at plan time and
-   * return true if it is DESCRIPTOR.
-   *
-   * Precedence (highest first): per-read DataFrame option on a `HadoopFsRelation` →
-   * Spark session conf → catalog-table property (when present) → default (DESCRIPTOR).
-   * The per-read option captures `.option("hoodie.read.blob.inline.mode", "CONTENT")`
-   * on `spark.read.format("hudi")`, which is the typical way users disable this check
-   * for a single query.
-   *
-   * Returns true (DESCRIPTOR) when no relation can be located — i.e., the rule prefers
-   * to fail noisily for an unrecognized relation shape rather than silently let a
-   * mixed projection through. The error message tells the user how to opt out.
-   */
-  private def effectiveModeIsDescriptor(plan: LogicalPlan): Boolean = {
-    val modeKey = HoodieReaderConfig.BLOB_INLINE_READ_MODE.key()
-    val maybeLr: Option[LogicalRelation] = plan.collectFirst { case lr: LogicalRelation => lr }
-    val relationOpt: Option[String] = maybeLr.flatMap { lr =>
-      lr.relation match {
-        case hfs: HadoopFsRelation => hfs.options.get(modeKey)
-        case _ => None
-      }
-    }
-    val tableProps: Map[String, String] = maybeLr
-      .flatMap(_.catalogTable)
-      .map(_.properties.toMap)
-      .getOrElse(Map.empty)
-    val effective = relationOpt
-      .orElse(spark.conf.getOption(modeKey))
-      .orElse(tableProps.get(modeKey))
-      .getOrElse(HoodieReaderConfig.BLOB_INLINE_READ_MODE.defaultValue())
-    effective.equalsIgnoreCase(HoodieReaderConfig.BLOB_INLINE_READ_MODE_DESCRIPTOR)
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
@@ -83,7 +83,7 @@ object ScalarFunctions {
           |
           |Caveat:
           |  Throws on INLINE rows under hoodie.read.blob.inline.mode=DESCRIPTOR.
-          |  Set CONTENT mode or read col.data directly to materialize INLINE bytes.
+          |  Set CONTENT mode directly to materialize INLINE bytes.
           |
           |Performance:
           |  - Configure batching: hoodie.blob.batching.max.gap.bytes (default 4096)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
@@ -81,6 +81,10 @@ object ScalarFunctions {
           |Returns:
           |  Binary data read from the file
           |
+          |Caveat:
+          |  Throws on INLINE rows under hoodie.read.blob.inline.mode=DESCRIPTOR.
+          |  Set CONTENT mode or read col.data directly to materialize INLINE bytes.
+          |
           |Performance:
           |  - Configure batching: hoodie.blob.batching.max.gap.bytes (default 4096)
           |  - Configure lookahead: hoodie.blob.batching.lookahead.size (default 50)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
@@ -82,12 +82,8 @@ object ScalarFunctions {
           |  Binary data read from the file
           |
           |Caveat:
-          |  On Lance tables under hoodie.read.blob.inline.mode=DESCRIPTOR (the default),
-          |  read_blob() materializes bytes via a 2-hop pread against the synthesized
-          |  reference. A query that mixes read_blob(col) with a direct projection of
-          |  any blob column in the same SELECT is rejected at plan time. Either set
-          |  hoodie.read.blob.inline.mode=CONTENT or restructure the projection.
-          |  Parquet currently ignores this mode and is unaffected.
+          |  Throws on INLINE rows under hoodie.read.blob.inline.mode=DESCRIPTOR.
+          |  Set CONTENT mode directly to materialize INLINE bytes.
           |
           |Performance:
           |  - Configure batching: hoodie.blob.batching.max.gap.bytes (default 4096)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
@@ -82,8 +82,12 @@ object ScalarFunctions {
           |  Binary data read from the file
           |
           |Caveat:
-          |  Throws on INLINE rows under hoodie.read.blob.inline.mode=DESCRIPTOR.
-          |  Set CONTENT mode directly to materialize INLINE bytes.
+          |  On Lance tables under hoodie.read.blob.inline.mode=DESCRIPTOR (the default),
+          |  read_blob() materializes bytes via a 2-hop pread against the synthesized
+          |  reference. A query that mixes read_blob(col) with a direct projection of
+          |  any blob column in the same SELECT is rejected at plan time. Either set
+          |  hoodie.read.blob.inline.mode=CONTENT or restructure the projection.
+          |  Parquet currently ignores this mode and is unaffected.
           |
           |Performance:
           |  - Configure batching: hoodie.blob.batching.max.gap.bytes (default 4096)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
@@ -83,7 +83,7 @@ object ScalarFunctions {
           |
           |Caveat:
           |  Throws on INLINE rows under hoodie.read.blob.inline.mode=DESCRIPTOR.
-          |  Set CONTENT mode or read col.data directly to materialize INLINE bytes.
+          |  Set CONTENT mode to materialize INLINE bytes.
           |
           |Performance:
           |  - Configure batching: hoodie.blob.batching.max.gap.bytes (default 4096)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/blob/ScalarFunctions.scala
@@ -83,7 +83,7 @@ object ScalarFunctions {
           |
           |Caveat:
           |  Throws on INLINE rows under hoodie.read.blob.inline.mode=DESCRIPTOR.
-          |  Set CONTENT mode directly to materialize INLINE bytes.
+          |  Set CONTENT mode or read col.data directly to materialize INLINE bytes.
           |
           |Performance:
           |  - Configure batching: hoodie.blob.batching.max.gap.bytes (default 4096)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -36,7 +36,7 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.types._
-import org.junit.jupiter.api.{AfterEach, BeforeEach}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertFalse, assertNotNull, assertTrue}
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.junit.jupiter.params.ParameterizedTest
@@ -851,8 +851,11 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     // Writer-side: prove the bytes actually routed through Lance's dedicated blob writer.
     assertLanceBlobEncoding(tablePath)
 
-    // Reader-side: in CONTENT mode the INLINE bytes come back directly in `data`.
-    val readRows = spark.read.format("hudi").load(tablePath)
+    // Reader-side: in CONTENT mode the INLINE bytes come back directly in `data`. Set the mode
+    // explicitly — the default is DESCRIPTOR, which would surface a reference instead.
+    val readRows = spark.read.format("hudi")
+      .option("hoodie.read.blob.inline.mode", "CONTENT")
+      .load(tablePath)
       .select($"id", $"payload")
       .orderBy($"id")
       .collect()
@@ -971,6 +974,115 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       val bytes = row.getAs[Array[Byte]]("bytes")
       assertArrayEquals(expectedPayloads(i), bytes,
         s"read_blob() bytes mismatch for id=$i")
+    }
+  }
+
+  /**
+   * Compaction must preserve INLINE blob bytes under the DESCRIPTOR default. MOR compaction reads
+   * the base file via {@link HoodieSparkLanceReader}, which hard-pins CONTENT regardless of the
+   * user-facing {@code hoodie.read.blob.inline.mode}. If that pin were to honor the default
+   * (DESCRIPTOR), compaction would read null {@code data} and rewrite a base file without bytes,
+   * silently corrupting untouched rows. This test inserts INLINE blobs, upserts a subset to force
+   * compaction, and asserts that touched rows carry the new bytes while untouched rows retain the
+   * originals.
+   */
+  @Test
+  def testBlobInlineCompactionRoundTrip(): Unit = {
+    val tableType = HoodieTableType.MERGE_ON_READ
+    val tableName = "test_lance_blob_inline_compact_mor"
+    val tablePath = s"$basePath/$tableName"
+
+    val payloadLen = 1024
+    val numRows = 6
+    val initialPayloads: Seq[Array[Byte]] = (0 until numRows).map { i =>
+      (0 until payloadLen).map(j => ((i + j) % 256).toByte).toArray
+    }
+    val sparkSess = spark
+    import sparkSess.implicits._
+
+    val canonicalSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("payload", BlobType().asInstanceOf[StructType], nullable = true,
+        BlobTestHelpers.blobMetadata)
+    ))
+    def asInlineDf(idToBytes: Seq[(Int, Array[Byte])]): DataFrame = {
+      val rawDf = idToBytes.toDF("id", "bytes")
+        .select($"id", BlobTestHelpers.inlineBlobStructCol("payload", $"bytes"))
+      spark.createDataFrame(rawDf.rdd, canonicalSchema)
+    }
+
+    // First commit: bulk_insert ids 0..5 with the initial pattern. Lands in a base file.
+    writeDataframe(tableType, tableName, tablePath,
+      asInlineDf(initialPayloads.zipWithIndex.map { case (b, i) => (i, b) }),
+      saveMode = SaveMode.Overwrite,
+      operation = Some("bulk_insert"),
+      extraOptions = Map(PRECOMBINE_FIELD.key() -> "id"))
+
+    assertLanceBlobEncoding(tablePath)
+
+    // Second commit: upsert ids 0..2 with all-0xEE payloads, triggering inline compaction. The
+    // compactor reads the base file + log via the CONTENT-pinned reader and rewrites a new base
+    // file. Ids 3..5 are untouched: their bytes must survive the compaction read/rewrite even
+    // though the user-facing default is now DESCRIPTOR.
+    val updatedPayloadByte: Byte = 0xEE.toByte
+    val updatedIds = 0 until 3
+    val updatedPayloads = updatedIds.map(i => (i, Array.fill[Byte](payloadLen)(updatedPayloadByte)))
+    writeDataframe(tableType, tableName, tablePath,
+      asInlineDf(updatedPayloads),
+      operation = Some("upsert"),
+      extraOptions = Map(PRECOMBINE_FIELD.key() -> "id",
+        "hoodie.compact.inline" -> "true",
+        "hoodie.compact.inline.max.delta.commits" -> "1"))
+
+    val metaClient = HoodieTableMetaClient.builder()
+      .setConf(HoodieTestUtils.getDefaultStorageConf)
+      .setBasePath(tablePath)
+      .build()
+    val compactionCommits = metaClient.reloadActiveTimeline().filterCompletedInstants()
+      .getInstants.asScala.filter(_.getAction == "commit")
+    assertTrue(compactionCommits.nonEmpty, "Compaction commit should be present after upsert")
+
+    val expected: Map[Int, Array[Byte]] = (
+      updatedIds.map(i => i -> Array.fill[Byte](payloadLen)(updatedPayloadByte)) ++
+        (updatedIds.length until numRows).map(i => i -> initialPayloads(i))
+      ).toMap
+
+    // Verify via the realistic user-facing path. After the flip, a plain read yields the
+    // DESCRIPTOR shape: INLINE type, null `data`, populated reference. This confirms the new
+    // default is in effect end-to-end.
+    val readRows = spark.read.format("hudi")
+      .load(tablePath)
+      .select($"id", $"payload")
+      .orderBy($"id")
+      .collect()
+    assertEquals(numRows, readRows.length)
+    readRows.foreach { row =>
+      val id = row.getInt(row.fieldIndex("id"))
+      val payload = row.getStruct(row.fieldIndex("payload"))
+      assertEquals(HoodieSchema.Blob.INLINE,
+        payload.getString(payload.fieldIndex(HoodieSchema.Blob.TYPE)),
+        s"Type must remain INLINE post-compaction (id=$id)")
+      assertTrue(payload.isNullAt(payload.fieldIndex(HoodieSchema.Blob.INLINE_DATA_FIELD)),
+        s"DESCRIPTOR default should null `data` on plain read (id=$id)")
+      assertNotNull(payload.getStruct(payload.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE)),
+        s"DESCRIPTOR default should populate reference on plain read (id=$id)")
+    }
+
+    // read_blob() is the canonical bytes-materializing path under the DESCRIPTOR default. The
+    // bytes can only come back if (a) HoodieSparkLanceReader's CONTENT pin held during the
+    // compactor's base-file read — otherwise untouched ids 3..5 would have been rewritten with
+    // null `data` — and (b) the compacted base file retained Lance blob encoding so the
+    // synthesized descriptor's positional read resolves. Failure on either side surfaces here.
+    val viewName = s"${tableName}_view"
+    spark.read.format("hudi").load(tablePath).createOrReplaceTempView(viewName)
+    val materialized = spark.sql(
+      s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
+    assertEquals(numRows, materialized.length)
+    materialized.foreach { row =>
+      val id = row.getInt(row.fieldIndex("id"))
+      val bytes = row.getAs[Array[Byte]]("bytes")
+      assertArrayEquals(expected(id), bytes,
+        s"read_blob() must return correct bytes post-compaction (id=$id)")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -988,24 +988,6 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       .flatMap(t => Option(t.getMessage)).mkString(" | ")
     assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
       s"error must mention INLINE and DESCRIPTOR; got: $msgChain")
-
-    // Same table, same rows, but read under CONTENT mode: read_blob() takes the 1-hop
-    // passthrough of inline_data and must return the originally-written bytes. This pins the
-    // write -> read roundtrip integrity for INLINE blobs (compaction/merge included for MOR)
-    // independently of the DESCRIPTOR-shape verification above.
-    val contentViewName = s"${tableName}_content_view"
-    spark.read.format("hudi")
-      .option(modeKey, "CONTENT")
-      .load(tablePath)
-      .createOrReplaceTempView(contentViewName)
-    val materialized = spark.sql(
-      s"SELECT id, read_blob(payload) AS bytes FROM $contentViewName ORDER BY id").collect()
-    assertEquals(numRows, materialized.length)
-    materialized.zipWithIndex.foreach { case (row, i) =>
-      assertEquals(i, row.getInt(row.fieldIndex("id")))
-      assertArrayEquals(expectedPayloads(i), row.getAs[Array[Byte]]("bytes"),
-        s"read_blob() bytes mismatch under CONTENT mode (id=$i)")
-    }
   }
 
   /**
@@ -1130,16 +1112,15 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
   /**
    * Plain struct projection across two INLINE blob columns: {@code SELECT payload_a, payload_b
-   * FROM table}. Each mode independently:
+   * FROM table}. The single-column shape is already pinned by {@code testBlobInlineRoundTrip}
+   * (CONTENT) and {@code testBlobInlineDescriptorMode} (DESCRIPTOR); this test only asserts the
+   * per-column-independence properties that are unique to the multi-column case:
    *
-   *   - CONTENT: both columns come back with {@code type=INLINE} and {@code data=bytes}. The
-   *     {@code reference} struct may be present with all-null leaves (Lance quirk — see
-   *     {@code testBlobInlineRoundTrip}); the test only requires {@code external_path} to be
-   *     null on it so downstream consumers can't mistake it for a real OUT_OF_LINE pointer.
-   *   - DESCRIPTOR (default): both columns come back with {@code type=INLINE, data=NULL} and a
-   *     populated synthesized {@code reference} (path ending in {@code .lance}, length equal
-   *     to the written payload, {@code is_managed=true}). Asserting on both columns confirms
-   *     the descriptor synthesis is per-column, not first-column-only.
+   *   - CONTENT: each column's {@code data} carries its own written bytes (distinct byte
+   *     patterns per column rule out cross-column aliasing).
+   *   - DESCRIPTOR (default): both columns independently get {@code data=null} and a populated
+   *     synthesized {@code reference} — i.e. the synthesis fires per-column, not just on the
+   *     first blob column.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -1153,7 +1134,8 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     import sparkSess.implicits._
     val modeKey = "hoodie.read.blob.inline.mode"
 
-    // CONTENT: data=bytes on both columns; reference (if present) has null external_path.
+    // CONTENT: per-column bytes must not alias — payload_a carries payloadsA, payload_b carries
+    // payloadsB. The byte patterns differ by construction (see writeMultiBlobInlineTable).
     val contentRows = spark.read.format("hudi")
       .option(modeKey, "CONTENT")
       .load(tablePath)
@@ -1162,25 +1144,17 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       .collect()
     assertEquals(numRows, contentRows.length)
     contentRows.zipWithIndex.foreach { case (row, i) =>
-      Seq(("payload_a", payloadsA(i)), ("payload_b", payloadsB(i))).foreach {
-        case (col, expected) =>
-          val payload = row.getStruct(row.fieldIndex(col))
-          assertEquals(HoodieSchema.Blob.INLINE,
-            payload.getString(payload.fieldIndex(HoodieSchema.Blob.TYPE)),
-            s"$col: type should remain INLINE under CONTENT (id=$i)")
-          assertArrayEquals(expected,
-            payload.getAs[Array[Byte]](HoodieSchema.Blob.INLINE_DATA_FIELD),
-            s"$col: data should match written bytes under CONTENT (id=$i)")
-          val refIdx = payload.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE)
-          if (!payload.isNullAt(refIdx)) {
-            val ref = payload.getStruct(refIdx)
-            assertTrue(ref.isNullAt(ref.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH)),
-              s"$col: reference.external_path should be null under CONTENT (id=$i)")
-          }
-      }
+      val a = row.getStruct(row.fieldIndex("payload_a"))
+      val b = row.getStruct(row.fieldIndex("payload_b"))
+      assertArrayEquals(payloadsA(i), a.getAs[Array[Byte]](HoodieSchema.Blob.INLINE_DATA_FIELD),
+        s"payload_a: bytes must match written payloadsA under CONTENT (id=$i)")
+      assertArrayEquals(payloadsB(i), b.getAs[Array[Byte]](HoodieSchema.Blob.INLINE_DATA_FIELD),
+        s"payload_b: bytes must match written payloadsB under CONTENT (id=$i)")
     }
 
-    // DESCRIPTOR (default): data=NULL, populated synthesized reference on both columns.
+    // DESCRIPTOR (default): descriptor synthesis must fire per-column. data=null and a
+    // populated reference on BOTH columns is the property that distinguishes this from the
+    // single-column DESCRIPTOR test.
     val descRows = spark.read.format("hudi")
       .load(tablePath)
       .select($"id", $"payload_a", $"payload_b")
@@ -1191,33 +1165,24 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       val id = row.getInt(row.fieldIndex("id"))
       Seq("payload_a", "payload_b").foreach { col =>
         val payload = row.getStruct(row.fieldIndex(col))
-        assertEquals(HoodieSchema.Blob.INLINE,
-          payload.getString(payload.fieldIndex(HoodieSchema.Blob.TYPE)),
-          s"$col: type should remain INLINE under DESCRIPTOR (id=$id)")
         assertTrue(payload.isNullAt(payload.fieldIndex(HoodieSchema.Blob.INLINE_DATA_FIELD)),
           s"$col: data should be null under DESCRIPTOR (id=$id)")
-        val ref = payload.getStruct(payload.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE))
-        assertNotNull(ref,
+        assertNotNull(payload.getStruct(payload.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE)),
           s"$col: reference should be populated under DESCRIPTOR (id=$id)")
-        assertEquals(payloadLen.toLong,
-          ref.getLong(ref.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE_LENGTH)),
-          s"$col: reference.length should equal payload length (id=$id)")
-        assertTrue(ref.getBoolean(ref.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED)),
-          s"$col: synthesized reference should be flagged managed (id=$id)")
       }
     }
   }
 
   /**
-   * Materializing both INLINE blob columns via {@code read_blob()} in a single query:
-   * {@code SELECT read_blob(payload_a), read_blob(payload_b) FROM table}.
+   * Materializing both INLINE blob columns via {@code read_blob()} in a single query under
+   * CONTENT mode: {@code SELECT read_blob(payload_a), read_blob(payload_b) FROM table}. Each
+   * column must resolve via the 1-hop {@code inline_data} passthrough with its own bytes —
+   * distinct byte patterns per column would surface a cross-column aliasing regression.
    *
-   *   - CONTENT: both columns resolve via the 1-hop {@code inline_data} passthrough. The bytes
-   *     for each column must match their respective written payloads — distinct byte patterns
-   *     are used per column so a cross-column aliasing regression would surface as a mismatch.
-   *   - DESCRIPTOR (default): the call throws. INLINE+DESCRIPTOR rejects {@code read_blob()}
-   *     regardless of which column trips the branch first, so the error chain must name both
-   *     INLINE and DESCRIPTOR for the failure to be actionable.
+   * The DESCRIPTOR-mode failure path for {@code read_blob()} on INLINE rows is pinned by
+   * {@code testBlobInlineDescriptorMode} (single column) and {@code
+   * testBlobInlineMultipleColumnsMixedSelect} (one read_blob + one struct projection); it is
+   * not re-asserted here.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -1228,7 +1193,6 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       tableType, tableName, numRows)
     val modeKey = "hoodie.read.blob.inline.mode"
 
-    // CONTENT: read_blob() on both columns materializes correct bytes via 1-hop passthrough.
     val contentView = s"${tableName}_content_view"
     spark.read.format("hudi")
       .option(modeKey, "CONTENT")
@@ -1245,24 +1209,6 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       assertArrayEquals(payloadsB(i), row.getAs[Array[Byte]]("bytes_b"),
         s"read_blob(payload_b) should match under CONTENT (id=$i)")
     }
-
-    // DESCRIPTOR (default): read_blob() on either INLINE column must throw.
-    val descView = s"${tableName}_desc_view"
-    spark.read.format("hudi")
-      .load(tablePath)
-      .createOrReplaceTempView(descView)
-    val ex = assertThrows(classOf[Throwable], new Executable {
-      override def execute(): Unit = {
-        spark.sql(
-          s"SELECT id, read_blob(payload_a) AS bytes_a, read_blob(payload_b) AS bytes_b " +
-            s"FROM $descView ORDER BY id").collect()
-      }
-    })
-    val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
-      .flatMap(t => Option(t.getMessage)).mkString(" | ")
-    assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
-      s"read_blob() on either INLINE column under DESCRIPTOR must throw with " +
-        s"INLINE+DESCRIPTOR error; got: $msgChain")
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -880,9 +880,13 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       }
     }
 
-    // read_blob() resolution path: INLINE payloads resolve to the same bytes.
+    // read_blob() resolution path: INLINE payloads resolve to the same bytes. CONTENT is set
+    // explicitly here — under the DESCRIPTOR default, read_blob() throws for INLINE rows.
     val viewName = s"${tableName}_view"
-    spark.read.format("hudi").load(tablePath).createOrReplaceTempView(viewName)
+    spark.read.format("hudi")
+      .option("hoodie.read.blob.inline.mode", "CONTENT")
+      .load(tablePath)
+      .createOrReplaceTempView(viewName)
     val materialized = spark.sql(
       s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
     assertEquals(numRows, materialized.length)
@@ -1170,13 +1174,16 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
         s"DESCRIPTOR default should populate reference on plain read (id=$id)")
     }
 
-    // read_blob() is the canonical bytes-materializing path under the DESCRIPTOR default. The
-    // bytes can only come back if (a) HoodieSparkLanceReader's CONTENT pin held during the
-    // compactor's base-file read — otherwise untouched ids 3..5 would have been rewritten with
-    // null `data` — and (b) the compacted base file retained Lance blob encoding so the
-    // synthesized descriptor's positional read resolves. Failure on either side surfaces here.
+    // read_blob() under CONTENT mode is what we use to verify the post-compaction bytes
+    // because read_blob() on INLINE rows throws under the DESCRIPTOR default. The bytes can
+    // only come back if HoodieSparkLanceReader's CONTENT pin held during the compactor's
+    // base-file read — otherwise untouched ids 3..5 would have been rewritten with null
+    // `data` and CONTENT-mode read would surface that.
     val viewName = s"${tableName}_view"
-    spark.read.format("hudi").load(tablePath).createOrReplaceTempView(viewName)
+    spark.read.format("hudi")
+      .option("hoodie.read.blob.inline.mode", "CONTENT")
+      .load(tablePath)
+      .createOrReplaceTempView(viewName)
     val materialized = spark.sql(
       s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
     assertEquals(numRows, materialized.length)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -907,12 +907,10 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
    * DESCRIPTOR mode on INLINE rows: user writes `data` bytes; on read with
    * `hoodie.read.blob.inline.mode=DESCRIPTOR` each row comes back with type still set to
    * {@code INLINE} (preserving the original storage mode) but with {@code data=null} and a
-   * populated synthesized {@code reference} pointing at the Lance file. A pure
-   * {@code SELECT read_blob(col)} query still resolves bytes — {@code BatchedBlobReader}
-   * materializes them via a 2-hop pread against the synthesized reference, reusing the same
-   * range-merged pread path used for OUT_OF_LINE rows. The synthesized reference is treated
-   * as an internal pointer; the mixed-projection variants are pinned separately in
-   * {@code testBlobInlineMixedProjection*}.
+   * populated synthesized {@code reference} pointing at the Lance file. The synthesized
+   * reference is an internal pointer, not user-facing storage. {@code read_blob()} is
+   * therefore unsupported on INLINE rows in this mode and must throw a clear error so
+   * callers don't conflate the synthesized pointer with durable metadata.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -972,22 +970,24 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
         s"synthetic reference to the Lance file should be flagged managed (id=$i)")
     }
 
-    // read_blob() under DESCRIPTOR mode resolves bytes via the 2-hop pread against the
-    // synthesized reference. The bytes must equal what was written — proves the synthesized
-    // reference points at the correct (path, offset, length) tuple inside the .lance file.
+    // read_blob() on INLINE rows under DESCRIPTOR mode is unsupported by design: DESCRIPTOR
+    // is metadata-only and the synthesized reference is an internal pointer into the .lance
+    // file's storage layout, not user-facing metadata. BatchedBlobReader must throw with a
+    // message that names both INLINE and DESCRIPTOR so the failure is actionable.
     val viewName = s"${tableName}_view"
     spark.read.format("hudi")
       .option(modeKey, "DESCRIPTOR")
       .load(tablePath)
       .createOrReplaceTempView(viewName)
-    val materialized = spark.sql(
-      s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
-    assertEquals(numRows, materialized.length)
-    materialized.zipWithIndex.foreach { case (row, i) =>
-      assertEquals(i, row.getInt(row.fieldIndex("id")))
-      assertArrayEquals(expectedPayloads(i), row.getAs[Array[Byte]]("bytes"),
-        s"read_blob() under DESCRIPTOR must return original bytes via 2-hop pread (id=$i)")
-    }
+    val ex = assertThrows(classOf[Throwable], new Executable {
+      override def execute(): Unit = {
+        spark.sql(s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
+      }
+    })
+    val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
+      .flatMap(t => Option(t.getMessage)).mkString(" | ")
+    assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
+      s"error must mention INLINE and DESCRIPTOR; got: $msgChain")
   }
 
   /**
@@ -1174,16 +1174,15 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
   }
 
   /**
-   * Materializing both INLINE blob columns via {@code read_blob()} in a single query:
-   * {@code SELECT read_blob(payload_a), read_blob(payload_b) FROM table}.
+   * Materializing both INLINE blob columns via {@code read_blob()} in a single query under
+   * CONTENT mode: {@code SELECT read_blob(payload_a), read_blob(payload_b) FROM table}. Each
+   * column must resolve via the 1-hop {@code inline_data} passthrough with its own bytes —
+   * distinct byte patterns per column would surface a cross-column aliasing regression.
    *
-   *   - CONTENT: both columns resolve via the 1-hop {@code inline_data} passthrough.
-   *   - DESCRIPTOR (default): the projection wraps every blob column in {@code read_blob()}
-   *     (no direct blob projection), so the analyzer's mixed-projection check does not fire
-   *     and {@code BatchedBlobReader} materializes bytes via the 2-hop pread against each
-   *     row's synthesized reference.
-   *
-   * Distinct byte patterns per column guard against cross-column aliasing under both modes.
+   * The DESCRIPTOR-mode failure path for {@code read_blob()} on INLINE rows is pinned by
+   * {@code testBlobInlineDescriptorMode} (single column) and {@code
+   * testBlobInlineMultipleColumnsMixedSelect} (one read_blob + one struct projection); it is
+   * not re-asserted here.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -1199,50 +1198,33 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       .option(modeKey, "CONTENT")
       .load(tablePath)
       .createOrReplaceTempView(contentView)
-    val contentMaterialized = spark.sql(
+    val materialized = spark.sql(
       s"SELECT id, read_blob(payload_a) AS bytes_a, read_blob(payload_b) AS bytes_b " +
         s"FROM $contentView ORDER BY id").collect()
-    assertEquals(numRows, contentMaterialized.length)
-    contentMaterialized.zipWithIndex.foreach { case (row, i) =>
+    assertEquals(numRows, materialized.length)
+    materialized.zipWithIndex.foreach { case (row, i) =>
       assertEquals(i, row.getInt(row.fieldIndex("id")))
       assertArrayEquals(payloadsA(i), row.getAs[Array[Byte]]("bytes_a"),
         s"read_blob(payload_a) should match under CONTENT (id=$i)")
       assertArrayEquals(payloadsB(i), row.getAs[Array[Byte]]("bytes_b"),
         s"read_blob(payload_b) should match under CONTENT (id=$i)")
     }
-
-    // DESCRIPTOR (default): both columns wrapped in read_blob() — no direct projection, so
-    // the mixed-projection analyzer error does not fire. BatchedBlobReader resolves bytes
-    // via the 2-hop pread against each row's synthesized reference. Bytes must match.
-    val descView = s"${tableName}_desc_view"
-    spark.read.format("hudi")
-      .load(tablePath)
-      .createOrReplaceTempView(descView)
-    val descMaterialized = spark.sql(
-      s"SELECT id, read_blob(payload_a) AS bytes_a, read_blob(payload_b) AS bytes_b " +
-        s"FROM $descView ORDER BY id").collect()
-    assertEquals(numRows, descMaterialized.length)
-    descMaterialized.zipWithIndex.foreach { case (row, i) =>
-      assertEquals(i, row.getInt(row.fieldIndex("id")))
-      assertArrayEquals(payloadsA(i), row.getAs[Array[Byte]]("bytes_a"),
-        s"read_blob(payload_a) should match under DESCRIPTOR via 2-hop pread (id=$i)")
-      assertArrayEquals(payloadsB(i), row.getAs[Array[Byte]]("bytes_b"),
-        s"read_blob(payload_b) should match under DESCRIPTOR via 2-hop pread (id=$i)")
-    }
   }
 
   /**
    * Mixed projection across two INLINE blob columns: {@code SELECT read_blob(payload_a),
    * payload_b FROM table}. One column is materialized via {@code read_blob()}, the other is
-   * left as a struct.
+   * left as a struct. This is the case explicitly raised in PR review — under the DESCRIPTOR
+   * default, a mixed query asking for bytes on one column and a pointer on another must fail
+   * loudly rather than silently returning one materialized and one synthesized shape.
    *
    *   - CONTENT: {@code payload_a} resolves to bytes (1-hop), {@code payload_b} comes back as
    *     the same content-shape struct as {@code testBlobInlineMultipleColumnsPlainSelect}
-   *     (data=bytes, reference present-but-empty).
-   *   - DESCRIPTOR (default): {@code ReadBlobRule} rejects the query at plan time with an
-   *     {@code AnalysisException}. Returning materialized bytes for one column alongside a
-   *     synthesized descriptor reference for another in the same row is misleading — the
-   *     synthesized reference is an internal Lance pointer, not durable metadata.
+   *     (data=bytes, reference present-but-empty). Pinning both shapes in the same row
+   *     confirms the projection doesn't bleed across columns.
+   *   - DESCRIPTOR (default): the {@code read_blob()} call on {@code payload_a} still hits
+   *     the INLINE+DESCRIPTOR branch even though {@code payload_b} is only being projected as
+   *     a struct. {@code payload_b}'s shape doesn't soften the failure.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -1282,9 +1264,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       }
     }
 
-    // DESCRIPTOR (default): the mixed projection is rejected at plan time by ReadBlobRule.
-    // The error must be analyzer-time (AnalysisException), not a runtime BatchedBlobReader
-    // throw, and the message must name both blob columns and the config key so it's actionable.
+    // DESCRIPTOR (default): read_blob(payload_a) trips even though payload_b is just a struct.
     val descView = s"${tableName}_desc_view"
     spark.read.format("hudi")
       .load(tablePath)
@@ -1298,96 +1278,9 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     })
     val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
       .flatMap(t => Option(t.getMessage)).mkString(" | ")
-    assertTrue(msgChain.contains("mix read_blob()") && msgChain.contains("payload_a") &&
-      msgChain.contains("payload_b") && msgChain.contains("DESCRIPTOR"),
-      s"mixed projection under DESCRIPTOR must throw an analyzer error naming both columns " +
-        s"and the mode; got: $msgChain")
-  }
-
-  /**
-   * Mixed projection on the **same** blob column: {@code SELECT read_blob(payload), payload
-   * FROM table}. This is the variant of {@code testBlobInlineMultipleColumnsMixedSelect}
-   * that uses a single blob column twice — once wrapped in {@code read_blob()} and once
-   * projected directly.
-   *
-   *   - CONTENT: succeeds. {@code read_blob(payload)} returns bytes (1-hop) and the direct
-   *     {@code payload} projection returns the content-shape struct. Both come from the
-   *     same source row but Spark resolves each independently.
-   *   - DESCRIPTOR (default): rejected at plan time by {@code ReadBlobRule}. The error must
-   *     name the column and the config key.
-   */
-  @ParameterizedTest
-  @EnumSource(value = classOf[HoodieTableType])
-  def testBlobInlineMixedProjectionSameColumn(tableType: HoodieTableType): Unit = {
-    val tableName = s"test_lance_blob_mixed_same_col_${tableType.name().toLowerCase}"
-    val tablePath = s"$basePath/$tableName"
-
-    val payloadLen = 512
-    val numRows = 4
-    val expectedPayloads: Seq[Array[Byte]] = (0 until numRows).map { i =>
-      (0 until payloadLen).map(j => ((i + j) % 256).toByte).toArray
-    }
-    val sparkSess = spark
-    import sparkSess.implicits._
-
-    val rawDf = expectedPayloads.zipWithIndex.map { case (b, i) => (i, b) }
-      .toDF("id", "bytes")
-      .select($"id", BlobTestHelpers.inlineBlobStructCol("payload", $"bytes"))
-    val canonicalSchema = StructType(Seq(
-      StructField("id", IntegerType, nullable = false),
-      StructField("payload", BlobType().asInstanceOf[StructType], nullable = true,
-        BlobTestHelpers.blobMetadata)
-    ))
-    val df = spark.createDataFrame(rawDf.rdd, canonicalSchema)
-    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite,
-      operation = Some("bulk_insert"),
-      extraOptions = Map(PRECOMBINE_FIELD.key() -> "id"))
-    assertLanceBlobEncoding(tablePath)
-
-    val modeKey = "hoodie.read.blob.inline.mode"
-
-    // CONTENT: both projections resolve independently — read_blob(payload) returns bytes,
-    // direct payload returns content-shape struct.
-    val contentView = s"${tableName}_content_view"
-    spark.read.format("hudi")
-      .option(modeKey, "CONTENT")
-      .load(tablePath)
-      .createOrReplaceTempView(contentView)
-    val rows = spark.sql(
-      s"SELECT id, read_blob(payload) AS bytes, payload " +
-        s"FROM $contentView ORDER BY id").collect()
-    assertEquals(numRows, rows.length)
-    rows.zipWithIndex.foreach { case (row, i) =>
-      assertEquals(i, row.getInt(row.fieldIndex("id")))
-      assertArrayEquals(expectedPayloads(i), row.getAs[Array[Byte]]("bytes"),
-        s"read_blob(payload) should return bytes under CONTENT (id=$i)")
-      val payload = row.getStruct(row.fieldIndex("payload"))
-      assertEquals(HoodieSchema.Blob.INLINE,
-        payload.getString(payload.fieldIndex(HoodieSchema.Blob.TYPE)),
-        s"direct payload: type should remain INLINE under CONTENT (id=$i)")
-      assertArrayEquals(expectedPayloads(i),
-        payload.getAs[Array[Byte]](HoodieSchema.Blob.INLINE_DATA_FIELD),
-        s"direct payload: data should match written bytes under CONTENT (id=$i)")
-    }
-
-    // DESCRIPTOR (default): analyzer rejects with a structured message naming the column.
-    val descView = s"${tableName}_desc_view"
-    spark.read.format("hudi")
-      .load(tablePath)
-      .createOrReplaceTempView(descView)
-    val ex = assertThrows(classOf[Throwable], new Executable {
-      override def execute(): Unit = {
-        spark.sql(
-          s"SELECT id, read_blob(payload) AS bytes, payload " +
-            s"FROM $descView ORDER BY id").collect()
-      }
-    })
-    val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
-      .flatMap(t => Option(t.getMessage)).mkString(" | ")
-    assertTrue(msgChain.contains("mix read_blob()") && msgChain.contains("payload") &&
-      msgChain.contains("DESCRIPTOR"),
-      s"same-column mixed projection under DESCRIPTOR must throw an analyzer error naming " +
-        s"the column and the mode; got: $msgChain")
+    assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
+      s"read_blob(payload_a) under DESCRIPTOR must throw INLINE+DESCRIPTOR error even when " +
+        s"mixed with a struct projection of another blob column; got: $msgChain")
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -975,6 +975,30 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       assertArrayEquals(expectedPayloads(i), bytes,
         s"read_blob() bytes mismatch for id=$i")
     }
+
+    // Mixed-usage regression: read_blob(payload) co-projected with payload.reference.* in a
+    // single SELECT. The INLINE-descriptor fallback in BatchedBlobReader is load-bearing, if
+    // read_blob() forced the scan to CONTENT shape, reference.* would all be null here.
+    val mixed = spark.sql(
+      s"""SELECT id,
+         |       read_blob(payload)              AS bytes,
+         |       payload.reference.external_path AS ext_path,
+         |       payload.reference.offset        AS off,
+         |       payload.reference.length        AS len
+         |  FROM $viewName ORDER BY id""".stripMargin).collect()
+    assertEquals(numRows, mixed.length)
+    mixed.zipWithIndex.foreach { case (row, i) =>
+      assertArrayEquals(expectedPayloads(i), row.getAs[Array[Byte]]("bytes"),
+        s"read_blob() bytes must survive co-projection with reference.* (id=$i)")
+      val ext = row.getAs[String]("ext_path")
+      assertNotNull(ext, s"reference.external_path must survive read_blob co-usage (id=$i)")
+      assertTrue(ext.endsWith(".lance"), s"external_path should point at .lance, got: $ext (id=$i)")
+      assertFalse(row.isNullAt(row.fieldIndex("off")),
+        s"reference.offset must not be null when co-selected with read_blob (id=$i)")
+      assertTrue(row.getLong(row.fieldIndex("off")) >= 0L)
+      assertEquals(payloadLen.toLong, row.getLong(row.fieldIndex("len")),
+        s"reference.length must equal payload length (id=$i)")
+    }
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -1084,6 +1084,260 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
   }
 
   /**
+   * Shared writer for multi-blob-column INLINE tests: writes a table with two INLINE blob
+   * columns ({@code payload_a}, {@code payload_b}) and returns the table path plus the
+   * payloads written for each column so individual tests can assert on read.
+   *
+   * Distinct byte patterns are used per column so a column-swap regression would surface
+   * immediately as a byte mismatch rather than silently passing.
+   */
+  private def writeMultiBlobInlineTable(
+      tableType: HoodieTableType,
+      tableName: String,
+      numRows: Int = 4,
+      payloadLen: Int = 512): (String, Seq[Array[Byte]], Seq[Array[Byte]]) = {
+    val tablePath = s"$basePath/$tableName"
+    val payloadsA: Seq[Array[Byte]] = (0 until numRows).map { i =>
+      (0 until payloadLen).map(j => ((i + j) % 256).toByte).toArray
+    }
+    val payloadsB: Seq[Array[Byte]] = (0 until numRows).map { i =>
+      (0 until payloadLen).map(j => ((i + j + 128) % 256).toByte).toArray
+    }
+    val sparkSess = spark
+    import sparkSess.implicits._
+
+    val baseDf = (0 until numRows).map(i => (i, payloadsA(i), payloadsB(i)))
+      .toDF("id", "bytes_a", "bytes_b")
+    val rawDf = baseDf.select(
+      $"id",
+      BlobTestHelpers.inlineBlobStructCol("payload_a", $"bytes_a"),
+      BlobTestHelpers.inlineBlobStructCol("payload_b", $"bytes_b"))
+    val canonicalSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("payload_a", BlobType().asInstanceOf[StructType], nullable = true,
+        BlobTestHelpers.blobMetadata),
+      StructField("payload_b", BlobType().asInstanceOf[StructType], nullable = true,
+        BlobTestHelpers.blobMetadata)
+    ))
+    val df = spark.createDataFrame(rawDf.rdd, canonicalSchema)
+
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite,
+      operation = Some("bulk_insert"),
+      extraOptions = Map(PRECOMBINE_FIELD.key() -> "id"))
+    assertLanceBlobEncoding(tablePath)
+    (tablePath, payloadsA, payloadsB)
+  }
+
+  /**
+   * Plain struct projection across two INLINE blob columns: {@code SELECT payload_a, payload_b
+   * FROM table}. Each mode independently:
+   *
+   *   - CONTENT: both columns come back with {@code type=INLINE} and {@code data=bytes}. The
+   *     {@code reference} struct may be present with all-null leaves (Lance quirk — see
+   *     {@code testBlobInlineRoundTrip}); the test only requires {@code external_path} to be
+   *     null on it so downstream consumers can't mistake it for a real OUT_OF_LINE pointer.
+   *   - DESCRIPTOR (default): both columns come back with {@code type=INLINE, data=NULL} and a
+   *     populated synthesized {@code reference} (path ending in {@code .lance}, length equal
+   *     to the written payload, {@code is_managed=true}). Asserting on both columns confirms
+   *     the descriptor synthesis is per-column, not first-column-only.
+   */
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testBlobInlineMultipleColumnsPlainSelect(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_blob_multi_plain_${tableType.name().toLowerCase}"
+    val payloadLen = 512
+    val numRows = 4
+    val (tablePath, payloadsA, payloadsB) = writeMultiBlobInlineTable(
+      tableType, tableName, numRows, payloadLen)
+    val sparkSess = spark
+    import sparkSess.implicits._
+    val modeKey = "hoodie.read.blob.inline.mode"
+
+    // CONTENT: data=bytes on both columns; reference (if present) has null external_path.
+    val contentRows = spark.read.format("hudi")
+      .option(modeKey, "CONTENT")
+      .load(tablePath)
+      .select($"id", $"payload_a", $"payload_b")
+      .orderBy($"id")
+      .collect()
+    assertEquals(numRows, contentRows.length)
+    contentRows.zipWithIndex.foreach { case (row, i) =>
+      Seq(("payload_a", payloadsA(i)), ("payload_b", payloadsB(i))).foreach {
+        case (col, expected) =>
+          val payload = row.getStruct(row.fieldIndex(col))
+          assertEquals(HoodieSchema.Blob.INLINE,
+            payload.getString(payload.fieldIndex(HoodieSchema.Blob.TYPE)),
+            s"$col: type should remain INLINE under CONTENT (id=$i)")
+          assertArrayEquals(expected,
+            payload.getAs[Array[Byte]](HoodieSchema.Blob.INLINE_DATA_FIELD),
+            s"$col: data should match written bytes under CONTENT (id=$i)")
+          val refIdx = payload.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE)
+          if (!payload.isNullAt(refIdx)) {
+            val ref = payload.getStruct(refIdx)
+            assertTrue(ref.isNullAt(ref.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH)),
+              s"$col: reference.external_path should be null under CONTENT (id=$i)")
+          }
+      }
+    }
+
+    // DESCRIPTOR (default): data=NULL, populated synthesized reference on both columns.
+    val descRows = spark.read.format("hudi")
+      .load(tablePath)
+      .select($"id", $"payload_a", $"payload_b")
+      .orderBy($"id")
+      .collect()
+    assertEquals(numRows, descRows.length)
+    descRows.foreach { row =>
+      val id = row.getInt(row.fieldIndex("id"))
+      Seq("payload_a", "payload_b").foreach { col =>
+        val payload = row.getStruct(row.fieldIndex(col))
+        assertEquals(HoodieSchema.Blob.INLINE,
+          payload.getString(payload.fieldIndex(HoodieSchema.Blob.TYPE)),
+          s"$col: type should remain INLINE under DESCRIPTOR (id=$id)")
+        assertTrue(payload.isNullAt(payload.fieldIndex(HoodieSchema.Blob.INLINE_DATA_FIELD)),
+          s"$col: data should be null under DESCRIPTOR (id=$id)")
+        val ref = payload.getStruct(payload.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE))
+        assertNotNull(ref,
+          s"$col: reference should be populated under DESCRIPTOR (id=$id)")
+        assertEquals(payloadLen.toLong,
+          ref.getLong(ref.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE_LENGTH)),
+          s"$col: reference.length should equal payload length (id=$id)")
+        assertTrue(ref.getBoolean(ref.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED)),
+          s"$col: synthesized reference should be flagged managed (id=$id)")
+      }
+    }
+  }
+
+  /**
+   * Materializing both INLINE blob columns via {@code read_blob()} in a single query:
+   * {@code SELECT read_blob(payload_a), read_blob(payload_b) FROM table}.
+   *
+   *   - CONTENT: both columns resolve via the 1-hop {@code inline_data} passthrough. The bytes
+   *     for each column must match their respective written payloads — distinct byte patterns
+   *     are used per column so a cross-column aliasing regression would surface as a mismatch.
+   *   - DESCRIPTOR (default): the call throws. INLINE+DESCRIPTOR rejects {@code read_blob()}
+   *     regardless of which column trips the branch first, so the error chain must name both
+   *     INLINE and DESCRIPTOR for the failure to be actionable.
+   */
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testBlobInlineMultipleColumnsReadBlobAll(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_blob_multi_readblob_${tableType.name().toLowerCase}"
+    val numRows = 4
+    val (tablePath, payloadsA, payloadsB) = writeMultiBlobInlineTable(
+      tableType, tableName, numRows)
+    val modeKey = "hoodie.read.blob.inline.mode"
+
+    // CONTENT: read_blob() on both columns materializes correct bytes via 1-hop passthrough.
+    val contentView = s"${tableName}_content_view"
+    spark.read.format("hudi")
+      .option(modeKey, "CONTENT")
+      .load(tablePath)
+      .createOrReplaceTempView(contentView)
+    val materialized = spark.sql(
+      s"SELECT id, read_blob(payload_a) AS bytes_a, read_blob(payload_b) AS bytes_b " +
+        s"FROM $contentView ORDER BY id").collect()
+    assertEquals(numRows, materialized.length)
+    materialized.zipWithIndex.foreach { case (row, i) =>
+      assertEquals(i, row.getInt(row.fieldIndex("id")))
+      assertArrayEquals(payloadsA(i), row.getAs[Array[Byte]]("bytes_a"),
+        s"read_blob(payload_a) should match under CONTENT (id=$i)")
+      assertArrayEquals(payloadsB(i), row.getAs[Array[Byte]]("bytes_b"),
+        s"read_blob(payload_b) should match under CONTENT (id=$i)")
+    }
+
+    // DESCRIPTOR (default): read_blob() on either INLINE column must throw.
+    val descView = s"${tableName}_desc_view"
+    spark.read.format("hudi")
+      .load(tablePath)
+      .createOrReplaceTempView(descView)
+    val ex = assertThrows(classOf[Throwable], new Executable {
+      override def execute(): Unit = {
+        spark.sql(
+          s"SELECT id, read_blob(payload_a) AS bytes_a, read_blob(payload_b) AS bytes_b " +
+            s"FROM $descView ORDER BY id").collect()
+      }
+    })
+    val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
+      .flatMap(t => Option(t.getMessage)).mkString(" | ")
+    assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
+      s"read_blob() on either INLINE column under DESCRIPTOR must throw with " +
+        s"INLINE+DESCRIPTOR error; got: $msgChain")
+  }
+
+  /**
+   * Mixed projection across two INLINE blob columns: {@code SELECT read_blob(payload_a),
+   * payload_b FROM table}. One column is materialized via {@code read_blob()}, the other is
+   * left as a struct. This is the case explicitly raised in PR review — under the DESCRIPTOR
+   * default, a mixed query asking for bytes on one column and a pointer on another must fail
+   * loudly rather than silently returning one materialized and one synthesized shape.
+   *
+   *   - CONTENT: {@code payload_a} resolves to bytes (1-hop), {@code payload_b} comes back as
+   *     the same content-shape struct as {@code testBlobInlineMultipleColumnsPlainSelect}
+   *     (data=bytes, reference present-but-empty). Pinning both shapes in the same row
+   *     confirms the projection doesn't bleed across columns.
+   *   - DESCRIPTOR (default): the {@code read_blob()} call on {@code payload_a} still hits
+   *     the INLINE+DESCRIPTOR branch even though {@code payload_b} is only being projected as
+   *     a struct. {@code payload_b}'s shape doesn't soften the failure.
+   */
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testBlobInlineMultipleColumnsMixedSelect(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_blob_multi_mixed_${tableType.name().toLowerCase}"
+    val numRows = 4
+    val (tablePath, payloadsA, payloadsB) = writeMultiBlobInlineTable(
+      tableType, tableName, numRows)
+    val modeKey = "hoodie.read.blob.inline.mode"
+
+    // CONTENT: read_blob() materializes payload_a; payload_b returned as content-shape struct.
+    val contentView = s"${tableName}_content_view"
+    spark.read.format("hudi")
+      .option(modeKey, "CONTENT")
+      .load(tablePath)
+      .createOrReplaceTempView(contentView)
+    val rows = spark.sql(
+      s"SELECT id, read_blob(payload_a) AS bytes_a, payload_b " +
+        s"FROM $contentView ORDER BY id").collect()
+    assertEquals(numRows, rows.length)
+    rows.zipWithIndex.foreach { case (row, i) =>
+      assertEquals(i, row.getInt(row.fieldIndex("id")))
+      assertArrayEquals(payloadsA(i), row.getAs[Array[Byte]]("bytes_a"),
+        s"read_blob(payload_a) should return bytes under CONTENT (id=$i)")
+      val payloadB = row.getStruct(row.fieldIndex("payload_b"))
+      assertEquals(HoodieSchema.Blob.INLINE,
+        payloadB.getString(payloadB.fieldIndex(HoodieSchema.Blob.TYPE)),
+        s"payload_b: type should remain INLINE under CONTENT (id=$i)")
+      assertArrayEquals(payloadsB(i),
+        payloadB.getAs[Array[Byte]](HoodieSchema.Blob.INLINE_DATA_FIELD),
+        s"payload_b: data should match written bytes under CONTENT (id=$i)")
+      val refIdx = payloadB.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE)
+      if (!payloadB.isNullAt(refIdx)) {
+        val ref = payloadB.getStruct(refIdx)
+        assertTrue(ref.isNullAt(ref.fieldIndex(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH)),
+          s"payload_b: reference.external_path should be null under CONTENT (id=$i)")
+      }
+    }
+
+    // DESCRIPTOR (default): read_blob(payload_a) trips even though payload_b is just a struct.
+    val descView = s"${tableName}_desc_view"
+    spark.read.format("hudi")
+      .load(tablePath)
+      .createOrReplaceTempView(descView)
+    val ex = assertThrows(classOf[Throwable], new Executable {
+      override def execute(): Unit = {
+        spark.sql(
+          s"SELECT id, read_blob(payload_a) AS bytes_a, payload_b " +
+            s"FROM $descView ORDER BY id").collect()
+      }
+    })
+    val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
+      .flatMap(t => Option(t.getMessage)).mkString(" | ")
+    assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
+      s"read_blob(payload_a) under DESCRIPTOR must throw INLINE+DESCRIPTOR error even when " +
+        s"mixed with a struct projection of another blob column; got: $msgChain")
+  }
+
+  /**
    * Compaction must preserve INLINE blob bytes under the DESCRIPTOR default. MOR compaction reads
    * the base file via {@link HoodieSparkLanceReader}, which hard-pins CONTENT regardless of the
    * user-facing {@code hoodie.read.blob.inline.mode}. If that pin were to honor the default
@@ -1144,9 +1398,39 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       .setConf(HoodieTestUtils.getDefaultStorageConf)
       .setBasePath(tablePath)
       .build()
-    val compactionCommits = metaClient.reloadActiveTimeline().filterCompletedInstants()
-      .getInstants.asScala.filter(_.getAction == "commit")
+    val completedInstants = metaClient.reloadActiveTimeline().filterCompletedInstants()
+      .getInstants.asScala
+    val deltaCommits = completedInstants.filter(_.getAction == "deltacommit")
+    assertTrue(deltaCommits.nonEmpty,
+      "Upsert must have written a deltacommit on MOR — without log files the compaction " +
+        "round-trip below would be a no-op and the test would silently pass even if the " +
+        "CONTENT-pin in HoodieSparkLanceReader were broken.")
+    val compactionCommits = completedInstants.filter(_.getAction == "commit")
     assertTrue(compactionCommits.nonEmpty, "Compaction commit should be present after upsert")
+
+    // Walk file groups in the (non-partitioned) table and verify at least one historical file
+    // slice carries log files. After compaction the latest slice is post-compaction (no logs),
+    // but the pre-compaction slice is still in the FSV's history, so `hasLogFiles` will flag
+    // it. This catches a regression where the upsert silently fell into a CoW-like path.
+    val engineCtx = new HoodieLocalEngineContext(metaClient.getStorageConf)
+    val metadataCfg = HoodieMetadataConfig.newBuilder.build
+    val viewManager = FileSystemViewManager.createViewManager(
+      engineCtx, metadataCfg, FileSystemViewStorageConfig.newBuilder.build,
+      HoodieCommonConfig.newBuilder.build,
+      (mc: HoodieTableMetaClient) => metaClient.getTableFormat
+        .getMetadataFactory.create(engineCtx, mc.getStorage, metadataCfg, tablePath))
+    val fsView = viewManager.getFileSystemView(metaClient)
+    try {
+      fsView.loadAllPartitions()
+      val anyHadLogs = fsView.getAllFileGroups("").iterator().asScala.exists { fg =>
+        fg.getAllFileSlices.iterator().asScala.exists(_.hasLogFiles)
+      }
+      assertTrue(anyHadLogs,
+        s"MOR upsert must have produced log files in at least one file slice at $tablePath; " +
+          s"none observed — upsert may have silently bypassed the deltacommit path")
+    } finally {
+      fsView.close()
+    }
 
     val expected: Map[Int, Array[Byte]] = (
       updatedIds.map(i => i -> Array.fill[Byte](payloadLen)(updatedPayloadByte)) ++

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -907,10 +907,12 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
    * DESCRIPTOR mode on INLINE rows: user writes `data` bytes; on read with
    * `hoodie.read.blob.inline.mode=DESCRIPTOR` each row comes back with type still set to
    * {@code INLINE} (preserving the original storage mode) but with {@code data=null} and a
-   * populated synthesized {@code reference} pointing at the Lance file. The synthesized
-   * reference is an internal pointer, not user-facing storage. {@code read_blob()} is
-   * therefore unsupported on INLINE rows in this mode and must throw a clear error so
-   * callers don't conflate the synthesized pointer with durable metadata.
+   * populated synthesized {@code reference} pointing at the Lance file. A pure
+   * {@code SELECT read_blob(col)} query still resolves bytes — {@code BatchedBlobReader}
+   * materializes them via a 2-hop pread against the synthesized reference, reusing the same
+   * range-merged pread path used for OUT_OF_LINE rows. The synthesized reference is treated
+   * as an internal pointer; the mixed-projection variants are pinned separately in
+   * {@code testBlobInlineMixedProjection*}.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -970,24 +972,22 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
         s"synthetic reference to the Lance file should be flagged managed (id=$i)")
     }
 
-    // read_blob() on INLINE rows under DESCRIPTOR mode is unsupported by design: DESCRIPTOR
-    // is metadata-only and the synthesized reference is an internal pointer into the .lance
-    // file's storage layout, not user-facing metadata. BatchedBlobReader must throw with a
-    // message that names both INLINE and DESCRIPTOR so the failure is actionable.
+    // read_blob() under DESCRIPTOR mode resolves bytes via the 2-hop pread against the
+    // synthesized reference. The bytes must equal what was written — proves the synthesized
+    // reference points at the correct (path, offset, length) tuple inside the .lance file.
     val viewName = s"${tableName}_view"
     spark.read.format("hudi")
       .option(modeKey, "DESCRIPTOR")
       .load(tablePath)
       .createOrReplaceTempView(viewName)
-    val ex = assertThrows(classOf[Throwable], new Executable {
-      override def execute(): Unit = {
-        spark.sql(s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
-      }
-    })
-    val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
-      .flatMap(t => Option(t.getMessage)).mkString(" | ")
-    assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
-      s"error must mention INLINE and DESCRIPTOR; got: $msgChain")
+    val materialized = spark.sql(
+      s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
+    assertEquals(numRows, materialized.length)
+    materialized.zipWithIndex.foreach { case (row, i) =>
+      assertEquals(i, row.getInt(row.fieldIndex("id")))
+      assertArrayEquals(expectedPayloads(i), row.getAs[Array[Byte]]("bytes"),
+        s"read_blob() under DESCRIPTOR must return original bytes via 2-hop pread (id=$i)")
+    }
   }
 
   /**
@@ -1174,15 +1174,16 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
   }
 
   /**
-   * Materializing both INLINE blob columns via {@code read_blob()} in a single query under
-   * CONTENT mode: {@code SELECT read_blob(payload_a), read_blob(payload_b) FROM table}. Each
-   * column must resolve via the 1-hop {@code inline_data} passthrough with its own bytes —
-   * distinct byte patterns per column would surface a cross-column aliasing regression.
+   * Materializing both INLINE blob columns via {@code read_blob()} in a single query:
+   * {@code SELECT read_blob(payload_a), read_blob(payload_b) FROM table}.
    *
-   * The DESCRIPTOR-mode failure path for {@code read_blob()} on INLINE rows is pinned by
-   * {@code testBlobInlineDescriptorMode} (single column) and {@code
-   * testBlobInlineMultipleColumnsMixedSelect} (one read_blob + one struct projection); it is
-   * not re-asserted here.
+   *   - CONTENT: both columns resolve via the 1-hop {@code inline_data} passthrough.
+   *   - DESCRIPTOR (default): the projection wraps every blob column in {@code read_blob()}
+   *     (no direct blob projection), so the analyzer's mixed-projection check does not fire
+   *     and {@code BatchedBlobReader} materializes bytes via the 2-hop pread against each
+   *     row's synthesized reference.
+   *
+   * Distinct byte patterns per column guard against cross-column aliasing under both modes.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -1198,33 +1199,50 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       .option(modeKey, "CONTENT")
       .load(tablePath)
       .createOrReplaceTempView(contentView)
-    val materialized = spark.sql(
+    val contentMaterialized = spark.sql(
       s"SELECT id, read_blob(payload_a) AS bytes_a, read_blob(payload_b) AS bytes_b " +
         s"FROM $contentView ORDER BY id").collect()
-    assertEquals(numRows, materialized.length)
-    materialized.zipWithIndex.foreach { case (row, i) =>
+    assertEquals(numRows, contentMaterialized.length)
+    contentMaterialized.zipWithIndex.foreach { case (row, i) =>
       assertEquals(i, row.getInt(row.fieldIndex("id")))
       assertArrayEquals(payloadsA(i), row.getAs[Array[Byte]]("bytes_a"),
         s"read_blob(payload_a) should match under CONTENT (id=$i)")
       assertArrayEquals(payloadsB(i), row.getAs[Array[Byte]]("bytes_b"),
         s"read_blob(payload_b) should match under CONTENT (id=$i)")
     }
+
+    // DESCRIPTOR (default): both columns wrapped in read_blob() — no direct projection, so
+    // the mixed-projection analyzer error does not fire. BatchedBlobReader resolves bytes
+    // via the 2-hop pread against each row's synthesized reference. Bytes must match.
+    val descView = s"${tableName}_desc_view"
+    spark.read.format("hudi")
+      .load(tablePath)
+      .createOrReplaceTempView(descView)
+    val descMaterialized = spark.sql(
+      s"SELECT id, read_blob(payload_a) AS bytes_a, read_blob(payload_b) AS bytes_b " +
+        s"FROM $descView ORDER BY id").collect()
+    assertEquals(numRows, descMaterialized.length)
+    descMaterialized.zipWithIndex.foreach { case (row, i) =>
+      assertEquals(i, row.getInt(row.fieldIndex("id")))
+      assertArrayEquals(payloadsA(i), row.getAs[Array[Byte]]("bytes_a"),
+        s"read_blob(payload_a) should match under DESCRIPTOR via 2-hop pread (id=$i)")
+      assertArrayEquals(payloadsB(i), row.getAs[Array[Byte]]("bytes_b"),
+        s"read_blob(payload_b) should match under DESCRIPTOR via 2-hop pread (id=$i)")
+    }
   }
 
   /**
    * Mixed projection across two INLINE blob columns: {@code SELECT read_blob(payload_a),
    * payload_b FROM table}. One column is materialized via {@code read_blob()}, the other is
-   * left as a struct. This is the case explicitly raised in PR review — under the DESCRIPTOR
-   * default, a mixed query asking for bytes on one column and a pointer on another must fail
-   * loudly rather than silently returning one materialized and one synthesized shape.
+   * left as a struct.
    *
    *   - CONTENT: {@code payload_a} resolves to bytes (1-hop), {@code payload_b} comes back as
    *     the same content-shape struct as {@code testBlobInlineMultipleColumnsPlainSelect}
-   *     (data=bytes, reference present-but-empty). Pinning both shapes in the same row
-   *     confirms the projection doesn't bleed across columns.
-   *   - DESCRIPTOR (default): the {@code read_blob()} call on {@code payload_a} still hits
-   *     the INLINE+DESCRIPTOR branch even though {@code payload_b} is only being projected as
-   *     a struct. {@code payload_b}'s shape doesn't soften the failure.
+   *     (data=bytes, reference present-but-empty).
+   *   - DESCRIPTOR (default): {@code ReadBlobRule} rejects the query at plan time with an
+   *     {@code AnalysisException}. Returning materialized bytes for one column alongside a
+   *     synthesized descriptor reference for another in the same row is misleading — the
+   *     synthesized reference is an internal Lance pointer, not durable metadata.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -1264,7 +1282,9 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       }
     }
 
-    // DESCRIPTOR (default): read_blob(payload_a) trips even though payload_b is just a struct.
+    // DESCRIPTOR (default): the mixed projection is rejected at plan time by ReadBlobRule.
+    // The error must be analyzer-time (AnalysisException), not a runtime BatchedBlobReader
+    // throw, and the message must name both blob columns and the config key so it's actionable.
     val descView = s"${tableName}_desc_view"
     spark.read.format("hudi")
       .load(tablePath)
@@ -1278,9 +1298,96 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     })
     val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
       .flatMap(t => Option(t.getMessage)).mkString(" | ")
-    assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
-      s"read_blob(payload_a) under DESCRIPTOR must throw INLINE+DESCRIPTOR error even when " +
-        s"mixed with a struct projection of another blob column; got: $msgChain")
+    assertTrue(msgChain.contains("mix read_blob()") && msgChain.contains("payload_a") &&
+      msgChain.contains("payload_b") && msgChain.contains("DESCRIPTOR"),
+      s"mixed projection under DESCRIPTOR must throw an analyzer error naming both columns " +
+        s"and the mode; got: $msgChain")
+  }
+
+  /**
+   * Mixed projection on the **same** blob column: {@code SELECT read_blob(payload), payload
+   * FROM table}. This is the variant of {@code testBlobInlineMultipleColumnsMixedSelect}
+   * that uses a single blob column twice — once wrapped in {@code read_blob()} and once
+   * projected directly.
+   *
+   *   - CONTENT: succeeds. {@code read_blob(payload)} returns bytes (1-hop) and the direct
+   *     {@code payload} projection returns the content-shape struct. Both come from the
+   *     same source row but Spark resolves each independently.
+   *   - DESCRIPTOR (default): rejected at plan time by {@code ReadBlobRule}. The error must
+   *     name the column and the config key.
+   */
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testBlobInlineMixedProjectionSameColumn(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_blob_mixed_same_col_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val payloadLen = 512
+    val numRows = 4
+    val expectedPayloads: Seq[Array[Byte]] = (0 until numRows).map { i =>
+      (0 until payloadLen).map(j => ((i + j) % 256).toByte).toArray
+    }
+    val sparkSess = spark
+    import sparkSess.implicits._
+
+    val rawDf = expectedPayloads.zipWithIndex.map { case (b, i) => (i, b) }
+      .toDF("id", "bytes")
+      .select($"id", BlobTestHelpers.inlineBlobStructCol("payload", $"bytes"))
+    val canonicalSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("payload", BlobType().asInstanceOf[StructType], nullable = true,
+        BlobTestHelpers.blobMetadata)
+    ))
+    val df = spark.createDataFrame(rawDf.rdd, canonicalSchema)
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite,
+      operation = Some("bulk_insert"),
+      extraOptions = Map(PRECOMBINE_FIELD.key() -> "id"))
+    assertLanceBlobEncoding(tablePath)
+
+    val modeKey = "hoodie.read.blob.inline.mode"
+
+    // CONTENT: both projections resolve independently — read_blob(payload) returns bytes,
+    // direct payload returns content-shape struct.
+    val contentView = s"${tableName}_content_view"
+    spark.read.format("hudi")
+      .option(modeKey, "CONTENT")
+      .load(tablePath)
+      .createOrReplaceTempView(contentView)
+    val rows = spark.sql(
+      s"SELECT id, read_blob(payload) AS bytes, payload " +
+        s"FROM $contentView ORDER BY id").collect()
+    assertEquals(numRows, rows.length)
+    rows.zipWithIndex.foreach { case (row, i) =>
+      assertEquals(i, row.getInt(row.fieldIndex("id")))
+      assertArrayEquals(expectedPayloads(i), row.getAs[Array[Byte]]("bytes"),
+        s"read_blob(payload) should return bytes under CONTENT (id=$i)")
+      val payload = row.getStruct(row.fieldIndex("payload"))
+      assertEquals(HoodieSchema.Blob.INLINE,
+        payload.getString(payload.fieldIndex(HoodieSchema.Blob.TYPE)),
+        s"direct payload: type should remain INLINE under CONTENT (id=$i)")
+      assertArrayEquals(expectedPayloads(i),
+        payload.getAs[Array[Byte]](HoodieSchema.Blob.INLINE_DATA_FIELD),
+        s"direct payload: data should match written bytes under CONTENT (id=$i)")
+    }
+
+    // DESCRIPTOR (default): analyzer rejects with a structured message naming the column.
+    val descView = s"${tableName}_desc_view"
+    spark.read.format("hudi")
+      .load(tablePath)
+      .createOrReplaceTempView(descView)
+    val ex = assertThrows(classOf[Throwable], new Executable {
+      override def execute(): Unit = {
+        spark.sql(
+          s"SELECT id, read_blob(payload) AS bytes, payload " +
+            s"FROM $descView ORDER BY id").collect()
+      }
+    })
+    val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
+      .flatMap(t => Option(t.getMessage)).mkString(" | ")
+    assertTrue(msgChain.contains("mix read_blob()") && msgChain.contains("payload") &&
+      msgChain.contains("DESCRIPTOR"),
+      s"same-column mixed projection under DESCRIPTOR must throw an analyzer error naming " +
+        s"the column and the mode; got: $msgChain")
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -37,8 +37,9 @@ import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
-import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertFalse, assertNotNull, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertFalse, assertNotNull, assertThrows, assertTrue}
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty
+import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, EnumSource, MethodSource}
 import org.lance.file.LanceFileReader
@@ -902,8 +903,10 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
    * DESCRIPTOR mode on INLINE rows: user writes `data` bytes; on read with
    * `hoodie.read.blob.inline.mode=DESCRIPTOR` each row comes back with type still set to
    * {@code INLINE} (preserving the original storage mode) but with {@code data=null} and a
-   * populated {@code reference} pointing at the Lance file. {@code read_blob()} then preads
-   * the bytes back from the .lance file via the reference.
+   * populated synthesized {@code reference} pointing at the Lance file. The synthesized
+   * reference is an internal pointer, not user-facing storage. {@code read_blob()} is
+   * therefore unsupported on INLINE rows in this mode and must throw a clear error so
+   * callers don't conflate the synthesized pointer with durable metadata.
    */
   @ParameterizedTest
   @EnumSource(value = classOf[HoodieTableType])
@@ -963,41 +966,116 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
         s"synthetic reference to the Lance file should be flagged managed (id=$i)")
     }
 
-    // read_blob() materializes bytes via BatchedBlobReader, which always reads with CONTENT
-    // mode (actual bytes) regardless of the user's inline read mode setting.
+    // read_blob() on INLINE rows under DESCRIPTOR mode is unsupported by design: DESCRIPTOR
+    // is metadata-only and the synthesized reference is an internal pointer into the .lance
+    // file's storage layout, not user-facing metadata. BatchedBlobReader must throw with a
+    // message that names both INLINE and DESCRIPTOR so the failure is actionable.
     val viewName = s"${tableName}_view"
-    spark.read.format("hudi").load(tablePath).createOrReplaceTempView(viewName)
+    spark.read.format("hudi")
+      .option(modeKey, "DESCRIPTOR")
+      .load(tablePath)
+      .createOrReplaceTempView(viewName)
+    val ex = assertThrows(classOf[Throwable], new Executable {
+      override def execute(): Unit = {
+        spark.sql(s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
+      }
+    })
+    val msgChain = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null)
+      .flatMap(t => Option(t.getMessage)).mkString(" | ")
+    assertTrue(msgChain.contains("INLINE") && msgChain.contains("DESCRIPTOR"),
+      s"error must mention INLINE and DESCRIPTOR; got: $msgChain")
+
+    // Same table, same rows, but read under CONTENT mode: read_blob() takes the 1-hop
+    // passthrough of inline_data and must return the originally-written bytes. This pins the
+    // write -> read roundtrip integrity for INLINE blobs (compaction/merge included for MOR)
+    // independently of the DESCRIPTOR-shape verification above.
+    val contentViewName = s"${tableName}_content_view"
+    spark.read.format("hudi")
+      .option(modeKey, "CONTENT")
+      .load(tablePath)
+      .createOrReplaceTempView(contentViewName)
     val materialized = spark.sql(
-      s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
+      s"SELECT id, read_blob(payload) AS bytes FROM $contentViewName ORDER BY id").collect()
     assertEquals(numRows, materialized.length)
     materialized.zipWithIndex.foreach { case (row, i) =>
-      val bytes = row.getAs[Array[Byte]]("bytes")
-      assertArrayEquals(expectedPayloads(i), bytes,
-        s"read_blob() bytes mismatch for id=$i")
+      assertEquals(i, row.getInt(row.fieldIndex("id")))
+      assertArrayEquals(expectedPayloads(i), row.getAs[Array[Byte]]("bytes"),
+        s"read_blob() bytes mismatch under CONTENT mode (id=$i)")
+    }
+  }
+
+  /**
+   * Mixed-storage table on Lance: one blob column holds both INLINE rows (small payloads
+   * stored inline) and OUT_OF_LINE rows (external file references). Under CONTENT mode,
+   * read_blob() must materialize the correct bytes for both shapes in a single query —
+   * INLINE rows go through the 1-hop inline_data passthrough, OUT_OF_LINE rows go through
+   * the external pread (with BatchedBlobReader merging consecutive ranges).
+   */
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testBlobMixedInlineAndOutOfLineContentMode(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_blob_mixed_content_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val payloadLen = 256
+    val numInline = 3
+    val numOutOfLine = 3
+    val externalFileSize = numOutOfLine * payloadLen
+    val externalDir = Files.createDirectories(
+      Paths.get(s"$basePath/_blob_ext_mixed_${tableType.name().toLowerCase}"))
+    val extPath = BlobTestHelpers.createTestFile(externalDir, "mixed_file.bin", externalFileSize)
+
+    val inlinePayloads: Seq[Array[Byte]] = (0 until numInline).map { i =>
+      (0 until payloadLen).map(j => ((i + j) % 256).toByte).toArray
     }
 
-    // Mixed-usage regression: read_blob(payload) co-projected with payload.reference.* in a
-    // single SELECT. The INLINE-descriptor fallback in BatchedBlobReader is load-bearing, if
-    // read_blob() forced the scan to CONTENT shape, reference.* would all be null here.
-    val mixed = spark.sql(
-      s"""SELECT id,
-         |       read_blob(payload)              AS bytes,
-         |       payload.reference.external_path AS ext_path,
-         |       payload.reference.offset        AS off,
-         |       payload.reference.length        AS len
-         |  FROM $viewName ORDER BY id""".stripMargin).collect()
-    assertEquals(numRows, mixed.length)
-    mixed.zipWithIndex.foreach { case (row, i) =>
-      assertArrayEquals(expectedPayloads(i), row.getAs[Array[Byte]]("bytes"),
-        s"read_blob() bytes must survive co-projection with reference.* (id=$i)")
-      val ext = row.getAs[String]("ext_path")
-      assertNotNull(ext, s"reference.external_path must survive read_blob co-usage (id=$i)")
-      assertTrue(ext.endsWith(".lance"), s"external_path should point at .lance, got: $ext (id=$i)")
-      assertFalse(row.isNullAt(row.fieldIndex("off")),
-        s"reference.offset must not be null when co-selected with read_blob (id=$i)")
-      assertTrue(row.getLong(row.fieldIndex("off")) >= 0L)
-      assertEquals(payloadLen.toLong, row.getLong(row.fieldIndex("len")),
-        s"reference.length must equal payload length (id=$i)")
+    val sparkSess = spark
+    import sparkSess.implicits._
+    val inlineDf = inlinePayloads.zipWithIndex.map { case (b, i) => (i, b) }
+      .toDF("id", "bytes")
+      .select($"id", BlobTestHelpers.inlineBlobStructCol("payload", $"bytes"))
+
+    val outOfLineDf = (0 until numOutOfLine).map { k =>
+      (numInline + k, extPath, (k * payloadLen).toLong, payloadLen.toLong)
+    }.toDF("id", "path", "offset", "length")
+      .select($"id", BlobTestHelpers.blobStructCol("payload", $"path", $"offset", $"length"))
+
+    val canonicalSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("payload", BlobType().asInstanceOf[StructType], nullable = true,
+        BlobTestHelpers.blobMetadata)
+    ))
+    val raw = inlineDf.unionByName(outOfLineDf)
+    val df = spark.createDataFrame(raw.rdd, canonicalSchema)
+
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite,
+      operation = Some("bulk_insert"),
+      extraOptions = Map(PRECOMBINE_FIELD.key() -> "id"))
+
+    assertLanceBlobEncoding(tablePath)
+
+    val viewName = s"${tableName}_mixed_view"
+    spark.read.format("hudi")
+      .option("hoodie.read.blob.inline.mode", "CONTENT")
+      .load(tablePath)
+      .createOrReplaceTempView(viewName)
+
+    val rows = spark.sql(
+      s"SELECT id, read_blob(payload) AS bytes FROM $viewName ORDER BY id").collect()
+    assertEquals(numInline + numOutOfLine, rows.length)
+
+    rows.foreach { row =>
+      val id = row.getInt(row.fieldIndex("id"))
+      val bytes = row.getAs[Array[Byte]]("bytes")
+      if (id < numInline) {
+        assertArrayEquals(inlinePayloads(id), bytes,
+          s"INLINE row: read_blob() bytes mismatch (id=$id)")
+      } else {
+        val k = id - numInline
+        assertEquals(payloadLen, bytes.length,
+          s"OUT_OF_LINE row: read_blob() length mismatch (id=$id)")
+        BlobTestHelpers.assertBytesContent(bytes, expectedOffset = k * payloadLen)
+      }
     }
   }
 

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -132,18 +132,19 @@ SELECT id, url, read_blob(image_blob) as image_bytes FROM my_table;
 
 `read_blob(<blob_column>)` is the canonical API for materializing raw blob bytes in a query. It returns the underlying `bytes` for:
 - Any `OUT_OF_LINE` row, regardless of mode.
-- `INLINE` rows under `CONTENT` mode.
+- `INLINE` rows under `CONTENT` mode (1-hop passthrough of `inline_data`).
+- `INLINE` rows on Lance under `DESCRIPTOR` mode (2-hop pread against the synthesized reference; the byte fetch reuses the same range-merged I/O path used for OUT_OF_LINE rows).
 - `INLINE` rows on Parquet under either mode (Parquet's DESCRIPTOR is a no-op today; rows arrive in CONTENT shape).
 
-`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`.
+The single case `read_blob()` does **not** support is when the **same query** also projects a blob column directly on a Lance table under `DESCRIPTOR` — e.g. `SELECT read_blob(col1), col1 FROM t` or `SELECT read_blob(col1), col2 FROM t` where `col2` is another blob column. The query is rejected by `ReadBlobRule` at plan time with a clear `AnalysisException` because returning materialized bytes for one column alongside a synthesized Lance-internal reference for another in the same row is misleading: the synthesized reference is an implementation detail, not durable metadata, and exposing it next to real bytes invites callers to treat the pointer as user-facing. The error names both the columns and the config key so the fix is obvious — either set `hoodie.read.blob.inline.mode=CONTENT` or drop the direct projection.
 
 Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *`) returns the underlying `Blob` struct as-is. The contents of that struct depend on the storage strategy, the file format, and the read mode, as summarized below.
 
 **Reader Configuration**
 
 - `hoodie.read.blob.inline.mode` — values `DESCRIPTOR` (default) | `CONTENT`.
-  - `DESCRIPTOR` (default): metadata-only for `INLINE` rows. On Lance, the engine returns a synthesized `reference` pointing at the backing file so callers can inspect `(path, offset, length)` without materializing bytes. `read_blob()` on these rows is **unsupported and throws** — switch to `CONTENT` or read `col.data` if you want bytes.
-  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field;
+  - `DESCRIPTOR` (default): on a plain `SELECT col`, the engine returns a synthesized `reference` pointing at the backing file so callers can inspect `(path, offset, length)` without materializing bytes. On `read_blob(col)` alone, the engine still materializes bytes via a 2-hop pread against that same reference. Mixing a `read_blob()` call with a direct projection of any blob column in the same query is rejected at plan time.
+  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field for every INLINE row at scan time. Both direct projection and `read_blob()` then resolve cleanly, and the mixed-projection error does not apply.
   - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes.
 
 **Behavior matrix**
@@ -151,13 +152,14 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 | Access pattern   | Storage      | File format | `hoodie.read.blob.inline.mode` | `data` field | `reference` field            | Raw bytes available?                              |
 |------------------|--------------|-------------|--------------------------------|--------------|------------------------------|---------------------------------------------------|
 | `SELECT read_blob(col) FROM table` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes (1-hop)                       |
-| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `CONTENT`                      | n/a          | n/a                          | Yes — returns bytes (1-hop)                       |
-| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `DESCRIPTOR` (default)         | n/a          | n/a                          | **No — throws.** Set `CONTENT` or use `col.data`. |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `CONTENT`                      | n/a          | n/a                          | Yes — returns bytes (1-hop passthrough)           |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `DESCRIPTOR` (default)         | n/a          | n/a                          | Yes — returns bytes (2-hop pread via synthesized reference) |
+| `SELECT read_blob(col), <any blob col> FROM table` | INLINE | Lance | `DESCRIPTOR` (default) | n/a | n/a | **No — analyzer throws.** Mixed projection rejected; set `CONTENT` or remove the direct blob projection. |
 | `SELECT read_blob(col) FROM table` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes (external pread)              |
 | `SELECT col FROM table`       | INLINE       | Parquet     | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
 | `SELECT col FROM table`       | INLINE       | Parquet     | `DESCRIPTOR` (default)         | bytes¹       | NULL¹                        | Yes — via `data`¹                                 |
 | `SELECT col FROM table`       | INLINE       | Lance       | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)      | No — metadata-only; switch mode to read bytes     |
+| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)      | No — descriptor-only; call `read_blob` to materialize |
 | `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
 
 
@@ -187,19 +189,21 @@ flowchart TD
     QI -->|"SELECT read_blob(col)"| RM{hoodie.read.blob.inline.mode}
     RM -->|CONTENT| RBC(["bytes from inline_data on the row<br/>1 hop"])
     RM -->|DESCRIPTOR default| RF{file format}
-    RF -->|Lance| RBL(["error: read_blob unsupported<br/>on INLINE rows under DESCRIPTOR<br/>(metadata-only mode)"])
+    RF -->|Lance| RBL(["bytes via 2-hop pread<br/>against synthesized reference<br/>(same code path as OUT_OF_LINE)"])
     RF -->|"Parquet (today: mode no-op)"| RBP(["bytes from inline_data on the row<br/>1 hop — same as CONTENT"])
+
+    QI -->|"SELECT read_blob(col1), col2"| MIX(["DESCRIPTOR (any format):<br/>ReadBlobRule throws AnalysisException —<br/>mixed projection unsupported.<br/>(Practically only Lance hits this; Parquet<br/>ignores the mode so the throw is recoverable<br/>by setting CONTENT.)<br/>CONTENT: succeeds; both shapes resolve."])
 ```
 
 
 ```mermaid
 flowchart LR
-    RB[/"SELECT read_blob(col)"/] --> Scan["Scan emits Blob struct"]
+    RB[/"SELECT read_blob(col)"/] --> PlanCheck{"projection<br/>also includes a direct<br/>blob-column reference?"}
+    PlanCheck -->|"yes AND effective mode = DESCRIPTOR"| Reject["ReadBlobRule throws<br/>AnalysisException at plan time<br/>(mixed projection unsupported)"]
+    PlanCheck -->|"no, or effective mode = CONTENT"| Scan["Scan emits Blob struct"]
     Scan --> Shape{"row shape"}
     Shape -->|"inline_data populated<br/>(CONTENT mode, or Parquet)"| Direct["BatchedBlobReader:<br/>read inline_data off the row<br/><b>1 hop total</b>"]
-    Shape -->|"reference populated"| Type{"storage_type"}
-    Type -->|"OUT_OF_LINE"| Indirect["BatchedBlobReader:<br/>openSeekable(external_path)<br/>seek(offset), readFully(length)<br/><b>2 hops total</b>"]
-    Type -->|"INLINE<br/>(DESCRIPTOR + Lance)"| Err["error: read_blob unsupported<br/>on INLINE rows under DESCRIPTOR"]
+    Shape -->|"reference populated"| Indirect["BatchedBlobReader:<br/>openSeekable(external_path)<br/>seek(offset), readFully(length)<br/><b>2 hops total</b><br/>(applies to OUT_OF_LINE and to<br/>INLINE+DESCRIPTOR on Lance —<br/>the synthesized reference is shaped<br/>identically to an external one)"]
     Direct --> Bytes(["bytes"])
     Indirect --> Bytes
 ```

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -131,11 +131,11 @@ SELECT id, url, read_blob(image_blob) as image_bytes FROM my_table;
 #### Read Modes: `read_blob` vs. `SELECT *`
 
 `read_blob(<blob_column>)` is the canonical API for materializing raw blob bytes in a query. It returns the underlying `bytes` for:
-- Any `OUT_OF_LINE` row, regardless of mode.
-- `INLINE` rows under `CONTENT` mode.
+- Any `OUT_OF_LINE` row (via external pread), regardless of mode.
+- `INLINE` rows under `CONTENT` mode (1-hop passthrough of `data`).
 - `INLINE` rows on Parquet under either mode (Parquet's DESCRIPTOR is a no-op today; rows arrive in CONTENT shape).
 
-`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`.
+`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`, or project `col.data` directly without `read_blob()`.
 
 Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *`) returns the underlying `Blob` struct as-is. The contents of that struct depend on the storage strategy, the file format, and the read mode, as summarized below.
 
@@ -143,8 +143,8 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 
 - `hoodie.read.blob.inline.mode` — values `DESCRIPTOR` (default) | `CONTENT`.
   - `DESCRIPTOR` (default): metadata-only for `INLINE` rows. On Lance, the engine returns a synthesized `reference` pointing at the backing file so callers can inspect `(path, offset, length)` without materializing bytes. `read_blob()` on these rows is **unsupported and throws** — switch to `CONTENT` or read `col.data` if you want bytes.
-  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field;
-  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes.
+  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field; `read_blob()` works as a 1-hop passthrough.
+  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes via external pread.
 
 **Behavior matrix**
 
@@ -160,6 +160,11 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 | `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)      | No — metadata-only; switch mode to read bytes     |
 | `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
 
+¹ **Parquet + DESCRIPTOR is a no-op today.** The Parquet reader path does not currently honor `hoodie.read.blob.inline.mode`, so on Parquet tables the config is ignored and INLINE rows always come back in `CONTENT` shape regardless of the setting. The default flip to `DESCRIPTOR` therefore has no observable effect on Parquet tables. The matrix row above shows what users will actually see today, not the eventual spec.
+
+**Eventual spec for Parquet + DESCRIPTOR (not yet implemented)**
+
+When Parquet gains DESCRIPTOR support, INLINE rows in `DESCRIPTOR` mode are intended to return `data = NULL` and `reference = NULL` (no native positional handle exists in Parquet for an inline byte array), with `read_blob` materializing bytes through a format-specific path. Until then, treat `DESCRIPTOR` as effectively `CONTENT` on Parquet.
 
 **Why Parquet and Lance differ in `DESCRIPTOR` mode**
 
@@ -191,6 +196,7 @@ flowchart TD
     RF -->|"Parquet (today: mode no-op)"| RBP(["bytes from inline_data on the row<br/>1 hop — same as CONTENT"])
 ```
 
+`read_blob(col)` byte resolution — hop count depends on the row shape that arrives. INLINE rows under DESCRIPTOR mode are rejected; the mode is metadata-only and the synthesized reference is an internal pointer, not user-facing storage.
 
 ```mermaid
 flowchart LR
@@ -203,6 +209,11 @@ flowchart LR
     Direct --> Bytes(["bytes"])
     Indirect --> Bytes
 ```
+
+Notes:
+- INLINE + DESCRIPTOR + `read_blob()` is unsupported by design. DESCRIPTOR is metadata-only for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`, or project `col.data` directly without `read_blob()`.
+- OUT_OF_LINE is unaffected by `hoodie.read.blob.inline.mode` — the descriptor is real user metadata and `read_blob()` always works via an external pread.
+- Plain `SELECT col` (no `read_blob`) is always 1 hop. DESCRIPTOR's win is that hop 1 skips blob decoding when bytes aren't needed.
 
 ### 3. Writer
 #### Phase 1: External Blob Support

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -130,31 +130,34 @@ SELECT id, url, read_blob(image_blob) as image_bytes FROM my_table;
 
 #### Read Modes: `read_blob` vs. `SELECT *`
 
-`read_blob(<blob_column>)` is the canonical, universal API for materializing raw blob bytes in a query. It always returns the underlying `bytes` regardless of:
-- Storage strategy (`INLINE` vs `OUT_OF_LINE`)
-- Base file format (Parquet, Lance, …)
-- Any reader-side config such as `hoodie.read.blob.inline.mode`
+`read_blob(<blob_column>)` is the canonical API for materializing raw blob bytes in a query. It returns the underlying `bytes` for:
+- Any `OUT_OF_LINE` row (via external pread), regardless of mode.
+- `INLINE` rows under `CONTENT` mode (1-hop passthrough of `data`).
+- `INLINE` rows on Parquet under either mode (Parquet's DESCRIPTOR is a no-op today; rows arrive in CONTENT shape).
+
+`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`, or project `col.data` directly without `read_blob()`.
 
 Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *`) returns the underlying `Blob` struct as-is. The contents of that struct depend on the storage strategy, the file format, and the read mode, as summarized below.
 
 **Reader Configuration**
 
 - `hoodie.read.blob.inline.mode` — values `DESCRIPTOR` (default) | `CONTENT`.
-  - `DESCRIPTOR` (default): the engine returns an `OUT_OF_LINE`-shaped descriptor in the `reference` field where the underlying file format supports it (Lance today), enabling lazy byte materialization via `read_blob`. For file formats without a native descriptor for inline payloads (Parquet), both `data` and `reference` are returned `NULL`, and the caller must use `read_blob` to retrieve bytes.
-  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field.
-  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting.
+  - `DESCRIPTOR` (default): metadata-only for `INLINE` rows. On Lance, the engine returns a synthesized `reference` pointing at the backing file so callers can inspect `(path, offset, length)` without materializing bytes. `read_blob()` on these rows is **unsupported and throws** — switch to `CONTENT` or read `col.data` if you want bytes.
+  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field; `read_blob()` works as a 1-hop passthrough.
+  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes via external pread.
 
 **Behavior matrix**
 
 | Access pattern   | Storage      | File format | `hoodie.read.blob.inline.mode` | `data` field | `reference` field            | Raw bytes available?                              |
 |------------------|--------------|-------------|--------------------------------|--------------|------------------------------|---------------------------------------------------|
-| `SELECT read_blob(col) FROM table` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
-| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
-| `SELECT read_blob(col) FROM table` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
+| `SELECT read_blob(col) FROM table` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes (1-hop)                       |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `CONTENT`                      | n/a          | n/a                          | Yes — returns bytes (1-hop)                       |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `DESCRIPTOR` (default)         | n/a          | n/a                          | **No — throws.** Set `CONTENT` or use `col.data`. |
+| `SELECT read_blob(col) FROM table` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes (external pread)              |
 | `SELECT col FROM table`       | INLINE       | Parquet     | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
 | `SELECT col FROM table`       | INLINE       | Parquet     | `DESCRIPTOR` (default)         | bytes¹       | NULL¹                        | Yes — via `data`¹                                 |
 | `SELECT col FROM table`       | INLINE       | Lance       | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (Lance blob enc.)  | No — descriptor visible; use `read_blob` for bytes|
+| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)      | No — metadata-only; switch mode to read bytes     |
 | `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
 
 ¹ **Parquet + DESCRIPTOR is a no-op today.** The Parquet reader path does not currently honor `hoodie.read.blob.inline.mode`, so on Parquet tables the config is ignored and INLINE rows always come back in `CONTENT` shape regardless of the setting. The default flip to `DESCRIPTOR` therefore has no observable effect on Parquet tables. The matrix row above shows what users will actually see today, not the eventual spec.
@@ -189,24 +192,27 @@ flowchart TD
     QI -->|"SELECT read_blob(col)"| RM{hoodie.read.blob.inline.mode}
     RM -->|CONTENT| RBC(["bytes from inline_data on the row<br/>1 hop"])
     RM -->|DESCRIPTOR default| RF{file format}
-    RF -->|Lance| RBL(["bytes via raw pread at<br/>synth reference offset/length<br/>2 hops"])
+    RF -->|Lance| RBL(["error: read_blob unsupported<br/>on INLINE rows under DESCRIPTOR<br/>(metadata-only mode)"])
     RF -->|"Parquet (today: mode no-op)"| RBP(["bytes from inline_data on the row<br/>1 hop — same as CONTENT"])
 ```
 
-`read_blob(col)` byte resolution — works regardless of storage type or mode, with hop count depending on the row shape that arrives:
+`read_blob(col)` byte resolution — hop count depends on the row shape that arrives. INLINE rows under DESCRIPTOR mode are rejected; the mode is metadata-only and the synthesized reference is an internal pointer, not user-facing storage.
 
 ```mermaid
 flowchart LR
     RB[/"SELECT read_blob(col)"/] --> Scan["Scan emits Blob struct"]
     Scan --> Shape{"row shape"}
-    Shape -->|"inline_data populated<br/>(CONTENT mode)"| Direct["BatchedBlobReader:<br/>read inline_data off the row<br/><b>1 hop total</b>"]
-    Shape -->|"reference populated<br/>(OUT_OF_LINE, or DESCRIPTOR + Lance)"| Indirect["BatchedBlobReader:<br/>openSeekable(external_path)<br/>seek(offset), readFully(length)<br/><b>2 hops total</b>"]
+    Shape -->|"inline_data populated<br/>(CONTENT mode, or Parquet)"| Direct["BatchedBlobReader:<br/>read inline_data off the row<br/><b>1 hop total</b>"]
+    Shape -->|"reference populated"| Type{"storage_type"}
+    Type -->|"OUT_OF_LINE"| Indirect["BatchedBlobReader:<br/>openSeekable(external_path)<br/>seek(offset), readFully(length)<br/><b>2 hops total</b>"]
+    Type -->|"INLINE<br/>(DESCRIPTOR + Lance)"| Err["error: read_blob unsupported<br/>on INLINE rows under DESCRIPTOR"]
     Direct --> Bytes(["bytes"])
     Indirect --> Bytes
 ```
 
 Notes:
-- For DESCRIPTOR + Lance, hop 2 is a raw filesystem `pread` against the `.lance` file at the descriptor's `(offset, length)`. It bypasses Lance's decoder entirely — the blob encoding (`lance-encoding:blob=true` on a `LargeBinary` column) stores blob bytes contiguously at the position Lance reports, so direct byte access is safe.
+- INLINE + DESCRIPTOR + `read_blob()` is unsupported by design. DESCRIPTOR is metadata-only for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`, or project `col.data` directly without `read_blob()`.
+- OUT_OF_LINE is unaffected by `hoodie.read.blob.inline.mode` — the descriptor is real user metadata and `read_blob()` always works via an external pread.
 - Plain `SELECT col` (no `read_blob`) is always 1 hop. DESCRIPTOR's win is that hop 1 skips blob decoding when bytes aren't needed.
 
 ### 3. Writer

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -132,19 +132,18 @@ SELECT id, url, read_blob(image_blob) as image_bytes FROM my_table;
 
 `read_blob(<blob_column>)` is the canonical API for materializing raw blob bytes in a query. It returns the underlying `bytes` for:
 - Any `OUT_OF_LINE` row, regardless of mode.
-- `INLINE` rows under `CONTENT` mode (1-hop passthrough of `inline_data`).
-- `INLINE` rows on Lance under `DESCRIPTOR` mode (2-hop pread against the synthesized reference; the byte fetch reuses the same range-merged I/O path used for OUT_OF_LINE rows).
+- `INLINE` rows under `CONTENT` mode.
 - `INLINE` rows on Parquet under either mode (Parquet's DESCRIPTOR is a no-op today; rows arrive in CONTENT shape).
 
-The single case `read_blob()` does **not** support is when the **same query** also projects a blob column directly on a Lance table under `DESCRIPTOR` — e.g. `SELECT read_blob(col1), col1 FROM t` or `SELECT read_blob(col1), col2 FROM t` where `col2` is another blob column. The query is rejected by `ReadBlobRule` at plan time with a clear `AnalysisException` because returning materialized bytes for one column alongside a synthesized Lance-internal reference for another in the same row is misleading: the synthesized reference is an implementation detail, not durable metadata, and exposing it next to real bytes invites callers to treat the pointer as user-facing. The error names both the columns and the config key so the fix is obvious — either set `hoodie.read.blob.inline.mode=CONTENT` or drop the direct projection.
+`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`.
 
 Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *`) returns the underlying `Blob` struct as-is. The contents of that struct depend on the storage strategy, the file format, and the read mode, as summarized below.
 
 **Reader Configuration**
 
 - `hoodie.read.blob.inline.mode` — values `DESCRIPTOR` (default) | `CONTENT`.
-  - `DESCRIPTOR` (default): on a plain `SELECT col`, the engine returns a synthesized `reference` pointing at the backing file so callers can inspect `(path, offset, length)` without materializing bytes. On `read_blob(col)` alone, the engine still materializes bytes via a 2-hop pread against that same reference. Mixing a `read_blob()` call with a direct projection of any blob column in the same query is rejected at plan time.
-  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field for every INLINE row at scan time. Both direct projection and `read_blob()` then resolve cleanly, and the mixed-projection error does not apply.
+  - `DESCRIPTOR` (default): metadata-only for `INLINE` rows. On Lance, the engine returns a synthesized `reference` pointing at the backing file so callers can inspect `(path, offset, length)` without materializing bytes. `read_blob()` on these rows is **unsupported and throws** — switch to `CONTENT` or read `col.data` if you want bytes.
+  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field;
   - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes.
 
 **Behavior matrix**
@@ -152,14 +151,13 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 | Access pattern   | Storage      | File format | `hoodie.read.blob.inline.mode` | `data` field | `reference` field            | Raw bytes available?                              |
 |------------------|--------------|-------------|--------------------------------|--------------|------------------------------|---------------------------------------------------|
 | `SELECT read_blob(col) FROM table` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes (1-hop)                       |
-| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `CONTENT`                      | n/a          | n/a                          | Yes — returns bytes (1-hop passthrough)           |
-| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `DESCRIPTOR` (default)         | n/a          | n/a                          | Yes — returns bytes (2-hop pread via synthesized reference) |
-| `SELECT read_blob(col), <any blob col> FROM table` | INLINE | Lance | `DESCRIPTOR` (default) | n/a | n/a | **No — analyzer throws.** Mixed projection rejected; set `CONTENT` or remove the direct blob projection. |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `CONTENT`                      | n/a          | n/a                          | Yes — returns bytes (1-hop)                       |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `DESCRIPTOR` (default)         | n/a          | n/a                          | **No — throws.** Set `CONTENT` or use `col.data`. |
 | `SELECT read_blob(col) FROM table` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes (external pread)              |
 | `SELECT col FROM table`       | INLINE       | Parquet     | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
 | `SELECT col FROM table`       | INLINE       | Parquet     | `DESCRIPTOR` (default)         | bytes¹       | NULL¹                        | Yes — via `data`¹                                 |
 | `SELECT col FROM table`       | INLINE       | Lance       | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)      | No — descriptor-only; call `read_blob` to materialize |
+| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)      | No — metadata-only; switch mode to read bytes     |
 | `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
 
 
@@ -189,21 +187,19 @@ flowchart TD
     QI -->|"SELECT read_blob(col)"| RM{hoodie.read.blob.inline.mode}
     RM -->|CONTENT| RBC(["bytes from inline_data on the row<br/>1 hop"])
     RM -->|DESCRIPTOR default| RF{file format}
-    RF -->|Lance| RBL(["bytes via 2-hop pread<br/>against synthesized reference<br/>(same code path as OUT_OF_LINE)"])
+    RF -->|Lance| RBL(["error: read_blob unsupported<br/>on INLINE rows under DESCRIPTOR<br/>(metadata-only mode)"])
     RF -->|"Parquet (today: mode no-op)"| RBP(["bytes from inline_data on the row<br/>1 hop — same as CONTENT"])
-
-    QI -->|"SELECT read_blob(col1), col2"| MIX(["DESCRIPTOR (any format):<br/>ReadBlobRule throws AnalysisException —<br/>mixed projection unsupported.<br/>(Practically only Lance hits this; Parquet<br/>ignores the mode so the throw is recoverable<br/>by setting CONTENT.)<br/>CONTENT: succeeds; both shapes resolve."])
 ```
 
 
 ```mermaid
 flowchart LR
-    RB[/"SELECT read_blob(col)"/] --> PlanCheck{"projection<br/>also includes a direct<br/>blob-column reference?"}
-    PlanCheck -->|"yes AND effective mode = DESCRIPTOR"| Reject["ReadBlobRule throws<br/>AnalysisException at plan time<br/>(mixed projection unsupported)"]
-    PlanCheck -->|"no, or effective mode = CONTENT"| Scan["Scan emits Blob struct"]
+    RB[/"SELECT read_blob(col)"/] --> Scan["Scan emits Blob struct"]
     Scan --> Shape{"row shape"}
     Shape -->|"inline_data populated<br/>(CONTENT mode, or Parquet)"| Direct["BatchedBlobReader:<br/>read inline_data off the row<br/><b>1 hop total</b>"]
-    Shape -->|"reference populated"| Indirect["BatchedBlobReader:<br/>openSeekable(external_path)<br/>seek(offset), readFully(length)<br/><b>2 hops total</b><br/>(applies to OUT_OF_LINE and to<br/>INLINE+DESCRIPTOR on Lance —<br/>the synthesized reference is shaped<br/>identically to an external one)"]
+    Shape -->|"reference populated"| Type{"storage_type"}
+    Type -->|"OUT_OF_LINE"| Indirect["BatchedBlobReader:<br/>openSeekable(external_path)<br/>seek(offset), readFully(length)<br/><b>2 hops total</b>"]
+    Type -->|"INLINE<br/>(DESCRIPTOR + Lance)"| Err["error: read_blob unsupported<br/>on INLINE rows under DESCRIPTOR"]
     Direct --> Bytes(["bytes"])
     Indirect --> Bytes
 ```

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -163,31 +163,45 @@ Lance's native blob encoding stores blobs in a way that already exposes a `(file
 
 **Visual**
 
-```
-  ┌──────────────────────────────────────────────────────────────────┐
-  │  read_blob(col)        ── universal, always materializes bytes ──│
-  │       │                                                          │
-  │       ▼                                                          │
-  │  ┌─────────────┐    INLINE ───► read inline payload              │
-  │  │ Hudi reader │ ──┤                                             │
-  │  └─────────────┘    OUT_OF_LINE ► follow reference → read bytes  │
-  └──────────────────────────────────────────────────────────────────┘
+What the user gets back, grouped by storage type (set at write time) and then by query shape:
 
-  ┌──────────────────────────────────────────────────────────────────┐
-  │  SELECT col  (returns Blob struct as-is)                         │
-  │       │                                                          │
-  │       ▼                                                          │
-  │  storage = OUT_OF_LINE  ─────────────► data=NULL, reference=set  │
-  │                                                                  │
-  │  storage = INLINE,                                               │
-  │   inline.mode = CONTENT (default) ───► data=<bytes>, ref=NULL    │
-  │                                                                  │
-  │  storage = INLINE,                                               │
-  │   inline.mode = DESCRIPTOR                                       │
-  │     ├─ Parquet  ─────────────────────► data=NULL, ref=NULL       │
-  │     └─ Lance    ─────────────────────► data=NULL, ref=set        │
-  └──────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    ST{storage_type}
+
+    ST -->|OUT_OF_LINE| QO{Query}
+    QO -->|"SELECT col"| OOL["type = OUT_OF_LINE<br/>inline_data = NULL<br/>reference = user-supplied"]
+    QO -->|"SELECT read_blob(col)"| RBO(["bytes — materialized<br/>via the external reference"])
+
+    ST -->|INLINE| QI{Query}
+    QI -->|"SELECT col"| M{hoodie.read.blob.inline.mode}
+    M -->|CONTENT default| CONT["type = INLINE<br/>inline_data = bytes<br/>reference = NULL"]
+    M -->|DESCRIPTOR| F{file format}
+    F -->|Lance| LD["type = INLINE<br/>inline_data = NULL<br/>reference = synthetic managed<br/>path, offset, length, is_managed=true"]
+    F -->|Parquet| PD["type = INLINE<br/>inline_data = NULL<br/>reference = NULL<br/>bytes only via read_blob"]
+
+    QI -->|"SELECT read_blob(col)"| RM{hoodie.read.blob.inline.mode}
+    RM -->|CONTENT default| RBC(["bytes from inline_data on the row<br/>1 hop"])
+    RM -->|DESCRIPTOR| RF{file format}
+    RF -->|Lance| RBL(["bytes via raw pread at<br/>synth reference offset/length<br/>2 hops"])
+    RF -->|Parquet| RBP(["bytes via format-specific<br/>materialization path<br/>row has no descriptor"])
 ```
+
+`read_blob(col)` byte resolution — works regardless of storage type or mode, with hop count depending on the row shape that arrives:
+
+```mermaid
+flowchart LR
+    RB[/"SELECT read_blob(col)"/] --> Scan["Scan emits Blob struct"]
+    Scan --> Shape{"row shape"}
+    Shape -->|"inline_data populated<br/>(CONTENT mode)"| Direct["BatchedBlobReader:<br/>read inline_data off the row<br/><b>1 hop total</b>"]
+    Shape -->|"reference populated<br/>(OUT_OF_LINE, or DESCRIPTOR + Lance)"| Indirect["BatchedBlobReader:<br/>openSeekable(external_path)<br/>seek(offset), readFully(length)<br/><b>2 hops total</b>"]
+    Direct --> Bytes(["bytes"])
+    Indirect --> Bytes
+```
+
+Notes:
+- For DESCRIPTOR + Lance, hop 2 is a raw filesystem `pread` against the `.lance` file at the descriptor's `(offset, length)`. It bypasses Lance's decoder entirely — the blob encoding (`lance-encoding:blob=true` on a `LargeBinary` column) stores blob bytes contiguously at the position Lance reports, so direct byte access is safe.
+- Plain `SELECT col` (no `read_blob`) is always 1 hop. DESCRIPTOR's win is that hop 1 skips blob decoding when bytes aren't needed.
 
 ### 3. Writer
 #### Phase 1: External Blob Support

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -139,9 +139,9 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 
 **Reader Configuration**
 
-- `hoodie.read.blob.inline.mode` — values `CONTENT` (default) | `DESCRIPTOR`.
+- `hoodie.read.blob.inline.mode` — values `DESCRIPTOR` (default) | `CONTENT`.
+  - `DESCRIPTOR` (default): the engine returns an `OUT_OF_LINE`-shaped descriptor in the `reference` field where the underlying file format supports it (Lance today), enabling lazy byte materialization via `read_blob`. For file formats without a native descriptor for inline payloads (Parquet), both `data` and `reference` are returned `NULL`, and the caller must use `read_blob` to retrieve bytes.
   - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field.
-  - `DESCRIPTOR`: the engine returns an `OUT_OF_LINE`-shaped descriptor in the `reference` field where the underlying file format supports it (Lance today), enabling lazy byte materialization via `read_blob`. For file formats without a native descriptor for inline payloads (Parquet), both `data` and `reference` are returned `NULL`, and the caller must use `read_blob` to retrieve bytes.
   - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting.
 
 **Behavior matrix**
@@ -151,15 +151,21 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 | `SELECT read_blob(col) FROM table` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
 | `SELECT read_blob(col) FROM table` | INLINE       | Lance       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
 | `SELECT read_blob(col) FROM table` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes                               |
-| `SELECT col FROM table`       | INLINE       | Parquet     | `CONTENT` (default)            | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT col FROM table`       | INLINE       | Parquet     | `DESCRIPTOR`                   | **NULL**     | **NULL**                     | No — must call `read_blob`                        |
-| `SELECT col FROM table`       | INLINE       | Lance       | `CONTENT` (default)            | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR`                   | NULL         | populated (Lance blob enc.)  | No — descriptor visible; use `read_blob` for bytes|
+| `SELECT col FROM table`       | INLINE       | Parquet     | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
+| `SELECT col FROM table`       | INLINE       | Parquet     | `DESCRIPTOR` (default)         | bytes¹       | NULL¹                        | Yes — via `data`¹                                 |
+| `SELECT col FROM table`       | INLINE       | Lance       | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
+| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (Lance blob enc.)  | No — descriptor visible; use `read_blob` for bytes|
 | `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
+
+¹ **Parquet + DESCRIPTOR is a no-op today.** The Parquet reader path does not currently honor `hoodie.read.blob.inline.mode`, so on Parquet tables the config is ignored and INLINE rows always come back in `CONTENT` shape regardless of the setting. The default flip to `DESCRIPTOR` therefore has no observable effect on Parquet tables. The matrix row above shows what users will actually see today, not the eventual spec.
+
+**Eventual spec for Parquet + DESCRIPTOR (not yet implemented)**
+
+When Parquet gains DESCRIPTOR support, INLINE rows in `DESCRIPTOR` mode are intended to return `data = NULL` and `reference = NULL` (no native positional handle exists in Parquet for an inline byte array), with `read_blob` materializing bytes through a format-specific path. Until then, treat `DESCRIPTOR` as effectively `CONTENT` on Parquet.
 
 **Why Parquet and Lance differ in `DESCRIPTOR` mode**
 
-Lance's native blob encoding stores blobs in a way that already exposes a `(file, offset, length)` descriptor cheaply, so `DESCRIPTOR` mode surfaces it directly in the `reference` field — effectively letting INLINE blobs be read with the same deferred-materialization path used for OUT_OF_LINE references. Parquet has no equivalent native descriptor for an inline byte array, so both fields are `NULL` in `DESCRIPTOR` mode and the caller must use `read_blob` to materialize bytes.
+Lance's native blob encoding stores blobs in a way that already exposes a `(file, offset, length)` descriptor cheaply, so `DESCRIPTOR` mode surfaces it directly in the `reference` field — effectively letting INLINE blobs be read with the same deferred-materialization path used for OUT_OF_LINE references. Parquet has no equivalent native descriptor for an inline byte array, which is why the DESCRIPTOR path is currently a no-op there.
 
 **Visual**
 
@@ -175,16 +181,16 @@ flowchart TD
 
     ST -->|INLINE| QI{Query}
     QI -->|"SELECT col"| M{hoodie.read.blob.inline.mode}
-    M -->|CONTENT default| CONT["type = INLINE<br/>inline_data = bytes<br/>reference = NULL"]
-    M -->|DESCRIPTOR| F{file format}
+    M -->|CONTENT| CONT["type = INLINE<br/>inline_data = bytes<br/>reference = NULL"]
+    M -->|DESCRIPTOR default| F{file format}
     F -->|Lance| LD["type = INLINE<br/>inline_data = NULL<br/>reference = synthetic managed<br/>path, offset, length, is_managed=true"]
-    F -->|Parquet| PD["type = INLINE<br/>inline_data = NULL<br/>reference = NULL<br/>bytes only via read_blob"]
+    F -->|"Parquet (today: mode no-op)"| PD["Parquet reader does not<br/>implement DESCRIPTOR yet —<br/>returns CONTENT shape:<br/>inline_data = bytes, reference = NULL"]
 
     QI -->|"SELECT read_blob(col)"| RM{hoodie.read.blob.inline.mode}
-    RM -->|CONTENT default| RBC(["bytes from inline_data on the row<br/>1 hop"])
-    RM -->|DESCRIPTOR| RF{file format}
+    RM -->|CONTENT| RBC(["bytes from inline_data on the row<br/>1 hop"])
+    RM -->|DESCRIPTOR default| RF{file format}
     RF -->|Lance| RBL(["bytes via raw pread at<br/>synth reference offset/length<br/>2 hops"])
-    RF -->|Parquet| RBP(["bytes via format-specific<br/>materialization path<br/>row has no descriptor"])
+    RF -->|"Parquet (today: mode no-op)"| RBP(["bytes from inline_data on the row<br/>1 hop — same as CONTENT"])
 ```
 
 `read_blob(col)` byte resolution — works regardless of storage type or mode, with hop count depending on the row shape that arrives:

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -131,11 +131,11 @@ SELECT id, url, read_blob(image_blob) as image_bytes FROM my_table;
 #### Read Modes: `read_blob` vs. `SELECT *`
 
 `read_blob(<blob_column>)` is the canonical API for materializing raw blob bytes in a query. It returns the underlying `bytes` for:
-- Any `OUT_OF_LINE` row (via external pread), regardless of mode.
-- `INLINE` rows under `CONTENT` mode (1-hop passthrough of `data`).
+- Any `OUT_OF_LINE` row, regardless of mode.
+- `INLINE` rows under `CONTENT` mode.
 - `INLINE` rows on Parquet under either mode (Parquet's DESCRIPTOR is a no-op today; rows arrive in CONTENT shape).
 
-`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`, or project `col.data` directly without `read_blob()`.
+`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`.
 
 Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *`) returns the underlying `Blob` struct as-is. The contents of that struct depend on the storage strategy, the file format, and the read mode, as summarized below.
 
@@ -143,8 +143,8 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 
 - `hoodie.read.blob.inline.mode` — values `DESCRIPTOR` (default) | `CONTENT`.
   - `DESCRIPTOR` (default): metadata-only for `INLINE` rows. On Lance, the engine returns a synthesized `reference` pointing at the backing file so callers can inspect `(path, offset, length)` without materializing bytes. `read_blob()` on these rows is **unsupported and throws** — switch to `CONTENT` or read `col.data` if you want bytes.
-  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field; `read_blob()` works as a 1-hop passthrough.
-  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes via external pread.
+  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field;
+  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes.
 
 **Behavior matrix**
 
@@ -160,11 +160,6 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 | `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)      | No — metadata-only; switch mode to read bytes     |
 | `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
 
-¹ **Parquet + DESCRIPTOR is a no-op today.** The Parquet reader path does not currently honor `hoodie.read.blob.inline.mode`, so on Parquet tables the config is ignored and INLINE rows always come back in `CONTENT` shape regardless of the setting. The default flip to `DESCRIPTOR` therefore has no observable effect on Parquet tables. The matrix row above shows what users will actually see today, not the eventual spec.
-
-**Eventual spec for Parquet + DESCRIPTOR (not yet implemented)**
-
-When Parquet gains DESCRIPTOR support, INLINE rows in `DESCRIPTOR` mode are intended to return `data = NULL` and `reference = NULL` (no native positional handle exists in Parquet for an inline byte array), with `read_blob` materializing bytes through a format-specific path. Until then, treat `DESCRIPTOR` as effectively `CONTENT` on Parquet.
 
 **Why Parquet and Lance differ in `DESCRIPTOR` mode**
 
@@ -196,7 +191,6 @@ flowchart TD
     RF -->|"Parquet (today: mode no-op)"| RBP(["bytes from inline_data on the row<br/>1 hop — same as CONTENT"])
 ```
 
-`read_blob(col)` byte resolution — hop count depends on the row shape that arrives. INLINE rows under DESCRIPTOR mode are rejected; the mode is metadata-only and the synthesized reference is an internal pointer, not user-facing storage.
 
 ```mermaid
 flowchart LR
@@ -209,11 +203,6 @@ flowchart LR
     Direct --> Bytes(["bytes"])
     Indirect --> Bytes
 ```
-
-Notes:
-- INLINE + DESCRIPTOR + `read_blob()` is unsupported by design. DESCRIPTOR is metadata-only for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`, or project `col.data` directly without `read_blob()`.
-- OUT_OF_LINE is unaffected by `hoodie.read.blob.inline.mode` — the descriptor is real user metadata and `read_blob()` always works via an external pread.
-- Plain `SELECT col` (no `read_blob`) is always 1 hop. DESCRIPTOR's win is that hop 1 skips blob decoding when bytes aren't needed.
 
 ### 3. Writer
 #### Phase 1: External Blob Support

--- a/rfc/rfc-100/rfc-100.md
+++ b/rfc/rfc-100/rfc-100.md
@@ -135,7 +135,7 @@ SELECT id, url, read_blob(image_blob) as image_bytes FROM my_table;
 - `INLINE` rows under `CONTENT` mode (1-hop passthrough of `data`).
 - `INLINE` rows on Parquet under either mode (Parquet's DESCRIPTOR is a no-op today; rows arrive in CONTENT shape).
 
-`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`, or project `col.data` directly without `read_blob()`.
+`INLINE` rows on Lance under `DESCRIPTOR` mode are **not supported** by `read_blob()` and the call throws a clear error. DESCRIPTOR is a metadata-only mode for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`.
 
 Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *`) returns the underlying `Blob` struct as-is. The contents of that struct depend on the storage strategy, the file format, and the read mode, as summarized below.
 
@@ -143,28 +143,23 @@ Selecting the blob column directly (e.g. `SELECT image_blob FROM t` or `SELECT *
 
 - `hoodie.read.blob.inline.mode` — values `DESCRIPTOR` (default) | `CONTENT`.
   - `DESCRIPTOR` (default): metadata-only for `INLINE` rows. On Lance, the engine returns a synthesized `reference` pointing at the backing file so callers can inspect `(path, offset, length)` without materializing bytes. `read_blob()` on these rows is **unsupported and throws** — switch to `CONTENT` or read `col.data` if you want bytes.
-  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field; `read_blob()` works as a 1-hop passthrough.
-  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes via external pread.
+  - `CONTENT`: the engine eagerly materializes inline bytes into the struct's `data` field.
+  - This config governs `INLINE` reads only. For `OUT_OF_LINE` storage, the engine always returns a populated `reference` regardless of this setting, and `read_blob()` always materializes bytes.
 
 **Behavior matrix**
 
-| Access pattern   | Storage      | File format | `hoodie.read.blob.inline.mode` | `data` field | `reference` field            | Raw bytes available?                              |
-|------------------|--------------|-------------|--------------------------------|--------------|------------------------------|---------------------------------------------------|
-| `SELECT read_blob(col) FROM table` | INLINE       | Parquet     | (any)                          | n/a          | n/a                          | Yes — returns bytes (1-hop)                       |
-| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `CONTENT`                      | n/a          | n/a                          | Yes — returns bytes (1-hop)                       |
-| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `DESCRIPTOR` (default)         | n/a          | n/a                          | **No — throws.** Set `CONTENT` or use `col.data`. |
-| `SELECT read_blob(col) FROM table` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                          | Yes — returns bytes (external pread)              |
-| `SELECT col FROM table`       | INLINE       | Parquet     | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT col FROM table`       | INLINE       | Parquet     | `DESCRIPTOR` (default)         | bytes¹       | NULL¹                        | Yes — via `data`¹                                 |
-| `SELECT col FROM table`       | INLINE       | Lance       | `CONTENT`                      | bytes        | NULL                         | Yes — via `data`                                  |
-| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)      | No — metadata-only; switch mode to read bytes     |
-| `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                    | No — must call `read_blob`                        |
+| Access pattern   | Storage      | File format | `hoodie.read.blob.inline.mode` | `data` field | `reference` field           | Raw bytes available?                              |
+|------------------|--------------|-------------|--------------------------------|--------------|-----------------------------|---------------------------------------------------|
+| `SELECT read_blob(col) FROM table` | INLINE       | Parquet     | (any)                          | n/a          | n/a                         | Yes — returns bytes (1-hop)                       |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `CONTENT`                      | n/a          | n/a                         | Yes — returns bytes (1-hop)                       |
+| `SELECT read_blob(col) FROM table` | INLINE       | Lance       | `DESCRIPTOR` (default)         | n/a          | n/a                         | **No — throws.** Set `CONTENT` or use `col.data`. |
+| `SELECT read_blob(col) FROM table` | OUT_OF_LINE  | (any)       | (any)                          | n/a          | n/a                         | Yes — returns bytes (external pread)              |
+| `SELECT col FROM table`       | INLINE       | Parquet     | `CONTENT`                      | bytes        | NULL                        | Yes — via `data`                                  |
+| `SELECT col FROM table`       | INLINE       | Parquet     | `DESCRIPTOR` (default)         | bytes¹       | NULL                        | Yes — via `data`¹                                 |
+| `SELECT col FROM table`       | INLINE       | Lance       | `CONTENT`                      | bytes        | NULL                        | Yes — via `data`                                  |
+| `SELECT col FROM table`       | INLINE       | Lance       | `DESCRIPTOR` (default)         | NULL         | populated (synthesized)     | No — metadata-only; switch mode to read bytes     |
+| `SELECT col FROM table`       | OUT_OF_LINE  | (any)       | (irrelevant)                   | NULL         | populated                   | No — must call `read_blob`                        |
 
-¹ **Parquet + DESCRIPTOR is a no-op today.** The Parquet reader path does not currently honor `hoodie.read.blob.inline.mode`, so on Parquet tables the config is ignored and INLINE rows always come back in `CONTENT` shape regardless of the setting. The default flip to `DESCRIPTOR` therefore has no observable effect on Parquet tables. The matrix row above shows what users will actually see today, not the eventual spec.
-
-**Eventual spec for Parquet + DESCRIPTOR (not yet implemented)**
-
-When Parquet gains DESCRIPTOR support, INLINE rows in `DESCRIPTOR` mode are intended to return `data = NULL` and `reference = NULL` (no native positional handle exists in Parquet for an inline byte array), with `read_blob` materializing bytes through a format-specific path. Until then, treat `DESCRIPTOR` as effectively `CONTENT` on Parquet.
 
 **Why Parquet and Lance differ in `DESCRIPTOR` mode**
 
@@ -211,7 +206,7 @@ flowchart LR
 ```
 
 Notes:
-- INLINE + DESCRIPTOR + `read_blob()` is unsupported by design. DESCRIPTOR is metadata-only for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`, or project `col.data` directly without `read_blob()`.
+- INLINE + DESCRIPTOR + `read_blob()` is unsupported by design. DESCRIPTOR is metadata-only for INLINE rows: bytes aren't materialized during the scan, and the synthesized `reference` is an internal pointer into the `.lance` file's storage layout, not user-facing metadata. To read bytes, set `hoodie.read.blob.inline.mode=CONTENT`.
 - OUT_OF_LINE is unaffected by `hoodie.read.blob.inline.mode` — the descriptor is real user metadata and `read_blob()` always works via an external pread.
 - Plain `SELECT col` (no `read_blob`) is always 1 hop. DESCRIPTOR's win is that hop 1 skips blob decoding when bytes aren't needed.
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes: #18742

### Summary and Changelog

Flip default of `hoodie.read.blob.inline.mode` from `CONTENT` to `DESCRIPTOR`, and make `DESCRIPTOR` a true metadata-only mode for INLINE rows.

- Plain reads on Lance tables no longer materialize inline blob payloads per row.
- `read_blob(col)` on INLINE rows under `DESCRIPTOR` now throws with an actionable message naming both `INLINE` and `DESCRIPTOR`, and the config to flip.
- `CONTENT` remains available as opt-in for byte-heavy workloads.

**Changes:**

- `HoodieReaderConfig`: default flipped to `DESCRIPTOR`; doc updated.
- `BatchedBlobReader`: INLINE branch throws `IllegalStateException` when `inline_data=NULL` (the Lance + DESCRIPTOR shape). CONTENT 1-hop passthrough preserved.
- `ScalarFunctions`: `read_blob` `DESCRIBE FUNCTION` gains a one-line caveat about the INLINE+DESCRIPTOR throw.
- `TestLanceDataSource`:
  - `testBlobInlineRoundTrip` opts into `CONTENT` explicitly.
  - `testBlobInlineDescriptorMode` asserts descriptor-shape on plain reads and that `read_blob()` throws with `INLINE` + `DESCRIPTOR` in the message chain.
  - `testBlobInlineCompactionRoundTrip` (MOR): inserts INLINE blobs, upserts a subset to force compaction, verifies touched rows carry new bytes and untouched rows retain originals. Asserts presence of log files and a compaction commit so a CoW-like fallthrough cannot silently pass.
  - `testBlobMixedInlineAndOutOfLineContentMode`: one column holding both INLINE and OUT_OF_LINE rows; CONTENT-mode `read_blob()` resolves each shape via its own path.
  - `testBlobInlineMultipleColumnsPlainSelect`: two INLINE blob columns with distinct byte patterns. CONTENT keeps per-column bytes independent; DESCRIPTOR synthesis fires per column.
  - `testBlobInlineMultipleColumnsReadBlobAll`: `SELECT read_blob(a), read_blob(b)` under CONTENT, distinct bytes catch cross-column aliasing.
  - `testBlobInlineMultipleColumnsMixedSelect`: `SELECT read_blob(a), b` (mixed materialize + struct projection). CONTENT returns bytes for `a` and content-shape struct for `b`. DESCRIPTOR still throws on `read_blob(a)` even when `b` is only projected as a struct.
  - Shared `writeMultiBlobInlineTable` helper for the multi-column tests.
- `rfc/rfc-100/rfc-100.md`: behavior matrix, prose, and mermaid diagrams refreshed.

Compaction-side CONTENT pin in `HoodieSparkLanceReader` is unchanged and exercised end-to-end by the MOR compaction test.

### Impact

User-facing behavior change for **Lance** INLINE blobs:

- `SELECT *` now returns `data=NULL` plus a synthesized `reference` by default (was `data=bytes, reference=NULL`).
- `read_blob(col)` on INLINE rows throws under the default. Callers either:
  - set `hoodie.read.blob.inline.mode=CONTENT` and use `read_blob(col)` (1-hop), or
  - read `col.data` directly under CONTENT.

Error message names both `INLINE` and `DESCRIPTOR` and the config to flip, so failures are actionable.

**Parquet unaffected.** The Parquet reader does not honor `hoodie.read.blob.inline.mode`; INLINE rows always come back in CONTENT shape there, so the new throw is unreachable.

**OUT_OF_LINE unaffected** under any mode. The setting governs INLINE reads only; OUT_OF_LINE descriptors are real user metadata and `read_blob()` always materializes via external pread.

**Why error rather than the 2-hop fallback:** the synthesized `reference` for INLINE+DESCRIPTOR is a pointer into `.lance` storage layout, not user-facing metadata. Silent 2-hop materialization let users project `col.reference.offset` next to `read_blob(col)` and treat the Lance-internal offset as durable. The error aligns the mode's behavior with its name: DESCRIPTOR is metadata-only.

### Risk Level

Medium. Default flip plus the new throw is a behavior change for any Lance caller using `read_blob()` on INLINE blobs. Mitigations:

- Restore prior behavior with `hoodie.read.blob.inline.mode=CONTENT`. Also the right setting for byte-heavy workloads (image processing, ML feature extraction, full-table exports).
- Error message is actionable and names the config to flip.
- Compaction-side reader is hard-pinned to CONTENT; MOR compaction test exercises the round-trip end-to-end.
- Mixed-storage test pins INLINE + OUT_OF_LINE in a single column.
- Multi-column tests pin per-column independence and rule out cross-column aliasing.

### Documentation Update

- `HoodieReaderConfig.BLOB_INLINE_READ_MODE` description updated.
- `ScalarFunctions.read_blob` `DESCRIBE FUNCTION` text gains an INLINE+DESCRIPTOR caveat block.
- RFC-100 behavior matrix, prose, and mermaid diagrams refreshed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable