### PR TITLE
feat(utilities): propagate per-partition event-time watermarks from upstream Hudi sources

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -951,6 +951,18 @@ public class HoodieWriteConfig extends HoodieConfig {
       .sinceVersion("1.1.0")
       .withDocumentation("Records event time watermark metadata in commit metadata when enabled");
 
+  public static final ConfigProperty<Boolean> TRACK_EVENT_TIME_PROPAGATE_FROM_UPSTREAM = ConfigProperty
+      .key("hoodie.write.track.event.time.propagate.from.upstream")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("When enabled, sources that read from an upstream Hudi table (e.g. HoodieIncrSource) "
+          + "propagate the upstream commit(s)' per-partition min/max event time into the downstream commit's "
+          + "per-partition write stats. This lets derived tables inherit freshness without retaining the "
+          + "event-time column in their schema. The propagation folds with any per-record event-time value "
+          + "via Math.min / Math.max, so it never regresses a value already set by the per-record path. "
+          + "Has no effect unless the upstream table itself was written with hoodie.write.track.event.time.watermark=true.");
+
   public static final ConfigProperty<String> MERGE_HANDLE_CLASS_NAME = ConfigProperty
       .key("hoodie.write.merge.handle.class")
       .defaultValue(FileGroupReaderBasedMergeHandle.class.getName())

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -175,6 +175,15 @@ public class ConfigUtils {
   }
 
   /**
+   * Check if per-partition event-time watermarks should be propagated from the upstream
+   * Hudi source's commit metadata into the downstream commit. Has no effect unless the
+   * upstream table itself was written with watermark tracking enabled.
+   */
+  public static boolean isPropagatingEventTimeFromUpstream(TypedProperties props) {
+    return props.getBoolean("hoodie.write.track.event.time.propagate.from.upstream", false);
+  }
+
+  /**
    * Check if logical timestamp should be made consistent.
    */
   public static boolean shouldKeepConsistentLogicalTimestamp(TypedProperties props) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/HoodieIncrSource.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
 import org.apache.hudi.common.table.checkpoint.CheckpointUtils;
@@ -33,9 +34,11 @@ import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.table.read.IncrementalQueryAnalyzer;
 import org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.QueryContext;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineLayout;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.collection.Pair;
@@ -46,6 +49,7 @@ import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper;
 import org.apache.hudi.utilities.sources.helpers.IncrSourceHelper.MissingCheckpointStrategy;
 import org.apache.hudi.utilities.sources.helpers.QueryInfo;
+import org.apache.hudi.utilities.sources.helpers.UpstreamEventTimeWatermarkExtractor;
 import org.apache.hudi.utilities.streamer.SourceProfile;
 import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 import org.apache.hudi.utilities.streamer.StreamContext;
@@ -163,6 +167,18 @@ public class HoodieIncrSource extends RowSource {
 
   private final Map<String, String> readOpts = new HashMap<>();
 
+  /**
+   * Per-partition (min, max) event time propagated from the upstream Hudi commits read in the
+   * most recent {@link #fetchNextBatch} call. Populated when
+   * {@code hoodie.write.track.event.time.propagate.from.upstream} is enabled and the upstream
+   * commits being read carry per-stat event-time metadata (i.e. were written with
+   * {@code hoodie.write.track.event.time.watermark=true}). Empty otherwise.
+   *
+   * <p>Reset to empty at the start of each {@code fetchNextBatch} call and read by the streamer
+   * via {@link #getUpstreamEventTimeWatermarks()} when constructing the InputBatch.
+   */
+  private transient Map<String, Pair<Long, Long>> upstreamEventTimeWatermarks = Collections.emptyMap();
+
   public HoodieIncrSource(TypedProperties props, JavaSparkContext sparkContext, SparkSession sparkSession,
                           StreamContext streamContext) {
     this(props, sparkContext, sparkSession, null, streamContext);
@@ -200,6 +216,9 @@ public class HoodieIncrSource extends RowSource {
 
   @Override
   public Pair<Option<Dataset<Row>>, Checkpoint> fetchNextBatch(Option<Checkpoint> lastCheckpoint, long sourceLimit) {
+    // Reset between batches so a previous batch's watermarks never leak forward when the current
+    // batch has no new commits to read.
+    this.upstreamEventTimeWatermarks = Collections.emptyMap();
     String srcPath = getStringWithAltKeys(props, HoodieIncrSourceConfig.HOODIE_SRC_BASE_PATH);
     HoodieTableVersion sourceTableVersion = HoodieTableConfig.loadFromHoodieProps(
         HoodieStorageUtils.getStorage(srcPath, HadoopFSUtils.getStorageConf(sparkContext.hadoopConfiguration())), srcPath).getTableVersion();
@@ -208,6 +227,11 @@ public class HoodieIncrSource extends RowSource {
     } else {
       return fetchNextBatchBasedOnRequestedTime(lastCheckpoint, sourceLimit);
     }
+  }
+
+  @Override
+  public Map<String, Pair<Long, Long>> getUpstreamEventTimeWatermarks() {
+    return upstreamEventTimeWatermarks;
   }
 
   private Pair<Option<Dataset<Row>>, Checkpoint> fetchNextBatchBasedOnCompletionTime(
@@ -340,6 +364,9 @@ public class HoodieIncrSource extends RowSource {
       metricsOption.ifPresent(metrics -> metrics.updateStreamerSourceParallelism(sourceProfile.getSourcePartitions()));
       return coalesceOrRepartition(sourceWithMetaColumnsDropped, sourceProfile.getSourcePartitions());
     }).orElse(sourceWithMetaColumnsDropped);
+
+    maybeExtractUpstreamWatermarksCompletionTime(queryContext, endCompletionTime);
+
     return Pair.of(Option.of(src), new StreamerCheckpointV2(endCompletionTime));
   }
 
@@ -439,11 +466,69 @@ public class HoodieIncrSource extends RowSource {
       metricsOption.ifPresent(metrics -> metrics.updateStreamerSourceParallelism(sourceProfile.getSourcePartitions()));
       return coalesceOrRepartition(sourceWithMetaColumnsDropped, sourceProfile.getSourcePartitions());
     }).orElse(sourceWithMetaColumnsDropped);
+
+    maybeExtractUpstreamWatermarksRequestTime(srcPath, queryInfo.getStartInstant(), queryInfo.getEndInstant());
+
     return Pair.of(Option.of(src), new StreamerCheckpointV1(queryInfo.getEndInstant()));
   }
 
   // Try to fetch the latestSourceProfile, this ensures the profile is refreshed if it's no longer valid.
   private Option<SourceProfile<Integer>> getLatestSourceProfile() {
     return sourceProfileSupplier.map(SourceProfileSupplier::getSourceProfile);
+  }
+
+  private void maybeExtractUpstreamWatermarksCompletionTime(QueryContext queryContext, String endCompletionTime) {
+    if (!ConfigUtils.isPropagatingEventTimeFromUpstream(props)) {
+      return;
+    }
+    if (StringUtils.isNullOrEmpty(endCompletionTime)) {
+      return;
+    }
+    List<HoodieInstant> instants = queryContext.getInstants().stream()
+        .filter(i -> compareTimestamps(i.getCompletionTime(), LESSER_THAN_OR_EQUALS, endCompletionTime))
+        .collect(Collectors.toList());
+    if (instants.isEmpty()) {
+      return;
+    }
+    this.upstreamEventTimeWatermarks = UpstreamEventTimeWatermarkExtractor
+        .extractPerPartitionWatermarks(queryContext.getActiveTimeline(), instants);
+    if (!this.upstreamEventTimeWatermarks.isEmpty()) {
+      log.info("Propagating upstream event-time watermarks for {} partition(s) from {} commit(s)",
+          this.upstreamEventTimeWatermarks.size(), instants.size());
+    }
+  }
+
+  private void maybeExtractUpstreamWatermarksRequestTime(String srcPath, String startInstant, String endInstant) {
+    if (!ConfigUtils.isPropagatingEventTimeFromUpstream(props)) {
+      return;
+    }
+    if (StringUtils.isNullOrEmpty(endInstant)) {
+      return;
+    }
+    String startExclusive = StringUtils.isNullOrEmpty(startInstant) ? "" : startInstant;
+    try {
+      HoodieTableMetaClient srcMetaClient = HoodieTableMetaClient.builder()
+          .setConf(HadoopFSUtils.getStorageConfWithCopy(sparkContext.hadoopConfiguration()))
+          .setBasePath(srcPath)
+          .setLoadActiveTimelineOnLoad(true)
+          .build();
+      HoodieTimeline completedCommits = srcMetaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
+      // Match the incremental query's (start, end] semantics: include commits whose requestedTime
+      // is strictly greater than start and less than or equal to end.
+      List<HoodieInstant> instants = completedCommits.findInstantsInClosedRange(startExclusive, endInstant)
+          .getInstantsAsStream()
+          .filter(i -> startExclusive.isEmpty() || !i.requestedTime().equals(startExclusive))
+          .collect(Collectors.toList());
+      this.upstreamEventTimeWatermarks = UpstreamEventTimeWatermarkExtractor
+          .extractPerPartitionWatermarks(completedCommits, instants);
+      if (!this.upstreamEventTimeWatermarks.isEmpty()) {
+        log.info("Propagating upstream event-time watermarks for {} partition(s) from {} commit(s)",
+            this.upstreamEventTimeWatermarks.size(), instants.size());
+      }
+    } catch (Exception e) {
+      // Don't fail the source if watermark extraction has trouble; propagation is best-effort.
+      log.warn("Failed to extract upstream event-time watermarks (request-time path) from {} ({}..{}]: {}",
+          srcPath, startExclusive, endInstant, e.getMessage());
+    }
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/InputBatch.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/InputBatch.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
 import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 
@@ -30,6 +31,9 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.spark.api.java.JavaSparkContext;
+
+import java.util.Collections;
+import java.util.Map;
 
 @AllArgsConstructor
 @Getter
@@ -39,9 +43,22 @@ public class InputBatch<T> {
   private final Checkpoint checkpointForNextBatch;
   @Getter(AccessLevel.NONE)
   private final SchemaProvider schemaProvider;
+  /**
+   * Per-partition (min, max) event time propagated from upstream Hudi commits when the source
+   * supports it and the user opts in via
+   * {@code hoodie.write.track.event.time.propagate.from.upstream}. Empty otherwise.
+   *
+   * <p>Folded into the downstream commit's per-partition write stats by the streamer before
+   * commit; see {@code StreamSync#buildUpstreamWatermarkPreCommitFunc}.
+   */
+  private final Map<String, Pair<Long, Long>> upstreamEventTimeWatermarks;
+
+  public InputBatch(Option<T> batch, Checkpoint checkpointForNextBatch, SchemaProvider schemaProvider) {
+    this(batch, checkpointForNextBatch, schemaProvider, Collections.emptyMap());
+  }
 
   public InputBatch(Option<T> batch, String checkpointForNextBatch, SchemaProvider schemaProvider) {
-    this(batch, new StreamerCheckpointV2(checkpointForNextBatch), schemaProvider);
+    this(batch, new StreamerCheckpointV2(checkpointForNextBatch), schemaProvider, Collections.emptyMap());
   }
 
   public InputBatch(Option<T> batch, String checkpointForNextBatch) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/RowSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/RowSource.java
@@ -66,7 +66,7 @@ public abstract class RowSource extends Source<Dataset<Row>> {
       SchemaProvider rowSchemaProvider = UtilHelpers.createRowBasedSchemaProvider(datasetSchema, props, sparkContext);
       Dataset<Row> wrappedDf = HoodieSparkUtils.maybeWrapDataFrameWithException(sanitizedRows, HoodieReadFromSourceException.class.getName(),
           "Failed to read from row source", ConfigUtils.getBooleanWithAltKeys(props, ROW_THROW_EXPLICIT_EXCEPTIONS));
-      return new InputBatch<>(Option.of(wrappedDf), res.getValue(), rowSchemaProvider);
-    }).orElseGet(() -> new InputBatch<>(res.getKey(), res.getValue()));
+      return new InputBatch<>(Option.of(wrappedDf), res.getValue(), rowSchemaProvider, getUpstreamEventTimeWatermarks());
+    }).orElseGet(() -> new InputBatch<>(res.getKey(), res.getValue(), null, getUpstreamEventTimeWatermarks()));
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
@@ -29,6 +29,7 @@ import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Either;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.utilities.callback.SourceCommitCallback;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.streamer.DefaultStreamContext;
@@ -46,6 +47,8 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.storage.StorageLevel;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.apache.hudi.common.table.checkpoint.CheckpointUtils.shouldTargetCheckpointV2;
 import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD;
@@ -212,5 +215,23 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
     } else if (cachedSourceRdd != null && cachedSourceRdd.isRight()) {
       cachedSourceRdd.asRight().unpersist();
     }
+  }
+
+  /**
+   * Per-partition (min, max) event time propagated from the most recently fetched upstream batch,
+   * for sources that read from a Hudi table and opted into
+   * {@code hoodie.write.track.event.time.propagate.from.upstream}.
+   *
+   * <p>The downstream streamer folds these values into the per-partition write stats of the
+   * downstream commit via {@code BaseHoodieWriteClient}'s {@code extraPreCommitFunc} hook, so
+   * derived tables inherit upstream freshness without retaining the event-time column.
+   *
+   * <p>Default implementation returns an empty map (no propagation). Concrete sources override
+   * when they have batch-scoped upstream watermark data to propagate. Always reflects the latest
+   * call to {@link #fetchNext}.
+   */
+  @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)
+  public Map<String, Pair<Long, Long>> getUpstreamEventTimeWatermarks() {
+    return Collections.emptyMap();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/UpstreamEventTimeWatermarkExtractor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/UpstreamEventTimeWatermarkExtractor.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Aggregates per-partition min/max event time across a set of upstream Hudi commits, using the
+ * per-partition rollup exposed on {@link HoodieCommitMetadata#getMinAndMaxEventTimePerPartition()}.
+ *
+ * <p>Used by Hudi sources (e.g. {@code HoodieIncrSource}) to propagate upstream freshness into the
+ * downstream commit's write stats when
+ * {@code hoodie.write.track.event.time.propagate.from.upstream} is enabled.
+ *
+ * <p>Fold semantics per partition:
+ * <ul>
+ *   <li>min event time: {@code Math.min} across all upstream commits' per-partition mins</li>
+ *   <li>max event time: {@code Math.max} across all upstream commits' per-partition maxes</li>
+ * </ul>
+ *
+ * <p>Commits whose per-partition rollup is empty (upstream did not track watermark, or carried no
+ * event-time-bearing write stats) contribute nothing. A partition with no signal in any commit is
+ * omitted from the returned map.
+ */
+@Slf4j
+public final class UpstreamEventTimeWatermarkExtractor {
+
+  private UpstreamEventTimeWatermarkExtractor() {
+  }
+
+  /**
+   * Folds per-partition min/max event time across the supplied commits.
+   *
+   * @param timeline       active commits timeline of the upstream table
+   * @param commitInstants instants to fold (must be {@code COMMIT} or {@code DELTA_COMMIT} actions
+   *                       that are present on {@code timeline}); pass an empty collection to get
+   *                       back an empty map
+   * @return partition path → (min, max) event time in millis. Partitions with no event-time signal
+   *         across the supplied commits are omitted.
+   */
+  public static Map<String, Pair<Long, Long>> extractPerPartitionWatermarks(
+      HoodieTimeline timeline,
+      Collection<HoodieInstant> commitInstants) {
+    if (commitInstants == null || commitInstants.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, Pair<Long, Long>> result = new HashMap<>();
+    for (HoodieInstant instant : commitInstants) {
+      HoodieCommitMetadata commitMetadata;
+      try {
+        commitMetadata = timeline.readCommitMetadata(instant);
+      } catch (Exception e) {
+        // Don't fail the source if a single commit's metadata can't be read; propagation is
+        // best-effort observability.
+        log.warn("Skipping upstream commit {} while extracting per-partition event-time watermarks: {}",
+            instant, e.getMessage());
+        continue;
+      }
+      Map<String, Pair<Option<Long>, Option<Long>>> perPartition =
+          commitMetadata.getMinAndMaxEventTimePerPartition();
+      for (Map.Entry<String, Pair<Option<Long>, Option<Long>>> entry : perPartition.entrySet()) {
+        Option<Long> upstreamMin = entry.getValue().getLeft();
+        Option<Long> upstreamMax = entry.getValue().getRight();
+        if (!upstreamMin.isPresent() && !upstreamMax.isPresent()) {
+          continue;
+        }
+        result.compute(entry.getKey(), (partition, existing) -> fold(existing, upstreamMin, upstreamMax));
+      }
+    }
+    return result;
+  }
+
+  private static Pair<Long, Long> fold(Pair<Long, Long> existing, Option<Long> upstreamMin, Option<Long> upstreamMax) {
+    Long existingMin = existing == null ? null : existing.getLeft();
+    Long existingMax = existing == null ? null : existing.getRight();
+    Long newMin = foldMin(existingMin, upstreamMin.orElse(null));
+    Long newMax = foldMax(existingMax, upstreamMax.orElse(null));
+    return Pair.of(newMin, newMax);
+  }
+
+  private static Long foldMin(Long a, Long b) {
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return Math.min(a, b);
+  }
+
+  private static Long foldMax(Long a, Long b) {
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return Math.max(a, b);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -42,10 +42,12 @@ import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.model.DefaultHoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
@@ -145,6 +147,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -902,7 +905,8 @@ public class StreamSync implements Serializable, Closeable {
               checkpointCommitMetadata, metaClient);
         }
 
-        success = writeClient.commit(instantTime, writeStatusRDD, Option.of(checkpointCommitMetadata), commitActionType, partitionToReplacedFileIds, Option.empty(),
+        success = writeClient.commit(instantTime, writeStatusRDD, Option.of(checkpointCommitMetadata), commitActionType, partitionToReplacedFileIds,
+            buildUpstreamWatermarkPreCommitFunc(inputBatch.getUpstreamEventTimeWatermarks()),
             Option.of(writeStatusValidator));
       } finally {
         if (shouldUnpersist) {
@@ -1380,6 +1384,43 @@ public class StreamSync implements Serializable, Closeable {
     } catch (IOException e) {
       throw new HoodieIOException("Failed to load meta client", e);
     }
+  }
+
+  /**
+   * Build a {@link BiConsumer} pre-commit hook that folds source-propagated per-partition (min,
+   * max) event-time watermarks into the per-partition write stats of the about-to-be-committed
+   * downstream {@link HoodieCommitMetadata}.
+   *
+   * <p>Uses {@link HoodieWriteStat#setMinEventTime(Long)} / {@link HoodieWriteStat#setMaxEventTime(Long)},
+   * which do null-aware {@code Math.min} / {@code Math.max} folds. Per-record values set during
+   * write therefore win over propagated values when more extreme, and propagation only fills
+   * in fields the per-record path left unset. Returns {@code Option.empty()} when there is
+   * nothing to propagate (most common case), keeping the existing commit path unchanged.
+   */
+  @VisibleForTesting
+  static Option<BiConsumer<HoodieTableMetaClient, HoodieCommitMetadata>> buildUpstreamWatermarkPreCommitFunc(
+      Map<String, Pair<Long, Long>> upstreamWatermarks) {
+    if (upstreamWatermarks == null || upstreamWatermarks.isEmpty()) {
+      return Option.empty();
+    }
+    return Option.of((HoodieTableMetaClient metaClient, HoodieCommitMetadata metadata) -> {
+      for (Map.Entry<String, List<HoodieWriteStat>> entry : metadata.getPartitionToWriteStats().entrySet()) {
+        Pair<Long, Long> upstream = upstreamWatermarks.get(entry.getKey());
+        if (upstream == null) {
+          continue;
+        }
+        Long min = upstream.getLeft();
+        Long max = upstream.getRight();
+        for (HoodieWriteStat stat : entry.getValue()) {
+          if (min != null) {
+            stat.setMinEventTime(min);
+          }
+          if (max != null) {
+            stat.setMaxEventTime(max);
+          }
+        }
+      }
+    });
   }
 
   class WriteClientWriteResult {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestUpstreamEventTimeWatermarkExtractor.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestUpstreamEventTimeWatermarkExtractor.java
@@ -29,12 +29,10 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestUpstreamEventTimeWatermarkExtractor.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestUpstreamEventTimeWatermarkExtractor.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.helpers;
+
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestUpstreamEventTimeWatermarkExtractor {
+
+  @Test
+  void emptyInstantCollectionReturnsEmptyMap() throws IOException {
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    Map<String, Pair<Long, Long>> result =
+        UpstreamEventTimeWatermarkExtractor.extractPerPartitionWatermarks(timeline, Collections.emptyList());
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void nullInstantCollectionReturnsEmptyMap() throws IOException {
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    Map<String, Pair<Long, Long>> result =
+        UpstreamEventTimeWatermarkExtractor.extractPerPartitionWatermarks(timeline, null);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void singleCommitWithEventTimePerPartitionRollsUp() throws IOException {
+    HoodieCommitMetadata commit = new HoodieCommitMetadata();
+    commit.addWriteStat("dt=2026-05-20", statWithEventTime(100L, 200L));
+    commit.addWriteStat("dt=2026-05-20", statWithEventTime(50L, 250L));
+    commit.addWriteStat("dt=2026-05-21", statWithEventTime(500L, 600L));
+
+    HoodieInstant instant = mock(HoodieInstant.class);
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    when(timeline.readCommitMetadata(any(HoodieInstant.class))).thenReturn(commit);
+
+    Map<String, Pair<Long, Long>> result =
+        UpstreamEventTimeWatermarkExtractor.extractPerPartitionWatermarks(timeline, Collections.singletonList(instant));
+
+    assertEquals(2, result.size());
+    assertEquals(Pair.of(50L, 250L), result.get("dt=2026-05-20"));
+    assertEquals(Pair.of(500L, 600L), result.get("dt=2026-05-21"));
+  }
+
+  @Test
+  void multipleCommitsAreFoldedAcross() throws IOException {
+    HoodieCommitMetadata commit1 = new HoodieCommitMetadata();
+    commit1.addWriteStat("dt=2026-05-20", statWithEventTime(100L, 200L));
+    HoodieCommitMetadata commit2 = new HoodieCommitMetadata();
+    commit2.addWriteStat("dt=2026-05-20", statWithEventTime(50L, 250L));
+    commit2.addWriteStat("dt=2026-05-21", statWithEventTime(500L, 600L));
+
+    HoodieInstant instant1 = mock(HoodieInstant.class);
+    HoodieInstant instant2 = mock(HoodieInstant.class);
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    when(timeline.readCommitMetadata(instant1)).thenReturn(commit1);
+    when(timeline.readCommitMetadata(instant2)).thenReturn(commit2);
+
+    Map<String, Pair<Long, Long>> result =
+        UpstreamEventTimeWatermarkExtractor.extractPerPartitionWatermarks(timeline, Arrays.asList(instant1, instant2));
+
+    assertEquals(Pair.of(50L, 250L), result.get("dt=2026-05-20"));
+    assertEquals(Pair.of(500L, 600L), result.get("dt=2026-05-21"));
+  }
+
+  @Test
+  void commitWithoutEventTimeIsSkipped() throws IOException {
+    HoodieCommitMetadata commitWithoutWatermark = new HoodieCommitMetadata();
+    commitWithoutWatermark.addWriteStat("dt=2026-05-20", new HoodieWriteStat());
+    HoodieCommitMetadata commitWithWatermark = new HoodieCommitMetadata();
+    commitWithWatermark.addWriteStat("dt=2026-05-20", statWithEventTime(100L, 200L));
+
+    HoodieInstant instant1 = mock(HoodieInstant.class);
+    HoodieInstant instant2 = mock(HoodieInstant.class);
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    when(timeline.readCommitMetadata(instant1)).thenReturn(commitWithoutWatermark);
+    when(timeline.readCommitMetadata(instant2)).thenReturn(commitWithWatermark);
+
+    Map<String, Pair<Long, Long>> result =
+        UpstreamEventTimeWatermarkExtractor.extractPerPartitionWatermarks(timeline, Arrays.asList(instant1, instant2));
+
+    assertEquals(1, result.size());
+    assertEquals(Pair.of(100L, 200L), result.get("dt=2026-05-20"));
+  }
+
+  @Test
+  void partialMinOnlyAndMaxOnlyAreFolded() throws IOException {
+    HoodieCommitMetadata commit1 = new HoodieCommitMetadata();
+    HoodieWriteStat minOnly = new HoodieWriteStat();
+    minOnly.setMinEventTime(100L);
+    commit1.addWriteStat("dt=2026-05-20", minOnly);
+
+    HoodieCommitMetadata commit2 = new HoodieCommitMetadata();
+    HoodieWriteStat maxOnly = new HoodieWriteStat();
+    maxOnly.setMaxEventTime(500L);
+    commit2.addWriteStat("dt=2026-05-20", maxOnly);
+
+    HoodieInstant instant1 = mock(HoodieInstant.class);
+    HoodieInstant instant2 = mock(HoodieInstant.class);
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    when(timeline.readCommitMetadata(instant1)).thenReturn(commit1);
+    when(timeline.readCommitMetadata(instant2)).thenReturn(commit2);
+
+    Map<String, Pair<Long, Long>> result =
+        UpstreamEventTimeWatermarkExtractor.extractPerPartitionWatermarks(timeline, Arrays.asList(instant1, instant2));
+
+    Pair<Long, Long> folded = result.get("dt=2026-05-20");
+    assertNotNull(folded);
+    assertEquals(Long.valueOf(100L), folded.getLeft());
+    assertEquals(Long.valueOf(500L), folded.getRight());
+  }
+
+  @Test
+  void readFailureSkipsCommitButContinues() throws IOException {
+    HoodieCommitMetadata goodCommit = new HoodieCommitMetadata();
+    goodCommit.addWriteStat("dt=2026-05-20", statWithEventTime(100L, 200L));
+
+    HoodieInstant failingInstant = mock(HoodieInstant.class);
+    HoodieInstant goodInstant = mock(HoodieInstant.class);
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    when(timeline.readCommitMetadata(failingInstant)).thenThrow(new IOException("simulated"));
+    when(timeline.readCommitMetadata(goodInstant)).thenReturn(goodCommit);
+
+    Map<String, Pair<Long, Long>> result =
+        UpstreamEventTimeWatermarkExtractor.extractPerPartitionWatermarks(timeline, Arrays.asList(failingInstant, goodInstant));
+
+    assertEquals(1, result.size());
+    assertEquals(Pair.of(100L, 200L), result.get("dt=2026-05-20"));
+  }
+
+  @Test
+  void emptyCommitMetadataYieldsEmptyResult() throws IOException {
+    HoodieCommitMetadata empty = new HoodieCommitMetadata();
+    HoodieInstant instant = mock(HoodieInstant.class);
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    when(timeline.readCommitMetadata(any(HoodieInstant.class))).thenReturn(empty);
+
+    Map<String, Pair<Long, Long>> result =
+        UpstreamEventTimeWatermarkExtractor.extractPerPartitionWatermarks(timeline, Collections.singletonList(instant));
+    assertTrue(result.isEmpty());
+  }
+
+  private static HoodieWriteStat statWithEventTime(long min, long max) {
+    HoodieWriteStat stat = new HoodieWriteStat();
+    stat.setMinEventTime(min);
+    stat.setMaxEventTime(max);
+    return stat;
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSyncUpstreamWatermarkPropagation.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSyncUpstreamWatermarkPropagation.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.streamer;
+
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link StreamSync#buildUpstreamWatermarkPreCommitFunc(Map)} — the BiConsumer
+ * that folds upstream-propagated per-partition (min, max) event-time into the downstream
+ * commit's per-partition write stats.
+ */
+class TestStreamSyncUpstreamWatermarkPropagation {
+
+  @Test
+  void emptyUpstreamWatermarksReturnsEmptyOption() {
+    assertFalse(StreamSync.buildUpstreamWatermarkPreCommitFunc(Collections.emptyMap()).isPresent());
+  }
+
+  @Test
+  void nullUpstreamWatermarksReturnsEmptyOption() {
+    assertFalse(StreamSync.buildUpstreamWatermarkPreCommitFunc(null).isPresent());
+  }
+
+  @Test
+  void propagatesIntoMatchingPartitionStatsWhenPerRecordValuesAbsent() {
+    Map<String, Pair<Long, Long>> upstream = new HashMap<>();
+    upstream.put("dt=2026-05-20", Pair.of(100L, 200L));
+    upstream.put("dt=2026-05-21", Pair.of(500L, 600L));
+
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    HoodieWriteStat statMay20 = new HoodieWriteStat();
+    statMay20.setPartitionPath("dt=2026-05-20");
+    metadata.addWriteStat("dt=2026-05-20", statMay20);
+    HoodieWriteStat statMay21 = new HoodieWriteStat();
+    statMay21.setPartitionPath("dt=2026-05-21");
+    metadata.addWriteStat("dt=2026-05-21", statMay21);
+
+    Option<BiConsumer<HoodieTableMetaClient, HoodieCommitMetadata>> hook =
+        StreamSync.buildUpstreamWatermarkPreCommitFunc(upstream);
+    assertTrue(hook.isPresent());
+    hook.get().accept(mock(HoodieTableMetaClient.class), metadata);
+
+    assertEquals(Long.valueOf(100L), statMay20.getMinEventTime());
+    assertEquals(Long.valueOf(200L), statMay20.getMaxEventTime());
+    assertEquals(Long.valueOf(500L), statMay21.getMinEventTime());
+    assertEquals(Long.valueOf(600L), statMay21.getMaxEventTime());
+  }
+
+  @Test
+  void perRecordExtremeValuesAreNotRegressedByPropagation() {
+    // Per-record path already produced a min lower than upstream and a max higher than upstream.
+    // The Math.min / Math.max fold semantics on setMinEventTime / setMaxEventTime must keep the
+    // more extreme per-record values.
+    Map<String, Pair<Long, Long>> upstream = Collections.singletonMap(
+        "dt=2026-05-20", Pair.of(100L, 200L));
+
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    HoodieWriteStat stat = new HoodieWriteStat();
+    stat.setPartitionPath("dt=2026-05-20");
+    stat.setMinEventTime(50L);  // lower than upstream 100 — should be preserved
+    stat.setMaxEventTime(300L); // higher than upstream 200 — should be preserved
+    metadata.addWriteStat("dt=2026-05-20", stat);
+
+    StreamSync.buildUpstreamWatermarkPreCommitFunc(upstream).get()
+        .accept(mock(HoodieTableMetaClient.class), metadata);
+
+    assertEquals(Long.valueOf(50L), stat.getMinEventTime());
+    assertEquals(Long.valueOf(300L), stat.getMaxEventTime());
+  }
+
+  @Test
+  void upstreamPartitionsWithNoDownstreamMatchAreIgnored() {
+    Map<String, Pair<Long, Long>> upstream = new HashMap<>();
+    upstream.put("dt=2026-05-20", Pair.of(100L, 200L));
+    upstream.put("dt=2026-05-99", Pair.of(999L, 999L)); // no matching downstream stat
+
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    HoodieWriteStat stat = new HoodieWriteStat();
+    stat.setPartitionPath("dt=2026-05-20");
+    metadata.addWriteStat("dt=2026-05-20", stat);
+
+    StreamSync.buildUpstreamWatermarkPreCommitFunc(upstream).get()
+        .accept(mock(HoodieTableMetaClient.class), metadata);
+
+    assertEquals(Long.valueOf(100L), stat.getMinEventTime());
+    assertEquals(Long.valueOf(200L), stat.getMaxEventTime());
+    // Only the original partition stat exists in metadata; no synthetic stat created for the
+    // unmatched upstream partition.
+    assertEquals(1, metadata.getPartitionToWriteStats().size());
+  }
+
+  @Test
+  void downstreamPartitionsWithNoUpstreamMatchAreLeftUntouched() {
+    Map<String, Pair<Long, Long>> upstream = Collections.singletonMap(
+        "dt=2026-05-20", Pair.of(100L, 200L));
+
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    HoodieWriteStat untouchedStat = new HoodieWriteStat();
+    untouchedStat.setPartitionPath("dt=2026-05-21");
+    metadata.addWriteStat("dt=2026-05-21", untouchedStat);
+
+    StreamSync.buildUpstreamWatermarkPreCommitFunc(upstream).get()
+        .accept(mock(HoodieTableMetaClient.class), metadata);
+
+    assertNull(untouchedStat.getMinEventTime());
+    assertNull(untouchedStat.getMaxEventTime());
+  }
+
+  @Test
+  void multipleStatsInSamePartitionAllReceivePropagation() {
+    // A partition may have multiple write stats (e.g., one per file group). Each should get the
+    // propagated values folded in.
+    Map<String, Pair<Long, Long>> upstream = Collections.singletonMap(
+        "dt=2026-05-20", Pair.of(100L, 200L));
+
+    HoodieCommitMetadata metadata = new HoodieCommitMetadata();
+    HoodieWriteStat stat1 = new HoodieWriteStat();
+    stat1.setPartitionPath("dt=2026-05-20");
+    HoodieWriteStat stat2 = new HoodieWriteStat();
+    stat2.setPartitionPath("dt=2026-05-20");
+    metadata.addWriteStat("dt=2026-05-20", stat1);
+    metadata.addWriteStat("dt=2026-05-20", stat2);
+
+    StreamSync.buildUpstreamWatermarkPreCommitFunc(upstream).get()
+        .accept(mock(HoodieTableMetaClient.class), metadata);
+
+    assertEquals(Long.valueOf(100L), stat1.getMinEventTime());
+    assertEquals(Long.valueOf(200L), stat1.getMaxEventTime());
+    assertEquals(Long.valueOf(100L), stat2.getMinEventTime());
+    assertEquals(Long.valueOf(200L), stat2.getMaxEventTime());
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Part of #17512 (Phase 2 of the reconcile plan). Builds on #18778 (Phase 1) which exposed per-partition event-time rollup on `HoodieCommitMetadata` and decoupled watermark tracking from `EVENT_TIME_ORDERING`.

Phase 2 closes the remaining ask from the issue discussion: when a derived table is built from a Hudi source via `HoodieIncrSource`, propagate the upstream commit(s)' per-partition (min, max) event time into the **downstream** commit's per-partition write stats. Derived tables inherit upstream freshness without retaining the event-time column in their schema.

### Summary and Changelog

The propagation is gated on a new opt-in config `hoodie.write.track.event.time.propagate.from.upstream` (default `false`, advanced, since 1.2.0). When enabled, `HoodieIncrSource` reads the per-partition rollup from each upstream commit in the read range (via the Phase 1 `HoodieCommitMetadata.getMinAndMaxEventTimePerPartition()` API), folds across commits, and exposes the result through a new `Source` hook. `StreamSync` reads the propagated map from the `InputBatch` and folds it into the downstream commit's per-partition write stats via the existing `extraPreCommitFunc` BiConsumer hook on `BaseHoodieWriteClient.commit(...)` — which was previously passed `Option.empty()` and now carries the propagation closure when there are watermarks to fold.

Fold semantics are inherited from Phase 1: `HoodieWriteStat.setMinEventTime` / `setMaxEventTime` already do null-aware `Math.min` / `Math.max` folds. So propagation **only fills in fields the per-record path left unset**, and per-record extreme values are preserved when more extreme than the upstream value. Back-fills cannot regress max watermarks at the per-commit level. Upstream partitions with no matching downstream stat are dropped silently (the common projection / aggregation case).

Changes:
- `HoodieWriteConfig.TRACK_EVENT_TIME_PROPAGATE_FROM_UPSTREAM`: new opt-in config.
- `ConfigUtils.isPropagatingEventTimeFromUpstream`: accessor mirroring the existing `isTrackingEventTimeWatermark`.
- `UpstreamEventTimeWatermarkExtractor`: helper that folds per-partition min/max across a set of upstream `HoodieInstant`s.
- `Source.getUpstreamEventTimeWatermarks()`: new EVOLVING hook, default returns empty map. Concrete sources override when they have batch-scoped propagated watermarks.
- `InputBatch`: optional `Map<String, Pair<Long, Long>> upstreamEventTimeWatermarks` field, plumbed through `RowSource`. Backward-compatible constructor overloads keep existing callers intact.
- `HoodieIncrSource`: when the config is on, computes folded watermarks for both the completion-time path (Hudi 1.x source tables) and the request-time path (legacy/Hudi 0.x source tables) and exposes via the new Source hook. Best-effort — read failures are logged and skipped rather than failing the source.
- `StreamSync.buildUpstreamWatermarkPreCommitFunc`: BiConsumer pre-commit hook that folds the propagated values into per-partition write stats. Returns `Option.empty()` when there is nothing to propagate (most common case), keeping the existing commit path unchanged.

Tests:
- `TestUpstreamEventTimeWatermarkExtractor` (8 tests): single-commit rollup, multi-commit fold, partial min/max, commit without watermark, read-failure tolerance, empty cases.
- `TestStreamSyncUpstreamWatermarkPropagation` (7 tests): BiConsumer fold semantics including the never-regress invariant, unmatched partitions in both directions, multiple stats per partition.

Regression: `TestHoodieCommitMetadata` (18), `TestHoodieWriteHandle` (11), `TestHoodieIncrSource` (21), `TestStreamSync` (32) all pass locally.

### Impact

Public API additions:
- `Source.getUpstreamEventTimeWatermarks()` (EVOLVING) — external `Source` subclasses outside the repo are unaffected (default returns empty map; no-op).
- New constructor overload on `InputBatch` carrying the propagated map. All existing constructors are preserved.

Behavior change for opted-in pipelines: `HoodieIncrSource` users that set both `hoodie.write.track.event.time.propagate.from.upstream=true` and read from an upstream Hudi table that itself was written with `hoodie.write.track.event.time.watermark=true` will see per-partition `minEventTime` / `maxEventTime` populated on the downstream commit's write stats, inherited from upstream. Tables that have not set the new flag see no change.

No performance impact: the extractor walks at most N upstream commits per batch (already reads them) and reads each commit metadata once; the BiConsumer fold is a small in-memory loop over the downstream commit's stats. No new RDD transformations, no broadcast variables.

### Risk Level

low

The new config is `false` by default. The new `Source` hook returns an empty map by default; the `StreamSync` hook returns `Option.empty()` when the map is empty, which produces an `extraPreCommitFunc` that is byte-identical to the previous `Option.empty()` argument at the same call site. `InputBatch` additions are constructor overloads. Verified by running the full local hudi-common and hudi-utilities test suites for the relevant test classes with no regressions; the existing `TestHoodieIncrSource` (21 tests) and `TestStreamSync` (32 tests) both pass against the modified files.

### Documentation Update

- The new `hoodie.write.track.event.time.propagate.from.upstream` config description is documented inline (its `ConfigProperty.withDocumentation(...)`) so it shows up on the Hudi configurations page on the website auto-generation pass.
- A user-facing website page covering the end-to-end propagation story (raw → derived freshness) can land alongside the planned follow-up PRs that wire Spark SQL Hudi source + Flink source.

### Follow-ups (called out in the Phase 2 plan in #17512, deliberately out of scope here):

- Spark SQL Hudi source propagation (Spark Datasource v2 path).
- Flink source propagation.
- Two-hop end-to-end test fixture (write raw table with event-time field, run streamer raw → derived with propagation on, assert derived commit inherits per-partition min/max). The propagation surface is small and well-tested at the unit level; an E2E fixture is most useful once the Spark SQL / Flink paths land so it can exercise all three engines.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable