### PR TITLE
feat(rollback): add RollbackOrphanDetector utility for archive orphan guard (#18783)

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
@@ -125,6 +125,20 @@ public class HoodieArchivalConfig extends HoodieConfig {
           + "is not removed for commits whose data files still exist on storage, preventing inconsistencies between "
           + "the timeline and the actual data.");
 
+  public static final ConfigProperty<String> ROLLBACK_ORPHAN_GUARD_MODE = ConfigProperty
+      .key("hoodie.archive.rollback.orphan.guard.mode")
+      .defaultValue("OFF")
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Controls whether the archive planner defers archival of a rollback instant when "
+          + "leftover orphan files from that rollback are still present on storage. Once the rollback record "
+          + "is archived, such orphans become indistinguishable from legitimate committed files and can lead "
+          + "to corrupt-parquet read errors or duplicate records. Allowed values: "
+          + "OFF (default; archive proceeds unconditionally), "
+          + "LIGHT (defer if HoodieRollbackMetadata.failedDeleteFiles is non-empty), "
+          + "THOROUGH (LIGHT plus a per-partition listing for files whose embedded instant matches the "
+          + "rollback's target instant — catches late-landing writes that completed after rollback ran).");
+
   /**
    * @deprecated Use {@link #MAX_COMMITS_TO_KEEP} and its methods instead
    */
@@ -218,6 +232,11 @@ public class HoodieArchivalConfig extends HoodieConfig {
 
     public Builder withBlockArchivalOnCleanECTR(boolean blockArchivalOnCleanECTR) {
       archivalConfig.setValue(BLOCK_ARCHIVAL_ON_LATEST_CLEAN_ECTR, String.valueOf(blockArchivalOnCleanECTR));
+      return this;
+    }
+
+    public Builder withRollbackOrphanGuardMode(String mode) {
+      archivalConfig.setValue(ROLLBACK_ORPHAN_GUARD_MODE, mode);
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2023,6 +2023,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieArchivalConfig.BLOCK_ARCHIVAL_ON_LATEST_CLEAN_ECTR);
   }
 
+  public String getRollbackOrphanGuardMode() {
+    return getString(HoodieArchivalConfig.ROLLBACK_ORPHAN_GUARD_MODE);
+  }
+
   public Boolean shouldCleanBootstrapBaseFile() {
     return getBoolean(HoodieCleanConfig.CLEANER_BOOTSTRAP_BASE_FILE_ENABLE);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackOrphanDetector.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackOrphanDetector.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.rollback;
+
+import org.apache.hudi.avro.model.HoodieInstantInfo;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.table.HoodieTable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Detects parquet/log files left behind by a rollback that did not fully complete.
+ *
+ * <p>This is the building block used by the archive precondition (see
+ * issue #18783) and the {@code hudi-cli} repair tool. It does not delete
+ * anything; callers decide what to do with the returned paths.
+ *
+ * <p>Two detection modes are supported:
+ * <ul>
+ *   <li>{@link Mode#LIGHT} — reads {@code HoodieRollbackMetadata} and returns
+ *       paths recorded in {@code failedDeleteFiles}. O(metadata size). Catches
+ *       files the rollback explicitly tried and failed to delete but misses
+ *       files that landed on storage <em>after</em> the rollback completed
+ *       (for example, a blocked storage {@code close()} returning late).</li>
+ *   <li>{@link Mode#THOROUGH} — additionally lists the partitions named in the
+ *       rollback metadata and matches filenames against the rollback's target
+ *       instant time(s). Catches post-rollback late landings. Bounded by the
+ *       partition count in the rollback metadata, not whole-table size.</li>
+ * </ul>
+ *
+ * <p>A safety floor cross-checks every candidate against the completed
+ * timeline: a file whose embedded instant appears as a {@code COMPLETED}
+ * commit in either the active or archived timeline is never flagged as an
+ * orphan, even if its filename matches the regex.
+ */
+public class RollbackOrphanDetector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RollbackOrphanDetector.class);
+
+  /** Matches Hudi base/log filenames carrying an embedded instant time at the trailing position. */
+  private static final String INSTANT_REGEX_BASE = "_(\\d+)\\.parquet$";
+  private static final String INSTANT_REGEX_LOG = "\\.log\\.\\d+_(\\d+)(?:_[^/]*)?$";
+
+  /** Detection mode controlling how aggressively we look for orphans. */
+  public enum Mode {
+    OFF,
+    LIGHT,
+    THOROUGH;
+
+    public static Mode parse(String value) {
+      if (value == null || value.isEmpty()) {
+        return OFF;
+      }
+      try {
+        return Mode.valueOf(value.trim().toUpperCase());
+      } catch (IllegalArgumentException e) {
+        LOG.warn("Unknown RollbackOrphanDetector mode '{}'; falling back to OFF", value);
+        return OFF;
+      }
+    }
+  }
+
+  /**
+   * Returns true iff any orphan files are detected for {@code rollbackInstant}.
+   * Optimised to short-circuit as soon as the first orphan is found in
+   * {@link Mode#THOROUGH}.
+   */
+  public boolean hasOrphans(HoodieTable<?, ?, ?, ?> table,
+                            HoodieInstant rollbackInstant,
+                            Mode mode) throws IOException {
+    return hasOrphans(table.getMetaClient(), rollbackInstant, mode);
+  }
+
+  /** Overload usable from contexts that only have a metaClient (e.g. {@code hudi-cli}). */
+  public boolean hasOrphans(HoodieTableMetaClient metaClient,
+                            HoodieInstant rollbackInstant,
+                            Mode mode) throws IOException {
+    if (mode == Mode.OFF) {
+      return false;
+    }
+    return !detectOrphans(metaClient, rollbackInstant, mode).isEmpty();
+  }
+
+  /**
+   * Returns the set of orphan file paths (absolute) still on storage for
+   * {@code rollbackInstant}. Empty if no orphans or {@code mode == OFF}.
+   */
+  public Set<String> detectOrphans(HoodieTable<?, ?, ?, ?> table,
+                                   HoodieInstant rollbackInstant,
+                                   Mode mode) throws IOException {
+    return detectOrphans(table.getMetaClient(), rollbackInstant, mode);
+  }
+
+  /** Overload usable from contexts that only have a metaClient (e.g. {@code hudi-cli}). */
+  public Set<String> detectOrphans(HoodieTableMetaClient metaClient,
+                                   HoodieInstant rollbackInstant,
+                                   Mode mode) throws IOException {
+    if (mode == Mode.OFF) {
+      return Collections.emptySet();
+    }
+    if (!rollbackInstant.getAction().equals(HoodieTimeline.ROLLBACK_ACTION)
+        || !rollbackInstant.isCompleted()) {
+      return Collections.emptySet();
+    }
+
+    HoodieRollbackMetadata metadata =
+        metaClient.getActiveTimeline().readRollbackMetadata(rollbackInstant);
+    Set<String> orphans = new LinkedHashSet<>(collectFailedDeleteFiles(metadata));
+
+    if (mode == Mode.LIGHT) {
+      return filterAgainstCompletedTimeline(metaClient, orphans, extractTargetInstants(metadata));
+    }
+
+    Set<String> targetInstants = extractTargetInstants(metadata);
+    if (targetInstants.isEmpty() || metadata.getPartitionMetadata() == null) {
+      return filterAgainstCompletedTimeline(metaClient, orphans, targetInstants);
+    }
+    Pattern[] patterns = buildPatterns(targetInstants);
+    HoodieStorage storage = metaClient.getStorage();
+    StoragePath basePath = metaClient.getBasePath();
+    for (String partitionPath : metadata.getPartitionMetadata().keySet()) {
+      orphans.addAll(scanPartition(storage, basePath, partitionPath, patterns));
+    }
+    return filterAgainstCompletedTimeline(metaClient, orphans, targetInstants);
+  }
+
+  private static Set<String> collectFailedDeleteFiles(HoodieRollbackMetadata metadata) {
+    if (metadata == null || metadata.getPartitionMetadata() == null) {
+      return Collections.emptySet();
+    }
+    Set<String> failed = new LinkedHashSet<>();
+    for (HoodieRollbackPartitionMetadata pm : metadata.getPartitionMetadata().values()) {
+      List<String> ff = pm.getFailedDeleteFiles();
+      if (ff != null) {
+        failed.addAll(ff);
+      }
+    }
+    return failed;
+  }
+
+  /** Returns target-instant times from either the typed or legacy field. */
+  static Set<String> extractTargetInstants(HoodieRollbackMetadata metadata) {
+    if (metadata == null) {
+      return Collections.emptySet();
+    }
+    Set<String> out = new HashSet<>();
+    List<HoodieInstantInfo> typed = metadata.getInstantsRollback();
+    if (typed != null) {
+      for (HoodieInstantInfo info : typed) {
+        if (info != null && info.getCommitTime() != null) {
+          out.add(info.getCommitTime());
+        }
+      }
+    }
+    List<String> legacy = metadata.getCommitsRollback();
+    if (legacy != null) {
+      out.addAll(legacy);
+    }
+    return out;
+  }
+
+  private static Pattern[] buildPatterns(Set<String> targetInstants) {
+    String alt = String.join("|", targetInstants);
+    return new Pattern[] {
+        Pattern.compile("_(" + alt + ")\\.parquet$"),
+        Pattern.compile("\\.log\\.\\d+_(" + alt + ")(?:_[^/]*)?$")
+    };
+  }
+
+  private static Set<String> scanPartition(HoodieStorage storage,
+                                           StoragePath basePath,
+                                           String partitionPath,
+                                           Pattern[] patterns) throws IOException {
+    StoragePath dir = partitionPath == null || partitionPath.isEmpty()
+        ? basePath
+        : new StoragePath(basePath, partitionPath);
+    if (!storage.exists(dir)) {
+      return Collections.emptySet();
+    }
+    Set<String> hits = new LinkedHashSet<>();
+    for (StoragePathInfo info : storage.listDirectEntries(dir)) {
+      if (!info.isFile()) {
+        continue;
+      }
+      String name = info.getPath().getName();
+      for (Pattern p : patterns) {
+        if (p.matcher(name).find()) {
+          hits.add(info.getPath().toString());
+          break;
+        }
+      }
+    }
+    return hits;
+  }
+
+  /**
+   * Safety floor: removes any candidate whose embedded instant time matches a
+   * COMPLETED commit anywhere in the active or archived timeline. Prevents
+   * false-positive flagging of legitimate committed files that happen to
+   * share a filename pattern.
+   */
+  private static Set<String> filterAgainstCompletedTimeline(HoodieTableMetaClient metaClient,
+                                                            Set<String> candidates,
+                                                            Set<String> targetInstants) {
+    if (candidates.isEmpty()) {
+      return Collections.emptySet();
+    }
+    Set<String> completedInstants = new HashSet<>();
+    metaClient.getActiveTimeline().filterCompletedInstants().getInstantsAsStream()
+        .map(HoodieInstant::requestedTime).forEach(completedInstants::add);
+    // Archived timeline lookup is intentionally not loaded here — it can be
+    // expensive on tables with long history. Callers needing a stricter
+    // check can extend this to also consult the archived timeline.
+    Set<String> filtered = new LinkedHashSet<>();
+    for (String path : candidates) {
+      String embedded = extractEmbeddedInstant(path);
+      if (embedded != null && completedInstants.contains(embedded)) {
+        // Legitimate committed file — never flag.
+        continue;
+      }
+      if (embedded != null && !targetInstants.isEmpty() && !targetInstants.contains(embedded)) {
+        // Embedded instant is not one of this rollback's targets — out of scope.
+        continue;
+      }
+      filtered.add(path);
+    }
+    return filtered;
+  }
+
+  private static String extractEmbeddedInstant(String path) {
+    String name = path.substring(path.lastIndexOf('/') + 1);
+    java.util.regex.Matcher m = Pattern.compile(INSTANT_REGEX_BASE).matcher(name);
+    if (m.find()) {
+      return m.group(1);
+    }
+    m = Pattern.compile(INSTANT_REGEX_LOG).matcher(name);
+    if (m.find()) {
+      return m.group(1);
+    }
+    return null;
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackOrphanDetector.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackOrphanDetector.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.rollback;
+
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.storage.StoragePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestRollbackOrphanDetector extends HoodieRollbackTestBase {
+
+  private static final String FAILED_INSTANT = "20260101000000000";
+  private static final String OTHER_INSTANT  = "20260102000000000";
+  private static final String PARTITION = "2026/01/01";
+  private static final String FILE_ID = "11111111-2222-3333-4444-555555555555-0";
+
+  private final RollbackOrphanDetector detector = new RollbackOrphanDetector();
+
+  @Test
+  public void modeOff_returnsEmpty_evenWithFailedDeleteFiles() throws IOException {
+    HoodieInstant rollback = stubRollbackInstant(rollbackMetadata(Arrays.asList("foo.parquet")));
+    assertTrue(detector.detectOrphans(table, rollback, RollbackOrphanDetector.Mode.OFF).isEmpty());
+    assertFalse(detector.hasOrphans(table, rollback, RollbackOrphanDetector.Mode.OFF));
+  }
+
+  @Test
+  public void modeLight_emptyFailedList_returnsEmpty() throws IOException {
+    HoodieInstant rollback = stubRollbackInstant(rollbackMetadata(Collections.emptyList()));
+    when(timeline.filterCompletedInstants()).thenReturn(timeline);
+    when(timeline.getInstantsAsStream()).thenReturn(java.util.stream.Stream.empty());
+    assertTrue(detector.detectOrphans(table, rollback, RollbackOrphanDetector.Mode.LIGHT).isEmpty());
+  }
+
+  @Test
+  public void modeLight_returnsFailedDeleteFiles_filteredByCompletedTimeline() throws IOException {
+    String orphanName = orphanBaseName(FILE_ID, FAILED_INSTANT);
+    String legitName = orphanBaseName(FILE_ID, OTHER_INSTANT);
+    List<String> failed = Arrays.asList(orphanName, legitName);
+    HoodieInstant rollback = stubRollbackInstant(rollbackMetadata(failed));
+    stubCompletedInstants(OTHER_INSTANT);
+
+    Set<String> orphans = detector.detectOrphans(table, rollback, RollbackOrphanDetector.Mode.LIGHT);
+    assertEquals(1, orphans.size());
+    assertTrue(orphans.iterator().next().endsWith(orphanName));
+  }
+
+  @Test
+  public void modeThorough_findsLateLandingFile_notInFailedDeleteList() throws IOException {
+    StoragePath orphan = createBaseFileToRollback(PARTITION, FILE_ID, FAILED_INSTANT);
+    HoodieInstant rollback = stubRollbackInstant(
+        rollbackMetadataWithPartition(Collections.emptyList(), PARTITION));
+    stubCompletedInstants();
+
+    Set<String> orphans = detector.detectOrphans(table, rollback, RollbackOrphanDetector.Mode.THOROUGH);
+    assertEquals(1, orphans.size());
+    assertTrue(orphans.iterator().next().endsWith(orphan.getName()));
+  }
+
+  @Test
+  public void modeThorough_skipsLegitimateCommittedFile_evenWhenFilenameMatches() throws IOException {
+    createBaseFileToRollback(PARTITION, FILE_ID, OTHER_INSTANT);
+    HoodieInstant rollback = stubRollbackInstant(
+        rollbackMetadataWithPartition(Collections.emptyList(), PARTITION));
+    stubCompletedInstants(OTHER_INSTANT);
+
+    Set<String> orphans = detector.detectOrphans(table, rollback, RollbackOrphanDetector.Mode.THOROUGH);
+    assertTrue(orphans.isEmpty(), "Legitimate committed file must not be flagged as orphan");
+  }
+
+  // ---- helpers ----
+
+  private HoodieInstant stubRollbackInstant(HoodieRollbackMetadata meta) throws IOException {
+    HoodieInstant rollback = mock(HoodieInstant.class);
+    when(rollback.getAction()).thenReturn(HoodieTimeline.ROLLBACK_ACTION);
+    when(rollback.isCompleted()).thenReturn(true);
+    when(rollback.requestedTime()).thenReturn("20260101010101010");
+    when(timeline.readRollbackMetadata(any(HoodieInstant.class))).thenReturn(meta);
+    return rollback;
+  }
+
+  private void stubCompletedInstants(String... instantTimes) {
+    when(timeline.filterCompletedInstants()).thenReturn(timeline);
+    List<HoodieInstant> instants = new ArrayList<>();
+    for (String t : instantTimes) {
+      HoodieInstant i = mock(HoodieInstant.class);
+      when(i.requestedTime()).thenReturn(t);
+      instants.add(i);
+    }
+    when(timeline.getInstantsAsStream()).thenReturn(instants.stream());
+  }
+
+  private HoodieRollbackMetadata rollbackMetadata(List<String> failedDeleteFiles) {
+    return rollbackMetadataWithPartition(failedDeleteFiles, PARTITION);
+  }
+
+  private HoodieRollbackMetadata rollbackMetadataWithPartition(List<String> failedDeleteFiles, String partition) {
+    HoodieRollbackPartitionMetadata pm = HoodieRollbackPartitionMetadata.newBuilder()
+        .setPartitionPath(partition)
+        .setSuccessDeleteFiles(Collections.emptyList())
+        .setFailedDeleteFiles(new ArrayList<>(failedDeleteFiles))
+        .build();
+    Map<String, HoodieRollbackPartitionMetadata> pmMap = new HashMap<>();
+    pmMap.put(partition, pm);
+    return HoodieRollbackMetadata.newBuilder()
+        .setStartRollbackTime("20260101010101010")
+        .setTimeTakenInMillis(0L)
+        .setTotalFilesDeleted(0)
+        .setCommitsRollback(Collections.singletonList(FAILED_INSTANT))
+        .setPartitionMetadata(pmMap)
+        .build();
+  }
+
+  private static String orphanBaseName(String fileId, String instantTime) {
+    return fileId + "_1-2-3_" + instantTime + ".parquet";
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

See issue #18783 for the full problem statement. In summary: when a rollback partially fails (crash mid-rollback, marker loss, or a blocked storage `close()` that lands data **after** rollback completed) and the rollback instant is later archived, the system loses the metadata anchor that lets readers filter out the orphan files. Readers then return corrupt-parquet errors or duplicate records — a hard violation of the reader/writer isolation guarantee.

This PR is the foundation for an archive-time precondition check that prevents that loss-of-anchor scenario. It introduces a `RollbackOrphanDetector` and a feature-flag config; the actual wiring into the archive planner is a follow-up cascade PR. **No behavior change yet.**

Related:
- Cascade PR (wires the detector in): `feat/rollback-orphan-archive-precondition` on the fork; will be opened after this merges
- Companion CLI PR: `feat/rollback-orphan-repair-cli` on the fork; will be opened after this merges

### Summary and Changelog

A new `RollbackOrphanDetector` utility plus the config that will eventually gate archival of rollback instants when their orphan files are still on storage. No behavior change yet — the config defaults to `OFF`.

1. New `RollbackOrphanDetector` in `hudi-client/hudi-client-common` under `org.apache.hudi.table.action.rollback`. Two detection modes:
   - `LIGHT` — reads `HoodieRollbackMetadata.failedDeleteFiles`. O(metadata size). Catches files the rollback explicitly tried and failed to delete but misses post-rollback late landings.
   - `THOROUGH` — additionally lists the partitions named in the rollback metadata and matches filenames against the rollback's target instant time(s) (both base parquet and MoR log file naming). Bounded by partition count in the rollback metadata, not whole-table size.
2. Safety floor: every candidate is cross-checked against completed instants in the active timeline — a file whose embedded instant is a `COMPLETED` commit is never flagged as an orphan, even if its filename matches the regex.
3. New config `hoodie.archive.rollback.orphan.guard.mode` (values `OFF` / `LIGHT` / `THOROUGH`, **default `OFF`**) and a getter on `HoodieWriteConfig`.
4. Two overloads: `(HoodieTable, HoodieInstant, Mode)` for the archive planner context and `(HoodieTableMetaClient, HoodieInstant, Mode)` for the `hudi-cli` context that follows in PR3.
5. `TestRollbackOrphanDetector` with 5 tests covering `OFF`, `LIGHT` with empty/non-empty `failedDeleteFiles`, `THOROUGH` with a real partition listing, and the safety-floor case.

### Impact

None until the new config is set to `LIGHT` or `THOROUGH`. The default `OFF` short-circuits before any work happens.

### Risk Level

low

### Documentation Update

A user-facing config doc update is appropriate once the cascade PR (which actually wires the detector in) lands — that's the change users would actually flip. This PR is plumbing only.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
