### PR TITLE
fix(append): size buffered record, not incoming, in block-flush gate

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -255,9 +255,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     deltaWriteStat.setFileId(fileId);
     Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
     // averageRecordSize is seeded lazily in flushToDiskIfRequired on the first buffered
-    // (post-prepareRecord) record — sizing the incoming record here under-counts heap on
-    // Spark engines, where the incoming record is a compact UnsafeRow but the buffered
-    // record is the larger Avro form actually retained in recordList.
+    // (post-prepareRecord) record. Sizing the incoming record here under-counts heap
+    // because recordList retains the post-prepareRecord clone: a fully-materialized Avro
+    // IndexedRecord with prepended meta-fields, whereas the incoming record's payload
+    // is typically still in its compact/deflated wire form.
     try {
       // Save hoodie partition meta in the partition path
       HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
@@ -638,12 +639,13 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
 
   /**
    * Buffers {@code record} for the next log block. Returns the record actually appended to
-   * {@link #recordList} (the post-{@code prepareRecord} object — typically a
-   * {@code HoodieAvroIndexedRecord} carrying a fully-deserialized {@code IndexedRecord}),
+   * {@link #recordList} — the post-{@code prepareRecord} clone of {@code populatedRecord}
+   * carrying a fully-materialized Avro {@code IndexedRecord} with prepended meta-fields —
    * or {@code null} when nothing was appended to {@code recordList} (delete, ignored, or
    * partition-mismatch failure). The returned reference is what {@link #flushToDiskIfRequired}
-   * sizes — sizing the incoming record under-counts heap on Spark engines where the incoming
-   * record is a compact {@code UnsafeRow} but the buffered record is the larger Avro form.
+   * sizes; sizing the incoming record under-counts heap because the incoming payload is
+   * typically still in its compact/deflated wire form, whereas the buffered record holds
+   * the fully-deserialized Avro graph plus meta-fields.
    */
   private HoodieRecord writeToBuffer(HoodieRecord<T> record) {
     if (!partitionPath.equals(record.getPartitionPath())) {
@@ -714,9 +716,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
    * <p>{@code bufferedRecord} is the record that was just appended to {@link #recordList} by
    * {@link #writeToBuffer} (or {@code null} for delete/ignored windows where {@code recordList}
    * did not grow). Sizing this object — rather than the incoming pre-{@code prepareRecord}
-   * record — keeps {@link #averageRecordSize} aligned with what is actually retained in heap,
-   * which matters on Spark engines where the incoming {@code HoodieSparkRecord}/{@code UnsafeRow}
-   * is many times smaller than the buffered {@code HoodieAvroIndexedRecord}.
+   * record — keeps {@link #averageRecordSize} aligned with what is actually retained in heap.
+   * The incoming record's payload is typically still compact/deflated; the buffered record
+   * holds the fully-materialized Avro {@code IndexedRecord} with prepended meta-fields, which
+   * is what {@code maxBlockSize} is meant to bound.
    */
   protected void flushToDiskIfRequired(HoodieRecord bufferedRecord, boolean appendDeleteBlocks) {
     if (bufferedRecord != null

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -54,6 +54,7 @@ import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.SizeEstimator;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieAppendException;
@@ -135,7 +136,7 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   private final long maxBlockSize = config.getLogFileDataBlockMaxSize();
   // Header metadata for a log block
   protected final Map<HeaderMetadataType, String> header = new HashMap<>();
-  private final SizeEstimator<HoodieRecord> sizeEstimator;
+  private SizeEstimator<HoodieRecord> sizeEstimator;
   // This is used to distinguish between normal append and logcompaction's append operation.
   private boolean isLogCompaction = false;
   // use writer schema for log compaction.
@@ -253,7 +254,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     deltaWriteStat.setPartitionPath(partitionPath);
     deltaWriteStat.setFileId(fileId);
     Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
-    averageRecordSize = sizeEstimator.sizeEstimate(record);
+    // averageRecordSize is seeded lazily in flushToDiskIfRequired on the first buffered
+    // (post-prepareRecord) record — sizing the incoming record here under-counts heap on
+    // Spark engines, where the incoming record is a compact UnsafeRow but the buffered
+    // record is the larger Avro form actually retained in recordList.
     try {
       // Save hoodie partition meta in the partition path
       HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
@@ -299,7 +303,13 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     return hoodieRecord.getCurrentLocation() != null;
   }
 
-  private void bufferRecord(HoodieRecord<T> hoodieRecord) {
+  /**
+   * Routes {@code hoodieRecord} to the insert/update or delete buffer. Returns the record
+   * actually appended to {@link #recordList} (post-{@code prependMetaFields} clone), or
+   * {@code null} for the delete path (which routes to {@code recordsToDeleteWithPositions}
+   * instead), the ignored-record path, or on caught error.
+   */
+  private HoodieRecord bufferRecord(HoodieRecord<T> hoodieRecord) {
     HoodieSchema schema = useWriterSchema ? writeSchemaWithMetaFields : writeSchema;
     Option<Map<String, String>> recordMetadata = getRecordMetadata(hoodieRecord, schema, recordProperties);
     try {
@@ -308,9 +318,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       boolean isUpdateRecord = isUpdateRecord(hoodieRecord);
       recordProperties.put(HoodiePayloadProps.PAYLOAD_IS_UPDATE_RECORD_FOR_MOR, String.valueOf(isUpdateRecord));
 
+      HoodieRecord bufferedRecord = null;
       // Check for delete
       if (config.allowOperationMetadataField() || !hoodieRecord.isDelete(deleteContext, recordProperties)) {
-        bufferInsertAndUpdate(schema, hoodieRecord, isUpdateRecord);
+        bufferedRecord = bufferInsertAndUpdate(schema, hoodieRecord, isUpdateRecord);
       } else {
         bufferDelete(hoodieRecord);
       }
@@ -320,12 +331,14 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       // part of marking
       // record successful.
       hoodieRecord.deflate();
+      return bufferedRecord;
     } catch (Exception e) {
       log.error("Error writing record {}", hoodieRecord, e);
       if (!config.getIgnoreWriteFailed()) {
         throw new HoodieException(e.getMessage(), e);
       }
       writeStatus.markFailure(hoodieRecord, e, recordMetadata);
+      return null;
     }
   }
 
@@ -473,8 +486,8 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     while (recordItr.hasNext()) {
       HoodieRecord record = recordItr.next();
       init(record);
-      flushToDiskIfRequired(record, false);
-      writeToBuffer(record);
+      HoodieRecord bufferedRecord = writeToBuffer(record);
+      flushToDiskIfRequired(bufferedRecord, false);
     }
     appendDataAndDeleteBlocks(header, true);
     estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
@@ -532,8 +545,8 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     Option<Map<String, String>> recordMetadata = record.getMetadata();
     try {
       init(record);
-      flushToDiskIfRequired(record, false);
-      writeToBuffer(record);
+      HoodieRecord bufferedRecord = writeToBuffer(record);
+      flushToDiskIfRequired(bufferedRecord, false);
     } catch (Throwable t) {
       log.error("Error writing record " + record, t);
       if (!config.getIgnoreWriteFailed()) {
@@ -597,8 +610,8 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       for (Map.Entry<String, HoodieRecord<T>> entry: recordMap.entrySet()) {
         HoodieRecord<T> record = entry.getValue();
         init(record);
-        flushToDiskIfRequired(record, false);
-        writeToBuffer(record);
+        HoodieRecord bufferedRecord = writeToBuffer(record);
+        flushToDiskIfRequired(bufferedRecord, false);
       }
       appendDataAndDeleteBlocks(header, true);
       estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
@@ -623,12 +636,21 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     return true;
   }
 
-  private void writeToBuffer(HoodieRecord<T> record) {
+  /**
+   * Buffers {@code record} for the next log block. Returns the record actually appended to
+   * {@link #recordList} (the post-{@code prepareRecord} object — typically a
+   * {@code HoodieAvroIndexedRecord} carrying a fully-deserialized {@code IndexedRecord}),
+   * or {@code null} when nothing was appended to {@code recordList} (delete, ignored, or
+   * partition-mismatch failure). The returned reference is what {@link #flushToDiskIfRequired}
+   * sizes — sizing the incoming record under-counts heap on Spark engines where the incoming
+   * record is a compact {@code UnsafeRow} but the buffered record is the larger Avro form.
+   */
+  private HoodieRecord writeToBuffer(HoodieRecord<T> record) {
     if (!partitionPath.equals(record.getPartitionPath())) {
       HoodieUpsertException failureEx = new HoodieUpsertException("mismatched partition path, record partition: "
           + record.getPartitionPath() + " but trying to insert into partition: " + partitionPath);
       writeStatus.markFailure(record, failureEx, record.getMetadata());
-      return;
+      return null;
     }
 
     // update the new location of the record, so we know where to find it next
@@ -637,15 +659,21 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       record.setNewLocation(newRecordLocation);
       record.seal();
     }
-    // fetch the ordering val first in case the record was deflated.
-    bufferRecord(record);
+    HoodieRecord bufferedRecord = bufferRecord(record);
     numberOfRecords++;
+    return bufferedRecord;
   }
 
-  private void bufferInsertAndUpdate(HoodieSchema schema, HoodieRecord<T> hoodieRecord, boolean isUpdateRecord) throws IOException {
+  /**
+   * Appends the post-{@code prependMetaFields} record to {@link #recordList}. Returns the
+   * appended record (the actual heap-retained object, used by
+   * {@link #flushToDiskIfRequired} for size estimation), or {@code null} when the record is
+   * skipped (e.g. ignored by {@code ExpressionPayload}).
+   */
+  private HoodieRecord bufferInsertAndUpdate(HoodieSchema schema, HoodieRecord<T> hoodieRecord, boolean isUpdateRecord) throws IOException {
     // Check if the record should be ignored (special case for [[ExpressionPayload]])
     if (hoodieRecord.shouldIgnore(schema, recordProperties)) {
-      return;
+      return null;
     }
 
     // Prepend meta-fields into the record
@@ -656,13 +684,15 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     // NOTE: Record have to be cloned here to make sure if it holds low-level engine-specific
     //       payload pointing into a shared, mutable (underlying) buffer we get a clean copy of
     //       it since these records will be put into the recordList(List).
-    recordList.add(populatedRecord.copy());
+    HoodieRecord bufferedRecord = populatedRecord.copy();
+    recordList.add(bufferedRecord);
     if (isUpdateRecord || isLogCompaction) {
       updatedRecordsWritten++;
     } else {
       insertRecordsWritten++;
     }
     recordsWritten++;
+    return bufferedRecord;
   }
 
   private void bufferDelete(HoodieRecord<T> hoodieRecord) {
@@ -680,23 +710,60 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
 
   /**
    * Checks if the number of records have reached the set threshold and then flushes the records to disk.
+   *
+   * <p>{@code bufferedRecord} is the record that was just appended to {@link #recordList} by
+   * {@link #writeToBuffer} (or {@code null} for delete/ignored windows where {@code recordList}
+   * did not grow). Sizing this object — rather than the incoming pre-{@code prepareRecord}
+   * record — keeps {@link #averageRecordSize} aligned with what is actually retained in heap,
+   * which matters on Spark engines where the incoming {@code HoodieSparkRecord}/{@code UnsafeRow}
+   * is many times smaller than the buffered {@code HoodieAvroIndexedRecord}.
    */
-  protected void flushToDiskIfRequired(HoodieRecord record, boolean appendDeleteBlocks) {
-    if (numberOfRecords >= (int) (maxBlockSize / averageRecordSize)
-        || numberOfRecords % NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE == 0) {
-      averageRecordSize = (long) (averageRecordSize * 0.8 + sizeEstimator.sizeEstimate(record) * 0.2);
+  protected void flushToDiskIfRequired(HoodieRecord bufferedRecord, boolean appendDeleteBlocks) {
+    if (bufferedRecord != null
+        && (averageRecordSize == 0
+            || numberOfRecords >= (int) (maxBlockSize / Math.max(averageRecordSize, 1))
+            || numberOfRecords % NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE == 0)) {
+      long sampled = sizeEstimator.sizeEstimate(bufferedRecord);
+      averageRecordSize = averageRecordSize == 0
+          ? sampled
+          : (long) (averageRecordSize * 0.8 + sampled * 0.2);
     }
 
-    // Append if max number of records reached to achieve block size
-    if (numberOfRecords >= (maxBlockSize / averageRecordSize)) {
-      // Recompute averageRecordSize before writing a new block and update existing value with
-      // avg of new and old
+    // Append if max number of records reached to achieve block size.
+    // Skip when averageRecordSize is still 0 (delete-only prefix before any insert/update).
+    if (averageRecordSize > 0 && numberOfRecords >= (maxBlockSize / averageRecordSize)) {
       log.info("Flush log block to disk, the current avgRecordSize => " + averageRecordSize);
       // Delete blocks will be appended after appending all the data blocks.
       appendDataAndDeleteBlocks(header, appendDeleteBlocks);
       estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
       numberOfRecords = 0;
     }
+  }
+
+  @VisibleForTesting
+  void setSizeEstimator(SizeEstimator<HoodieRecord> sizeEstimator) {
+    this.sizeEstimator = sizeEstimator;
+  }
+
+  @VisibleForTesting
+  long getAverageRecordSize() {
+    return averageRecordSize;
+  }
+
+  @VisibleForTesting
+  long getNumberOfRecordsForTest() {
+    return numberOfRecords;
+  }
+
+  @VisibleForTesting
+  long getEstimatedBytesWrittenForTest() {
+    return estimatedNumberOfBytesWritten;
+  }
+
+  @VisibleForTesting
+  void simulateBufferedRecordForTest(HoodieRecord bufferedRecord) {
+    numberOfRecords++;
+    flushToDiskIfRequired(bufferedRecord, false);
   }
 
   protected HoodieLogBlock.HoodieLogBlockType getLogBlockType() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -719,7 +719,7 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   protected void flushToDiskIfRequired(HoodieRecord bufferedRecord, boolean appendDeleteBlocks) {
     if (bufferedRecord != null
         && (averageRecordSize == 0
-            || numberOfRecords >= (int) (maxBlockSize / Math.max(averageRecordSize, 1))
+            || numberOfRecords >= (int) (maxBlockSize / averageRecordSize)
             || numberOfRecords % NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE == 0)) {
       long sampled = sizeEstimator.sizeEstimate(bufferedRecord);
       averageRecordSize = averageRecordSize == 0

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -254,11 +254,6 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     deltaWriteStat.setPartitionPath(partitionPath);
     deltaWriteStat.setFileId(fileId);
     Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
-    // averageRecordSize is seeded lazily in flushToDiskIfRequired on the first buffered
-    // (post-prepareRecord) record. Sizing the incoming record here under-counts heap
-    // because recordList retains the post-prepareRecord clone: a fully-materialized Avro
-    // IndexedRecord with prepended meta-fields, whereas the incoming record's payload
-    // is typically still in its compact/deflated wire form.
     try {
       // Save hoodie partition meta in the partition path
       HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
@@ -754,17 +749,22 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   }
 
   @VisibleForTesting
-  long getNumberOfRecordsForTest() {
+  long getNumberOfRecords() {
     return numberOfRecords;
   }
 
   @VisibleForTesting
-  long getEstimatedBytesWrittenForTest() {
+  long getEstimatedNumberOfBytesWritten() {
     return estimatedNumberOfBytesWritten;
   }
 
+  /**
+   * Drives a single iteration of {@link #flushToDiskIfRequired} as if a buffered record had just
+   * been appended to {@code recordList}. {@code null} signals a delete/ignored window (the same
+   * path the production call sites take when buffering returns null).
+   */
   @VisibleForTesting
-  void simulateBufferedRecordForTest(HoodieRecord bufferedRecord) {
+  void simulateBufferedRecord(HoodieRecord bufferedRecord) {
     numberOfRecords++;
     flushToDiskIfRequired(bufferedRecord, false);
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
@@ -105,7 +105,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TestableAppendHandle handle = newTestableHandle(spy);
 
     HoodieRecord buffered = mock(HoodieRecord.class);
-    handle.simulateBufferedRecordForTest(buffered);
+    handle.simulateBufferedRecord(buffered);
 
     assertEquals(1, spy.sizedObjects.size(), "estimator should be invoked once on the first buffered record");
     assertSame(buffered, spy.sizedObjects.get(0),
@@ -123,7 +123,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
 
     assertEquals(0L, handle.getAverageRecordSize(), "no records yet — estimate is unseeded");
 
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
 
     assertEquals(2048L, handle.getAverageRecordSize(),
         "first buffered record seeds averageRecordSize directly (no EWMA on first sample)");
@@ -139,7 +139,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TestableAppendHandle handle = newTestableHandle(spy);
 
     for (int i = 0; i < 250; i++) {
-      handle.simulateBufferedRecordForTest(null);
+      handle.simulateBufferedRecord(null);
     }
 
     assertEquals(0, spy.sizedObjects.size(), "estimator never invoked on delete-only windows");
@@ -155,13 +155,13 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
   void testEwmaBlendsSamplesAfterFirstSeed() {
     TestableAppendHandle handle = newTestableHandle(new SteppedSizeEstimator(1000L, 5000L));
 
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
     assertEquals(1000L, handle.getAverageRecordSize(), "first record seeds the estimate at 1000");
 
     // 99 more records — the sampler will not fire again until numberOfRecords % 100 == 0.
     // Record #100 returns the second sample (5000); EWMA blends to 0.8*1000 + 0.2*5000 = 1800.
     for (int i = 0; i < 99; i++) {
-      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+      handle.simulateBufferedRecord(mock(HoodieRecord.class));
     }
     assertEquals(1800L, handle.getAverageRecordSize(), "EWMA after the second sample: 0.8*1000 + 0.2*5000");
   }
@@ -176,14 +176,14 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TestableAppendHandle handle = newTestableHandle(new RecordingSizeEstimator(perRecord));
 
     for (int i = 0; i < 9; i++) {
-      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+      handle.simulateBufferedRecord(mock(HoodieRecord.class));
     }
     assertEquals(0, handle.appendInvocations.get(), "9 records of perRecord-sized buffer: gate has not fired yet");
 
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
     assertEquals(1, handle.appendInvocations.get(), "10th record fills the block — flush fires");
-    assertEquals(0L, handle.getNumberOfRecordsForTest(), "numberOfRecords resets after flush");
-    assertTrue(handle.getEstimatedBytesWrittenForTest() > 0, "estimatedNumberOfBytesWritten advances after flush");
+    assertEquals(0L, handle.getNumberOfRecords(), "numberOfRecords resets after flush");
+    assertTrue(handle.getEstimatedNumberOfBytesWritten() > 0, "estimatedNumberOfBytesWritten advances after flush");
   }
 
   /** Guards against the test harness silently no-op'ing the flush hook. */
@@ -193,10 +193,10 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
         newTestableHandle(new RecordingSizeEstimator(writeConfig.getLogFileDataBlockMaxSize()));
     // Single record whose size == maxBlockSize: gate fires immediately on record #1
     // (numberOfRecords == 1 >= maxBlockSize / maxBlockSize == 1).
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
     assertEquals(1, handle.appendInvocations.get(),
         "harness must route flushes through the override, not the real writer");
-    assertNotEquals(0L, handle.getEstimatedBytesWrittenForTest());
+    assertNotEquals(0L, handle.getEstimatedNumberOfBytesWritten());
     assertFalse(handle.getAverageRecordSize() == 0L);
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.LocalTaskContextSupplier;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.util.SizeEstimator;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.TestBaseHoodieTable;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link HoodieAppendHandle}'s block-flush sizing logic.
+ *
+ * <p>The block-flush trigger sizes the post-{@code prepareRecord} record (the object actually
+ * retained in {@code recordList}), not the incoming pre-{@code prepareRecord} record. On Spark
+ * engines the incoming record is a compact {@code UnsafeRow} while the buffered record is a
+ * full {@code HoodieAvroIndexedRecord} — sizing the wrong one caused production OOMs on
+ * metadata-table writes by letting the buffer grow many times past {@code maxBlockSize} worth
+ * of heap before the gate fired.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
+
+  private static final String TEST_INSTANT_TIME = "20231201120000";
+  private static final String TEST_PARTITION_PATH = DEFAULT_FIRST_PARTITION_PATH;
+  private static final String TEST_FILE_ID = "file-001";
+
+  private HoodieWriteConfig writeConfig;
+  private TaskContextSupplier taskContextSupplier;
+  private HoodieTable hoodieTable;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    initPath();
+    initMetaClient(false);
+    initTestDataGenerator();
+
+    writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withMarkersType("DIRECT")
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .build();
+    hoodieTable = new TestBaseHoodieTable(writeConfig, getEngineContext(), metaClient);
+    taskContextSupplier = new LocalTaskContextSupplier();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    cleanMetaClient();
+    cleanupTestDataGenerator();
+  }
+
+  /**
+   * The estimator must size the post-{@code prepareRecord} buffered record, not the incoming
+   * pre-{@code prepareRecord} record. On Spark engines, the incoming record is a compact
+   * {@code UnsafeRow} while the buffered record is a full {@code HoodieAvroIndexedRecord} —
+   * sizing the wrong one was the root cause of production OOMs on metadata-table writes.
+   */
+  @Test
+  void testSizeEstimatorReceivesBufferedRecord() {
+    RecordingSizeEstimator spy = new RecordingSizeEstimator(1000L);
+    TestableAppendHandle handle = newTestableHandle(spy);
+
+    HoodieRecord buffered = mock(HoodieRecord.class);
+    handle.simulateBufferedRecordForTest(buffered);
+
+    assertEquals(1, spy.sizedObjects.size(), "estimator should be invoked once on the first buffered record");
+    assertSame(buffered, spy.sizedObjects.get(0),
+        "estimator must size the post-prepareRecord buffered record, not the incoming record");
+  }
+
+  /**
+   * The initial estimate is seeded lazily on the first buffered record — the old code seeded it
+   * eagerly from the incoming pre-{@code prepareRecord} record in {@code init()}, which
+   * dramatically under-counted heap on Spark engines.
+   */
+  @Test
+  void testInitialEstimateSeededFromFirstBufferedRecord() {
+    TestableAppendHandle handle = newTestableHandle(new RecordingSizeEstimator(2048L));
+
+    assertEquals(0L, handle.getAverageRecordSize(), "no records yet — estimate is unseeded");
+
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+
+    assertEquals(2048L, handle.getAverageRecordSize(),
+        "first buffered record seeds averageRecordSize directly (no EWMA on first sample)");
+  }
+
+  /**
+   * A delete-only window must not perturb {@code averageRecordSize} and must not trigger a
+   * flush — {@code recordList} did not grow, so there is no in-heap buffer to bound.
+   */
+  @Test
+  void testDeleteOnlyDoesNotPerturbEstimateOrFlush() {
+    RecordingSizeEstimator spy = new RecordingSizeEstimator(1234L);
+    TestableAppendHandle handle = newTestableHandle(spy);
+
+    for (int i = 0; i < 250; i++) {
+      handle.simulateBufferedRecordForTest(null);
+    }
+
+    assertEquals(0, spy.sizedObjects.size(), "estimator never invoked on delete-only windows");
+    assertEquals(0L, handle.getAverageRecordSize(), "estimate remains unseeded with no buffered records");
+    assertEquals(0, handle.appendInvocations.get(), "flush gate never fires when averageRecordSize is 0");
+  }
+
+  /**
+   * Once seeded, the EWMA blends new samples (20%) with the running estimate (80%). The sampler
+   * fires every {@code NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE} records.
+   */
+  @Test
+  void testEwmaBlendsSamplesAfterFirstSeed() {
+    TestableAppendHandle handle = newTestableHandle(new SteppedSizeEstimator(1000L, 5000L));
+
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    assertEquals(1000L, handle.getAverageRecordSize(), "first record seeds the estimate at 1000");
+
+    // 99 more records — the sampler will not fire again until numberOfRecords % 100 == 0.
+    // Record #100 returns the second sample (5000); EWMA blends to 0.8*1000 + 0.2*5000 = 1800.
+    for (int i = 0; i < 99; i++) {
+      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    }
+    assertEquals(1800L, handle.getAverageRecordSize(), "EWMA after the second sample: 0.8*1000 + 0.2*5000");
+  }
+
+  /**
+   * When the per-record estimate reaches {@code maxBlockSize / N}, the gate trips after N
+   * records — i.e. {@code numberOfRecords >= maxBlockSize / averageRecordSize}.
+   */
+  @Test
+  void testFlushTriggersWhenBufferedRecordsExceedMaxBlockSize() {
+    long perRecord = writeConfig.getLogFileDataBlockMaxSize() / 10;
+    TestableAppendHandle handle = newTestableHandle(new RecordingSizeEstimator(perRecord));
+
+    for (int i = 0; i < 9; i++) {
+      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    }
+    assertEquals(0, handle.appendInvocations.get(), "9 records of perRecord-sized buffer: gate has not fired yet");
+
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    assertEquals(1, handle.appendInvocations.get(), "10th record fills the block — flush fires");
+    assertEquals(0L, handle.getNumberOfRecordsForTest(), "numberOfRecords resets after flush");
+    assertTrue(handle.getEstimatedBytesWrittenForTest() > 0, "estimatedNumberOfBytesWritten advances after flush");
+  }
+
+  /** Guards against the test harness silently no-op'ing the flush hook. */
+  @Test
+  void testHarnessAppendOverrideIsActuallyInvoked() {
+    TestableAppendHandle handle =
+        newTestableHandle(new RecordingSizeEstimator(writeConfig.getLogFileDataBlockMaxSize()));
+    // Single record whose size == maxBlockSize: gate fires immediately on record #1
+    // (numberOfRecords == 1 >= maxBlockSize / maxBlockSize == 1).
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    assertEquals(1, handle.appendInvocations.get(),
+        "harness must route flushes through the override, not the real writer");
+    assertNotEquals(0L, handle.getEstimatedBytesWrittenForTest());
+    assertFalse(handle.getAverageRecordSize() == 0L);
+  }
+
+  private TestableAppendHandle newTestableHandle(SizeEstimator<HoodieRecord> estimator) {
+    TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, taskContextSupplier);
+    handle.setSizeEstimator(estimator);
+    return handle;
+  }
+
+  /** Records (and counts) every object handed to {@link #sizeEstimate}. */
+  private static final class RecordingSizeEstimator implements SizeEstimator<HoodieRecord> {
+    final List<HoodieRecord> sizedObjects = new ArrayList<>();
+    private final long fixedSize;
+
+    RecordingSizeEstimator(long fixedSize) {
+      this.fixedSize = fixedSize;
+    }
+
+    @Override
+    public long sizeEstimate(HoodieRecord r) {
+      sizedObjects.add(r);
+      return fixedSize;
+    }
+  }
+
+  /** Returns {@code first} on the first call, then {@code rest} on every subsequent call. */
+  private static final class SteppedSizeEstimator implements SizeEstimator<HoodieRecord> {
+    private final long first;
+    private final long rest;
+    private boolean firstCallDone = false;
+
+    SteppedSizeEstimator(long first, long rest) {
+      this.first = first;
+      this.rest = rest;
+    }
+
+    @Override
+    public long sizeEstimate(HoodieRecord r) {
+      if (!firstCallDone) {
+        firstCallDone = true;
+        return first;
+      }
+      return rest;
+    }
+  }
+
+  /**
+   * Test handle that overrides the disk-flush side-effect — we are only validating the sizing
+   * and gate logic, not the writer plumbing.
+   */
+  private static final class TestableAppendHandle extends HoodieAppendHandle<Object, Object, Object, Object> {
+    final AtomicInteger appendInvocations = new AtomicInteger(0);
+
+    TestableAppendHandle(HoodieWriteConfig writeConfig, HoodieTable hoodieTable,
+                         TaskContextSupplier taskContextSupplier) {
+      super(writeConfig, TEST_INSTANT_TIME, hoodieTable, TEST_PARTITION_PATH, TEST_FILE_ID, taskContextSupplier);
+    }
+
+    @Override
+    protected void appendDataAndDeleteBlocks(Map<HeaderMetadataType, String> header, boolean appendDeleteBlocks) {
+      appendInvocations.incrementAndGet();
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18844

`HoodieAppendHandle.bufferRecord` / `bufferInsertAndUpdate` adds the post-`prepareRecord` object — a clone of `populatedRecord` (a `HoodieAvroIndexedRecord` wrapping a fully-deserialized `IndexedRecord`, many KB per record on Spark engines) — to `recordList`. But the block-flush gate in `flushToDiskIfRequired` sized the **incoming** record, which on Spark engines is a compact `UnsafeRow` many times smaller. The estimate under-counted retained heap, so the gate `numberOfRecords >= maxBlockSize / averageRecordSize` fired far too late, `recordList` grew well past one block's worth of heap, and the subsequent `HFileDataBlock` serialization OOMed on metadata-table writes.

For Avro-engine writes the incoming and post-prepare shapes are similar, so this change is effectively a no-op on those paths.

### Summary and Changelog

**Behavior change:** `averageRecordSize` now reflects the buffered (post-`prepareRecord`) record — the object actually retained on heap — rather than the incoming record handed to the handle.

**Code changes (`hudi-client-common/.../HoodieAppendHandle.java`):**

- `writeToBuffer`, `bufferRecord`, `bufferInsertAndUpdate` now return the buffered record (or `null` for delete/ignored/error paths).
- Call sites in `doAppend` / `doWrite` / `write(Map)` flip order: buffer first, then gate-check with the buffered record.
- `flushToDiskIfRequired` sizes the buffered record. Seeds the EWMA lazily on the first non-null buffered record (replacing the wrong eager seed in `init()` that ran before any `prepareRecord` conversion). Guards the gate against `averageRecordSize == 0` to avoid div-by-zero on delete-only prefixes.
- `sizeEstimator` changed from `final` to settable via `@VisibleForTesting setSizeEstimator`; other `@VisibleForTesting` getters added for the new test.

**Tests (`hudi-client-common/.../TestHoodieAppendHandle.java`, new):**

6 unit tests covering: estimator sees buffered (not incoming) record; lazy initial seed; delete-only windows do not perturb the estimate or trigger flush; EWMA blends 0.8/0.2 after the second sample; gate fires when buffered records exceed `maxBlockSize`; harness self-check.

### Impact

- **Spark engine MOR writes**: block-flush gate now trips correctly. `recordList` stays bounded to ~one `maxBlockSize` worth of buffered records, downstream HFile / Avro serialization heap stays bounded. Fixes the heap-pressure failure mode described in #18844.
- **Avro engine writes**: incoming and post-prepare shapes are similar — effectively a no-op.
- `estimatedNumberOfBytesWritten` (consumed by `canWrite` to roll log file groups) now reflects the JOL size of the buffered Avro record — a strict overestimate of on-disk bytes. Log file groups roll slightly earlier on Spark engines as a result; the existing `hoodie.logfile.to.parquet.compression.ratio` knob retunes if needed.
- No public API change. `sizeEstimator` is a private field; the `@VisibleForTesting` setter is for unit tests only.

### Risk Level

**low** — the change is local to one file, behind-the-scenes (no API/config), and is a no-op for the Avro path. The Spark-path behavior change is a bug fix: the buffer is now bounded as `maxBlockSize` already promises. The only externally-visible knock-on is that `canWrite` may roll log file groups slightly earlier on Spark; the `logFileToParquetCompressionRatio` config exists precisely for this approximation.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
