### PR TITLE
chore: fix asf.yaml invalid key

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,7 +34,6 @@ github:
     issues: true
     projects: true
     discussions: true
-    automerge_allowed: true
   enabled_merge_buttons:
     squash:  true
     merge:   false


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->
Got error report in email when merging PRs:

```
An error occurred while processing the github feature in .asf.yaml:

while parsing a mapping
unexpected key not in schema 'automerge_allowed'
  in "hudi.git/.asf.yaml::github", line 18, column 1:
      automerge_allowed: 'true'
    ^ (line: 18)

---
With regards, ASF Infra.
For further information, please see the .asf.yaml documentation at:
https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
```

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->
Removed invalid key

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->
None

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->
None
### Documentation Update
None
<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
