### PR TITLE
fix(metadata): propagate spillable-map config family from main dataset to metadata

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -59,6 +59,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.SpillableMapBasedFileSystemView;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
@@ -144,7 +145,7 @@ public class HoodieMetadataWriteUtils {
   // built from scratch and does not otherwise inherit HoodieCommonConfig / HoodieMemoryConfig
   // values, so without explicit propagation user overrides set on the data-table write
   // config are silently ignored by the MDT writer/compactor.
-  private static final List<ConfigProperty<?>> MDT_INHERITED_SPILLABLE_MAP_CONFIGS = List.of(
+  private static final List<ConfigProperty<?>> MDT_INHERITED_SPILLABLE_MAP_CONFIGS = CollectionUtils.createImmutableList(
       HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE,
       HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED,
       HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -87,7 +87,6 @@ import org.apache.hudi.util.Lazy;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -145,7 +144,7 @@ public class HoodieMetadataWriteUtils {
   // built from scratch and does not otherwise inherit HoodieCommonConfig / HoodieMemoryConfig
   // values, so without explicit propagation user overrides set on the data-table write
   // config are silently ignored by the MDT writer/compactor.
-  private static final List<ConfigProperty<?>> MDT_INHERITED_SPILLABLE_MAP_CONFIGS = Arrays.asList(
+  private static final List<ConfigProperty<?>> MDT_INHERITED_SPILLABLE_MAP_CONFIGS = List.of(
       HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE,
       HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED,
       HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -21,6 +21,9 @@ package org.apache.hudi.metadata;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.client.FailOnFirstErrorWriteStatus;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieTableServiceManagerConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
@@ -84,6 +87,7 @@ import org.apache.hudi.util.Lazy;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -135,6 +139,21 @@ public class HoodieMetadataWriteUtils {
   // ever. Hence, we use a very large basefile size in metadata table. The actual size of the HFiles created will
   // eventually depend on the number of file groups selected for each partition (See estimateFileGroupCount function)
   private static final long MDT_MAX_HFILE_SIZE_BYTES = 10 * 1024 * 1024 * 1024L; // 10GB
+
+  // Configs that control the spillable-map machinery used by the MDT writer and compactor
+  // (ExternalSpillableMap + HoodieMergedLogRecordScanner). The MDT HoodieWriteConfig is
+  // built from scratch and does not otherwise inherit HoodieCommonConfig / HoodieMemoryConfig
+  // values, so without explicit propagation user overrides set on the data-table write
+  // config are silently ignored by the MDT writer/compactor.
+  private static final List<ConfigProperty<?>> MDT_INHERITED_SPILLABLE_MAP_CONFIGS = Arrays.asList(
+      HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE,
+      HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED,
+      HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH,
+      HoodieMemoryConfig.MAX_MEMORY_FOR_COMPACTION,
+      HoodieMemoryConfig.MAX_MEMORY_FRACTION_FOR_COMPACTION,
+      HoodieMemoryConfig.MAX_MEMORY_FOR_MERGE,
+      HoodieMemoryConfig.MAX_MEMORY_FRACTION_FOR_MERGE,
+      HoodieMemoryConfig.MAX_DFS_STREAM_BUFFER_SIZE);
 
   /**
    * Create a {@code HoodieWriteConfig} to use for the Metadata Table.
@@ -278,6 +297,21 @@ public class HoodieMetadataWriteUtils {
         .withWriteRecordPositionsEnabled(false)
         .withWriteConcurrencyMode(concurrencyMode)
         .withLockConfig(lockConfig);
+
+    // Inherit spillable-map / memory configs so user overrides (e.g.
+    // hoodie.common.spillable.diskmap.type=ROCKS_DB) actually reach the MDT
+    // writer/compactor. Guarded by containsKey so that configs without defaults
+    // (e.g. SPILLABLE_MAP_BASE_PATH, MAX_MEMORY_FOR_COMPACTION) aren't forged
+    // into "user-set" on the MDT side when the user hasn't set them.
+    Properties spillableMapProperties = new Properties();
+    Properties dataTableProps = writeConfig.getProps();
+    for (ConfigProperty<?> inheritedConfig : MDT_INHERITED_SPILLABLE_MAP_CONFIGS) {
+      if (dataTableProps.containsKey(inheritedConfig.key())) {
+        spillableMapProperties.setProperty(inheritedConfig.key(),
+            dataTableProps.getProperty(inheritedConfig.key()));
+      }
+    }
+    builder.withProperties(spillableMapProperties);
 
     // RecordKey properties are needed for the metadata table records
     final Properties properties = new Properties();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
@@ -23,12 +23,15 @@ import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.client.transaction.lock.StorageBasedLockProvider;
 import org.apache.hudi.client.transaction.lock.ZookeeperBasedImplicitBasePathLockProvider;
 import org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider;
+import org.apache.hudi.common.config.HoodieCommonConfig;
+import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -498,6 +501,70 @@ public class TestHoodieMetadataWriteUtils {
         HoodieMetadataWriteUtils.createMetadataWriteConfig(
             writeConfig, HoodieFailedWritesCleaningPolicy.EAGER, HoodieTableVersion.EIGHT));
     assertTrue(ex.getMessage().contains("only supported for built-in lock providers"));
+  }
+
+  @Test
+  public void testSpillableMapConfigPropagation() {
+    // Without any user overrides, the MDT write config should fall back to the same
+    // common-config defaults as the user write config (BITCASK + compression enabled).
+    HoodieWriteConfig writeConfigDefault = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .build();
+    HoodieWriteConfig metadataWriteConfigDefault = HoodieMetadataWriteUtils.createMetadataWriteConfig(
+        writeConfigDefault, HoodieFailedWritesCleaningPolicy.EAGER, HoodieTableVersion.SIX);
+    assertEquals(ExternalSpillableMap.DiskMapType.BITCASK,
+        metadataWriteConfigDefault.getCommonConfig().getSpillableDiskMapType());
+    assertTrue(metadataWriteConfigDefault.getCommonConfig().isBitCaskDiskMapCompressionEnabled());
+
+    // Configs with noDefaultValue() must not be forged onto the MDT write config when the
+    // user didn't set them; otherwise IOUtils.getMaxMemoryPerCompaction would skip its
+    // fraction fallback and code paths reading SPILLABLE_MAP_BASE_PATH would see a
+    // hardcoded value rather than the inferred system default.
+    assertFalse(metadataWriteConfigDefault.getProps().containsKey(HoodieMemoryConfig.MAX_MEMORY_FOR_COMPACTION.key()),
+        "Unset no-default config MAX_MEMORY_FOR_COMPACTION must not be forged on the MDT write config");
+    assertFalse(metadataWriteConfigDefault.getProps().containsKey(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key()),
+        "Unset no-default config SPILLABLE_MAP_BASE_PATH must not be forged on the MDT write config");
+
+    // User overrides on the main write config must propagate to the MDT write config,
+    // otherwise MDT compaction silently uses defaults regardless of the user setting.
+    Properties properties = new Properties();
+    properties.setProperty(HoodieCommonConfig.SPILLABLE_DISK_MAP_TYPE.key(),
+        ExternalSpillableMap.DiskMapType.ROCKS_DB.name());
+    properties.setProperty(HoodieCommonConfig.DISK_MAP_BITCASK_COMPRESSION_ENABLED.key(), "false");
+    properties.setProperty(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key(), "/tmp/mdt-spill");
+    properties.setProperty(HoodieMemoryConfig.MAX_MEMORY_FOR_COMPACTION.key(), "12345");
+    properties.setProperty(HoodieMemoryConfig.MAX_MEMORY_FRACTION_FOR_COMPACTION.key(), "0.42");
+    properties.setProperty(HoodieMemoryConfig.MAX_MEMORY_FOR_MERGE.key(), "67890");
+    properties.setProperty(HoodieMemoryConfig.MAX_MEMORY_FRACTION_FOR_MERGE.key(), "0.37");
+    properties.setProperty(HoodieMemoryConfig.MAX_DFS_STREAM_BUFFER_SIZE.key(), "2097152");
+    HoodieWriteConfig writeConfigOverridden = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withProperties(properties)
+        .build();
+
+    HoodieWriteConfig metadataWriteConfigOverridden = HoodieMetadataWriteUtils.createMetadataWriteConfig(
+        writeConfigOverridden, HoodieFailedWritesCleaningPolicy.EAGER, HoodieTableVersion.SIX);
+
+    assertEquals(ExternalSpillableMap.DiskMapType.ROCKS_DB,
+        metadataWriteConfigOverridden.getCommonConfig().getSpillableDiskMapType(),
+        "User-supplied spillable diskmap type must propagate to the metadata table write config");
+    assertFalse(metadataWriteConfigOverridden.getCommonConfig().isBitCaskDiskMapCompressionEnabled(),
+        "User-supplied bitcask compression flag must propagate to the metadata table write config");
+    assertEquals("/tmp/mdt-spill", metadataWriteConfigOverridden.getSpillableMapBasePath(),
+        "User-supplied spillable map base path must propagate to the metadata table write config");
+    assertEquals("12345",
+        metadataWriteConfigOverridden.getProps().getProperty(HoodieMemoryConfig.MAX_MEMORY_FOR_COMPACTION.key()),
+        "User-supplied max memory for compaction must propagate to the metadata table write config");
+    assertEquals("0.42",
+        metadataWriteConfigOverridden.getProps().getProperty(HoodieMemoryConfig.MAX_MEMORY_FRACTION_FOR_COMPACTION.key()),
+        "User-supplied max memory fraction for compaction must propagate to the metadata table write config");
+    assertEquals(67890L, metadataWriteConfigOverridden.getMaxMemoryPerPartitionMerge(),
+        "User-supplied max memory for merge must propagate to the metadata table write config");
+    assertEquals("0.37",
+        metadataWriteConfigOverridden.getProps().getProperty(HoodieMemoryConfig.MAX_MEMORY_FRACTION_FOR_MERGE.key()),
+        "User-supplied max memory fraction for merge must propagate to the metadata table write config");
+    assertEquals(2097152, metadataWriteConfigOverridden.getMaxDFSStreamBufferSize(),
+        "User-supplied DFS stream buffer size must propagate to the metadata table write config");
   }
 
   private void validateMetadataWriteConfig(HoodieWriteConfig metadataWriteConfig, HoodieFailedWritesCleaningPolicy expectedPolicy,


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`HoodieMetadataWriteUtils.createMetadataWriteConfig` builds the MDT `HoodieWriteConfig` from scratch and does not copy `HoodieCommonConfig` / `HoodieMemoryConfig` values from the data-table write config. As a result, user overrides in the spillable-map config family take effect for the data-table writer but are silently ignored by the MDT writer/compactor.

The most visible symptom is that `hoodie.common.spillable.diskmap.type=ROCKS_DB` has no effect on MDT compaction. `HoodieCompactor` reads the value via `config.getCommonConfig().getSpillableDiskMapType()`, and `commonConfig` on the MDT `HoodieWriteConfig` is the default-only instance. MDT compaction tasks therefore continue to use a BITCASK `ExternalSpillableMap` and can stall in `BitCaskDiskMap$CompressionHandler.decompressBytes` during merges even after operators apply the override at the table level.

### Summary and Changelog

Inherit the configs that drive the MDT writer's `ExternalSpillableMap` and `HoodieMergedLogRecordScanner`:

| Key | Defined in |
|-----|-----------|
| `hoodie.common.spillable.diskmap.type` | HoodieCommonConfig |
| `hoodie.common.diskmap.compression.enabled` | HoodieCommonConfig |
| `hoodie.memory.spillable.map.path` | HoodieMemoryConfig |
| `hoodie.memory.compaction.max.size` | HoodieCommonConfig / HoodieMemoryConfig |
| `hoodie.memory.compaction.fraction` | HoodieMemoryConfig |
| `hoodie.memory.merge.max.size` | HoodieMemoryConfig |
| `hoodie.memory.merge.fraction` | HoodieMemoryConfig |
| `hoodie.memory.dfs.buffer.max.size` | HoodieCommonConfig / HoodieMemoryConfig |

Propagation is implemented as a static `MDT_INHERITED_SPILLABLE_MAP_CONFIGS` list driving a `containsKey`-guarded copy loop. The guard matters for the two `noDefaultValue()` configs (`SPILLABLE_MAP_BASE_PATH` and `MAX_MEMORY_FOR_COMPACTION`): without it, the MDT side would observe a "user-set" value when the data-table side actually relies on `IOUtils.getMaxMemoryPerCompaction`'s fraction fallback or the inferred default spill path, breaking that fallback chain.

This mirrors the precedent set by `fix(metadata): propagate timeline server config from main dataset to metadata (#17486)`.

### Impact

No new configs; no default value changes; no public API change. Behavior change is limited to MDT writers when the user has set one of the eight keys above: previously the MDT writer silently ignored the override and used the default, now it honors the user value.

### Risk Level

low — the propagation is scoped to a small explicit list of configs, defaults remain unchanged, and an opt-in (no-override) path is preserved via the `containsKey` guard. Existing `TestHoodieMetadataWriteUtils` tests continue to pass (19/19).

### Documentation Update

none — existing config docs already describe the user-facing keys; this PR just makes the MDT writer honor them.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added (`TestHoodieMetadataWriteUtils#testSpillableMapConfigPropagation`)