### PR TITLE
feat(flink): support singleton RocksDBDAO creation in RocksDBIndexBackend

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAOFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAOFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util.collection;
+
+import org.apache.hudi.common.serialization.CustomSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory that creates and caches {@link RocksDBDAO} singletons keyed by {@code (basePath, rocksDBBasePath)}.
+ *
+ * <p>Multiple callers that supply identical parameters share a single underlying RocksDB instance.
+ * The factory tracks a reference count; the instance is physically closed and evicted only when
+ * every holder has called {@link #release}.
+ *
+ * <p>Callers <em>must</em> call {@link #release} (not {@link RocksDBDAO#close}) when they are
+ * done with the instance, so that the reference count is decremented correctly.
+ *
+ * <p>Note: column-family serializers and the {@code disableWAL} flag are applied only on the
+ * first creation for a given key. Subsequent callers that pass different values for these
+ * parameters will share the instance created by the first caller.
+ */
+public class RocksDBDAOFactory {
+  private static final Object LOCK = new Object();
+  private static final Map<String, Entry> INSTANCES = new HashMap<>();
+
+  private RocksDBDAOFactory() {
+  }
+
+  /**
+   * Returns a shared {@link RocksDBDAO} for the given parameters, creating one if absent.
+   *
+   * <p>Increments the internal reference count. Callers must invoke {@link #release} with the
+   * same {@code basePath} and {@code rocksDBBasePath} when the instance is no longer needed.
+   *
+   * @param basePath                logical base path identifying the Hudi table
+   * @param rocksDBBasePath         filesystem path under which RocksDB stores its data
+   * @param columnFamilySerializers per-column-family serializers (applied only on first creation)
+   * @param disableWAL              whether to disable the write-ahead log (applied only on first creation)
+   * @return shared {@link RocksDBDAO} instance
+   */
+  public static RocksDBDAO getOrCreate(
+      String basePath,
+      String rocksDBBasePath,
+      ConcurrentHashMap<String, CustomSerializer<?>> columnFamilySerializers,
+      boolean disableWAL) {
+    String key = buildKey(basePath, rocksDBBasePath);
+    synchronized (LOCK) {
+      Entry entry = INSTANCES.computeIfAbsent(key,
+          k -> new Entry(new RocksDBDAO(basePath, rocksDBBasePath, columnFamilySerializers, disableWAL)));
+      entry.refCount++;
+      return entry.dao;
+    }
+  }
+
+  /**
+   * Releases a previously acquired {@link RocksDBDAO}.
+   *
+   * <p>Decrements the reference count for the instance identified by the given parameters.
+   * When the count reaches zero the underlying RocksDB instance is closed and removed from
+   * the cache. Subsequent calls to {@link #getOrCreate} with the same parameters will create
+   * a fresh instance.
+   *
+   * @param basePath        logical base path used when acquiring the instance
+   * @param rocksDBBasePath filesystem path used when acquiring the instance
+   */
+  public static void release(String basePath, String rocksDBBasePath) {
+    String key = buildKey(basePath, rocksDBBasePath);
+    RocksDBDAO toClose = null;
+    synchronized (LOCK) {
+      Entry entry = INSTANCES.get(key);
+      if (entry != null && --entry.refCount <= 0) {
+        INSTANCES.remove(key);
+        toClose = entry.dao;
+      }
+    }
+    // Close outside the lock so we do not hold it during potentially blocking I/O.
+    if (toClose != null) {
+      toClose.close();
+    }
+  }
+
+  private static String buildKey(String basePath, String rocksDBBasePath) {
+    return basePath + "|" + rocksDBBasePath;
+  }
+
+  private static final class Entry {
+    final RocksDBDAO dao;
+    int refCount;
+
+    Entry(RocksDBDAO dao) {
+      this.dao = dao;
+      this.refCount = 0;
+    }
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestRocksDBDAOFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestRocksDBDAOFactory.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util.collection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link RocksDBDAOFactory}.
+ */
+public class TestRocksDBDAOFactory {
+
+  private static final String BASE_PATH = "/hudi/factory/test";
+  private static final String FAMILY = "test_family";
+
+  // -------------------------------------------------------------------------
+  // Singleton identity
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testSameParametersReturnSameInstance(@TempDir File tempDir) {
+    String rocksDBBasePath = tempDir.getAbsolutePath();
+
+    RocksDBDAO dao1 = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    RocksDBDAO dao2 = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    try {
+      assertSame(dao1, dao2, "Same parameters must return the identical RocksDBDAO instance");
+    } finally {
+      RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+      RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+    }
+  }
+
+  @Test
+  void testDifferentRocksDBBasePathReturnDifferentInstances(@TempDir File dir1, @TempDir File dir2) {
+    RocksDBDAO dao1 = RocksDBDAOFactory.getOrCreate(BASE_PATH, dir1.getAbsolutePath(), new ConcurrentHashMap<>(), false);
+    RocksDBDAO dao2 = RocksDBDAOFactory.getOrCreate(BASE_PATH, dir2.getAbsolutePath(), new ConcurrentHashMap<>(), false);
+    try {
+      assertNotSame(dao1, dao2, "Different rocksDBBasePath values must produce distinct instances");
+    } finally {
+      RocksDBDAOFactory.release(BASE_PATH, dir1.getAbsolutePath());
+      RocksDBDAOFactory.release(BASE_PATH, dir2.getAbsolutePath());
+    }
+  }
+
+  @Test
+  void testDifferentBasePathReturnDifferentInstances(@TempDir File tempDir) {
+    String rocksDBBasePath = tempDir.getAbsolutePath();
+    String basePath1 = "/hudi/table/a";
+    String basePath2 = "/hudi/table/b";
+
+    RocksDBDAO dao1 = RocksDBDAOFactory.getOrCreate(basePath1, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    RocksDBDAO dao2 = RocksDBDAOFactory.getOrCreate(basePath2, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    try {
+      assertNotSame(dao1, dao2, "Different basePath values must produce distinct instances");
+    } finally {
+      RocksDBDAOFactory.release(basePath1, rocksDBBasePath);
+      RocksDBDAOFactory.release(basePath2, rocksDBBasePath);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Reference counting
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testPartialReleasesDoNotCloseDAO(@TempDir File tempDir) {
+    String rocksDBBasePath = tempDir.getAbsolutePath();
+
+    RocksDBDAO dao1 = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    RocksDBDAO dao2 = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    RocksDBDAO dao3 = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+
+    dao1.addColumnFamily(FAMILY);
+    dao1.put(FAMILY, "key1", "value1");
+
+    // Releasing two of the three references must not close the DAO.
+    RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+    assertEquals("value1", dao2.<String>get(FAMILY, "key1"),
+        "DAO must remain usable after first release");
+
+    RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+    assertEquals("value1", dao3.<String>get(FAMILY, "key1"),
+        "DAO must remain usable after second release");
+
+    // Last release closes the DAO.
+    RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+  }
+
+  @Test
+  void testLastReleaseClosesAndEvictsDAO(@TempDir File tempDir) {
+    String rocksDBBasePath = tempDir.getAbsolutePath();
+
+    RocksDBDAO dao = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    String physicalPath = dao.getRocksDBBasePath();
+    assertTrue(new File(physicalPath).exists(), "RocksDB directory must exist after creation");
+
+    RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+
+    // RocksDBDAO.close() deletes the physical directory; its absence confirms the DAO was closed.
+    assertFalse(new File(physicalPath).exists(),
+        "RocksDB directory must be deleted after the last release");
+  }
+
+  @Test
+  void testReacquireAfterLastReleaseCreatesFreshInstance(@TempDir File tempDir) {
+    String rocksDBBasePath = tempDir.getAbsolutePath();
+
+    RocksDBDAO first = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+
+    RocksDBDAO second = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    try {
+      assertNotSame(first, second,
+          "After the last release, getOrCreate must create a fresh RocksDBDAO instance");
+    } finally {
+      RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+    }
+  }
+
+  @Test
+  void testReleaseWithoutAcquireIsNoop() {
+    // Must not throw even if no matching entry exists in the factory.
+    RocksDBDAOFactory.release("/nonexistent/base", "/nonexistent/rocks");
+  }
+
+  // -------------------------------------------------------------------------
+  // Data isolation
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testDistinctInstancesDoNotShareData(@TempDir File dir1, @TempDir File dir2) {
+    RocksDBDAO dao1 = RocksDBDAOFactory.getOrCreate(BASE_PATH, dir1.getAbsolutePath(), new ConcurrentHashMap<>(), false);
+    RocksDBDAO dao2 = RocksDBDAOFactory.getOrCreate(BASE_PATH, dir2.getAbsolutePath(), new ConcurrentHashMap<>(), false);
+    try {
+      dao1.addColumnFamily(FAMILY);
+      dao2.addColumnFamily(FAMILY);
+
+      dao1.put(FAMILY, "key1", "value1");
+
+      assertNull(dao2.<String>get(FAMILY, "key1"),
+          "Distinct RocksDBDAO instances must not share data");
+    } finally {
+      RocksDBDAOFactory.release(BASE_PATH, dir1.getAbsolutePath());
+      RocksDBDAOFactory.release(BASE_PATH, dir2.getAbsolutePath());
+    }
+  }
+
+  @Test
+  void testSharedInstanceSharesData(@TempDir File tempDir) {
+    String rocksDBBasePath = tempDir.getAbsolutePath();
+
+    RocksDBDAO dao1 = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    RocksDBDAO dao2 = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false);
+    try {
+      dao1.addColumnFamily(FAMILY);
+      dao1.put(FAMILY, "shared_key", "shared_value");
+
+      assertEquals("shared_value", dao2.<String>get(FAMILY, "shared_key"),
+          "Callers sharing the same DAO must observe each other's writes");
+    } finally {
+      RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+      RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Thread safety
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testConcurrentGetOrCreateReturnsSameInstance(@TempDir File tempDir) throws InterruptedException {
+    String rocksDBBasePath = tempDir.getAbsolutePath();
+    int numThreads = 10;
+
+    List<RocksDBDAO> results = new ArrayList<>();
+    for (int i = 0; i < numThreads; i++) {
+      results.add(null);
+    }
+
+    ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(numThreads);
+    AtomicReference<Throwable> error = new AtomicReference<>();
+
+    for (int i = 0; i < numThreads; i++) {
+      final int idx = i;
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          results.set(idx,
+              RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDBBasePath, new ConcurrentHashMap<>(), false));
+        } catch (Throwable t) {
+          error.compareAndSet(null, t);
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    assertTrue(doneLatch.await(30, TimeUnit.SECONDS), "Threads did not finish in time");
+    executor.shutdownNow();
+
+    assertNull(error.get(), "Concurrent getOrCreate threw an exception: " + error.get());
+
+    RocksDBDAO expected = results.get(0);
+    for (int i = 1; i < numThreads; i++) {
+      assertSame(expected, results.get(i),
+          "All concurrent getOrCreate calls must return the same instance");
+    }
+
+    // Release all numThreads references acquired above.
+    for (int i = 0; i < numThreads; i++) {
+      RocksDBDAOFactory.release(BASE_PATH, rocksDBBasePath);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
@@ -21,6 +21,7 @@ package org.apache.hudi.sink.partitioner.index;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.serialization.CustomSerializer;
 import org.apache.hudi.common.util.collection.RocksDBDAO;
+import org.apache.hudi.common.util.collection.RocksDBDAOFactory;
 import org.apache.hudi.metrics.FlinkRocksDBIndexMetrics;
 
 import lombok.extern.slf4j.Slf4j;
@@ -37,18 +38,21 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 public class RocksDBIndexBackend implements GlobalIndexBackend {
   private static final String COLUMN_FAMILY = "index_cache";
+  private static final String BASE_PATH = "hudi-index-backend";
 
   private final RocksDBDAO rocksDBDAO;
+  private final String rocksDbBasePath;
   private transient FlinkRocksDBIndexMetrics rocksDBIndexMetrics;
 
   public RocksDBIndexBackend(String rocksDbBasePath, boolean isPartitionedTable) {
+    this.rocksDbBasePath = rocksDbBasePath;
     // Register custom serializer for HoodieRecordGlobalLocation to minimize storage overhead
     ConcurrentHashMap<String, CustomSerializer<?>> serializers = new ConcurrentHashMap<>();
     serializers.put(COLUMN_FAMILY, isPartitionedTable
         ? new CodedRecordGlobalLocationSerializer()
         : new RecordGlobalLocationSerializer());
 
-    this.rocksDBDAO = new RocksDBDAO("hudi-index-backend", rocksDbBasePath, serializers, true);
+    this.rocksDBDAO = RocksDBDAOFactory.getOrCreate(BASE_PATH, rocksDbBasePath, serializers, true);
     this.rocksDBDAO.addColumnFamily(COLUMN_FAMILY);
   }
 
@@ -94,6 +98,6 @@ public class RocksDBIndexBackend implements GlobalIndexBackend {
 
   @Override
   public void close() throws IOException {
-    this.rocksDBDAO.close();
+    RocksDBDAOFactory.release(BASE_PATH, rocksDbBasePath);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBIndexBackend.java
@@ -180,4 +180,36 @@ public class TestRocksDBIndexBackend {
     assertEquals(0D, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_HIT_RATIO).getValue()).doubleValue());
     assertEquals(0D, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_HIT_RATIO).getValue()).doubleValue());
   }
+
+  @Test
+  void testMultipleInstancesSamePathShareSingleDAO() throws Exception {
+    // Two backends pointing at the same rocksDbBasePath share the same RocksDBDAO.
+    // A record written through one must be immediately visible through the other.
+    try (RocksDBIndexBackend backend1 = new RocksDBIndexBackend(tempFile.getAbsolutePath(), false);
+         RocksDBIndexBackend backend2 = new RocksDBIndexBackend(tempFile.getAbsolutePath(), false)) {
+
+      HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("", "001", UUID.randomUUID().toString());
+      backend1.update("shared_key", location);
+
+      assertEquals(location, backend2.get("shared_key"),
+          "Backend2 must see records written by backend1 when they share the same DAO");
+    }
+  }
+
+  @Test
+  void testDaoRemainsUsableUntilLastInstanceCloses() throws Exception {
+    // The underlying DAO must stay open as long as at least one backend holds a reference.
+    RocksDBIndexBackend backend1 = new RocksDBIndexBackend(tempFile.getAbsolutePath(), false);
+    RocksDBIndexBackend backend2 = new RocksDBIndexBackend(tempFile.getAbsolutePath(), false);
+
+    HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("", "001", UUID.randomUUID().toString());
+    backend1.update("key1", location);
+
+    // Closing backend1 must not close the DAO while backend2 still holds a reference.
+    backend1.close();
+    assertEquals(location, backend2.get("key1"),
+        "DAO must remain usable after the first backend closes while a second still holds a reference");
+
+    backend2.close();
+  }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Create singleton RocksDBDAO creation pattern for Flink operator to share the same rocksdb instance.

### Summary and Changelog

1. Added RocksDBDAOFactory for RocksDBDAO creation
2. Updated RocksDBIndexBackend with the change
3. Added test cases for new changes

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
