### PR TITLE
feat(utilities): add SparkWriteErrorValidator as pure pre-commit validator - Phase 1 of HSWSV migration

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/validator/SparkWriteErrorValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/validator/SparkWriteErrorValidator.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.streamer.validator;
+
+import org.apache.hudi.client.validator.BasePreCommitValidator;
+import org.apache.hudi.client.validator.ValidationContext;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.config.HoodiePreCommitValidatorConfig;
+import org.apache.hudi.config.HoodiePreCommitValidatorConfig.ValidationFailurePolicy;
+import org.apache.hudi.exception.HoodieValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Pure pre-commit validator that fails the commit when any records failed to write.
+ *
+ * <p>This is Phase 1 of migrating {@code HoodieStreamerWriteStatusValidator} (HSWSV) into the
+ * pre-commit validator framework (issue #18750). It mirrors the boolean error check from
+ * HSWSV ({@code hasErrorRecords = totalErroredRecords &gt; 0}) without any of HSWSV's
+ * side effects — no error-table commit, no top-100 error logging, no instant rollback.
+ * Those concerns are extracted in subsequent phases.</p>
+ *
+ * <p>Behavior mapping from HSWSV:</p>
+ * <ul>
+ *   <li>{@code cfg.commitOnErrors = false} (default) ↔ {@code failure.policy = FAIL}</li>
+ *   <li>{@code cfg.commitOnErrors = true} ↔ {@code failure.policy = WARN_LOG}</li>
+ * </ul>
+ *
+ * <p>Configuration:</p>
+ * <ul>
+ *   <li>{@code hoodie.precommit.validators}: Include
+ *       {@code org.apache.hudi.utilities.streamer.validator.SparkWriteErrorValidator}</li>
+ *   <li>{@code hoodie.precommit.validators.failure.policy}: FAIL (default) or WARN_LOG</li>
+ * </ul>
+ *
+ * <p><b>Important:</b> In Phase 1 this validator is opt-in and runs <i>alongside</i> HSWSV,
+ * not in place of it. HSWSV remains the canonical path that commits the error table and
+ * rolls back the instant on failure. Enabling this validator gives an additional pre-commit
+ * guard but does not yet allow HSWSV to be disabled.</p>
+ *
+ * <p>Like {@link SparkKafkaOffsetValidator}, this class extends {@link BasePreCommitValidator}
+ * and must be invoked via {@link SparkStreamerValidatorUtils} — not {@code SparkValidatorUtils},
+ * which expects a different constructor signature.</p>
+ */
+@Slf4j
+public class SparkWriteErrorValidator extends BasePreCommitValidator {
+
+  private final ValidationFailurePolicy failurePolicy;
+
+  public SparkWriteErrorValidator(TypedProperties config) {
+    super(config);
+    String policyStr = config.getString(
+        HoodiePreCommitValidatorConfig.VALIDATION_FAILURE_POLICY.key(),
+        HoodiePreCommitValidatorConfig.VALIDATION_FAILURE_POLICY.defaultValue());
+    this.failurePolicy = ValidationFailurePolicy.valueOf(policyStr);
+  }
+
+  @Override
+  public void validateWithMetadata(ValidationContext context) throws HoodieValidationException {
+    long totalErrors = context.getTotalWriteErrors();
+    long totalRecordsWritten = context.getTotalRecordsWritten();
+    // Total records considered for the commit includes both successfully written records
+    // and records that failed to write. HSWSV computes this from the raw WriteStatus RDD;
+    // here we derive the equivalent from HoodieWriteStat fields exposed by ValidationContext.
+    long totalRecords = totalRecordsWritten + totalErrors;
+
+    if (totalRecords == 0) {
+      // Mirrors HSWSV: "No new data, perform empty commit." — nothing to validate.
+      log.info("Empty commit (no records written, no errors). Skipping write-error validation "
+          + "for instant {}.", context.getInstantTime());
+      return;
+    }
+
+    if (totalErrors == 0) {
+      log.info("Write-error validation passed for instant {}: 0 errors out of {} records.",
+          context.getInstantTime(), totalRecords);
+      return;
+    }
+
+    String errorMsg = String.format(
+        "Write-error validation failed for instant %s. "
+            + "Errors: %d, Total: %d. "
+            + "To allow the commit to proceed despite write errors, set "
+            + "%s=WARN_LOG (mirrors hoodie.streamer.commit.on.errors=true).",
+        context.getInstantTime(), totalErrors, totalRecords,
+        HoodiePreCommitValidatorConfig.VALIDATION_FAILURE_POLICY.key());
+
+    if (failurePolicy == ValidationFailurePolicy.WARN_LOG) {
+      log.warn("{} (failure policy is WARN_LOG, commit will proceed)", errorMsg);
+    } else {
+      throw new HoodieValidationException(errorMsg);
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/validator/TestSparkWriteErrorValidator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/validator/TestSparkWriteErrorValidator.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.streamer.validator;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodiePreCommitValidatorConfig;
+import org.apache.hudi.exception.HoodieValidationException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link SparkWriteErrorValidator}.
+ */
+public class TestSparkWriteErrorValidator {
+
+  private static final String INSTANT = "20260520120000000";
+
+  // ========== Helpers ==========
+
+  private static TypedProperties failConfig() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodiePreCommitValidatorConfig.VALIDATION_FAILURE_POLICY.key(), "FAIL");
+    return props;
+  }
+
+  private static TypedProperties warnConfig() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodiePreCommitValidatorConfig.VALIDATION_FAILURE_POLICY.key(), "WARN_LOG");
+    return props;
+  }
+
+  private static HoodieWriteStat stat(String partition, long numInserts, long numUpdates, long writeErrors) {
+    HoodieWriteStat s = new HoodieWriteStat();
+    s.setPartitionPath(partition);
+    s.setNumInserts(numInserts);
+    s.setNumUpdateWrites(numUpdates);
+    s.setTotalWriteErrors(writeErrors);
+    return s;
+  }
+
+  private static SparkValidationContext context(List<HoodieWriteStat> writeStats) {
+    return new SparkValidationContext(
+        INSTANT,
+        Option.of(new HoodieCommitMetadata()),
+        Option.of(writeStats),
+        Option.empty());
+  }
+
+  // ========== Tests ==========
+
+  @Test
+  public void testNoErrorsPasses() {
+    // 1000 records written, no errors -> passes
+    SparkValidationContext ctx = context(Collections.singletonList(stat("p1", 1000, 0, 0)));
+
+    SparkWriteErrorValidator validator = new SparkWriteErrorValidator(failConfig());
+    assertDoesNotThrow(() -> validator.validateWithMetadata(ctx));
+  }
+
+  @Test
+  public void testErrorsWithFailPolicyThrows() {
+    // 500 written + 50 errors -> fails under FAIL policy (mirrors commitOnErrors=false)
+    SparkValidationContext ctx = context(Collections.singletonList(stat("p1", 500, 0, 50)));
+
+    SparkWriteErrorValidator validator = new SparkWriteErrorValidator(failConfig());
+    HoodieValidationException ex = assertThrows(HoodieValidationException.class,
+        () -> validator.validateWithMetadata(ctx));
+    assertTrue(ex.getMessage().contains("Errors: 50"), "message should report error count");
+    assertTrue(ex.getMessage().contains("Total: 550"), "message should report total record count");
+  }
+
+  @Test
+  public void testErrorsWithWarnPolicyDoesNotThrow() {
+    // 500 written + 50 errors -> passes under WARN_LOG (mirrors commitOnErrors=true)
+    SparkValidationContext ctx = context(Collections.singletonList(stat("p1", 500, 0, 50)));
+
+    SparkWriteErrorValidator validator = new SparkWriteErrorValidator(warnConfig());
+    assertDoesNotThrow(() -> validator.validateWithMetadata(ctx));
+  }
+
+  @Test
+  public void testEmptyCommitPasses() {
+    // 0 records, 0 errors -> empty commit, validation is skipped
+    SparkValidationContext ctx = context(Collections.singletonList(stat("p1", 0, 0, 0)));
+
+    SparkWriteErrorValidator validator = new SparkWriteErrorValidator(failConfig());
+    assertDoesNotThrow(() -> validator.validateWithMetadata(ctx));
+  }
+
+  @Test
+  public void testNoWriteStatsTreatedAsEmpty() {
+    SparkValidationContext ctx = new SparkValidationContext(
+        INSTANT,
+        Option.of(new HoodieCommitMetadata()),
+        Option.empty(),
+        Option.empty());
+
+    SparkWriteErrorValidator validator = new SparkWriteErrorValidator(failConfig());
+    assertDoesNotThrow(() -> validator.validateWithMetadata(ctx));
+  }
+
+  @Test
+  public void testErrorsAcrossMultiplePartitionsAreSummed() {
+    // p1: 100 written + 5 errors. p2: 200 written + 10 errors. Total errors > 0 -> fail.
+    SparkValidationContext ctx = context(Arrays.asList(
+        stat("p1", 100, 0, 5),
+        stat("p2", 200, 0, 10)));
+
+    SparkWriteErrorValidator validator = new SparkWriteErrorValidator(failConfig());
+    HoodieValidationException ex = assertThrows(HoodieValidationException.class,
+        () -> validator.validateWithMetadata(ctx));
+    assertTrue(ex.getMessage().contains("Errors: 15"),
+        "errors should be summed across partitions, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("Total: 315"),
+        "total should be inserts + updates + errors across partitions, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testUpdatesCountedTowardTotal() {
+    // 0 inserts, 100 updates, 1 error -> 1/101 -> fail under FAIL
+    SparkValidationContext ctx = context(Collections.singletonList(stat("p1", 0, 100, 1)));
+
+    SparkWriteErrorValidator validator = new SparkWriteErrorValidator(failConfig());
+    HoodieValidationException ex = assertThrows(HoodieValidationException.class,
+        () -> validator.validateWithMetadata(ctx));
+    assertTrue(ex.getMessage().contains("Total: 101"),
+        "updates should count toward total, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testDefaultPolicyIsFail() {
+    // No failure.policy set -> default is FAIL
+    TypedProperties props = new TypedProperties();
+    SparkValidationContext ctx = context(Collections.singletonList(stat("p1", 10, 0, 1)));
+
+    SparkWriteErrorValidator validator = new SparkWriteErrorValidator(props);
+    assertThrows(HoodieValidationException.class, () -> validator.validateWithMetadata(ctx));
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Phase 1 of #18750 — migrating `HoodieStreamerWriteStatusValidator` (HSWSV) into the pre-commit validator framework. Additive only.

### Summary and Changelog

Adds `SparkWriteErrorValidator extends BasePreCommitValidator` — a pure extract of HSWSV's `hasErrorRecords > 0` check, with no side effects (no error-table commit, no top-100 logging, no rollback). Those are extracted in later phases.

Behavior mapping from HSWSV:
- `commitOnErrors = false` ↔ `failure.policy = FAIL` (default)
- `commitOnErrors = true`  ↔ `failure.policy = WARN_LOG`

No new config. No changes to `StreamSync` — plugs into the existing `SparkStreamerValidatorUtils.runValidators()` wiring from #18405.

Phased rollout (tracked in #18750): **Phase 1** (this PR) additive validator → Phase 2 carve out side effects → Phase 3 flip call site → Phase 4 delete HSWSV.

### Impact

New public class `org.apache.hudi.utilities.streamer.validator.SparkWriteErrorValidator`. Opt-in via:
```
hoodie.precommit.validators=org.apache.hudi.utilities.streamer.validator.SparkWriteErrorValidator
hoodie.precommit.validators.failure.policy=FAIL   # or WARN_LOG
```
Runs alongside HSWSV; does not replace it. Zero overhead when not configured.

### Risk Level

**low** — purely additive, opt-in, no existing path modified.

Verified: `test-compile` BUILD SUCCESS · `TestSparkWriteErrorValidator` 8/8 · sibling validator tests 44/44 · checkstyle 0 · RAT 0.

### Documentation Update

None in Phase 1. `VALIDATOR_CLASS_NAMES` doc will be updated in Phase 4 when HSWSV is removed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
