### PR TITLE
fix: Use the latest docker image in hudi-integ-test for Macbook

### DIFF
--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -522,7 +522,7 @@
       <id>m1-mac</id>
       <properties>
         <dockerCompose.file>
-          ${project.basedir}/../docker/compose/docker-compose_hadoop284_hive233_spark244_mac_aarch64.yml
+          ${project.basedir}/../docker/compose/docker-compose_hadoop284_hive2310_spark353_arm64.yml
         </dockerCompose.file>
       </properties>
       <activation>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR updates the docker image in `hudi-integ-test` module for Macbook.

### Summary and Changelog

As above

### Impact

The existing image has been removed and no longer works.  This fixes the issue.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
