### PR TITLE
fix: Fix SQL syntax parser for CREATE TABLE on Spark 4.1

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hudi.ddl
 
-import org.apache.hudi.{DataSourceWriteOptions, HoodieSparkUtils}
+import org.apache.hudi.DataSourceWriteOptions
 import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType, WriteOperationType}
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
@@ -42,20 +42,10 @@ import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.{disableComplexKeygenValidation, getLastCommitMetadata}
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNull, assertTrue}
-import org.scalatest.{Canceled, Outcome}
 
 import scala.collection.JavaConverters._
 
 class TestCreateTable extends HoodieSparkSqlTestBase {
-
-  // TODO(SPARK-4.1): Re-enable after fixing inline compaction hang on Spark 4.1
-  override def withFixture(test: NoArgTest): Outcome = {
-    if (HoodieSparkUtils.gteqSpark4_1) {
-      Canceled("Disabled on Spark 4.1 due to inline compaction hang during MOR table creation")
-    } else {
-      super.withFixture(test)
-    }
-  }
 
   test("Test Create Managed Hoodie Table") {
     val databaseName = "hudi_database"

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/antlr4/imports/SqlBase.g4
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/antlr4/imports/SqlBase.g4
@@ -948,7 +948,7 @@ dataType
     | INTERVAL from=(YEAR | MONTH) (TO to=MONTH)?               #yearMonthIntervalDataType
     | INTERVAL from=(DAY | HOUR | MINUTE | SECOND)
       (TO to=(HOUR | MINUTE | SECOND))?                         #dayTimeIntervalDataType
-    | identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?  #primitiveDataType
+    | typeName=identifier ('(' (INTEGER_VALUE | identifier) (',' (INTEGER_VALUE | identifier))* ')')?  #primitiveDataType
     ;
 
 qualifiedColTypeWithPositionList

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
@@ -2618,7 +2618,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * Resolve/create a primitive type.
    */
   override def visitPrimitiveDataType(ctx: PrimitiveDataTypeContext): DataType = withOrigin(ctx) {
-    val dataType = ctx.identifier.getText.toLowerCase(Locale.ROOT)
+    val dataType = ctx.typeName.getText.toLowerCase(Locale.ROOT)
     (dataType, ctx.INTEGER_VALUE().asScala.toList) match {
       case ("boolean", Nil) => BooleanType
       case ("tinyint" | "byte", Nil) => ByteType


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18609.

`TestCreateTable` is currently skipped in its entirety on Spark 4.1 via a
class-level `withFixture` override that cancels every test with the message
*"Disabled on Spark 4.1 due to inline compaction hang during MOR table
creation"*. This PR removes that blanket cancel so the suite actually runs
on the `spark4.1` + `scala-2.13` profile.

Re-enabling the suite surfaced a real parser regression: the
`primitiveDataType` rule in the Spark 4.1 fork of `SqlBase.g4` only
accepted `INTEGER_VALUE` tokens inside the type-parameter parens, which
broke Hudi's `VECTOR(N, T)` syntax (where `T` is an identifier:
`FLOAT`, `DOUBLE`, `INT8`). Tests like
`test create table with VECTOR column with element type`,
`test create table with multiple VECTOR columns`, and
`test create table with INT8 VECTOR column` all failed with
`PARSE_SYNTAX_ERROR` at the element-type token before the AST builder
ran. The Spark 3.3, 3.4, 3.5, and 4.0 modules already carry the extended
grammar; the 4.1 fork was the lone outlier. This PR brings it into line.

### Summary and Changelog

1. **`hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala`**
   - Remove the class-level `withFixture` override that unconditionally
     cancelled every test in the class when `HoodieSparkUtils.gteqSpark4_1`
     was true.
   - Drop the now-unused imports (`HoodieSparkUtils`,
     `org.scalatest.Canceled`, `org.scalatest.Outcome`) that only
     supported that override.

2. **`hudi-spark-datasource/hudi-spark4.1.x/src/main/antlr4/imports/SqlBase.g4`**
   - Update `primitiveDataType` to allow either `INTEGER_VALUE` or
     `identifier` as type-parameter args, matching the rule already
     present in the 3.3 / 3.4 / 3.5 / 4.0 modules.
   - Add the `typeName=` alias on the leading identifier so the AST
     builder can distinguish the type name from identifier args (now
     that identifier appears in multiple positions of the rule).

3. **`hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala`**
   - In `visitPrimitiveDataType`, read `ctx.typeName.getText` instead of
     `ctx.identifier.getText`, mirroring
     `HoodieSpark4_0ExtendedSqlAstBuilder` line 2596.

No production code logic is changed beyond bringing the 4.1 parser into
parity with the other Spark forks for VECTOR's existing typed-element
syntax.

### Impact

User-facing: makes `VECTOR(N, FLOAT|DOUBLE|INT8)` syntax usable on Spark
4.1, which already works on Spark 3.3 / 3.4 / 3.5 / 4.0. No public API
or storage format change.

Performance: none.

### Risk Level

low

- The test-side change only removes a hard-coded skip; it cannot regress
  behavior on any Spark version other than 4.1 (the override was guarded
  by `HoodieSparkUtils.gteqSpark4_1`).
- The grammar/builder change is scoped to the 4.1 module only and is a
  byte-for-byte port of the rule and lookup that the 3.3 / 3.4 / 3.5 /
  4.0 modules have shipped for multiple releases.
- All VECTOR-related tests in `TestCreateTable` exercise this code path
  and will gate the change in CI.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable