### PR TITLE
fix: Add Apache Licence to hudi-notebooks/requirements.txt

### DIFF
--- a/hudi-notebooks/requirements.txt
+++ b/hudi-notebooks/requirements.txt
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 jupyter
 pandas
 numpy


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR adds Apache Licence to hudi-notebooks/requirements.txt for compliance.

### Summary and Changelog

As above.

### Impact

Unblock release build.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
