### PR TITLE
feat(flink): Add metrics for remote RLI lookup time in BucketAssign op

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkPartitionedIndexBackendMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkPartitionedIndexBackendMetrics.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import com.codahale.metrics.SlidingWindowReservoir;
+import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.hudi.common.util.VisibleForTesting;
+
+/**
+ * Metrics for the {@link org.apache.hudi.sink.partitioner.index.RecordLevelIndexBackend}.
+ *
+ * <p>The partitioned RLI backend's only remote operation is the one-shot per-partition bootstrap
+ * into the local cache; regular records are served entirely from the local cache. The lookup-
+ * centric metrics in {@link FlinkIndexBackendMetrics} therefore do not apply here. This class
+ * instead tracks the distribution of per-bootstrap latency and per-bootstrap key counts on each
+ * subtask. The histogram {@code count} field doubles as the cumulative bootstrap count for the
+ * subtask.
+ */
+public class FlinkPartitionedIndexBackendMetrics extends HoodieFlinkMetrics {
+  private static final int HISTOGRAM_WINDOW_SIZE = 100;
+  private static final String PARTITION_BOOTSTRAP_KEY = "partition_bootstrap";
+
+  static final String PARTITION_BOOTSTRAP_LATENCY_MILLIS = "partition_bootstrap_latency_millis";
+  static final String PARTITION_BOOTSTRAP_KEYS_LOADED = "partition_bootstrap_keys_loaded";
+
+  /** Latency of each partition bootstrap on this subtask, in milliseconds. */
+  private final Histogram partitionBootstrapLatencyMillis;
+
+  /** Number of RLI rows loaded into the local cache per partition bootstrap (post ownership filter). */
+  private final Histogram partitionBootstrapKeysLoaded;
+
+  public FlinkPartitionedIndexBackendMetrics(MetricGroup metricGroup) {
+    super(metricGroup);
+    this.partitionBootstrapLatencyMillis = new DropwizardHistogramWrapper(
+        new com.codahale.metrics.Histogram(new SlidingWindowReservoir(HISTOGRAM_WINDOW_SIZE)));
+    this.partitionBootstrapKeysLoaded = new DropwizardHistogramWrapper(
+        new com.codahale.metrics.Histogram(new SlidingWindowReservoir(HISTOGRAM_WINDOW_SIZE)));
+  }
+
+  @Override
+  public void registerMetrics() {
+    metricGroup.histogram(PARTITION_BOOTSTRAP_LATENCY_MILLIS, partitionBootstrapLatencyMillis);
+    metricGroup.histogram(PARTITION_BOOTSTRAP_KEYS_LOADED, partitionBootstrapKeysLoaded);
+  }
+
+  public void startPartitionBootstrap() {
+    startTimer(PARTITION_BOOTSTRAP_KEY);
+  }
+
+  public void endPartitionBootstrap() {
+    partitionBootstrapLatencyMillis.update(stopTimer(PARTITION_BOOTSTRAP_KEY));
+  }
+
+  public void updatePartitionBootstrapKeysLoaded(long n) {
+    partitionBootstrapKeysLoaded.update(n);
+  }
+
+  @VisibleForTesting
+  public long getPartitionBootstrapCount() {
+    return partitionBootstrapLatencyMillis.getCount();
+  }
+
+  @VisibleForTesting
+  public long getPartitionBootstrapKeysLoadedSampleCount() {
+    return partitionBootstrapKeysLoaded.getCount();
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkPartitionedIndexBackendMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkPartitionedIndexBackendMetrics.java
@@ -69,8 +69,8 @@ public class FlinkPartitionedIndexBackendMetrics extends HoodieFlinkMetrics {
     partitionBootstrapLatencyMillis.update(stopTimer(PARTITION_BOOTSTRAP_KEY));
   }
 
-  public void updatePartitionBootstrapKeysLoaded(long n) {
-    partitionBootstrapKeysLoaded.update(n);
+  public void updatePartitionBootstrapKeysLoaded(long keysLoaded) {
+    partitionBootstrapKeysLoaded.update(keysLoaded);
   }
 
   @VisibleForTesting

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DynamicBucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/DynamicBucketAssignFunction.java
@@ -109,6 +109,7 @@ public class DynamicBucketAssignFunction
     this.indexBackend = isInsertOverwrite
         ? new DummyPartitionedIndexBackend()
         : new RecordLevelIndexBackend(conf, (partitionPath, recordKey, fileId) -> isRecordKeyOfThisTask(recordKey));
+    this.indexBackend.registerMetrics(getRuntimeContext().getMetricGroup());
   }
 
   private boolean isRecordKeyOfThisTask(String recordKey) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -41,6 +41,7 @@ import org.apache.hudi.sink.utils.SamplingActionExecutor;
 import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.StreamerUtil;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
@@ -77,7 +78,7 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
   private final long maxCacheSizeInBytes;
   private final BootstrapFilter bootstrapFilter;
   private HoodieTableMetadata metadataTable;
-  @Getter
+  @Getter(AccessLevel.PACKAGE)
   private FlinkIndexBackendMetrics metrics;
 
   @Getter

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -35,6 +35,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metrics.FlinkIndexBackendMetrics;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.sink.utils.SamplingActionExecutor;
 import org.apache.hudi.util.FlinkWriteClients;
@@ -43,6 +44,8 @@ import org.apache.hudi.util.StreamerUtil;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -74,6 +77,8 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
   private final long maxCacheSizeInBytes;
   private final BootstrapFilter bootstrapFilter;
   private HoodieTableMetadata metadataTable;
+  @Getter
+  private FlinkIndexBackendMetrics metrics;
 
   @Getter
   private final Map<String, BucketCache> partitionBucketCaches = new LinkedHashMap<>(16, 0.75f, true);
@@ -96,7 +101,16 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
     this.metaClient = StreamerUtil.createMetaClient(conf);
     this.maxCacheSizeInBytes = conf.get(FlinkOptions.INDEX_RLI_CACHE_SIZE) * 1024 * 1024;
     this.bootstrapFilter = bootstrapFilter;
+    // Pre-seed metrics with an unregistered group so the backend is safe to use before the
+    // bucket assign operator wires the real metric group via registerMetrics(MetricGroup).
+    registerMetrics(new UnregisteredMetricsGroup());
     reloadMetadataTable();
+  }
+
+  @Override
+  public void registerMetrics(MetricGroup metricGroup) {
+    this.metrics = new FlinkIndexBackendMetrics(metricGroup);
+    this.metrics.registerMetrics();
   }
 
   @Override
@@ -161,15 +175,30 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
       return cache;
     }
 
+    // Time the remote metadata-table reads (RLI bucket listing + record index location read) so
+    // operators can observe per-partition bootstrap latency. The local cache fill is excluded so
+    // the histogram tracks remote cost only, matching remoteIndexLookupLatency on the global RLI path.
+    metrics.startRemoteIndexLookup();
+    final HoodiePairData<String, HoodieRecordGlobalLocation> locations;
     try {
       Map<String, List<FileSlice>> partitionedFileGroups =
           metadataTable.getBucketizedFileGroupsForPartitionedRLI(MetadataPartitionType.RECORD_INDEX);
       List<FileSlice> fileSlices = partitionedFileGroups.get(partitionPath);
       if (fileSlices == null || fileSlices.isEmpty()) {
+        metrics.endRemoteIndexLookup();
+        metrics.updateRemoteLookupKeysCount(0L);
         return cache;
       }
-      HoodiePairData<String, HoodieRecordGlobalLocation> locations =
-          metadataTable.readRecordIndexLocations(fileSlicesToFilter -> fileSlices);
+      locations = metadataTable.readRecordIndexLocations(fileSlicesToFilter -> fileSlices);
+      metrics.endRemoteIndexLookup();
+    } catch (Exception e) {
+      // Stop the timer to avoid leaking the start timestamp into the next bootstrap call.
+      metrics.endRemoteIndexLookup();
+      cache.close();
+      throw new HoodieException("Failed to bootstrap partitioned RLI cache for partition " + partitionPath, e);
+    }
+
+    try {
       final AtomicLong totalCnt = new AtomicLong();
       locations.forEach(locationPair -> {
         String recordKey = locationPair.getLeft();
@@ -179,6 +208,7 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
         }
         totalCnt.incrementAndGet();
       });
+      metrics.updateRemoteLookupKeysCount(totalCnt.get());
       log.info("Bootstrapped partitioned RLI cache for partition {} with {} owned records from total {} RLI records.",
           partitionPath, cache.size(), totalCnt.get());
       return cache;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -176,30 +176,21 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
       return cache;
     }
 
-    // Time the remote metadata-table reads (RLI bucket listing + record index location read) so
-    // operators can observe per-partition bootstrap latency. The local cache fill is excluded so
-    // the histogram tracks remote cost only, matching remoteIndexLookupLatency on the global RLI path.
+    // Time the remote metadata-table reads. readRecordIndexLocations returns a lazy HoodieListData
+    // whose underlying file-slice scan only runs during the forEach below, so the timer must span
+    // the iteration as well to capture the bulk of the remote cost. This matches the bracketing
+    // used by GlobalRecordLevelIndexBackend around its remote lookup.
     metrics.startRemoteIndexLookup();
-    final HoodiePairData<String, HoodieRecordGlobalLocation> locations;
     try {
       Map<String, List<FileSlice>> partitionedFileGroups =
           metadataTable.getBucketizedFileGroupsForPartitionedRLI(MetadataPartitionType.RECORD_INDEX);
       List<FileSlice> fileSlices = partitionedFileGroups.get(partitionPath);
       if (fileSlices == null || fileSlices.isEmpty()) {
-        metrics.endRemoteIndexLookup();
         metrics.updateRemoteLookupKeysCount(0L);
         return cache;
       }
-      locations = metadataTable.readRecordIndexLocations(fileSlicesToFilter -> fileSlices);
-      metrics.endRemoteIndexLookup();
-    } catch (Exception e) {
-      // Stop the timer to avoid leaking the start timestamp into the next bootstrap call.
-      metrics.endRemoteIndexLookup();
-      cache.close();
-      throw new HoodieException("Failed to bootstrap partitioned RLI cache for partition " + partitionPath, e);
-    }
-
-    try {
+      HoodiePairData<String, HoodieRecordGlobalLocation> locations =
+          metadataTable.readRecordIndexLocations(fileSlicesToFilter -> fileSlices);
       final AtomicLong totalCnt = new AtomicLong();
       locations.forEach(locationPair -> {
         String recordKey = locationPair.getLeft();
@@ -216,6 +207,8 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
     } catch (Exception e) {
       cache.close();
       throw new HoodieException("Failed to bootstrap partitioned RLI cache for partition " + partitionPath, e);
+    } finally {
+      metrics.endRemoteIndexLookup();
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -35,7 +35,7 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.MetadataPartitionType;
-import org.apache.hudi.metrics.FlinkIndexBackendMetrics;
+import org.apache.hudi.metrics.FlinkPartitionedIndexBackendMetrics;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.sink.utils.SamplingActionExecutor;
 import org.apache.hudi.util.FlinkWriteClients;
@@ -79,7 +79,7 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
   private final BootstrapFilter bootstrapFilter;
   private HoodieTableMetadata metadataTable;
   @Getter(AccessLevel.PACKAGE)
-  private FlinkIndexBackendMetrics metrics;
+  private FlinkPartitionedIndexBackendMetrics metrics;
 
   @Getter
   private final Map<String, BucketCache> partitionBucketCaches = new LinkedHashMap<>(16, 0.75f, true);
@@ -110,7 +110,7 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
 
   @Override
   public void registerMetrics(MetricGroup metricGroup) {
-    this.metrics = new FlinkIndexBackendMetrics(metricGroup);
+    this.metrics = new FlinkPartitionedIndexBackendMetrics(metricGroup);
     this.metrics.registerMetrics();
   }
 
@@ -176,17 +176,16 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
       return cache;
     }
 
-    // Time the remote metadata-table reads. readRecordIndexLocations returns a lazy HoodieListData
-    // whose underlying file-slice scan only runs during the forEach below, so the timer must span
-    // the iteration as well to capture the bulk of the remote cost. This matches the bracketing
-    // used by GlobalRecordLevelIndexBackend around its remote lookup.
-    metrics.startRemoteIndexLookup();
+    // Time the partition bootstrap. readRecordIndexLocations returns a lazy HoodieListData whose
+    // underlying file-slice scan only runs during the forEach below, so the timer must span the
+    // iteration to capture the full remote cost.
+    metrics.startPartitionBootstrap();
     try {
       Map<String, List<FileSlice>> partitionedFileGroups =
           metadataTable.getBucketizedFileGroupsForPartitionedRLI(MetadataPartitionType.RECORD_INDEX);
       List<FileSlice> fileSlices = partitionedFileGroups.get(partitionPath);
       if (fileSlices == null || fileSlices.isEmpty()) {
-        metrics.updateRemoteLookupKeysCount(0L);
+        metrics.updatePartitionBootstrapKeysLoaded(0L);
         return cache;
       }
       HoodiePairData<String, HoodieRecordGlobalLocation> locations =
@@ -200,7 +199,7 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
         }
         totalCnt.incrementAndGet();
       });
-      metrics.updateRemoteLookupKeysCount(totalCnt.get());
+      metrics.updatePartitionBootstrapKeysLoaded(cache.size());
       log.info("Bootstrapped partitioned RLI cache for partition {} with {} owned records from total {} RLI records.",
           partitionPath, cache.size(), totalCnt.get());
       return cache;
@@ -208,7 +207,7 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
       cache.close();
       throw new HoodieException("Failed to bootstrap partitioned RLI cache for partition " + partitionPath, e);
     } finally {
-      metrics.endRemoteIndexLookup();
+      metrics.endPartitionBootstrap();
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkPartitionedIndexBackendMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkPartitionedIndexBackendMetrics.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link FlinkPartitionedIndexBackendMetrics}.
+ */
+class TestFlinkPartitionedIndexBackendMetrics {
+
+  private CapturingMetricGroup metricGroup;
+  private FlinkPartitionedIndexBackendMetrics metrics;
+
+  @BeforeEach
+  void setUp() {
+    metricGroup = new CapturingMetricGroup();
+    metrics = new FlinkPartitionedIndexBackendMetrics(metricGroup);
+    metrics.registerMetrics();
+  }
+
+  @Test
+  void testRegisterMetricsRegistersHistograms() {
+    assertNotNull(metricGroup.getHistogram(FlinkPartitionedIndexBackendMetrics.PARTITION_BOOTSTRAP_LATENCY_MILLIS));
+    assertNotNull(metricGroup.getHistogram(FlinkPartitionedIndexBackendMetrics.PARTITION_BOOTSTRAP_KEYS_LOADED));
+  }
+
+  @Test
+  void testPartitionBootstrapUpdatesLatencyHistogramCount() {
+    Histogram hist = metricGroup.getHistogram(FlinkPartitionedIndexBackendMetrics.PARTITION_BOOTSTRAP_LATENCY_MILLIS);
+    assertEquals(0, hist.getCount());
+
+    metrics.startPartitionBootstrap();
+    metrics.endPartitionBootstrap();
+    assertEquals(1, hist.getCount());
+
+    metrics.startPartitionBootstrap();
+    metrics.endPartitionBootstrap();
+    assertEquals(2, hist.getCount());
+  }
+
+  @Test
+  void testPartitionBootstrapLatencyIsNonNegative() {
+    metrics.startPartitionBootstrap();
+    metrics.endPartitionBootstrap();
+
+    Histogram hist = metricGroup.getHistogram(FlinkPartitionedIndexBackendMetrics.PARTITION_BOOTSTRAP_LATENCY_MILLIS);
+    assertTrue(hist.getStatistics().getMin() >= 0);
+  }
+
+  @Test
+  void testEndPartitionBootstrapWithoutStartRecordsZero() {
+    metrics.endPartitionBootstrap();
+
+    Histogram hist = metricGroup.getHistogram(FlinkPartitionedIndexBackendMetrics.PARTITION_BOOTSTRAP_LATENCY_MILLIS);
+    assertEquals(1, hist.getCount());
+    assertEquals(0, hist.getStatistics().getMax());
+  }
+
+  @Test
+  void testUpdatePartitionBootstrapKeysLoadedUpdatesHistogram() {
+    Histogram hist = metricGroup.getHistogram(FlinkPartitionedIndexBackendMetrics.PARTITION_BOOTSTRAP_KEYS_LOADED);
+    assertEquals(0, hist.getCount());
+
+    metrics.updatePartitionBootstrapKeysLoaded(10);
+    assertEquals(1, hist.getCount());
+    assertEquals(10, hist.getStatistics().getMax());
+
+    metrics.updatePartitionBootstrapKeysLoaded(20);
+    assertEquals(2, hist.getCount());
+    assertEquals(20, hist.getStatistics().getMax());
+  }
+
+  @Test
+  void testUpdatePartitionBootstrapKeysLoadedAcceptsZero() {
+    metrics.updatePartitionBootstrapKeysLoaded(0);
+
+    Histogram hist = metricGroup.getHistogram(FlinkPartitionedIndexBackendMetrics.PARTITION_BOOTSTRAP_KEYS_LOADED);
+    assertEquals(1, hist.getCount());
+    assertEquals(0, hist.getStatistics().getMax());
+  }
+
+  @Test
+  void testVisibleForTestingGetters() {
+    assertEquals(0, metrics.getPartitionBootstrapCount());
+    assertEquals(0, metrics.getPartitionBootstrapKeysLoadedSampleCount());
+
+    metrics.startPartitionBootstrap();
+    metrics.endPartitionBootstrap();
+    assertEquals(1, metrics.getPartitionBootstrapCount());
+
+    metrics.updatePartitionBootstrapKeysLoaded(7);
+    assertEquals(1, metrics.getPartitionBootstrapKeysLoadedSampleCount());
+  }
+
+  @Test
+  void testCombinedBootstrapRecordsBothHistograms() {
+    metrics.startPartitionBootstrap();
+    metrics.endPartitionBootstrap();
+    metrics.updatePartitionBootstrapKeysLoaded(42);
+
+    assertEquals(1, metrics.getPartitionBootstrapCount());
+    assertEquals(1, metrics.getPartitionBootstrapKeysLoadedSampleCount());
+    Histogram keysHist = metricGroup.getHistogram(FlinkPartitionedIndexBackendMetrics.PARTITION_BOOTSTRAP_KEYS_LOADED);
+    assertEquals(42, keysHist.getStatistics().getMax());
+  }
+
+  private static class CapturingMetricGroup extends UnregisteredMetricsGroup {
+    private final Map<String, Histogram> histograms = new HashMap<>();
+
+    @Override
+    public <H extends Histogram> H histogram(String name, H histogram) {
+      histograms.put(name, histogram);
+      return histogram;
+    }
+
+    Histogram getHistogram(String name) {
+      return histograms.get(name);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -184,7 +185,7 @@ public class TestRecordLevelIndexBackend {
 
       assertNotNull(backend.getMetrics());
       // The second call must rewire the field so the active metrics publish to the real metric group.
-      assertFalse(preSeeded == backend.getMetrics());
+      assertNotSame(preSeeded, backend.getMetrics());
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
@@ -20,7 +20,7 @@ package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.configuration.FlinkOptions;
-import org.apache.hudi.metrics.FlinkIndexBackendMetrics;
+import org.apache.hudi.metrics.FlinkPartitionedIndexBackendMetrics;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
@@ -167,20 +167,20 @@ public class TestRecordLevelIndexBackend {
   }
 
   @Test
-  public void testRegisterMetricsRegistersRemoteRliHistograms() throws Exception {
+  public void testRegisterMetricsRegistersPartitionBootstrapHistograms() throws Exception {
     CapturingMetricGroup metricGroup = new CapturingMetricGroup();
     try (RecordLevelIndexBackend backend = createBackend()) {
       backend.registerMetrics(metricGroup);
 
-      assertNotNull(metricGroup.getHistogram("remoteIndexLookupLatency"));
-      assertNotNull(metricGroup.getHistogram("remoteLookupKeysNum"));
+      assertNotNull(metricGroup.getHistogram("partition_bootstrap_latency_millis"));
+      assertNotNull(metricGroup.getHistogram("partition_bootstrap_keys_loaded"));
     }
   }
 
   @Test
   public void testRegisterMetricsReplacesPreSeededMetrics() throws Exception {
     try (RecordLevelIndexBackend backend = createBackend()) {
-      FlinkIndexBackendMetrics preSeeded = backend.getMetrics();
+      FlinkPartitionedIndexBackendMetrics preSeeded = backend.getMetrics();
       backend.registerMetrics(new CapturingMetricGroup());
 
       assertNotNull(backend.getMetrics());

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
@@ -20,11 +20,14 @@ package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.metrics.FlinkIndexBackendMetrics;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,6 +40,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -152,6 +156,38 @@ public class TestRecordLevelIndexBackend {
     }
   }
 
+  @Test
+  public void testConstructorPreSeedsMetricsForNullSafety() throws Exception {
+    // Without pre-seeding, bootstrapPartition would NPE before the bucket assign operator
+    // wires the real MetricGroup via registerMetrics(MetricGroup).
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      assertNotNull(backend.getMetrics());
+    }
+  }
+
+  @Test
+  public void testRegisterMetricsRegistersRemoteRliHistograms() throws Exception {
+    CapturingMetricGroup metricGroup = new CapturingMetricGroup();
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      backend.registerMetrics(metricGroup);
+
+      assertNotNull(metricGroup.getHistogram("remoteIndexLookupLatency"));
+      assertNotNull(metricGroup.getHistogram("remoteLookupKeysNum"));
+    }
+  }
+
+  @Test
+  public void testRegisterMetricsReplacesPreSeededMetrics() throws Exception {
+    try (RecordLevelIndexBackend backend = createBackend()) {
+      FlinkIndexBackendMetrics preSeeded = backend.getMetrics();
+      backend.registerMetrics(new CapturingMetricGroup());
+
+      assertNotNull(backend.getMetrics());
+      // The second call must rewire the field so the active metrics publish to the real metric group.
+      assertFalse(preSeeded == backend.getMetrics());
+    }
+  }
+
   private RecordLevelIndexBackend createBackend() {
     return new RecordLevelIndexBackend(conf, (partitionPath, recordKey, fileId) -> true);
   }
@@ -185,6 +221,20 @@ public class TestRecordLevelIndexBackend {
     @Override
     public Map<Long, String> requestInflightInstants() {
       return inflightInstants;
+    }
+  }
+
+  private static class CapturingMetricGroup extends UnregisteredMetricsGroup {
+    private final Map<String, Histogram> histograms = new HashMap<>();
+
+    @Override
+    public <H extends Histogram> H histogram(String name, H histogram) {
+      histograms.put(name, histogram);
+      return histogram;
+    }
+
+    Histogram getHistogram(String name) {
+      return histograms.get(name);
     }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Add metrics for remote RLI lookup time in BucketAssign op to monitor remote RLI lookup latency.

Fixes #18734

### Summary and Changelog

Add metrics for remote RLI lookup time in BucketAssign op

### Impact

Add metrics

### Risk Level

None

### Documentation Update

None

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
