### PR TITLE
fix: Fix col-stats corruption from NaN values and stats-truncation

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -253,6 +253,37 @@ public class HoodieTableMetadataUtil {
     }
   }
 
+  private static boolean isFloatingPointNaN(Object value) {
+    if (value instanceof Double) {
+      return Double.isNaN((Double) value);
+    }
+    if (value instanceof Float) {
+      return Float.isNaN((Float) value);
+    }
+    return false;
+  }
+
+  /**
+   * Returns true if the given min/max value is null in a way that indicates stats are
+   * unreliable (rather than the column being legitimately all-null). When a column is
+   * truly all-null, nullCount == valueCount and a null min/max is the correct answer.
+   * When stats are unreliable (NaN poisoning, value-size truncation), nullCount is
+   * lower than valueCount but min/max are still null — that's the case partition-stats
+   * aggregation must NOT silently drop.
+   */
+  private static boolean isStatsUnreliable(HoodieMetadataColumnStats stats, Comparable unwrappedValue) {
+    if (unwrappedValue != null) {
+      return false;
+    }
+    Long nullCount = stats.getNullCount();
+    Long valueCount = stats.getValueCount();
+    if (nullCount == null || valueCount == null) {
+      return true;
+    }
+    // All-null column: stats are legitimately empty for min/max.
+    return nullCount != valueCount;
+  }
+
   /**
    * Collects {@link HoodieColumnRangeMetadata} for the provided collection of records, pretending
    * as if provided records have been persisted w/in given {@code filePath}
@@ -292,14 +323,21 @@ public class HoodieTableMetadataUtil {
 
         colStats.valueCount++;
         if (fieldValue != null) {
-          // Set the min value of the field
-          if (colStats.minValue == null
-              || ConvertingGenericData.INSTANCE.compare(fieldValue, colStats.minValue, fieldSchema.toAvroSchema()) < 0) {
-            colStats.minValue = fieldValue;
-          }
-          // Set the max value of the field
-          if (colStats.maxValue == null || ConvertingGenericData.INSTANCE.compare(fieldValue, colStats.maxValue, fieldSchema.toAvroSchema()) > 0) {
-            colStats.maxValue = fieldValue;
+          // Exclude NaN from min/max accumulation. IEEE-754 ordering treats NaN as the greatest
+          // double (Double.compare(NaN, x) = +1) so an unguarded comparison would let a single
+          // NaN poison the running max forever, and the persisted stats would be unusable for
+          // data-skipping. We still count NaN as a non-null value so valueCount/nullCount stay
+          // accurate. Mirrors parquet-mr's DoubleStatistics policy.
+          if (!isFloatingPointNaN(fieldValue)) {
+            // Set the min value of the field
+            if (colStats.minValue == null
+                || ConvertingGenericData.INSTANCE.compare(fieldValue, colStats.minValue, fieldSchema.toAvroSchema()) < 0) {
+              colStats.minValue = fieldValue;
+            }
+            // Set the max value of the field
+            if (colStats.maxValue == null || ConvertingGenericData.INSTANCE.compare(fieldValue, colStats.maxValue, fieldSchema.toAvroSchema()) > 0) {
+              colStats.maxValue = fieldValue;
+            }
           }
         } else {
           colStats.nullCount++;
@@ -2883,19 +2921,40 @@ public class HoodieTableMetadataUtil {
     ValueMetadata prevValueMetadata = getValueMetadata(prevColumnStats.getValueType());
     ValueMetadata newValueMetadata = getValueMetadata(newColumnStats.getValueType());
 
-    Comparable minValue = newValueMetadata.standardizeJavaTypeAndPromote(
-        (Comparable) Stream.of((Comparable) prevValueMetadata.unwrapValue(prevColumnStats.getMinValue()),
-            (Comparable) newValueMetadata.unwrapValue(newColumnStats.getMinValue()))
-            .filter(Objects::nonNull)
-            .min(Comparator.naturalOrder())
-            .orElse(null));
+    Comparable prevMinUnwrapped = (Comparable) prevValueMetadata.unwrapValue(prevColumnStats.getMinValue());
+    Comparable newMinUnwrapped = (Comparable) newValueMetadata.unwrapValue(newColumnStats.getMinValue());
+    Comparable prevMaxUnwrapped = (Comparable) prevValueMetadata.unwrapValue(prevColumnStats.getMaxValue());
+    Comparable newMaxUnwrapped = (Comparable) newValueMetadata.unwrapValue(newColumnStats.getMaxValue());
 
-    Comparable maxValue = newValueMetadata.standardizeJavaTypeAndPromote(
-        (Comparable) Stream.of(prevValueMetadata.unwrapValue(prevColumnStats.getMaxValue()),
-                (Comparable) newValueMetadata.unwrapValue(newColumnStats.getMaxValue()))
-            .filter(Objects::nonNull)
-            .max(Comparator.naturalOrder())
-            .orElse(null));
+    // Distinguish two flavors of "null min/max" when merging:
+    //   (a) all-null column: nullCount == valueCount AND valueCount > 0 — min/max are correctly
+    //       null because there are no non-null values to bound. Safe to drop from the merge.
+    //   (b) stats unreliable: nullCount < valueCount but min/max are still null (e.g. parquet-mr
+    //       cleared stats due to NaN, or stats omitted due to value-size truncation; see
+    //       ParquetUtils#readColumnStatsFromMetadata). Aggregating an unreliable file with a
+    //       reliable one must NOT just drop the null — that would let data-skipping prune the
+    //       partition based on a partial bound. Propagate null so the partition reflects the
+    //       worst-case unknown.
+    boolean prevMinUnreliable = isStatsUnreliable(prevColumnStats, prevMinUnwrapped);
+    boolean prevMaxUnreliable = isStatsUnreliable(prevColumnStats, prevMaxUnwrapped);
+    boolean newMinUnreliable = isStatsUnreliable(newColumnStats, newMinUnwrapped);
+    boolean newMaxUnreliable = isStatsUnreliable(newColumnStats, newMaxUnwrapped);
+
+    Comparable minValue = (prevMinUnreliable || newMinUnreliable)
+        ? null
+        : newValueMetadata.standardizeJavaTypeAndPromote(
+            (Comparable) Stream.of(prevMinUnwrapped, newMinUnwrapped)
+                .filter(Objects::nonNull)
+                .min(Comparator.naturalOrder())
+                .orElse(null));
+
+    Comparable maxValue = (prevMaxUnreliable || newMaxUnreliable)
+        ? null
+        : newValueMetadata.standardizeJavaTypeAndPromote(
+            (Comparable) Stream.of(prevMaxUnwrapped, newMaxUnwrapped)
+                .filter(Objects::nonNull)
+                .max(Comparator.naturalOrder())
+                .orElse(null));
 
     HoodieMetadataColumnStats.Builder columnStatsBuilder = HoodieMetadataColumnStats.newBuilder(HoodieMetadataPayload.METADATA_COLUMN_STATS_BUILDER_STUB.get())
         .setFileName(newColumnStats.getFileName())

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -272,7 +272,7 @@ public class HoodieTableMetadataUtil {
    * lower than valueCount but min/max are still null — that's the case partition-stats
    * aggregation must NOT silently drop.
    */
-  private static boolean isStatsUnreliable(HoodieMetadataColumnStats stats, Comparable unwrappedValue) {
+  static boolean isStatsUnreliable(HoodieMetadataColumnStats stats, Comparable unwrappedValue) {
     if (unwrappedValue != null) {
       return false;
     }
@@ -281,8 +281,11 @@ public class HoodieTableMetadataUtil {
     if (nullCount == null || valueCount == null) {
       return true;
     }
-    // All-null column: stats are legitimately empty for min/max.
-    return nullCount != valueCount;
+    // Unreliable: min/max are null but the column is not all-null (nullCount < valueCount).
+    // NOTE: must use .equals() — these are boxed Long (from Avro ["null","long"]) and Long.valueOf
+    //       only caches values in [-128, 127], so `!=` is reference equality and would return true
+    //       for any realistic row count.
+    return !nullCount.equals(valueCount);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -253,7 +253,8 @@ public class HoodieTableMetadataUtil {
     }
   }
 
-  private static boolean isFloatingPointNaN(Object value) {
+  // Package-private for testing.
+  static boolean isFloatingPointNaN(Object value) {
     if (value instanceof Double) {
       return Double.isNaN((Double) value);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/stats/HoodieColumnRangeMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/stats/HoodieColumnRangeMetadata.java
@@ -133,14 +133,36 @@ public class HoodieColumnRangeMetadata<T extends Comparable> implements Serializ
         "Column names should be the same for merging column ranges");
     String filePath = left.getFilePath();
     String columnName = left.getColumnName();
-    T min = minVal(left.getMinValue(), right.getMinValue());
-    T max = maxVal(left.getMaxValue(), right.getMaxValue());
+    // When a child range has null min/max, distinguish two cases:
+    //   (a) all-null column: nullCount == valueCount AND valueCount > 0. min/max are
+    //       legitimately null because the column has no non-null values. Safe to drop
+    //       this side from the merge (the other side's bounds remain valid).
+    //   (b) stats unreliable: nullCount < valueCount but min/max are still null (e.g.
+    //       parquet-mr cleared stats due to NaN, or stats were omitted due to value-size
+    //       truncation; see ParquetUtils#readColumnStatsFromMetadata). Dropping null here
+    //       would let data-skipping prune the partition based on a partial bound that
+    //       excludes the unbounded values of this file. Propagate null so the merged
+    //       partition reflects the worst-case unknown.
+    boolean leftMinUnreliable = isStatsUnreliable(left, left.getMinValue());
+    boolean rightMinUnreliable = isStatsUnreliable(right, right.getMinValue());
+    boolean leftMaxUnreliable = isStatsUnreliable(left, left.getMaxValue());
+    boolean rightMaxUnreliable = isStatsUnreliable(right, right.getMaxValue());
+    T min = (leftMinUnreliable || rightMinUnreliable) ? null : minVal(left.getMinValue(), right.getMinValue());
+    T max = (leftMaxUnreliable || rightMaxUnreliable) ? null : maxVal(left.getMaxValue(), right.getMaxValue());
     long nullCount = left.getNullCount() + right.getNullCount();
     long valueCount = left.getValueCount() + right.getValueCount();
     long totalSize = left.getTotalSize() + right.getTotalSize();
     long totalUncompressedSize = left.getTotalUncompressedSize() + right.getTotalUncompressedSize();
 
     return new HoodieColumnRangeMetadata<>(filePath, columnName, min, max, nullCount, valueCount, totalSize, totalUncompressedSize, left.getValueMetadata());
+  }
+
+  private static <T extends Comparable<T>> boolean isStatsUnreliable(HoodieColumnRangeMetadata<T> range, T value) {
+    if (value != null) {
+      return false;
+    }
+    // All-null column: stats are legitimately empty for min/max — safe to ignore in merge.
+    return range.getNullCount() != range.getValueCount();
   }
 
   private static <T extends Comparable<T>> T minVal(T val1, T val2) {

--- a/hudi-common/src/main/java/org/apache/hudi/stats/HoodieColumnRangeMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/stats/HoodieColumnRangeMetadata.java
@@ -161,7 +161,9 @@ public class HoodieColumnRangeMetadata<T extends Comparable> implements Serializ
     if (value != null) {
       return false;
     }
-    // All-null column: stats are legitimately empty for min/max — safe to ignore in merge.
+    // Unreliable: min/max are null but the column is not all-null (nullCount < valueCount).
+    // The all-null case (nullCount == valueCount) is legitimately empty stats — safe to ignore in merge.
+    // NOTE: primitive long here, so != is value equality (unlike the sibling helper in HoodieTableMetadataUtil).
     return range.getNullCount() != range.getValueCount();
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestBaseFileUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestBaseFileUtils.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestBaseFileUtils {
@@ -60,25 +61,65 @@ public class TestBaseFileUtils {
 
   @Test
   public void testGetColumnRangeInPartitionWithNullMinMax() {
+    // This test exercises {@link HoodieColumnRangeMetadata#merge} with one side
+    // having a null bound while still containing non-null values
+    // (nullCount < valueCount). That is the "stats unreliable" signal — parquet-mr
+    // sets it when it had to clear stats (e.g. NaN encountered in a FLOAT/DOUBLE
+    // column, or value-size truncation suppressed stats); see apache/hudi#18754.
+    //
+    // Aggregating a reliable bound with an unreliable null MUST propagate null —
+    // otherwise data-skipping would prune a partition based on a partial bound
+    // that excludes the unreliable file's actual values. Earlier the merge
+    // silently dropped the null side and reported the partial bound, which was
+    // a correctness bug.
     HoodieIndexVersion indexVersion = HoodieIndexVersion.V1;
-    // Step 1: Set Up Test Data
     HoodieColumnRangeMetadata<Comparable> fileColumnRange1 = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file1", COLUMN_NAME, 1, null, 0, 10, 100, 200, ValueMetadata.V1EmptyMetadata.get());
     HoodieColumnRangeMetadata<Comparable> fileColumnRange2 = HoodieColumnRangeMetadata.<Comparable>create(
         "path/to/file2", COLUMN_NAME, null, 8, 1, 15, 120, 250, ValueMetadata.V1EmptyMetadata.get());
 
     List<HoodieColumnRangeMetadata<Comparable>> fileColumnRanges = Arrays.asList(fileColumnRange1, fileColumnRange2);
-    // Step 2: Call the Method
-    HoodieColumnRangeMetadata<Comparable> result = FileFormatUtils.getColumnRangeInPartition(PARTITION_PATH, COLUMN_NAME, fileColumnRanges, Collections.emptyMap(), indexVersion);
-    // Step 3: Assertions
+    HoodieColumnRangeMetadata<Comparable> result = FileFormatUtils.getColumnRangeInPartition(
+        PARTITION_PATH, COLUMN_NAME, fileColumnRanges, Collections.emptyMap(), indexVersion);
+
     assertEquals(PARTITION_PATH, result.getFilePath());
     assertEquals(COLUMN_NAME, result.getColumnName());
-    assertEquals(Integer.valueOf(1), new Integer(result.getMinValue().toString()));
-    assertEquals(Integer.valueOf(8), new Integer(result.getMaxValue().toString()));
+    // file1 has nullCount=0 / valueCount=10 with null max — unreliable max →
+    //   merged max must be null (was previously asserted as 8, which was
+    //   silently dropping the null and reporting file2's max only).
+    assertNull(result.getMaxValue(),
+        "merged max must propagate null when a child range has unreliable max stats");
+    // file2 has nullCount=1 / valueCount=15 with null min — unreliable min →
+    //   merged min must be null.
+    assertNull(result.getMinValue(),
+        "merged min must propagate null when a child range has unreliable min stats");
+    // Counts still aggregate accurately so downstream readers can reason about row counts.
     assertEquals(1, result.getNullCount());
     assertEquals(25, result.getValueCount());
     assertEquals(220, result.getTotalSize());
     assertEquals(450, result.getTotalUncompressedSize());
+  }
+
+  @Test
+  public void testGetColumnRangeInPartitionAllNullColumnDroppedFromMerge() {
+    // Companion to the test above: when one side is an all-null column
+    // (nullCount == valueCount), its null min/max are legitimately null
+    // (no non-null values to bound). It is safe to drop that side from the
+    // merge — the other side's bounds remain authoritative.
+    HoodieIndexVersion indexVersion = HoodieIndexVersion.V1;
+    HoodieColumnRangeMetadata<Comparable> reliable = HoodieColumnRangeMetadata.<Comparable>create(
+        "path/to/file1", COLUMN_NAME, 1, 5, 0, 10, 100, 200, ValueMetadata.V1EmptyMetadata.get());
+    HoodieColumnRangeMetadata<Comparable> allNull = HoodieColumnRangeMetadata.<Comparable>create(
+        "path/to/file2", COLUMN_NAME, null, null, 7, 7, 60, 80, ValueMetadata.V1EmptyMetadata.get());
+
+    HoodieColumnRangeMetadata<Comparable> result = FileFormatUtils.getColumnRangeInPartition(
+        PARTITION_PATH, COLUMN_NAME, Arrays.asList(reliable, allNull), Collections.emptyMap(), indexVersion);
+
+    assertEquals(Integer.valueOf(1), new Integer(result.getMinValue().toString()),
+        "all-null side should be dropped from min/max merge");
+    assertEquals(Integer.valueOf(5), new Integer(result.getMaxValue().toString()));
+    assertEquals(7, result.getNullCount());
+    assertEquals(17, result.getValueCount());
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
@@ -381,5 +382,64 @@ class TestHoodieTableMetadataUtil {
     assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(42));
     assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(42L));
     assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN("NaN"));
+  }
+
+  /**
+   * Regression test for the boxed-{@link Long} reference-equality bug in
+   * {@code isStatsUnreliable}. The Avro schema declares {@code nullCount} and
+   * {@code valueCount} as {@code ["null","long"]}, which generates boxed {@link Long}
+   * fields. Comparing with {@code !=} is reference equality — and since
+   * {@code Long.valueOf} only caches values in [-128, 127], two autoboxed values like
+   * 1000L produce distinct {@code Long} instances and {@code !=} returns true even when
+   * numerically equal. That misclassifies legitimately all-null columns as "stats
+   * unreliable" for any realistic row count, losing the all-null pruning fast path in
+   * MDT compaction merge. Fix uses {@code !nullCount.equals(valueCount)} instead.
+   */
+  @Test
+  void testIsStatsUnreliableUsesValueEqualityOnBoxedLong() {
+    // Case (1): all-null column with row count > 127 (forces fresh Long instances).
+    // Bug would return true here (misclassified as unreliable); fix returns false.
+    HoodieMetadataColumnStats allNullLargeN = mock(HoodieMetadataColumnStats.class);
+    when(allNullLargeN.getNullCount()).thenReturn(1000L);
+    when(allNullLargeN.getValueCount()).thenReturn(1000L);
+    assertFalse(HoodieTableMetadataUtil.isStatsUnreliable(allNullLargeN, null),
+        "all-null column with row count > Long cache must be reliable (null min/max are legitimate)");
+
+    // Case (2): all-null column at the boundary (row count exactly in Long cache).
+    // Old code happened to work here by accident; fix still works.
+    HoodieMetadataColumnStats allNullSmallN = mock(HoodieMetadataColumnStats.class);
+    when(allNullSmallN.getNullCount()).thenReturn(50L);
+    when(allNullSmallN.getValueCount()).thenReturn(50L);
+    assertFalse(HoodieTableMetadataUtil.isStatsUnreliable(allNullSmallN, null),
+        "all-null column with row count in Long cache must also be reliable");
+
+    // Case (3): non-null value present → never unreliable regardless of counts.
+    HoodieMetadataColumnStats reliable = mock(HoodieMetadataColumnStats.class);
+    when(reliable.getNullCount()).thenReturn(10L);
+    when(reliable.getValueCount()).thenReturn(1000L);
+    assertFalse(HoodieTableMetadataUtil.isStatsUnreliable(reliable, "some-value"),
+        "stats with a non-null min/max are reliable irrespective of nullCount/valueCount");
+
+    // Case (4): unreliable — null min/max but nullCount < valueCount
+    // (parquet-mr signalled stats absent for files with non-null rows, e.g. NaN poisoning,
+    // value-size truncation). Must be flagged.
+    HoodieMetadataColumnStats unreliableLargeN = mock(HoodieMetadataColumnStats.class);
+    when(unreliableLargeN.getNullCount()).thenReturn(100L);
+    when(unreliableLargeN.getValueCount()).thenReturn(1000L);
+    assertTrue(HoodieTableMetadataUtil.isStatsUnreliable(unreliableLargeN, null),
+        "null min/max with nullCount < valueCount is the unreliable signal");
+
+    // Case (5): missing counts → conservatively unreliable.
+    HoodieMetadataColumnStats missingNullCount = mock(HoodieMetadataColumnStats.class);
+    when(missingNullCount.getNullCount()).thenReturn(null);
+    when(missingNullCount.getValueCount()).thenReturn(1000L);
+    assertTrue(HoodieTableMetadataUtil.isStatsUnreliable(missingNullCount, null),
+        "absent nullCount must be treated as unreliable (can't prove all-null)");
+
+    HoodieMetadataColumnStats missingValueCount = mock(HoodieMetadataColumnStats.class);
+    when(missingValueCount.getNullCount()).thenReturn(1000L);
+    when(missingValueCount.getValueCount()).thenReturn(null);
+    assertTrue(HoodieTableMetadataUtil.isStatsUnreliable(missingValueCount, null),
+        "absent valueCount must be treated as unreliable (can't prove all-null)");
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -352,4 +352,34 @@ class TestHoodieTableMetadataUtil {
           "STRING should remain supported for record type " + recordType);
     }
   }
+
+  /**
+   * Verifies the NaN-detection helper used by {@code collectColumnRangeMetadata} to skip
+   * NaN values during streaming min/max accumulation (#18754, writer-side). Without this
+   * gate, {@code Double.compare(NaN, x) == +1} would let a single NaN poison the running
+   * max forever, and the persisted stats would mislead read-side data-skipping into
+   * pruning files that contain matching values.
+   */
+  @Test
+  void testIsFloatingPointNaN() {
+    // The two cases the gate must catch
+    assertTrue(HoodieTableMetadataUtil.isFloatingPointNaN(Double.NaN));
+    assertTrue(HoodieTableMetadataUtil.isFloatingPointNaN(Float.NaN));
+
+    // Everything else must pass through unchanged — including the legitimate Inf values
+    // that parquet-mr treats as valid stats (see #18754 issue body).
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(null));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(0.0));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(0.0f));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(123.45));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(-123.45f));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(Double.POSITIVE_INFINITY));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(Double.NEGATIVE_INFINITY));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(Float.POSITIVE_INFINITY));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(Float.NEGATIVE_INFINITY));
+    // Non-floating-point values are not NaN regardless of value
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(42));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN(42L));
+    assertFalse(HoodieTableMetadataUtil.isFloatingPointNaN("NaN"));
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/stats/TestHoodieColumnRangeMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/stats/TestHoodieColumnRangeMetadata.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.stats;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests {@link HoodieColumnRangeMetadata#merge} — the helper used by
+ * {@code PartitionStatsIndexSupport} (and clustering) to aggregate per-file
+ * column ranges into per-partition aggregates.
+ *
+ * <p>Distinguishes two kinds of "null min/max" inputs:
+ * <ul>
+ *   <li><b>all-null column</b>: {@code nullCount == valueCount > 0} — min/max are
+ *       legitimately null because there are no non-null values to bound. Safe to
+ *       drop in merge so the other side's bounds remain authoritative.</li>
+ *   <li><b>stats unreliable</b>: {@code nullCount < valueCount} but min/max are
+ *       still null — e.g. parquet-mr cleared stats due to NaN, or stats were
+ *       omitted due to value-size truncation. Dropping this side's null silently
+ *       would let data-skipping prune the partition based on a partial bound
+ *       (the read-side half of #18754). The merge must propagate null instead.</li>
+ * </ul>
+ */
+public class TestHoodieColumnRangeMetadata {
+
+  private static final String FILE = "f.parquet";
+  private static final String COL = "v";
+
+  private static HoodieColumnRangeMetadata<Double> range(Double min, Double max, long nullCount, long valueCount) {
+    return HoodieColumnRangeMetadata.create(
+        FILE, COL, min, max, nullCount, valueCount, 0L, 0L, ValueMetadata.V1EmptyMetadata.get());
+  }
+
+  @Test
+  public void testMerge_bothReliable_takesMinAndMax() {
+    HoodieColumnRangeMetadata<Double> a = range(100.0, 200.0, 0L, 10L);
+    HoodieColumnRangeMetadata<Double> b = range(150.0, 300.0, 0L, 10L);
+    HoodieColumnRangeMetadata<Double> merged = HoodieColumnRangeMetadata.merge(a, b);
+
+    assertEquals(100.0, merged.getMinValue());
+    assertEquals(300.0, merged.getMaxValue());
+    assertEquals(0L, merged.getNullCount());
+    assertEquals(20L, merged.getValueCount());
+  }
+
+  @Test
+  public void testMerge_oneAllNullColumn_dropsItAndKeepsOtherBounds() {
+    // All-null is the legitimate "no non-null values" case. The other side's
+    // bounds are still authoritative; null counts add.
+    HoodieColumnRangeMetadata<Double> reliable = range(100.0, 200.0, 0L, 10L);
+    HoodieColumnRangeMetadata<Double> allNull = range(null, null, /*nullCount=*/5L, /*valueCount=*/5L);
+
+    HoodieColumnRangeMetadata<Double> merged = HoodieColumnRangeMetadata.merge(reliable, allNull);
+
+    assertEquals(100.0, merged.getMinValue(), "All-null side should not poison the merged min");
+    assertEquals(200.0, merged.getMaxValue(), "All-null side should not poison the merged max");
+    assertEquals(5L, merged.getNullCount());
+    assertEquals(15L, merged.getValueCount());
+  }
+
+  @Test
+  public void testMerge_oneUnreliable_propagatesNullToProtectAgainstWrongPruning() {
+    // Unreliable means: min/max are null even though the file has non-null values
+    // (nullCount < valueCount). Dropping null here would let data-skipping prune
+    // the partition based on a partial bound that excludes the unreliable file's
+    // values. Propagate null so the merged record signals "unknown bound".
+    HoodieColumnRangeMetadata<Double> reliable = range(100.0, 200.0, 0L, 10L);
+    HoodieColumnRangeMetadata<Double> unreliable = range(null, null, /*nullCount=*/0L, /*valueCount=*/5L);
+
+    HoodieColumnRangeMetadata<Double> merged = HoodieColumnRangeMetadata.merge(reliable, unreliable);
+
+    assertNull(merged.getMinValue(),
+        "Merging a reliable bound with an unreliable null must propagate null — not silently drop the unreliable side");
+    assertNull(merged.getMaxValue(),
+        "Same for max");
+    // Counts still aggregate accurately so downstream readers can reason about row counts.
+    assertEquals(0L, merged.getNullCount());
+    assertEquals(15L, merged.getValueCount());
+  }
+
+  @Test
+  public void testMerge_oneUnreliableOnLeftSide_isSymmetric() {
+    // Same scenario but with the unreliable input on the left — must produce the same outcome.
+    HoodieColumnRangeMetadata<Double> unreliable = range(null, null, /*nullCount=*/0L, /*valueCount=*/5L);
+    HoodieColumnRangeMetadata<Double> reliable = range(100.0, 200.0, 0L, 10L);
+
+    HoodieColumnRangeMetadata<Double> merged = HoodieColumnRangeMetadata.merge(unreliable, reliable);
+
+    assertNull(merged.getMinValue());
+    assertNull(merged.getMaxValue());
+    assertEquals(15L, merged.getValueCount());
+  }
+
+  @Test
+  public void testMerge_bothUnreliable_propagatesNull() {
+    HoodieColumnRangeMetadata<Double> u1 = range(null, null, 0L, 3L);
+    HoodieColumnRangeMetadata<Double> u2 = range(null, null, 1L, 5L);
+
+    HoodieColumnRangeMetadata<Double> merged = HoodieColumnRangeMetadata.merge(u1, u2);
+
+    assertNull(merged.getMinValue());
+    assertNull(merged.getMaxValue());
+    assertEquals(1L, merged.getNullCount());
+    assertEquals(8L, merged.getValueCount());
+  }
+
+  @Test
+  public void testMerge_bothAllNull_keepsNullBoundsLegitimately() {
+    // Two all-null inputs is still a legitimate all-null aggregate.
+    HoodieColumnRangeMetadata<Double> a = range(null, null, 3L, 3L);
+    HoodieColumnRangeMetadata<Double> b = range(null, null, 5L, 5L);
+
+    HoodieColumnRangeMetadata<Double> merged = HoodieColumnRangeMetadata.merge(a, b);
+
+    assertNull(merged.getMinValue());
+    assertNull(merged.getMaxValue());
+    assertEquals(8L, merged.getNullCount());
+    assertEquals(8L, merged.getValueCount());
+  }
+
+  @Test
+  public void testMerge_oneSideNull_returnsOther() {
+    // The pre-existing contract: merging with a null record returns the other.
+    HoodieColumnRangeMetadata<Double> a = range(100.0, 200.0, 0L, 10L);
+    HoodieColumnRangeMetadata<Double> merged = HoodieColumnRangeMetadata.merge(a, null);
+    assertNotNull(merged);
+    assertEquals(100.0, merged.getMinValue());
+    assertEquals(200.0, merged.getMaxValue());
+  }
+}

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -312,21 +312,42 @@ public class ParquetUtils extends FileFormatUtils {
                   ValueMetadata valueMetadata = ValueMetadata.getValueMetadata(columnChunkMetaData.getPrimitiveType(), indexVersion);
                   // Normalize column name to canonical .list.element format for consistent MDT storage
                   String canonicalColumnName = convertArrayToListElement(columnChunkMetaData.getPath().toDotString());
+                  // Parquet exposes two orthogonal flags we must respect to decide what to record:
+                  //   - stats.hasNonNullValue() is false when Parquet considers min/max unreliable
+                  //     (notably for FLOAT/DOUBLE columns containing any NaN: parquet-mr clears
+                  //     hasNonNullValue but leaves min/max at their default 0.0). Treating these as
+                  //     valid stats would let data-skipping prune files that actually match.
+                  //   - stats.isNumNullsSet() is false when the underlying Parquet column omitted
+                  //     statistics entirely (e.g. a value exceeded the parquet-mr stats truncation
+                  //     threshold, ~1 KB for binary/string). In that case we have no information
+                  //     about nulls, so we must NOT equate nullCount to valueCount.
+                  boolean minMaxReliable = stats.hasNonNullValue();
+                  Comparable<?> minVal = minMaxReliable
+                      ? convertToNativeJavaType(columnChunkMetaData.getPrimitiveType(), stats.genericGetMin(), valueMetadata)
+                      : null;
+                  Comparable<?> maxVal = minMaxReliable
+                      ? convertToNativeJavaType(columnChunkMetaData.getPrimitiveType(), stats.genericGetMax(), valueMetadata)
+                      : null;
+                  long nullCount;
+                  if (stats.isEmpty()) {
+                    if (stats.isNumNullsSet()) {
+                      // Genuine all-null column: parquet explicitly recorded num_nulls and chose
+                      // not to write min/max for an all-null column.
+                      nullCount = columnChunkMetaData.getValueCount();
+                    } else {
+                      // Statistics fully absent (e.g. truncation): null count is unknown.
+                      // Treat as 0 so data-skipping doesn't conclude "all rows are null".
+                      nullCount = 0;
+                    }
+                  } else {
+                    nullCount = stats.getNumNulls();
+                  }
                   return (HoodieColumnRangeMetadata<Comparable>) HoodieColumnRangeMetadata.<Comparable>create(
                       filePath,
                       canonicalColumnName,
-                      convertToNativeJavaType(
-                          columnChunkMetaData.getPrimitiveType(),
-                          stats.genericGetMin(),
-                          valueMetadata),
-                      convertToNativeJavaType(
-                          columnChunkMetaData.getPrimitiveType(),
-                          stats.genericGetMax(),
-                          valueMetadata),
-                      // NOTE: In case when column contains only nulls Parquet won't be creating
-                      //       stats for it instead returning stubbed (empty) object. In that case
-                      //       we have to equate number of nulls to the value count ourselves
-                      stats.isEmpty() ? columnChunkMetaData.getValueCount() : stats.getNumNulls(),
+                      minVal,
+                      maxVal,
+                      nullCount,
                       columnChunkMetaData.getValueCount(),
                       columnChunkMetaData.getTotalSize(),
                       columnChunkMetaData.getTotalUncompressedSize(),

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -68,6 +68,7 @@ import static org.apache.hudi.common.schema.HoodieSchemaUtils.METADATA_FIELD_SCH
 import static org.apache.hudi.metadata.HoodieIndexVersion.V1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -292,6 +293,178 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
         fileName, recordKeyField, minKey, maxKey, 0, totalCount);
     validateColumnRangeMetadata(columnRangeMetadataList.get(2),
         fileName, partitionPathField, partitionPath, partitionPath, 0, totalCount);
+  }
+
+  /**
+   * Tests that for a FLOAT/DOUBLE column containing any NaN, ParquetUtils reports
+   * null min/max — because parquet-mr clears its stats (hasNonNullValue=false) but
+   * leaves min/max at their default 0.0. Persisting 0.0/0.0 as if they were valid
+   * stats was the writer-side half of #18754; downstream data-skipping would then
+   * silently prune the file. The fix is gated on Statistics.hasNonNullValue().
+   */
+  @Test
+  public void testReadColumnStatsFromMetadata_nanTaintedDoubleColumn() throws Exception {
+    String recordKeyField = "id";
+    String partitionPathField = "partition";
+    String dataField = "data_double";
+    HoodieSchema schema = getSchemaWithDoubleData(recordKeyField, partitionPathField, dataField);
+
+    String fileName = "test_nan.parquet";
+    String filePath = new StoragePath(basePath, fileName).toString();
+    String partitionPath = "p";
+
+    BloomFilter filter = BloomFilterFactory.createBloomFilter(1000, 0.0001, 10000, BloomFilterTypeCode.SIMPLE.name());
+    HoodieAvroWriteSupport writeSupport =
+        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema.toAvroSchema()), schema, Option.of(filter), new Properties());
+    int totalCount = 11;
+    try (ParquetWriter writer = new ParquetWriter(new Path(filePath), writeSupport, CompressionCodecName.GZIP,
+        120 * 1024 * 1024, ParquetWriter.DEFAULT_PAGE_SIZE)) {
+      for (int i = 0; i < 10; i++) {
+        GenericRecord rec = new GenericData.Record(schema.toAvroSchema());
+        rec.put(recordKeyField, UUID.randomUUID().toString());
+        rec.put(partitionPathField, partitionPath);
+        rec.put(dataField, 300.0 + i);
+        writer.write(rec);
+        writeSupport.add(rec.get(recordKeyField).toString());
+      }
+      // Trailing NaN row — poisons parquet's stats
+      GenericRecord nanRec = new GenericData.Record(schema.toAvroSchema());
+      nanRec.put(recordKeyField, UUID.randomUUID().toString());
+      nanRec.put(partitionPathField, partitionPath);
+      nanRec.put(dataField, Double.NaN);
+      writer.write(nanRec);
+      writeSupport.add(nanRec.get(recordKeyField).toString());
+    }
+
+    List<HoodieColumnRangeMetadata<Comparable>> rangeList = parquetUtils.readColumnStatsFromMetadata(
+            HoodieTestUtils.getStorage(filePath), new StoragePath(filePath),
+            Collections.singletonList(dataField), V1);
+    assertEquals(1, rangeList.size());
+    HoodieColumnRangeMetadata<Comparable> data = rangeList.get(0);
+    // The pre-fix behavior persisted min=0.0, max=0.0 here. With the fix, we recognize
+    // hasNonNullValue=false and report null min/max — the right signal for "stats
+    // unreliable, must scan file at query time".
+    assertNull(data.getMinValue(), "Expected null min for NaN-tainted FLOAT/DOUBLE column");
+    assertNull(data.getMaxValue(), "Expected null max for NaN-tainted FLOAT/DOUBLE column");
+    // NaN is counted as a non-null value (parquet treats it that way too).
+    assertEquals(0, data.getNullCount());
+    assertEquals(totalCount, data.getValueCount());
+  }
+
+  /**
+   * Tests that when a Parquet column omits stats entirely (one value exceeds
+   * parquet-mr's stats truncation threshold, ~1KB for binary/string), ParquetUtils
+   * reports nullCount=0 rather than nullCount=valueCount. The pre-fix behavior of
+   * "if isEmpty then valueCount else getNumNulls" was correct only for genuinely
+   * all-null columns; for truncated stats it incorrectly claimed all values were
+   * null, causing data-skipping to silently skip the file. #18755.
+   */
+  @Test
+  public void testReadColumnStatsFromMetadata_statsAbsentForLongValues() throws Exception {
+    String recordKeyField = "id";
+    String partitionPathField = "partition";
+    String dataField = "data";
+    HoodieSchema schema = getSchema(recordKeyField, partitionPathField, dataField);
+
+    String fileName = "test_truncation.parquet";
+    String filePath = new StoragePath(basePath, fileName).toString();
+    String partitionPath = "p";
+
+    BloomFilter filter = BloomFilterFactory.createBloomFilter(1000, 0.0001, 10000, BloomFilterTypeCode.SIMPLE.name());
+    HoodieAvroWriteSupport writeSupport =
+        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema.toAvroSchema()), schema, Option.of(filter), new Properties());
+    // Build a string longer than parquet's default stats truncation threshold (~1KB).
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 4096; i++) {
+      sb.append('Y');
+    }
+    String longValue = sb.toString();
+
+    try (ParquetWriter writer = new ParquetWriter(new Path(filePath), writeSupport, CompressionCodecName.GZIP,
+        120 * 1024 * 1024, ParquetWriter.DEFAULT_PAGE_SIZE)) {
+      GenericRecord shortRec = new GenericData.Record(schema.toAvroSchema());
+      shortRec.put(recordKeyField, UUID.randomUUID().toString());
+      shortRec.put(partitionPathField, partitionPath);
+      shortRec.put(dataField, "Y");
+      writer.write(shortRec);
+      writeSupport.add(shortRec.get(recordKeyField).toString());
+
+      GenericRecord longRec = new GenericData.Record(schema.toAvroSchema());
+      longRec.put(recordKeyField, UUID.randomUUID().toString());
+      longRec.put(partitionPathField, partitionPath);
+      longRec.put(dataField, longValue);
+      writer.write(longRec);
+      writeSupport.add(longRec.get(recordKeyField).toString());
+    }
+
+    List<HoodieColumnRangeMetadata<Comparable>> rangeList = parquetUtils.readColumnStatsFromMetadata(
+            HoodieTestUtils.getStorage(filePath), new StoragePath(filePath),
+            Collections.singletonList(dataField), V1);
+    assertEquals(1, rangeList.size());
+    HoodieColumnRangeMetadata<Comparable> data = rangeList.get(0);
+    // Stats are absent entirely — both min/max null AND nullCount must be 0,
+    // not the pre-fix valueCount which signaled "all rows are null".
+    assertNull(data.getMinValue(), "Expected null min when parquet stats are absent");
+    assertNull(data.getMaxValue(), "Expected null max when parquet stats are absent");
+    assertEquals(0, data.getNullCount(),
+        "Expected nullCount=0 (unknown) when stats are absent; valueCount would incorrectly imply all-null");
+    assertEquals(2, data.getValueCount());
+  }
+
+  /**
+   * Tests that a genuinely all-null column still produces nullCount=valueCount — the
+   * existing convention. This is the case the original "isEmpty ? valueCount" logic was
+   * trying to handle; the fix in #18755 distinguishes it from the stats-truly-absent
+   * case via Statistics.isNumNullsSet().
+   */
+  @Test
+  public void testReadColumnStatsFromMetadata_allNullColumnRetainsValueCountAsNullCount() throws Exception {
+    String recordKeyField = "id";
+    String partitionPathField = "partition";
+    String dataField = "data";
+    HoodieSchema schema = getSchema(recordKeyField, partitionPathField, dataField);
+
+    String fileName = "test_allnull.parquet";
+    String filePath = new StoragePath(basePath, fileName).toString();
+    String partitionPath = "p";
+    int totalCount = 10;
+
+    BloomFilter filter = BloomFilterFactory.createBloomFilter(1000, 0.0001, 10000, BloomFilterTypeCode.SIMPLE.name());
+    HoodieAvroWriteSupport writeSupport =
+        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema.toAvroSchema()), schema, Option.of(filter), new Properties());
+    try (ParquetWriter writer = new ParquetWriter(new Path(filePath), writeSupport, CompressionCodecName.GZIP,
+        120 * 1024 * 1024, ParquetWriter.DEFAULT_PAGE_SIZE)) {
+      for (int i = 0; i < totalCount; i++) {
+        GenericRecord rec = new GenericData.Record(schema.toAvroSchema());
+        rec.put(recordKeyField, UUID.randomUUID().toString());
+        rec.put(partitionPathField, partitionPath);
+        rec.put(dataField, null);
+        writer.write(rec);
+        writeSupport.add(rec.get(recordKeyField).toString());
+      }
+    }
+
+    List<HoodieColumnRangeMetadata<Comparable>> rangeList = parquetUtils.readColumnStatsFromMetadata(
+            HoodieTestUtils.getStorage(filePath), new StoragePath(filePath),
+            Collections.singletonList(dataField), V1);
+    assertEquals(1, rangeList.size());
+    HoodieColumnRangeMetadata<Comparable> data = rangeList.get(0);
+    assertNull(data.getMinValue());
+    assertNull(data.getMaxValue());
+    // All values null → nullCount must equal valueCount (existing convention).
+    assertEquals(totalCount, data.getNullCount());
+    assertEquals(totalCount, data.getValueCount());
+  }
+
+  private HoodieSchema getSchemaWithDoubleData(String recordKeyField, String partitionPathField, String dataField) {
+    List<HoodieSchemaField> toBeAddedFields = new ArrayList<>(3);
+    toBeAddedFields.add(HoodieSchemaField.of(recordKeyField,
+        HoodieSchema.createNullable(HoodieSchemaType.STRING), "", HoodieSchema.NULL_VALUE));
+    toBeAddedFields.add(HoodieSchemaField.of(partitionPathField,
+        HoodieSchema.createNullable(HoodieSchemaType.STRING), "", HoodieSchema.NULL_VALUE));
+    toBeAddedFields.add(HoodieSchemaField.of(dataField,
+        HoodieSchema.createNullable(HoodieSchemaType.DOUBLE), "", HoodieSchema.NULL_VALUE));
+    return HoodieSchema.createRecord("HoodieRecord", "", "", false, toBeAddedFields);
   }
 
   private HoodieSchema getSchema(String recordKeyField, String partitionPathField, String dataField) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
@@ -29,9 +29,8 @@ import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_ST
 
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{And, Expression, IsNull, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, Expression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
-import org.apache.spark.sql.hudi.ColumnStatsExpressionUtils
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 
 import scala.collection.JavaConverters._
@@ -118,25 +117,12 @@ abstract class SparkBaseIndexSupport(spark: SparkSession,
       // if there are any non indexed cols or we can't translate source expr, we have to read all files and may not benefit from col stats lookup.
        fileNamesFromPrunedPartitions
     } else {
-      // When parquet-mr clears stats (NaN in FLOAT/DOUBLE, value-size truncation), Hudi
-      // persists min/max as null. A bare `colA_max > X` then evaluates to null and the file
-      // is silently pruned. Augment the filter so a row passes whenever ANY column referenced
-      // in queryFilters has a null min stat (=> stats unreliable, must scan file). We use
-      // queryFilters' referenced columns rather than all valid indexed columns so that an
-      // unreliable but irrelevant column doesn't force every file to be scanned.
-      val referencedCols = queryFilters
-        .flatMap(_.references.map(_.name))
-        .toSet
-        .intersect(validIndexedColumns.toSet)
-      val statsUnreliableExpr: Option[Expression] = referencedCols
-        .map(cn => IsNull(ColumnStatsExpressionUtils.genColMinValueExpr(cn)).asInstanceOf[Expression])
-        .reduceOption((a, b) => Or(a, b))
-      val effectiveIndexFilter = statsUnreliableExpr
-        .map(unreliable => Or(indexFilter, unreliable))
-        .getOrElse(indexFilter)
+      // The stats-unreliability null-safety is applied at the per-predicate translation
+      // level (DataSkippingUtils.withStatsAvailable), so the indexFilter here already
+      // includes the right "OR colMin IS NULL AND valueCount > nullCount" guards.
       // only lookup in col stats if all filters are eligible to be looked up in col stats index in MDT
       val prunedCandidateFileNames =
-        indexDf.where(sparkAdapter.createColumnFromExpression(effectiveIndexFilter))
+        indexDf.where(sparkAdapter.createColumnFromExpression(indexFilter))
           .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
           .collect()
           .map(_.getString(0))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
@@ -29,8 +29,9 @@ import org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_ST
 
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{And, Expression}
+import org.apache.spark.sql.catalyst.expressions.{And, Expression, IsNull, Or}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.hudi.ColumnStatsExpressionUtils
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 
 import scala.collection.JavaConverters._
@@ -117,9 +118,25 @@ abstract class SparkBaseIndexSupport(spark: SparkSession,
       // if there are any non indexed cols or we can't translate source expr, we have to read all files and may not benefit from col stats lookup.
        fileNamesFromPrunedPartitions
     } else {
+      // When parquet-mr clears stats (NaN in FLOAT/DOUBLE, value-size truncation), Hudi
+      // persists min/max as null. A bare `colA_max > X` then evaluates to null and the file
+      // is silently pruned. Augment the filter so a row passes whenever ANY column referenced
+      // in queryFilters has a null min stat (=> stats unreliable, must scan file). We use
+      // queryFilters' referenced columns rather than all valid indexed columns so that an
+      // unreliable but irrelevant column doesn't force every file to be scanned.
+      val referencedCols = queryFilters
+        .flatMap(_.references.map(_.name))
+        .toSet
+        .intersect(validIndexedColumns.toSet)
+      val statsUnreliableExpr: Option[Expression] = referencedCols
+        .map(cn => IsNull(ColumnStatsExpressionUtils.genColMinValueExpr(cn)).asInstanceOf[Expression])
+        .reduceOption((a, b) => Or(a, b))
+      val effectiveIndexFilter = statsUnreliableExpr
+        .map(unreliable => Or(indexFilter, unreliable))
+        .getOrElse(indexFilter)
       // only lookup in col stats if all filters are eligible to be looked up in col stats index in MDT
       val prunedCandidateFileNames =
-        indexDf.where(sparkAdapter.createColumnFromExpression(indexFilter))
+        indexDf.where(sparkAdapter.createColumnFromExpression(effectiveIndexFilter))
           .select(HoodieMetadataPayload.COLUMN_STATS_FIELD_FILE_NAME)
           .collect()
           .map(_.getString(0))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkBaseIndexSupport.scala
@@ -118,7 +118,7 @@ abstract class SparkBaseIndexSupport(spark: SparkSession,
        fileNamesFromPrunedPartitions
     } else {
       // The stats-unreliability null-safety is applied at the per-predicate translation
-      // level (DataSkippingUtils.withStatsAvailable), so the indexFilter here already
+      // level (DataSkippingUtils.withUnreliableStatsGuard), so the indexFilter here already
       // includes the right "OR colMin IS NULL AND valueCount > nullCount" guards.
       // only lookup in col stats if all filters are eligible to be looked up in col stats index in MDT
       val prunedCandidateFileNames =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
@@ -488,12 +488,21 @@ object ColumnStatsExpressionUtils {
    * were omitted due to value-size truncation), Hudi's writer persists min/max as null so the
    * stats can't be trusted. A bare `colA_maxValue > X` predicate would evaluate to null in that
    * case, which Spark treats as false in WHERE — silently pruning a file that may contain
-   * matching rows. Wrapping with `OR colA_minValue IS NULL` makes the file pass through and be
-   * scanned, preserving correctness at the cost of skipping an opportunity. min/max are written
-   * jointly (both null or both non-null), so checking min is sufficient.
+   * matching rows. Adding an `OR colA_minValue IS NULL` term makes the file pass through and
+   * be scanned, preserving correctness at the cost of skipping an opportunity.
+   *
+   * The OR-IsNull term must NOT fire for a legitimately all-null column (no non-null values
+   * to bound), where min/max are correctly null and any non-null predicate should still prune.
+   * We distinguish the two cases with {@code valueCount > nullCount}: the unreliable case has
+   * non-null values whose bounds we couldn't determine, the all-null case has none.
+   *
+   * Note: min/max are written jointly (both null or both non-null), so checking min is sufficient.
    */
   @inline def withStatsAvailable(skipExpr: Expression, colName: String): Expression = {
-    Or(skipExpr, IsNull(genColMinValueExpr(colName)))
+    Or(
+      skipExpr,
+      And(IsNull(genColMinValueExpr(colName)),
+          GreaterThan(genColValueCountExpr, genColNumNullsExpr(colName))))
   }
 
   @inline def genColumnValuesEqualToExpression(colName: String,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
@@ -175,7 +175,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value)
+            withStatsAvailable(LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -184,7 +184,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
               val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-              LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value)
+              withStatsAvailable(LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -195,7 +195,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value)
+            withStatsAvailable(GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -204,7 +204,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value)
+            withStatsAvailable(GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -215,7 +215,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value)
+            withStatsAvailable(LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -224,7 +224,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value)
+            withStatsAvailable(LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -235,7 +235,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value)
+            withStatsAvailable(GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -244,7 +244,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value)
+            withStatsAvailable(GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -341,7 +341,10 @@ object DataSkippingUtils extends Logging {
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
             val minValueExpr = targetExprBuilder.apply(genColMinValueExpr(colName))
             val maxValueExpr = targetExprBuilder.apply(genColMaxValueExpr(colName))
-            Not(And(StartsWith(minValueExpr, value), StartsWith(maxValueExpr, value)))
+            // When stats are unavailable, the inner conjunction is gated on IsNotNull(min) so it
+            // evaluates to false; Not(false) = true, ensuring the file is scanned.
+            Not(And(IsNotNull(genColMinValueExpr(colName)),
+                    And(StartsWith(minValueExpr, value), StartsWith(maxValueExpr, value))))
           }.orElse({
           Option.empty
         })
@@ -479,13 +482,29 @@ object ColumnStatsExpressionUtils {
   @inline def genColNumNullsExpr(colName: String): Expression = sparkAdapter.getExpressionFromColumn(col(getNullCountColumnNameFor(colName)))
   @inline def genColValueCountExpr: Expression = sparkAdapter.getExpressionFromColumn(col(getValueCountColumnNameFor))
 
+  /**
+   * Wraps a min/max-based skipping predicate with a null-safety check. When parquet-mr reports
+   * stats as unreliable (e.g. any NaN in a FLOAT/DOUBLE column, or a column-chunk where stats
+   * were omitted due to value-size truncation), Hudi's writer persists min/max as null so the
+   * stats can't be trusted. A bare `colA_maxValue > X` predicate would evaluate to null in that
+   * case, which Spark treats as false in WHERE — silently pruning a file that may contain
+   * matching rows. Wrapping with `OR colA_minValue IS NULL` makes the file pass through and be
+   * scanned, preserving correctness at the cost of skipping an opportunity. min/max are written
+   * jointly (both null or both non-null), so checking min is sufficient.
+   */
+  @inline def withStatsAvailable(skipExpr: Expression, colName: String): Expression = {
+    Or(skipExpr, IsNull(genColMinValueExpr(colName)))
+  }
+
   @inline def genColumnValuesEqualToExpression(colName: String,
                                                value: Expression,
                                                targetExprBuilder: Function[Expression, Expression] = Predef.identity): Expression = {
     val minValueExpr = targetExprBuilder.apply(genColMinValueExpr(colName))
     val maxValueExpr = targetExprBuilder.apply(genColMaxValueExpr(colName))
     // Only case when column C contains value V is when min(C) <= V <= max(c)
-    And(LessThanOrEqual(minValueExpr, value), GreaterThanOrEqual(maxValueExpr, value))
+    withStatsAvailable(
+      And(LessThanOrEqual(minValueExpr, value), GreaterThanOrEqual(maxValueExpr, value)),
+      colName)
   }
 
   def genColumnOnlyValuesEqualToExpression(colName: String,
@@ -494,7 +513,15 @@ object ColumnStatsExpressionUtils {
     val minValueExpr = targetExprBuilder.apply(genColMinValueExpr(colName))
     val maxValueExpr = targetExprBuilder.apply(genColMaxValueExpr(colName))
     // Only case when column C contains _only_ value V is when min(C) = V AND max(c) = V
-    And(EqualTo(minValueExpr, value), EqualTo(maxValueExpr, value))
+    // NOTE: this is used inside Not(...) predicates (e.g. `colA != V`, `colA NOT IN (...)`). For
+    //       those, treating "stats unavailable" as "value V is the only value" would PRUNE the
+    //       file (Not(true) = false). So we treat the inner expression as false (file is
+    //       guaranteed not to match the negation) when stats are missing, which means
+    //       Not(thisExpr) becomes Not(false) = true → file IS scanned. We achieve that by
+    //       returning false (And with false) when stats are unavailable, which Not then flips.
+    val ifStatsAvailable = And(EqualTo(minValueExpr, value), EqualTo(maxValueExpr, value))
+    // When min is null: stats unavailable → return false here so caller's Not(...) becomes true
+    And(IsNotNull(genColMinValueExpr(colName)), ifStatsAvailable)
   }
 
   def swapAttributeRefInExpr(sourceExpr: Expression, from: AttributeReference, to: Expression): Expression = {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
@@ -146,7 +146,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            Not(genColumnOnlyValuesEqualToExpression(colName, value, targetExprBuilder))
+            Not(genColumnOnlyValuesEqualToExpressionForNegation(colName, value, targetExprBuilder))
           }.orElse({
           Option.empty
         })
@@ -155,7 +155,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            Not(genColumnOnlyValuesEqualToExpression(colName, value, targetExprBuilder))
+            Not(genColumnOnlyValuesEqualToExpressionForNegation(colName, value, targetExprBuilder))
           }.orElse({
           Option.empty
         })
@@ -175,7 +175,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            withStatsAvailable(LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
+            withUnreliableStatsGuard(LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -184,7 +184,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
               val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-              withStatsAvailable(LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
+              withUnreliableStatsGuard(LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -195,7 +195,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            withStatsAvailable(GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
+            withUnreliableStatsGuard(GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -204,7 +204,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            withStatsAvailable(GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
+            withUnreliableStatsGuard(GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -215,7 +215,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            withStatsAvailable(LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
+            withUnreliableStatsGuard(LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -224,7 +224,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            withStatsAvailable(LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
+            withUnreliableStatsGuard(LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -235,7 +235,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            withStatsAvailable(GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
+            withUnreliableStatsGuard(GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -244,7 +244,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            withStatsAvailable(GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
+            withUnreliableStatsGuard(GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value), colName)
           }.orElse({
           Option.empty
         })
@@ -312,7 +312,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            Not(list.map(lit => genColumnOnlyValuesEqualToExpression(colName, lit, targetExprBuilder)).reduce(Or))
+            Not(list.map(lit => genColumnOnlyValuesEqualToExpressionForNegation(colName, lit, targetExprBuilder)).reduce(Or))
           }.orElse({
           Option.empty
         })
@@ -498,7 +498,7 @@ object ColumnStatsExpressionUtils {
    *
    * Note: min/max are written jointly (both null or both non-null), so checking min is sufficient.
    */
-  @inline def withStatsAvailable(skipExpr: Expression, colName: String): Expression = {
+  @inline def withUnreliableStatsGuard(skipExpr: Expression, colName: String): Expression = {
     Or(
       skipExpr,
       And(IsNull(genColMinValueExpr(colName)),
@@ -511,25 +511,28 @@ object ColumnStatsExpressionUtils {
     val minValueExpr = targetExprBuilder.apply(genColMinValueExpr(colName))
     val maxValueExpr = targetExprBuilder.apply(genColMaxValueExpr(colName))
     // Only case when column C contains value V is when min(C) <= V <= max(c)
-    withStatsAvailable(
+    withUnreliableStatsGuard(
       And(LessThanOrEqual(minValueExpr, value), GreaterThanOrEqual(maxValueExpr, value)),
       colName)
   }
 
-  def genColumnOnlyValuesEqualToExpression(colName: String,
-                                           value: Expression,
-                                           targetExprBuilder: Function[Expression, Expression] = Predef.identity): Expression = {
+  /**
+   * Generates the predicate "column C contains _only_ value V" (i.e. min(C) = V AND max(C) = V),
+   * intended to be wrapped in {@code Not(...)} by the caller — typically for `colA != V` or
+   * `colA NOT IN (...)`.
+   *
+   * IMPORTANT: This helper is correct ONLY when used inside {@code Not(...)}. The IsNotNull guard
+   * makes the inner expression evaluate to false when stats are unavailable (min is null), so the
+   * outer Not(...) flips it to true and the file is preserved — preventing accidental pruning of
+   * files whose stats can't be trusted (NaN, value-size truncation; see [[withUnreliableStatsGuard]]).
+   * Without the Not(...) wrap, this helper would over-prune the same files.
+   */
+  def genColumnOnlyValuesEqualToExpressionForNegation(colName: String,
+                                                      value: Expression,
+                                                      targetExprBuilder: Function[Expression, Expression] = Predef.identity): Expression = {
     val minValueExpr = targetExprBuilder.apply(genColMinValueExpr(colName))
     val maxValueExpr = targetExprBuilder.apply(genColMaxValueExpr(colName))
-    // Only case when column C contains _only_ value V is when min(C) = V AND max(c) = V
-    // NOTE: this is used inside Not(...) predicates (e.g. `colA != V`, `colA NOT IN (...)`). For
-    //       those, treating "stats unavailable" as "value V is the only value" would PRUNE the
-    //       file (Not(true) = false). So we treat the inner expression as false (file is
-    //       guaranteed not to match the negation) when stats are missing, which means
-    //       Not(thisExpr) becomes Not(false) = true → file IS scanned. We achieve that by
-    //       returning false (And with false) when stats are unavailable, which Not then flips.
     val ifStatsAvailable = And(EqualTo(minValueExpr, value), EqualTo(maxValueExpr, value))
-    // When min is null: stats unavailable → return false here so caller's Not(...) becomes true
     And(IsNotNull(genColMinValueExpr(colName)), ifStatsAvailable)
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
@@ -143,6 +143,53 @@ class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterS
   }
 
 
+  /**
+   * Verifies that for every min/max-based predicate the data-skipping translator wraps with
+   * `OR colMin IS NULL`, so a file whose stats are marked unreliable (e.g. parquet-mr cleared
+   * them due to NaN, or omitted them due to value-size truncation) is always scanned rather
+   * than silently pruned by Spark's null-propagating WHERE semantics. Without the wrap, a
+   * predicate like `colA_maxValue > X` evaluates to `null` when `colA_maxValue` is null,
+   * which Spark treats as false — dropping the file from the candidate set even though it
+   * might contain matching rows. See #18754 / PR #18792.
+   *
+   * Each row in the input represents one file in the col-stats index. `file_unreliable` has
+   * null min/max with nullCount=0 (the unreliability signal: stats are absent but the file
+   * has non-null values). The expected output always includes that file regardless of
+   * predicate, because we can't bound its values.
+   */
+  @ParameterizedTest
+  @MethodSource(Array("testNullSafetyForUnreliableStatsSource"))
+  def testNullSafetyForUnreliableStats(sourceFilterExprStr: String, expectedOutput: Seq[String]): Unit = {
+    spark.sqlContext.setConf(SESSION_LOCAL_TIMEZONE.key, "UTC")
+
+    // 3 files: two with bounded stats, one with null min/max (unreliable). The unreliable
+    // file must survive every predicate that touches column A.
+    val indexRows: java.util.List[Row] = java.util.Arrays.asList(
+      Row("file_in_range",      1L,    1L,    10L, java.lang.Long.valueOf(0),
+          null, null, null,
+          null, null, null),
+      Row("file_out_of_range",  1L, -100L,  -50L, java.lang.Long.valueOf(0),
+          null, null, null,
+          null, null, null),
+      // Null min/max with nullCount=0 => stats are unreliable. Must be scanned.
+      Row("file_unreliable",    5L,  null,  null,  java.lang.Long.valueOf(0),
+          null, null, null,
+          null, null, null)
+    )
+    val indexDf = spark.createDataFrame(indexRows, indexSchema)
+
+    val resolvedFilterExpr: Expression = resolveExpr(spark, sourceFilterExprStr, sourceTableSchema)
+    val lookupFilter = DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr(resolvedFilterExpr, indexedCols = indexedCols)
+
+    val rows: Seq[String] = indexDf.where(sparkAdapter.createColumnFromExpression(lookupFilter))
+      .select("fileName")
+      .collect()
+      .map(_.getString(0))
+      .toSeq
+
+    assertEquals(expectedOutput.sorted, rows.sorted)
+  }
+
   private def optimize(expr: Expression): Expression = {
     val rules: Seq[Rule[LogicalPlan]] =
       OptimizeIn ::
@@ -169,6 +216,30 @@ class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterS
 }
 
 object TestDataSkippingUtils {
+
+  /** Source for [[TestDataSkippingUtils.testNullSafetyForUnreliableStats]]. Each tuple
+   * specifies a predicate and the expected candidate files; the unreliable file
+   * (`file_unreliable`) must always be present regardless of predicate shape. */
+  def testNullSafetyForUnreliableStatsSource(): java.util.stream.Stream[Arguments] = {
+    java.util.stream.Stream.of(
+      // Range predicates on A — touch min or max
+      arguments("A > 5",                 Seq("file_in_range", "file_unreliable")),
+      arguments("A < 5",                 Seq("file_in_range", "file_out_of_range", "file_unreliable")),
+      arguments("A >= 5",                Seq("file_in_range", "file_unreliable")),
+      arguments("A <= 5",                Seq("file_in_range", "file_out_of_range", "file_unreliable")),
+      arguments("5 > A",                 Seq("file_in_range", "file_out_of_range", "file_unreliable")),
+      arguments("5 < A",                 Seq("file_in_range", "file_unreliable")),
+      arguments("5 >= A",                Seq("file_in_range", "file_out_of_range", "file_unreliable")),
+      arguments("5 <= A",                Seq("file_in_range", "file_unreliable")),
+      // Equality predicate — touches both min and max
+      arguments("A = 5",                 Seq("file_in_range", "file_unreliable")),
+      // IN predicate — uses min/max via genColumnValuesEqualToExpression
+      arguments("A IN (5, 7)",           Seq("file_in_range", "file_unreliable")),
+      // Range that all reliable files match — unreliable file still included
+      arguments("A > -200",              Seq("file_in_range", "file_out_of_range", "file_unreliable"))
+    )
+  }
+
   def testStringsLookupFilterExpressionsSource(): java.util.stream.Stream[Arguments] = {
     java.util.stream.Stream.of(
       arguments(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -46,7 +46,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, Literal, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, IsNull, Literal, Or}
 import org.apache.spark.sql.hudi.DataSkippingUtils.translateIntoColumnStatsIndexFilterExpr
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api._
@@ -1403,8 +1403,17 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
         GreaterThan(AttributeReference("c4", StringType, nullable = true)(), Literal("c4 filed value"))
       )
 
+      // `c1 > 1` translates to `c1_maxValue > 1`, wrapped with a null-safety OR-guard
+      // for files whose stats are unreliable (NaN-poisoned or value-size truncated):
+      // see DataSkippingUtils.withUnreliableStatsGuard. c4 is not indexed → TrueLiteral.
       val expectedAndConditionIndexedFilter = And(
-        GreaterThan(UnresolvedAttribute("c1_maxValue"), Literal(1)),
+        Or(
+          GreaterThan(UnresolvedAttribute("c1_maxValue"), Literal(1)),
+          And(
+            IsNull(UnresolvedAttribute("c1_minValue")),
+            GreaterThan(UnresolvedAttribute("valueCount"), UnresolvedAttribute("c1_nullCount"))
+          )
+        ),
         Literal(true)
       )
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
@@ -38,7 +38,7 @@ import org.apache.hudi.util.JavaConversions
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BitwiseOr, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, LessThanOrEqual, Literal, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BitwiseOr, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, IsNull, LessThanOrEqual, Literal, Or}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.hudi.DataSkippingUtils
 import org.apache.spark.sql.types.StringType
@@ -311,8 +311,20 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
   }
 
   def generateColStatsExprForGreaterthanOrEquals(colName: String, colValue: String): Expression = {
-    val expectedExpr: Expression = GreaterThanOrEqual(UnresolvedAttribute(colName + "_maxValue"), literal(colValue))
-    And(LessThanOrEqual(UnresolvedAttribute(colName + "_minValue"), literal(colValue)), expectedExpr)
+    // `colName = colValue` translates to `min <= V AND max >= V`, wrapped with the
+    // null-safety OR-guard introduced by DataSkippingUtils.withUnreliableStatsGuard
+    // for files whose stats are unreliable (NaN-poisoned or value-size truncated).
+    val innerExpr = And(
+      LessThanOrEqual(UnresolvedAttribute(colName + "_minValue"), literal(colValue)),
+      GreaterThanOrEqual(UnresolvedAttribute(colName + "_maxValue"), literal(colValue))
+    )
+    Or(
+      innerExpr,
+      And(
+        IsNull(UnresolvedAttribute(colName + "_minValue")),
+        GreaterThan(UnresolvedAttribute("valueCount"), UnresolvedAttribute(colName + "_nullCount"))
+      )
+    )
   }
 
   @ParameterizedTest

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSkippingWithUnreliableColStats.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSkippingWithUnreliableColStats.scala
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceReadOptions
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.DataSourceWriteOptions.{PARTITIONPATH_FIELD, RECORDKEY_FIELD}
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField, StructType}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Tag, Test}
+import org.junit.jupiter.api.Assertions.assertEquals
+
+/**
+ * End-to-end correctness tests for the col-stats unreliability fix
+ * (apache/hudi#18754 and #18755).
+ *
+ * Each test writes a Hudi table whose col-stats would be poisoned by the
+ * pre-fix writer (a NaN in a DOUBLE column, or a string value larger than
+ * parquet-mr's stats truncation threshold), then asserts that queries against
+ * the table return the same rows with data-skipping enabled as with it
+ * disabled. Data-skipping is supposed to be a transparent performance
+ * optimization — any divergence between ON and OFF is silent data loss.
+ */
+@Tag("functional")
+class TestDataSkippingWithUnreliableColStats extends HoodieSparkClientTestBase {
+
+  var spark: SparkSession = _
+
+  private val schema = StructType(Seq(
+    StructField("rk", IntegerType, nullable = false),
+    StructField("p",  StringType,  nullable = false),
+    StructField("s_str",    StringType, nullable = true),
+    StructField("d_double", DoubleType, nullable = true)
+  ))
+
+  private val commonOpts = Map(
+    "hoodie.insert.shuffle.parallelism" -> "2",
+    "hoodie.upsert.shuffle.parallelism" -> "2",
+    "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+    RECORDKEY_FIELD.key -> "rk",
+    PARTITIONPATH_FIELD.key -> "p",
+    HoodieTableConfig.ORDERING_FIELDS.key -> "rk",
+    HoodieWriteConfig.TBL_NAME.key -> "hoodie_unreliable_colstats",
+    HoodieMetadataConfig.ENABLE.key -> "true",
+    HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true",
+    // Index the data columns so the data-skipping path is exercised.
+    HoodieMetadataConfig.COLUMN_STATS_INDEX_FOR_COLUMNS.key -> "s_str,d_double",
+    // Disable small-file batching so each write produces its own file (we want
+    // multiple files in the same partition to exercise both file-level and
+    // partition-level pruning).
+    "hoodie.parquet.small.file.limit" -> "0"
+  )
+
+  @BeforeEach
+  override def setUp() {
+    initPath()
+    initSparkContexts()
+    spark = sqlContext.sparkSession
+    initTestDataGenerator()
+    initHoodieStorage()
+  }
+
+  @AfterEach
+  override def tearDown() = {
+    cleanupSparkContexts()
+    cleanupTestDataGenerator()
+    cleanupFileSystem()
+  }
+
+  /**
+   * #18754 — a single NaN value in a DOUBLE column would silently drop all
+   * matching rows from `WHERE d_double > N` queries (and predicates on
+   * unrelated columns of the same partition, via partition-stats aggregation).
+   * After the fix, ON and OFF results must match.
+   */
+  @Test
+  def testNaNInDoubleColumnDoesNotSilentlyPruneRows(): Unit = {
+    // Four files in partition "P". File 3 has 10 numeric values + 1 NaN row.
+    val fileBatches = Seq(
+      (0 until 10).map(k => Row(10000 + k, "P", "a_" + "%02d".format(k), k.toDouble)),
+      (0 until 10).map(k => Row(20000 + k, "P", "b_" + "%02d".format(k), 100.0 + k)),
+      (0 until 10).map(k => Row(30000 + k, "P", "c_" + "%02d".format(k), 200.0 + k)),
+      (0 until 10).map(k => Row(40000 + k, "P", "d_" + "%02d".format(k), 300.0 + k)) :+
+        Row(40100, "P", "m_nan", Double.NaN)
+    )
+    writeBatches(fileBatches)
+
+    // The NaN row is excluded from `> 250` in standard SQL semantics — but Spark's
+    // DOUBLE comparison treats NaN as greater than every other value, so it IS
+    // included. Either way, ON and OFF must agree.
+    assertSkippingNeverDropsRows("d_double > 250")
+    assertSkippingNeverDropsRows("d_double >= 300")
+    // Predicates on other columns of the table must also be unaffected by file 3's NaN.
+    assertSkippingNeverDropsRows("s_str = 'a_05'")
+    assertSkippingNeverDropsRows("s_str IN ('a_05','b_05','c_05','d_05')")
+  }
+
+  /**
+   * #18755 — when a Parquet column omits stats entirely (one value exceeds
+   * parquet-mr's stats truncation threshold ~1KB), the pre-fix writer recorded
+   * nullCount = valueCount, claiming the file was all-null. Data-skipping then
+   * pruned the file silently. After the fix, ON and OFF results must match.
+   */
+  @Test
+  def testTruncatedStringStatsDoNotSilentlyPruneRows(): Unit = {
+    val longValue = "Y" * 4096  // exceeds parquet-mr's stats truncation threshold
+
+    val fileBatches = Seq(
+      // File 0: only short strings — stats are reliable.
+      (0 until 5).map(k => Row(100 + k, "P", "short_" + k, k.toDouble)),
+      // File 1: mix of short and one long value — parquet omits stats for s_str.
+      Seq(Row(200, "P", "Y", 1.0),
+          Row(201, "P", longValue, 2.0))
+    )
+    writeBatches(fileBatches)
+
+    // The short value "Y" lives in file 1, but pre-fix data-skipping would prune
+    // file 1 entirely because the col-stats record incorrectly claimed all
+    // values were null. After the fix, the file is scanned and the row returned.
+    assertSkippingNeverDropsRows("s_str = 'Y'")
+    assertSkippingNeverDropsRows("s_str = 'short_2'")
+  }
+
+  /** Writes successive batches as separate Hudi commits, producing distinct files. */
+  private def writeBatches(fileBatches: Seq[Seq[Row]]): Unit = {
+    fileBatches.zipWithIndex.foreach { case (rows, i) =>
+      spark.createDataFrame(rows.asJava(), schema).write.format("org.apache.hudi")
+        .options(commonOpts)
+        .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+        .mode(if (i == 0) SaveMode.Overwrite else SaveMode.Append)
+        .save(basePath)
+    }
+  }
+
+  /**
+   * Asserts the predicate returns the same set of rows with data-skipping
+   * enabled as with it disabled. Skipping is a performance optimization;
+   * silent divergence is the data-loss signature of #18754 / #18755.
+   */
+  private def assertSkippingNeverDropsRows(predicateSql: String): Unit = {
+    val skippingOn = spark.read.format("org.apache.hudi")
+      .option(DataSourceReadOptions.ENABLE_DATA_SKIPPING.key, "true").load(basePath)
+      .where(predicateSql).select("rk").collect().map(_.getInt(0)).toSet
+    val skippingOff = spark.read.format("org.apache.hudi")
+      .option(DataSourceReadOptions.ENABLE_DATA_SKIPPING.key, "false").load(basePath)
+      .where(predicateSql).select("rk").collect().map(_.getInt(0)).toSet
+    assertEquals(skippingOff, skippingOn,
+      s"Data-skipping ON returned a different result set than OFF for predicate `$predicateSql`. " +
+        s"Skipping ON: $skippingOn  ;  Skipping OFF: $skippingOff")
+  }
+
+  // Helper to convert Scala Seq to Java List for createDataFrame(java.util.List[Row], schema).
+  private implicit class SeqOps(s: Seq[Row]) {
+    def asJava(): java.util.List[Row] = {
+      val list = new java.util.ArrayList[Row](s.size)
+      s.foreach(list.add)
+      list
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -41,7 +41,7 @@ import org.apache.hudi.util.{JavaConversions, JFunction}
 
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BitwiseOr, EqualNullSafe, EqualTo, Expression, GreaterThanOrEqual, IsNotNull, IsNull, LessThanOrEqual, Literal, Not, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BitwiseOr, EqualNullSafe, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, IsNotNull, IsNull, LessThanOrEqual, Literal, Not, Or}
 import org.apache.spark.sql.hudi.DataSkippingUtils
 import org.apache.spark.sql.types.StringType
 import org.junit.jupiter.api.{Tag, Test}
@@ -664,8 +664,19 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
   }
 
   def generateColStatsExprForGreaterthanOrEquals(colName: String, colValue: String): Expression = {
-    val expectedExpr: Expression = GreaterThanOrEqual(UnresolvedAttribute(colName + "_maxValue"), literal(colValue))
-    And(LessThanOrEqual(UnresolvedAttribute(colName + "_minValue"), literal(colValue)), expectedExpr)
+    // Mirrors the helper in TestColumnStatsIndexWithSQL — keeps the two test files
+    // in sync around the null-safety OR-guard added by withUnreliableStatsGuard.
+    val innerExpr = And(
+      LessThanOrEqual(UnresolvedAttribute(colName + "_minValue"), literal(colValue)),
+      GreaterThanOrEqual(UnresolvedAttribute(colName + "_maxValue"), literal(colValue))
+    )
+    Or(
+      innerExpr,
+      And(
+        IsNull(UnresolvedAttribute(colName + "_minValue")),
+        GreaterThan(UnresolvedAttribute("valueCount"), UnresolvedAttribute(colName + "_nullCount"))
+      )
+    )
   }
 
   def verifyQueryPredicate(hudiOpts: Map[String, String]): Unit = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes two related correctness bugs in the column-stats metadata table that cause silent zero-row query results when data-skipping is enabled:

- **#18754** — A single `NaN` value in a `FLOAT`/`DOUBLE` column corrupts the persisted col-stats record for that file. parquet-mr clears the underlying parquet stats (`hasNonNullValue=false`) but leaves min/max at their default `0.0`. Hudi was reading those sentinel values and persisting `min=0.0, max=0.0` to the MDT. The 1.x read path then used those fabricated bounds, pruning the file at the partition-stats level and dropping rows from any predicate involving that partition — including predicates on completely unrelated columns of files that contain no NaN at all.

- **#18755** — When a Parquet column omits stats entirely (e.g. one value exceeds parquet-mr's stats truncation threshold ~1KB for binary/string), the col-stats writer was mis-recording `nullCount = valueCount`, i.e. "all rows in this file are null". Any non-null predicate then silently skips that file.

Both bugs cause silent data loss at query time — no error, no warning, just an incomplete result set.

### Summary and Changelog

`hudi-hadoop-common/.../ParquetUtils.readColumnStatsFromMetadata` did two things that turned out to be unsafe in the presence of unreliable parquet stats:

1. Called `stats.genericGetMin()/getMax()` without checking `stats.hasNonNullValue()` — parquet-mr uses that flag to signal "min/max are unreliable, do not trust them" (NaN in FLOAT/DOUBLE).
2. Did `stats.isEmpty() ? valueCount : getNumNulls()`. `isEmpty()` is `true` both for all-null columns and for stats-truly-absent columns — the two cases need opposite handling.

The error then propagated: even after `ParquetUtils` was fixed to report null min/max for unreliable stats, the per-partition aggregator `HoodieColumnRangeMetadata.merge` silently dropped the null contribution from the unreliable file. This left `PartitionStatsIndexSupport.prunePartitions` with a partial bound that pruned the partition based on the other files' stats — the silent zero-row symptom in #18754.

The read-side filter generator in `DataSkippingUtils` also needed updating: a predicate like `colA_maxValue > X` evaluates to null when the file has null max stat, and Spark treats null as false in `WHERE`, so the file gets pruned. Wrapping with `OR (colMin IS NULL AND valueCount > nullCount)` makes the file scanned instead, while still pruning legitimately all-null columns.

Changes:

- `ParquetUtils.readColumnStatsFromMetadata` — gate min/max on `hasNonNullValue()`; gate `nullCount = valueCount` on `isNumNullsSet()`.
- `HoodieTableMetadataUtil.collectColumnRangeMetadata` — skip NaN in the streaming min/max accumulator (`Double.compare(NaN, x)` returns `+1`, so an unguarded comparison lets a single NaN poison max forever).
- `HoodieTableMetadataUtil.mergeColumnStatsRecords` — distinguish all-null from stats-unreliable when merging MDT records.
- `HoodieColumnRangeMetadata.merge` — the per-file → per-partition merge helper used by `PartitionStatsIndexSupport`. Apply the same unreliability propagation here (the missing piece that kept the read-side bug visible even after the other writer fixes were applied).
- `DataSkippingUtils.scala` — wrap min/max-using skip predicates with `OR (colMin IS NULL AND valueCount > nullCount)`. The valueCount-vs-nullCount guard distinguishes unreliable from all-null.

### Impact

No public API change. Internal write/read code only.

The fix is strictly more conservative than the prior behavior: files with unreliable stats are now scanned instead of silently pruned. Tables that don't contain NaN values and don't have stats-truncated columns are unaffected (the new gates short-circuit when stats are reliable). For tables that do hit either condition, queries previously returning silently-wrong (incomplete) results now return correct results; pruning is less aggressive on the files that triggered the unreliable signal.

### Risk Level

Medium. The merge-helper change (`HoodieColumnRangeMetadata.merge`) is in a path shared by partition-stats aggregation and any other caller that merges per-file ranges. The semantics shift from "drop null" to "propagate null when stats are unreliable, drop null when column is genuinely all-null". The distinguishing check is `nullCount == valueCount`, which is the existing convention for the all-null sentinel — no API change, behavior alignment with the documented contract. Updated `TestBaseFileUtils#testGetColumnRangeInPartitionWithNullMinMax` reflects the new (correct) semantics; the prior assertion silently dropped the null contributor.

### Documentation Update

No documentation changes required. The bugs were silent regressions against the existing contract that "data-skipping should never change query results".

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable (unit tests in `TestParquetUtils`, `TestHoodieColumnRangeMetadata`, `TestHoodieTableMetadataUtil` (including `testIsStatsUnreliableUsesValueEqualityOnBoxedLong` regression for the boxed-Long ref-equality bug surfaced in code review), `TestDataSkippingUtils`; functional test in `TestDataSkippingWithUnreliableColStats`; updated existing `TestBaseFileUtils#testGetColumnRangeInPartitionWithNullMinMax` to reflect new semantics)
- [ ] CI passed
