### PR TITLE
fix(flink): set canonical base path in Hive sync config

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/HiveSyncContext.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 
 import java.util.Properties;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.BASE_PATH;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_AUTO_CREATE_DATABASE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_IGNORE_EXCEPTIONS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_PASS;
@@ -101,6 +102,7 @@ public class HiveSyncContext {
   @VisibleForTesting
   public static Properties buildSyncConfig(Configuration conf) {
     TypedProperties props = StreamerUtil.flinkConf2TypedProperties(conf);
+    props.setPropertyIfNonNull(BASE_PATH.key(), conf.get(FlinkOptions.PATH));
     props.setPropertyIfNonNull(META_SYNC_BASE_PATH.key(), conf.get(FlinkOptions.PATH));
     props.setPropertyIfNonNull(META_SYNC_BASE_FILE_FORMAT.key(), conf.get(FlinkOptions.HIVE_SYNC_FILE_FORMAT));
     props.setPropertyIfNonNull(META_SYNC_DATABASE_NAME.key(), conf.get(FlinkOptions.HIVE_SYNC_DB));

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestHiveSyncContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/TestHiveSyncContext.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
+import static org.apache.hudi.common.config.HoodieCommonConfig.BASE_PATH;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,6 +58,21 @@ public class TestHiveSyncContext {
 
     assertEquals(hiveSyncPartitionField, props1.getProperty(META_SYNC_PARTITION_FIELDS.key()));
     assertEquals(partitionPathField, props2.getProperty(META_SYNC_PARTITION_FIELDS.key()));
+  }
+
+  /**
+   * Test table path syncs to both canonical and meta sync base path configs.
+   */
+  @Test
+  void testSyncedBasePath() {
+    Configuration configuration = new Configuration();
+    String basePath = "/tmp/hudi_table";
+    configuration.set(FlinkOptions.PATH, basePath);
+
+    Properties props = HiveSyncContext.buildSyncConfig(configuration);
+
+    assertEquals(basePath, props.getProperty(BASE_PATH.key()));
+    assertEquals(basePath, props.getProperty(META_SYNC_BASE_PATH.key()));
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink Hive Sync currently only sets `hoodie.datasource.meta.sync.base.path` when building the sync configuration from Flink options. However, shared sync components read the canonical base path through `HoodieSyncConfig#getBasePath()`, which resolves `HoodieCommonConfig.BASE_PATH` (`hoodie.base.path`).

As a result, Flink Hive Sync can build a configuration where `hoodie.datasource.meta.sync.base.path` is present but `hoodie.base.path` is missing. Components that still rely on the canonical base path, such as Hive Sync metrics setup, can then fail with a null base path.

No GitHub issue is filed for this change.

### Summary and Changelog

Set the Flink table path on both the canonical base path config and the meta sync base path config when building Hive Sync properties.

Changes:

- Add `hoodie.base.path` to the properties built by `HiveSyncContext.buildSyncConfig`.
- Keep the existing `hoodie.datasource.meta.sync.base.path` assignment unchanged.
- Add a unit test to verify that Flink `path` is propagated to both base path config keys.

No code was copied from external sources.

### Impact

User-facing behavior:

- Flink Hive Sync now provides a consistent base path configuration to shared sync components.
- Hive Sync components that read the canonical `hoodie.base.path` can resolve the table base path correctly.
- This prevents null base path failures in paths such as Hive Sync metrics initialization.

Compatibility:

- No new public API is introduced.
- No storage format, table metadata, or persisted data layout changes.
- No new configuration is added; this only populates an existing canonical config key from the existing Flink table path.

Performance:

- No performance impact.

### Risk Level

low

The change is limited to Flink Hive Sync configuration construction. It mirrors the same Flink table path into the existing canonical base path key while preserving the existing meta sync base path behavior.

Verification performed:

```bash
mvn -pl hudi-flink-datasource/hudi-flink -am -Dtest=TestHiveSyncContext -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -Dcheckstyle.skip=true -DfailIfNoTests=false test
```

Result:

- `TestHiveSyncContext`: 4 tests run, 0 failures, 0 errors, 0 skipped.
- Maven build completed successfully.

### Documentation Update

none

No new user-facing option is introduced and no documented config default is changed. This only ensures the existing Flink table path is also available through the existing canonical `hoodie.base.path` key during Hive Sync.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable