### PR TITLE
chore: remove outdated required status checks in asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,10 +48,6 @@ github:
           - validate-source
           - validate-pr
           - validate-pr-title
-          - test-spark-client-and-hadoop-common (scala-2.12, spark3.5, flink1.18)
-          - test-utilities (scala-2.12, spark3.5, flink1.18)
-          - test-common-and-other-modules (scala-2.12, spark3.5, flink1.18)
-          - test-hudi-hadoop-mr-and-hudi-java-client (scala-2.12, spark3.5, flink1.20)
           - test-hudi-trino-plugin
           - test-spark-java-tests-part1 (scala-2.12, spark3.4, hudi-spark-datasource/hudi-spark3.4.x)
           - test-spark-java-tests-part1 (scala-2.12, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
@@ -79,10 +75,8 @@ github:
           - test-flink-1 (flink1.20, 1.11.4, 1.13.1)
           - test-flink-1 (flink2.0, 1.11.4, 1.14.4)
           - test-flink-1 (flink2.1, 1.11.4, 1.15.2)
-          - test-flink-2 (flink1.20, 1.11.4, 1.13.1)
           - build-spark-java17 (scala-2.12, spark3.4, hudi-spark-datasource/hudi-spark3.4.x)
           - build-spark-java17 (scala-2.12, spark3.5, hudi-spark-datasource/hudi-spark3.5.x)
-          - build-flink-java17 (scala-2.12, flink1.20, 1.11.4, 1.13.1)
           - validate-bundles (scala-2.12, flink1.17, 1.11.4, 1.12.3, spark3.5, spark3.5.1)
           - validate-bundles (scala-2.12, flink1.18, 1.11.4, 1.13.1, spark3.4, spark3.4.3)
           - validate-bundles (scala-2.13, flink1.19, 1.11.4, 1.13.1, spark3.5, spark3.5.1)
@@ -90,10 +84,6 @@ github:
           - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.0, spark4.0.0)
           - validate-bundles-java11 (scala-2.12, flink2.0, 1.11.4, 1.14.4, spark3.5, spark3.5.1)
           - validate-bundles-java11 (scala-2.12, flink2.1, 1.11.4, 1.15.2, spark3.5, spark3.5.1)
-          - docker-java17-test (scala-2.12, flink1.20, spark3.5, spark3.5.0)
-          - docker-java17-test (scala-2.13, flink1.20, spark3.5, spark3.5.0)
-          - docker-java17-test (scala-2.13, flink1.20, spark4.0, spark4.0.0)
-          - integration-tests (spark3.5, flink1.20, spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz)
   collaborators:
     - ad1happy2go
     - rangareddy


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The `required_status_checks` list in `.asf.yaml` references job contexts that no longer run on master, blocking PRs (e.g. #18831) because the required checks remain pending forever.

The Flink IT/UT matrix was migrated from `flink1.20`/`flink1.18` to `flink2.1` in #18717, but the corresponding contexts in `.asf.yaml` were not updated.

### Summary and Changelog

Remove the following stale required-status-check contexts so master PRs are no longer blocked:

- `build-flink-java17 (scala-2.12, flink1.20, 1.11.4, 1.13.1)`
- `docker-java17-test (scala-2.12, flink1.20, spark3.5, spark3.5.0)`
- `docker-java17-test (scala-2.13, flink1.20, spark3.5, spark3.5.0)`
- `docker-java17-test (scala-2.13, flink1.20, spark4.0, spark4.0.0)`
- `integration-tests (spark3.5, flink1.20, spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz)`
- `test-common-and-other-modules (scala-2.12, spark3.5, flink1.18)`
- `test-flink-2 (flink1.20, 1.11.4, 1.13.1)`
- `test-hudi-hadoop-mr-and-hudi-java-client (scala-2.12, spark3.5, flink1.20)`
- `test-spark-client-and-hadoop-common (scala-2.12, spark3.5, flink1.18)`
- `test-utilities (scala-2.12, spark3.5, flink1.18)`

### Impact

None — CI-only configuration change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable