### PR TITLE
fix(flink): remove pre-seed in metrics in GlobalRecordLevelIndexBackend and RecordLevelIndexBackend

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/GlobalRecordLevelIndexBackend.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.sink.partitioner.index;
 
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.data.HoodiePairData;
@@ -71,7 +70,6 @@ public class GlobalRecordLevelIndexBackend implements MinibatchIndexBackend {
     this.metaClient = StreamerUtil.createMetaClient(conf);
     this.conf = conf;
     this.recordIndexCache = new RecordIndexCache(conf, initCheckpointId);
-    registerMetrics(new UnregisteredMetricsGroup());
     reloadMetadataTable();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RecordLevelIndexBackend.java
@@ -41,12 +41,10 @@ import org.apache.hudi.sink.utils.SamplingActionExecutor;
 import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.StreamerUtil;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -78,7 +76,6 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
   private final long maxCacheSizeInBytes;
   private final BootstrapFilter bootstrapFilter;
   private HoodieTableMetadata metadataTable;
-  @Getter(AccessLevel.PACKAGE)
   private FlinkPartitionedIndexBackendMetrics metrics;
 
   @Getter
@@ -102,9 +99,6 @@ public class RecordLevelIndexBackend implements PartitionedIndexBackend {
     this.metaClient = StreamerUtil.createMetaClient(conf);
     this.maxCacheSizeInBytes = conf.get(FlinkOptions.INDEX_RLI_CACHE_SIZE) * 1024 * 1024;
     this.bootstrapFilter = bootstrapFilter;
-    // Pre-seed metrics with an unregistered group so the backend is safe to use before the
-    // bucket assign operator wires the real metric group via registerMetrics(MetricGroup).
-    registerMetrics(new UnregisteredMetricsGroup());
     reloadMetadataTable();
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestGlobalRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestGlobalRecordLevelIndexBackend.java
@@ -138,6 +138,7 @@ public class TestGlobalRecordLevelIndexBackend {
     conf.set(FlinkOptions.INDEX_RLI_CACHE_SIZE, 1L);
 
     try (GlobalRecordLevelIndexBackend globalRecordLevelIndexBackend = new GlobalRecordLevelIndexBackend(conf, -1)) {
+      globalRecordLevelIndexBackend.registerMetrics(TaskManagerMetricGroup.createTaskManagerMetricGroup(registry, "localhost", ResourceID.generate()));
 
       for (int i = 0; i < 1500; i++) {
         globalRecordLevelIndexBackend.update("id1_" + i,
@@ -200,18 +201,6 @@ public class TestGlobalRecordLevelIndexBackend {
       assertEquals("par1", globalRecordLevelIndexBackend.get(Collections.singletonList("id2_0")).get("id2_0").getPartitionPath());
       assertEquals("par1", globalRecordLevelIndexBackend.get(Collections.singletonList("id3_0")).get("id3_0").getPartitionPath());
       assertEquals("par1", globalRecordLevelIndexBackend.get(Collections.singletonList("id4_0")).get("id4_0").getPartitionPath());
-    }
-  }
-
-  @Test
-  void testLookupWithoutMetricsRegistrationIsNullSafe() throws Exception {
-    // Verifies that the if (metrics != null) guards in get(List) don't throw even when
-    // registerMetrics was never called.
-    try (GlobalRecordLevelIndexBackend backend = new GlobalRecordLevelIndexBackend(conf, -1)) {
-      HoodieRecordGlobalLocation location = new HoodieRecordGlobalLocation("par1", "000000001", "file-id-1");
-      backend.update("null_metrics_key", location);
-      Map<String, HoodieRecordGlobalLocation> result = backend.get(Collections.singletonList("null_metrics_key"));
-      assertEquals(location, result.get("null_metrics_key"));
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRecordLevelIndexBackend.java
@@ -20,7 +20,6 @@ package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.configuration.FlinkOptions;
-import org.apache.hudi.metrics.FlinkPartitionedIndexBackendMetrics;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.util.StreamerUtil;
 import org.apache.hudi.utils.TestConfigurations;
@@ -41,7 +40,6 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -158,15 +156,6 @@ public class TestRecordLevelIndexBackend {
   }
 
   @Test
-  public void testConstructorPreSeedsMetricsForNullSafety() throws Exception {
-    // Without pre-seeding, bootstrapPartition would NPE before the bucket assign operator
-    // wires the real MetricGroup via registerMetrics(MetricGroup).
-    try (RecordLevelIndexBackend backend = createBackend()) {
-      assertNotNull(backend.getMetrics());
-    }
-  }
-
-  @Test
   public void testRegisterMetricsRegistersPartitionBootstrapHistograms() throws Exception {
     CapturingMetricGroup metricGroup = new CapturingMetricGroup();
     try (RecordLevelIndexBackend backend = createBackend()) {
@@ -174,18 +163,6 @@ public class TestRecordLevelIndexBackend {
 
       assertNotNull(metricGroup.getHistogram("partition_bootstrap_latency_millis"));
       assertNotNull(metricGroup.getHistogram("partition_bootstrap_keys_loaded"));
-    }
-  }
-
-  @Test
-  public void testRegisterMetricsReplacesPreSeededMetrics() throws Exception {
-    try (RecordLevelIndexBackend backend = createBackend()) {
-      FlinkPartitionedIndexBackendMetrics preSeeded = backend.getMetrics();
-      backend.registerMetrics(new CapturingMetricGroup());
-
-      assertNotNull(backend.getMetrics());
-      // The second call must rewire the field so the active metrics publish to the real metric group.
-      assertNotSame(preSeeded, backend.getMetrics());
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The pre-seed logic in metrics in GlobalRecordLevelIndexBackend and RecordLevelIndexBackend are not needed by production code and they only existed for test purpose. This PR removes this unnecessary step and fix all test cases.

Fixes #18734

### Summary and Changelog

Remove pre-seed in metrics in GlobalRecordLevelIndexBackend and RecordLevelIndexBackend and fix test cases

### Impact

None

### Risk Level

None. Production code doesn't need pre-seed.

### Documentation Update

N/A

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
