### PR TITLE
fix(hudi-sync): Fix Hive test temp directory cleanup with JUnit TempDir

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -75,7 +76,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -181,6 +181,8 @@ public class TestHiveSyncTool {
 
   private HiveSyncTool hiveSyncTool;
   private HoodieHiveSyncClient hiveClient;
+  @TempDir
+  java.nio.file.Path tempDir;
 
   @AfterAll
   public static void cleanUpClass() throws IOException {
@@ -213,7 +215,7 @@ public class TestHiveSyncTool {
 
   @BeforeEach
   public void setUp() throws Exception {
-    HiveTestUtil.setUp(Option.empty(), true);
+    HiveTestUtil.setUp(Option.empty(), true, tempDir);
   }
 
   @AfterEach
@@ -243,7 +245,7 @@ public class TestHiveSyncTool {
     HiveTestUtil.fileSystem.delete(new Path(basePath), true);
 
     // create a new cow table and reSync
-    basePath = Files.createTempDirectory("hivesynctest" + Instant.now().toEpochMilli()).toUri().toString();
+    basePath = createTempBasePath("hivesynctest");
     hiveSyncProps.setProperty(META_SYNC_BASE_PATH.key(), basePath);
     HiveTestUtil.createCOWTable(instantTime, 1, useSchemaFromCommitMetadata);
     reInitHiveSyncClient();
@@ -864,7 +866,7 @@ public class TestHiveSyncTool {
 
     String commitTime2 = "105";
     // let's update the basepath
-    basePath = Files.createTempDirectory("hivesynctest_new" + Instant.now().toEpochMilli()).toUri().toString();
+    basePath = createTempBasePath("hivesynctest-new");
     hiveSyncProps.setProperty(META_SYNC_BASE_PATH.key(), basePath);
 
     // let's create new table in new basepath
@@ -1116,7 +1118,7 @@ public class TestHiveSyncTool {
     reSyncHiveTable();
 
     // change the hoodie base path
-    basePath = Files.createTempDirectory("hivesynctest_new" + Instant.now().toEpochMilli()).toUri().toString();
+    basePath = createTempBasePath("hivesynctest-new");
     hiveSyncProps.setProperty(META_SYNC_BASE_PATH.key(), basePath);
 
     String instantTime2 = "102";
@@ -2266,6 +2268,10 @@ public class TestHiveSyncTool {
   private void reInitHiveSyncClient() {
     hiveSyncTool = new HiveSyncTool(hiveSyncProps, HiveTestUtil.getHiveConf());
     hiveClient = (HoodieHiveSyncClient) hiveSyncTool.syncClient;
+  }
+
+  private String createTempBasePath(String prefix) throws IOException {
+    return Files.createTempDirectory(tempDir, prefix).toUri().toString();
   }
 
   private int getPartitionFieldSize() {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -85,7 +85,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -140,6 +139,11 @@ public class HiveTestUtil {
   private static Set<String> createdTablesSet = new HashSet<>();
 
   public static void setUp(Option<TypedProperties> hiveSyncProperties, boolean shouldClearBasePathAndTables) throws Exception {
+    setUp(hiveSyncProperties, shouldClearBasePathAndTables, null);
+  }
+
+  public static void setUp(Option<TypedProperties> hiveSyncProperties, boolean shouldClearBasePathAndTables,
+                           java.nio.file.Path tempDir) throws Exception {
     configuration = new Configuration();
     if (zkServer == null) {
       zkService = new ZookeeperTestService(configuration);
@@ -155,7 +159,10 @@ public class HiveTestUtil {
       hiveSyncProps.setProperty(HIVE_URL.key(), hiveTestService.getJdbcHive2Url());
       basePath = hiveSyncProps.getProperty(META_SYNC_BASE_PATH.key());
     } else {
-      basePath = Files.createTempDirectory("hivesynctest" + Instant.now().toEpochMilli()).toUri().toString();
+      java.nio.file.Path baseDir = tempDir == null
+          ? Files.createTempDirectory("hivesynctest")
+          : Files.createTempDirectory(Files.createDirectories(tempDir), "hivesynctest");
+      basePath = baseDir.toUri().toString();
 
       hiveSyncProps = new TypedProperties();
       hiveSyncProps.setProperty(HIVE_URL.key(), hiveTestService.getJdbcHive2Url());
@@ -183,15 +190,17 @@ public class HiveTestUtil {
     if (shouldClearBasePathAndTables) {
       clear();
     }
+    if (!hiveSyncProperties.isPresent()) {
+      HoodieTableMetaClient.newTableBuilder()
+          .setTableType(HoodieTableType.COPY_ON_WRITE)
+          .setTableName(TABLE_NAME)
+          .setPayloadClass(HoodieAvroPayload.class)
+          .initTable(HadoopFSUtils.getStorageConfWithCopy(configuration), basePath);
+    }
   }
 
   public static void clear() throws IOException, HiveException, MetaException {
     fileSystem.delete(new Path(basePath), true);
-    HoodieTableMetaClient.newTableBuilder()
-        .setTableType(HoodieTableType.COPY_ON_WRITE)
-        .setTableName(TABLE_NAME)
-        .setPayloadClass(HoodieAvroPayload.class)
-        .initTable(HadoopFSUtils.getStorageConfWithCopy(configuration), basePath);
 
     if (ddlExecutor != null) {
       for (String tableName : createdTablesSet) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
@@ -67,7 +67,7 @@ public class TestHiveIncrementalPuller {
 
   @BeforeEach
   public void setUp() throws Exception {
-    HiveTestUtil.setUp(Option.empty(), true);
+    HiveTestUtil.setUp(Option.empty(), true, tempDir);
   }
 
   @AfterEach

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHudiHiveSyncJob.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHudiHiveSyncJob.java
@@ -67,7 +67,7 @@ public class TestHudiHiveSyncJob {
 
   @BeforeEach
   void setUp() throws Exception {
-    HiveTestUtil.setUp(Option.empty(), true);
+    HiveTestUtil.setUp(Option.empty(), true, tempDir);
   }
 
   @AfterEach


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  `HiveTestUtil.clear()` deletes the test base path and then immediately reinitializes a Hudi table under the same path. This recreates the temporary `hivesynctest*`
  directory during cleanup, leaving test-generated directories behind after Hive sync tests finish.

  This PR refactors Hive test temporary directory handling so tests can use JUnit-managed `@TempDir` paths, while keeping cleanup free of table reinitialization side
  effects.

### Summary and Changelog

  Fix Hive sync test temporary directory cleanup by separating test setup from cleanup.

  Changes:

  - Add a `HiveTestUtil.setUp(..., Path tempDir)` overload so JUnit tests can pass an `@TempDir` root.
  - Create default Hive test base paths under the provided JUnit temp directory when available.
  - Move empty Hudi table initialization into `setUp()` after cleanup, preserving existing test setup behavior.
  - Remove `HoodieTableMetaClient.newTableBuilder().initTable()` from `clear()` so cleanup does not recreate deleted directories.
  - Update `TestHiveSyncTool`, `TestHiveIncrementalPuller`, and `TestHudiHiveSyncJob` to pass their JUnit `@TempDir` into `HiveTestUtil`.
  - Update base-path-change cases in `TestHiveSyncTool` to create replacement base paths under the same JUnit temp directory.

  No code was copied.

### Impact

  No public API, storage format, table metadata, or user-facing behavior change.

  This change only affects test utilities and tests. Hive sync tests should leave fewer residual temporary directories on local disks and CI workers.

### Risk Level

  low

  The change is scoped to test code. The main behavioral risk is altering the lifecycle of `HiveTestUtil` setup and cleanup. To reduce that risk, empty table
  initialization is still performed during `setUp()` for existing default test setup paths, but no longer during `clear()`.

  Verification performed:

  ```bash
  git diff --check

  Maven test compilation was not run locally because mvn is not available in the current environment.

### Documentation Update

  none

  No user-facing feature, configuration, or documented behavior changes.

### Contributor's checklist

  - [x] Read through contributor's guide (https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable