### PR TITLE
fix(cli): Fix the typo in show-inflight CLI command

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -363,7 +363,7 @@ public class CommitsCommand {
         limit, headerOnly, rows, exportTableName);
   }
 
-  @ShellMethod(key = "commits show_infights", value = "Show inflight instants that are left longer than a certain duration")
+  @ShellMethod(key = "commits show_inflights", value = "Show inflight instants that are left longer than a certain duration")
   public String showInflightCommits(
       @ShellOption(value = {"--lookbackInMins"}, help = "Only show inflight commits that started before the specified lookback duration (in minutes).", defaultValue = "0") final Long durationInMins) {
     HoodieTableMetaClient metaClient = HoodieCLI.getTableMetaClient();

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestCommitsCommand.java
@@ -609,7 +609,7 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     // Reload meta client to pick up new instants
     metaClient = HoodieTableMetaClient.reload(HoodieCLI.getTableMetaClient());
 
-    Object lookupBackInZeroMinsResult = shell.evaluate(() -> "commits show_infights --lookbackInMins 0");
+    Object lookupBackInZeroMinsResult = shell.evaluate(() -> "commits show_inflights --lookbackInMins 0");
     assertTrue(ShellEvaluationResultUtil.isSuccess(lookupBackInZeroMinsResult));
 
     // All three instants should be shown when duration is 0
@@ -619,21 +619,21 @@ public class TestCommitsCommand extends CLIFunctionalTestHarness {
     assertTrue(output.contains(oldInstantTime3));
 
     // Only one instants should be shown when duration is 15 since 2nd commit is a completed commit.
-    Object lookupBackIn15MinsResult = shell.evaluate(() -> "commits show_infights --lookbackInMins 15");
+    Object lookupBackIn15MinsResult = shell.evaluate(() -> "commits show_inflights --lookbackInMins 15");
     assertTrue(ShellEvaluationResultUtil.isSuccess(lookupBackIn15MinsResult));
     output = lookupBackIn15MinsResult.toString();
     assertTrue(output.contains(oldInstantTime1));
     assertFalse(output.contains(oldInstantTime2));
 
     // Only one instant should be shown when duration is 50
-    Object lookupBackIn50MinsResult = shell.evaluate(() -> "commits show_infights --lookbackInMins 50");
+    Object lookupBackIn50MinsResult = shell.evaluate(() -> "commits show_inflights --lookbackInMins 50");
     assertTrue(ShellEvaluationResultUtil.isSuccess(lookupBackIn50MinsResult));
     output = lookupBackIn50MinsResult.toString();
     assertTrue(output.contains(oldInstantTime1));
     assertFalse(output.contains(oldInstantTime2));
 
     // No instants should be shown when duration is > 60
-    Object lookupBackIn70MinsResult = shell.evaluate(() -> "commits show_infights --lookbackInMins 70");
+    Object lookupBackIn70MinsResult = shell.evaluate(() -> "commits show_inflights --lookbackInMins 70");
     assertTrue(ShellEvaluationResultUtil.isSuccess(lookupBackIn70MinsResult));
     output = lookupBackIn70MinsResult.toString();
     assertTrue(output.contains(oldInstantTime1));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR fixes the typo in show-inflight CLI command.

### Summary and Changelog

As above.

### Impact

Fixes typo.

### Risk Level

none

### Documentation Update

Docs uses the right CLI naming.  A new minor release will use the right naming.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
