### PR TITLE
[HUDI-18888] fix(streamer): downgrade source-emitted V2 checkpoint to V1 for v6 writes

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -57,6 +57,9 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
+import org.apache.hudi.common.table.checkpoint.CheckpointUtils;
+import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV1;
+import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -947,10 +950,21 @@ public class StreamSync implements Serializable, Closeable {
       return Collections.emptyMap();
     }
 
-    // If we have a next checkpoint batch, use its metadata
+    // If we have a next checkpoint batch, use its metadata. Some Source implementations (e.g.
+    // DFSPathSelector-backed *DFSSource) unconditionally return a StreamerCheckpointV2 regardless
+    // of the target table version. The persisted checkpoint key must match the table version
+    // contract enforced by CheckpointUtils.shouldTargetCheckpointV2 (V2 keys are only valid for
+    // writeTableVersion >= 8 and outside the not-supported set). Normalize here so that a v6
+    // write does not get a V2 key stamped into its commit metadata.
     if (inputBatch.getCheckpointForNextBatch() != null) {
-      return inputBatch.getCheckpointForNextBatch()
-          .getCheckpointCommitMetadata(cfg.checkpoint, cfg.ignoreCheckpoint);
+      Checkpoint sourceCheckpoint = inputBatch.getCheckpointForNextBatch();
+      boolean targetV2 = CheckpointUtils.shouldTargetCheckpointV2(versionCode, cfg.sourceClassName);
+      if (targetV2 && sourceCheckpoint instanceof StreamerCheckpointV1) {
+        sourceCheckpoint = new StreamerCheckpointV2(sourceCheckpoint);
+      } else if (!targetV2 && sourceCheckpoint instanceof StreamerCheckpointV2) {
+        sourceCheckpoint = new StreamerCheckpointV1(sourceCheckpoint);
+      }
+      return sourceCheckpoint.getCheckpointCommitMetadata(cfg.checkpoint, cfg.ignoreCheckpoint);
     }
 
     // Otherwise create new checkpoint based on version

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -472,8 +472,15 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         metaClient, metaClient.getActiveTimeline().lastInstant().get());
     assertFalse(metadata.isEmpty());
     Map<String, String> extraMetadata = metadata.get().getExtraMetadata();
-    assertTrue(extraMetadata.containsKey(STREAMER_CHECKPOINT_KEY_V2));
-    assertFalse(extraMetadata.containsKey(STREAMER_CHECKPOINT_KEY_V1));
+    // V1 vs V2 is driven by CheckpointUtils.shouldTargetCheckpointV2 — for v6 tables the contract
+    // is V1, so the assertion is conditional on the on-disk table version.
+    if (metaClient.getTableConfig().getTableVersion().versionCode() >= HoodieTableVersion.EIGHT.versionCode()) {
+      assertTrue(extraMetadata.containsKey(STREAMER_CHECKPOINT_KEY_V2));
+      assertFalse(extraMetadata.containsKey(STREAMER_CHECKPOINT_KEY_V1));
+    } else {
+      assertTrue(extraMetadata.containsKey(STREAMER_CHECKPOINT_KEY_V1));
+      assertFalse(extraMetadata.containsKey(STREAMER_CHECKPOINT_KEY_V2));
+    }
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSync.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/streamer/TestStreamSync.java
@@ -28,6 +28,8 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.checkpoint.Checkpoint;
+import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV1;
+import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.collection.Triple;
@@ -52,7 +54,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -62,6 +66,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.table.checkpoint.StreamerCheckpointV1.STREAMER_CHECKPOINT_KEY_V1;
+import static org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2.STREAMER_CHECKPOINT_KEY_V2;
 import static org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2.STREAMER_CHECKPOINT_RESET_KEY_V2;
 import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_ENABLE_VALIDATE_TARGET_SCHEMA;
 import static org.apache.hudi.utilities.config.HoodieStreamerConfig.CHECKPOINT_FORCE_SKIP;
@@ -373,6 +379,90 @@ public class TestStreamSync extends SparkClientFunctionalTestHarness {
     expected.put(CHECKPOINT_IGNORE_KEY, "test-ignore");
     expected.put(STREAMER_CHECKPOINT_RESET_KEY_V2, "test-checkpoint");
     assertEquals(expected, result, "Should return default metadata when checkpoint is null");
+  }
+
+  /**
+   * Coerces a source-emitted V2 checkpoint to V1 when the target table version is below 8.
+   * Many source helpers (DFSPathSelector, DatePartitionPathSelector, KafkaSource via InputBatch
+   * String constructor, etc.) construct StreamerCheckpointV2 unconditionally; on a v6 write we
+   * must downgrade before persisting the commit's extraMetadata.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "org.apache.hudi.utilities.sources.ParquetDFSSource",
+      "org.apache.hudi.utilities.sources.JsonDFSSource",
+      "org.apache.hudi.utilities.sources.AvroDFSSource",
+      "org.apache.hudi.utilities.sources.CsvDFSSource",
+      "org.apache.hudi.utilities.sources.ORCDFSSource",
+      "org.apache.hudi.utilities.sources.KafkaSource",
+      "org.apache.hudi.utilities.sources.JsonKafkaSource",
+      "org.apache.hudi.utilities.sources.AvroKafkaSource",
+      "org.apache.hudi.utilities.sources.KinesisSource",
+      "org.apache.hudi.utilities.sources.PulsarSource",
+      "org.apache.hudi.utilities.sources.JdbcSource",
+      "org.apache.hudi.utilities.sources.SqlSource",
+      "org.apache.hudi.utilities.sources.SqlFileBasedSource",
+      "org.apache.hudi.utilities.sources.HiveIncrPullSource",
+      "org.apache.hudi.utilities.sources.HoodieIncrSource",
+      "org.apache.hudi.utilities.sources.S3EventsHoodieIncrSource",
+      "org.apache.hudi.utilities.sources.GcsEventsHoodieIncrSource",
+      "org.apache.hudi.utilities.sources.GcsEventsSource"
+  })
+  public void testExtractCheckpointMetadata_V2FromSourceDowngradedToV1OnV6Write(String sourceClassName) {
+    HoodieStreamer.Config cfg = new HoodieStreamer.Config();
+    cfg.sourceClassName = sourceClassName;
+    StreamSync streamSync = setupStreamSync();
+    TypedProperties props = new TypedProperties();
+
+    InputBatch inputBatch = mock(InputBatch.class);
+    when(inputBatch.getCheckpointForNextBatch()).thenReturn(new StreamerCheckpointV2("v2-key"));
+
+    Map<String, String> result = streamSync.extractCheckpointMetadata(
+        inputBatch, props, HoodieTableVersion.SIX.versionCode(), cfg);
+
+    assertEquals("v2-key", result.get(STREAMER_CHECKPOINT_KEY_V1),
+        "V6 write should persist V1 key (downgrade applied) for source " + sourceClassName);
+    assertNull(result.get(STREAMER_CHECKPOINT_KEY_V2),
+        "V6 write must not persist V2 key for source " + sourceClassName);
+  }
+
+  /**
+   * Symmetric direction: a v8+ write against a source that returns V1 must be upgraded to V2,
+   * unless the source is in DATASOURCES_NOT_SUPPORTED_WITH_CKPT_V2 (S3/Gcs IncrSources stay V1).
+   */
+  @ParameterizedTest
+  @CsvSource({
+      "org.apache.hudi.utilities.sources.ParquetDFSSource, true",
+      "org.apache.hudi.utilities.sources.JsonDFSSource, true",
+      "org.apache.hudi.utilities.sources.KafkaSource, true",
+      "org.apache.hudi.utilities.sources.HoodieIncrSource, true",
+      "org.apache.hudi.utilities.sources.S3EventsHoodieIncrSource, false",
+      "org.apache.hudi.utilities.sources.GcsEventsHoodieIncrSource, false"
+  })
+  public void testExtractCheckpointMetadata_V1FromSourceUpgradedToV2OnV8Write(String sourceClassName, boolean expectV2) {
+    HoodieStreamer.Config cfg = new HoodieStreamer.Config();
+    cfg.sourceClassName = sourceClassName;
+    StreamSync streamSync = setupStreamSync();
+    TypedProperties props = new TypedProperties();
+
+    InputBatch inputBatch = mock(InputBatch.class);
+    when(inputBatch.getCheckpointForNextBatch()).thenReturn(new StreamerCheckpointV1("v1-key"));
+
+    Map<String, String> result = streamSync.extractCheckpointMetadata(
+        inputBatch, props, HoodieTableVersion.EIGHT.versionCode(), cfg);
+
+    if (expectV2) {
+      assertEquals("v1-key", result.get(STREAMER_CHECKPOINT_KEY_V2),
+          "V8 write should persist V2 key for source " + sourceClassName);
+      assertNull(result.get(STREAMER_CHECKPOINT_KEY_V1),
+          "V8 write must not persist V1 key for source " + sourceClassName);
+    } else {
+      // S3/Gcs IncrSources are not supported on V2 — stays V1 even on v8.
+      assertEquals("v1-key", result.get(STREAMER_CHECKPOINT_KEY_V1),
+          "V8 write should still persist V1 key for V2-unsupported source " + sourceClassName);
+      assertNull(result.get(STREAMER_CHECKPOINT_KEY_V2),
+          "V8 write must not persist V2 key for V2-unsupported source " + sourceClassName);
+    }
   }
 
   @Test


### PR DESCRIPTION
### Change Logs

When `HoodieStreamer` ingests with `hoodie.write.table.version=6`, the persisted commit metadata was carrying the V2 checkpoint key `streamer.checkpoint.key.v2` instead of the V1 key `deltastreamer.checkpoint.key`. `CheckpointUtils.shouldTargetCheckpointV2` returns false for `writeTableVersion < 8`, so this violated the contract.

**Root cause:** `DFSPathSelector.getNextFilePathsAndMaxModificationTime` (lines 154 & 160) and many other source helpers unconditionally construct `new StreamerCheckpointV2(...)`. `*DFSSource` implementations pipe that V2 checkpoint into `InputBatch#getCheckpointForNextBatch`, and `StreamSync.extractCheckpointMetadata` trusted the type blindly. The very next code path two lines below (the no-batch fallback) already calls `buildCheckpointFromGeneralSource` and gets the version contract right — so this was a missed branch in an existing chokepoint, not a missing primitive.

**Fix:** type-based normalization at the chokepoint in `StreamSync.extractCheckpointMetadata`. When the source returns a checkpoint, coerce its concrete type to whatever `shouldTargetCheckpointV2(versionCode, sourceClassName)` permits before calling `getCheckpointCommitMetadata`. Mirrors the inbound translation already done in `Source.translateCheckpoint`.

**Coverage audit:** all 17 `new StreamerCheckpointV2(...)` construction sites in `hudi-utilities/src/main` funnel through this chokepoint — DFS family, Kafka family, Kinesis, Pulsar, Jdbc, Sql, Hive, HoodieIncrSource, GcsEventsSource, DatePartitionPathSelector, Debezium, S3EventsMetaSelector. The `DATASOURCES_NOT_SUPPORTED_WITH_CKPT_V2` carve-out (S3EventsHoodieIncrSource / GcsEventsHoodieIncrSource) is preserved: those sources stay V1 even on v8+ writes.

### Impact

Bug fix: prevents the wrong checkpoint key from being persisted on v6 tables. Resumed ingestion against a v6 table will now correctly continue reading `deltastreamer.checkpoint.key` from prior commits.

### Risk level

low

### Documentation Update

No user-facing config or API change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Adequate tests added

### Test Plan

- `testExtractCheckpointMetadata_V2FromSourceDowngradedToV1OnV6Write` — 19 source classes covering DFS, Kafka, Kinesis, Pulsar, Jdbc, Sql, SqlFileBased, Hive, Hoodie/S3Events/GcsEvents IncrSources, GcsEventsSource. All pass.
- `testExtractCheckpointMetadata_V1FromSourceUpgradedToV2OnV8Write` — 6 cases including the S3/Gcs IncrSource carve-out. All pass.
- Full `TestStreamSync#testExtractCheckpointMetadata*` — 28/28 pass.
- `mvn -pl hudi-utilities checkstyle:check` — 0 violations.

Closes #18888