### PR TITLE
feat(append): dynamically cap log-block buffer at per-task memory

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -255,9 +255,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     deltaWriteStat.setFileId(fileId);
     Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
     // averageRecordSize is seeded lazily in flushToDiskIfRequired on the first buffered
-    // (post-prepareRecord) record — sizing the incoming record here under-counts heap on
-    // Spark engines, where the incoming record is a compact UnsafeRow but the buffered
-    // record is the larger Avro form actually retained in recordList.
+    // (post-prepareRecord) record. Sizing the incoming record here under-counts heap
+    // because recordList retains the post-prepareRecord clone: a fully-materialized Avro
+    // IndexedRecord with prepended meta-fields, whereas the incoming record's payload
+    // is typically still in its compact/deflated wire form.
     try {
       // Save hoodie partition meta in the partition path
       HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
@@ -638,12 +639,13 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
 
   /**
    * Buffers {@code record} for the next log block. Returns the record actually appended to
-   * {@link #recordList} (the post-{@code prepareRecord} object — typically a
-   * {@code HoodieAvroIndexedRecord} carrying a fully-deserialized {@code IndexedRecord}),
+   * {@link #recordList} — the post-{@code prepareRecord} clone of {@code populatedRecord}
+   * carrying a fully-materialized Avro {@code IndexedRecord} with prepended meta-fields —
    * or {@code null} when nothing was appended to {@code recordList} (delete, ignored, or
    * partition-mismatch failure). The returned reference is what {@link #flushToDiskIfRequired}
-   * sizes — sizing the incoming record under-counts heap on Spark engines where the incoming
-   * record is a compact {@code UnsafeRow} but the buffered record is the larger Avro form.
+   * sizes; sizing the incoming record under-counts heap because the incoming payload is
+   * typically still in its compact/deflated wire form, whereas the buffered record holds
+   * the fully-deserialized Avro graph plus meta-fields.
    */
   private HoodieRecord writeToBuffer(HoodieRecord<T> record) {
     if (!partitionPath.equals(record.getPartitionPath())) {
@@ -714,9 +716,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
    * <p>{@code bufferedRecord} is the record that was just appended to {@link #recordList} by
    * {@link #writeToBuffer} (or {@code null} for delete/ignored windows where {@code recordList}
    * did not grow). Sizing this object — rather than the incoming pre-{@code prepareRecord}
-   * record — keeps {@link #averageRecordSize} aligned with what is actually retained in heap,
-   * which matters on Spark engines where the incoming {@code HoodieSparkRecord}/{@code UnsafeRow}
-   * is many times smaller than the buffered {@code HoodieAvroIndexedRecord}.
+   * record — keeps {@link #averageRecordSize} aligned with what is actually retained in heap.
+   * The incoming record's payload is typically still compact/deflated; the buffered record
+   * holds the fully-materialized Avro {@code IndexedRecord} with prepended meta-fields, which
+   * is what {@code maxBlockSize} is meant to bound.
    */
   protected void flushToDiskIfRequired(HoodieRecord bufferedRecord, boolean appendDeleteBlocks) {
     if (bufferedRecord != null

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.io;
 
 import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.FSUtils;
@@ -132,8 +133,15 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   protected long estimatedNumberOfBytesWritten;
   // Number of records that must be written to meet the max block size for a log block
   private long numberOfRecords = 0;
-  // Max block size to limit to for a log block
-  private final long maxBlockSize = config.getLogFileDataBlockMaxSize();
+  // Configured block-size ceiling (hoodie.logfile.data.block.max.size). Surface for canWrite /
+  // log-file-group rolling code paths and operator-visible logging.
+  private final long maxBlockSize;
+  // Effective per-block heap budget used by the flush gate: min(maxBlockSize, dynamic per-task
+  // ceiling). On Spark the dynamic ceiling = (executorMemory * (1 - spark.memory.fraction) /
+  // task slots) * hoodie.memory.logfile.append.fraction, floored at
+  // HoodieMemoryConfig.MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES (16MB). When the engine does
+  // not expose memory/cores the dynamic ceiling is absent and this equals maxBlockSize.
+  private final long effectiveBlockSize;
   // Header metadata for a log block
   protected final Map<HeaderMetadataType, String> header = new HashMap<>();
   private SizeEstimator<HoodieRecord> sizeEstimator;
@@ -184,6 +192,20 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     this.baseFileInstantTimeOfPositions = shouldWriteRecordPositions
         ? getBaseFileInstantTimeOfPositions()
         : Option.empty();
+    this.maxBlockSize = config.getLogFileDataBlockMaxSize();
+    String appendFraction = config.getStringOrDefault(HoodieMemoryConfig.MAX_MEMORY_FRACTION_FOR_LOG_APPEND);
+    Option<Long> dynamicCeiling = IOUtils.getMaxMemoryAllowedForLogAppend(
+        taskContextSupplier,
+        appendFraction,
+        HoodieMemoryConfig.MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES);
+    this.effectiveBlockSize = dynamicCeiling.isPresent()
+        ? Math.min(this.maxBlockSize, dynamicCeiling.get())
+        : this.maxBlockSize;
+    if (dynamicCeiling.isPresent() && dynamicCeiling.get() < this.maxBlockSize) {
+      log.info("HoodieAppendHandle for fileId={} capping block buffer at {} bytes "
+              + "(dynamic per-task ceiling) below configured maxBlockSize={} bytes",
+          fileId, this.effectiveBlockSize, this.maxBlockSize);
+    }
   }
 
   public HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
@@ -719,12 +741,12 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
    * record — keeps {@link #averageRecordSize} aligned with what is actually retained in heap.
    * The incoming record's payload is typically still compact/deflated; the buffered record
    * holds the fully-materialized Avro {@code IndexedRecord} with prepended meta-fields, which
-   * is what {@code maxBlockSize} is meant to bound.
+   * is what {@link #effectiveBlockSize} is meant to bound.
    */
   protected void flushToDiskIfRequired(HoodieRecord bufferedRecord, boolean appendDeleteBlocks) {
     if (bufferedRecord != null
         && (averageRecordSize == 0
-            || numberOfRecords >= (int) (maxBlockSize / Math.max(averageRecordSize, 1))
+            || numberOfRecords >= (int) (effectiveBlockSize / Math.max(averageRecordSize, 1))
             || numberOfRecords % NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE == 0)) {
       long sampled = sizeEstimator.sizeEstimate(bufferedRecord);
       averageRecordSize = averageRecordSize == 0
@@ -734,7 +756,7 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
 
     // Append if max number of records reached to achieve block size.
     // Skip when averageRecordSize is still 0 (delete-only prefix before any insert/update).
-    if (averageRecordSize > 0 && numberOfRecords >= (maxBlockSize / averageRecordSize)) {
+    if (averageRecordSize > 0 && numberOfRecords >= (effectiveBlockSize / averageRecordSize)) {
       log.info("Flush log block to disk, the current avgRecordSize => " + averageRecordSize);
       // Delete blocks will be appended after appending all the data blocks.
       appendDataAndDeleteBlocks(header, appendDeleteBlocks);
@@ -767,6 +789,16 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   void simulateBufferedRecordForTest(HoodieRecord bufferedRecord) {
     numberOfRecords++;
     flushToDiskIfRequired(bufferedRecord, false);
+  }
+
+  @VisibleForTesting
+  long getEffectiveBlockSizeForTest() {
+    return effectiveBlockSize;
+  }
+
+  @VisibleForTesting
+  long getMaxBlockSizeForTest() {
+    return maxBlockSize;
   }
 
   protected HoodieLogBlock.HoodieLogBlockType getLogBlockType() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -276,11 +276,6 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     deltaWriteStat.setPartitionPath(partitionPath);
     deltaWriteStat.setFileId(fileId);
     Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
-    // averageRecordSize is seeded lazily in flushToDiskIfRequired on the first buffered
-    // (post-prepareRecord) record. Sizing the incoming record here under-counts heap
-    // because recordList retains the post-prepareRecord clone: a fully-materialized Avro
-    // IndexedRecord with prepended meta-fields, whereas the incoming record's payload
-    // is typically still in its compact/deflated wire form.
     try {
       // Save hoodie partition meta in the partition path
       HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -54,6 +54,7 @@ import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.SizeEstimator;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieAppendException;
@@ -135,7 +136,7 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   private final long maxBlockSize = config.getLogFileDataBlockMaxSize();
   // Header metadata for a log block
   protected final Map<HeaderMetadataType, String> header = new HashMap<>();
-  private final SizeEstimator<HoodieRecord> sizeEstimator;
+  private SizeEstimator<HoodieRecord> sizeEstimator;
   // This is used to distinguish between normal append and logcompaction's append operation.
   private boolean isLogCompaction = false;
   // use writer schema for log compaction.
@@ -253,7 +254,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     deltaWriteStat.setPartitionPath(partitionPath);
     deltaWriteStat.setFileId(fileId);
     Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
-    averageRecordSize = sizeEstimator.sizeEstimate(record);
+    // averageRecordSize is seeded lazily in flushToDiskIfRequired on the first buffered
+    // (post-prepareRecord) record — sizing the incoming record here under-counts heap on
+    // Spark engines, where the incoming record is a compact UnsafeRow but the buffered
+    // record is the larger Avro form actually retained in recordList.
     try {
       // Save hoodie partition meta in the partition path
       HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
@@ -299,7 +303,13 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     return hoodieRecord.getCurrentLocation() != null;
   }
 
-  private void bufferRecord(HoodieRecord<T> hoodieRecord) {
+  /**
+   * Routes {@code hoodieRecord} to the insert/update or delete buffer. Returns the record
+   * actually appended to {@link #recordList} (post-{@code prependMetaFields} clone), or
+   * {@code null} for the delete path (which routes to {@code recordsToDeleteWithPositions}
+   * instead), the ignored-record path, or on caught error.
+   */
+  private HoodieRecord bufferRecord(HoodieRecord<T> hoodieRecord) {
     HoodieSchema schema = useWriterSchema ? writeSchemaWithMetaFields : writeSchema;
     Option<Map<String, String>> recordMetadata = getRecordMetadata(hoodieRecord, schema, recordProperties);
     try {
@@ -308,9 +318,10 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       boolean isUpdateRecord = isUpdateRecord(hoodieRecord);
       recordProperties.put(HoodiePayloadProps.PAYLOAD_IS_UPDATE_RECORD_FOR_MOR, String.valueOf(isUpdateRecord));
 
+      HoodieRecord bufferedRecord = null;
       // Check for delete
       if (config.allowOperationMetadataField() || !hoodieRecord.isDelete(deleteContext, recordProperties)) {
-        bufferInsertAndUpdate(schema, hoodieRecord, isUpdateRecord);
+        bufferedRecord = bufferInsertAndUpdate(schema, hoodieRecord, isUpdateRecord);
       } else {
         bufferDelete(hoodieRecord);
       }
@@ -320,12 +331,14 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       // part of marking
       // record successful.
       hoodieRecord.deflate();
+      return bufferedRecord;
     } catch (Exception e) {
       log.error("Error writing record {}", hoodieRecord, e);
       if (!config.getIgnoreWriteFailed()) {
         throw new HoodieException(e.getMessage(), e);
       }
       writeStatus.markFailure(hoodieRecord, e, recordMetadata);
+      return null;
     }
   }
 
@@ -473,8 +486,8 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     while (recordItr.hasNext()) {
       HoodieRecord record = recordItr.next();
       init(record);
-      flushToDiskIfRequired(record, false);
-      writeToBuffer(record);
+      HoodieRecord bufferedRecord = writeToBuffer(record);
+      flushToDiskIfRequired(bufferedRecord, false);
     }
     appendDataAndDeleteBlocks(header, true);
     estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
@@ -532,8 +545,8 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     Option<Map<String, String>> recordMetadata = record.getMetadata();
     try {
       init(record);
-      flushToDiskIfRequired(record, false);
-      writeToBuffer(record);
+      HoodieRecord bufferedRecord = writeToBuffer(record);
+      flushToDiskIfRequired(bufferedRecord, false);
     } catch (Throwable t) {
       log.error("Error writing record " + record, t);
       if (!config.getIgnoreWriteFailed()) {
@@ -597,8 +610,8 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       for (Map.Entry<String, HoodieRecord<T>> entry: recordMap.entrySet()) {
         HoodieRecord<T> record = entry.getValue();
         init(record);
-        flushToDiskIfRequired(record, false);
-        writeToBuffer(record);
+        HoodieRecord bufferedRecord = writeToBuffer(record);
+        flushToDiskIfRequired(bufferedRecord, false);
       }
       appendDataAndDeleteBlocks(header, true);
       estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
@@ -623,12 +636,21 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     return true;
   }
 
-  private void writeToBuffer(HoodieRecord<T> record) {
+  /**
+   * Buffers {@code record} for the next log block. Returns the record actually appended to
+   * {@link #recordList} (the post-{@code prepareRecord} object — typically a
+   * {@code HoodieAvroIndexedRecord} carrying a fully-deserialized {@code IndexedRecord}),
+   * or {@code null} when nothing was appended to {@code recordList} (delete, ignored, or
+   * partition-mismatch failure). The returned reference is what {@link #flushToDiskIfRequired}
+   * sizes — sizing the incoming record under-counts heap on Spark engines where the incoming
+   * record is a compact {@code UnsafeRow} but the buffered record is the larger Avro form.
+   */
+  private HoodieRecord writeToBuffer(HoodieRecord<T> record) {
     if (!partitionPath.equals(record.getPartitionPath())) {
       HoodieUpsertException failureEx = new HoodieUpsertException("mismatched partition path, record partition: "
           + record.getPartitionPath() + " but trying to insert into partition: " + partitionPath);
       writeStatus.markFailure(record, failureEx, record.getMetadata());
-      return;
+      return null;
     }
 
     // update the new location of the record, so we know where to find it next
@@ -637,15 +659,21 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       record.setNewLocation(newRecordLocation);
       record.seal();
     }
-    // fetch the ordering val first in case the record was deflated.
-    bufferRecord(record);
+    HoodieRecord bufferedRecord = bufferRecord(record);
     numberOfRecords++;
+    return bufferedRecord;
   }
 
-  private void bufferInsertAndUpdate(HoodieSchema schema, HoodieRecord<T> hoodieRecord, boolean isUpdateRecord) throws IOException {
+  /**
+   * Appends the post-{@code prependMetaFields} record to {@link #recordList}. Returns the
+   * appended record (the actual heap-retained object, used by
+   * {@link #flushToDiskIfRequired} for size estimation), or {@code null} when the record is
+   * skipped (e.g. ignored by {@code ExpressionPayload}).
+   */
+  private HoodieRecord bufferInsertAndUpdate(HoodieSchema schema, HoodieRecord<T> hoodieRecord, boolean isUpdateRecord) throws IOException {
     // Check if the record should be ignored (special case for [[ExpressionPayload]])
     if (hoodieRecord.shouldIgnore(schema, recordProperties)) {
-      return;
+      return null;
     }
 
     // Prepend meta-fields into the record
@@ -656,13 +684,15 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     // NOTE: Record have to be cloned here to make sure if it holds low-level engine-specific
     //       payload pointing into a shared, mutable (underlying) buffer we get a clean copy of
     //       it since these records will be put into the recordList(List).
-    recordList.add(populatedRecord.copy());
+    HoodieRecord bufferedRecord = populatedRecord.copy();
+    recordList.add(bufferedRecord);
     if (isUpdateRecord || isLogCompaction) {
       updatedRecordsWritten++;
     } else {
       insertRecordsWritten++;
     }
     recordsWritten++;
+    return bufferedRecord;
   }
 
   private void bufferDelete(HoodieRecord<T> hoodieRecord) {
@@ -680,23 +710,60 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
 
   /**
    * Checks if the number of records have reached the set threshold and then flushes the records to disk.
+   *
+   * <p>{@code bufferedRecord} is the record that was just appended to {@link #recordList} by
+   * {@link #writeToBuffer} (or {@code null} for delete/ignored windows where {@code recordList}
+   * did not grow). Sizing this object — rather than the incoming pre-{@code prepareRecord}
+   * record — keeps {@link #averageRecordSize} aligned with what is actually retained in heap,
+   * which matters on Spark engines where the incoming {@code HoodieSparkRecord}/{@code UnsafeRow}
+   * is many times smaller than the buffered {@code HoodieAvroIndexedRecord}.
    */
-  protected void flushToDiskIfRequired(HoodieRecord record, boolean appendDeleteBlocks) {
-    if (numberOfRecords >= (int) (maxBlockSize / averageRecordSize)
-        || numberOfRecords % NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE == 0) {
-      averageRecordSize = (long) (averageRecordSize * 0.8 + sizeEstimator.sizeEstimate(record) * 0.2);
+  protected void flushToDiskIfRequired(HoodieRecord bufferedRecord, boolean appendDeleteBlocks) {
+    if (bufferedRecord != null
+        && (averageRecordSize == 0
+            || numberOfRecords >= (int) (maxBlockSize / Math.max(averageRecordSize, 1))
+            || numberOfRecords % NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE == 0)) {
+      long sampled = sizeEstimator.sizeEstimate(bufferedRecord);
+      averageRecordSize = averageRecordSize == 0
+          ? sampled
+          : (long) (averageRecordSize * 0.8 + sampled * 0.2);
     }
 
-    // Append if max number of records reached to achieve block size
-    if (numberOfRecords >= (maxBlockSize / averageRecordSize)) {
-      // Recompute averageRecordSize before writing a new block and update existing value with
-      // avg of new and old
+    // Append if max number of records reached to achieve block size.
+    // Skip when averageRecordSize is still 0 (delete-only prefix before any insert/update).
+    if (averageRecordSize > 0 && numberOfRecords >= (maxBlockSize / averageRecordSize)) {
       log.info("Flush log block to disk, the current avgRecordSize => " + averageRecordSize);
       // Delete blocks will be appended after appending all the data blocks.
       appendDataAndDeleteBlocks(header, appendDeleteBlocks);
       estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
       numberOfRecords = 0;
     }
+  }
+
+  @VisibleForTesting
+  void setSizeEstimator(SizeEstimator<HoodieRecord> sizeEstimator) {
+    this.sizeEstimator = sizeEstimator;
+  }
+
+  @VisibleForTesting
+  long getAverageRecordSize() {
+    return averageRecordSize;
+  }
+
+  @VisibleForTesting
+  long getNumberOfRecordsForTest() {
+    return numberOfRecords;
+  }
+
+  @VisibleForTesting
+  long getEstimatedBytesWrittenForTest() {
+    return estimatedNumberOfBytesWritten;
+  }
+
+  @VisibleForTesting
+  void simulateBufferedRecordForTest(HoodieRecord bufferedRecord) {
+    numberOfRecords++;
+    flushToDiskIfRequired(bufferedRecord, false);
   }
 
   protected HoodieLogBlock.HoodieLogBlockType getLogBlockType() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -771,28 +771,28 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   }
 
   @VisibleForTesting
-  long getNumberOfRecordsForTest() {
+  long getNumberOfRecords() {
     return numberOfRecords;
   }
 
   @VisibleForTesting
-  long getEstimatedBytesWrittenForTest() {
+  long getEstimatedNumberOfBytesWritten() {
     return estimatedNumberOfBytesWritten;
   }
 
   @VisibleForTesting
-  void simulateBufferedRecordForTest(HoodieRecord bufferedRecord) {
+  void simulateBufferedRecord(HoodieRecord bufferedRecord) {
     numberOfRecords++;
     flushToDiskIfRequired(bufferedRecord, false);
   }
 
   @VisibleForTesting
-  long getEffectiveBlockSizeForTest() {
+  long getEffectiveBlockSize() {
     return effectiveBlockSize;
   }
 
   @VisibleForTesting
-  long getMaxBlockSizeForTest() {
+  long getMaxBlockSize() {
     return maxBlockSize;
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/IOUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/IOUtils.java
@@ -111,12 +111,12 @@ public class IOUtils {
    * cores per task into total cores to get task slots).
    *
    * <p>Distinct from {@link #getMaxMemoryAllowedForMerge} in two ways: returns {@code Option}
-   * rather than collapsing the absent case to a default, and accepts the floor as a parameter
-   * so callers (e.g., {@code HoodieAppendHandle}) can use a smaller floor than the spillable-map
-   * 100MB.
+   * rather than collapsing the absent case to a default, and accepts the minimum-bytes value
+   * as a parameter so callers (e.g., {@code HoodieAppendHandle}) can use a smaller floor than
+   * the spillable-map 100MB.
    */
   public static Option<Long> getMaxMemoryAllowedForLogAppend(
-      TaskContextSupplier context, String maxMemoryFraction, long minFloor) {
+      TaskContextSupplier context, String maxMemoryFraction, long minBytes) {
     Option<String> totalMemoryOpt = context.getProperty(EngineProperty.TOTAL_MEMORY_AVAILABLE);
     Option<String> memoryFractionOpt = context.getProperty(EngineProperty.MEMORY_FRACTION_IN_USE);
     Option<String> totalCoresOpt = context.getProperty(EngineProperty.TOTAL_CORES_PER_EXECUTOR);
@@ -134,7 +134,7 @@ public class IOUtils {
     }
     double userAvailableMemory = executorMemoryInBytes * (1 - memoryFraction) / executorTaskNum;
     long ceiling = (long) Math.floor(userAvailableMemory * appendFraction);
-    return Option.of(Math.max(minFloor, ceiling));
+    return Option.of(Math.max(minBytes, ceiling));
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/IOUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/IOUtils.java
@@ -99,6 +99,45 @@ public class IOUtils {
   }
 
   /**
+   * Returns {@code Option.of(per-task memory ceiling in bytes)} when the engine exposes
+   * {@link EngineProperty#TOTAL_MEMORY_AVAILABLE}, {@link EngineProperty#MEMORY_FRACTION_IN_USE},
+   * and {@link EngineProperty#TOTAL_CORES_PER_EXECUTOR} (Spark). Returns {@code Option.empty()}
+   * otherwise (engines that do not expose memory/cores) so callers can fall back to a static
+   * config-driven cap rather than the spillable-map 1GB default.
+   *
+   * <p>Formula mirrors {@link #getMaxMemoryAllowedForMerge}: {@code userAvailableMemory =
+   * totalExecutorMemory * (1 - memoryFraction) / executorTaskNum}, then multiplied by the
+   * supplied fraction. Honors {@link EngineProperty#SINGLE_TASK_CORES} when present (divides
+   * cores per task into total cores to get task slots).
+   *
+   * <p>Distinct from {@link #getMaxMemoryAllowedForMerge} in two ways: returns {@code Option}
+   * rather than collapsing the absent case to a default, and accepts the floor as a parameter
+   * so callers (e.g., {@code HoodieAppendHandle}) can use a smaller floor than the spillable-map
+   * 100MB.
+   */
+  public static Option<Long> getMaxMemoryAllowedForLogAppend(
+      TaskContextSupplier context, String maxMemoryFraction, long minFloor) {
+    Option<String> totalMemoryOpt = context.getProperty(EngineProperty.TOTAL_MEMORY_AVAILABLE);
+    Option<String> memoryFractionOpt = context.getProperty(EngineProperty.MEMORY_FRACTION_IN_USE);
+    Option<String> totalCoresOpt = context.getProperty(EngineProperty.TOTAL_CORES_PER_EXECUTOR);
+    if (!(totalMemoryOpt.isPresent() && memoryFractionOpt.isPresent() && totalCoresOpt.isPresent())) {
+      return Option.empty();
+    }
+    long executorMemoryInBytes = Long.parseLong(totalMemoryOpt.get());
+    double memoryFraction = Double.parseDouble(memoryFractionOpt.get());
+    double appendFraction = Double.parseDouble(maxMemoryFraction);
+    long executorCores = Long.parseLong(totalCoresOpt.get());
+    Option<String> singleTaskCoresOpt = context.getProperty(EngineProperty.SINGLE_TASK_CORES);
+    long executorTaskNum = executorCores;
+    if (singleTaskCoresOpt.isPresent()) {
+      executorTaskNum = executorCores / Long.parseLong(singleTaskCoresOpt.get());
+    }
+    double userAvailableMemory = executorMemoryInBytes * (1 - memoryFraction) / executorTaskNum;
+    long ceiling = (long) Math.floor(userAvailableMemory * appendFraction);
+    return Option.of(Math.max(minFloor, ceiling));
+  }
+
+  /**
    * Triggers the merge action with given merge handle {@code HoodieMergeHandle}.
    *
    * <p>Note: it can be either regular write path merging

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
@@ -18,12 +18,15 @@
 
 package org.apache.hudi.io;
 
+import org.apache.hudi.common.config.HoodieMemoryConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.EngineProperty;
 import org.apache.hudi.common.engine.LocalTaskContextSupplier;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SizeEstimator;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
@@ -40,6 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
@@ -258,6 +262,153 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     @Override
     protected void appendDataAndDeleteBlocks(Map<HeaderMetadataType, String> header, boolean appendDeleteBlocks) {
       appendInvocations.incrementAndGet();
+    }
+  }
+
+  /**
+   * When the engine does not expose memory/cores (e.g., Flink, or Spark without {@code SparkEnv}),
+   * the dynamic ceiling is absent and the flush gate continues to use the configured
+   * {@code maxBlockSize}. {@link LocalTaskContextSupplier} returns {@code Option.empty()} for all
+   * engine properties, so this is the fallback path.
+   */
+  @Test
+  void testEffectiveBlockSizeFallsBackToMaxBlockSizeWhenNoEngineProps() {
+    TestableAppendHandle handle = newTestableHandle(new RecordingSizeEstimator(1000L));
+    assertEquals(handle.getMaxBlockSizeForTest(), handle.getEffectiveBlockSizeForTest(),
+        "no engine properties — effective cap collapses to maxBlockSize");
+  }
+
+  /**
+   * On a small executor, the dynamic per-task ceiling is smaller than the configured
+   * {@code maxBlockSize} and must win. With 200MB executor / 0.6 memory.fraction / 1 core / 0.6
+   * append-fraction the ceiling is 48MB, well below the default 256MB block size.
+   */
+  @Test
+  void testEffectiveBlockSizeIsDynamicCeilingWhenSmallerThanMaxBlockSize() {
+    long executorBytes = 200L * 1024 * 1024;
+    TaskContextSupplier supplier = new StubTaskContextSupplier(executorBytes, 0.6, 1);
+    TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, supplier);
+
+    long expectedDynamic = (long) Math.floor(executorBytes * (1 - 0.6) / 1 * 0.6); // 48MB
+    assertEquals(expectedDynamic, handle.getEffectiveBlockSizeForTest(),
+        "small executor — dynamic ceiling wins over configured maxBlockSize");
+    assertTrue(handle.getEffectiveBlockSizeForTest() < handle.getMaxBlockSizeForTest(),
+        "effective cap is below maxBlockSize on a tight executor");
+  }
+
+  /**
+   * The dynamic ceiling is floored at
+   * {@link HoodieMemoryConfig#MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES} (16MB). With a tiny 50MB
+   * executor the raw computation yields ~12MB, but the floor pulls it back to 16MB.
+   */
+  @Test
+  void testEffectiveBlockSizeRespects16MBFloor() {
+    long executorBytes = 50L * 1024 * 1024;
+    TaskContextSupplier supplier = new StubTaskContextSupplier(executorBytes, 0.6, 1);
+    TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, supplier);
+
+    assertEquals(HoodieMemoryConfig.MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES,
+        handle.getEffectiveBlockSizeForTest(),
+        "raw computation falls below 16MB floor — floor wins");
+  }
+
+  /**
+   * When the dynamic ceiling is larger than the configured {@code maxBlockSize}, the latter wins.
+   * 16GB executor / 0.6 / 4 cores / 0.6 append-fraction → 960MB ceiling, much larger than the
+   * default 256MB block size.
+   */
+  @Test
+  void testEffectiveBlockSizeKeepsMaxBlockSizeWhenDynamicIsLarger() {
+    long executorBytes = 16L * 1024 * 1024 * 1024;
+    TaskContextSupplier supplier = new StubTaskContextSupplier(executorBytes, 0.6, 4);
+    TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, supplier);
+
+    assertEquals(handle.getMaxBlockSizeForTest(), handle.getEffectiveBlockSizeForTest(),
+        "large executor — configured maxBlockSize is the binding ceiling");
+  }
+
+  /**
+   * The flush gate must use {@code effectiveBlockSize}, not {@code maxBlockSize}. With a 48MB
+   * dynamic ceiling (200MB executor / 0.6 / 1 core / 0.6 append-fraction) and 4MB per-record,
+   * the gate fires after 12 records (48MB / 4MB), well before the 256MB / 4MB = 64 records the
+   * old code would have allowed.
+   */
+  @Test
+  void testFlushGateFiresAtDynamicCeilingNotMaxBlockSize() {
+    long executorBytes = 200L * 1024 * 1024;
+    TaskContextSupplier supplier = new StubTaskContextSupplier(executorBytes, 0.6, 1);
+    TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, supplier);
+    long perRecord = 4L * 1024 * 1024;
+    handle.setSizeEstimator(new RecordingSizeEstimator(perRecord));
+
+    long expectedRecordsAtFlush = handle.getEffectiveBlockSizeForTest() / perRecord;
+    long recordsAtFlushWithMaxBlockSize = handle.getMaxBlockSizeForTest() / perRecord;
+    assertTrue(expectedRecordsAtFlush < recordsAtFlushWithMaxBlockSize,
+        "test setup: dynamic ceiling must trip the gate earlier than maxBlockSize would");
+
+    for (int i = 0; i < expectedRecordsAtFlush - 1; i++) {
+      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    }
+    assertEquals(0, handle.appendInvocations.get(),
+        "below the dynamic ceiling: gate has not fired yet");
+
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    assertEquals(1, handle.appendInvocations.get(),
+        "buffered records hit the dynamic ceiling — flush fires earlier than maxBlockSize would have allowed");
+  }
+
+  /**
+   * {@link TaskContextSupplier} stub returning the three engine properties the dynamic-ceiling
+   * formula consumes — mirrors what {@code SparkTaskContextSupplier} exposes.
+   */
+  private static final class StubTaskContextSupplier extends TaskContextSupplier {
+    private final long executorMemoryBytes;
+    private final double memoryFraction;
+    private final int executorCores;
+
+    StubTaskContextSupplier(long executorMemoryBytes, double memoryFraction, int executorCores) {
+      this.executorMemoryBytes = executorMemoryBytes;
+      this.memoryFraction = memoryFraction;
+      this.executorCores = executorCores;
+    }
+
+    @Override
+    public Option<String> getProperty(EngineProperty prop) {
+      switch (prop) {
+        case TOTAL_MEMORY_AVAILABLE:
+          return Option.of(String.valueOf(executorMemoryBytes));
+        case MEMORY_FRACTION_IN_USE:
+          return Option.of(String.valueOf(memoryFraction));
+        case TOTAL_CORES_PER_EXECUTOR:
+          return Option.of(String.valueOf(executorCores));
+        default:
+          return Option.empty();
+      }
+    }
+
+    @Override
+    public Supplier<Integer> getPartitionIdSupplier() {
+      return () -> 0;
+    }
+
+    @Override
+    public Supplier<Integer> getStageIdSupplier() {
+      return () -> 0;
+    }
+
+    @Override
+    public Supplier<Long> getAttemptIdSupplier() {
+      return () -> 0L;
+    }
+
+    @Override
+    public Supplier<Integer> getTaskAttemptNumberSupplier() {
+      return () -> -1;
+    }
+
+    @Override
+    public Supplier<Integer> getStageAttemptNumberSupplier() {
+      return () -> -1;
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
@@ -109,7 +109,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TestableAppendHandle handle = newTestableHandle(spy);
 
     HoodieRecord buffered = mock(HoodieRecord.class);
-    handle.simulateBufferedRecordForTest(buffered);
+    handle.simulateBufferedRecord(buffered);
 
     assertEquals(1, spy.sizedObjects.size(), "estimator should be invoked once on the first buffered record");
     assertSame(buffered, spy.sizedObjects.get(0),
@@ -127,7 +127,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
 
     assertEquals(0L, handle.getAverageRecordSize(), "no records yet — estimate is unseeded");
 
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
 
     assertEquals(2048L, handle.getAverageRecordSize(),
         "first buffered record seeds averageRecordSize directly (no EWMA on first sample)");
@@ -143,7 +143,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TestableAppendHandle handle = newTestableHandle(spy);
 
     for (int i = 0; i < 250; i++) {
-      handle.simulateBufferedRecordForTest(null);
+      handle.simulateBufferedRecord(null);
     }
 
     assertEquals(0, spy.sizedObjects.size(), "estimator never invoked on delete-only windows");
@@ -159,13 +159,13 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
   void testEwmaBlendsSamplesAfterFirstSeed() {
     TestableAppendHandle handle = newTestableHandle(new SteppedSizeEstimator(1000L, 5000L));
 
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
     assertEquals(1000L, handle.getAverageRecordSize(), "first record seeds the estimate at 1000");
 
     // 99 more records — the sampler will not fire again until numberOfRecords % 100 == 0.
     // Record #100 returns the second sample (5000); EWMA blends to 0.8*1000 + 0.2*5000 = 1800.
     for (int i = 0; i < 99; i++) {
-      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+      handle.simulateBufferedRecord(mock(HoodieRecord.class));
     }
     assertEquals(1800L, handle.getAverageRecordSize(), "EWMA after the second sample: 0.8*1000 + 0.2*5000");
   }
@@ -180,14 +180,14 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TestableAppendHandle handle = newTestableHandle(new RecordingSizeEstimator(perRecord));
 
     for (int i = 0; i < 9; i++) {
-      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+      handle.simulateBufferedRecord(mock(HoodieRecord.class));
     }
     assertEquals(0, handle.appendInvocations.get(), "9 records of perRecord-sized buffer: gate has not fired yet");
 
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
     assertEquals(1, handle.appendInvocations.get(), "10th record fills the block — flush fires");
-    assertEquals(0L, handle.getNumberOfRecordsForTest(), "numberOfRecords resets after flush");
-    assertTrue(handle.getEstimatedBytesWrittenForTest() > 0, "estimatedNumberOfBytesWritten advances after flush");
+    assertEquals(0L, handle.getNumberOfRecords(), "numberOfRecords resets after flush");
+    assertTrue(handle.getEstimatedNumberOfBytesWritten() > 0, "estimatedNumberOfBytesWritten advances after flush");
   }
 
   /** Guards against the test harness silently no-op'ing the flush hook. */
@@ -197,10 +197,10 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
         newTestableHandle(new RecordingSizeEstimator(writeConfig.getLogFileDataBlockMaxSize()));
     // Single record whose size == maxBlockSize: gate fires immediately on record #1
     // (numberOfRecords == 1 >= maxBlockSize / maxBlockSize == 1).
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
     assertEquals(1, handle.appendInvocations.get(),
         "harness must route flushes through the override, not the real writer");
-    assertNotEquals(0L, handle.getEstimatedBytesWrittenForTest());
+    assertNotEquals(0L, handle.getEstimatedNumberOfBytesWritten());
     assertFalse(handle.getAverageRecordSize() == 0L);
   }
 
@@ -274,7 +274,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
   @Test
   void testEffectiveBlockSizeFallsBackToMaxBlockSizeWhenNoEngineProps() {
     TestableAppendHandle handle = newTestableHandle(new RecordingSizeEstimator(1000L));
-    assertEquals(handle.getMaxBlockSizeForTest(), handle.getEffectiveBlockSizeForTest(),
+    assertEquals(handle.getMaxBlockSize(), handle.getEffectiveBlockSize(),
         "no engine properties — effective cap collapses to maxBlockSize");
   }
 
@@ -290,9 +290,9 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, supplier);
 
     long expectedDynamic = (long) Math.floor(executorBytes * (1 - 0.6) / 1 * 0.6); // 48MB
-    assertEquals(expectedDynamic, handle.getEffectiveBlockSizeForTest(),
+    assertEquals(expectedDynamic, handle.getEffectiveBlockSize(),
         "small executor — dynamic ceiling wins over configured maxBlockSize");
-    assertTrue(handle.getEffectiveBlockSizeForTest() < handle.getMaxBlockSizeForTest(),
+    assertTrue(handle.getEffectiveBlockSize() < handle.getMaxBlockSize(),
         "effective cap is below maxBlockSize on a tight executor");
   }
 
@@ -308,7 +308,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, supplier);
 
     assertEquals(HoodieMemoryConfig.MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES,
-        handle.getEffectiveBlockSizeForTest(),
+        handle.getEffectiveBlockSize(),
         "raw computation falls below 16MB floor — floor wins");
   }
 
@@ -323,7 +323,7 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     TaskContextSupplier supplier = new StubTaskContextSupplier(executorBytes, 0.6, 4);
     TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, supplier);
 
-    assertEquals(handle.getMaxBlockSizeForTest(), handle.getEffectiveBlockSizeForTest(),
+    assertEquals(handle.getMaxBlockSize(), handle.getEffectiveBlockSize(),
         "large executor — configured maxBlockSize is the binding ceiling");
   }
 
@@ -341,18 +341,18 @@ public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
     long perRecord = 4L * 1024 * 1024;
     handle.setSizeEstimator(new RecordingSizeEstimator(perRecord));
 
-    long expectedRecordsAtFlush = handle.getEffectiveBlockSizeForTest() / perRecord;
-    long recordsAtFlushWithMaxBlockSize = handle.getMaxBlockSizeForTest() / perRecord;
+    long expectedRecordsAtFlush = handle.getEffectiveBlockSize() / perRecord;
+    long recordsAtFlushWithMaxBlockSize = handle.getMaxBlockSize() / perRecord;
     assertTrue(expectedRecordsAtFlush < recordsAtFlushWithMaxBlockSize,
         "test setup: dynamic ceiling must trip the gate earlier than maxBlockSize would");
 
     for (int i = 0; i < expectedRecordsAtFlush - 1; i++) {
-      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+      handle.simulateBufferedRecord(mock(HoodieRecord.class));
     }
     assertEquals(0, handle.appendInvocations.get(),
         "below the dynamic ceiling: gate has not fired yet");
 
-    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    handle.simulateBufferedRecord(mock(HoodieRecord.class));
     assertEquals(1, handle.appendInvocations.get(),
         "buffered records hit the dynamic ceiling — flush fires earlier than maxBlockSize would have allowed");
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieAppendHandle.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.LocalTaskContextSupplier;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
+import org.apache.hudi.common.util.SizeEstimator;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.TestBaseHoodieTable;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH;
+import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link HoodieAppendHandle}'s block-flush sizing logic.
+ *
+ * <p>The block-flush trigger sizes the post-{@code prepareRecord} record (the object actually
+ * retained in {@code recordList}), not the incoming pre-{@code prepareRecord} record. On Spark
+ * engines the incoming record is a compact {@code UnsafeRow} while the buffered record is a
+ * full {@code HoodieAvroIndexedRecord} — sizing the wrong one caused production OOMs on
+ * metadata-table writes by letting the buffer grow many times past {@code maxBlockSize} worth
+ * of heap before the gate fired.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestHoodieAppendHandle extends HoodieCommonTestHarness {
+
+  private static final String TEST_INSTANT_TIME = "20231201120000";
+  private static final String TEST_PARTITION_PATH = DEFAULT_FIRST_PARTITION_PATH;
+  private static final String TEST_FILE_ID = "file-001";
+
+  private HoodieWriteConfig writeConfig;
+  private TaskContextSupplier taskContextSupplier;
+  private HoodieTable hoodieTable;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    initPath();
+    initMetaClient(false);
+    initTestDataGenerator();
+
+    writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(basePath)
+        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withMarkersType("DIRECT")
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .build();
+    hoodieTable = new TestBaseHoodieTable(writeConfig, getEngineContext(), metaClient);
+    taskContextSupplier = new LocalTaskContextSupplier();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    cleanMetaClient();
+    cleanupTestDataGenerator();
+  }
+
+  /**
+   * The estimator must size the post-{@code prepareRecord} buffered record, not the incoming
+   * pre-{@code prepareRecord} record. On Spark engines, the incoming record is a compact
+   * {@code UnsafeRow} while the buffered record is a full {@code HoodieAvroIndexedRecord} —
+   * sizing the wrong one was the root cause of production OOMs on metadata-table writes.
+   */
+  @Test
+  void testSizeEstimatorReceivesBufferedRecord() {
+    RecordingSizeEstimator spy = new RecordingSizeEstimator(1000L);
+    TestableAppendHandle handle = newTestableHandle(spy);
+
+    HoodieRecord buffered = mock(HoodieRecord.class);
+    handle.simulateBufferedRecordForTest(buffered);
+
+    assertEquals(1, spy.sizedObjects.size(), "estimator should be invoked once on the first buffered record");
+    assertSame(buffered, spy.sizedObjects.get(0),
+        "estimator must size the post-prepareRecord buffered record, not the incoming record");
+  }
+
+  /**
+   * The initial estimate is seeded lazily on the first buffered record — the old code seeded it
+   * eagerly from the incoming pre-{@code prepareRecord} record in {@code init()}, which
+   * dramatically under-counted heap on Spark engines.
+   */
+  @Test
+  void testInitialEstimateSeededFromFirstBufferedRecord() {
+    TestableAppendHandle handle = newTestableHandle(new RecordingSizeEstimator(2048L));
+
+    assertEquals(0L, handle.getAverageRecordSize(), "no records yet — estimate is unseeded");
+
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+
+    assertEquals(2048L, handle.getAverageRecordSize(),
+        "first buffered record seeds averageRecordSize directly (no EWMA on first sample)");
+  }
+
+  /**
+   * A delete-only window must not perturb {@code averageRecordSize} and must not trigger a
+   * flush — {@code recordList} did not grow, so there is no in-heap buffer to bound.
+   */
+  @Test
+  void testDeleteOnlyDoesNotPerturbEstimateOrFlush() {
+    RecordingSizeEstimator spy = new RecordingSizeEstimator(1234L);
+    TestableAppendHandle handle = newTestableHandle(spy);
+
+    for (int i = 0; i < 250; i++) {
+      handle.simulateBufferedRecordForTest(null);
+    }
+
+    assertEquals(0, spy.sizedObjects.size(), "estimator never invoked on delete-only windows");
+    assertEquals(0L, handle.getAverageRecordSize(), "estimate remains unseeded with no buffered records");
+    assertEquals(0, handle.appendInvocations.get(), "flush gate never fires when averageRecordSize is 0");
+  }
+
+  /**
+   * Once seeded, the EWMA blends new samples (20%) with the running estimate (80%). The sampler
+   * fires every {@code NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE} records.
+   */
+  @Test
+  void testEwmaBlendsSamplesAfterFirstSeed() {
+    TestableAppendHandle handle = newTestableHandle(new SteppedSizeEstimator(1000L, 5000L));
+
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    assertEquals(1000L, handle.getAverageRecordSize(), "first record seeds the estimate at 1000");
+
+    // 99 more records — the sampler will not fire again until numberOfRecords % 100 == 0.
+    // Record #100 returns the second sample (5000); EWMA blends to 0.8*1000 + 0.2*5000 = 1800.
+    for (int i = 0; i < 99; i++) {
+      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    }
+    assertEquals(1800L, handle.getAverageRecordSize(), "EWMA after the second sample: 0.8*1000 + 0.2*5000");
+  }
+
+  /**
+   * When the per-record estimate reaches {@code maxBlockSize / N}, the gate trips after N
+   * records — i.e. {@code numberOfRecords >= maxBlockSize / averageRecordSize}.
+   */
+  @Test
+  void testFlushTriggersWhenBufferedRecordsExceedMaxBlockSize() {
+    long perRecord = writeConfig.getLogFileDataBlockMaxSize() / 10;
+    TestableAppendHandle handle = newTestableHandle(new RecordingSizeEstimator(perRecord));
+
+    for (int i = 0; i < 9; i++) {
+      handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    }
+    assertEquals(0, handle.appendInvocations.get(), "9 records of perRecord-sized buffer: gate has not fired yet");
+
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    assertEquals(1, handle.appendInvocations.get(), "10th record fills the block — flush fires");
+    assertEquals(0L, handle.getNumberOfRecordsForTest(), "numberOfRecords resets after flush");
+    assertTrue(handle.getEstimatedBytesWrittenForTest() > 0, "estimatedNumberOfBytesWritten advances after flush");
+  }
+
+  /** Guards against the test harness silently no-op'ing the flush hook. */
+  @Test
+  void testHarnessAppendOverrideIsActuallyInvoked() {
+    TestableAppendHandle handle =
+        newTestableHandle(new RecordingSizeEstimator(writeConfig.getLogFileDataBlockMaxSize()));
+    // Single record whose size == maxBlockSize: gate fires immediately on record #1
+    // (numberOfRecords == 1 >= maxBlockSize / maxBlockSize == 1).
+    handle.simulateBufferedRecordForTest(mock(HoodieRecord.class));
+    assertEquals(1, handle.appendInvocations.get(),
+        "harness must route flushes through the override, not the real writer");
+    assertNotEquals(0L, handle.getEstimatedBytesWrittenForTest());
+    assertFalse(handle.getAverageRecordSize() == 0L);
+  }
+
+  private TestableAppendHandle newTestableHandle(SizeEstimator<HoodieRecord> estimator) {
+    TestableAppendHandle handle = new TestableAppendHandle(writeConfig, hoodieTable, taskContextSupplier);
+    handle.setSizeEstimator(estimator);
+    return handle;
+  }
+
+  /** Records (and counts) every object handed to {@link #sizeEstimate}. */
+  private static final class RecordingSizeEstimator implements SizeEstimator<HoodieRecord> {
+    final List<HoodieRecord> sizedObjects = new ArrayList<>();
+    private final long fixedSize;
+
+    RecordingSizeEstimator(long fixedSize) {
+      this.fixedSize = fixedSize;
+    }
+
+    @Override
+    public long sizeEstimate(HoodieRecord r) {
+      sizedObjects.add(r);
+      return fixedSize;
+    }
+  }
+
+  /** Returns {@code first} on the first call, then {@code rest} on every subsequent call. */
+  private static final class SteppedSizeEstimator implements SizeEstimator<HoodieRecord> {
+    private final long first;
+    private final long rest;
+    private boolean firstCallDone = false;
+
+    SteppedSizeEstimator(long first, long rest) {
+      this.first = first;
+      this.rest = rest;
+    }
+
+    @Override
+    public long sizeEstimate(HoodieRecord r) {
+      if (!firstCallDone) {
+        firstCallDone = true;
+        return first;
+      }
+      return rest;
+    }
+  }
+
+  /**
+   * Test handle that overrides the disk-flush side-effect — we are only validating the sizing
+   * and gate logic, not the writer plumbing.
+   */
+  private static final class TestableAppendHandle extends HoodieAppendHandle<Object, Object, Object, Object> {
+    final AtomicInteger appendInvocations = new AtomicInteger(0);
+
+    TestableAppendHandle(HoodieWriteConfig writeConfig, HoodieTable hoodieTable,
+                         TaskContextSupplier taskContextSupplier) {
+      super(writeConfig, TEST_INSTANT_TIME, hoodieTable, TEST_PARTITION_PATH, TEST_FILE_ID, taskContextSupplier);
+    }
+
+    @Override
+    protected void appendDataAndDeleteBlocks(Map<HeaderMetadataType, String> header, boolean appendDeleteBlocks) {
+      appendInvocations.incrementAndGet();
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestIOUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestIOUtils.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.common.engine.EngineProperty;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link IOUtils#getMaxMemoryAllowedForLogAppend} — the dynamic per-task memory
+ * helper used by {@code HoodieAppendHandle} to cap its in-memory log-block buffer.
+ *
+ * <p>Pins the helper's contract directly: absent-engine-props → empty option, formula,
+ * parameterized floor, and {@link EngineProperty#SINGLE_TASK_CORES} accounting.
+ */
+public class TestIOUtils {
+
+  private static final String DEFAULT_FRACTION = "0.6";
+  private static final long FLOOR_16MB = 16L * 1024 * 1024;
+
+  /**
+   * When the engine does not expose memory/cores (engines whose {@code TaskContextSupplier}
+   * returns {@code Option.empty()}, including Spark without {@code SparkEnv}), the helper must
+   * return {@code Option.empty()} so callers can fall back to a static config-driven cap rather
+   * than the spillable-map 1GB default.
+   */
+  @Test
+  void testReturnsEmptyWhenAnyEnginePropertyMissing() {
+    assertFalse(IOUtils.getMaxMemoryAllowedForLogAppend(
+        new StubTaskContextSupplier(null, null, null, null), DEFAULT_FRACTION, FLOOR_16MB).isPresent());
+    assertFalse(IOUtils.getMaxMemoryAllowedForLogAppend(
+        new StubTaskContextSupplier(1024L, null, 1, null), DEFAULT_FRACTION, FLOOR_16MB).isPresent());
+    assertFalse(IOUtils.getMaxMemoryAllowedForLogAppend(
+        new StubTaskContextSupplier(1024L, 0.6, null, null), DEFAULT_FRACTION, FLOOR_16MB).isPresent());
+    assertFalse(IOUtils.getMaxMemoryAllowedForLogAppend(
+        new StubTaskContextSupplier(null, 0.6, 1, null), DEFAULT_FRACTION, FLOOR_16MB).isPresent());
+  }
+
+  /**
+   * Formula check on a "normal" executor: 4GB / 0.6 memory-fraction / 4 cores = 400MB user
+   * memory per task, * 0.6 append-fraction = 240MB ceiling.
+   */
+  @Test
+  void testComputesPerTaskCeilingFromEngineProperties() {
+    long executorBytes = 4L * 1024 * 1024 * 1024;
+    Option<Long> ceiling = IOUtils.getMaxMemoryAllowedForLogAppend(
+        new StubTaskContextSupplier(executorBytes, 0.6, 4, null),
+        DEFAULT_FRACTION,
+        FLOOR_16MB);
+
+    assertTrue(ceiling.isPresent());
+    long expected = (long) Math.floor(executorBytes * (1 - 0.6) / 4 * 0.6);
+    assertEquals(expected, ceiling.get().longValue());
+  }
+
+  /**
+   * When the raw computation falls below the supplied floor, the floor wins. Mirrors the
+   * "tiny executor" path that the 16MB floor protects against.
+   */
+  @Test
+  void testRespectsConfigurableFloor() {
+    long executorBytes = 50L * 1024 * 1024;
+    Option<Long> ceiling = IOUtils.getMaxMemoryAllowedForLogAppend(
+        new StubTaskContextSupplier(executorBytes, 0.6, 1, null),
+        DEFAULT_FRACTION,
+        FLOOR_16MB);
+
+    assertTrue(ceiling.isPresent());
+    long rawComputed = (long) Math.floor(executorBytes * (1 - 0.6) / 1 * 0.6);
+    assertTrue(rawComputed < FLOOR_16MB, "test setup must drive computation below floor");
+    assertEquals(FLOOR_16MB, ceiling.get().longValue());
+  }
+
+  /**
+   * The floor is genuinely parameterized — callers can choose a different lower bound. Pin this
+   * so the merge/compaction call sites (which use the 100MB spillable floor via the sibling
+   * helper) and the log-append call site (16MB) cannot collide on a shared constant.
+   */
+  @Test
+  void testFloorIsParameterized() {
+    long executorBytes = 50L * 1024 * 1024;
+    long floor1MB = 1024 * 1024L;
+    Option<Long> ceiling = IOUtils.getMaxMemoryAllowedForLogAppend(
+        new StubTaskContextSupplier(executorBytes, 0.6, 1, null),
+        DEFAULT_FRACTION,
+        floor1MB);
+
+    assertTrue(ceiling.isPresent());
+    long rawComputed = (long) Math.floor(executorBytes * (1 - 0.6) / 1 * 0.6);
+    assertEquals(rawComputed, ceiling.get().longValue(),
+        "with a 1MB floor, the raw computation (12MB) wins");
+  }
+
+  /**
+   * When the engine exposes {@link EngineProperty#SINGLE_TASK_CORES} (e.g., for tasks that take
+   * multiple cores), the formula divides executor cores by single-task cores to get the task
+   * slot count. With 8 cores / 2-core-per-task = 4 task slots (vs. 8 in the single-core case),
+   * the per-task memory is computed against fewer slots so each task gets more memory.
+   */
+  @Test
+  void testHonorsSingleTaskCores() {
+    long executorBytes = 4L * 1024 * 1024 * 1024;
+    StubTaskContextSupplier singleCoreSupplier = new StubTaskContextSupplier(executorBytes, 0.6, 8, null);
+    StubTaskContextSupplier twoCorePerTaskSupplier = new StubTaskContextSupplier(executorBytes, 0.6, 8, 2);
+
+    Option<Long> singleCore = IOUtils.getMaxMemoryAllowedForLogAppend(singleCoreSupplier, DEFAULT_FRACTION, FLOOR_16MB);
+    Option<Long> twoCorePerTask = IOUtils.getMaxMemoryAllowedForLogAppend(twoCorePerTaskSupplier, DEFAULT_FRACTION, FLOOR_16MB);
+
+    assertTrue(singleCore.isPresent() && twoCorePerTask.isPresent());
+    long singleCoreExpected = (long) Math.floor(executorBytes * (1 - 0.6) / 8 * 0.6);
+    long twoCorePerTaskExpected = (long) Math.floor(executorBytes * (1 - 0.6) / 4 * 0.6);
+    assertEquals(singleCoreExpected, singleCore.get().longValue());
+    assertEquals(twoCorePerTaskExpected, twoCorePerTask.get().longValue());
+    assertTrue(twoCorePerTask.get() > singleCore.get(),
+        "with cores-per-task > 1, fewer task slots → more memory per task");
+  }
+
+  /**
+   * {@link TaskContextSupplier} stub returning configurable responses for each engine property
+   * the formula consumes. {@code null} signals "engine did not expose this property" (which maps
+   * to {@link Option#empty()}).
+   */
+  private static final class StubTaskContextSupplier extends TaskContextSupplier {
+    private final Long executorMemoryBytes;
+    private final Double memoryFraction;
+    private final Integer executorCores;
+    private final Integer singleTaskCores;
+
+    StubTaskContextSupplier(Long executorMemoryBytes, Double memoryFraction, Integer executorCores, Integer singleTaskCores) {
+      this.executorMemoryBytes = executorMemoryBytes;
+      this.memoryFraction = memoryFraction;
+      this.executorCores = executorCores;
+      this.singleTaskCores = singleTaskCores;
+    }
+
+    @Override
+    public Option<String> getProperty(EngineProperty prop) {
+      switch (prop) {
+        case TOTAL_MEMORY_AVAILABLE:
+          return executorMemoryBytes == null ? Option.empty() : Option.of(String.valueOf(executorMemoryBytes));
+        case MEMORY_FRACTION_IN_USE:
+          return memoryFraction == null ? Option.empty() : Option.of(String.valueOf(memoryFraction));
+        case TOTAL_CORES_PER_EXECUTOR:
+          return executorCores == null ? Option.empty() : Option.of(String.valueOf(executorCores));
+        case SINGLE_TASK_CORES:
+          return singleTaskCores == null ? Option.empty() : Option.of(String.valueOf(singleTaskCores));
+        default:
+          return Option.empty();
+      }
+    }
+
+    @Override
+    public Supplier<Integer> getPartitionIdSupplier() {
+      return () -> 0;
+    }
+
+    @Override
+    public Supplier<Integer> getStageIdSupplier() {
+      return () -> 0;
+    }
+
+    @Override
+    public Supplier<Long> getAttemptIdSupplier() {
+      return () -> 0L;
+    }
+
+    @Override
+    public Supplier<Integer> getTaskAttemptNumberSupplier() {
+      return () -> -1;
+    }
+
+    @Override
+    public Supplier<Integer> getStageAttemptNumberSupplier() {
+      return () -> -1;
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMemoryConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMemoryConfig.java
@@ -64,6 +64,22 @@ public class HoodieMemoryConfig extends HoodieConfig {
   public static final long DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES = HoodieCommonConfig.DEFAULT_MAX_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES;
   // Minimum memory size (100MB) for the spillable map.
   public static final long DEFAULT_MIN_MEMORY_FOR_SPILLABLE_MAP_IN_BYTES = 100 * 1024 * 1024L;
+  // Minimum memory size (16MB) for the HoodieAppendHandle in-memory log-block buffer.
+  // Floor is smaller than the spillable-map floor: the append-handle buffer is per-handle and
+  // many handles may be active concurrently in a task, so we tolerate smaller blocks on tight
+  // executors to avoid OOM.
+  public static final long MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES = 16 * 1024 * 1024L;
+
+  public static final ConfigProperty<String> MAX_MEMORY_FRACTION_FOR_LOG_APPEND = ConfigProperty
+      .key("hoodie.memory.logfile.append.fraction")
+      .defaultValue(String.valueOf(0.6))
+      .markAdvanced()
+      .withDocumentation("Fraction of per-task user memory available to a HoodieAppendHandle's "
+          + "in-memory log-block buffer. Multiplied with the user memory fraction "
+          + "(1 - spark.memory.fraction) and divided by executor cores to derive a dynamic "
+          + "per-task ceiling, which then bounds hoodie.logfile.data.block.max.size from above. "
+          + "Only used when the engine exposes memory/cores (Spark); otherwise the configured "
+          + "block size is honored as-is.");
 
   public static final ConfigProperty<Long> MAX_MEMORY_FOR_MERGE = ConfigProperty
       .key("hoodie.memory.merge.max.size")

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMemoryConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieMemoryConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.apache.hudi.common.config.HoodieMemoryConfig.MAX_MEMORY_FRACTION_FOR_LOG_APPEND;
+import static org.apache.hudi.common.config.HoodieMemoryConfig.MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests {@link HoodieMemoryConfig} — focused on the log-append fraction config added for
+ * dynamic per-task memory capping of {@code HoodieAppendHandle}'s in-memory buffer.
+ */
+class TestHoodieMemoryConfig {
+
+  /** Default fraction matches the merge/compaction defaults so out-of-the-box behavior is consistent. */
+  @Test
+  void testLogAppendFractionDefault() {
+    HoodieMemoryConfig memoryConfig = HoodieMemoryConfig.newBuilder()
+        .fromProperties(new Properties())
+        .build();
+
+    assertEquals(0.6, memoryConfig.getDouble(MAX_MEMORY_FRACTION_FOR_LOG_APPEND),
+        "default log-append fraction is 0.6 — matches merge/compaction defaults");
+  }
+
+  /** User-supplied fraction via Properties overrides the default. */
+  @Test
+  void testLogAppendFractionOverrideViaProperties() {
+    Properties props = new Properties();
+    props.setProperty(MAX_MEMORY_FRACTION_FOR_LOG_APPEND.key(), "0.42");
+    HoodieMemoryConfig memoryConfig = HoodieMemoryConfig.newBuilder()
+        .fromProperties(props)
+        .build();
+
+    assertEquals(0.42, memoryConfig.getDouble(MAX_MEMORY_FRACTION_FOR_LOG_APPEND),
+        "user-supplied fraction overrides the default");
+  }
+
+  /**
+   * Pins the 16MB floor that bounds the dynamic per-task ceiling on very small executors —
+   * smaller than the 100MB spillable-map floor because many append handles can be active
+   * concurrently in a single task and we tolerate small blocks on tight executors over OOM.
+   */
+  @Test
+  void testLogAppendBufferFloorIs16MB() {
+    assertEquals(16 * 1024 * 1024L, MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES,
+        "log-append buffer floor pinned at 16MB — see HoodieAppendHandle effectiveBlockSize derivation");
+  }
+}


### PR DESCRIPTION
### Change Logs

Adds a dynamic per-task memory ceiling on `HoodieAppendHandle`'s in-memory record buffer, applied as an upper bound on top of `hoodie.logfile.data.block.max.size`. Closes #18859.

The flush gate in `flushToDiskIfRequired` now uses
```
effectiveBlockSize = min(hoodie.logfile.data.block.max.size, dynamicCeiling)
```
where `dynamicCeiling = executorMemory * (1 - spark.memory.fraction) / task_slots * hoodie.memory.logfile.append.fraction`, floored at `HoodieMemoryConfig.MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES` (16 MB — smaller than the 100 MB spillable-map floor because many append handles can be active concurrently in a single task).

When the engine does not expose memory/cores (Flink's `TaskContextSupplier.getProperty` returns `Option.empty()` unconditionally; Spark also returns empty if `SparkEnv` is absent), the new sibling `IOUtils` helper returns `Option.empty()` and `effectiveBlockSize` collapses to `maxBlockSize` — no behavior change on those engines.

**Stacked on #18843.** That PR makes `averageRecordSize` accurate by sizing the buffered post-`prepareRecord` record; without that, the dynamic cap is computed against an under-counted estimate and the gate still misses. Please merge #18843 first.

### New config

- `hoodie.memory.logfile.append.fraction` (default `0.6`, advanced) — fraction of per-task user memory available to the append-handle buffer. Default matches `hoodie.memory.merge.fraction` and `hoodie.memory.compaction.fraction`. Users who never set it get sensible behavior.

### Implementation

- **`HoodieMemoryConfig`**: new `MAX_MEMORY_FRACTION_FOR_LOG_APPEND` ConfigProperty + `MIN_MEMORY_FOR_LOG_APPEND_BUFFER_IN_BYTES` constant (16 MB).
- **`IOUtils`**: new `getMaxMemoryAllowedForLogAppend(supplier, fraction, minFloor): Option<Long>`. Distinct from the existing `getMaxMemoryAllowedForMerge` in two ways: returns `Option` (lets callers fall back to a static cap rather than the spillable-map 1GB default when engine properties are absent), and accepts the floor as a parameter (so the 100 MB spillable-map floor and the smaller 16 MB log-append floor cannot collide on a shared constant). Honors `EngineProperty.SINGLE_TASK_CORES` like the existing helper. Existing merge/compaction callers untouched.
- **`HoodieAppendHandle`**: `maxBlockSize` moves to constructor init alongside a new `effectiveBlockSize` field; both `maxBlockSize` references in `flushToDiskIfRequired` swap to `effectiveBlockSize`. INFO log line when the dynamic cap is below the configured ceiling. `@VisibleForTesting` getters for `effectiveBlockSize` and `maxBlockSize`.

### Behavior

- **Avro engine writes**: unaffected — the heap pressure addressed here is most acute on Spark engines where `prepareRecord` materializes the Avro graph.
- **Spark engine writes**: gate trips earlier on tight executors, buffer stays bounded by per-task heap, downstream serialization OOMs prevented.
- **Flink**: unchanged.
- `canWrite` / `estimatedNumberOfBytesWritten` still use `maxBlockSize` indirectly to roll log-file groups; this change is intentionally scoped to the flush gate only. Lowering log-file-group rolling thresholds is a follow-up if warranted.
- Small Spark executors will see smaller, more numerous log blocks — intentional tradeoff vs. OOM. Read-path compaction merges blocks, so on-disk file count is unaffected.

### Impact

**On Spark**: a job running with `hoodie.logfile.data.block.max.size=256m` (default) on a 2 GB / 4 core executor with `spark.memory.fraction=0.6` and the default `hoodie.memory.logfile.append.fraction=0.6` will now cap the buffer at `2GB * 0.4 / 4 * 0.6 = 120 MB` instead of 256 MB. On a generous 16 GB / 4 core executor, the dynamic ceiling (~960 MB) exceeds the 256 MB configured ceiling, so the configured value wins. **No regression on appropriately-sized executors.**

**On Flink**: zero behavior change. The cap depends on engine-property exposure that Flink does not provide.

### Risk level (write none, low medium or high below)

low

### Documentation Update

- New advanced config `hoodie.memory.logfile.append.fraction` will appear in the auto-generated config docs (via `markAdvanced()` + `withDocumentation(...)`).
- No migration steps required. Existing deployments get the new behavior automatically on Spark and continue to behave identically on Flink.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly consistent with the [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute).
- [x] Adequate tests were added if applicable. See `TestHoodieAppendHandle` (5 new tests covering fallback, cap, floor, ceiling-wins, gate-fires-early) and new `TestIOUtils` (5 tests covering empty-when-any-prop-missing, formula, parameterized floor, `SINGLE_TASK_CORES` accounting).
- [x] CI passed