### PR TITLE
chore: Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -141,7 +141,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -199,7 +199,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -298,7 +298,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -351,7 +351,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -419,7 +419,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -480,7 +480,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -541,7 +541,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -602,7 +602,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -652,7 +652,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -707,7 +707,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -777,7 +777,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -840,7 +840,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -903,7 +903,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true
@@ -966,7 +966,7 @@ jobs:
         run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
       - name: Upload coverage to Codecov
         if: always() && needs.changes.outputs.relevant == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./jacoco-report.xml
           disable_search: true

--- a/.github/workflows/pr_title_validation.yml
+++ b/.github/workflows/pr_title_validation.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Validate PR title with Conventional Commits spec
         if: steps.check-legacy-format.outputs.skip_conventional == 'false'
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Pins third-party GitHub Actions that were referenced by mutable tags to full commit SHAs in the affected workflow(s).

### Summary and Changelog

A mutable tag can be repointed by the upstream owner, or by an attacker who compromises the action's repository, to arbitrary code that then runs in CI with the workflow's token and secrets. That is the failure mode behind CVE-2025-30066 (the tj-actions/changed-files compromise). Pinning to an immutable commit SHA makes the referenced code deterministic. GitHub-maintained `actions/*` were left on their existing refs.

### Impact

CI/build hardening only. No public API, runtime behavior, or user-facing change. Each pinned SHA corresponds to the same release the tag pointed to, so workflow behavior is unchanged.

### Risk Level

none

### Documentation Update

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable