### PR TITLE
feat(metadata): optimize RLI bootstrap by sizing file groups from base file footer row counts

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -826,28 +826,54 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         dataMetaClient,
         dataWriteConfig);
 
-    // Initialize the file groups
-    final int fileGroupCount = estimateFileGroupCount(records);
+    Pair<Integer, Integer> bounds = getRLIFileGroupCountBounds();
+    int minFileGroupCount = bounds.getLeft();
+    int maxFileGroupCount = bounds.getRight();
+
+    int fileGroupCount;
+    if (minFileGroupCount != maxFileGroupCount) {
+      // Estimate file group count based on record count read from base file footer metadata.
+      // Avoids the expensive records.persist() + records.count() pass over materialized records.
+      List<Pair<String, HoodieBaseFile>> partitionBaseFilePairs = latestMergedPartitionFileSliceList.stream()
+          .filter(p -> p.getRight().getBaseFile().isPresent())
+          .map(p -> Pair.of(p.getLeft(), p.getRight().getBaseFile().get()))
+          .collect(Collectors.toList());
+      fileGroupCount = estimateFileGroupCountFromBaseFiles(
+          partitionBaseFilePairs, minFileGroupCount, maxFileGroupCount);
+      LOG.info("Estimated {} file groups from base file footer metadata", fileGroupCount);
+    } else {
+      // min == max: skip estimation, use the fixed value directly.
+      fileGroupCount = minFileGroupCount;
+      LOG.info("Using user-configured file group count: {}", fileGroupCount);
+    }
+
     LOG.info("Initializing record index with {} file groups.", fileGroupCount);
     return Pair.of(fileGroupCount, records);
   }
 
-  private int estimateFileGroupCount(HoodieData<HoodieRecord> records) {
-    int minFileGroupCount;
-    int maxFileGroupCount;
+  /**
+   * Returns the (min, max) file group count bounds for RLI based on which RLI variant is enabled.
+   */
+  private Pair<Integer, Integer> getRLIFileGroupCountBounds() {
     if (dataWriteConfig.isRecordLevelIndexEnabled()) {
-      minFileGroupCount = dataWriteConfig.getRecordLevelIndexMinFileGroupCount();
-      maxFileGroupCount = dataWriteConfig.getRecordLevelIndexMaxFileGroupCount();
-    } else {
-      minFileGroupCount = dataWriteConfig.getGlobalRecordLevelIndexMinFileGroupCount();
-      maxFileGroupCount = dataWriteConfig.getGlobalRecordLevelIndexMaxFileGroupCount();
+      return Pair.of(dataWriteConfig.getRecordLevelIndexMinFileGroupCount(),
+          dataWriteConfig.getRecordLevelIndexMaxFileGroupCount());
     }
-    Supplier<Long> recordCountSupplier = () -> {
-      records.persist("MEMORY_AND_DISK_SER");
-      long count = records.count();
-      LOG.info("Initializing record index with {} mappings", count);
-      return count;
-    };
+    return Pair.of(dataWriteConfig.getGlobalRecordLevelIndexMinFileGroupCount(),
+        dataWriteConfig.getGlobalRecordLevelIndexMaxFileGroupCount());
+  }
+
+  /**
+   * Estimates RLI file group count using a record count derived from base file footer metadata.
+   * Reading row counts from the footer is an O(1)-per-file operation that avoids materializing
+   * records to compute a count.
+   */
+  private int estimateFileGroupCountFromBaseFiles(List<Pair<String, HoodieBaseFile>> partitionBaseFilePairs,
+                                                  int minFileGroupCount,
+                                                  int maxFileGroupCount) {
+    long estimatedRecordCount = estimateRecordCountFromBaseFiles(partitionBaseFilePairs);
+    LOG.info("Estimated total record count from base file footers: {}", estimatedRecordCount);
+    Supplier<Long> recordCountSupplier = () -> estimatedRecordCount;
     return HoodieTableMetadataUtil.estimateFileGroupCount(
         MetadataPartitionType.RECORD_INDEX,
         recordCountSupplier,
@@ -857,6 +883,32 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         dataWriteConfig.getRecordIndexGrowthFactor(),
         dataWriteConfig.getRecordIndexMaxFileGroupSizeBytes()
     );
+  }
+
+  /**
+   * Sums row counts read from each base file's footer metadata, in parallel via the engine context.
+   * Used in place of materializing and counting an RDD of records during RLI bootstrap.
+   */
+  private long estimateRecordCountFromBaseFiles(List<Pair<String, HoodieBaseFile>> partitionBaseFilePairs) {
+    if (partitionBaseFilePairs.isEmpty()) {
+      return 0L;
+    }
+    int parallelism = Math.min(partitionBaseFilePairs.size(),
+        dataWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism());
+    StorageConfiguration<?> storageConfBroadcast = storageConf;
+    return engineContext.parallelize(partitionBaseFilePairs, parallelism)
+        .map(partitionAndBaseFile -> {
+          HoodieBaseFile baseFile = partitionAndBaseFile.getValue();
+          StoragePath path = baseFile.getStoragePath();
+          try {
+            HoodieStorage storage = HoodieStorageUtils.getStorage(path, storageConfBroadcast);
+            return HoodieIOFactory.getIOFactory(storage).getFileFormatUtils(path).getRowCount(storage, path);
+          } catch (Exception e) {
+            LOG.warn("Failed to read row count from base file footer: {}", path, e);
+            return 0L;
+          }
+        })
+        .collectAsList().stream().mapToLong(Long::longValue).sum();
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -756,8 +756,15 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     createRecordIndexDefinition(dataMetaClient, Collections.singletonMap(HoodieRecordIndex.IS_PARTITIONED_OPTION, String.valueOf(isPartitionedRLI)));
     HoodieData<HoodieRecord> recordIndexRecords;
     int fileGroupCount;
+    // Happy path consumes the RDD exactly once (the bulk-insert below) so we deliberately do not
+    // persist it. When validation is enabled the same RDD is also forced by validateRecordIndex
+    // via recordIndexRecords.count(), which would otherwise re-read every base file and re-derive
+    // keys — so we declare persistence *before* bulk-insert on that path, letting bulkCommit's
+    // materialization populate the cache and validateRecordIndex#count read it back.
+    boolean validationEnabled = dataWriteConfig.getMetadataConfig().isRecordIndexInitializationValidationEnabled();
     if (isPartitionedRLI) {
-      Pair<Integer, HoodieData<HoodieRecord>> fgCountAndRecords = initializeFilegroupsAndCommitToPartitionedRecordIndexPartition(commitTimeForPartition, lazyLatestMergedPartitionFileSliceList);
+      Pair<Integer, HoodieData<HoodieRecord>> fgCountAndRecords = initializeFilegroupsAndCommitToPartitionedRecordIndexPartition(
+          commitTimeForPartition, lazyLatestMergedPartitionFileSliceList, validationEnabled);
       fileGroupCount = fgCountAndRecords.getKey();
       recordIndexRecords = fgCountAndRecords.getValue();
     } else {
@@ -765,17 +772,20 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
           dataWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism());
       fileGroupCount = fgCountAndRecordIndexRecords.getKey();
       recordIndexRecords = fgCountAndRecordIndexRecords.getRight();
+      if (validationEnabled) {
+        recordIndexRecords.persist("MEMORY_AND_DISK_SER");
+      }
       initializeFilegroupsAndCommit(RECORD_INDEX, RECORD_INDEX.getPartitionPath(), fgCountAndRecordIndexRecords, commitTimeForPartition);
     }
-    // Validate record index after commit if validation is enabled
-    if (dataWriteConfig.getMetadataConfig().isRecordIndexInitializationValidationEnabled()) {
+    if (validationEnabled) {
       validateRecordIndex(recordIndexRecords, fileGroupCount);
+      recordIndexRecords.unpersist();
     }
-    recordIndexRecords.unpersist();
   }
 
   private Pair<Integer, HoodieData<HoodieRecord>> initializeFilegroupsAndCommitToPartitionedRecordIndexPartition(String commitTimeForPartition,
-                                                                              Lazy<List<Pair<String, FileSlice>>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+                                                                              Lazy<List<Pair<String, FileSlice>>> lazyLatestMergedPartitionFileSliceList,
+                                                                              boolean persistRecordsForValidation) throws IOException {
     Map<String, List<Pair<String, FileSlice>>> partitionFileSlicePairsMap = lazyLatestMergedPartitionFileSliceList.get().stream()
         .collect(Collectors.groupingBy(Pair::getKey));
     Map<String, Pair<Integer, HoodieData<HoodieRecord>>> fileGroupCountAndRecordsPairMap = new HashMap<>(partitionFileSlicePairsMap.size());
@@ -802,6 +812,12 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       partitionSizes.put(dataPartition, fileGroupCountAndRecordsPair.getKey());
       initializeFileGroups(dataMetaClient, RECORD_INDEX, commitTimeForPartition, fileGroupCountAndRecordsPair.getKey(), RECORD_INDEX.getPartitionPath(), Option.of(dataPartition));
       records = records.union(fileGroupCountAndRecordsPair.getValue());
+    }
+
+    if (persistRecordsForValidation) {
+      // Caller will re-read this union via validateRecordIndex#count(); declare persistence
+      // here so bulkCommit's materialization populates the cache for that re-read.
+      records.persist("MEMORY_AND_DISK_SER");
     }
 
     // Perform the commit using bulkCommit
@@ -834,6 +850,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     if (minFileGroupCount != maxFileGroupCount) {
       // Estimate file group count based on record count read from base file footer metadata.
       // Avoids the expensive records.persist() + records.count() pass over materialized records.
+      // Filtering to base-file-only slices is safe for RLI: log files in a slice can only carry
+      // updates or deletes for existing records, never new inserts (RLI is keyed by record key
+      // and updates rewrite the entry rather than add one), so they do not contribute to the
+      // distinct-record-count estimate that sizes the file groups.
       List<Pair<String, HoodieBaseFile>> partitionBaseFilePairs = latestMergedPartitionFileSliceList.stream()
           .filter(p -> p.getRight().getBaseFile().isPresent())
           .map(p -> Pair.of(p.getLeft(), p.getRight().getBaseFile().get()))
@@ -888,6 +908,11 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   /**
    * Sums row counts read from each base file's footer metadata, in parallel via the engine context.
    * Used in place of materializing and counting an RDD of records during RLI bootstrap.
+   *
+   * <p>Errors (e.g. {@link UnsupportedOperationException} from {@code HFileUtils.getRowCount},
+   * IO failures) are rethrown rather than swallowed — silently returning {@code 0L} per failed
+   * file would systematically undercount the estimate and provision RLI at
+   * {@code minFileGroupCount}. The contract mirrors {@link #countRecordsInHFiles(List)}.
    */
   private long estimateRecordCountFromBaseFiles(List<Pair<String, HoodieBaseFile>> partitionBaseFilePairs) {
     if (partitionBaseFilePairs.isEmpty()) {
@@ -900,13 +925,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         .map(partitionAndBaseFile -> {
           HoodieBaseFile baseFile = partitionAndBaseFile.getRight();
           StoragePath path = baseFile.getStoragePath();
-          try {
-            HoodieStorage storage = HoodieStorageUtils.getStorage(path, storageConfBroadcast);
-            return HoodieIOFactory.getIOFactory(storage).getFileFormatUtils(path).getRowCount(storage, path);
-          } catch (Exception e) {
-            LOG.warn("Failed to read row count from base file footer: {}", path, e);
-            return 0L;
-          }
+          HoodieStorage storage = HoodieStorageUtils.getStorage(path, storageConfBroadcast);
+          return HoodieIOFactory.getIOFactory(storage).getFileFormatUtils(path).getRowCount(storage, path);
         })
         .collectAsList().stream().mapToLong(Long::longValue).sum();
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -898,7 +898,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     StorageConfiguration<?> storageConfBroadcast = storageConf;
     return engineContext.parallelize(partitionBaseFilePairs, parallelism)
         .map(partitionAndBaseFile -> {
-          HoodieBaseFile baseFile = partitionAndBaseFile.getValue();
+          HoodieBaseFile baseFile = partitionAndBaseFile.getRight();
           StoragePath path = baseFile.getStoragePath();
           try {
             HoodieStorage storage = HoodieStorageUtils.getStorage(path, storageConfBroadcast);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -4389,11 +4389,19 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     init(tableType);
     HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
 
+    // Pin the inputs so the estimator's output is the only thing that determines fileGroupCount:
+    //   expectedNumRecords = 200 records * growthFactor(2.0) = 400
+    //   maxRecordsPerFileGroup = maxFileGroupSizeBytes(2400) / avgRecordSize(48) = 50
+    //   estimatedFileGroupCount = 400 / 50 = 8 (within configured bounds [1, 10])
+    // If the estimator returned 0, fileGroupCount would clamp to minFileGroupCount=1, so an
+    // assertion of fileGroupCount > 1 proves the estimator's row-count read drove the sizing.
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(false, true, false)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(true)
             .withEnableRecordLevelIndex(true)
             .withPartitionedRecordIndexFileGroupCount(1, 10)
+            .withRecordIndexGrowthFactor(2.0f)
+            .withRecordIndexMaxFileGroupSizeBytes(2400L)
             .build())
         .withIndexConfig(HoodieIndexConfig.newBuilder()
             .withIndexType(HoodieIndex.IndexType.RECORD_INDEX)
@@ -4421,8 +4429,9 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       int fileGroupCount = HoodieTableMetadataUtil.getPartitionLatestFileSlices(
           metadataReader.getMetadataMetaClient(), Option.empty(),
           RECORD_INDEX.getPartitionPath()).size();
-      assertTrue(fileGroupCount >= 1 && fileGroupCount <= 10,
-          "File group count should be within configured bounds [1, 10]: " + fileGroupCount);
+      assertTrue(fileGroupCount > 1 && fileGroupCount <= 10,
+          "Estimator should have driven fileGroupCount above minFileGroupCount=1 (got: "
+              + fileGroupCount + "); a value of 1 implies the row-count estimate was 0 or unused.");
 
       validateMetadata(client);
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -4379,6 +4379,104 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     }
   }
 
+  /**
+   * Validates that RLI initialization estimates file group count from base file footer metadata
+   * (instead of materializing and counting records) when min != max file group count.
+   */
+  @ParameterizedTest
+  @EnumSource(HoodieTableType.class)
+  public void testRecordIndexFileGroupEstimation(HoodieTableType tableType) throws Exception {
+    init(tableType);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+
+    HoodieWriteConfig writeConfig = getWriteConfigBuilder(false, true, false)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withEnableRecordLevelIndex(true)
+            .withPartitionedRecordIndexFileGroupCount(1, 10)
+            .build())
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .withIndexType(HoodieIndex.IndexType.RECORD_INDEX)
+            .build())
+        .build();
+
+    try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
+      String firstCommit = client.startCommit();
+      List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
+      List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
+      assertNoWriteErrors(writeStatuses);
+      client.commit(firstCommit, jsc.parallelize(writeStatuses));
+
+      String secondCommit = client.startCommit();
+      records = dataGen.generateInserts(secondCommit, 100);
+      writeStatuses = client.insert(jsc.parallelize(records, 1), secondCommit).collect();
+      assertNoWriteErrors(writeStatuses);
+      client.commit(secondCommit, jsc.parallelize(writeStatuses));
+
+      metaClient = HoodieTableMetaClient.reload(metaClient);
+      assertTrue(metaClient.getTableConfig().isMetadataPartitionAvailable(RECORD_INDEX),
+          "RLI should be initialized");
+
+      HoodieBackedTableMetadata metadataReader = (HoodieBackedTableMetadata) metadata(client, storage);
+      int fileGroupCount = HoodieTableMetadataUtil.getPartitionLatestFileSlices(
+          metadataReader.getMetadataMetaClient(), Option.empty(),
+          RECORD_INDEX.getPartitionPath()).size();
+      assertTrue(fileGroupCount >= 1 && fileGroupCount <= 10,
+          "File group count should be within configured bounds [1, 10]: " + fileGroupCount);
+
+      validateMetadata(client);
+    }
+  }
+
+  /**
+   * Validates that RLI initialization uses the fixed file group count when min == max
+   * and skips estimation entirely.
+   */
+  @ParameterizedTest
+  @EnumSource(HoodieTableType.class)
+  public void testRecordIndexWithFixedFileGroupCount(HoodieTableType tableType) throws Exception {
+    init(tableType);
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+
+    HoodieWriteConfig writeConfig = getWriteConfigBuilder(false, true, false)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withEnableGlobalRecordLevelIndex(true)
+            .withRecordIndexFileGroupCount(2, 2)
+            .build())
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .withIndexType(HoodieIndex.IndexType.RECORD_INDEX)
+            .build())
+        .build();
+
+    try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
+      String firstCommit = client.startCommit();
+      List<HoodieRecord> records = dataGen.generateInserts(firstCommit, 100);
+      List<WriteStatus> writeStatuses = client.insert(jsc.parallelize(records, 1), firstCommit).collect();
+      assertNoWriteErrors(writeStatuses);
+      client.commit(firstCommit, jsc.parallelize(writeStatuses));
+
+      String secondCommit = client.startCommit();
+      records = dataGen.generateInserts(secondCommit, 100);
+      writeStatuses = client.insert(jsc.parallelize(records, 1), secondCommit).collect();
+      assertNoWriteErrors(writeStatuses);
+      client.commit(secondCommit, jsc.parallelize(writeStatuses));
+
+      metaClient = HoodieTableMetaClient.reload(metaClient);
+      assertTrue(metaClient.getTableConfig().isMetadataPartitionAvailable(RECORD_INDEX),
+          "RLI should be initialized");
+
+      HoodieBackedTableMetadata metadataReader = (HoodieBackedTableMetadata) metadata(client, storage);
+      int fileGroupCount = HoodieTableMetadataUtil.getPartitionLatestFileSlices(
+          metadataReader.getMetadataMetaClient(), Option.empty(),
+          RECORD_INDEX.getPartitionPath()).size();
+      assertEquals(2, fileGroupCount,
+          "File group count should be exactly 2 as configured (min == max)");
+
+      validateMetadata(client);
+    }
+  }
+
   @Override
   protected HoodieTableType getTableType() {
     return tableType;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18825.

During RLI bootstrap, `HoodieBackedTableMetadataWriter#initializeRecordIndexPartition`
previously persisted the full materialized RDD of RLI records
(`records.persist("MEMORY_AND_DISK_SER")`) and counted it
(`records.count()`) purely to obtain the total record count used to size
the RLI file groups. On large tables this is the primary latency and
memory bottleneck of RLI bootstrap.

### Summary and Changelog

- Replaces the persist+count of the RLI records with a direct row-count
  read from each base file's footer metadata via
  `FileFormatUtils.getRowCount(...)`. Footer reads are O(1) per file and
  avoid materializing the record dataset.
- Reuses the file slices already collected for record-key reading; for
  MOR, base files are extracted from the file slices already in hand
  (estimation uses base file row counts only; log file deltas are
  bounded and not material for sizing).
- Bypasses estimation entirely when the user pins the RLI file group
  count via `min == max`, and uses the configured value directly.
- Adds `TestHoodieBackedMetadata#testRecordIndexFileGroupEstimation` and
  `testRecordIndexWithFixedFileGroupCount` covering both COW and MOR.

### Impact

Decouples RLI file group sizing from materializing the record-keys RDD.
Eliminates the persist+count pass during RLI bootstrap, which is the
primary latency bottleneck on large tables. No public API changes.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
