### PR TITLE
fix(lance): Support Lance file format on Spark 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2834,8 +2834,7 @@
         <hadoop.version>3.4.2</hadoop.version>
         <kafka.version>3.9.1</kafka.version>
         <hive.storage.version>2.8.1</hive.storage.version>
-        <lance.spark.artifact>lance-spark-4.0_2.13</lance.spark.artifact>
-        <lance.skip.tests>false</lance.skip.tests>
+        <lance.spark.artifact>lance-spark-4.1_2.13</lance.spark.artifact>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are

--- a/pom.xml
+++ b/pom.xml
@@ -2835,6 +2835,7 @@
         <kafka.version>3.9.1</kafka.version>
         <hive.storage.version>2.8.1</hive.storage.version>
         <lance.spark.artifact>lance-spark-4.1_2.13</lance.spark.artifact>
+        <lance.skip.tests>false</lance.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are

--- a/pom.xml
+++ b/pom.xml
@@ -2834,9 +2834,8 @@
         <hadoop.version>3.4.2</hadoop.version>
         <kafka.version>3.9.1</kafka.version>
         <hive.storage.version>2.8.1</hive.storage.version>
-        <!-- TODO: Enable lance tests on Spark 4.1 (https://github.com/apache/hudi/issues/18607) -->
         <lance.spark.artifact>lance-spark-4.0_2.13</lance.spark.artifact>
-        <lance.skip.tests>true</lance.skip.tests>
+        <lance.skip.tests>false</lance.skip.tests>
         <!-- NOTE: Some Hudi modules require standalone Parquet/Orc/etc file-format dependency (hudi-hive-sync,
                    hudi-hadoop-mr, for ex). Since these Hudi modules might be used from w/in the execution engine(s)
                    bringing these file-formats as dependencies as well, we need to make sure that versions are


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18607.

Lance tests were previously skipped on the Spark 4.1 profile because only the `lance-spark-4.0_2.13` artifact was available.

### Summary and Changelog

- Bump `lance.spark.artifact` from `lance-spark-4.0_2.13` to `lance-spark-4.1_2.13`.
- Set `lance.skip.tests` to `false` so Lance tests run under the Spark 4.1 profile.
- Drop the related TODO comment.

### Impact

Test-only. No public API or runtime behavior change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable