### PR TITLE
fix: strip Hudi meta fields from write schema

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
@@ -272,6 +272,9 @@ public abstract class BaseCommitActionExecutor<T, I, K, O, R>
 
   /**
    * By default, return the writer schema in Write Config for storing in commit.
+   * The returned schema is sanitized of Hudi meta fields by
+   * {@link CommitUtils#sanitizeSchemaForCommitMetadata(String)} when the commit
+   * metadata is built, so callers do not need to strip meta fields here.
    */
   protected String getSchemaToStoreInCommit() {
     return config.getSchema();

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CommitUtils.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -94,10 +95,30 @@ public class CommitUtils {
     if (extraMetadata.isPresent()) {
       extraMetadata.get().forEach(commitMetadata::addMetadata);
     }
-    commitMetadata.addMetadata(HoodieCommitMetadata.SCHEMA_KEY, (schemaToStoreInCommit == null || schemaToStoreInCommit.equals(NULL_SCHEMA_STR))
-        ? "" : schemaToStoreInCommit);
+    commitMetadata.addMetadata(HoodieCommitMetadata.SCHEMA_KEY,
+        sanitizeSchemaForCommitMetadata(schemaToStoreInCommit));
     commitMetadata.setOperationType(operationType);
     return commitMetadata;
+  }
+
+  /**
+   * Returns the value to persist under {@link HoodieCommitMetadata#SCHEMA_KEY}.
+   * The schema stored in commit extraMetadata must be the user/write schema and
+   * must NOT contain Hudi meta fields ({@code _hoodie_commit_time}, etc.). If
+   * the caller-provided schema has meta fields (e.g. because some upstream code
+   * mutated the in-memory write config schema with reader-schema-with-meta-fields,
+   * or because a previously-polluted SCHEMA_KEY was read back into the config),
+   * this strips them so the persisted schema is always clean.
+   */
+  public static String sanitizeSchemaForCommitMetadata(String schemaToStoreInCommit) {
+    if (schemaToStoreInCommit == null || schemaToStoreInCommit.equals(NULL_SCHEMA_STR)) {
+      return "";
+    }
+    HoodieSchema schema = HoodieSchema.parse(schemaToStoreInCommit);
+    if (schema.isSchemaNull()) {
+      return "";
+    }
+    return HoodieSchemaUtils.removeMetadataFields(schema).toString();
   }
 
   private static HoodieCommitMetadata buildMetadataFromStats(List<HoodieWriteStat> writeStats,

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
@@ -24,13 +24,16 @@ import org.apache.hudi.avro.model.HoodieClusteringPlan;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.ClusteringUtils;
@@ -83,6 +86,8 @@ import java.util.stream.IntStream;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.parquet.avro.AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSparkSortAndSizeClustering extends HoodieSparkClientTestHarness {
@@ -127,6 +132,99 @@ public class TestSparkSortAndSizeClustering extends HoodieSparkClientTestHarness
   @Test
   public void testClusteringWithRow() throws IOException {
     writeAndClustering(true);
+  }
+
+  /**
+   * Asserts that the schema persisted under HoodieCommitMetadata.SCHEMA_KEY in a completed
+   * replace (clustering) commit does NOT contain Hudi meta fields like _hoodie_commit_time.
+   * The schema stored in commit metadata is meant to be the user/write schema.
+   */
+  @Test
+  public void testReplaceCommitSchemaHasNoMetaFields() throws Exception {
+    setup(102400);
+    config.setValue("hoodie.datasource.write.row.writer.enable", "false");
+    config.setValue("hoodie.metadata.enable", "false");
+    config.setValue("hoodie.clustering.plan.strategy.daybased.lookback.partitions", "1");
+    config.setValue("hoodie.clustering.plan.strategy.target.file.max.bytes", String.valueOf(1024 * 1024));
+    config.setValue("hoodie.clustering.plan.strategy.max.bytes.per.group", String.valueOf(2 * 1024 * 1024));
+
+    writeData(1000, true, System.currentTimeMillis());
+
+    String clusteringTime = (String) writeClient.scheduleClustering(Option.empty()).get();
+    writeClient.cluster(clusteringTime, true);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieInstant replaceInstant = metaClient.getActiveTimeline()
+        .getCompletedReplaceTimeline()
+        .filter(i -> i.requestedTime().equals(clusteringTime))
+        .firstInstant()
+        .orElseThrow(() -> new AssertionError("No completed replace commit found for " + clusteringTime));
+
+    HoodieReplaceCommitMetadata replaceCommitMetadata =
+        metaClient.getActiveTimeline().readReplaceCommitMetadata(replaceInstant);
+    assertSchemaHasNoMetaFields(replaceCommitMetadata, "replace (clustering) commit");
+  }
+
+  /**
+   * Even when {@code config.getSchema()} is pre-polluted with Hudi meta fields
+   * (simulating upstream paths like compaction reader-schema setup that may set
+   * a schema-with-meta-fields back onto the write config), both ingestion and
+   * clustering commits must persist a clean schema (without meta fields) under
+   * {@link HoodieCommitMetadata#SCHEMA_KEY}. This guards the sanitization in
+   * {@code CommitUtils#sanitizeSchemaForCommitMetadata(String)}.
+   */
+  @Test
+  public void testCommitSchemaCleanedEvenWhenConfigSchemaHasMetaFields() throws Exception {
+    setup(102400);
+    config.setValue("hoodie.datasource.write.row.writer.enable", "false");
+    config.setValue("hoodie.metadata.enable", "false");
+    config.setValue("hoodie.clustering.plan.strategy.daybased.lookback.partitions", "1");
+    config.setValue("hoodie.clustering.plan.strategy.target.file.max.bytes", String.valueOf(1024 * 1024));
+    config.setValue("hoodie.clustering.plan.strategy.max.bytes.per.group", String.valueOf(2 * 1024 * 1024));
+
+    // Pre-pollute the write config schema with Hudi meta fields.
+    HoodieSchema pollutedSchema = HoodieSchemaUtils.addMetadataFields(getSchema());
+    assertTrue(pollutedSchema.getField(HoodieRecord.COMMIT_TIME_METADATA_FIELD).isPresent(),
+        "Sanity check: polluted schema must contain meta fields");
+    config.setSchema(pollutedSchema.toString());
+
+    writeData(1000, true, System.currentTimeMillis());
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieInstant ingestionInstant = metaClient.getActiveTimeline()
+        .getCommitsTimeline()
+        .filterCompletedInstants()
+        .lastInstant()
+        .orElseThrow(() -> new AssertionError("No completed ingestion commit found"));
+    HoodieCommitMetadata ingestionMetadata =
+        metaClient.getActiveTimeline().readCommitMetadata(ingestionInstant);
+    assertSchemaHasNoMetaFields(ingestionMetadata, "ingestion commit");
+
+    String clusteringTime = (String) writeClient.scheduleClustering(Option.empty()).get();
+    writeClient.cluster(clusteringTime, true);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    HoodieInstant replaceInstant = metaClient.getActiveTimeline()
+        .getCompletedReplaceTimeline()
+        .filter(i -> i.requestedTime().equals(clusteringTime))
+        .firstInstant()
+        .orElseThrow(() -> new AssertionError("No completed replace commit found for " + clusteringTime));
+    HoodieReplaceCommitMetadata replaceMetadata =
+        metaClient.getActiveTimeline().readReplaceCommitMetadata(replaceInstant);
+    assertSchemaHasNoMetaFields(replaceMetadata, "replace (clustering) commit");
+  }
+
+  private static void assertSchemaHasNoMetaFields(HoodieCommitMetadata commitMetadata, String label) {
+    String schemaStr = commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY);
+    assertNotNull(schemaStr, label + " must persist a schema under SCHEMA_KEY");
+    assertFalse(schemaStr.isEmpty(), label + " schema must not be empty");
+    HoodieSchema storedSchema = HoodieSchema.parse(schemaStr);
+    List<String> metaFieldsPresent = HoodieRecord.HOODIE_META_COLUMNS.stream()
+        .filter(metaField -> storedSchema.getField(metaField).isPresent())
+        .collect(Collectors.toList());
+    assertTrue(metaFieldsPresent.isEmpty(),
+        label + " schema should not contain Hudi meta fields, but found: " + metaFieldsPresent
+            + ". Stored schema: " + schemaStr);
   }
 
   public void writeAndClustering(boolean isRow) throws IOException {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkSortAndSizeClustering.java
@@ -142,11 +142,7 @@ public class TestSparkSortAndSizeClustering extends HoodieSparkClientTestHarness
   @Test
   public void testReplaceCommitSchemaHasNoMetaFields() throws Exception {
     setup(102400);
-    config.setValue("hoodie.datasource.write.row.writer.enable", "false");
-    config.setValue("hoodie.metadata.enable", "false");
-    config.setValue("hoodie.clustering.plan.strategy.daybased.lookback.partitions", "1");
-    config.setValue("hoodie.clustering.plan.strategy.target.file.max.bytes", String.valueOf(1024 * 1024));
-    config.setValue("hoodie.clustering.plan.strategy.max.bytes.per.group", String.valueOf(2 * 1024 * 1024));
+    setupClusteringConfig();
 
     writeData(1000, true, System.currentTimeMillis());
 
@@ -176,11 +172,7 @@ public class TestSparkSortAndSizeClustering extends HoodieSparkClientTestHarness
   @Test
   public void testCommitSchemaCleanedEvenWhenConfigSchemaHasMetaFields() throws Exception {
     setup(102400);
-    config.setValue("hoodie.datasource.write.row.writer.enable", "false");
-    config.setValue("hoodie.metadata.enable", "false");
-    config.setValue("hoodie.clustering.plan.strategy.daybased.lookback.partitions", "1");
-    config.setValue("hoodie.clustering.plan.strategy.target.file.max.bytes", String.valueOf(1024 * 1024));
-    config.setValue("hoodie.clustering.plan.strategy.max.bytes.per.group", String.valueOf(2 * 1024 * 1024));
+    setupClusteringConfig();
 
     // Pre-pollute the write config schema with Hudi meta fields.
     HoodieSchema pollutedSchema = HoodieSchemaUtils.addMetadataFields(getSchema());
@@ -212,6 +204,14 @@ public class TestSparkSortAndSizeClustering extends HoodieSparkClientTestHarness
     HoodieReplaceCommitMetadata replaceMetadata =
         metaClient.getActiveTimeline().readReplaceCommitMetadata(replaceInstant);
     assertSchemaHasNoMetaFields(replaceMetadata, "replace (clustering) commit");
+  }
+
+  private void setupClusteringConfig() {
+    config.setValue("hoodie.datasource.write.row.writer.enable", "false");
+    config.setValue("hoodie.metadata.enable", "false");
+    config.setValue("hoodie.clustering.plan.strategy.daybased.lookback.partitions", "1");
+    config.setValue("hoodie.clustering.plan.strategy.target.file.max.bytes", String.valueOf(1024 * 1024));
+    config.setValue("hoodie.clustering.plan.strategy.max.bytes.per.group", String.valueOf(2 * 1024 * 1024));
   }
 
   private static void assertSchemaHasNoMetaFields(HoodieCommitMetadata commitMetadata, String label) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The schema persisted under `HoodieCommitMetadata.SCHEMA_KEY` is expected to be the user/write schema (without Hudi meta fields). The write path relied on `config.getSchema()` being clean by convention with no enforcement: any upstream mutation that sets a schema-with-meta-fields onto the write config (e.g. compaction reader-schema setup, conflict-resolution rewriting `SCHEMA_KEY`, or reading a previously-polluted `SCHEMA_KEY` back into the config) propagates polluted schemas into every subsequent commit's `extraMetadata` — affecting both ingestion and clustering replace commits.

### Summary and Changelog

- Centralize sanitization in `CommitUtils.sanitizeSchemaForCommitMetadata` and route the existing `buildMetadata` `SCHEMA_KEY` write through it, so all commit paths (`BaseHoodieWriteClient.commitStats` for ingestion, Spark / Java / Flink commit-action executors, the `executeClustering` fallback) are clean by construction.
- Added two functional tests in `TestSparkSortAndSizeClustering`:
  - `testReplaceCommitSchemaHasNoMetaFields` — asserts the schema in a clustering replace commit has no Hudi meta fields.
  - `testCommitSchemaCleanedEvenWhenConfigSchemaHasMetaFields` — pre-pollutes `config.getSchema()` with meta fields and asserts both the ingestion and the clustering replace commit persist a clean schema.

### Impact

No public API or user-facing config change. Behavior is restricted to what gets persisted under `SCHEMA_KEY` in commit metadata — it is now always sanitized of Hudi meta fields, as the documented contract already implied.

### Risk Level

low — the change only normalizes the value already being written under `SCHEMA_KEY`; readers of commit metadata that expected a clean schema continue to see one (and now reliably so).

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable