### PR TITLE
fix(spark): use HoodieStorageUtils factory in Spark 4.1 legacy parquet read

### DIFF
--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark41LegacyHoodieParquetFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark41LegacyHoodieParquetFileFormat.scala
@@ -24,10 +24,11 @@ import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion
 import org.apache.hudi.common.util.InternalSchemaCache
 import org.apache.hudi.common.util.StringUtils.isNullOrEmpty
 import org.apache.hudi.common.util.collection.Pair
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.internal.schema.InternalSchema
 import org.apache.hudi.internal.schema.action.InternalSchemaMerger
 import org.apache.hudi.internal.schema.utils.{InternalSchemaUtils, SerDeHelper}
-import org.apache.hudi.storage.hadoop.HoodieHadoopStorage
+import org.apache.hudi.storage.HoodieStorageUtils
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapred.FileSplit
@@ -176,7 +177,7 @@ class Spark41LegacyHoodieParquetFileFormat(private val shouldAppendPartitionValu
       val fileSchema = if (shouldUseInternalSchema) {
         val commitInstantTime = FSUtils.getCommitTime(filePath.getName).toLong;
         val validCommits = sharedConf.get(SparkInternalSchemaConverter.HOODIE_VALID_COMMITS_LIST)
-        val storage = new HoodieHadoopStorage(tablePath, sharedConf)
+        val storage = HoodieStorageUtils.getStorage(tablePath, HadoopFSUtils.getStorageConf(sharedConf))
         //TODO: HARDCODED TIMELINE OBJECT
         val layout = TimelineLayout.fromVersion(TimelineLayoutVersion.CURR_LAYOUT_VERSION)
         InternalSchemaCache.getInternalSchemaByVersionId(


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Spark 4.1 PR (#17674) was open from December 2025 to April 2026. During that window, #17661 replaced direct `HoodieHadoopStorage` instantiation with `HoodieStorageUtils.getStorage(...)` across `hudi-spark3.3.x`/`3.4.x`/`3.5.x`/`4.0.x`, but the in-flight Spark 4.1 branch was not rebased to pick it up.

As a result, `Spark41LegacyHoodieParquetFileFormat` is the only legacy parquet read path left that bypasses the `hoodie.storage.class` config plumbing — any user-configured custom `HoodieStorage` implementation is silently ignored on Spark 4.1.

### Summary and Changelog

Mirror the one-line change from #17661 in `Spark41LegacyHoodieParquetFileFormat.scala`:

- Import `HoodieStorageUtils` and `HadoopFSUtils` instead of `HoodieHadoopStorage`.
- Replace `new HoodieHadoopStorage(tablePath, sharedConf)` with `HoodieStorageUtils.getStorage(tablePath, HadoopFSUtils.getStorageConf(sharedConf))`.

No behavior change for the default `HoodieHadoopStorage`; the difference is only visible when `hoodie.storage.class` is overridden.

### Impact

- Custom `HoodieStorage` implementations now take effect on the Spark 4.1 legacy parquet read path, matching the behavior of all other Spark version modules.
- No public API or config change.

### Risk Level

low — three-line cherry-pick of an established refactor pattern that has been in production on every other Spark version module since #17661 merged.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable