### PR TITLE
feat: add bucketassign minibatch cache hit/miss metrics

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkIndexBackendMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkIndexBackendMetrics.java
@@ -20,18 +20,22 @@ package org.apache.hudi.metrics;
 
 import com.codahale.metrics.SlidingWindowReservoir;
 import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.hudi.common.util.VisibleForTesting;
 
 /**
  * Metrics for the {@link org.apache.hudi.sink.partitioner.index.GlobalRecordLevelIndexBackend}.
- * Tracks cache hit/miss counts and the latency of local (cache) vs. remote (metadata table) lookups.
+ * Tracks the latency of local (cache) vs. remote (metadata table) lookups, the per-lookup key
+ * counts, and the per-mini-batch in-memory cache hit ratio.
  */
 public class FlinkIndexBackendMetrics extends HoodieFlinkMetrics {
   private static final int HISTOGRAM_WINDOW_SIZE = 100;
   private static final String LOCAL_INDEX_LOOKUP_KEY = "local_index_lookup";
   private static final String REMOTE_INDEX_LOOKUP_KEY = "remote_index_lookup";
+
+  public static final String LOOKUP_CACHE_HIT_RATIO = "lookupCacheHitRatio";
 
   /** Latency of the local (cache) phase of each index lookup, in milliseconds. */
   private final Histogram localIndexLookupLatency;
@@ -44,6 +48,15 @@ public class FlinkIndexBackendMetrics extends HoodieFlinkMetrics {
 
   /** Number of keys that missed the local cache and were fetched remotely per lookup. */
   private final Histogram remoteLookupKeysNum;
+
+  /**
+   * Latest per-mini-batch in-memory cache hit ratio (hits / (hits + misses)).
+   * Set on each {@link #updateLookupCacheHitRatio(long, long)} call; defaults to 0.0
+   * and is left unchanged when a lookup observes zero total keys.
+   * Marked {@code volatile} because Flink's reporter thread reads it while the
+   * bucket-assign task thread writes to it.
+   */
+  private volatile double lookupCacheHitRatio = 0.0D;
 
   public FlinkIndexBackendMetrics(MetricGroup metricGroup) {
     super(metricGroup);
@@ -63,6 +76,21 @@ public class FlinkIndexBackendMetrics extends HoodieFlinkMetrics {
     metricGroup.histogram("remoteIndexLookupLatency", remoteIndexLookupLatency);
     metricGroup.histogram("localLookupKeysNum", localLookupKeysNum);
     metricGroup.histogram("remoteLookupKeysNum", remoteLookupKeysNum);
+    metricGroup.gauge(LOOKUP_CACHE_HIT_RATIO, (Gauge<Double>) () -> lookupCacheHitRatio);
+  }
+
+  /**
+   * Updates the per-mini-batch cache hit-ratio gauge from the hit/miss counts already
+   * fed into {@link #updateLocalLookupKeysCount(long)} and {@link #updateRemoteLookupKeysCount(long)}.
+   * When the lookup observed no keys, the previous value is preserved so dashboards
+   * don't oscillate back to zero on idle mini-batches.
+   */
+  public void updateLookupCacheHitRatio(long hitCount, long missCount) {
+    long total = hitCount + missCount;
+    if (total <= 0L) {
+      return;
+    }
+    lookupCacheHitRatio = (double) hitCount / total;
   }
 
   public void startLocalIndexLookup() {
@@ -107,5 +135,10 @@ public class FlinkIndexBackendMetrics extends HoodieFlinkMetrics {
   @VisibleForTesting
   public long getRemoteLookupKeysSampleCount() {
     return remoteLookupKeysNum.getCount();
+  }
+
+  @VisibleForTesting
+  public double getLookupCacheHitRatio() {
+    return lookupCacheHitRatio;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordLevelIndexBackend.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.sink.partitioner.index;
 
-import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.data.HoodieListData;
@@ -37,6 +36,7 @@ import org.apache.hudi.util.StreamerUtil;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.MetricGroup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -106,8 +106,10 @@ public class GlobalRecordLevelIndexBackend implements MinibatchIndexBackend {
       }
     }
 
+    int hitCount = recordKeys.size() - missedKeys.size();
     metrics.endLocalIndexLookup();
-    metrics.updateLocalLookupKeysCount(recordKeys.size() - missedKeys.size());
+    metrics.updateLocalLookupKeysCount(hitCount);
+    metrics.updateLookupCacheHitRatio(hitCount, missedKeys.size());
 
     if (!missedKeys.isEmpty()) {
       metrics.startRemoteIndexLookup();

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkIndexBackendMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkIndexBackendMetrics.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metrics;
 
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
@@ -52,6 +53,46 @@ class TestFlinkIndexBackendMetrics {
     assertNotNull(metricGroup.getHistogram("remoteIndexLookupLatency"));
     assertNotNull(metricGroup.getHistogram("localLookupKeysNum"));
     assertNotNull(metricGroup.getHistogram("remoteLookupKeysNum"));
+  }
+
+  @Test
+  void testRegisterMetricsRegistersHitRatioGauge() {
+    Gauge<?> gauge = metricGroup.getGauge(FlinkIndexBackendMetrics.LOOKUP_CACHE_HIT_RATIO);
+    assertNotNull(gauge);
+    assertEquals(0.0D, ((Double) gauge.getValue()).doubleValue());
+  }
+
+  @Test
+  void testUpdateLookupCacheHitRatioTracksLatestMiniBatch() {
+    Gauge<?> gauge = metricGroup.getGauge(FlinkIndexBackendMetrics.LOOKUP_CACHE_HIT_RATIO);
+
+    metrics.updateLookupCacheHitRatio(3L, 1L);
+    assertEquals(0.75D, ((Double) gauge.getValue()).doubleValue());
+    assertEquals(0.75D, metrics.getLookupCacheHitRatio());
+
+    // gauge reflects the latest mini-batch, not a running average.
+    metrics.updateLookupCacheHitRatio(1L, 3L);
+    assertEquals(0.25D, ((Double) gauge.getValue()).doubleValue());
+
+    metrics.updateLookupCacheHitRatio(5L, 0L);
+    assertEquals(1.0D, ((Double) gauge.getValue()).doubleValue());
+
+    metrics.updateLookupCacheHitRatio(0L, 5L);
+    assertEquals(0.0D, ((Double) gauge.getValue()).doubleValue());
+  }
+
+  @Test
+  void testUpdateLookupCacheHitRatioPreservesPreviousValueOnEmptyBatch() {
+    metrics.updateLookupCacheHitRatio(3L, 1L);
+    assertEquals(0.75D, metrics.getLookupCacheHitRatio());
+
+    // empty mini-batch (no keys looked up) must not reset the ratio to NaN or 0.
+    metrics.updateLookupCacheHitRatio(0L, 0L);
+    assertEquals(0.75D, metrics.getLookupCacheHitRatio());
+
+    // negative counts are treated as an empty batch (defensive guard).
+    metrics.updateLookupCacheHitRatio(-1L, -2L);
+    assertEquals(0.75D, metrics.getLookupCacheHitRatio());
   }
 
   @Test
@@ -189,6 +230,7 @@ class TestFlinkIndexBackendMetrics {
 
   private static class CapturingMetricGroup extends UnregisteredMetricsGroup {
     private final Map<String, Histogram> histograms = new HashMap<>();
+    private final Map<String, Gauge<?>> gauges = new HashMap<>();
 
     @Override
     public <H extends Histogram> H histogram(String name, H histogram) {
@@ -196,8 +238,18 @@ class TestFlinkIndexBackendMetrics {
       return histogram;
     }
 
+    @Override
+    public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+      gauges.put(name, gauge);
+      return gauge;
+    }
+
     Histogram getHistogram(String name) {
       return histograms.get(name);
+    }
+
+    Gauge<?> getGauge(String name) {
+      return gauges.get(name);
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestGlobalRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestGlobalRecordLevelIndexBackend.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.metrics.FlinkIndexBackendMetrics;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
@@ -31,6 +32,8 @@ import org.apache.hudi.utils.TestData;
 import org.apache.hudi.utils.TestUtils;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,8 +51,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -221,5 +228,85 @@ public class TestGlobalRecordLevelIndexBackend {
       backend.update("idempotent_key", location);
       assertEquals(location, backend.get(Collections.singletonList("idempotent_key")).get("idempotent_key"));
     }
+  }
+
+  @Test
+  void testGetUpdatesCacheHitRatioGauge() throws Exception {
+    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+
+    try (GlobalRecordLevelIndexBackend backend = new GlobalRecordLevelIndexBackend(conf, -1)) {
+      Map<String, Gauge<?>> gauges = new HashMap<>();
+      backend.registerMetrics(captureGauges(gauges));
+
+      Gauge<?> hitRatioGauge = gauges.get(FlinkIndexBackendMetrics.LOOKUP_CACHE_HIT_RATIO);
+      assertNotNull(hitRatioGauge);
+      // no lookups yet: gauge is at its initial value.
+      assertEquals(0.0D, ((Double) hitRatioGauge.getValue()).doubleValue());
+
+      // first lookup for two known + one unknown key: 0 / 3 hit ratio, then the two known keys
+      // are populated into the cache by the metadata table fallback.
+      Map<String, HoodieRecordGlobalLocation> firstLookup =
+          backend.get(Arrays.asList("id1", "id2", "missing_key"));
+      assertEquals(2, firstLookup.size());
+      assertEquals(0.0D, ((Double) hitRatioGauge.getValue()).doubleValue());
+
+      // second lookup: id1 and id2 are now cached so they should be hits; missing_key remains a miss.
+      // ratio = 2 hits / (2 hits + 1 miss).
+      backend.get(Arrays.asList("id1", "id2", "missing_key"));
+      assertEquals(2.0D / 3.0D, ((Double) hitRatioGauge.getValue()).doubleValue());
+    }
+  }
+
+  @Test
+  void testRegisterMetricsRegistersHitRatioGauge() throws Exception {
+    try (GlobalRecordLevelIndexBackend backend = new GlobalRecordLevelIndexBackend(conf, -1)) {
+      Map<String, Gauge<?>> gauges = new HashMap<>();
+      backend.registerMetrics(captureGauges(gauges));
+
+      assertTrue(gauges.containsKey(FlinkIndexBackendMetrics.LOOKUP_CACHE_HIT_RATIO));
+      assertEquals(0.0D, ((Double) gauges.get(FlinkIndexBackendMetrics.LOOKUP_CACHE_HIT_RATIO).getValue()).doubleValue());
+    }
+  }
+
+  @Test
+  void testGetUpdatesCacheHitRatioGaugeForCachedLookup() throws Exception {
+    // Cache-only variant of testGetUpdatesCacheHitRatioGauge: pre-populates the cache
+    // so the metadata-table fallback is skipped, which keeps the test from depending on
+    // any writer/runtime setup while still exercising the get(List) -> gauge wire-up.
+    try (GlobalRecordLevelIndexBackend backend = new GlobalRecordLevelIndexBackend(conf, -1)) {
+      Map<String, Gauge<?>> gauges = new HashMap<>();
+      backend.registerMetrics(captureGauges(gauges));
+
+      Gauge<?> hitRatioGauge = gauges.get(FlinkIndexBackendMetrics.LOOKUP_CACHE_HIT_RATIO);
+      assertNotNull(hitRatioGauge);
+      // no lookups yet: gauge is at its initial value.
+      assertEquals(0.0D, ((Double) hitRatioGauge.getValue()).doubleValue());
+
+      HoodieRecordGlobalLocation location1 = new HoodieRecordGlobalLocation("par1", "000000001", "file-id-1");
+      HoodieRecordGlobalLocation location2 = new HoodieRecordGlobalLocation("par1", "000000001", "file-id-2");
+      backend.update("cached_key_1", location1);
+      backend.update("cached_key_2", location2);
+
+      // all keys served from the in-memory cache: ratio = 2 / 2 = 1.0.
+      Map<String, HoodieRecordGlobalLocation> result =
+          backend.get(Arrays.asList("cached_key_1", "cached_key_2"));
+      assertEquals(2, result.size());
+      assertEquals(1.0D, ((Double) hitRatioGauge.getValue()).doubleValue());
+
+      // a second, single-key cached lookup keeps the ratio at 1.0.
+      backend.get(Collections.singletonList("cached_key_1"));
+      assertEquals(1.0D, ((Double) hitRatioGauge.getValue()).doubleValue());
+    }
+  }
+
+  private static MetricGroup captureGauges(Map<String, Gauge<?>> sink) {
+    MetricGroup metricGroup = mock(MetricGroup.class);
+    doAnswer(invocation -> {
+      String name = invocation.getArgument(0);
+      Gauge<?> gauge = invocation.getArgument(1);
+      sink.put(name, gauge);
+      return gauge;
+    }).when(metricGroup).gauge(anyString(), any(Gauge.class));
+    return metricGroup;
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
The Flink bucket-assign operator on the global record-level index (GRLI) path keeps an in-memory `RecordIndexCache` to serve record-key lookups, falling back to the metadata table on a miss. Today the cache is a black box at runtime — operators have no visibility into how effective it is, which makes it impossible to alert on a degraded hit ratio (e.g. due to undersized cache, eviction churn, or key-skew patterns) or to tune `INDEX_RLI_CACHE_SIZE` based on real workload behavior.
This PR adds two counter metrics so the in-memory cache hit / miss volume becomes observable and alertable. It builds on top of #18762, which recently introduced `FlinkIndexBackendMetrics` and the per-call histograms (`localLookupKeysNum`, `remoteLookupKeysNum`). Those histograms describe the per-batch distribution; the new counters add the cumulative running totals that are cheaper to scrape and easier to ratio in dashboards/alerts.
### Summary and Changelog
Adds two Flink counter metrics on the bucket-assign operator's `MetricGroup`, registered automatically whenever the GRLI backend is in use:
- `bucketassign.minibatch.cache.hit.count` — cumulative record-key lookups served by the in-memory `RecordIndexCache`.
- `bucketassign.minibatch.cache.miss.count` — cumulative record-key lookups that fell back to a metadata-table read.
Changelog:
- `org.apache.hudi.metrics.FlinkIndexBackendMetrics` (existing class, introduced in #18762):
  - Adds two `SimpleCounter` fields `cacheHitCount` / `cacheMissCount` and public constants `BUCKET_ASSIGN_MINIBATCH_CACHE_HIT_COUNT` / `BUCKET_ASSIGN_MINIBATCH_CACHE_MISS_COUNT`.
  - Registers both counters in `registerMetrics()` alongside the existing histograms.
  - Exposes `markCacheHit(long)` / `markCacheMiss(long)` helpers that short-circuit on `n <= 0` so a single call site can drain a whole batch's hit/miss counts in one shot.
  - Adds `@VisibleForTesting` getters `getCacheHitCount()` / `getCacheMissCount()`.
- `org.apache.hudi.sink.partitioner.index.GlobalRecordLevelIndexBackend`:
  - In `get(List<String> recordKeys)`, alongside the existing `updateLocalLookupKeysCount(...)` call, bumps the new hit/miss counters by `recordKeys.size() - missedKeys.size()` and `missedKeys.size()` respectively. No new field, no extra branching — same metrics object that the backend already constructs.
- New tests in `TestFlinkIndexBackendMetrics` (counter registration, increments, zero/negative no-op) and `TestGlobalRecordLevelIndexBackend` (end-to-end: counters bump correctly across a cold and a warm batch lookup; counters are registered on the supplied `MetricGroup`).
No code copied from other projects.
### Impact
- **User-facing**: Two new Flink counter metrics are exposed under the bucket-assign operator's metric group. Existing dashboards/alerts are unchanged; the new metrics are purely additive.
- **Public API**: None. No new configuration keys, no behavior changes to bucket assignment, cache eviction, or metadata-table reads.
- **Performance**: Negligible. The hot path adds one subtraction and at most two `Counter.inc(long)` calls per batch lookup, sitting next to the existing histogram update.
### Risk Level
low
The change is observability-only: cache lookup semantics are unchanged, no new public APIs, no new config keys, and the increment path is a constant-time pair of counter bumps next to existing metric updates. The backend constructor already pre-initializes `metrics` with an `UnregisteredMetricsGroup`, so the new calls cannot NPE regardless of whether `registerMetrics(...)` was later invoked by the operator.
Verification: new and existing unit tests covering the bucket-assign + metrics surface pass with `-Pspark3.3,flink1.18` (`TestFlinkIndexBackendMetrics`, `TestFlinkBucketAssignMetrics`, `TestGlobalRecordLevelIndexBackend`).
### Documentation Update
none — no new config or user-facing feature beyond two additional metrics emitted by the existing operator. The metric names are self-descriptive and follow the same convention as the sibling histograms in `FlinkIndexBackendMetrics`.
### Contributor's checklist
- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable