### PR TITLE
fix(flink): fix the write handle close for append write

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
@@ -166,6 +166,17 @@ public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {
     writeMetrics.registerMetrics();
   }
 
+  @Override
+  public void close() throws Exception {
+    try {
+      if (this.writerHelper != null) {
+        this.writerHelper.close();
+      }
+    } finally {
+      super.close();
+    }
+  }
+
   /**
    * Update metrics and log for errors in write status.
    *

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithBIMBufferSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithBIMBufferSort.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -228,8 +229,15 @@ public class AppendWriteFunctionWithBIMBufferSort<T> extends AppendWriteFunction
   @Override
   public void close() throws Exception {
     try {
-      if (asyncWriteExecutor != null && !asyncWriteExecutor.isShutdown()) {
-        asyncWriteExecutor.shutdown();
+      if (asyncWriteExecutor != null) {
+        if (!asyncWriteExecutor.isShutdown()) {
+          asyncWriteExecutor.shutdown();
+        }
+        // Do not release the sort buffers while an already-submitted flush is still using them.
+        waitForAsyncWriteCompletion();
+        if (!asyncWriteExecutor.awaitTermination(10, TimeUnit.MINUTES)) {
+          log.warn("Timed out waiting for async write executor to terminate");
+        }
       }
       if (memorySegmentPools != null) {
         for (MemorySegmentPool memorySegmentPool : memorySegmentPools) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/TestAppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/TestAppendWriteFunction.java
@@ -23,8 +23,11 @@ import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.sink.bulk.BulkInsertWriterHelper;
 import org.apache.hudi.util.StreamerUtil;
 
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -40,6 +43,8 @@ import org.junit.jupiter.api.BeforeEach;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test cases for {@link AppendWriteFunction}.
@@ -120,5 +125,17 @@ public class TestAppendWriteFunction {
 
     // Should record total 5 failures across both write statuses
     assertEquals(5, flinkStreamWriteMetrics.getNumOfRecordWriteFailures());
+  }
+
+  @Test
+  void testCloseClosesWriterHelper() throws Exception {
+    AppendWriteFunction<Object> function =
+        new AppendWriteFunction<>(new Configuration(), RowType.of(VarCharType.STRING_TYPE));
+    BulkInsertWriterHelper writerHelper = mock(BulkInsertWriterHelper.class);
+    function.writerHelper = writerHelper;
+
+    function.close();
+
+    verify(writerHelper).close();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/TestAppendWriteFunctionWithBIMBufferSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/TestAppendWriteFunctionWithBIMBufferSort.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.append;
+
+import org.apache.hudi.sink.bulk.BulkInsertWriterHelper;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test cases for {@link AppendWriteFunctionWithBIMBufferSort}.
+ */
+public class TestAppendWriteFunctionWithBIMBufferSort {
+
+  @Test
+  @Timeout(10)
+  void testCloseWaitsForAsyncWriteBeforeClosingWriterHelper() throws Exception {
+    AppendWriteFunctionWithBIMBufferSort<Object> function =
+        new AppendWriteFunctionWithBIMBufferSort<>(new Configuration(), RowType.of(VarCharType.STRING_TYPE));
+    ExecutorService asyncWriteExecutor = Executors.newSingleThreadExecutor();
+    CountDownLatch asyncWriteStarted = new CountDownLatch(1);
+    CountDownLatch releaseAsyncWrite = new CountDownLatch(1);
+    AtomicBoolean writerHelperClosed = new AtomicBoolean(false);
+    BulkInsertWriterHelper writerHelper = mock(BulkInsertWriterHelper.class);
+    doAnswer(invocation -> {
+      writerHelperClosed.set(true);
+      return null;
+    }).when(writerHelper).close();
+    function.writerHelper = writerHelper;
+
+    CompletableFuture<Void> asyncWriteTask = CompletableFuture.runAsync(() -> {
+      asyncWriteStarted.countDown();
+      try {
+        releaseAsyncWrite.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }, asyncWriteExecutor);
+    assertTrue(asyncWriteStarted.await(1, TimeUnit.SECONDS));
+
+    setField(function, "asyncWriteExecutor", asyncWriteExecutor);
+    setField(function, "asyncWriteTask", new AtomicReference<>(asyncWriteTask));
+    setField(function, "isBackgroundBufferBeingProcessed", new AtomicBoolean(true));
+
+    CountDownLatch closeStarted = new CountDownLatch(1);
+    CompletableFuture<Void> closeTask = CompletableFuture.runAsync(() -> {
+      try {
+        closeStarted.countDown();
+        function.close();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    assertTrue(closeStarted.await(1, TimeUnit.SECONDS));
+    Thread.sleep(100);
+    assertFalse(closeTask.isDone());
+    assertFalse(writerHelperClosed.get());
+
+    releaseAsyncWrite.countDown();
+    closeTask.get(1, TimeUnit.SECONDS);
+
+    assertTrue(writerHelperClosed.get());
+    verify(writerHelper).close();
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = AppendWriteFunctionWithBIMBufferSort.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`AppendWriteFunctionWithBIMBufferSort` can have an in-flight async flush when the Flink task is being closed. The existing shutdown path stopped accepting new async work but did not wait for already-submitted work before releasing the sort buffers, which could allow background writes to overlap with resource cleanup during failover or cancellation.

In addition, `AppendWriteFunction` did not close a surviving `BulkInsertWriterHelper` from its `close()` path, leaving helper-owned write resources open when a task shuts down before the normal checkpoint flush path closes them.

### Summary and Changelog

This change tightens append-writer shutdown behavior so async buffer flushing completes before dependent resources are released, and any surviving writer helper is closed during function shutdown.

#### Working tree: harden append writer shutdown cleanup
- Update `AppendWriteFunction.close()` to close `writerHelper` when it is still present during task shutdown.
- Update `AppendWriteFunctionWithBIMBufferSort.close()` to shut down the async executor, wait for in-flight async flush work to finish, and only then release memory segment pools.
- Extend `TestAppendWriteFunction` with `testCloseClosesWriterHelper`.
- Add `TestAppendWriteFunctionWithBIMBufferSort` with `testCloseWaitsForAsyncWriteBeforeClosingWriterHelper` to verify close ordering when async work is still running.
- Validate related append-buffer behavior with:
  - `TestAppendWriteFunction`
  - `TestAppendWriteFunctionWithBIMBufferSort`
  - `TestAppendWriteFunctionWithBufferSort`

### Impact

This change affects Flink append-write task shutdown behavior only. It does not change public APIs, configuration, storage format, or normal write semantics.

The main user-facing effect is safer cleanup during cancellation/failover for append writers using bounded in-memory buffer sort, reducing the chance of resource cleanup racing with already-submitted async write work.

### Risk Level

low

The change is localized to append-writer shutdown paths and adds explicit waiting during close, so the primary risk is a longer close path if async work is still in progress. This is mitigated by targeted unit coverage and successful validation with:

`mvn -pl hudi-flink-datasource/hudi-flink -DskipITs -Dtest=TestAppendWriteFunction,TestAppendWriteFunctionWithBIMBufferSort,TestAppendWriteFunctionWithBufferSort test`

Result: `16` tests run, `0` failures, `0` errors.

### Documentation Update

none

No user-facing configuration, API, or behavior contract changed; this is an internal lifecycle and cleanup fix.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
