### PR TITLE
feat(utilities): Migrate schema providers to HoodieSchema

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.schema;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
@@ -31,8 +32,6 @@ import org.apache.hudi.utilities.sources.helpers.SanitizationUtils;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
-import lombok.Getter;
-import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -55,10 +54,9 @@ public class FilebasedSchemaProvider extends SchemaProvider {
   private final String sourceFile;
   private final String targetFile;
 
-  @Getter
-  protected Schema sourceSchema;
+  protected HoodieSchema sourceSchema;
 
-  protected Schema targetSchema;
+  protected HoodieSchema targetSchema;
 
   public FilebasedSchemaProvider(TypedProperties props, JavaSparkContext jssc) {
     super(props, jssc);
@@ -72,26 +70,31 @@ public class FilebasedSchemaProvider extends SchemaProvider {
     }
   }
 
-  private Schema parseSchema(String schemaFile) {
+  private HoodieSchema parseSchema(String schemaFile) {
     return readSchemaFromFile(schemaFile, this.fs, config);
   }
 
   @Override
-  public Schema getTargetSchema() {
+  public HoodieSchema getSourceHoodieSchema() {
+    return sourceSchema;
+  }
+
+  @Override
+  public HoodieSchema getTargetHoodieSchema() {
     if (targetSchema != null) {
       return targetSchema;
     } else {
-      return super.getTargetSchema();
+      return super.getTargetHoodieSchema();
     }
   }
 
-  private static Schema readSchemaFromFile(String schemaPath, FileSystem fs, TypedProperties props) {
+  private static HoodieSchema readSchemaFromFile(String schemaPath, FileSystem fs, TypedProperties props) {
     return schemaPath.endsWith(".json")
         ? readJsonSchemaFromFile(schemaPath, fs, props)
         : readAvroSchemaFromFile(schemaPath, fs, props);
   }
 
-  private static Schema readJsonSchemaFromFile(String schemaPath, FileSystem fs, TypedProperties props) {
+  private static HoodieSchema readJsonSchemaFromFile(String schemaPath, FileSystem fs, TypedProperties props) {
     String schemaConverterClass = getStringWithAltKeys(props, HoodieSchemaProviderConfig.SCHEMA_CONVERTER, true);
     SchemaRegistryProvider.SchemaConverter schemaConverter;
     try {
@@ -111,16 +114,16 @@ public class FilebasedSchemaProvider extends SchemaProvider {
       throw new HoodieSchemaProviderException(String.format("Error converting json schema from file %s", schemaPath),
           e);
     }
-    return new Schema.Parser().parse(convertedSchema);
+    return new HoodieSchema.Parser().parse(convertedSchema);
   }
 
-  private static Schema readAvroSchemaFromFile(String schemaPath,
-                                               FileSystem fs,
-                                               TypedProperties props) {
+  private static HoodieSchema readAvroSchemaFromFile(String schemaPath,
+                                                     FileSystem fs,
+                                                     TypedProperties props) {
     boolean shouldSanitize = SanitizationUtils.shouldSanitize(props);
     String invalidCharMask = SanitizationUtils.getInvalidCharMask(props);
     String schemaStr = readSchemaString(schemaPath, fs);
-    return SanitizationUtils.parseAvroSchema(schemaStr, shouldSanitize, invalidCharMask).toAvroSchema();
+    return SanitizationUtils.parseAvroSchema(schemaStr, shouldSanitize, invalidCharMask);
   }
 
   private static String readSchemaString(String schemaPath, FileSystem fs) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/FilebasedSchemaProvider.java
@@ -32,6 +32,7 @@ import org.apache.hudi.utilities.sources.helpers.SanitizationUtils;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -80,12 +81,20 @@ public class FilebasedSchemaProvider extends SchemaProvider {
   }
 
   @Override
+  @Deprecated
+  public Schema getSourceSchema() {
+    return getSourceHoodieSchema().toAvroSchema();
+  }
+
+  @Override
   public HoodieSchema getTargetHoodieSchema() {
-    if (targetSchema != null) {
-      return targetSchema;
-    } else {
-      return super.getTargetHoodieSchema();
-    }
+    return targetSchema != null ? targetSchema : getSourceHoodieSchema();
+  }
+
+  @Override
+  @Deprecated
+  public Schema getTargetSchema() {
+    return getTargetHoodieSchema().toAvroSchema();
   }
 
   private static HoodieSchema readSchemaFromFile(String schemaPath, FileSystem fs, TypedProperties props) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/HiveSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/HiveSchemaProvider.java
@@ -25,8 +25,6 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.utilities.config.HiveSchemaProviderConfig;
 import org.apache.hudi.utilities.exception.HoodieSchemaFetchException;
 
-import lombok.Getter;
-import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -43,7 +41,6 @@ import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 /**
  * A schema provider to get data schema through user specified hive table.
  */
-@Getter
 public class HiveSchemaProvider extends SchemaProvider {
 
   private final HoodieSchema sourceHoodieSchema;
@@ -86,18 +83,16 @@ public class HiveSchemaProvider extends SchemaProvider {
   }
 
   @Override
-  @Deprecated
-  public Schema getSourceSchema() {
-    return getSourceHoodieSchema().toAvroSchema();
+  public HoodieSchema getSourceHoodieSchema() {
+    return sourceHoodieSchema;
   }
 
   @Override
-  @Deprecated
-  public Schema getTargetSchema() {
-    if (getTargetHoodieSchema() != null) {
-      return getTargetHoodieSchema().toAvroSchema();
+  public HoodieSchema getTargetHoodieSchema() {
+    if (targetHoodieSchema != null) {
+      return targetHoodieSchema;
     } else {
-      return super.getTargetSchema();
+      return super.getTargetHoodieSchema();
     }
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/HiveSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/HiveSchemaProvider.java
@@ -25,6 +25,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.utilities.config.HiveSchemaProviderConfig;
 import org.apache.hudi.utilities.exception.HoodieSchemaFetchException;
 
+import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -88,11 +89,19 @@ public class HiveSchemaProvider extends SchemaProvider {
   }
 
   @Override
+  @Deprecated
+  public Schema getSourceSchema() {
+    return getSourceHoodieSchema().toAvroSchema();
+  }
+
+  @Override
   public HoodieSchema getTargetHoodieSchema() {
-    if (targetHoodieSchema != null) {
-      return targetHoodieSchema;
-    } else {
-      return super.getTargetHoodieSchema();
-    }
+    return targetHoodieSchema != null ? targetHoodieSchema : getSourceHoodieSchema();
+  }
+
+  @Override
+  @Deprecated
+  public Schema getTargetSchema() {
+    return getTargetHoodieSchema().toAvroSchema();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/JdbcbasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/JdbcbasedSchemaProvider.java
@@ -19,9 +19,9 @@
 package org.apache.hudi.utilities.schema;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.utilities.UtilHelpers;
 
-import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 
 import java.util.HashMap;
@@ -40,7 +40,7 @@ import static org.apache.hudi.utilities.config.JdbcbasedSchemaProviderConfig.SOU
  * A schema provider to get metadata through Jdbc.
  */
 public class JdbcbasedSchemaProvider extends SchemaProvider {
-  private Schema sourceSchema;
+  private HoodieSchema sourceSchema;
   private final Map<String, String> options = new HashMap<>();
 
   public JdbcbasedSchemaProvider(TypedProperties props, JavaSparkContext jssc) {
@@ -57,11 +57,11 @@ public class JdbcbasedSchemaProvider extends SchemaProvider {
   }
 
   @Override
-  public Schema getSourceSchema() {
+  public HoodieSchema getSourceHoodieSchema() {
     if (this.sourceSchema != null) {
       return sourceSchema;
     }
 
-    return UtilHelpers.getJDBCSchema(options).toAvroSchema();
+    return UtilHelpers.getJDBCSchema(options);
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/JdbcbasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/JdbcbasedSchemaProvider.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.utilities.UtilHelpers;
 
+import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 
 import java.util.HashMap;
@@ -63,5 +64,11 @@ public class JdbcbasedSchemaProvider extends SchemaProvider {
     }
 
     return UtilHelpers.getJDBCSchema(options);
+  }
+
+  @Override
+  @Deprecated
+  public Schema getSourceSchema() {
+    return getSourceHoodieSchema().toAvroSchema();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/ProtoClassBasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/ProtoClassBasedSchemaProvider.java
@@ -21,12 +21,12 @@ package org.apache.hudi.utilities.schema;
 
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.internal.schema.HoodieSchemaException;
 import org.apache.hudi.utilities.config.ProtoClassBasedSchemaProviderConfig;
 import org.apache.hudi.utilities.sources.helpers.ProtoConversionUtil;
 
-import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 
 import java.util.Collections;
@@ -64,7 +64,7 @@ public class ProtoClassBasedSchemaProvider extends SchemaProvider {
   /**
    * To be lazily initiated on executors.
    */
-  private transient Schema schema;
+  private transient HoodieSchema schema;
 
   public ProtoClassBasedSchemaProvider(TypedProperties props, JavaSparkContext jssc) {
     super(props, jssc);
@@ -79,21 +79,20 @@ public class ProtoClassBasedSchemaProvider extends SchemaProvider {
   }
 
   @Override
-  public Schema getSourceSchema() {
+  public HoodieSchema getSourceHoodieSchema() {
     if (schema == null) {
       try {
-        Schema.Parser parser = new Schema.Parser();
+        HoodieSchema.Parser parser = new HoodieSchema.Parser();
         schema = parser.parse(schemaString);
       } catch (Exception e) {
         throw new HoodieSchemaException("Failed to parse schema: " + schemaString, e);
       }
-
     }
     return schema;
   }
 
   @Override
-  public Schema getTargetSchema() {
-    return getSourceSchema();
+  public HoodieSchema getTargetHoodieSchema() {
+    return getSourceHoodieSchema();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/ProtoClassBasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/ProtoClassBasedSchemaProvider.java
@@ -27,6 +27,7 @@ import org.apache.hudi.internal.schema.HoodieSchemaException;
 import org.apache.hudi.utilities.config.ProtoClassBasedSchemaProviderConfig;
 import org.apache.hudi.utilities.sources.helpers.ProtoConversionUtil;
 
+import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 
 import java.util.Collections;
@@ -89,6 +90,12 @@ public class ProtoClassBasedSchemaProvider extends SchemaProvider {
       }
     }
     return schema;
+  }
+
+  @Override
+  @Deprecated
+  public Schema getSourceSchema() {
+    return getSourceHoodieSchema().toAvroSchema();
   }
 
   @Override

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/RowBasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/RowBasedSchemaProvider.java
@@ -22,6 +22,7 @@ import org.apache.hudi.HoodieSchemaConversionUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 
+import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.types.StructType;
 
@@ -45,5 +46,11 @@ public class RowBasedSchemaProvider extends SchemaProvider {
   @Override
   public HoodieSchema getSourceHoodieSchema() {
     return HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(rowStruct, HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE);
+  }
+
+  @Override
+  @Deprecated
+  public Schema getSourceSchema() {
+    return getSourceHoodieSchema().toAvroSchema();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProviderWithPostProcessor.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProviderWithPostProcessor.java
@@ -39,19 +39,29 @@ public class SchemaProviderWithPostProcessor extends SchemaProvider {
   }
 
   @Override
+  public HoodieSchema getSourceHoodieSchema() {
+    HoodieSchema sourceSchema = schemaProvider.getSourceHoodieSchema();
+    return schemaPostProcessor.map(processor -> processor.processSchema(sourceSchema))
+        .orElse(sourceSchema);
+  }
+
+  @Override
+  public HoodieSchema getTargetHoodieSchema() {
+    HoodieSchema targetSchema = schemaProvider.getTargetHoodieSchema();
+    return schemaPostProcessor.map(processor -> processor.processSchema(targetSchema))
+        .orElse(targetSchema);
+  }
+
+  @Override
   @Deprecated
   public Schema getSourceSchema() {
-    HoodieSchema sourceSchema = schemaProvider.getSourceHoodieSchema();
-    return schemaPostProcessor.map(processor -> processor.processSchema(sourceSchema).toAvroSchema())
-        .orElse(sourceSchema.toAvroSchema());
+    return getSourceHoodieSchema().toAvroSchema();
   }
 
   @Override
   @Deprecated
   public Schema getTargetSchema() {
-    HoodieSchema targetSchema = schemaProvider.getTargetHoodieSchema();
-    return schemaPostProcessor.map(processor -> processor.processSchema(targetSchema).toAvroSchema())
-        .orElse(targetSchema.toAvroSchema());
+    return getTargetHoodieSchema().toAvroSchema();
   }
 
   public SchemaProvider getOriginalSchemaProvider() {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -20,6 +20,7 @@ package org.apache.hudi.utilities.schema;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.function.SerializableFunctionUnchecked;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
@@ -41,7 +42,6 @@ import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.avro.Schema;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
@@ -148,9 +148,9 @@ public class SchemaRegistryProvider extends SchemaProvider {
     String convert(ParsedSchema schema) throws IOException;
   }
 
-  public Schema parseSchemaFromRegistry(String registryUrl) {
+  public HoodieSchema parseSchemaFromRegistry(String registryUrl) {
     String schema = fetchSchemaFromRegistry(registryUrl);
-    return new Schema.Parser().parse(schema);
+    return new HoodieSchema.Parser().parse(schema);
   }
 
   /**
@@ -308,7 +308,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
   }
 
   @Override
-  public Schema getSourceSchema() {
+  public HoodieSchema getSourceHoodieSchema() {
     String registryUrl = getStringWithAltKeys(config, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL);
     try {
       return parseSchemaFromRegistry(registryUrl);
@@ -321,7 +321,7 @@ public class SchemaRegistryProvider extends SchemaProvider {
   }
 
   @Override
-  public Schema getTargetSchema() {
+  public HoodieSchema getTargetHoodieSchema() {
     String registryUrl = getStringWithAltKeys(config, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL);
     String targetRegistryUrl =
         getStringWithAltKeys(config, HoodieSchemaProviderConfig.TARGET_SCHEMA_REGISTRY_URL, registryUrl);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -342,4 +342,10 @@ public class SchemaRegistryProvider extends SchemaProvider {
           StringUtils.truncate(targetRegistryUrl, 10, 10)), e);
     }
   }
+
+  @Override
+  @Deprecated
+  public Schema getTargetSchema() {
+    return getTargetHoodieSchema().toAvroSchema();
+  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -42,6 +42,7 @@ import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
@@ -318,6 +319,12 @@ public class SchemaRegistryProvider extends SchemaProvider {
           Config.SRC_SCHEMA_REGISTRY_URL_PROP,
           StringUtils.truncate(registryUrl, 10, 10)), e);
     }
+  }
+
+  @Override
+  @Deprecated
+  public Schema getSourceSchema() {
+    return getSourceHoodieSchema().toAvroSchema();
   }
 
   @Override

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SimpleSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SimpleSchemaProvider.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utilities.schema;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 
+import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 
 public class SimpleSchemaProvider extends SchemaProvider {
@@ -34,5 +35,11 @@ public class SimpleSchemaProvider extends SchemaProvider {
   @Override
   public HoodieSchema getSourceHoodieSchema() {
     return sourceSchema;
+  }
+
+  @Override
+  @Deprecated
+  public Schema getSourceSchema() {
+    return getSourceHoodieSchema().toAvroSchema();
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SimpleSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SimpleSchemaProvider.java
@@ -21,17 +21,18 @@ package org.apache.hudi.utilities.schema;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 
-import lombok.Getter;
-import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
 
-@Getter
 public class SimpleSchemaProvider extends SchemaProvider {
-
-  private final Schema sourceSchema;
+  private final HoodieSchema sourceSchema;
 
   public SimpleSchemaProvider(JavaSparkContext jssc, HoodieSchema sourceSchema, TypedProperties props) {
     super(props, jssc);
-    this.sourceSchema = sourceSchema.toAvroSchema();
+    this.sourceSchema = sourceSchema;
+  }
+
+  @Override
+  public HoodieSchema getSourceHoodieSchema() {
+    return sourceSchema;
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestRowBasedSchemaProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestRowBasedSchemaProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.schema;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestRowBasedSchemaProvider {
+
+  @Test
+  void testGetSourceHoodieSchema() {
+    StructType rowStruct = new StructType()
+        .add("id", DataTypes.StringType, false)
+        .add("name", DataTypes.StringType, true);
+
+    RowBasedSchemaProvider rowBasedSchemaProvider = new RowBasedSchemaProvider(rowStruct);
+    HoodieSchema sourceSchema = rowBasedSchemaProvider.getSourceHoodieSchema();
+
+    List<String> actualFieldNames = sourceSchema.getFields().stream()
+        .map(HoodieSchemaField::name)
+        .collect(Collectors.toList());
+
+    assertEquals(RowBasedSchemaProvider.HOODIE_RECORD_STRUCT_NAME, sourceSchema.getName());
+    assertEquals(Arrays.asList("id", "name"), actualFieldNames);
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSimpleSchemaProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/schema/TestSimpleSchemaProvider.java
@@ -18,32 +18,20 @@
 
 package org.apache.hudi.utilities.schema;
 
-import org.apache.hudi.HoodieSchemaConversionUtils;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
 
-public class RowBasedSchemaProvider extends SchemaProvider {
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-  // Used in GenericRecord conversions
-  public static final String HOODIE_RECORD_NAMESPACE = "hoodie.source";
-  public static final String HOODIE_RECORD_STRUCT_NAME = "hoodie_source";
+class TestSimpleSchemaProvider {
 
-  private StructType rowStruct;
+  @Test
+  void testGetSourceHoodieSchema() {
+    HoodieSchema sourceSchema = HoodieSchema.parse("{\"type\": \"record\", \"name\": \"example\", \"fields\": [{\"name\": \"id\", \"type\": \"string\"}]}");
+    SimpleSchemaProvider simpleSchemaProvider = new SimpleSchemaProvider(null, sourceSchema, new TypedProperties());
 
-  public RowBasedSchemaProvider(TypedProperties props, JavaSparkContext jssc) {
-    super(props, jssc);
-  }
-
-  public RowBasedSchemaProvider(StructType rowStruct) {
-    super(null, null);
-    this.rowStruct = rowStruct;
-  }
-
-  @Override
-  public HoodieSchema getSourceHoodieSchema() {
-    return HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(rowStruct, HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE);
+    assertEquals(sourceSchema, simpleSchemaProvider.getSourceHoodieSchema());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses
Part of #14281 (RFC-99 #14263)

### Summary and Changelog
Migrate all schema providers in hudi-utilities from Avro Schema to HoodieSchema, plus the post-processor wrapper.

Providers migrated to expose getSourceHoodieSchema() / getTargetHoodieSchema(), with the deprecated Avro getSourceSchema() / getTargetSchema() retained as thin bridges for backward compatibility:
- FilebasedSchemaProvider
- HiveSchemaProvider
- SchemaRegistryProvider (also adds the getTargetSchema() bridge, since it reads a distinct target registry URL and must not fall through to the source schema)
- SimpleSchemaProvider
- JdbcbasedSchemaProvider
- ProtoClassBasedSchemaProvider
- RowBasedSchemaProvider

SchemaProviderWithPostProcessor: HoodieSchema getters are now the primary implementation; the Avro getters are kept as delegating bridges, since this wrapper is the pipeline-wide compatibility boundary for callers still on the Avro API (e.g. BootstrapExecutorUtils, WriterContext).

Tests added: TestSimpleSchemaProvider, TestRowBasedSchemaProvider.

hudi-sync: no migration needed. There are zero org.apache.avro.Schema usages across the module (it operates on Parquet MessageType, not Avro Schema).

### Impact
None. RFC-99 guarantees binary compatibility with Avro in this phase. No on-disk or serialization formats change.

### Risk Level
Low. Follows the established RFC-99 pattern. Built locally (hudi-utilities + dependencies) and the schema provider tests pass with 0 checkstyle violations.

### Documentation Update
None

### Contributor's checklist
- [x] Read through contributor's guide
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable