### PR TITLE
feat(spark): add input records & bytes metrics

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieMergeOnReadRDDV2.scala
@@ -42,7 +42,7 @@ import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration
 import org.apache.avro.generic.IndexedRecord
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapred.JobConf
-import org.apache.spark.{Partition, SerializableWritable, SparkContext, TaskContext}
+import org.apache.spark.{HoodieSparkInputMetricsUtils, Partition, SerializableWritable, SparkContext, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -146,6 +146,7 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
 
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
     val partition = split.asInstanceOf[HoodieMergeOnReadPartition]
+    val bytesReadCallback = HoodieSparkInputMetricsUtils.getFSBytesReadOnThreadCallback()
 
     val iter: Iterator[InternalRow] = partition.split match {
       case dataFileOnlySplit if dataFileOnlySplit.logFiles.isEmpty =>
@@ -203,15 +204,9 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
         }
     }
 
-    if (iter.isInstanceOf[Closeable]) {
-      // register a callback to close logScanner which will be executed on task completion.
-      // when tasks finished, this method will be called, and release resources.
-      Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => iter.asInstanceOf[Closeable].close()))
-    }
-
     val commitTimeMetadataFieldIdx = requiredSchema.structTypeSchema.fieldNames.indexOf(HoodieRecord.COMMIT_TIME_METADATA_FIELD)
     val needsFiltering = commitTimeMetadataFieldIdx >= 0 && includedInstantTimeSet.isDefined
-    if (needsFiltering) {
+    val resultIter = if (needsFiltering) {
       val filterT: Predicate[InternalRow] = new Predicate[InternalRow] {
         override def test(row: InternalRow): Boolean = {
           val commitTime = row.getString(commitTimeMetadataFieldIdx)
@@ -219,10 +214,11 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
         }
       }
       iter.filter(filterT.test)
-    }
-    else {
+    } else {
       iter
     }
+
+    withInputMetrics(resultIter, iter, context, bytesReadCallback)
   }
 
   override protected def getPartitions: Array[Partition] =
@@ -259,6 +255,34 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
     }
   }
 
+  private def withInputMetrics(iter: Iterator[InternalRow],
+                               closeableIter: Iterator[InternalRow],
+                               context: TaskContext,
+                               bytesReadCallback: () => Long): Iterator[InternalRow] = {
+    val metricIter = new Iterator[InternalRow] with Closeable {
+      override def hasNext: Boolean = iter.hasNext
+
+      override def next(): InternalRow = {
+        val row = iter.next()
+        HoodieSparkInputMetricsUtils.incRecordsRead(context, 1)
+        row
+      }
+
+      override def close(): Unit = {
+        closeableIter match {
+          case closeable: Closeable => closeable.close()
+          case _ =>
+        }
+      }
+    }
+
+    context.addTaskCompletionListener[Unit] { _ =>
+      HoodieSparkInputMetricsUtils.incBytesRead(context, bytesReadCallback())
+      metricIter.close()
+    }
+    metricIter
+  }
+
   private def getPartitionPath(split: HoodieMergeOnReadFileSplit): StoragePath = {
     // Determine partition path as an immediate parent folder of either
     //    - The base file
@@ -273,4 +297,3 @@ class HoodieMergeOnReadRDDV2(@transient sc: SparkContext,
 object HoodieMergeOnReadRDDV2 {
   val CONFIG_INSTANTIATION_LOCK = new Object()
 }
-

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/HoodieSparkInputMetricsUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/HoodieSparkInputMetricsUtils.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.deploy.SparkHadoopUtil
+
+object HoodieSparkInputMetricsUtils {
+
+  def getFSBytesReadOnThreadCallback(): () => Long = {
+    SparkHadoopUtil.get.getFSBytesReadOnThreadCallback()
+  }
+
+  def incRecordsRead(taskContext: TaskContext, count: Long): Unit = {
+    if (taskContext != null) {
+      taskContext.taskMetrics().inputMetrics.incRecordsRead(count)
+    }
+  }
+
+  def incBytesRead(taskContext: TaskContext, bytes: Long): Unit = {
+    if (taskContext != null) {
+      taskContext.taskMetrics().inputMetrics.incBytesRead(bytes)
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Spark UI does not report input records or input bytes for Hudi Merge-On-Read reads that are executed through Hudi's custom `HoodieMergeOnReadRDDV2` path. The data is read correctly, but Spark task input metrics remain incomplete because this custom RDD path bypasses Spark's standard file scan metric accounting.

This makes it harder to inspect Hudi MOR read jobs from Spark UI and event logs, especially for metadata-table reads and other paths that still use `HoodieMergeOnReadRDDV2` directly.

No GitHub issue is filed for this change.

### Summary and Changelog

Add Spark input metric reporting for `HoodieMergeOnReadRDDV2` so Spark UI can show input records and input bytes for Hudi's custom MOR RDD read path.

Changes:

- Add `HoodieSparkInputMetricsUtils` under the `org.apache.spark` package to access Spark's input metrics and filesystem bytes-read callback.
- Wrap the final `HoodieMergeOnReadRDDV2.compute()` result iterator so each successfully returned row increments `taskMetrics.inputMetrics.recordsRead`.
- Capture Spark's `getFSBytesReadOnThreadCallback()` at task start and increment `taskMetrics.inputMetrics.bytesRead` when the task completes.
- Preserve the existing close lifecycle by closing the original underlying iterator on task completion, including when the returned iterator is a filtered wrapper.
- Keep the change scoped to the custom RDD path. The `HoodieFileGroupReaderBasedFileFormat` path is not changed, since Spark's standard file scan execution owns metric accounting there.

### Impact

User-facing behavior:

- Spark UI and Spark event logs can report input records and input bytes for Hudi MOR reads that run through `HoodieMergeOnReadRDDV2`.
- No query result semantics change.
- No new configuration, public API, storage format, or table metadata change.

Performance:

- Low overhead: one metric increment per returned row and one bytes-read metric update on task completion.

### Risk Level

low

The implementation is limited to Spark's custom `HoodieMergeOnReadRDDV2` read path. It does not add manual metrics to Spark `FileFormat` scan paths, avoiding double-counting where Spark already owns input metric updates.

Verification performed:

```bash
mvn -pl hudi-spark-datasource/hudi-spark-common -am \
  -DskipTests -DskipITs -Drat.skip=true -Dcheckstyle.skip=true test-compile
```

The build completed successfully, including Scala compilation and scalastyle for `hudi-spark-common_2.12`.

### Documentation Update

none

No new user-facing option is introduced and no documented configuration behavior changes. This only fills Spark task input metrics for an existing read path.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
