### PR TITLE
chore: add spark4.1 and flink2.1 profile entries to RC bundle validation

### DIFF
--- a/.github/workflows/release_candidate_validation.yml
+++ b/.github/workflows/release_candidate_validation.yml
@@ -77,6 +77,10 @@ jobs:
             flinkProfile: 'flink1.20'
             sparkProfile: 'spark4.0'
             sparkRuntime: 'spark4.0.0'
+          - scalaProfile: 'scala-2.13'
+            flinkProfile: 'flink1.20'
+            sparkProfile: 'spark4.1'
+            sparkRuntime: 'spark4.1.1'
     steps:
       - uses: actions/checkout@v5
       - name: Set up JDK 17
@@ -106,6 +110,10 @@ jobs:
         include:
           - scalaProfile: 'scala-2.12'
             flinkProfile: 'flink2.0'
+            sparkProfile: 'spark3.5'
+            sparkRuntime: 'spark3.5.1'
+          - scalaProfile: 'scala-2.12'
+            flinkProfile: 'flink2.1'
             sparkProfile: 'spark3.5'
             sparkRuntime: 'spark3.5.1'
     steps:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The RC bundle validation workflow is missing matrix entries for newly supported `spark4.1` and `flink2.1` profiles, so those bundles aren't exercised during release validation.

### Summary and Changelog

Adds a `spark4.1` (scala-2.13, flink1.20, spark4.1.1) entry to `validate-release-candidate-bundles-spark4` and a `flink2.1` (scala-2.12, spark3.5.1) entry to `validate-release-candidate-bundles-flink2`.

### Impact

CI-only change to the release candidate validation matrix; no user-facing impact.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable