### PR TITLE
chore: Harden workflow against command injection in PR title validation

### DIFF
--- a/.github/workflows/pr_title_validation.yml
+++ b/.github/workflows/pr_title_validation.yml
@@ -15,11 +15,13 @@ jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for legacy PR title format using JIRA or MINOR
-        id: check-legacy-format
-        run: |
-          title="${{ github.event.pull_request.title }}"
-          echo "Checking PR title: $title"
+     - name: Check for legacy PR title format using JIRA or MINOR
+      id: check-legacy-format
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        title="$PR_TITLE"
+        echo "Checking PR title: $title"
           
           # Check for HUDI JIRA format: [HUDI-1234] description
           if [[ "$title" =~ ^\[HUDI-[0-9]+\]\ .+ ]]; then

--- a/.github/workflows/pr_title_validation.yml
+++ b/.github/workflows/pr_title_validation.yml
@@ -15,13 +15,13 @@ jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
     steps:
-     - name: Check for legacy PR title format using JIRA or MINOR
-      id: check-legacy-format
-      env:
-        PR_TITLE: ${{ github.event.pull_request.title }}
-      run: |
-        title="$PR_TITLE"
-        echo "Checking PR title: $title"
+      - name: Check for legacy PR title format using JIRA or MINOR
+        id: check-legacy-format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          title="$PR_TITLE"
+          echo "Checking PR title: $title"
           
           # Check for HUDI JIRA format: [HUDI-1234] description
           if [[ "$title" =~ ^\[HUDI-[0-9]+\]\ .+ ]]; then


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Hi Apache Hudi Team,

As requested and suggested by Piotr P. Karwasz from the Apache Security Team, I am submitting this pull request to apply a security hardening improvement to the `pr_title_validation.yml` workflow.

### Summary and Changelog

- Mapped the user-controlled `github.event.pull_request.title` context variable into an environment variable (`env: PR_TITLE`).
- Updated the inline shell script to reference the environment variable `$PR_TITLE` instead of direct inline expansion.

This protects the project's CI/CD runner environment from potential arbitrary command execution (Command Injection) through crafted PR titles if trigger types or job permissions are ever modified in the future.

Best regards,
Rasul Rasulzada

### Impact

Security fix


### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable