### PR TITLE
[MINOR] Guard detailed metadata size metrics with a config

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1984,7 +1984,9 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     metadataMetaClient.reloadActiveTimeline();
 
     // Update total size of the metadata and count of base/log files
-    metrics.ifPresent(m -> m.updateSizeMetrics(metadataMetaClient, metadata, dataMetaClient.getTableConfig().getMetadataPartitions()));
+    if (metrics.isPresent() && metrics.get().shouldEnableDetailedMetadataMetrics()) {
+      metrics.get().updateSizeMetrics(metadataMetaClient, metadata, dataMetaClient.getTableConfig().getMetadataPartitions());
+    }
   }
 
   protected abstract void bulkInsertAndCommit(BaseHoodieWriteClient<?, I, ?, O> writeClient, String instantTime, I preppedRecordInputs, Option<BulkInsertPartitioner> bulkInsertPartitioner);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1984,9 +1984,11 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     metadataMetaClient.reloadActiveTimeline();
 
     // Update total size of the metadata and count of base/log files
-    if (metrics.isPresent() && metrics.get().shouldEnableDetailedMetadataMetrics()) {
-      metrics.get().updateSizeMetrics(metadataMetaClient, metadata, dataMetaClient.getTableConfig().getMetadataPartitions());
-    }
+    metrics.ifPresent(m -> {
+      if (m.isDetailedMetricsEnabled()) {
+        m.updateSizeMetrics(metadataMetaClient, metadata, dataMetaClient.getTableConfig().getMetadataPartitions());
+      }
+    });
   }
 
   protected abstract void bulkInsertAndCommit(BaseHoodieWriteClient<?, I, ?, O> writeClient, String instantTime, I preppedRecordInputs, Option<BulkInsertPartitioner> bulkInsertPartitioner);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -98,7 +98,7 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
     super(context, config, table, instantTime);
     this.txnManager = new TransactionManager(config, table.getStorage());
     if (config.getMetadataConfig().isMetricsEnabled()) {
-      this.metrics = Option.of(new HoodieMetadataMetrics(config.getMetricsConfig(), table.getStorage()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(config.getMetricsConfig(), table.getStorage(), config.getMetadataConfig().shouldEnableDetailedMetrics()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/RunIndexActionExecutor.java
@@ -98,7 +98,7 @@ public class RunIndexActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I,
     super(context, config, table, instantTime);
     this.txnManager = new TransactionManager(config, table.getStorage());
     if (config.getMetadataConfig().isMetricsEnabled()) {
-      this.metrics = Option.of(new HoodieMetadataMetrics(config.getMetricsConfig(), table.getStorage(), config.getMetadataConfig().shouldEnableDetailedMetrics()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(config.getMetricsConfig(), table.getStorage(), config.getMetadataConfig().isDetailedMetricsEnabled()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -98,7 +98,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   protected void initRegistry() {
     if (metadataWriteConfig.isMetricsOn()) {
       // should support executor metrics
-      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().shouldEnableDetailedMetrics()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -98,7 +98,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   protected void initRegistry() {
     if (metadataWriteConfig.isMetricsOn()) {
       // should support executor metrics
-      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().shouldEnableDetailedMetrics()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().isDetailedMetricsEnabled()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
@@ -82,7 +82,7 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
   @Override
   protected void initRegistry() {
     if (metadataWriteConfig.isMetricsOn()) {
-      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().shouldEnableDetailedMetrics()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().isDetailedMetricsEnabled()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
@@ -82,7 +82,7 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
   @Override
   protected void initRegistry() {
     if (metadataWriteConfig.isMetricsOn()) {
-      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().shouldEnableDetailedMetrics()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/TestHoodieMetadataBase.java
@@ -308,6 +308,7 @@ public class TestHoodieMetadataBase extends HoodieJavaClientTestHarness {
             .enable(useFileListingMetadata)
             .withMetadataIndexColumnStats(false)
             .enableMetrics(enableMetrics)
+            .enableDetailedMetadataMetrics(enableMetrics)
             .ignoreSpuriousDeletes(validateMetadataPayloadConsistency)
             .withMetadataIndexColumnStats(false) // HUDI-8774
             .withEngineType(EngineType.JAVA)

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -138,7 +138,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
       } else {
         registry = Registry.getRegistry("HoodieMetadata");
       }
-      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().shouldEnableDetailedMetrics()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -138,7 +138,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
       } else {
         registry = Registry.getRegistry("HoodieMetadata");
       }
-      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().shouldEnableDetailedMetrics()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().isDetailedMetricsEnabled()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -106,7 +106,7 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
       } else {
         registry = Registry.getRegistry("HoodieMetadata");
       }
-      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().shouldEnableDetailedMetrics()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().isDetailedMetricsEnabled()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -106,7 +106,7 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
       } else {
         registry = Registry.getRegistry("HoodieMetadata");
       }
-      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage()));
+      this.metrics = Option.of(new HoodieMetadataMetrics(metadataWriteConfig.getMetricsConfig(), dataMetaClient.getStorage(), dataWriteConfig.getMetadataConfig().shouldEnableDetailedMetrics()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
@@ -344,6 +344,7 @@ public class TestHoodieMetadataBase extends HoodieSparkClientTestHarness {
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(useFileListingMetadata)
             .enableMetrics(enableMetrics)
+            .enableDetailedMetadataMetrics(enableMetrics)
             .ignoreSpuriousDeletes(validateMetadataPayloadConsistency)
             .build())
         .withMetricsConfig(HoodieMetricsConfig.newBuilder().on(enableMetrics)

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -683,6 +683,13 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "with the actual record count stored in the metadata table. This validation runs in a distributed manner "
           + "using the compute engine. Disabled by default as it adds overhead to the initialization process.");
 
+  public static final ConfigProperty<Boolean> ENABLE_DETAILED_METRICS = ConfigProperty
+      .key(METADATA_PREFIX + ".enable.detailed.metrics")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("0.14.2")
+      .withDocumentation("Enables detailed metadata table metrics");
+
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
@@ -1020,6 +1027,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return subIndexNameToDrop.contains(indexName);
   }
 
+  public boolean shouldEnableDetailedMetrics() {
+    return getBoolean(ENABLE_DETAILED_METRICS);
+  }
+
   public static class Builder {
 
     private EngineType engineType = EngineType.SPARK;
@@ -1346,6 +1357,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withAutoDeletePartitions(boolean autoDeletePartitions) {
       metadataConfig.setValue(AUTO_DELETE_PARTITIONS, String.valueOf(autoDeletePartitions));
+      return this;
+    }
+
+    public Builder enableDetailedMetadataMetrics(boolean enableMetrics) {
+      metadataConfig.setValue(ENABLE_DETAILED_METRICS, String.valueOf(enableMetrics));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -688,7 +688,9 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .defaultValue(false)
       .markAdvanced()
       .sinceVersion("1.3.0")
-      .withDocumentation("Enables detailed metadata table metrics");
+      .withDocumentation("Enables detailed metadata table metrics — per-metadata-partition file size and base/log "
+          + "file counts. Emitting these requires building a HoodieTableFileSystemView for the metadata table on "
+          + "the driver, which adds memory pressure at scale; leave disabled unless you need the breakdown.");
 
   public long getMaxLogFileSize() {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
@@ -1027,7 +1029,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return subIndexNameToDrop.contains(indexName);
   }
 
-  public boolean shouldEnableDetailedMetrics() {
+  public boolean isDetailedMetricsEnabled() {
     return getBoolean(ENABLE_DETAILED_METRICS);
   }
 
@@ -1360,8 +1362,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder enableDetailedMetadataMetrics(boolean enableMetrics) {
-      metadataConfig.setValue(ENABLE_DETAILED_METRICS, String.valueOf(enableMetrics));
+    public Builder enableDetailedMetadataMetrics(boolean enable) {
+      metadataConfig.setValue(ENABLE_DETAILED_METRICS, String.valueOf(enable));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -687,7 +687,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".enable.detailed.metrics")
       .defaultValue(false)
       .markAdvanced()
-      .sinceVersion("0.14.2")
+      .sinceVersion("1.3.0")
       .withDocumentation("Enables detailed metadata table metrics");
 
   public long getMaxLogFileSize() {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -95,7 +95,7 @@ public abstract class BaseTableMetadata extends AbstractHoodieTableMetadata {
     if (metadataConfig.isMetricsEnabled()) {
       this.metrics = Option.of(new HoodieMetadataMetrics(HoodieMetricsConfig.newBuilder()
           .fromProperties(metadataConfig.getProps()).withPath(dataBasePath).build(), dataMetaClient.getStorage(),
-          metadataConfig.shouldEnableDetailedMetrics()));
+          metadataConfig.isDetailedMetricsEnabled()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -94,7 +94,8 @@ public abstract class BaseTableMetadata extends AbstractHoodieTableMetadata {
 
     if (metadataConfig.isMetricsEnabled()) {
       this.metrics = Option.of(new HoodieMetadataMetrics(HoodieMetricsConfig.newBuilder()
-          .fromProperties(metadataConfig.getProps()).withPath(dataBasePath).build(), dataMetaClient.getStorage()));
+          .fromProperties(metadataConfig.getProps()).withPath(dataBasePath).build(), dataMetaClient.getStorage(),
+          metadataConfig.shouldEnableDetailedMetrics()));
     } else {
       this.metrics = Option.empty();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -85,10 +85,12 @@ public class HoodieMetadataMetrics implements Serializable {
 
   private final transient MetricRegistry metricsRegistry;
   private final transient Metrics metrics;
+  private final boolean enabledDetailedMetadataMetrics;
 
-  public HoodieMetadataMetrics(HoodieMetricsConfig metricsConfig, HoodieStorage storage) {
+  public HoodieMetadataMetrics(HoodieMetricsConfig metricsConfig, HoodieStorage storage, boolean enabledDetailedMetadataMetrics) {
     this.metrics = Metrics.getInstance(metricsConfig, storage);
     this.metricsRegistry = metrics.getRegistry();
+    this.enabledDetailedMetadataMetrics = enabledDetailedMetadataMetrics;
   }
 
   public Map<String, String> getStats(boolean detailed, HoodieTableMetaClient metaClient, HoodieTableMetadata metadata, Set<String> metadataPartitions) {
@@ -99,6 +101,10 @@ public class HoodieMetadataMetrics implements Serializable {
     } catch (IOException ioe) {
       throw new HoodieIOException("Unable to get metadata stats.", ioe);
     }
+  }
+
+  public boolean shouldEnableDetailedMetadataMetrics() {
+    return enabledDetailedMetadataMetrics;
   }
 
   private Map<String, String> getStats(HoodieTableFileSystemView fsView, boolean detailed, HoodieTableMetadata tableMetadata, Set<String> metadataPartitions)

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -85,12 +85,12 @@ public class HoodieMetadataMetrics implements Serializable {
 
   private final transient MetricRegistry metricsRegistry;
   private final transient Metrics metrics;
-  private final boolean enabledDetailedMetadataMetrics;
+  private final boolean detailedMetricsEnabled;
 
-  public HoodieMetadataMetrics(HoodieMetricsConfig metricsConfig, HoodieStorage storage, boolean enabledDetailedMetadataMetrics) {
+  public HoodieMetadataMetrics(HoodieMetricsConfig metricsConfig, HoodieStorage storage, boolean detailedMetricsEnabled) {
     this.metrics = Metrics.getInstance(metricsConfig, storage);
     this.metricsRegistry = metrics.getRegistry();
-    this.enabledDetailedMetadataMetrics = enabledDetailedMetadataMetrics;
+    this.detailedMetricsEnabled = detailedMetricsEnabled;
   }
 
   public Map<String, String> getStats(boolean detailed, HoodieTableMetaClient metaClient, HoodieTableMetadata metadata, Set<String> metadataPartitions) {
@@ -103,8 +103,8 @@ public class HoodieMetadataMetrics implements Serializable {
     }
   }
 
-  public boolean shouldEnableDetailedMetadataMetrics() {
-    return enabledDetailedMetadataMetrics;
+  public boolean isDetailedMetricsEnabled() {
+    return detailedMetricsEnabled;
   }
 
   private Map<String, String> getStats(HoodieTableFileSystemView fsView, boolean detailed, HoodieTableMetadata tableMetadata, Set<String> metadataPartitions)

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
@@ -269,4 +269,28 @@ class TestHoodieMetadataConfig {
             .withTableServiceManagerEnabled(true)
             .build());
   }
+
+  @Test
+  void testMetricsConfig() {
+    // Test default value
+    HoodieMetadataConfig config = HoodieMetadataConfig.newBuilder().build();
+    assertFalse(config.isMetricsEnabled());
+
+    Properties props = new Properties();
+    props.put(HoodieMetadataConfig.METRICS_ENABLE.key(), true);
+    config = HoodieMetadataConfig.newBuilder()
+        .fromProperties(props)
+        .build();
+    assertTrue(config.isMetricsEnabled());
+    assertFalse(config.shouldEnableDetailedMetrics());
+
+    props = new Properties();
+    props.put(HoodieMetadataConfig.METRICS_ENABLE.key(), true);
+    props.put(HoodieMetadataConfig.ENABLE_DETAILED_METRICS.key(), true);
+    config = HoodieMetadataConfig.newBuilder()
+        .fromProperties(props)
+        .build();
+    assertTrue(config.isMetricsEnabled());
+    assertTrue(config.shouldEnableDetailedMetrics());
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMetadataConfig.java
@@ -282,7 +282,7 @@ class TestHoodieMetadataConfig {
         .fromProperties(props)
         .build();
     assertTrue(config.isMetricsEnabled());
-    assertFalse(config.shouldEnableDetailedMetrics());
+    assertFalse(config.isDetailedMetricsEnabled());
 
     props = new Properties();
     props.put(HoodieMetadataConfig.METRICS_ENABLE.key(), true);
@@ -291,6 +291,6 @@ class TestHoodieMetadataConfig {
         .fromProperties(props)
         .build();
     assertTrue(config.isMetricsEnabled());
-    assertTrue(config.shouldEnableDetailedMetrics());
+    assertTrue(config.isDetailedMetricsEnabled());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Detailed size metrics in the metadata table cause `HoodieTableFileSystemView` (FSV) to be built for MDT in the driver, which adds memory pressure at scale.

### Summary and Changelog

Introduce a new config `hoodie.metadata.enable.detailed.metrics` (default: `false`) that gates emission of the detailed size + file-count metrics per metadata partition. When disabled, `HoodieBackedTableMetadataWriter#updateSizeMetrics` is skipped.

Changes:
- New config `HoodieMetadataConfig.ENABLE_DETAILED_METRICS` (default false).
- `HoodieMetadataMetrics` carries a `detailedMetricsEnabled` flag in its constructor.
- `HoodieBackedTableMetadataWriter#updateSizeMetrics` only runs when detailed metrics are enabled.
- All `HoodieMetadataMetrics` construction sites updated (Spark/Flink/Java writers, `RunIndexActionExecutor`, `BaseTableMetadata`, `SparkHoodieBackedTableMetadataWriterTableVersionSix`).
- Tests cover default, metrics-enabled, and detailed-metrics-enabled paths.

### Impact

Reduced driver memory pressure for large metadata tables. No behavior change unless `hoodie.metadata.enable.detailed.metrics=true` is explicitly set.

### Risk Level

low

### Documentation Update

The new config description is added in `HoodieMetadataConfig`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
