### PR TITLE
fix(flink): Trigger a failover after pending instants recommitted for…

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -232,10 +232,6 @@ public class OptionsResolver {
     return indexType == HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX;
   }
 
-  public static boolean isRLIWithBootstrap(Configuration conf) {
-    return isGlobalRecordLevelIndex(conf) && conf.get(FlinkOptions.INDEX_BOOTSTRAP_ENABLED);
-  }
-
   /**
    * Returns whether it is a MERGE_ON_READ table, and updates by bucket index.
    */

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -330,7 +330,7 @@ public class StreamWriteOperatorCoordinator
       // resetToCheckpoint() is called in two cases:
       // 1. The job is restarted from state, start() will be called later.
       // 2. The job is recovered from global failover. The coordinator is already started, and start() will not be called again.
-      if (executor != null && tableState.isRLIWithBootstrap) {
+      if (executor != null && tableState.isRecordLevelIndex) {
         // use sync execution here to make sure the recommitting finishes before RLI bootstrapping
         this.executor.executeSync(this::restoreEvents, "Recommit pending instants on resetting to checkpoint: %s.", checkpointID);
       }
@@ -373,7 +373,7 @@ public class StreamWriteOperatorCoordinator
   @Override
   public void subtaskReset(int i, long resetCkpId) {
     // There exists pending instants waiting for recommiting.
-    if (tableState.isRLIWithBootstrap && !eventBuffers.getPendingInstantsBefore(resetCkpId).isEmpty()) {
+    if (tableState.isRecordLevelIndex && !eventBuffers.getPendingInstantsBefore(resetCkpId).isEmpty()) {
       // use sync execution here to make sure the recommitting finishes before RLI bootstrapping
       executor.executeSync(() -> commitInstants(resetCkpId), "Recommit pending instants on resetting subtask %s to checkpoint: %s.", i, resetCkpId);
     }
@@ -565,7 +565,7 @@ public class StreamWriteOperatorCoordinator
     if (eventBuffer.allBootstrapEventsReceived()) {
       // start to recommit the instant.
       boolean committed = recommitInstant(event.getCheckpointId(), event.getInstantTime(), eventBuffer);
-      if (committed && tableState.isRLIWithBootstrap) {
+      if (committed && tableState.isRecordLevelIndex) {
         context.failJob(new HoodieException("There are pending instants recommitted on job restart,"
             + "triggering a global failover so that RLI bootstrap operator can load the record level index completely."));
       }
@@ -759,7 +759,7 @@ public class StreamWriteOperatorCoordinator
     final boolean syncMetadata;
     final boolean isDeltaTimeCompaction;
     final boolean isStreamingIndexWriteEnabled;
-    final boolean isRLIWithBootstrap;
+    final boolean isRecordLevelIndex;
 
     private TableState(Configuration conf) {
       this.operationType = WriteOperationType.fromValue(conf.get(FlinkOptions.OPERATION));
@@ -773,7 +773,7 @@ public class StreamWriteOperatorCoordinator
       this.syncMetadata = conf.get(FlinkOptions.METADATA_ENABLED);
       this.isDeltaTimeCompaction = OptionsResolver.isDeltaTimeCompaction(conf);
       this.isStreamingIndexWriteEnabled = OptionsResolver.isStreamingIndexWriteEnabled(conf);
-      this.isRLIWithBootstrap = OptionsResolver.isRLIWithBootstrap(conf);
+      this.isRecordLevelIndex = OptionsResolver.isGlobalRecordLevelIndex(conf) || OptionsResolver.isRecordLevelIndex(conf);
     }
 
     public static TableState create(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -72,6 +72,7 @@ import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -305,6 +306,18 @@ public class TestStreamWriteOperatorCoordinator {
     coordinator.notifyCheckpointComplete(1);
     lastCompleted = TestUtils.getLastCompleteInstant(tempFile.getAbsolutePath());
     assertThat("Recommits the instant with partial uncommitted events", lastCompleted, is(instant));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"GLOBAL_RECORD_LEVEL_INDEX", "RECORD_LEVEL_INDEX"})
+  public void testRecordLevelIndexFlag(String indexType) throws Exception {
+    Configuration conf = TestConfigurations.getDefaultConf(new File(tempFile, indexType).getAbsolutePath());
+    conf.set(FlinkOptions.INDEX_TYPE, indexType);
+    conf.set(FlinkOptions.INDEX_WRITE_TASKS, 1);
+
+    try (StreamWriteOperatorCoordinator coordinator = createCoordinator(conf, 1)) {
+      assertTrue(getRecordLevelIndexFlag(coordinator));
+    }
   }
 
   @Test
@@ -774,6 +787,16 @@ public class TestStreamWriteOperatorCoordinator {
     assertThat(coordinator.getContext(), instanceOf(MockOperatorCoordinatorContext.class));
     MockOperatorCoordinatorContext context = (MockOperatorCoordinatorContext) coordinator.getContext();
     assertTrue(context.isJobFailed(), message);
+  }
+
+  private static boolean getRecordLevelIndexFlag(StreamWriteOperatorCoordinator coordinator) throws Exception {
+    Field tableStateField = StreamWriteOperatorCoordinator.class.getDeclaredField("tableState");
+    tableStateField.setAccessible(true);
+    Object tableState = tableStateField.get(coordinator);
+
+    Field recordLevelIndexField = tableState.getClass().getDeclaredField("isRecordLevelIndex");
+    recordLevelIndexField.setAccessible(true);
+    return recordLevelIndexField.getBoolean(tableState);
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
@@ -167,9 +167,7 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public void coordinatorFails() throws Exception {
-    this.coordinator.close();
-    this.coordinator.start();
-    this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
+    // Do nothing since there is no state recovery for bulk insert.
   }
 
   public void restartCoordinator() throws Exception {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/InsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/InsertFunctionWrapper.java
@@ -49,6 +49,8 @@ import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -70,6 +72,7 @@ public class InsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
 
   private final boolean asyncClustering;
   private ClusteringFunctionWrapper clusteringFunctionWrapper;
+  private final TreeMap<Long, byte[]> coordinatorStateStore;
 
   /**
    * Append write function.
@@ -97,6 +100,7 @@ public class InsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
     this.coordinatorContext = new MockOperatorCoordinatorContext(new OperatorID(), 1);
     this.coordinator = new StreamWriteOperatorCoordinator(conf, this.coordinatorContext);
     this.stateInitializationContext = new MockStateInitializationContext();
+    this.coordinatorStateStore = new TreeMap<>();
 
     this.asyncClustering = OptionsResolver.needsAsyncClustering(conf);
     StreamConfig streamConfig = new StreamConfig(conf);
@@ -142,8 +146,10 @@ public class InsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public void checkpointFunction(long checkpointId) throws Exception {
+    CompletableFuture<byte[]> completableFuture = new CompletableFuture<>();
     // checkpoint the coordinator first
-    this.coordinator.checkpointCoordinator(checkpointId, new CompletableFuture<>());
+    this.coordinator.checkpointCoordinator(checkpointId, completableFuture);
+    this.coordinatorStateStore.put(checkpointId, completableFuture.get());
 
     writeFunction.snapshotState(new MockFunctionSnapshotContext(checkpointId));
     stateInitializationContext.checkpointBegin(checkpointId);
@@ -167,9 +173,15 @@ public class InsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public void coordinatorFails() throws Exception {
-    this.coordinator.close();
-    this.coordinator.start();
-    this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
+    resetCoordinatorToCheckpoint();
+  }
+
+  private void resetCoordinatorToCheckpoint() {
+    if (coordinatorStateStore.isEmpty()) {
+      return;
+    }
+    Map.Entry<Long, byte[]> latestState = this.coordinatorStateStore.lastEntry();
+    this.coordinator.resetToCheckpoint(latestState.getKey(), latestState.getValue());
   }
 
   public void restartCoordinator() throws Exception {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
@@ -369,6 +369,9 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
 
   public void coordinatorFails() throws Exception {
     this.coordinator.close();
+    if (isStreamingWriteIndexEnabled) {
+      this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
+    }
     resetCoordinatorToCheckpoint();
     this.coordinator.start();
     this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
@@ -370,9 +370,14 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   public void coordinatorFails() throws Exception {
     this.coordinator.close();
     if (isStreamingWriteIndexEnabled) {
-      this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
+      // RLI restore needs a synchronous executor before start() recreates the coordinator executor.
+      try (MockCoordinatorExecutor resetExecutor = new MockCoordinatorExecutor(coordinatorContext)) {
+        this.coordinator.setExecutor(resetExecutor);
+        resetCoordinatorToCheckpoint();
+      }
+    } else {
+      resetCoordinatorToCheckpoint();
     }
-    resetCoordinatorToCheckpoint();
     this.coordinator.start();
     this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/StreamWriteFunctionWrapper.java
@@ -368,18 +368,7 @@ public class StreamWriteFunctionWrapper<I> implements TestFunctionWrapper<I> {
   }
 
   public void coordinatorFails() throws Exception {
-    this.coordinator.close();
-    if (isStreamingWriteIndexEnabled) {
-      // RLI restore needs a synchronous executor before start() recreates the coordinator executor.
-      try (MockCoordinatorExecutor resetExecutor = new MockCoordinatorExecutor(coordinatorContext)) {
-        this.coordinator.setExecutor(resetExecutor);
-        resetCoordinatorToCheckpoint();
-      }
-    } else {
-      resetCoordinatorToCheckpoint();
-    }
-    this.coordinator.start();
-    this.coordinator.setExecutor(new MockCoordinatorExecutor(coordinatorContext));
+    resetCoordinatorToCheckpoint();
   }
 
   public void restartCoordinator() throws Exception {


### PR DESCRIPTION
… both global and partitioned RLI

### Describe the issue this Pull Request addresses

Flink streaming recovery can leave pending instants that need to be recommitted before record level index state is bootstrapped or reused after failover. The previous guard was tied specifically to global RLI bootstrap configuration, which made the recovery/failover handling too narrow for RLI-backed writes.

This PR adjusts the write coordinator recovery path so pending instant recommits and follow-up failover handling are driven from the coordinator's table-state RLI flag rather than the removed bootstrap-specific helper.

### Summary and Changelog
- Removed `OptionsResolver.isRLIWithBootstrap`, which only checked global RLI with index bootstrap enabled.
- Updated `StreamWriteOperatorCoordinator` reset and subtask-reset paths to use `tableState.isRecordLevelIndex` when recommitting pending instants.
- Updated bootstrap event handling to trigger job failover after pending instants are recommitted for RLI tables, allowing the RLI bootstrap operator to reload index state completely.
- Added `TableState.isRecordLevelIndex` to centralize the coordinator's RLI-related recovery decision.

### Impact

RLI recovery handling is intended to apply to both global and partitioned RLI paths when pending instants are recommitted after restart or failover.

### Risk Level
low

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
