### PR TITLE
Skip source RDD persist when index is RECORD_INDEX

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/ProtoKafkaSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/ProtoKafkaSource.java
@@ -103,7 +103,8 @@ public class ProtoKafkaSource extends KafkaSource<JavaRDD<Message>> {
   protected boolean isAllowSourcePersistRdd() {
     // Persisting proto messages where protobuf class is unknown, is expensive because of the overhead.
     // Eg: Persisting DynamicMessage using kryo requires attaching descriptor info for each message.
-    return allowSourcePersistRdd && deserializerName.equals(ByteArrayDeserializer.class.getName());
+    // Delegate to super so the RLI bypass in Source#isAllowSourcePersistRdd is also honored here.
+    return super.isAllowSourcePersistRdd() && deserializerName.equals(ByteArrayDeserializer.class.getName());
   }
 
   private static class ProtoDeserializer implements Serializable {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
@@ -29,13 +29,14 @@ import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Either;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.utilities.callback.SourceCommitCallback;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.streamer.DefaultStreamContext;
 import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
 import org.apache.hudi.utilities.streamer.StreamContext;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.api.java.JavaRDD;
@@ -74,7 +75,6 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
   @Getter
   private final SourceType sourceType;
   private final StorageLevel storageLevel;
-  @Getter(AccessLevel.PROTECTED)
   protected final boolean allowSourcePersistRdd;
   private Either<Dataset<Row>, JavaRDD<?>> cachedSourceRdd = null;
 
@@ -203,6 +203,34 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
         javaRDD.persist(storageLevel);
       }
     }
+  }
+
+  /**
+   * Whether the source RDD/DataFrame should be persisted via {@link #persist(Object)}.
+   *
+   * <p>Returns {@code false} when the writer's index type is a metadata-table-backed record
+   * index ({@code RECORD_INDEX} or {@code PARTITIONED_RECORD_INDEX}), even if
+   * {@code hoodie.errortable.source.rdd.persist=true}. The RLI tagging path already persists
+   * the records RDD inside {@code SparkMetadataTableRecordIndex#tagLocation}, and the
+   * downstream commit executor persists the tagged records again. Caching the upstream
+   * Dataset on top of those two triples the on-heap serialized footprint and contends with
+   * the MDT {@code HoodieAppendHandle} buffer, which has caused executor OOMKills on
+   * RLI-indexed tables.
+   */
+  protected boolean isAllowSourcePersistRdd() {
+    if (!allowSourcePersistRdd) {
+      return false;
+    }
+    return !usesRecordIndex();
+  }
+
+  private boolean usesRecordIndex() {
+    String indexType = props.getString(HoodieIndexConfig.INDEX_TYPE.key(), "");
+    if (indexType.isEmpty()) {
+      return false;
+    }
+    return HoodieIndex.IndexType.RECORD_INDEX.name().equalsIgnoreCase(indexType)
+        || HoodieIndex.IndexType.PARTITIONED_RECORD_INDEX.name().equalsIgnoreCase(indexType);
   }
 
   @Override

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSource.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieErrorTableConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.hudi.utilities.streamer.SourceProfileSupplier;
+import org.apache.hudi.utilities.streamer.StreamContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link Source#isAllowSourcePersistRdd()}.
+ *
+ * <p>The source-RDD persist controlled by
+ * {@code hoodie.errortable.source.rdd.persist} is bypassed when the writer is
+ * configured with a metadata-table-backed record index, since
+ * {@code SparkMetadataTableRecordIndex#tagLocation} already persists the
+ * records RDD at {@code MEMORY_AND_DISK_SER}. Double-caching has caused
+ * executor OOMKills on RLI-indexed tables.
+ */
+public class TestSource {
+
+  @Test
+  public void isAllowSourcePersistRddReturnsFalseWhenPersistFlagIsDisabled() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD.key(), "false");
+    props.setProperty(HoodieIndexConfig.INDEX_TYPE.key(), HoodieIndex.IndexType.BLOOM.name());
+
+    assertFalse(new NoopSource(props).isAllowSourcePersistRdd(),
+        "persist flag off must always disable source persist");
+  }
+
+  @Test
+  public void isAllowSourcePersistRddReturnsTrueWhenIndexTypeIsAbsent() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD.key(), "true");
+
+    assertTrue(new NoopSource(props).isAllowSourcePersistRdd(),
+        "absent index type must not bypass persist (engine-level default applies elsewhere)");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = HoodieIndex.IndexType.class,
+      names = {"RECORD_INDEX", "PARTITIONED_RECORD_INDEX"})
+  public void isAllowSourcePersistRddReturnsFalseForRecordIndexTypes(HoodieIndex.IndexType indexType) {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD.key(), "true");
+    props.setProperty(HoodieIndexConfig.INDEX_TYPE.key(), indexType.name());
+
+    assertFalse(new NoopSource(props).isAllowSourcePersistRdd(),
+        "RLI index types must bypass source persist to avoid double-caching");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = HoodieIndex.IndexType.class,
+      names = {"BLOOM", "GLOBAL_BLOOM", "SIMPLE", "GLOBAL_SIMPLE", "BUCKET", "HBASE", "INMEMORY"})
+  public void isAllowSourcePersistRddReturnsTrueForNonRecordIndexTypes(HoodieIndex.IndexType indexType) {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD.key(), "true");
+    props.setProperty(HoodieIndexConfig.INDEX_TYPE.key(), indexType.name());
+
+    assertTrue(new NoopSource(props).isAllowSourcePersistRdd(),
+        "non-RLI index types must preserve existing source-persist behavior");
+  }
+
+  @Test
+  public void isAllowSourcePersistRddIsCaseInsensitiveOnIndexType() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD.key(), "true");
+    props.setProperty(HoodieIndexConfig.INDEX_TYPE.key(), "record_index");
+
+    assertFalse(new NoopSource(props).isAllowSourcePersistRdd(),
+        "lower-case index type must still be recognized as RLI");
+  }
+
+  /**
+   * Minimal {@link Source} subclass for exercising the persist-gating logic without standing
+   * up a real Spark context. The constructor only stores the inputs and reads the persist
+   * and storage-level configs, so passing {@code null} for the Spark fields is safe — they
+   * are never touched by {@link Source#isAllowSourcePersistRdd()}.
+   */
+  private static final class NoopSource extends Source<Object> {
+    NoopSource(TypedProperties props) {
+      super(props, null, null, SourceType.AVRO, new TestStreamContext());
+    }
+
+    @Override
+    protected InputBatch<Object> fetchNewData(Option<String> lastCkptStr, long sourceLimit) {
+      throw new UnsupportedOperationException("not used in this test");
+    }
+  }
+
+  private static final class TestStreamContext implements StreamContext {
+    @Override
+    public SchemaProvider getSchemaProvider() {
+      return null;
+    }
+
+    @Override
+    public Option<SourceProfileSupplier> getSourceProfileSupplier() {
+      return Option.empty();
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

When `hoodie.errortable.source.rdd.persist=true` is set on tables backed by `RECORD_INDEX` (or `PARTITIONED_RECORD_INDEX`), the source DataFrame is cached three times at `MEMORY_AND_DISK_SER`:

1. `Source#persist` — gated by `hoodie.errortable.source.rdd.persist`
2. `SparkMetadataTableRecordIndex#tagLocation` — gated by `hoodie.record.index.use.caching` (default true)
3. `BaseSparkCommitActionExecutor#execute` — unconditional persist of tagged records

All three live on the same executor heap and contend with the MDT `HoodieAppendHandle` log-block buffer (`hoodie.logfile.data.block.max.size`, default 256 MB per task). On wide-row tables (log/JSON ingest with large raw blobs in the source schema) this has caused container OOMKills.

This PR makes `Source#isAllowSourcePersistRdd` return `false` when the configured index type is `RECORD_INDEX` or `PARTITIONED_RECORD_INDEX`, even when the persist flag is true. The downstream RLI-layer persist already covers the re-read between lookup and tagging, so removing the top-level source persist is safe and drops the widest (and largest) of the three caches.

`ProtoKafkaSource#isAllowSourcePersistRdd` now delegates to `super.isAllowSourcePersistRdd()` so the RLI bypass is honored on the proto path too.

### Behavior

| `errortable.source.rdd.persist` | Index type | Before | After |
|---|---|---|---|
| `false` | any | no persist | no persist |
| `true` | `BLOOM` / `SIMPLE` / `HBASE` / others | persist | persist (unchanged) |
| `true` | `RECORD_INDEX` | persist | **no persist** |
| `true` | `PARTITIONED_RECORD_INDEX` | persist | **no persist** |
| `true` | unset / blank | persist | persist (unchanged) |

### Impact

Error-table writes have to re-read the source from upstream when the gate fires. For wide-row pipelines this is cheap relative to the heap cost of triple-caching; for narrow tables the saving is modest but never negative.

### Risk level

low — gated by `hoodie.index.type`, no behavior change for non-RLI tables, default `hoodie.errortable.source.rdd.persist` is false.

### Documentation Update

n/a

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly consistent with the [PR title](https://hudi.apache.org/contribute/developer-setup#pull-request-and-issue-management)
- [x] Adequate tests were added if applicable
- [x] CI passed