### PR TITLE
[MINOR] Fix typos in comments and assertion messages

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LazyIterableIterator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/LazyIterableIterator.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
  * Provide a way to obtain a inputItr of type O (output), out of an inputItr of type I (input)
  * <p>
  * Things to remember: - Assumes Spark calls hasNext() to check for elements, before calling next() to obtain them -
- * Assumes hasNext() gets called atleast once. - Concrete Implementation is responsible for calling inputIterator.next()
+ * Assumes hasNext() gets called at least once. - Concrete Implementation is responsible for calling inputIterator.next()
  * and doing the processing in computeNext()
  */
 public abstract class LazyIterableIterator<I, O> implements Iterable<O>, Iterator<O> {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -2026,7 +2026,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         // scheduling of INDEX only initializes the file group and not add commit
         // so if there are no committed file slices, look for inflight slices
         if (isNonGlobalRLI) {
-          // For isNonGlobalRLI, new partitions added to the data table will cause new filegroups that are not yet commited
+          // For isNonGlobalRLI, new partitions added to the data table will cause new filegroups that are not yet committed
           // therefore, we always need to look for inflight filegroups
           fileSlices = getPartitionLatestFileSlicesIncludingInflight(metadataMetaClient, Option.ofNullable(fsView), partitionPath);
         } else if (fileSlices.isEmpty()) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCoalescingPartitioner.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestCoalescingPartitioner.java
@@ -123,7 +123,7 @@ public class TestCoalescingPartitioner extends HoodieClientTestBase {
     }, true).collect();
 
     assertEquals(targetPartitions, countsPerPartition.size());
-    // lets validate that atleast we have 50% of data in each spark partition compared to ideal scenario (we can't assume hash of strings will evenly distribute).
+    // lets validate that at least we have 50% of data in each spark partition compared to ideal scenario (we can't assume hash of strings will evenly distribute).
     countsPerPartition.forEach(pair -> {
       int numElements = pair.getValue();
       int idealExpectedCount = inputNumPartitions / targetPartitions;

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieSparkTable.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/TestHoodieSparkTable.java
@@ -107,7 +107,7 @@ public class TestHoodieSparkTable extends HoodieCommonTestHarness {
         // lets create the data file. so that we can validate later.
         localStorage.create(storagePath);
       } catch (IOException e) {
-        throw new HoodieException("Failed to check data file existance " + fileName);
+        throw new HoodieException("Failed to check data file existence " + fileName);
       }
     });
     HoodieTable hoodieTable = HoodieSparkTable.create(writeConfig, getEngineContext(), metaClient);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/compact/CompactionTestBase.java
@@ -104,7 +104,7 @@ public class CompactionTestBase extends HoodieClientTestBase {
       if (opPair != null) {
         assertEquals(fileSlice.getBaseInstantTime(), opPair.getKey(), "Expect baseInstant to match compaction Instant");
         assertTrue(fileSlice.getLogFiles().count() > 0,
-            "Expect atleast one log file to be present where the latest delta commit was written");
+            "Expect at least one log file to be present where the latest delta commit was written");
         assertFalse(fileSlice.getBaseFile().isPresent(), "Expect no data-file to be present");
       } else {
         assertTrue(fileSlice.getBaseInstantTime().compareTo(latestDeltaCommit) <= 0,
@@ -210,7 +210,7 @@ public class CompactionTestBase extends HoodieClientTestBase {
 
     if (hasDeltaCommitAfterPendingCompaction) {
       assertFalse(fileSliceList.stream().anyMatch(fs -> fs.getLogFiles().count() == 0),
-          "Verify all file-slices have atleast one log-file");
+          "Verify all file-slices have at least one log-file");
     } else {
       assertFalse(fileSliceList.stream().anyMatch(fs -> fs.getLogFiles().count() > 0),
           "Verify all file-slices have no log-files");

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/GenericRecordPartialPayloadGenerator.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/generator/GenericRecordPartialPayloadGenerator.java
@@ -63,7 +63,7 @@ public class GenericRecordPartialPayloadGenerator extends GenericRecordFullPaylo
     return validate((Object) record);
   }
 
-  // Atleast 1 entry should be null
+  // At least 1 entry should be null
   private boolean validate(Object object) {
     if (object == null) {
       return true;

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/TestFileDeltaInputWriter.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/testsuite/TestFileDeltaInputWriter.java
@@ -98,7 +98,7 @@ public class TestFileDeltaInputWriter extends UtilitiesTestBase {
     DeltaWriteStats deltaWriteStats = fileSinkWriter.getDeltaWriteStats();
     FileSystem fs = HadoopFSUtils.getFs(basePath, jsc.hadoopConfiguration());
     FileStatus[] fileStatuses = fs.listStatus(new Path(deltaWriteStats.getFilePath()));
-    // Atleast 1 file was written
+    // At least 1 file was written
     assertEquals(1, fileStatuses.length);
     // File length should be greater than 0
     assertTrue(fileStatuses[0].getLen() > 0);

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark41LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark41LegacyHoodieParquetFileFormat.scala
@@ -186,7 +186,7 @@ class Spark41LegacyHoodieParquetFileFormat(private val shouldAppendPartitionValu
       }
 
       // When there are vectorized reads, we can avoid
-      // 1. opening the file twice by transfering the SeekableInputStream
+      // 1. opening the file twice by transferring the SeekableInputStream
       // 2. reading the footer twice by reading all row groups in advance and filter row groups
       //    according to filters that require push down
       val openedFooter = ParquetFooterReader.openFileAndReadFooter(sharedConf, file, enableVectorizedReader)

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark41ParquetReader.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark41ParquetReader.scala
@@ -108,7 +108,7 @@ class Spark41ParquetReader(enableVectorizedReader: Boolean,
       partitionSchema, internalSchemaOpt)
 
     // When there are vectorized reads, we can avoid
-    // 1. opening the file twice by transfering the SeekableInputStream
+    // 1. opening the file twice by transferring the SeekableInputStream
     // 2. reading the footer twice by reading all row groups in advance and filter row groups
     //    according to filters that require push down
     val originalFooter =

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -419,7 +419,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
       });
       Future backfillJobFuture = service.submit(() -> {
         try {
-          // trigger backfill atleast after 1 requested entry is added to timeline from continuous job. If not, there is a chance that backfill will complete even before
+          // trigger backfill at least after 1 requested entry is added to timeline from continuous job. If not, there is a chance that backfill will complete even before
           // continuous job starts.
           awaitCondition(new GetCommitsAfterInstant(tableBasePath, lastSuccessfulCommit));
           backfillJob.sync();

--- a/scripts/pr_compliance.py
+++ b/scripts/pr_compliance.py
@@ -46,7 +46,7 @@ class Outcomes:
     #parsing the next section
     NEXTSECTION = 2
 
-    #parsing has concluded succesfully, exit with no error
+    #parsing has concluded successfully, exit with no error
     SUCCESS = 3
 
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This is a minor cleanup PR. While reading through the codebase I noticed a handful of long-standing English typos in code comments and test assertion messages (`atleast`, `commited`, `existance`, `transfering`, `succesfully`). They don't affect behavior but reduce readability and surface in IDE spellcheckers and code search.

### Summary and Changelog

Corrects 12 typo occurrences across 11 files. All changes are confined to comments and assertion-message string literals — no identifiers, configs, public APIs, or runtime behavior are touched.

- `atleast` → `at least` (8 occurrences across `LazyIterableIterator`, `TestCoalescingPartitioner`, `CompactionTestBase` x2, `GenericRecordPartialPayloadGenerator`, `TestFileDeltaInputWriter`, `TestHoodieDeltaStreamerWithMultiWriter`)
- `commited` → `committed` (1 occurrence in a comment in `HoodieBackedTableMetadataWriter`)
- `existance` → `existence` (1 occurrence in an exception message in `TestHoodieSparkTable`)
- `transfering` → `transferring` (2 occurrences in comments in `Spark41LegacyHoodieParquetFileFormat` and `Spark41ParquetReader`)
- `succesfully` → `successfully` (1 occurrence in a comment in `scripts/pr_compliance.py`)

### Impact

None. Comment-only and assertion-message string changes; no public API, config, storage format, or behavioral changes.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable