### PR TITLE
fix: do not fall back to timeline server markers on transient HDFS failures

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
@@ -74,13 +74,13 @@ public class MarkerBasedRollbackUtils {
         // Do NOT fall back to TIMELINE_SERVER_BASED on transient IO failures (e.g., HDFS throttling).
         // The timeline server looks in a different location and would return 0 markers, causing the
         // rollback to skip deleting data files and leaving orphan files on the table.
-        LOG.warn(String.format("%s not present and %s marker listing failed with IO error: %s. "
+        log.warn(String.format("%s not present and %s marker listing failed with IO error: %s. "
                 + "Propagating exception — rollback will retry rather than fall back to %s.",
             MARKER_TYPE_FILENAME, DIRECT, e.getMessage(), TIMELINE_SERVER_BASED));
         throw e;
       } catch (IllegalArgumentException e) {
         // IllegalArgumentException indicates a marker path format mismatch — fall back to timeline server.
-        LOG.warn(String.format("%s not present and %s marker failed with error: %s. So, falling back to %s marker",
+        log.warn(String.format("%s not present and %s marker failed with error: %s. So, falling back to %s marker",
             MARKER_TYPE_FILENAME, DIRECT, e.getMessage(), TIMELINE_SERVER_BASED));
         return getTimelineServerBasedMarkers(context, parallelism, markerDir, fileSystem);
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
@@ -70,10 +70,19 @@ public class MarkerBasedRollbackUtils {
       WriteMarkers writeMarkers = WriteMarkersFactory.get(DIRECT, table, instant);
       try {
         return new ArrayList<>(writeMarkers.allMarkerFilePaths());
-      } catch (IOException | IllegalArgumentException e) {
-        log.warn("{} not present and {} marker failed with error: {}. Falling back to {} marker",
-            MARKER_TYPE_FILENAME, DIRECT, e.getMessage(), TIMELINE_SERVER_BASED);
-        return getTimelineServerBasedMarkers(context, parallelism, markerDir, storage);
+      } catch (IOException e) {
+        // Do NOT fall back to TIMELINE_SERVER_BASED on transient IO failures (e.g., HDFS throttling).
+        // The timeline server looks in a different location and would return 0 markers, causing the
+        // rollback to skip deleting data files and leaving orphan files on the table.
+        LOG.warn(String.format("%s not present and %s marker listing failed with IO error: %s. "
+                + "Propagating exception — rollback will retry rather than fall back to %s.",
+            MARKER_TYPE_FILENAME, DIRECT, e.getMessage(), TIMELINE_SERVER_BASED));
+        throw e;
+      } catch (IllegalArgumentException e) {
+        // IllegalArgumentException indicates a marker path format mismatch — fall back to timeline server.
+        LOG.warn(String.format("%s not present and %s marker failed with error: %s. So, falling back to %s marker",
+            MARKER_TYPE_FILENAME, DIRECT, e.getMessage(), TIMELINE_SERVER_BASED));
+        return getTimelineServerBasedMarkers(context, parallelism, markerDir, fileSystem);
       }
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
@@ -75,11 +75,11 @@ public class MarkerBasedRollbackUtils {
         // The timeline server looks in a different location and would return 0 markers, causing the
         // rollback to skip deleting data files and leaving orphan files on the table.
         log.warn("{} not present and {} marker listing failed with IO error. "
-                + "Propagating exception — rollback will retry rather than fall back to {}.",
+                + "Propagating exception, rollback will retry rather than fall back to {}.",
             MARKER_TYPE_FILENAME, DIRECT, TIMELINE_SERVER_BASED, e);
         throw e;
       } catch (IllegalArgumentException e) {
-        // IllegalArgumentException indicates a marker path format mismatch — fall back to timeline server.
+        // IllegalArgumentException indicates a marker path format mismatch, fall back to timeline server.
         log.warn("{} not present and {} marker failed. Falling back to {} marker",
             MARKER_TYPE_FILENAME, DIRECT, TIMELINE_SERVER_BASED, e);
         return getTimelineServerBasedMarkers(context, parallelism, markerDir, storage);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/MarkerBasedRollbackUtils.java
@@ -74,15 +74,15 @@ public class MarkerBasedRollbackUtils {
         // Do NOT fall back to TIMELINE_SERVER_BASED on transient IO failures (e.g., HDFS throttling).
         // The timeline server looks in a different location and would return 0 markers, causing the
         // rollback to skip deleting data files and leaving orphan files on the table.
-        log.warn(String.format("%s not present and %s marker listing failed with IO error: %s. "
-                + "Propagating exception — rollback will retry rather than fall back to %s.",
-            MARKER_TYPE_FILENAME, DIRECT, e.getMessage(), TIMELINE_SERVER_BASED));
+        log.warn("{} not present and {} marker listing failed with IO error. "
+                + "Propagating exception — rollback will retry rather than fall back to {}.",
+            MARKER_TYPE_FILENAME, DIRECT, TIMELINE_SERVER_BASED, e);
         throw e;
       } catch (IllegalArgumentException e) {
         // IllegalArgumentException indicates a marker path format mismatch — fall back to timeline server.
-        log.warn(String.format("%s not present and %s marker failed with error: %s. So, falling back to %s marker",
-            MARKER_TYPE_FILENAME, DIRECT, e.getMessage(), TIMELINE_SERVER_BASED));
-        return getTimelineServerBasedMarkers(context, parallelism, markerDir, fileSystem);
+        log.warn("{} not present and {} marker failed. Falling back to {} marker",
+            MARKER_TYPE_FILENAME, DIRECT, TIMELINE_SERVER_BASED, e);
+        return getTimelineServerBasedMarkers(context, parallelism, markerDir, storage);
       }
     }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/marker/TestMarkerBasedRollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/marker/TestMarkerBasedRollbackUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.table.marker;
+
+import org.apache.hudi.common.config.SerializableConfiguration;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.fs.HoodieWrapperFileSystem;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.table.HoodieTable;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.apache.hudi.common.util.MarkerUtils.MARKER_TYPE_FILENAME;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+public class TestMarkerBasedRollbackUtils {
+
+  /**
+   * Verifies that a transient IO failure (e.g., HDFS "Server too busy") while listing the
+   * DIRECT marker directory propagates as IOException rather than silently falling back to
+   * TIMELINE_SERVER_BASED markers. The timeline server uses a different directory and would
+   * return 0 marker paths, causing rollback to skip deleting data files and leaving orphans.
+   */
+  @Test
+  public void testGetAllMarkerPathsThrowsIOExceptionOnTransientHdfsFailure() throws IOException {
+    String instant = "20260101000000";
+    String basePath = "/tmp/test-table";
+    String markerDir = basePath + "/.hoodie/.temp/" + instant;
+
+    HoodieTable mockTable = Mockito.mock(HoodieTable.class);
+    HoodieTableMetaClient mockMetaClient = Mockito.mock(HoodieTableMetaClient.class);
+    HoodieEngineContext mockContext = Mockito.mock(HoodieEngineContext.class);
+    HoodieWrapperFileSystem mockFs = Mockito.mock(HoodieWrapperFileSystem.class);
+
+    when(mockTable.getMetaClient()).thenReturn(mockMetaClient);
+    when(mockTable.getContext()).thenReturn(mockContext);
+    when(mockMetaClient.getFs()).thenReturn(mockFs);
+    when(mockMetaClient.getBasePath()).thenReturn(basePath);
+    when(mockMetaClient.getMarkerFolderPath(instant)).thenReturn(markerDir);
+    when(mockContext.getHadoopConf()).thenReturn(new SerializableConfiguration(new Configuration()));
+
+    // MARKERS.type is absent — simulates a write that was interrupted before writing the type file
+    when(mockFs.exists(new Path(markerDir, MARKER_TYPE_FILENAME))).thenReturn(false);
+    // The marker directory itself exists (the write had started creating marker files)
+    when(mockFs.exists(new Path(markerDir))).thenReturn(true);
+    // Listing the marker dir fails transiently (e.g., HDFS namenode throttling)
+    when(mockFs.listStatus(new Path(markerDir)))
+        .thenThrow(new IOException("Server too busy - disconnecting"));
+
+    // IOException must propagate so the rollback can retry once HDFS recovers.
+    // If it were swallowed and fell back to TIMELINE_SERVER_BASED, rollback would return
+    // 0 marker paths and leave orphan data files on the table.
+    assertThrows(IOException.class,
+        () -> MarkerBasedRollbackUtils.getAllMarkerPaths(mockTable, mockContext, instant, 1));
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/marker/TestMarkerBasedRollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/marker/TestMarkerBasedRollbackUtils.java
@@ -52,9 +52,9 @@ import static org.mockito.Mockito.when;
  * <p>The tests mock the {@link HoodieStorage} seams the production code actually goes
  * through:
  * <ul>
- *   <li>{@code readMarkerType(...)} → {@code storage.exists(MARKERS.type)} = false
- *   <li>{@code DirectWriteMarkers.doesMarkerDirExist()} → {@code storage.exists(markerDir)} = true
- *   <li>{@code FSUtils.processFiles} → {@code storage.listDirectEntries(markerDir)} throws
+ *   <li>{@code readMarkerType(...)} -&gt; {@code storage.exists(MARKERS.type)} = false
+ *   <li>{@code DirectWriteMarkers.doesMarkerDirExist()} -&gt; {@code storage.exists(markerDir)} = true
+ *   <li>{@code FSUtils.processFiles} -&gt; {@code storage.listDirectEntries(markerDir)} throws
  * </ul>
  */
 public class TestMarkerBasedRollbackUtils {
@@ -87,7 +87,7 @@ public class TestMarkerBasedRollbackUtils {
 
     StoragePath markerDirPath = new StoragePath(MARKER_DIR);
     StoragePath markerTypeFilePath = new StoragePath(markerDirPath, MARKER_TYPE_FILENAME);
-    // MARKERS.type is absent — this drives execution into the fallback branch under test.
+    // MARKERS.type is absent, this drives execution into the fallback branch under test.
     when(mockStorage.exists(markerTypeFilePath)).thenReturn(false);
     // The marker directory itself exists so DirectWriteMarkers.allMarkerFilePaths()
     // proceeds to list entries (rather than early-returning an empty set).
@@ -113,7 +113,7 @@ public class TestMarkerBasedRollbackUtils {
 
   /**
    * IllegalArgumentException (e.g., marker path format mismatch) must retain the original
-   * fallback behavior — read markers via TIMELINE_SERVER_BASED path instead of failing.
+   * fallback behavior, read markers via TIMELINE_SERVER_BASED path instead of failing.
    *
    * <p>Both DirectWriteMarkers and the timeline-server-based reader end up calling
    * {@code storage.listDirectEntries(markerDir)}. We stub the first invocation to throw
@@ -126,7 +126,7 @@ public class TestMarkerBasedRollbackUtils {
         .thenThrow(new IllegalArgumentException("bad marker path"))
         .thenReturn(Collections.emptyList());
 
-    // No exception should surface — the IllegalArgumentException must be handled by the
+    // No exception should surface, the IllegalArgumentException must be handled by the
     // fallback rather than propagating to the caller.
     assertDoesNotThrow(
         () -> MarkerBasedRollbackUtils.getAllMarkerPaths(mockTable, mockContext, INSTANT, 1));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/marker/TestMarkerBasedRollbackUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/marker/TestMarkerBasedRollbackUtils.java
@@ -19,61 +19,116 @@
 
 package org.apache.hudi.table.marker;
 
-import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.common.fs.HoodieWrapperFileSystem;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.apache.hudi.common.util.MarkerUtils.MARKER_TYPE_FILENAME;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for {@link MarkerBasedRollbackUtils}.
+ *
+ * <p>These tests target the {@code MARKERS.type}-absent code path in
+ * {@link MarkerBasedRollbackUtils#getAllMarkerPaths}. That branch attempts to list DIRECT
+ * markers first and used to catch {@code IOException | IllegalArgumentException} and fall
+ * back to TIMELINE_SERVER_BASED. A transient HDFS failure would therefore be swallowed and
+ * the rollback would return zero marker paths, leaving orphan data files on the table.
+ *
+ * <p>The tests mock the {@link HoodieStorage} seams the production code actually goes
+ * through:
+ * <ul>
+ *   <li>{@code readMarkerType(...)} → {@code storage.exists(MARKERS.type)} = false
+ *   <li>{@code DirectWriteMarkers.doesMarkerDirExist()} → {@code storage.exists(markerDir)} = true
+ *   <li>{@code FSUtils.processFiles} → {@code storage.listDirectEntries(markerDir)} throws
+ * </ul>
+ */
 public class TestMarkerBasedRollbackUtils {
 
-  /**
-   * Verifies that a transient IO failure (e.g., HDFS "Server too busy") while listing the
-   * DIRECT marker directory propagates as IOException rather than silently falling back to
-   * TIMELINE_SERVER_BASED markers. The timeline server uses a different directory and would
-   * return 0 marker paths, causing rollback to skip deleting data files and leaving orphans.
-   */
-  @Test
-  public void testGetAllMarkerPathsThrowsIOExceptionOnTransientHdfsFailure() throws IOException {
-    String instant = "20260101000000";
-    String basePath = "/tmp/test-table";
-    String markerDir = basePath + "/.hoodie/.temp/" + instant;
+  private static final String INSTANT = "20260101000000";
+  private static final String BASE_PATH = "/tmp/test-table";
+  private static final String MARKER_DIR = BASE_PATH + "/.hoodie/.temp/" + INSTANT;
 
-    HoodieTable mockTable = Mockito.mock(HoodieTable.class);
-    HoodieTableMetaClient mockMetaClient = Mockito.mock(HoodieTableMetaClient.class);
-    HoodieEngineContext mockContext = Mockito.mock(HoodieEngineContext.class);
-    HoodieWrapperFileSystem mockFs = Mockito.mock(HoodieWrapperFileSystem.class);
+  private HoodieTable mockTable;
+  private HoodieTableMetaClient mockMetaClient;
+  private HoodieEngineContext mockContext;
+  private HoodieStorage mockStorage;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    mockTable = mock(HoodieTable.class);
+    mockMetaClient = mock(HoodieTableMetaClient.class);
+    mockContext = mock(HoodieEngineContext.class);
+    mockStorage = mock(HoodieStorage.class);
+    HoodieTableConfig mockTableConfig = mock(HoodieTableConfig.class);
 
     when(mockTable.getMetaClient()).thenReturn(mockMetaClient);
     when(mockTable.getContext()).thenReturn(mockContext);
-    when(mockMetaClient.getFs()).thenReturn(mockFs);
-    when(mockMetaClient.getBasePath()).thenReturn(basePath);
-    when(mockMetaClient.getMarkerFolderPath(instant)).thenReturn(markerDir);
-    when(mockContext.getHadoopConf()).thenReturn(new SerializableConfiguration(new Configuration()));
+    when(mockTable.getStorage()).thenReturn(mockStorage);
+    when(mockMetaClient.getBasePath()).thenReturn(new StoragePath(BASE_PATH));
+    when(mockMetaClient.getMarkerFolderPath(INSTANT)).thenReturn(MARKER_DIR);
+    when(mockMetaClient.getTableConfig()).thenReturn(mockTableConfig);
+    // Table version 8+ selects DirectWriteMarkers in WriteMarkersFactory.
+    when(mockTableConfig.getTableVersion()).thenReturn(HoodieTableVersion.EIGHT);
 
-    // MARKERS.type is absent — simulates a write that was interrupted before writing the type file
-    when(mockFs.exists(new Path(markerDir, MARKER_TYPE_FILENAME))).thenReturn(false);
-    // The marker directory itself exists (the write had started creating marker files)
-    when(mockFs.exists(new Path(markerDir))).thenReturn(true);
-    // Listing the marker dir fails transiently (e.g., HDFS namenode throttling)
-    when(mockFs.listStatus(new Path(markerDir)))
+    StoragePath markerDirPath = new StoragePath(MARKER_DIR);
+    StoragePath markerTypeFilePath = new StoragePath(markerDirPath, MARKER_TYPE_FILENAME);
+    // MARKERS.type is absent — this drives execution into the fallback branch under test.
+    when(mockStorage.exists(markerTypeFilePath)).thenReturn(false);
+    // The marker directory itself exists so DirectWriteMarkers.allMarkerFilePaths()
+    // proceeds to list entries (rather than early-returning an empty set).
+    when(mockStorage.exists(markerDirPath)).thenReturn(true);
+  }
+
+  /**
+   * A transient IO failure while listing DIRECT markers must propagate as IOException
+   * rather than silently falling back to TIMELINE_SERVER_BASED. Falling back would return
+   * zero marker paths (timeline server uses a different location) and cause rollback to
+   * leave orphan data files on the table.
+   */
+  @Test
+  public void testGetAllMarkerPathsPropagatesIOExceptionOnTransientListingFailure() throws IOException {
+    when(mockStorage.listDirectEntries(new StoragePath(MARKER_DIR)))
         .thenThrow(new IOException("Server too busy - disconnecting"));
 
-    // IOException must propagate so the rollback can retry once HDFS recovers.
-    // If it were swallowed and fell back to TIMELINE_SERVER_BASED, rollback would return
-    // 0 marker paths and leave orphan data files on the table.
-    assertThrows(IOException.class,
-        () -> MarkerBasedRollbackUtils.getAllMarkerPaths(mockTable, mockContext, instant, 1));
+    IOException thrown = assertThrows(IOException.class,
+        () -> MarkerBasedRollbackUtils.getAllMarkerPaths(mockTable, mockContext, INSTANT, 1));
+    // Verify the original transient error surfaces to the caller (not a wrapped fallback error).
+    assertEquals("Server too busy - disconnecting", thrown.getMessage());
+  }
+
+  /**
+   * IllegalArgumentException (e.g., marker path format mismatch) must retain the original
+   * fallback behavior — read markers via TIMELINE_SERVER_BASED path instead of failing.
+   *
+   * <p>Both DirectWriteMarkers and the timeline-server-based reader end up calling
+   * {@code storage.listDirectEntries(markerDir)}. We stub the first invocation to throw
+   * (triggering the fallback under test) and subsequent invocations to return an empty
+   * list so the fallback path completes cleanly.
+   */
+  @Test
+  public void testGetAllMarkerPathsFallsBackToTimelineServerOnIllegalArgumentException() throws IOException {
+    when(mockStorage.listDirectEntries(new StoragePath(MARKER_DIR)))
+        .thenThrow(new IllegalArgumentException("bad marker path"))
+        .thenReturn(Collections.emptyList());
+
+    // No exception should surface — the IllegalArgumentException must be handled by the
+    // fallback rather than propagating to the caller.
+    assertDoesNotThrow(
+        () -> MarkerBasedRollbackUtils.getAllMarkerPaths(mockTable, mockContext, INSTANT, 1));
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When `MARKERS.type` is absent, `MarkerBasedRollbackUtils.getAllMarkerPaths()` first tries `DIRECT` markers and catches `IOException | IllegalArgumentException` to fall back to `TIMELINE_SERVER_BASED`. This catch is too broad.

A transient HDFS error (e.g. "Server too busy" / `RetriableException`) is also an `IOException`. When it is caught, the code falls back to the timeline server marker path, which looks in a different location and finds 0 markers. The rollback then skips deleting data files, leaving orphan files on the table.

### Summary and Changelog

Rollback no longer silently degrades into a no-op when marker listing hits a transient storage failure. Instead the rollback fails loudly and can be retried, so orphan data files are not left behind.

- `MarkerBasedRollbackUtils.getAllMarkerPaths()`: split the combined `catch (IOException | IllegalArgumentException)` into two catches.
  - `IOException`: log and rethrow, so the rollback fails and is retried rather than falling back.
  - `IllegalArgumentException`: keep the existing fallback to `TIMELINE_SERVER_BASED`, since this indicates a marker path format mismatch, which is the intended fallback case.
- Both log statements now pass the exception as the last argument so the stack trace is preserved.
- New test `TestMarkerBasedRollbackUtils` (hudi-client-common) covering:
  - `IOException` from marker listing is propagated and no fallback occurs.
  - `IllegalArgumentException` still falls back to timeline-server-based markers.

No code was copied from elsewhere.

### Impact

No public API, config, or user-facing behavior change other than the failure mode of this one code path: a rollback that previously "succeeded" while deleting nothing on a transient IO error now fails and is retried. This only affects tables where `MARKERS.type` is missing from the marker directory.

### Risk Level

low

The change is confined to the `MARKERS.type`-absent branch of `getAllMarkerPaths()` and only alters behavior for transient IO failures. The `IllegalArgumentException` fallback is preserved unchanged, and both branches are covered by the new unit tests.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
