### PR TITLE
fix(common): normalize hudi table base path in StorageBasedLockProvider

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
@@ -31,7 +31,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
-import static org.apache.hudi.common.fs.FSUtils.s3aToS3;
+import static org.apache.hudi.common.fs.FSUtils.normalizeBasePathForLocking;
 
 /**
  * A DynamoDB based lock.
@@ -43,7 +43,7 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
   protected static final Logger LOG = LoggerFactory.getLogger(DynamoDBBasedImplicitPartitionKeyLockProvider.class);
 
   private final String hudiTableBasePath;
- 
+
   public DynamoDBBasedImplicitPartitionKeyLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf) {
     this(lockConfiguration, conf, null);
   }
@@ -51,18 +51,25 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
   public DynamoDBBasedImplicitPartitionKeyLockProvider(
       final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf, DynamoDbClient dynamoDB) {
     super(lockConfiguration, conf, dynamoDB);
-    hudiTableBasePath = s3aToS3(lockConfiguration.getConfig().getString(HoodieCommonConfig.BASE_PATH.key()));
+    hudiTableBasePath = normalizeBasePathForLocking(
+        lockConfiguration.getConfig().getString(HoodieCommonConfig.BASE_PATH.key()));
+  }
+
+  /**
+   * Compute the DynamoDB partition key for a given Hudi table base path. Exposed as a static
+   * helper so that the formula is testable without standing up a DynamoDB client.
+   */
+  public static String derivePartitionKey(String hudiTableBasePath) {
+    String normalized = normalizeBasePathForLocking(hudiTableBasePath);
+    String partitionKey = HashID.generateXXHashAsString(normalized, HashID.Size.BITS_64);
+    LOG.info(String.format("The DynamoDB partition key of the lock provider for the base path %s (normalized: %s) is %s",
+        hudiTableBasePath, normalized, partitionKey));
+    return partitionKey;
   }
 
   @Override
   public String getDynamoDBPartitionKey(LockConfiguration lockConfiguration) {
-    // Ensure consistent format for S3 URI.
-    String hudiTableBasePathNormalized = s3aToS3(lockConfiguration.getConfig().getString(
-        HoodieCommonConfig.BASE_PATH.key()));
-    String partitionKey = HashID.generateXXHashAsString(hudiTableBasePathNormalized, HashID.Size.BITS_64);
-    LOG.info(String.format("The DynamoDB partition key of the lock provider for the base path %s is %s",
-        hudiTableBasePathNormalized, partitionKey));
-    return partitionKey;
+    return derivePartitionKey(lockConfiguration.getConfig().getString(HoodieCommonConfig.BASE_PATH.key()));
   }
 
   @Override

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
@@ -58,12 +58,17 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
   /**
    * Compute the DynamoDB partition key for a given Hudi table base path. Exposed as a static
    * helper so that the formula is testable without standing up a DynamoDB client.
+   *
+   * <p>Accepts a raw basePath — normalization is applied here. {@code normalizeBasePathForLocking}
+   * is idempotent, so passing an already-normalized path is safe. Note that the instance field
+   * {@code hudiTableBasePath} cannot be used here: the parent constructor invokes this through
+   * {@code getDynamoDBPartitionKey} before the subclass has a chance to assign the field.
    */
   public static String derivePartitionKey(String hudiTableBasePath) {
     String normalized = normalizeBasePathForLocking(hudiTableBasePath);
     String partitionKey = HashID.generateXXHashAsString(normalized, HashID.Size.BITS_64);
-    LOG.info(String.format("The DynamoDB partition key of the lock provider for the base path %s (normalized: %s) is %s",
-        hudiTableBasePath, normalized, partitionKey));
+    LOG.info("The DynamoDB partition key of the lock provider for the base path {} (normalized: {}) is {}",
+        hudiTableBasePath, normalized, partitionKey);
     return partitionKey;
   }
 

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/transaction/lock/DynamoDBBasedImplicitPartitionKeyLockProvider.java
@@ -42,7 +42,7 @@ import static org.apache.hudi.common.fs.FSUtils.normalizeBasePathForLocking;
 public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBasedLockProviderBase {
   protected static final Logger LOG = LoggerFactory.getLogger(DynamoDBBasedImplicitPartitionKeyLockProvider.class);
 
-  private final String hudiTableBasePath;
+  private final String normalizedHudiTableBasePath;
 
   public DynamoDBBasedImplicitPartitionKeyLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf) {
     this(lockConfiguration, conf, null);
@@ -51,7 +51,7 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
   public DynamoDBBasedImplicitPartitionKeyLockProvider(
       final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf, DynamoDbClient dynamoDB) {
     super(lockConfiguration, conf, dynamoDB);
-    hudiTableBasePath = normalizeBasePathForLocking(
+    normalizedHudiTableBasePath = normalizeBasePathForLocking(
         lockConfiguration.getConfig().getString(HoodieCommonConfig.BASE_PATH.key()));
   }
 
@@ -61,8 +61,8 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
    *
    * <p>Accepts a raw basePath — normalization is applied here. {@code normalizeBasePathForLocking}
    * is idempotent, so passing an already-normalized path is safe. Note that the instance field
-   * {@code hudiTableBasePath} cannot be used here: the parent constructor invokes this through
-   * {@code getDynamoDBPartitionKey} before the subclass has a chance to assign the field.
+   * {@code normalizedHudiTableBasePath} cannot be used here: the parent constructor invokes this
+   * through {@code getDynamoDBPartitionKey} before the subclass has a chance to assign the field.
    */
   public static String derivePartitionKey(String hudiTableBasePath) {
     String normalized = normalizeBasePathForLocking(hudiTableBasePath);
@@ -81,6 +81,6 @@ public class DynamoDBBasedImplicitPartitionKeyLockProvider extends DynamoDBBased
   protected String generateLogSuffixString() {
     return StringUtils.join("DynamoDb table = ", tableName,
         ", partition key = ", dynamoDBPartitionKey,
-        ", hudi table base path = ", hudiTableBasePath);
+        ", hudi table base path = ", normalizedHudiTableBasePath);
   }
 }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/transaction/integ/ITTestDynamoDBBasedLockProvider.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/transaction/integ/ITTestDynamoDBBasedLockProvider.java
@@ -187,11 +187,12 @@ public class ITTestDynamoDBBasedLockProvider {
     } else if (lockProviderClass.equals(DynamoDBBasedImplicitPartitionKeyLockProvider.class)) {
       String tableName = (String) lockConfig.getConfig().get(HoodieTableConfig.HOODIE_TABLE_NAME_KEY);
       String basePath = (String) lockConfig.getConfig().get(HoodieCommonConfig.BASE_PATH.key());
-      // Base path is constructed with prefix s3a, verify that for partition key calculation, s3a is replaced with s3
+      // Base path is constructed with prefix s3a; verify that for partition key calculation, s3a
+      // is replaced with s3 AND the path is normalized (trailing slash). The fixture URI here has
+      // no trailing slash, so normalization adds one before hashing.
       Assertions.assertTrue(basePath.startsWith(SCHEME_S3A));
-      // Verify base path only scheme partition key
       Assertions.assertEquals(
-          HashID.generateXXHashAsString(SCHEME_S3 + URI_NO_CLOUD_PROVIDER_PREFIX, HashID.Size.BITS_64),
+          HashID.generateXXHashAsString(SCHEME_S3 + URI_NO_CLOUD_PROVIDER_PREFIX + "/", HashID.Size.BITS_64),
           dynamoDbBasedLockProvider.getPartitionKey());
     }
 

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/transaction/lock/TestDynamoDBBasedImplicitPartitionKeyLockProvider.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/transaction/lock/TestDynamoDBBasedImplicitPartitionKeyLockProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.aws.transaction.lock;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link DynamoDBBasedImplicitPartitionKeyLockProvider#derivePartitionKey} as a pure
+ * function — no DynamoDB client required. Verifies that benign formatting variations in the
+ * hudi table base path (trailing slash, multi-slash, whitespace, s3a vs s3 scheme) all produce
+ * the same DynamoDB partition key. Without this invariant, two engines writing the same Hudi
+ * table can take independent locks and lose mutual exclusion.
+ */
+class TestDynamoDBBasedImplicitPartitionKeyLockProvider {
+
+  private static final String BASE_PATH_WITH_SLASH = "s3://my-bucket/my_lake/my_table/";
+  private static final String BASE_PATH_NO_SLASH = "s3://my-bucket/my_lake/my_table";
+
+  @Test
+  void trailingSlashVariantsProduceSamePartitionKey() {
+    String withSlash = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey(BASE_PATH_WITH_SLASH);
+    String noSlash = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey(BASE_PATH_NO_SLASH);
+    Assertions.assertEquals(withSlash, noSlash);
+  }
+
+  @Test
+  void multipleTrailingSlashesProduceSamePartitionKey() {
+    String once = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey(BASE_PATH_WITH_SLASH);
+    String twice = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey(BASE_PATH_NO_SLASH + "//");
+    String thrice = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey(BASE_PATH_NO_SLASH + "///");
+    Assertions.assertEquals(once, twice);
+    Assertions.assertEquals(once, thrice);
+  }
+
+  @Test
+  void surroundingWhitespaceProducesSamePartitionKey() {
+    String clean = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey(BASE_PATH_WITH_SLASH);
+    String padded = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey("  " + BASE_PATH_NO_SLASH + "  ");
+    Assertions.assertEquals(clean, padded);
+  }
+
+  @Test
+  void s3aSchemeProducesSamePartitionKeyAsS3() {
+    String s3 = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey(BASE_PATH_WITH_SLASH);
+    String s3a = DynamoDBBasedImplicitPartitionKeyLockProvider.derivePartitionKey(
+        BASE_PATH_WITH_SLASH.replaceFirst("^s3://", "s3a://"));
+    Assertions.assertEquals(s3, s3a);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/StorageBasedLockProvider.java
@@ -59,6 +59,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static org.apache.hudi.common.config.LockConfiguration.DEFAULT_LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS;
+import static org.apache.hudi.common.fs.FSUtils.normalizeBasePathForLocking;
 import static org.apache.hudi.common.lock.LockState.ACQUIRED;
 import static org.apache.hudi.common.lock.LockState.ACQUIRING;
 import static org.apache.hudi.common.lock.LockState.FAILED_TO_ACQUIRE;
@@ -109,7 +110,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
   private final transient Thread shutdownThread;
   private final Option<HoodieLockMetrics> hoodieLockMetrics;
   private Option<AuditService> auditService;
-  private final String basePath;
+  private final String normalizedHudiTableBasePath;
 
   @GuardedBy("this")
   private StorageLockFile currentLockObj = null;
@@ -194,8 +195,8 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
     StorageBasedLockConfig config = new StorageBasedLockConfig.Builder().fromProperties(properties).build();
     long heartbeatPollSeconds = config.getRenewIntervalSecs();
     this.lockValiditySecs = config.getValiditySeconds();
-    this.basePath = config.getHudiTableBasePath();
-    String lockFolderPath = StorageLockClient.getLockFolderPath(basePath);
+    this.normalizedHudiTableBasePath = normalizeBasePathForLocking(config.getHudiTableBasePath());
+    String lockFolderPath = StorageLockClient.getLockFolderPath(normalizedHudiTableBasePath);
     this.lockFilePath = new StoragePath(lockFolderPath, DEFAULT_TABLE_LOCK_FILE_NAME).toString();
     this.heartbeatManager = heartbeatManagerLoader.apply(ownerId, TimeUnit.SECONDS.toMillis(heartbeatPollSeconds), this::renewLock);
     this.storageLockClient = storageLockClientLoader.apply(ownerId, lockFilePath, properties);
@@ -402,7 +403,7 @@ public class StorageBasedLockProvider implements LockProvider<StorageLockFile> {
     // Create audit service lazily on first successful lock acquisition if auditing is enabled
     if (auditService.isEmpty()) {
       auditService = AuditServiceFactory.createLockProviderAuditService(
-          ownerId, basePath, storageLockClient, acquisitionTimestamp,
+          ownerId, normalizedHudiTableBasePath, storageLockClient, acquisitionTimestamp,
           this::calculateLockExpiration, this::actuallyHoldsLock);
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/ZookeeperBasedImplicitBasePathLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/ZookeeperBasedImplicitBasePathLockProvider.java
@@ -46,6 +46,13 @@ public class ZookeeperBasedImplicitBasePathLockProvider extends BaseZookeeperBas
   public static final String LOCK_KEY = "lock_key";
   private final String hudiTableBasePath;
 
+  /**
+   * Compute the Zookeeper lock base path for a given Hudi table base path.
+   *
+   * <p>Accepts a raw basePath — normalization is applied here. {@code normalizeBasePathForLocking}
+   * is idempotent, so callers that already hold a normalized value (e.g. the constructor's
+   * {@code hudiTableBasePath} field) can pass it through without harm.
+   */
   public static String getLockBasePath(String hudiTableBasePath) {
     String normalized = normalizeBasePathForLocking(hudiTableBasePath);
     String lockBasePath = "/tmp/" + HashID.generateXXHashAsString(normalized, HashID.Size.BITS_64);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/ZookeeperBasedImplicitBasePathLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/ZookeeperBasedImplicitBasePathLockProvider.java
@@ -44,14 +44,14 @@ import static org.apache.hudi.common.fs.FSUtils.normalizeBasePathForLocking;
 public class ZookeeperBasedImplicitBasePathLockProvider extends BaseZookeeperBasedLockProvider {
 
   public static final String LOCK_KEY = "lock_key";
-  private final String hudiTableBasePath;
+  private final String normalizedHudiTableBasePath;
 
   /**
    * Compute the Zookeeper lock base path for a given Hudi table base path.
    *
    * <p>Accepts a raw basePath — normalization is applied here. {@code normalizeBasePathForLocking}
    * is idempotent, so callers that already hold a normalized value (e.g. the constructor's
-   * {@code hudiTableBasePath} field) can pass it through without harm.
+   * {@code normalizedHudiTableBasePath} field) can pass it through without harm.
    */
   public static String getLockBasePath(String hudiTableBasePath) {
     String normalized = normalizeBasePathForLocking(hudiTableBasePath);
@@ -63,7 +63,7 @@ public class ZookeeperBasedImplicitBasePathLockProvider extends BaseZookeeperBas
 
   public ZookeeperBasedImplicitBasePathLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf) {
     super(lockConfiguration, conf);
-    hudiTableBasePath = normalizeBasePathForLocking(
+    normalizedHudiTableBasePath = normalizeBasePathForLocking(
         lockConfiguration.getConfig().getString(HoodieCommonConfig.BASE_PATH.key()));
   }
 
@@ -82,6 +82,6 @@ public class ZookeeperBasedImplicitBasePathLockProvider extends BaseZookeeperBas
   @Override
   protected String generateLogSuffixString() {
     return StringUtils.join("ZkBasePath = ", zkBasePath,
-        ", lock key = ", lockKey, ", hudi table base path = ", hudiTableBasePath);
+        ", lock key = ", lockKey, ", hudi table base path = ", normalizedHudiTableBasePath);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/ZookeeperBasedImplicitBasePathLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/ZookeeperBasedImplicitBasePathLockProvider.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
-import static org.apache.hudi.common.fs.FSUtils.s3aToS3;
+import static org.apache.hudi.common.fs.FSUtils.normalizeBasePathForLocking;
 
 /**
  * A zookeeper based lock. This {@link LockProvider} implementation allows to lock table operations
@@ -47,15 +47,17 @@ public class ZookeeperBasedImplicitBasePathLockProvider extends BaseZookeeperBas
   private final String hudiTableBasePath;
 
   public static String getLockBasePath(String hudiTableBasePath) {
-    // Ensure consistent format for S3 URI.
-    String lockBasePath = "/tmp/" + HashID.generateXXHashAsString(s3aToS3(hudiTableBasePath), HashID.Size.BITS_64);
-    log.info("The Zookeeper lock key for the base path {} is {}", hudiTableBasePath, lockBasePath);
+    String normalized = normalizeBasePathForLocking(hudiTableBasePath);
+    String lockBasePath = "/tmp/" + HashID.generateXXHashAsString(normalized, HashID.Size.BITS_64);
+    log.info("The Zookeeper lock key for the base path {} (normalized: {}) is {}",
+        hudiTableBasePath, normalized, lockBasePath);
     return lockBasePath;
   }
 
   public ZookeeperBasedImplicitBasePathLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> conf) {
     super(lockConfiguration, conf);
-    hudiTableBasePath = s3aToS3(lockConfiguration.getConfig().getString(HoodieCommonConfig.BASE_PATH.key()));
+    hudiTableBasePath = normalizeBasePathForLocking(
+        lockConfiguration.getConfig().getString(HoodieCommonConfig.BASE_PATH.key()));
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestStorageBasedLockProvider.java
@@ -1070,4 +1070,53 @@ class TestStorageBasedLockProvider {
     }
   }
 
+  // -----------------------------------------
+  // lockFilePath invariance
+  // -----------------------------------------
+  //
+  // The basePath is canonicalized via FSUtils.normalizeBasePathForLocking before lockFilePath is
+  // derived. The normalization helper itself is covered by TestFSUtils; these tests prove the
+  // end-to-end invariant in this LP — two writers passing benignly-different basePath strings
+  // must end up at the SAME lockFilePath, or they lose mutual exclusion. lockFilePath is captured
+  // by intercepting the storageLockClientLoader (which receives lockFilePath as its 2nd arg).
+
+  private static String captureLockFilePath(String basePath) {
+    TypedProperties props = new TypedProperties();
+    props.put(BASE_PATH.key(), basePath);
+    String[] captured = new String[1];
+    new StorageBasedLockProvider(
+        UUID.randomUUID().toString(),
+        props,
+        (ownerId, ms, supplier) -> mock(HeartbeatManager.class),
+        (ownerId, lockFilePath, properties) -> {
+          captured[0] = lockFilePath;
+          return mock(StorageLockClient.class);
+        },
+        mock(Logger.class),
+        null);
+    return captured[0];
+  }
+
+  @Test
+  void lockFilePathIsInvariantUnderSchemeDrift() {
+    assertEquals(
+        captureLockFilePath("s3://my-bucket/my_lake/my_table"),
+        captureLockFilePath("s3a://my-bucket/my_lake/my_table"));
+  }
+
+  @Test
+  void lockFilePathIsInvariantUnderSurroundingWhitespace() {
+    assertEquals(
+        captureLockFilePath("s3://my-bucket/my_lake/my_table"),
+        captureLockFilePath("  s3://my-bucket/my_lake/my_table  "));
+  }
+
+  @Test
+  void lockFilePathIsInvariantUnderTrailingSlash() {
+    // Already guaranteed by StoragePath; regression-protect it so a future refactor doesn't
+    // drop that guarantee silently.
+    assertEquals(
+        captureLockFilePath("s3://my-bucket/my_lake/my_table"),
+        captureLockFilePath("s3://my-bucket/my_lake/my_table/"));
+  }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestZookeeperBasedImplicitBasePathLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestZookeeperBasedImplicitBasePathLockProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.transaction.lock;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link ZookeeperBasedImplicitBasePathLockProvider#getLockBasePath} as a pure
+ * function — no Zookeeper server required. Verifies that benign formatting variations in the
+ * hudi table base path (trailing slash, multi-slash, whitespace, s3a vs s3 scheme) all produce
+ * the same Zookeeper lock base path. Without this invariant, two engines writing the same Hudi
+ * table can take independent locks and lose mutual exclusion.
+ */
+class TestZookeeperBasedImplicitBasePathLockProvider {
+
+  private static final String BASE_PATH_WITH_SLASH = "s3://my-bucket/my_lake/my_table/";
+  private static final String BASE_PATH_NO_SLASH = "s3://my-bucket/my_lake/my_table";
+
+  @Test
+  void trailingSlashVariantsProduceSameLockBasePath() {
+    String withSlash = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath(BASE_PATH_WITH_SLASH);
+    String noSlash = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath(BASE_PATH_NO_SLASH);
+    Assertions.assertEquals(withSlash, noSlash);
+    Assertions.assertTrue(withSlash.startsWith("/tmp/"), "Lock path must keep its /tmp/ prefix");
+  }
+
+  @Test
+  void multipleTrailingSlashesProduceSameLockBasePath() {
+    String once = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath(BASE_PATH_WITH_SLASH);
+    String twice = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath(BASE_PATH_NO_SLASH + "//");
+    String thrice = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath(BASE_PATH_NO_SLASH + "///");
+    Assertions.assertEquals(once, twice);
+    Assertions.assertEquals(once, thrice);
+  }
+
+  @Test
+  void surroundingWhitespaceProducesSameLockBasePath() {
+    String clean = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath(BASE_PATH_WITH_SLASH);
+    String padded = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath("  " + BASE_PATH_NO_SLASH + "  ");
+    Assertions.assertEquals(clean, padded);
+  }
+
+  @Test
+  void s3aSchemeProducesSameLockBasePathAsS3() {
+    String s3 = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath(BASE_PATH_WITH_SLASH);
+    String s3a = ZookeeperBasedImplicitBasePathLockProvider.getLockBasePath(
+        BASE_PATH_WITH_SLASH.replaceFirst("^s3://", "s3a://"));
+    Assertions.assertEquals(s3, s3a);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -767,6 +767,10 @@ public class FSUtils {
    * hash, so any benign formatting drift in the basePath has to be eliminated before hashing.
    * This method trims surrounding whitespace, normalizes s3a:// to s3://, then forces exactly
    * one trailing slash. Inner double slashes are intentionally preserved.
+   *
+   * <p>Scheme-only inputs (e.g. {@code "s3://"}, {@code "s3a:///"}) and all-slash inputs
+   * (e.g. {@code "///"}) are rejected — stripping the trailing slashes from those leaves
+   * nothing meaningful to lock against.
    */
   public static String normalizeBasePathForLocking(String basePath) {
     if (basePath == null) {
@@ -780,6 +784,12 @@ public class FSUtils {
     int end = schemeNormalized.length();
     while (end > 0 && schemeNormalized.charAt(end - 1) == '/') {
       end--;
+    }
+    // Reject "///"-style inputs (nothing left) and "s3://"/"s3a:///"-style scheme-only
+    // inputs (stripping the slashes leaves only the scheme prefix ending in ':').
+    if (end == 0 || schemeNormalized.charAt(end - 1) == ':') {
+      throw new IllegalArgumentException(
+          "Hudi table base path is not a valid lockable path: '" + basePath + "'");
     }
     return schemeNormalized.substring(0, end) + "/";
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -759,6 +759,31 @@ public class FSUtils {
     return s3aUrl.replaceFirst("(?i)^s3a://", "s3://");
   }
 
+  /**
+   * Canonicalize a Hudi table base path for use as the input to implicit lock-key derivation.
+   *
+   * <p>Implicit lock providers (DynamoDB and Zookeeper variants) hash this string to choose the
+   * lock row / znode for a table. Two callers writing to the same table must produce the same
+   * hash, so any benign formatting drift in the basePath has to be eliminated before hashing.
+   * This method trims surrounding whitespace, normalizes s3a:// to s3://, then forces exactly
+   * one trailing slash. Inner double slashes are intentionally preserved.
+   */
+  public static String normalizeBasePathForLocking(String basePath) {
+    if (basePath == null) {
+      throw new IllegalArgumentException("Hudi table base path cannot be null");
+    }
+    String trimmed = basePath.trim();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException("Hudi table base path cannot be empty");
+    }
+    String schemeNormalized = s3aToS3(trimmed);
+    int end = schemeNormalized.length();
+    while (end > 0 && schemeNormalized.charAt(end - 1) == '/') {
+      end--;
+    }
+    return schemeNormalized.substring(0, end) + "/";
+  }
+
   public static StoragePathInfo toStoragePathInfo(HoodieFileStatus fileStatus) {
     if (null == fileStatus) {
       return null;

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
@@ -689,9 +689,33 @@ public class TestFSUtils extends HoodieCommonTestHarness {
       "gs://my-bucket/path/to/s3a://object",
       "gs://my-bucket s3a://my-object",
   })
-  
+
   void testUriDoesNotChange(String uri) {
     assertEquals(uri, FSUtils.s3aToS3(uri));
+  }
+
+  @Test
+  void testNormalizeBasePathForLocking() {
+    // Canonical form ends with exactly one trailing slash.
+    assertEquals("s3://my-bucket/path/", FSUtils.normalizeBasePathForLocking("s3://my-bucket/path"));
+    assertEquals("s3://my-bucket/path/", FSUtils.normalizeBasePathForLocking("s3://my-bucket/path/"));
+    // Multiple trailing slashes collapse to one.
+    assertEquals("s3://my-bucket/path/", FSUtils.normalizeBasePathForLocking("s3://my-bucket/path///"));
+    // s3a:// is normalized to s3:// (delegates to s3aToS3).
+    assertEquals("s3://my-bucket/path/", FSUtils.normalizeBasePathForLocking("s3a://my-bucket/path"));
+    assertEquals("s3://my-bucket/path/", FSUtils.normalizeBasePathForLocking("S3A://my-bucket/path/"));
+    // Whitespace surrounding the path is trimmed.
+    assertEquals("s3://my-bucket/path/", FSUtils.normalizeBasePathForLocking("  s3://my-bucket/path  "));
+    assertEquals("s3://my-bucket/path/", FSUtils.normalizeBasePathForLocking("\ts3a://my-bucket/path/\n"));
+    // Non-S3 schemes pass through (still get trailing-slash normalization).
+    assertEquals("gs://my-bucket/path/", FSUtils.normalizeBasePathForLocking("gs://my-bucket/path"));
+    assertEquals("gs://my-bucket/path/", FSUtils.normalizeBasePathForLocking("gs://my-bucket/path//"));
+    // Inner consecutive slashes are intentionally NOT touched (could be a real S3 key).
+    assertEquals("s3://my-bucket//inner/path/", FSUtils.normalizeBasePathForLocking("s3://my-bucket//inner/path"));
+    // Null and empty are rejected.
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking(null));
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking(""));
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking("   "));
   }
 
   private StoragePath getHoodieTempDir() {

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestFSUtils.java
@@ -712,10 +712,25 @@ public class TestFSUtils extends HoodieCommonTestHarness {
     assertEquals("gs://my-bucket/path/", FSUtils.normalizeBasePathForLocking("gs://my-bucket/path//"));
     // Inner consecutive slashes are intentionally NOT touched (could be a real S3 key).
     assertEquals("s3://my-bucket//inner/path/", FSUtils.normalizeBasePathForLocking("s3://my-bucket//inner/path"));
+    // Random ASCII chars (URL-unsafe and equals/colon/plus/hash/ampersand/space) pass through
+    // unchanged except for the trailing-slash and s3a-scheme rules. Hudi does not re-encode
+    // paths internally so the lock key must be byte-stable across these characters.
+    assertEquals(
+        "s3://my-bucket/datalake/db=foo:bar/dt=2024-01-01T00:00:00+05:30/region=us east/category=a&b=c/vehicle#1/file/",
+        FSUtils.normalizeBasePathForLocking(
+            "s3a://my-bucket/datalake/db=foo:bar/dt=2024-01-01T00:00:00+05:30/region=us east/category=a&b=c/vehicle#1/file"));
     // Null and empty are rejected.
     assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking(null));
     assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking(""));
     assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking("   "));
+    // Scheme-only inputs and all-slash inputs are rejected — stripping leaves nothing
+    // meaningful to lock against.
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking("s3://"));
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking("s3:///"));
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking("s3a://"));
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking("s3a:///"));
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking("///"));
+    assertThrows(IllegalArgumentException.class, () -> FSUtils.normalizeBasePathForLocking("/"));
   }
 
   private StoragePath getHoodieTempDir() {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Follow-up to #18814, which introduced `FSUtils.normalizeBasePathForLocking` for the implicit-key lock providers. `StorageBasedLockProvider` derives `lockFilePath` directly from the raw \`hoodie.base.path\` config value:

\`\`\`java
this.basePath = config.getHudiTableBasePath();
String lockFolderPath = StorageLockClient.getLockFolderPath(basePath);  // new StoragePath(basePath, ".locks")
this.lockFilePath = new StoragePath(lockFolderPath, DEFAULT_TABLE_LOCK_FILE_NAME).toString();
\`\`\`

\`StoragePath\` absorbs trailing-slash drift, so \`s3://b/t\` and \`s3://b/t/\` already produce the same lock file. But two other classes of benign basePath drift do **not** get absorbed and route the writers to different lock files:

| Drift | Same lock file today? | Reason |
|---|---|---|
| Trailing slash (\`s3://b/t\` vs \`s3://b/t/\`) | ✅ yes | \`StoragePath\` normalizes |
| Scheme case (\`s3a://b/t\` vs \`s3://b/t\`) | ❌ **no** | Scheme is preserved verbatim through \`StoragePath\` |
| Surrounding whitespace | ❌ **no** | Whitespace becomes part of the URI |

Two writers that disagree on those benign formatting details acquire **different** lock files and lose mutual exclusion. Same class of bug as #18814, lower severity because the divergence is a visible second lock file rather than a silent hash split, but still a correctness issue.

### Summary and Changelog

Route the raw basePath through \`FSUtils.normalizeBasePathForLocking\` (the helper introduced in #18814) before building \`lockFilePath\`. Using the same canonicalization API as the implicit-key LPs keeps the contract for "what counts as the same Hudi table" consistent across all lock providers.

Also rename the stored field \`basePath\` → \`normalizedHudiTableBasePath\` so the name reflects what's actually stored.

### Impact

- **Behavior**: \`StorageBasedLockProvider\` will produce the same \`lockFilePath\` for a Hudi table regardless of trailing-slash, surrounding whitespace, or \`s3a\`/\`s3\` scheme variations. No public API signature change.
- **Performance**: Negligible — one extra \`trim()\` and a short scheme rewrite per LP construction.
- **Compatibility (rollout caveat)**: Lock files keyed under the previous \`s3a://...\` form effectively orphan at deploy time, since the new code looks at \`s3://...\` for the same logical table. Operators upgrading should coordinate the deploy across all writers that share a Hudi table that uses this LP, or briefly quiesce writers while rolling out. Stale lock files can be cleaned up manually after the cutover. No rollout impact for callers that already pass \`s3://...\`.

### Risk Level

low

The change only affects how raw config strings are canonicalized before being fed to existing path-derivation code. Existing trailing-slash callers will see no change in derived lockFilePath (\`StoragePath\` already absorbed that). The only callers whose lock file moves are those that supplied an \`s3a://...\` basePath or surrounding whitespace.

Mitigation:
- Existing TestStorageBasedLockProvider suite continues to pass.
- New tests cover the invariant directly: scheme drift, whitespace, and trailing-slash variants all produce the same lockFilePath.

### Documentation Update

none — no user-facing config or website change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

**Note**: This PR is stacked on top of #18814 — its diff currently includes the parent PR's changes until #18814 merges. The StorageBasedLockProvider-specific commit is the last one in the branch.