### PR TITLE
feat(trino): [RFC-105] Trino Hudi Connector — Shim/Bundle Refactor

### DIFF
--- a/rfc/rfc-105/rfc-105.md
+++ b/rfc/rfc-105/rfc-105.md
@@ -34,30 +34,19 @@ Issue: [HUDI-18780](https://github.com/apache/hudi/issues/18780)
 
 ## Motivation
 
-The Trino-Hudi connector currently lives in `trinodb/trino` at `plugin/trino-hudi`. Maintaining and evolving it inside Trino OSS has stalled in practice:
+The Trino-Hudi connector currently lives in `trinodb/trino` at `plugin/trino-hudi`. Maintaining and evolving the connector through the Trino-OSS-only path has stalled in practice, and the cost falls on Hudi users:
 
-- **Limited Trino-side maintainer bandwidth for Hudi.** Trino maintainers' active focus is on Iceberg and, to a lesser extent, Delta Lake. As stated by Trino maintainer @raunaqm in the `#dev` Slack thread: *"the unfortunate reality is that Hudi is not a priority for any maintainer at the moment and that's unlikely to change."*
-- **PRs closed for inactivity.** Four stacked Hudi-side improvement PRs from @voonhous were closed by Trino's stale-bot for lack of review:
+- **Hudi-side improvement PRs to the Trino Hudi connector are not landing.** Four stacked PRs targeting the Trino Hudi connector were closed by Trino's stale-bot for lack of review:
   - [trinodb/trino#28518](https://github.com/trinodb/trino/pull/28518)
   - [trinodb/trino#28533](https://github.com/trinodb/trino/pull/28533)
   - [trinodb/trino#28644](https://github.com/trinodb/trino/pull/28644)
   - [trinodb/trino#28645](https://github.com/trinodb/trino/pull/28645)
-- **Significant Hudi-side work is ready but unable to land**: metadata-table-driven partition listing, eight `HudiIndexSupport` strategies (column stats, partition stats, record-level, secondary, expression, bloom, bucket, partition bloom), MOR snapshot-isolation fixes (worker-side use of the latest commit time from the table handle), and file-system caching integration.
+- **Significant Hudi-side work for the Trino connector is ready but cannot land** through the current path: metadata-table-driven partition listing, eight `HudiIndexSupport` strategies (column stats, partition stats, record-level, secondary, expression, bloom, bucket, partition bloom), MOR snapshot-isolation fixes (worker-side use of the latest commit time from the table handle), and file-system caching integration.
+- **The current arrangement does not scale.** Connector evolution must go through Trino-side review for every change, while the expertise and the source-of-truth for Hudi internals live in this project. Hudi releases cannot directly deliver improvements to Hudi users querying via Trino.
 
-In the `#dev` Slack thread (May 2026), Trino maintainer @raunaqm proposed reducing Trino's Hudi connector to a thin layer around a Hudi-side library:
+Following alignment between the Hudi and Trino communities, the agreed direction is to split the connector into a thin Trino-side shim plus a Hudi-published artifact carrying the connector logic. This lets the Hudi project ship Trino-Hudi improvements with each Hudi release, while Trino picks them up via a one-line dependency-version bump.
 
-> *"Reduce Hudi connector to a thin layer around the hudi library. Then Hudi connector changes mostly become version bumps (after the initial refactor), and you won't be blocked on maintainer reviews."*
-
-The Hudi community (@yihua, @voonhous) accepted, with a single condition from @raunaqm:
-
-> *"I would only request that we still maintain a comprehensive test suite on Trino side."*
-
-Stakeholders aligned on this approach:
-
-- **Hudi side:** @yihua (Y Ethan Guo), @voonhous (Su Voon Hou), @bhasudha (sudha_s).
-- **Trino side:** @raunaqm, @ebyhr, @mariusgrama (Marius Grama), @findepi, @manfred-moser (Manfred Moser).
-
-This RFC documents the agreed approach and the implementation plan.
+The single requirement carried over from the Trino side is that a comprehensive test suite for the connector continues to be maintained on the Trino side. This RFC documents the agreed approach and the implementation plan.
 
 ## Abstract
 
@@ -72,45 +61,30 @@ The first publication ships in **Hudi 1.3.0**. The Trino-side shim PR pins `org.
 
 ### State of the Trino-side connector today
 
-`plugin/trino-hudi` in `trinodb/trino`:
-
-- ~4,142 LOC across ~40 Java files under `io.trino.plugin.hudi.*`.
-- Depends on `hudi-common`, `hudi-io` (Hudi 1.1.1) with aggressive transitive exclusions.
-- No direct Hadoop imports in main code; uses Hudi's `HoodieStorage` abstraction (RFC-74) with a `TrinoHudiStorage` bridge that wraps `TrinoFileSystem`.
-- 20 test files including `HudiQueryRunner`, smoke tests, MinIO/S3 integration tests, plugin loading tests, config tests.
-- Implements the standard Trino SPI: `Plugin`, `ConnectorFactory`, `Connector`, `ConnectorMetadata`, `ConnectorSplitManager`, `ConnectorPageSourceProvider`, `ConnectorSplit`, `ConnectorTableHandle`, `ConnectorSplitSource`.
+`plugin/trino-hudi` in `trinodb/trino` is the baseline: it implements the standard Trino SPI (`Plugin`, `ConnectorFactory`, `Connector`, `ConnectorMetadata`, `ConnectorSplitManager`, `ConnectorPageSourceProvider`, etc.), depends on `hudi-common` and `hudi-io`, and uses Hudi's `HoodieStorage` abstraction (RFC-74) over Trino's `TrinoFileSystem`. No direct Hadoop imports.
 
 ### State of the Hudi-side `hudi-trino-plugin` work
 
-A more advanced version of the connector exists in Hudi-side branches under `hudi-trino-plugin/`:
+A more advanced version of the connector exists in Hudi-side branches under `hudi-trino-plugin/` (same `io.trino.plugin.hudi.*` package, built against a recent Trino release). On top of the Trino-OSS baseline it adds:
 
-- ~9,650 LOC across ~66 Java files; same package namespace (`io.trino.plugin.hudi.*`).
-- Built against Trino 472.
-- Adds advanced features absent from Trino OSS today:
-  - `io.trino.plugin.hudi.query.index/` — eight `HudiIndexSupport` strategies driving file-level and partition-level pruning via Hudi metadata tables.
-  - `io.trino.plugin.hudi.storage/` — `HudiTrinoStorage`, `HudiTrinoInlineStorage` (HoodieStorage implementations over `TrinoFileSystem`).
-  - `io.trino.plugin.hudi.io/` — `HudiTrinoIOFactory`, `HudiTrinoFileReaderFactory`, `TrinoSeekableDataInputStream` (Hudi I/O factory bridges).
-  - `io.trino.plugin.hudi.reader/` — `HudiTrinoReaderContext` for MOR record-level merging via `HoodieFileGroupReader`.
-  - `io.trino.plugin.hudi.partition/` — async, resumable partition discovery; metadata-table-driven listing.
-  - `io.trino.plugin.hudi.stats/` — `HudiTableStatistics`, statistics reader.
-  - `io.trino.plugin.hudi.cache/` — file-system cache key provider.
-  - Background, async split generation (`HudiBackgroundSplitLoader`) with size-based split weighting.
-  - Lazy commit-time on `HudiTableHandle` for snapshot-isolated MOR reads across workers.
-  - Multi-reader strategy: `HudiPageSource` for MOR with merging vs `HudiBaseFileOnlyPageSource` for COW/RO base files.
-- 22 test files including `HudiQueryRunner`, smoke tests, MinIO smoke tests, Alluxio caching tests, file-operation tests.
-- No Hadoop imports in main code; all FS access via `TrinoFileSystem` + `HudiTrinoStorage`.
+- Eight `HudiIndexSupport` strategies (column stats, partition stats, record-level, secondary, expression, bloom, bucket, partition bloom) for file- and partition-level pruning via metadata tables.
+- Metadata-table-driven partition discovery (async, resumable).
+- MOR record-level merging via `HoodieFileGroupReader` (`HudiTrinoReaderContext`).
+- Lazy commit-time on `HudiTableHandle` for snapshot-isolated MOR reads across workers.
+- Background, weighted split generation; size-based split weighting; multi-reader routing (`HudiPageSource` for MOR, `HudiBaseFileOnlyPageSource` for COW/RO).
+- File-system cache integration.
+- HoodieStorage / HoodieIOFactory bridges over `TrinoFileSystem` (`HudiTrinoStorage`, `HudiTrinoInlineStorage`, `HudiTrinoIOFactory`).
 
 This is the body of code that will move into the `hudi-trino` Maven module on the Hudi side.
 
 ### Why a "shim + Hudi-published artifact" pattern
 
-Trino already establishes precedent for connectors built as thin shims around an upstream library:
+This pattern decouples Trino-Hudi connector evolution from the Trino-side release cycle:
 
-- **`plugin/trino-iceberg`** depends directly on `iceberg-api`, `iceberg-core`, `iceberg-aws`, `iceberg-azure`, `iceberg-gcp`, `iceberg-parquet` and delegates most of its work to those libraries.
-- **`plugin/trino-delta-lake`** depends on `delta-kernel-api`.
-- **`plugin/trino-postgresql`** and other JDBC plugins are extremely thin wrappers over `trino-base-jdbc` and the upstream JDBC driver.
-
-The novelty here is that `hudi-trino` is **purpose-built for Trino** rather than a general-purpose library that Trino adapts. This means **no adapter glue is needed between the published artifact and the Trino SPI** — the artifact implements the Trino SPI directly. The shim is correspondingly minimal: a single `HudiPlugin` class plus the test harness.
+- The Hudi project can publish Trino-Hudi improvements with each Hudi release, without waiting for Trino-side reviews of every change.
+- The Trino-side surface shrinks to a stable plugin-registration shim, so Trino-side review burden is minimal — typically a one-line version bump per Hudi release.
+- All Hudi-Trino integration code (`io.trino.plugin.hudi.*`) is co-located with the Hudi core libraries it depends on. Changes that cross the Hudi-internal / connector boundary can land atomically.
+- The artifact is **purpose-built for Trino** and implements Trino's SPI directly, so no intermediate adapter layer is needed between the published artifact and the Trino plugin.
 
 Trino's `trino-spi` is governed by `revapi-maven-plugin` (see `core/trino-spi/pom.xml`) which enforces backward compatibility on the SPI surface. This is what makes a single `hudi-trino` artifact targeting the latest Trino release viable across multiple subsequent Trino releases.
 
@@ -121,49 +95,25 @@ Trino loads each plugin in an isolated `URLClassLoader`. Transitive dependencies
 ### Architecture
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│  Trino OSS — trinodb/trino                                   │
-│  ─────────────────────────                                   │
-│  plugin/trino-hudi    (packaging = trino-plugin)             │
-│    ├─ src/main/java/io/trino/plugin/hudi/                    │
-│    │    └─ HudiPlugin.java   ← single trivial class          │
-│    ├─ src/main/resources/META-INF/services/                  │
-│    │    └─ io.trino.spi.Plugin    (→ HudiPlugin)             │
-│    ├─ src/test/java/...   (smoke tests, query runner,        │
-│    │                       MinIO tests, plugin/config tests) │
-│    └─ pom.xml                                                │
-│         └─ depends on org.apache.hudi:hudi-trino:1.3.0       │
-└──────────────────────────────────────────────────────────────┘
-                              │
-                              │  Maven Central
-                              ▼
-┌──────────────────────────────────────────────────────────────┐
-│  Hudi OSS — apache/hudi                                      │
-│  ──────────────────────                                      │
-│  hudi-trino-plugin/    (separate Maven profile;              │
-│                         excluded from default reactor;       │
-│                         Java 25 required)                    │
-│    ├─ src/main/java/io/trino/plugin/hudi/                    │
-│    │    └─ HudiConnectorFactory, HudiConnector,              │
-│    │       HudiMetadata, HudiSplitManager,                   │
-│    │       HudiPageSourceProvider,                           │
-│    │       cache/, file/, io/, partition/,                   │
-│    │       query/ (incl. 8 index-support strategies),        │
-│    │       reader/, split/, stats/, storage/, util/          │
-│    ├─ src/test/java/...   (full test duplication of          │
-│    │                       Trino-side tests + Hudi-side      │
-│    │                       expansion)                        │
-│    └─ pom.xml                                                │
-│         ├─ compile: hudi-common, hudi-io, hudi-hive-sync,    │
-│         │          hudi-sync-common (regular Maven deps)     │
-│         ├─ compile: trino-filesystem, trino-hive,            │
-│         │          trino-metastore, trino-parquet,           │
-│         │          trino-cache                               │
-│         └─ provided: trino-spi, Airlift, Jackson,            │
-│                      OpenTelemetry API, JOL                  │
-│                                                              │
-│  Published as: org.apache.hudi:hudi-trino:1.3.0              │
-└──────────────────────────────────────────────────────────────┘
+trinodb/trino : plugin/trino-hudi   (packaging = trino-plugin)
+    HudiPlugin.java       ← thin shim: trivial Plugin SPI registration
+    META-INF/services/io.trino.spi.Plugin
+    src/test/java/...     ← full Trino-side test suite
+    pom.xml               ← depends on org.apache.hudi:hudi-trino:1.3.0
+                                       │
+                                       │  Maven Central
+                                       ▼
+apache/hudi : hudi-trino-plugin/    (Maven profile -Phudi-trino,
+                                     excluded from default reactor,
+                                     JDK 25 required)
+    io.trino.plugin.hudi.*           ← all connector logic:
+        HudiConnectorFactory, HudiConnector, HudiMetadata,
+        HudiSplitManager, HudiPageSourceProvider,
+        cache/, file/, io/, partition/,
+        query/ (incl. 8 index-support strategies),
+        reader/, split/, stats/, storage/, util/
+    src/test/java/...                 ← full duplicated + expanded suite
+  Published as: org.apache.hudi:hudi-trino:1.3.0
 ```
 
 ### What lives where
@@ -175,7 +125,7 @@ Trino loads each plugin in an isolated `URLClassLoader`. Transitive dependencies
 | `src/main/java/io/trino/plugin/hudi/HudiPlugin.java` | Implements `io.trino.spi.Plugin`. Single method returning `new HudiConnectorFactory()` (from the `hudi-trino` artifact). ~10 lines. |
 | `src/main/resources/META-INF/services/io.trino.spi.Plugin` | Service-loader pointer to `io.trino.plugin.hudi.HudiPlugin`. |
 | `pom.xml` | `<packaging>trino-plugin</packaging>`; pins `org.apache.hudi:hudi-trino:<version>`; SPI deps as `provided`. |
-| `src/test/java/...` | All current Trino-side tests stay: `HudiQueryRunner`, `TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiConnectorTest`, `TestHudiSharedMetastore`, `TestHudiSystemTables`, `TestHudiPlugin`, `TestHudiConfig`, plus data initializers. Per @raunaqm's requirement. |
+| `src/test/java/...` | All current Trino-side tests stay: `HudiQueryRunner`, `TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiConnectorTest`, `TestHudiSharedMetastore`, `TestHudiSystemTables`, `TestHudiPlugin`, `TestHudiConfig`, plus data initializers. Required by the Trino-side test-coverage commitment. |
 
 #### Hudi-side `hudi-trino-plugin/` (the engine)
 
@@ -204,166 +154,72 @@ The boundary between the shim and the published artifact is **Trino's SPI itself
 
 ### Maven dependencies for `hudi-trino`
 
-Strict dependency hygiene:
-
-- **`compile`:** `hudi-common`, `hudi-io`, `hudi-hive-sync`, `hudi-sync-common` (all at the same Hudi version); `trino-filesystem`, `trino-hive`, `trino-metastore`, `trino-parquet`, `trino-cache`; Guice; Airlift modules (bootstrap, config, json, log, units, concurrent); Caffeine.
-- **`provided`:** `trino-spi`, `slice`, Jackson annotations, OpenTelemetry API, JOL, JetBrains annotations. Supplied by Trino at runtime.
+- **`compile`:** Hudi libs (`hudi-common`, `hudi-io`, `hudi-hive-sync`, `hudi-sync-common`) and Trino libs (`trino-filesystem`, `trino-hive`, `trino-metastore`, `trino-parquet`, `trino-cache`), Guice, Airlift, Caffeine.
+- **`provided`:** `trino-spi`, `slice`, Jackson, OpenTelemetry API, JOL (supplied by Trino at runtime).
 - **`runtime`:** log-manager, Dropwizard metrics, OpenTelemetry SDK, `trino-hive-formats`.
-- **`test`:** `trino-testing`, `trino-main`, `trino-testing-containers`, `trino-testing-services`, `trino-hdfs`, `trino-parser`; AssertJ, JUnit 5; Hudi test JARs (`hudi-client-common`, `hudi-hadoop-common`, `hudi-java-client`).
+- **`test`:** Trino testing libs (`trino-testing`, `trino-main`, `trino-testing-containers`, `trino-hdfs`), AssertJ, JUnit 5, Hudi test JARs.
 
-#### Version alignment policy
-
-The Trino runtime is the canonical source of truth for shared library versions. The `hudi-trino` POM uses `<dependencyManagement>` to **pin Avro, Parquet, Jackson, Airlift versions to whatever the targeted Trino release uses**. If Hudi internals require a newer Parquet/Avro than Trino's current version, the resolution is to:
-
-1. Either bump Trino's version (and rebuild `hudi-trino` against the new Trino release), or
-2. Fix Hudi internals to work with Trino's version range.
-
-We do **not** ship a version of `hudi-trino` that introduces a divergent Parquet/Avro version on the Trino classpath.
+**Version alignment policy.** Trino versions are authoritative for shared libraries (Avro, Parquet, Jackson, Airlift). The `hudi-trino` POM pins these via `<dependencyManagement>` to whatever the targeted Trino release uses. If Hudi internals need a newer version, the fix is on the Hudi side or via a Trino-version bump — never by shipping divergent classpath versions.
 
 ### Build target on Hudi side
 
-`hudi-trino-plugin` is **excluded from the default `mvn install` reactor** because:
-
-- Trino requires **Java 25** (per Trino's `.java-version`).
-- The rest of Hudi targets a lower Java floor.
-- Most Hudi contributors do not need to build `hudi-trino-plugin` for their day-to-day work.
-
-Mechanism:
+Trino requires Java 25, while the rest of Hudi targets a lower Java floor. `hudi-trino-plugin` therefore lives behind a Maven profile (`-Phudi-trino`) and is **excluded from the default `mvn install` reactor**:
 
 ```xml
-<!-- root pom.xml -->
 <profile>
   <id>hudi-trino</id>
-  <activation>
-    <activeByDefault>false</activeByDefault>
-  </activation>
   <modules>
     <module>hudi-trino-plugin</module>
   </modules>
 </profile>
 ```
 
-Default build: `mvn install` — `hudi-trino-plugin` is **not** built.
-Trino-targeted build: `mvn install -Phudi-trino` — requires Java 25.
+Default build (`mvn install`) skips it; Trino-targeted build (`mvn install -Phudi-trino`) requires JDK 25.
 
-### CI on Hudi side
+### CI
 
-Two new GitHub Actions workflows, both required to pass before merge to `master` for changes touching `hudi-trino-plugin/**`:
+Two new GitHub Actions on the Hudi side, required for any change touching `hudi-trino-plugin/**`:
 
-1. **`hudi-trino-ci.yml` — Full test suite.**
-   - Triggers on push / PR touching `hudi-trino-plugin/**`.
-   - Runs `mvn verify -Phudi-trino` on JDK 25.
-   - Executes the full duplicated test suite (smoke tests, MinIO smoke tests, MOR/COW tests, index support tests, page source tests, partition discovery tests, statistics tests, cache tests).
-   - Goal: catch regressions in Hudi-internal changes before they ship in a Hudi release.
+1. **`hudi-trino-ci.yml`** — runs the full test suite via `mvn verify -Phudi-trino` on JDK 25. Catches regressions before they ship in a Hudi release.
+2. **`hudi-trino-compat.yml`** — nightly: pulls latest `trinodb/trino` master, builds Trino's relevant modules, then compiles `hudi-trino-plugin` against them. Compile-only; flags SPI drift before the next Trino release.
 
-2. **`hudi-trino-compat.yml` — Compile-against-latest-Trino check.**
-   - Triggers nightly and on PRs touching `hudi-trino-plugin/**`.
-   - Pulls latest `trinodb/trino` master.
-   - Builds Trino's `trino-spi`, `trino-filesystem`, `trino-hive`, `trino-metastore`, `trino-parquet`, `trino-cache` modules locally.
-   - Builds `hudi-trino-plugin` against the freshly-built Trino artifacts (with the local versions injected via `-Dtrino.version=<sha-snapshot>`).
-   - **Compile-only** — failure indicates an upcoming SPI change in Trino master that will break us when Trino releases.
-   - Goal: catch SPI drift well before a Trino release ships, so we can adapt `hudi-trino` ahead of time.
-
-### Trino-side CI
-
-Trino's existing CI continues to compile and test `plugin/trino-hudi`. Because the shim is small and the heavy tests live there too, Trino's CI exercises a real, end-to-end Hudi connector against the published `hudi-trino` artifact on every Trino PR.
+On the Trino side, existing CI continues to build and test `plugin/trino-hudi`, exercising the published `hudi-trino` artifact end-to-end on every Trino PR.
 
 ### Test strategy
 
 **Full test duplication.** The Trino-side smoke tests (`TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiConnectorTest`, etc.) are mirrored on the Hudi side and additionally extended.
 
-- **Trino side runs them** on every Trino PR — fulfilling @raunaqm's requirement.
+- **Trino side runs them** on every Trino PR — fulfilling the Trino-side test-coverage commitment.
 - **Hudi side runs them** on every Hudi PR touching `hudi-trino-plugin` — so Hudi contributors catch regressions before they ship in a Hudi release. The Hudi-side suite is also **expanded** with more granular unit tests covering split generation edge cases, all eight index-support strategies, the MOR record-merging path, lazy-commit-time snapshot isolation, and the cache-key provider.
 
 This duplication has a known cost — two places to update when adding tests — but is the right trade-off given:
-- The Trino-side suite must remain comprehensive (@raunaqm's condition).
+- The Trino-side suite must remain comprehensive as agreed with the Trino community.
 - Hudi-side contributors need fast feedback without waiting for a Trino-side PR cycle.
 
 ### Risks & caveats
 
-1. **Trino SPI drift.** If a future Trino release introduces an SPI change that the pre-built `hudi-trino` artifact didn't anticipate, the connector breaks at runtime when a user upgrades Trino. RevAPI on `trino-spi` makes the SPI surface backward-compatible by policy, but drift can accumulate. **Mitigation:** the nightly `hudi-trino-compat.yml` CI workflow on the Hudi side recompiles `hudi-trino` against Trino master and flags incompatibilities before a Trino release ships, giving Hudi time to react.
-
-2. **Avro / Parquet / Jackson version skew.** Hudi and Trino each have opinions on these library versions. **Resolution policy:** Trino's versions are prioritized; the `hudi-trino` POM forces alignment with the targeted Trino release via `<dependencyManagement>`. If Hudi internals require a newer version than Trino exposes, the fix is on the Hudi side or via a Trino-version bump — not by introducing divergent classpath versions in `hudi-trino`.
-
-3. **Test infrastructure dependency direction.** `hudi-trino-plugin` test scope depends on `trino-testing`, `trino-main`, `trino-testing-containers`. These are public Maven artifacts but they couple Hudi's `hudi-trino-plugin` build to Trino releases having shipped to Maven Central. Acceptable cost.
-
-4. **Classloader / shadowing concerns.** Trino isolates each plugin in its own `URLClassLoader`. Transitive deps of `hudi-trino` (Avro, Parquet, etc.) are isolated from other plugins. Not a risk in practice.
-
-5. **Release coordination.** A critical bug in `hudi-trino` requires a new Hudi release to ship the fix. **Mitigation:** keep the Trino-side shim trivially small so virtually all fixes land in `hudi-trino`; Hudi will increase release cadence to support this model; for emergencies, a Trino-side fork pinned to a Hudi snapshot is always possible.
-
-6. **License / ASF process.** Both projects are ASF projects. Publishing the `hudi-trino` artifact under Hudi's `org.apache.hudi` group ID is straightforward and aligns with how Hudi already publishes connector-style artifacts (`hudi-spark-bundle`, `hudi-flink-bundle`, etc.). Cross-project announcements to both PMCs at first release.
+- **Trino SPI drift.** A future Trino SPI change could break the pre-built `hudi-trino` artifact at runtime. Mitigation: the nightly compat CI flags incompatibilities against Trino master before a Trino release ships.
+- **Avro / Parquet / Jackson version skew.** Resolved by policy: Trino's versions are authoritative, pinned via `<dependencyManagement>` in the `hudi-trino` POM. Hudi-side fixes or Trino-version bumps adjust to it.
+- **Test-infrastructure coupling.** `hudi-trino-plugin`'s test scope depends on `trino-testing`, `trino-main`, etc., coupling the Hudi build to Trino artifacts on Maven Central. Acceptable cost.
+- **Release coordination.** A critical fix in `hudi-trino` ships only via a Hudi release. Mitigation: keep the Trino-side shim trivial so virtually all fixes can land in `hudi-trino`, and increase Hudi release cadence.
+- **License / ASF process.** Cross-project releases between two ASF projects; covered by standard PMC announcements at first release.
 
 ## Rollout/Adoption Plan
 
-### Step 1 — Hudi 1.3.0 prepares and publishes `hudi-trino`
+**Step 1 — Hudi 1.3.0 publishes `hudi-trino`.** Land the `hudi-trino-plugin` work in `apache/hudi` master behind the `-Phudi-trino` profile, land the two CI workflows, then publish `org.apache.hudi:hudi-trino:1.3.0` to Maven Central as part of the 1.3.0 release. Hudi commits to a more frequent release cadence going forward.
 
-- Land the existing `hudi-trino-plugin` work in `apache/hudi` master.
-- Add the `hudi-trino` Maven profile to the root POM so the module is excluded from the default reactor.
-- Land the two GitHub Actions workflows: `hudi-trino-ci.yml` (full test suite, JDK 25) and `hudi-trino-compat.yml` (compile against latest Trino master).
-- Verify the produced artifact's POM declares Hudi deps as `compile`, Trino SPI deps as `provided`, no Hadoop in non-test scope.
-- **Hudi 1.3.0 release** publishes `org.apache.hudi:hudi-trino:1.3.0` to Maven Central.
-- Hudi commits to a more frequent release cadence going forward to support the integration model.
+**Step 2 — Trino-side shim PR.** A small PR against `trinodb/trino` that replaces the contents of `plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/` with a single `HudiPlugin.java`, keeps `META-INF/services/io.trino.spi.Plugin` and all current tests, and adds `org.apache.hudi:hudi-trino:1.3.0` as a `compile` dependency. The PR is small by design — deletes connector code, points at the published artifact — so Trino-maintainer review burden is minimal.
 
-### Step 2 — Trino-side shim PR
+**Step 3 — Steady state.** Trino-Hudi feature work and bug fixes happen on the Hudi side. Each Hudi release publishes a new `hudi-trino` artifact. Trino picks up changes by bumping the pinned version — a one-line PR per release.
 
-A small PR against `trinodb/trino`:
-
-- Replace `plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/*` with a single `HudiPlugin.java`.
-- Keep `src/main/resources/META-INF/services/io.trino.spi.Plugin`.
-- Update `plugin/trino-hudi/pom.xml`:
-  - Add `org.apache.hudi:hudi-trino:1.3.0` as a `compile` dependency.
-  - Remove direct dependencies on `hudi-common`, `hudi-io` (now transitive via `hudi-trino`).
-  - Keep test dependencies as-is.
-- Keep all `src/test/java/...` files (smoke tests, query runners, MinIO tests, plugin loading tests).
-- Run Trino's full test suite locally; iterate to green.
-
-This PR is **small and obviously correct** — it deletes code and points at a published artifact. Trino-maintainer review burden is minimal, addressing the root complaint that drove this RFC.
-
-### Step 3 — Steady state
-
-- Trino-Hudi feature work and bug fixes happen on the Hudi side in `hudi-trino-plugin`.
-- Each Hudi release publishes a new `hudi-trino` artifact.
-- Trino picks up changes by bumping the pinned version in `plugin/trino-hudi/pom.xml` — small, easy-to-review PRs against `trinodb/trino`.
-- Critical fixes can ship via point releases of Hudi.
-
-### Impact on existing users
-
-- **No behavioral change.** The connector continues to be `io.trino.plugin.hudi.HudiPlugin` registered the same way; catalog configuration syntax is unchanged.
-- **Feature uplift.** First Trino release picking up `hudi-trino:1.3.0` gains all features from the four closed PRs: metadata-table partition listing, index support, MOR snapshot-isolation correctness, file-system caching, advanced split generation.
-
-### Migration tools
-
-None needed. The change is transparent to users.
-
-### Removal of existing behavior
-
-None. The shim retains the same SPI registration.
+**Impact on existing users.** No behavioral change: same `HudiPlugin` registration, same catalog config. The first Trino release picking up `hudi-trino:1.3.0` gains the features that the previously-stalled PRs covered (metadata-table partition listing, index support, MOR snapshot-isolation correctness, file-system caching, advanced split generation). No migration tools needed.
 
 ## Test Plan
 
-How we will know the implementation works:
+The RFC is validated when:
 
-- [ ] `hudi-trino-plugin` builds successfully on Hudi side under JDK 25 via `mvn install -Phudi-trino`.
-- [ ] `hudi-trino-plugin` test suite passes on Hudi side via `mvn verify -Phudi-trino`, covering:
-  - `TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiAlluxioCachingSmokeTest`
-  - `TestHudiConnectorTest`, `TestHudiConnectorParquetColumnNamesTest`
-  - `TestHudiPageSource`, `TestHudiPageSourceProviderTest`
-  - `TestHudiSplitFactory`
-  - `TestHudiSystemTables`, `TestHudiSharedMetastore`
-  - Cache file-operation tests
-  - Plugin / config / session-property tests
-- [ ] New `hudi-trino-compat.yml` workflow successfully compiles `hudi-trino-plugin` against latest `trinodb/trino` master.
-- [ ] Hudi 1.3.0 release artifact `org.apache.hudi:hudi-trino:1.3.0` is published to Maven Central.
-- [ ] Trino-side shim PR's full test suite passes against the published `1.3.0` artifact:
-  - All current `trino-hudi` tests
-  - MinIO/S3 integration tests
-  - Plugin loading tests
-- [ ] `mvn dependency:tree -Phudi-trino` on the Hudi side shows no `org.apache.hadoop:*` in non-test scope.
-- [ ] Trino-side `mvn dependency:tree -pl :trino-hudi` shows the same — no Hadoop leakage from the published artifact.
-- [ ] At least one Hudi-side patch release cycle exercises the "bump-version-in-Trino" steady-state flow successfully.
-
-We will know nothing broke when:
-
-- Trino's CI for `plugin/trino-hudi` is green after the shim PR.
-- Hudi's `hudi-trino-ci.yml` and `hudi-trino-compat.yml` workflows are green continuously.
-- No regressions reported by users on the `trinodb/trino` issue tracker for Hudi-related queries after the shim PR ships.
+- [ ] `hudi-trino-plugin` builds and its full test suite passes on the Hudi side via `mvn verify -Phudi-trino` (JDK 25), covering smoke tests, MinIO/Alluxio caching tests, MOR/COW tests, page source tests, split-factory tests, index support tests, system-table tests, and plugin/config tests.
+- [ ] The `hudi-trino-compat.yml` workflow compiles `hudi-trino-plugin` against `trinodb/trino` master successfully.
+- [ ] `org.apache.hudi:hudi-trino:1.3.0` is published to Maven Central.
+- [ ] The Trino-side shim PR is green: Trino's CI for `plugin/trino-hudi` passes against the published `1.3.0` artifact, including MinIO/S3 integration and plugin-loading tests.
+- [ ] At least one subsequent Hudi-side patch release exercises the "bump version in Trino" steady-state flow end-to-end.

--- a/rfc/rfc-105/rfc-105.md
+++ b/rfc/rfc-105/rfc-105.md
@@ -181,7 +181,7 @@ Default build (`mvn install`) skips it; Trino-targeted build (`mvn install -Phud
 Two new GitHub Actions on the Hudi side, required for any change touching `hudi-trino-plugin/**`:
 
 1. **`hudi-trino-ci.yml`** — runs the full test suite via `mvn verify -Phudi-trino` on JDK 25. Catches regressions before they ship in a Hudi release.
-2. **`hudi-trino-compat.yml`** — nightly: pulls latest `trinodb/trino` master, builds Trino's relevant modules, then compiles `hudi-trino-plugin` against them. Compile-only; flags SPI drift before the next Trino release.
+2. **`hudi-trino-compat.yml`** — nightly: pulls latest `trinodb/trino` master and latest `apache/hudi` master, builds Trino's relevant modules, then compiles `hudi-trino-plugin` against them and runs the `hudi-trino-plugin` test suite. Catches both SPI drift and behavioral incompatibilities before the next Trino release.
 
 On the Trino side, existing CI continues to build and test `plugin/trino-hudi`, exercising the published `hudi-trino` artifact end-to-end on every Trino PR.
 
@@ -198,7 +198,7 @@ This duplication has a known cost — two places to update when adding tests —
 
 ### Risks & caveats
 
-- **Trino SPI drift.** A future Trino SPI change could break the pre-built `hudi-trino` artifact at runtime. Mitigation: the nightly compat CI flags incompatibilities against Trino master before a Trino release ships.
+- **Trino SPI drift.** A future Trino SPI change could break the pre-built `hudi-trino` artifact at runtime. Mitigation: the nightly compat CI compiles and runs the `hudi-trino-plugin` test suite against Trino master, flagging both compile-time and behavioral incompatibilities before a Trino release ships.
 - **Avro / Parquet / Jackson version skew.** Resolved by policy: Trino's versions are authoritative, pinned via `<dependencyManagement>` in the `hudi-trino` POM. Hudi-side fixes or Trino-version bumps adjust to it.
 - **Test-infrastructure coupling.** `hudi-trino-plugin`'s test scope depends on `trino-testing`, `trino-main`, etc., coupling the Hudi build to Trino artifacts on Maven Central. Acceptable cost.
 - **Release coordination.** A critical fix in `hudi-trino` ships only via a Hudi release. Mitigation: keep the Trino-side shim trivial so virtually all fixes can land in `hudi-trino`, and increase Hudi release cadence.
@@ -206,11 +206,11 @@ This duplication has a known cost — two places to update when adding tests —
 
 ## Rollout/Adoption Plan
 
-**Step 1 — Hudi 1.3.0 publishes `hudi-trino`.** Land the `hudi-trino-plugin` work in `apache/hudi` master behind the `-Phudi-trino` profile, land the two CI workflows, then publish `org.apache.hudi:hudi-trino:1.3.0` to Maven Central as part of the 1.3.0 release. Hudi commits to a more frequent release cadence going forward.
+**Step 1 — Hudi 1.3.0 publishes `hudi-trino`.** Land the `hudi-trino-plugin` work in `apache/hudi` master behind the `-Phudi-trino` profile, land the two CI workflows, then publish `org.apache.hudi:hudi-trino:1.3.0` to Maven Central as part of the 1.3.0 release. Hudi commits to a more frequent release cadence going forward: to start, a major release roughly every month, with more frequent minor releases to stabilize this module. A `hudi-trino` artifact is cut whenever there are enough improvements to ship to Trino users. Cadence is owned by the Hudi release cycle; Trino releases are not blocked on it.
 
 **Step 2 — Trino-side shim PR.** A small PR against `trinodb/trino` that replaces the contents of `plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/` with a single `HudiPlugin.java`, keeps `META-INF/services/io.trino.spi.Plugin` and all current tests, and adds `org.apache.hudi:hudi-trino:1.3.0` as a `compile` dependency. The PR is small by design — deletes connector code, points at the published artifact — so Trino-maintainer review burden is minimal.
 
-**Step 3 — Steady state.** Trino-Hudi feature work and bug fixes happen on the Hudi side. Each Hudi release publishes a new `hudi-trino` artifact. Trino picks up changes by bumping the pinned version — a one-line PR per release.
+**Step 3 — Steady state.** Trino-Hudi feature work and bug fixes happen on the Hudi side. Each Hudi release publishes a new `hudi-trino` artifact. Trino picks up changes by bumping the pinned version — a one-line PR per release. Because Trino pins `hudi-trino` as a compile-time dependency, the `hudi-trino` ↔ Trino release mapping is **one-to-one**: each `hudi-trino` version is the version that ships embedded in a specific Trino release. This one-to-one mapping makes feature support and bug-fix tracking easy to reason about for both users and maintainers. Hudi publishes and maintains this version-compatibility table on the Hudi website (hudi.apache.org), and the Trino-side `plugin/trino-hudi` README links to it as the single source of truth.
 
 **Impact on existing users.** No behavioral change: same `HudiPlugin` registration, same catalog config. The first Trino release picking up `hudi-trino:1.3.0` gains the features that the previously-stalled PRs covered (metadata-table partition listing, index support, MOR snapshot-isolation correctness, file-system caching, advanced split generation). No migration tools needed.
 

--- a/rfc/rfc-105/rfc-105.md
+++ b/rfc/rfc-105/rfc-105.md
@@ -1,0 +1,369 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+# RFC-105: Trino Hudi Connector — Shim/Bundle Refactor
+
+## Proposers
+
+- @yihua
+- @voonhous
+
+## Approvers
+
+- @codope
+- @vinothchandar
+
+## Status
+
+Issue: [HUDI-18780](https://github.com/apache/hudi/issues/18780)
+
+> Please keep the status updated in `rfc/README.md`.
+
+## Motivation
+
+The Trino-Hudi connector currently lives in `trinodb/trino` at `plugin/trino-hudi`. Maintaining and evolving it inside Trino OSS has stalled in practice:
+
+- **Limited Trino-side maintainer bandwidth for Hudi.** Trino maintainers' active focus is on Iceberg and, to a lesser extent, Delta Lake. As stated by Trino maintainer @raunaqm in the `#dev` Slack thread: *"the unfortunate reality is that Hudi is not a priority for any maintainer at the moment and that's unlikely to change."*
+- **PRs closed for inactivity.** Four stacked Hudi-side improvement PRs from @voonhous were closed by Trino's stale-bot for lack of review:
+  - [trinodb/trino#28518](https://github.com/trinodb/trino/pull/28518)
+  - [trinodb/trino#28533](https://github.com/trinodb/trino/pull/28533)
+  - [trinodb/trino#28644](https://github.com/trinodb/trino/pull/28644)
+  - [trinodb/trino#28645](https://github.com/trinodb/trino/pull/28645)
+- **Significant Hudi-side work is ready but unable to land**: metadata-table-driven partition listing, eight `HudiIndexSupport` strategies (column stats, partition stats, record-level, secondary, expression, bloom, bucket, partition bloom), MOR snapshot-isolation fixes (worker-side use of the latest commit time from the table handle), and file-system caching integration.
+
+In the `#dev` Slack thread (May 2026), Trino maintainer @raunaqm proposed reducing Trino's Hudi connector to a thin layer around a Hudi-side library:
+
+> *"Reduce Hudi connector to a thin layer around the hudi library. Then Hudi connector changes mostly become version bumps (after the initial refactor), and you won't be blocked on maintainer reviews."*
+
+The Hudi community (@yihua, @voonhous) accepted, with a single condition from @raunaqm:
+
+> *"I would only request that we still maintain a comprehensive test suite on Trino side."*
+
+Stakeholders aligned on this approach:
+
+- **Hudi side:** @yihua (Y Ethan Guo), @voonhous (Su Voon Hou), @bhasudha (sudha_s).
+- **Trino side:** @raunaqm, @ebyhr, @mariusgrama (Marius Grama), @findepi, @manfred-moser (Manfred Moser).
+
+This RFC documents the agreed approach and the implementation plan.
+
+## Abstract
+
+We split the Trino-Hudi connector into two Maven artifacts:
+
+1. **`io.trino:trino-hudi`** stays in Trino OSS (`plugin/trino-hudi`) as a thin shim — a `HudiPlugin` class that registers the `io.trino.spi.Plugin` SPI entry point — plus the test harness (smoke tests, query runners, MinIO-backed integration tests). This module mostly does not change once landed.
+2. **`org.apache.hudi:hudi-trino`** is a new Hudi-published Maven artifact (regular, non-shaded JAR) containing the actual connector logic at `io.trino.plugin.hudi.*` — `HudiConnectorFactory`, `HudiConnector`, `HudiMetadata`, `HudiSplitManager`, `HudiPageSourceProvider`, all index-support strategies, the `HoodieStorage`/`HoodieIOFactory` bridges to Trino's filesystem, etc. The artifact is built against the latest Trino release's SPI; it declares `hudi-common`, `hudi-io`, etc. as transitive dependencies and Trino's `trino-spi`, `trino-filesystem`, etc. as `provided`.
+
+The first publication ships in **Hudi 1.3.0**. The Trino-side shim PR pins `org.apache.hudi:hudi-trino:1.3.0`. Going forward, all Trino-Hudi connector evolution happens in Hudi OSS; Trino picks up changes by bumping the dependency version. To support this integration model, **Hudi will increase its release cadence**.
+
+## Background
+
+### State of the Trino-side connector today
+
+`plugin/trino-hudi` in `trinodb/trino`:
+
+- ~4,142 LOC across ~40 Java files under `io.trino.plugin.hudi.*`.
+- Depends on `hudi-common`, `hudi-io` (Hudi 1.1.1) with aggressive transitive exclusions.
+- No direct Hadoop imports in main code; uses Hudi's `HoodieStorage` abstraction (RFC-74) with a `TrinoHudiStorage` bridge that wraps `TrinoFileSystem`.
+- 20 test files including `HudiQueryRunner`, smoke tests, MinIO/S3 integration tests, plugin loading tests, config tests.
+- Implements the standard Trino SPI: `Plugin`, `ConnectorFactory`, `Connector`, `ConnectorMetadata`, `ConnectorSplitManager`, `ConnectorPageSourceProvider`, `ConnectorSplit`, `ConnectorTableHandle`, `ConnectorSplitSource`.
+
+### State of the Hudi-side `hudi-trino-plugin` work
+
+A more advanced version of the connector exists in Hudi-side branches under `hudi-trino-plugin/`:
+
+- ~9,650 LOC across ~66 Java files; same package namespace (`io.trino.plugin.hudi.*`).
+- Built against Trino 472.
+- Adds advanced features absent from Trino OSS today:
+  - `io.trino.plugin.hudi.query.index/` — eight `HudiIndexSupport` strategies driving file-level and partition-level pruning via Hudi metadata tables.
+  - `io.trino.plugin.hudi.storage/` — `HudiTrinoStorage`, `HudiTrinoInlineStorage` (HoodieStorage implementations over `TrinoFileSystem`).
+  - `io.trino.plugin.hudi.io/` — `HudiTrinoIOFactory`, `HudiTrinoFileReaderFactory`, `TrinoSeekableDataInputStream` (Hudi I/O factory bridges).
+  - `io.trino.plugin.hudi.reader/` — `HudiTrinoReaderContext` for MOR record-level merging via `HoodieFileGroupReader`.
+  - `io.trino.plugin.hudi.partition/` — async, resumable partition discovery; metadata-table-driven listing.
+  - `io.trino.plugin.hudi.stats/` — `HudiTableStatistics`, statistics reader.
+  - `io.trino.plugin.hudi.cache/` — file-system cache key provider.
+  - Background, async split generation (`HudiBackgroundSplitLoader`) with size-based split weighting.
+  - Lazy commit-time on `HudiTableHandle` for snapshot-isolated MOR reads across workers.
+  - Multi-reader strategy: `HudiPageSource` for MOR with merging vs `HudiBaseFileOnlyPageSource` for COW/RO base files.
+- 22 test files including `HudiQueryRunner`, smoke tests, MinIO smoke tests, Alluxio caching tests, file-operation tests.
+- No Hadoop imports in main code; all FS access via `TrinoFileSystem` + `HudiTrinoStorage`.
+
+This is the body of code that will move into the `hudi-trino` Maven module on the Hudi side.
+
+### Why a "shim + Hudi-published artifact" pattern
+
+Trino already establishes precedent for connectors built as thin shims around an upstream library:
+
+- **`plugin/trino-iceberg`** depends directly on `iceberg-api`, `iceberg-core`, `iceberg-aws`, `iceberg-azure`, `iceberg-gcp`, `iceberg-parquet` and delegates most of its work to those libraries.
+- **`plugin/trino-delta-lake`** depends on `delta-kernel-api`.
+- **`plugin/trino-postgresql`** and other JDBC plugins are extremely thin wrappers over `trino-base-jdbc` and the upstream JDBC driver.
+
+The novelty here is that `hudi-trino` is **purpose-built for Trino** rather than a general-purpose library that Trino adapts. This means **no adapter glue is needed between the published artifact and the Trino SPI** — the artifact implements the Trino SPI directly. The shim is correspondingly minimal: a single `HudiPlugin` class plus the test harness.
+
+Trino's `trino-spi` is governed by `revapi-maven-plugin` (see `core/trino-spi/pom.xml`) which enforces backward compatibility on the SPI surface. This is what makes a single `hudi-trino` artifact targeting the latest Trino release viable across multiple subsequent Trino releases.
+
+Trino loads each plugin in an isolated `URLClassLoader`. Transitive dependencies of `hudi-trino` (Avro, Parquet, etc.) are isolated to the plugin's classloader and cannot conflict with other plugins.
+
+## Implementation
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Trino OSS — trinodb/trino                                   │
+│  ─────────────────────────                                   │
+│  plugin/trino-hudi    (packaging = trino-plugin)             │
+│    ├─ src/main/java/io/trino/plugin/hudi/                    │
+│    │    └─ HudiPlugin.java   ← single trivial class          │
+│    ├─ src/main/resources/META-INF/services/                  │
+│    │    └─ io.trino.spi.Plugin    (→ HudiPlugin)             │
+│    ├─ src/test/java/...   (smoke tests, query runner,        │
+│    │                       MinIO tests, plugin/config tests) │
+│    └─ pom.xml                                                │
+│         └─ depends on org.apache.hudi:hudi-trino:1.3.0       │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              │  Maven Central
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│  Hudi OSS — apache/hudi                                      │
+│  ──────────────────────                                      │
+│  hudi-trino-plugin/    (separate Maven profile;              │
+│                         excluded from default reactor;       │
+│                         Java 25 required)                    │
+│    ├─ src/main/java/io/trino/plugin/hudi/                    │
+│    │    └─ HudiConnectorFactory, HudiConnector,              │
+│    │       HudiMetadata, HudiSplitManager,                   │
+│    │       HudiPageSourceProvider,                           │
+│    │       cache/, file/, io/, partition/,                   │
+│    │       query/ (incl. 8 index-support strategies),        │
+│    │       reader/, split/, stats/, storage/, util/          │
+│    ├─ src/test/java/...   (full test duplication of          │
+│    │                       Trino-side tests + Hudi-side      │
+│    │                       expansion)                        │
+│    └─ pom.xml                                                │
+│         ├─ compile: hudi-common, hudi-io, hudi-hive-sync,    │
+│         │          hudi-sync-common (regular Maven deps)     │
+│         ├─ compile: trino-filesystem, trino-hive,            │
+│         │          trino-metastore, trino-parquet,           │
+│         │          trino-cache                               │
+│         └─ provided: trino-spi, Airlift, Jackson,            │
+│                      OpenTelemetry API, JOL                  │
+│                                                              │
+│  Published as: org.apache.hudi:hudi-trino:1.3.0              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### What lives where
+
+#### Trino-side `plugin/trino-hudi` (the shim)
+
+| File | Purpose |
+|---|---|
+| `src/main/java/io/trino/plugin/hudi/HudiPlugin.java` | Implements `io.trino.spi.Plugin`. Single method returning `new HudiConnectorFactory()` (from the `hudi-trino` artifact). ~10 lines. |
+| `src/main/resources/META-INF/services/io.trino.spi.Plugin` | Service-loader pointer to `io.trino.plugin.hudi.HudiPlugin`. |
+| `pom.xml` | `<packaging>trino-plugin</packaging>`; pins `org.apache.hudi:hudi-trino:<version>`; SPI deps as `provided`. |
+| `src/test/java/...` | All current Trino-side tests stay: `HudiQueryRunner`, `TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiConnectorTest`, `TestHudiSharedMetastore`, `TestHudiSystemTables`, `TestHudiPlugin`, `TestHudiConfig`, plus data initializers. Per @raunaqm's requirement. |
+
+#### Hudi-side `hudi-trino-plugin/` (the engine)
+
+Everything else from the current `hudi-trino-plugin/` work, organized exactly as it is today:
+
+| Subpackage | Responsibility |
+|---|---|
+| `io.trino.plugin.hudi` | `HudiConnectorFactory`, `HudiConnector`, `HudiMetadata`, `HudiSplitManager`, `HudiPageSourceProvider`, `HudiSplit`, `HudiTableHandle`, `HudiModule`, `HudiConfig`, `HudiSessionProperties`, `HudiTableProperties`, `HudiTransactionManager`, `HudiMetadataFactory`. |
+| `.cache` | `HudiCacheKeyProvider` for file-system cache integration. |
+| `.file` | `HudiBaseFile`, `HudiLogFile`, file metadata abstractions. |
+| `.io` | `HudiTrinoIOFactory` (extends `HoodieIOFactory`), `HudiTrinoFileReaderFactory`, `TrinoSeekableDataInputStream`. |
+| `.partition` | `HudiPartitionInfo`, `HiveHudiPartitionInfo`, `HudiPartitionInfoLoader` (async resumable task). |
+| `.query` | `HudiDirectoryLister`, `HudiReadOptimizedDirectoryLister`, `HudiSnapshotDirectoryLister`; `query.index` package with 8 `HudiIndexSupport` strategies. |
+| `.reader` | `HudiTrinoReaderContext extends HoodieReaderContext<IndexedRecord>` for MOR record merging. |
+| `.split` | `HudiSplitFactory`, `HudiBackgroundSplitLoader`, `HudiSplitSource`, `HudiSplitWeightProvider`, `SizeBasedSplitWeightProvider`. |
+| `.stats` | `HudiTableStatistics`, `TableStatisticsReader`. |
+| `.storage` | `HudiTrinoStorage` (extends `HoodieStorage`), `HudiTrinoInlineStorage`, `TrinoStorageConfiguration`. |
+| `.util` | Serialization helpers, column synthesis, tuple-domain conversion, table-type utilities. |
+
+### API boundary
+
+The boundary between the shim and the published artifact is **Trino's SPI itself** — no intermediate API layer is introduced.
+
+- **Shim → artifact:** `HudiPlugin.getConnectorFactories()` returns `new HudiConnectorFactory()` defined in the artifact. Trino's runtime then calls `factory.create(catalogName, config, context)`. The `ConnectorContext` argument carries everything the artifact needs — `TypeManager`, `NodeManager`, `MetadataProvider`, `PageSorter`, `PageIndexerFactory`, `OpenTelemetry`, `Tracer`, `CatalogHandle` — without the artifact importing implementation classes.
+- **Artifact → Trino:** the artifact's `HudiConnector` exposes the standard SPI providers (`ConnectorMetadata`, `ConnectorSplitManager`, `ConnectorPageSourceProvider`, etc.). Trino calls these. Classloader context is handled by the standard `ClassLoaderSafe*` wrappers (`io.trino.plugin.base.classloader.*`) — already used today.
+
+### Maven dependencies for `hudi-trino`
+
+Strict dependency hygiene:
+
+- **`compile`:** `hudi-common`, `hudi-io`, `hudi-hive-sync`, `hudi-sync-common` (all at the same Hudi version); `trino-filesystem`, `trino-hive`, `trino-metastore`, `trino-parquet`, `trino-cache`; Guice; Airlift modules (bootstrap, config, json, log, units, concurrent); Caffeine.
+- **`provided`:** `trino-spi`, `slice`, Jackson annotations, OpenTelemetry API, JOL, JetBrains annotations. Supplied by Trino at runtime.
+- **`runtime`:** log-manager, Dropwizard metrics, OpenTelemetry SDK, `trino-hive-formats`.
+- **`test`:** `trino-testing`, `trino-main`, `trino-testing-containers`, `trino-testing-services`, `trino-hdfs`, `trino-parser`; AssertJ, JUnit 5; Hudi test JARs (`hudi-client-common`, `hudi-hadoop-common`, `hudi-java-client`).
+
+#### Version alignment policy
+
+The Trino runtime is the canonical source of truth for shared library versions. The `hudi-trino` POM uses `<dependencyManagement>` to **pin Avro, Parquet, Jackson, Airlift versions to whatever the targeted Trino release uses**. If Hudi internals require a newer Parquet/Avro than Trino's current version, the resolution is to:
+
+1. Either bump Trino's version (and rebuild `hudi-trino` against the new Trino release), or
+2. Fix Hudi internals to work with Trino's version range.
+
+We do **not** ship a version of `hudi-trino` that introduces a divergent Parquet/Avro version on the Trino classpath.
+
+### Build target on Hudi side
+
+`hudi-trino-plugin` is **excluded from the default `mvn install` reactor** because:
+
+- Trino requires **Java 25** (per Trino's `.java-version`).
+- The rest of Hudi targets a lower Java floor.
+- Most Hudi contributors do not need to build `hudi-trino-plugin` for their day-to-day work.
+
+Mechanism:
+
+```xml
+<!-- root pom.xml -->
+<profile>
+  <id>hudi-trino</id>
+  <activation>
+    <activeByDefault>false</activeByDefault>
+  </activation>
+  <modules>
+    <module>hudi-trino-plugin</module>
+  </modules>
+</profile>
+```
+
+Default build: `mvn install` — `hudi-trino-plugin` is **not** built.
+Trino-targeted build: `mvn install -Phudi-trino` — requires Java 25.
+
+### CI on Hudi side
+
+Two new GitHub Actions workflows, both required to pass before merge to `master` for changes touching `hudi-trino-plugin/**`:
+
+1. **`hudi-trino-ci.yml` — Full test suite.**
+   - Triggers on push / PR touching `hudi-trino-plugin/**`.
+   - Runs `mvn verify -Phudi-trino` on JDK 25.
+   - Executes the full duplicated test suite (smoke tests, MinIO smoke tests, MOR/COW tests, index support tests, page source tests, partition discovery tests, statistics tests, cache tests).
+   - Goal: catch regressions in Hudi-internal changes before they ship in a Hudi release.
+
+2. **`hudi-trino-compat.yml` — Compile-against-latest-Trino check.**
+   - Triggers nightly and on PRs touching `hudi-trino-plugin/**`.
+   - Pulls latest `trinodb/trino` master.
+   - Builds Trino's `trino-spi`, `trino-filesystem`, `trino-hive`, `trino-metastore`, `trino-parquet`, `trino-cache` modules locally.
+   - Builds `hudi-trino-plugin` against the freshly-built Trino artifacts (with the local versions injected via `-Dtrino.version=<sha-snapshot>`).
+   - **Compile-only** — failure indicates an upcoming SPI change in Trino master that will break us when Trino releases.
+   - Goal: catch SPI drift well before a Trino release ships, so we can adapt `hudi-trino` ahead of time.
+
+### Trino-side CI
+
+Trino's existing CI continues to compile and test `plugin/trino-hudi`. Because the shim is small and the heavy tests live there too, Trino's CI exercises a real, end-to-end Hudi connector against the published `hudi-trino` artifact on every Trino PR.
+
+### Test strategy
+
+**Full test duplication.** The Trino-side smoke tests (`TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiConnectorTest`, etc.) are mirrored on the Hudi side and additionally extended.
+
+- **Trino side runs them** on every Trino PR — fulfilling @raunaqm's requirement.
+- **Hudi side runs them** on every Hudi PR touching `hudi-trino-plugin` — so Hudi contributors catch regressions before they ship in a Hudi release. The Hudi-side suite is also **expanded** with more granular unit tests covering split generation edge cases, all eight index-support strategies, the MOR record-merging path, lazy-commit-time snapshot isolation, and the cache-key provider.
+
+This duplication has a known cost — two places to update when adding tests — but is the right trade-off given:
+- The Trino-side suite must remain comprehensive (@raunaqm's condition).
+- Hudi-side contributors need fast feedback without waiting for a Trino-side PR cycle.
+
+### Risks & caveats
+
+1. **Trino SPI drift.** If a future Trino release introduces an SPI change that the pre-built `hudi-trino` artifact didn't anticipate, the connector breaks at runtime when a user upgrades Trino. RevAPI on `trino-spi` makes the SPI surface backward-compatible by policy, but drift can accumulate. **Mitigation:** the nightly `hudi-trino-compat.yml` CI workflow on the Hudi side recompiles `hudi-trino` against Trino master and flags incompatibilities before a Trino release ships, giving Hudi time to react.
+
+2. **Avro / Parquet / Jackson version skew.** Hudi and Trino each have opinions on these library versions. **Resolution policy:** Trino's versions are prioritized; the `hudi-trino` POM forces alignment with the targeted Trino release via `<dependencyManagement>`. If Hudi internals require a newer version than Trino exposes, the fix is on the Hudi side or via a Trino-version bump — not by introducing divergent classpath versions in `hudi-trino`.
+
+3. **Test infrastructure dependency direction.** `hudi-trino-plugin` test scope depends on `trino-testing`, `trino-main`, `trino-testing-containers`. These are public Maven artifacts but they couple Hudi's `hudi-trino-plugin` build to Trino releases having shipped to Maven Central. Acceptable cost.
+
+4. **Classloader / shadowing concerns.** Trino isolates each plugin in its own `URLClassLoader`. Transitive deps of `hudi-trino` (Avro, Parquet, etc.) are isolated from other plugins. Not a risk in practice.
+
+5. **Release coordination.** A critical bug in `hudi-trino` requires a new Hudi release to ship the fix. **Mitigation:** keep the Trino-side shim trivially small so virtually all fixes land in `hudi-trino`; Hudi will increase release cadence to support this model; for emergencies, a Trino-side fork pinned to a Hudi snapshot is always possible.
+
+6. **License / ASF process.** Both projects are ASF projects. Publishing the `hudi-trino` artifact under Hudi's `org.apache.hudi` group ID is straightforward and aligns with how Hudi already publishes connector-style artifacts (`hudi-spark-bundle`, `hudi-flink-bundle`, etc.). Cross-project announcements to both PMCs at first release.
+
+## Rollout/Adoption Plan
+
+### Step 1 — Hudi 1.3.0 prepares and publishes `hudi-trino`
+
+- Land the existing `hudi-trino-plugin` work in `apache/hudi` master.
+- Add the `hudi-trino` Maven profile to the root POM so the module is excluded from the default reactor.
+- Land the two GitHub Actions workflows: `hudi-trino-ci.yml` (full test suite, JDK 25) and `hudi-trino-compat.yml` (compile against latest Trino master).
+- Verify the produced artifact's POM declares Hudi deps as `compile`, Trino SPI deps as `provided`, no Hadoop in non-test scope.
+- **Hudi 1.3.0 release** publishes `org.apache.hudi:hudi-trino:1.3.0` to Maven Central.
+- Hudi commits to a more frequent release cadence going forward to support the integration model.
+
+### Step 2 — Trino-side shim PR
+
+A small PR against `trinodb/trino`:
+
+- Replace `plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/*` with a single `HudiPlugin.java`.
+- Keep `src/main/resources/META-INF/services/io.trino.spi.Plugin`.
+- Update `plugin/trino-hudi/pom.xml`:
+  - Add `org.apache.hudi:hudi-trino:1.3.0` as a `compile` dependency.
+  - Remove direct dependencies on `hudi-common`, `hudi-io` (now transitive via `hudi-trino`).
+  - Keep test dependencies as-is.
+- Keep all `src/test/java/...` files (smoke tests, query runners, MinIO tests, plugin loading tests).
+- Run Trino's full test suite locally; iterate to green.
+
+This PR is **small and obviously correct** — it deletes code and points at a published artifact. Trino-maintainer review burden is minimal, addressing the root complaint that drove this RFC.
+
+### Step 3 — Steady state
+
+- Trino-Hudi feature work and bug fixes happen on the Hudi side in `hudi-trino-plugin`.
+- Each Hudi release publishes a new `hudi-trino` artifact.
+- Trino picks up changes by bumping the pinned version in `plugin/trino-hudi/pom.xml` — small, easy-to-review PRs against `trinodb/trino`.
+- Critical fixes can ship via point releases of Hudi.
+
+### Impact on existing users
+
+- **No behavioral change.** The connector continues to be `io.trino.plugin.hudi.HudiPlugin` registered the same way; catalog configuration syntax is unchanged.
+- **Feature uplift.** First Trino release picking up `hudi-trino:1.3.0` gains all features from the four closed PRs: metadata-table partition listing, index support, MOR snapshot-isolation correctness, file-system caching, advanced split generation.
+
+### Migration tools
+
+None needed. The change is transparent to users.
+
+### Removal of existing behavior
+
+None. The shim retains the same SPI registration.
+
+## Test Plan
+
+How we will know the implementation works:
+
+- [ ] `hudi-trino-plugin` builds successfully on Hudi side under JDK 25 via `mvn install -Phudi-trino`.
+- [ ] `hudi-trino-plugin` test suite passes on Hudi side via `mvn verify -Phudi-trino`, covering:
+  - `TestHudiSmokeTest`, `TestHudiMinioConnectorSmokeTest`, `TestHudiAlluxioCachingSmokeTest`
+  - `TestHudiConnectorTest`, `TestHudiConnectorParquetColumnNamesTest`
+  - `TestHudiPageSource`, `TestHudiPageSourceProviderTest`
+  - `TestHudiSplitFactory`
+  - `TestHudiSystemTables`, `TestHudiSharedMetastore`
+  - Cache file-operation tests
+  - Plugin / config / session-property tests
+- [ ] New `hudi-trino-compat.yml` workflow successfully compiles `hudi-trino-plugin` against latest `trinodb/trino` master.
+- [ ] Hudi 1.3.0 release artifact `org.apache.hudi:hudi-trino:1.3.0` is published to Maven Central.
+- [ ] Trino-side shim PR's full test suite passes against the published `1.3.0` artifact:
+  - All current `trino-hudi` tests
+  - MinIO/S3 integration tests
+  - Plugin loading tests
+- [ ] `mvn dependency:tree -Phudi-trino` on the Hudi side shows no `org.apache.hadoop:*` in non-test scope.
+- [ ] Trino-side `mvn dependency:tree -pl :trino-hudi` shows the same — no Hadoop leakage from the published artifact.
+- [ ] At least one Hudi-side patch release cycle exercises the "bump-version-in-Trino" steady-state flow successfully.
+
+We will know nothing broke when:
+
+- Trino's CI for `plugin/trino-hudi` is green after the shim PR.
+- Hudi's `hudi-trino-ci.yml` and `hudi-trino-compat.yml` workflows are green continuously.
+- No regressions reported by users on the `trinodb/trino` issue tracker for Hudi-related queries after the shim PR ships.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Adds the design document for **RFC-105**: refactor the Trino Hudi connector into a thin Trino-side shim plus a Hudi-published `org.apache.hudi:hudi-trino` artifact. First publication ships in Hudi 1.3.0.

Tracking issue: #18780
Companion PR (reserves RFC number, must merge first): #18781

### Summary and Changelog

See `rfc/rfc-105/rfc-105.md` for the full design.

### Impact

Documentation-only — adds `rfc/rfc-105/rfc-105.md`. The actual code refactor lands in follow-up PRs per the RFC's rollout plan.

### Risk Level

none

### Documentation Update

Adds `rfc/rfc-105/rfc-105.md`. No Hudi website update needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable