### PR TITLE
feat(flink): support remote partitioner for simple bucket index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -252,7 +252,7 @@ public class EmbeddedTimelineService {
 
   private static TimelineServiceIdentifier getTimelineServiceIdentifier(String hostAddr, HoodieWriteConfig writeConfig) {
     return new TimelineServiceIdentifier(hostAddr, writeConfig.getMarkersType(), writeConfig.isMetadataTableEnabled(),
-        writeConfig.isEarlyConflictDetectionEnable());
+        writeConfig.isEarlyConflictDetectionEnable(), writeConfig.isUsingRemotePartitioner());
   }
 
   static class TimelineServiceIdentifier {
@@ -260,15 +260,18 @@ public class EmbeddedTimelineService {
     private final MarkerType markerType;
     private final boolean isMetadataEnabled;
     private final boolean isEarlyConflictDetectionEnable;
+    private final boolean isRemotePartitionerEnabled;
 
     public TimelineServiceIdentifier(String hostAddr,
                                      MarkerType markerType,
                                      boolean isMetadataEnabled,
-                                     boolean isEarlyConflictDetectionEnable) {
+                                     boolean isEarlyConflictDetectionEnable,
+                                     boolean isRemotePartitionerEnabled) {
       this.hostAddr = hostAddr;
       this.markerType = markerType;
       this.isMetadataEnabled = isMetadataEnabled;
       this.isEarlyConflictDetectionEnable = isEarlyConflictDetectionEnable;
+      this.isRemotePartitionerEnabled = isRemotePartitionerEnabled;
     }
 
     @Override
@@ -280,17 +283,16 @@ public class EmbeddedTimelineService {
         return false;
       }
       TimelineServiceIdentifier that = (TimelineServiceIdentifier) o;
-      if (this.hostAddr != null && that.hostAddr != null) {
-        return isMetadataEnabled == that.isMetadataEnabled && isEarlyConflictDetectionEnable == that.isEarlyConflictDetectionEnable
-            && hostAddr.equals(that.hostAddr) && markerType == that.markerType;
-      } else {
-        return (hostAddr == null && that.hostAddr == null);
-      }
+      return isMetadataEnabled == that.isMetadataEnabled
+          && isEarlyConflictDetectionEnable == that.isEarlyConflictDetectionEnable
+          && isRemotePartitionerEnabled == that.isRemotePartitionerEnabled
+          && Objects.equals(hostAddr, that.hostAddr)
+          && markerType == that.markerType;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(hostAddr, markerType, isMetadataEnabled, isEarlyConflictDetectionEnable);
+      return Objects.hash(hostAddr, markerType, isMetadataEnabled, isEarlyConflictDetectionEnable, isRemotePartitionerEnabled);
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/embedded/TestEmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/embedded/TestEmbeddedTimelineService.java
@@ -21,6 +21,7 @@ package org.apache.hudi.client.embedded;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -30,7 +31,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,6 +47,25 @@ import static org.mockito.Mockito.when;
  * These tests are mainly focused on testing the creation and reuse of the embedded timeline server.
  */
 public class TestEmbeddedTimelineService extends HoodieCommonTestHarness {
+
+  @Test
+  public void timelineServiceIdentifierConsidersAllFieldsWhenHostIsNull() {
+    EmbeddedTimelineService.TimelineServiceIdentifier identifier =
+        new EmbeddedTimelineService.TimelineServiceIdentifier(null, MarkerType.DIRECT, true, false, false);
+    EmbeddedTimelineService.TimelineServiceIdentifier sameIdentifier =
+        new EmbeddedTimelineService.TimelineServiceIdentifier(null, MarkerType.DIRECT, true, false, false);
+
+    assertEquals(identifier, sameIdentifier);
+    assertEquals(identifier.hashCode(), sameIdentifier.hashCode());
+    assertNotEquals(identifier,
+        new EmbeddedTimelineService.TimelineServiceIdentifier(null, MarkerType.TIMELINE_SERVER_BASED, true, false, false));
+    assertNotEquals(identifier,
+        new EmbeddedTimelineService.TimelineServiceIdentifier(null, MarkerType.DIRECT, false, false, false));
+    assertNotEquals(identifier,
+        new EmbeddedTimelineService.TimelineServiceIdentifier(null, MarkerType.DIRECT, true, true, false));
+    assertNotEquals(identifier,
+        new EmbeddedTimelineService.TimelineServiceIdentifier(null, MarkerType.DIRECT, true, false, true));
+  }
 
   @Test
   public void embeddedTimelineServiceReused() throws Exception {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -638,6 +638,14 @@ public class FlinkOptions extends HoodieConfig {
       .withDescription("Users can use this parameter to specify expression and the corresponding bucket "
           + "numbers (separated by commas).Multiple rules are separated by semicolons like "
           + "hoodie.bucket.index.partition.expressions=expression1,bucket-number1;expression2,bucket-number2");
+
+  @AdvancedConfig
+  public static final ConfigOption<Boolean> BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE = ConfigOptions
+      .key(HoodieIndexConfig.BUCKET_PARTITIONER.key())
+      .booleanType()
+      .defaultValue(HoodieIndexConfig.BUCKET_PARTITIONER.defaultValue())
+      .withDescription("Whether to use remote partitioner backed by the embedded timeline server for simple bucket index.");
+
   public static final ConfigOption<String> PARTITION_PATH_FIELD = ConfigOptions
       .key(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key())
       .stringType()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -639,13 +639,6 @@ public class FlinkOptions extends HoodieConfig {
           + "numbers (separated by commas).Multiple rules are separated by semicolons like "
           + "hoodie.bucket.index.partition.expressions=expression1,bucket-number1;expression2,bucket-number2");
 
-  @AdvancedConfig
-  public static final ConfigOption<Boolean> BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE = ConfigOptions
-      .key(HoodieIndexConfig.BUCKET_PARTITIONER.key())
-      .booleanType()
-      .defaultValue(HoodieIndexConfig.BUCKET_PARTITIONER.defaultValue())
-      .withDescription("Whether to use remote partitioner backed by the embedded timeline server for simple bucket index.");
-
   public static final ConfigOption<String> PARTITION_PATH_FIELD = ConfigOptions
       .key(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key())
       .stringType()

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.HoodieIndex;
@@ -261,19 +262,18 @@ public class OptionsResolver {
   /**
    * Returns whether the simple bucket index should use remote partitioner.
    */
-  public static boolean enableBucketRemotePartitioner(Configuration conf) {
+  public static boolean shouldUseBucketRemotePartitioner(Configuration conf) {
     return isSimpleBucketIndexType(conf)
-        && isBucketRemotePartitionerEnabled(conf)
-        && Boolean.parseBoolean(conf.getString(
-            HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(),
-            HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.defaultValue()));
+        && isBucketRemotePartitionerEnabled(conf);
   }
 
   /**
    * Returns whether the bucket index remote partitioner option is enabled.
    */
   public static boolean isBucketRemotePartitionerEnabled(Configuration conf) {
-    return conf.get(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE);
+    return Boolean.parseBoolean(conf.getString(
+        HoodieIndexConfig.BUCKET_PARTITIONER.key(),
+        HoodieIndexConfig.BUCKET_PARTITIONER.defaultValue().toString()));
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -259,6 +259,24 @@ public class OptionsResolver {
   }
 
   /**
+   * Returns whether the simple bucket index should use remote partitioner.
+   */
+  public static boolean enableBucketRemotePartitioner(Configuration conf) {
+    return isSimpleBucketIndexType(conf)
+        && isBucketRemotePartitionerEnabled(conf)
+        && Boolean.parseBoolean(conf.getString(
+            HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(),
+            HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.defaultValue()));
+  }
+
+  /**
+   * Returns whether the bucket index remote partitioner option is enabled.
+   */
+  public static boolean isBucketRemotePartitionerEnabled(Configuration conf) {
+    return conf.get(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE);
+  }
+
+  /**
    * Returns the default plan strategy class.
    */
   public static String getDefaultPlanStrategyClassName(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -78,7 +78,7 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
    */
   private Functions.Function3<Integer, String, Integer, Integer> partitionIndexFunc;
 
-  private boolean remotePartitionerEnabled;
+  private boolean isRemotePartitionerEnabled;
 
   private transient RemotePartitionHelper remotePartitionHelper;
 
@@ -114,8 +114,8 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
     this.isInsertOverwrite = OptionsResolver.isInsertOverwrite(config);
     this.numBucketsFunction = new NumBucketsFunction(config.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         config.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), config.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
-    this.remotePartitionerEnabled = OptionsResolver.enableBucketRemotePartitioner(config);
-    if (remotePartitionerEnabled) {
+    this.isRemotePartitionerEnabled = OptionsResolver.shouldUseBucketRemotePartitioner(config);
+    if (isRemotePartitionerEnabled) {
       this.remotePartitionHelper = new RemotePartitionHelper(writeClient.getConfig().getViewStorageConfig());
       log.info("BucketStreamWriteFunction enables remote partitioner.");
     }
@@ -170,7 +170,7 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
    * partitionIndex == this taskID belongs to this task.
    */
   public boolean isBucketToLoad(int bucketNumber, String partition) {
-    if (remotePartitionerEnabled) {
+    if (isRemotePartitionerEnabled) {
       return BucketIndexRemotePartitioner.getRemotePartition(
           remotePartitionHelper, numBucketsFunction, partition, bucketNumber, parallelism) == taskID;
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -78,8 +78,6 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
    */
   private Functions.Function3<Integer, String, Integer, Integer> partitionIndexFunc;
 
-  private boolean isRemotePartitionerEnabled;
-
   private transient RemotePartitionHelper remotePartitionHelper;
 
   /**
@@ -114,8 +112,7 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
     this.isInsertOverwrite = OptionsResolver.isInsertOverwrite(config);
     this.numBucketsFunction = new NumBucketsFunction(config.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         config.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), config.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
-    this.isRemotePartitionerEnabled = OptionsResolver.shouldUseBucketRemotePartitioner(config);
-    if (isRemotePartitionerEnabled) {
+    if (OptionsResolver.shouldUseBucketRemotePartitioner(config)) {
       this.remotePartitionHelper = new RemotePartitionHelper(writeClient.getConfig().getViewStorageConfig());
       log.info("BucketStreamWriteFunction enables remote partitioner.");
     }
@@ -170,7 +167,7 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
    * partitionIndex == this taskID belongs to this task.
    */
   public boolean isBucketToLoad(int bucketNumber, String partition) {
-    if (isRemotePartitionerEnabled) {
+    if (remotePartitionHelper != null) {
       return BucketIndexRemotePartitioner.getRemotePartition(
           remotePartitionHelper, numBucketsFunction, partition, bucketNumber, parallelism) == taskID;
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -20,12 +20,14 @@ package org.apache.hudi.sink.bucket;
 
 import org.apache.hudi.client.model.HoodieFlinkInternalRow;
 import org.apache.hudi.common.util.Functions;
+import org.apache.hudi.common.util.RemotePartitionHelper;
 import org.apache.hudi.common.util.hash.BucketIndexUtil;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.hudi.sink.StreamWriteFunction;
+import org.apache.hudi.sink.partitioner.BucketIndexRemotePartitioner;
 import org.apache.hudi.utils.RuntimeContextUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -75,6 +77,11 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
    * Functions for calculating the task partition to dispatch.
    */
   private Functions.Function3<Integer, String, Integer, Integer> partitionIndexFunc;
+
+  private boolean remotePartitionerEnabled;
+
+  private transient RemotePartitionHelper remotePartitionHelper;
+
   /**
    * Function to calculate num buckets per partition.
    */
@@ -107,6 +114,11 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
     this.isInsertOverwrite = OptionsResolver.isInsertOverwrite(config);
     this.numBucketsFunction = new NumBucketsFunction(config.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         config.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), config.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
+    this.remotePartitionerEnabled = OptionsResolver.enableBucketRemotePartitioner(config);
+    if (remotePartitionerEnabled) {
+      this.remotePartitionHelper = new RemotePartitionHelper(writeClient.getConfig().getViewStorageConfig());
+      log.info("BucketStreamWriteFunction enables remote partitioner.");
+    }
   }
 
   @Override
@@ -158,6 +170,10 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
    * partitionIndex == this taskID belongs to this task.
    */
   public boolean isBucketToLoad(int bucketNumber, String partition) {
+    if (remotePartitionerEnabled) {
+      return BucketIndexRemotePartitioner.getRemotePartition(
+          remotePartitionHelper, numBucketsFunction, partition, bucketNumber, parallelism) == taskID;
+    }
     int numBuckets = numBucketsFunction.getNumBuckets(partition);
     return this.partitionIndexFunc.apply(numBuckets, partition, bucketNumber) == taskID;
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitionerFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitionerFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.configuration.OptionsResolver;
+
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Factory for simple bucket index partitioners.
+ */
+public class BucketIndexPartitionerFactory {
+
+  private BucketIndexPartitionerFactory() {
+  }
+
+  public static Partitioner<HoodieKey> create(Configuration conf) {
+    return create(conf, OptionsResolver.getIndexKeyField(conf));
+  }
+
+  public static Partitioner<HoodieKey> create(Configuration conf, String indexKeyFields) {
+    return OptionsResolver.shouldUseBucketRemotePartitioner(conf)
+        ? new BucketIndexRemotePartitioner<>(conf, indexKeyFields)
+        : new BucketIndexPartitioner<>(conf, indexKeyFields);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
@@ -33,7 +33,7 @@ import org.apache.flink.configuration.Configuration;
 /**
  * Bucket index input partitioner backed by the embedded timeline service.
  *
- * @param <T> The type of object to hash
+ * @param <T> The Hoodie key type used for bucket partitioning
  */
 public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partitioner<T> {
 
@@ -50,12 +50,17 @@ public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partit
         conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
   }
 
+  BucketIndexRemotePartitioner(Configuration conf, String indexKeyFields, RemotePartitionHelper remotePartitionHelper) {
+    this(conf, indexKeyFields);
+    this.remotePartitionHelper = remotePartitionHelper;
+  }
+
   @Override
   public int partition(T key, int numPartitions) {
     String partitionPath = normalizePartitionPath(key.getPartitionPath());
     int numBuckets = numBucketsFunction.getNumBuckets(partitionPath);
     int curBucket = BucketIdentifier.getBucketId(key.getRecordKey(), indexKeyFields, numBuckets);
-    return getRemotePartition(getRemotePartitionHelper(), numBuckets, partitionPath, curBucket, numPartitions);
+    return doGetRemotePartition(getRemotePartitionHelper(), numBuckets, partitionPath, curBucket, numPartitions);
   }
 
   public static int getRemotePartition(
@@ -66,10 +71,10 @@ public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partit
       int numPartitions) {
     String normalizedPartitionPath = normalizePartitionPath(partitionPath);
     int numBuckets = numBucketsFunction.getNumBuckets(normalizedPartitionPath);
-    return getRemotePartition(remotePartitionHelper, numBuckets, normalizedPartitionPath, curBucket, numPartitions);
+    return doGetRemotePartition(remotePartitionHelper, numBuckets, normalizedPartitionPath, curBucket, numPartitions);
   }
 
-  private static int getRemotePartition(
+  private static int doGetRemotePartition(
       RemotePartitionHelper remotePartitionHelper,
       int numBuckets,
       String partitionPath,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.util.RemotePartitionHelper;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.hudi.util.ViewStorageProperties;
@@ -54,7 +55,7 @@ public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partit
     String partitionPath = normalizePartitionPath(key.getPartitionPath());
     int numBuckets = numBucketsFunction.getNumBuckets(partitionPath);
     int curBucket = BucketIdentifier.getBucketId(key.getRecordKey(), indexKeyFields, numBuckets);
-    return getRemotePartition(getRemotePartitionHelper(), numBucketsFunction, partitionPath, curBucket, numPartitions);
+    return getRemotePartition(getRemotePartitionHelper(), numBuckets, partitionPath, curBucket, numPartitions);
   }
 
   public static int getRemotePartition(
@@ -64,20 +65,31 @@ public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partit
       int curBucket,
       int numPartitions) {
     String normalizedPartitionPath = normalizePartitionPath(partitionPath);
+    int numBuckets = numBucketsFunction.getNumBuckets(normalizedPartitionPath);
+    return getRemotePartition(remotePartitionHelper, numBuckets, normalizedPartitionPath, curBucket, numPartitions);
+  }
+
+  private static int getRemotePartition(
+      RemotePartitionHelper remotePartitionHelper,
+      int numBuckets,
+      String partitionPath,
+      int curBucket,
+      int numPartitions) {
+    int partition;
     try {
-      int partition = remotePartitionHelper.getPartition(
-          numBucketsFunction.getNumBuckets(normalizedPartitionPath),
-          normalizedPartitionPath,
+      partition = remotePartitionHelper.getPartition(
+          numBuckets,
+          partitionPath,
           curBucket,
           numPartitions);
-      if (partition < 0) {
-        throw new RuntimeException(
-            "Get remote partition succeeded, but the subtask id is negative: " + partition);
-      }
-      return partition;
     } catch (Exception e) {
-      throw new RuntimeException("Get remote partition failed.", e);
+      throw new HoodieException("Get remote partition failed.", e);
     }
+    if (partition < 0) {
+      throw new HoodieException(
+          "Get remote partition succeeded, but the subtask id is negative: " + partition);
+    }
+    return partition;
   }
 
   private static String normalizePartitionPath(String partitionPath) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
+import org.apache.hudi.common.util.RemotePartitionHelper;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.index.bucket.BucketIdentifier;
+import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
+import org.apache.hudi.util.ViewStorageProperties;
+
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Bucket index input partitioner backed by the embedded timeline service.
+ *
+ * @param <T> The type of object to hash
+ */
+public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partitioner<T> {
+
+  private final Configuration conf;
+  private final String indexKeyFields;
+  private final NumBucketsFunction numBucketsFunction;
+
+  private transient RemotePartitionHelper remotePartitionHelper;
+
+  public BucketIndexRemotePartitioner(Configuration conf, String indexKeyFields) {
+    this.conf = conf;
+    this.indexKeyFields = indexKeyFields;
+    this.numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
+        conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
+  }
+
+  @Override
+  public int partition(T key, int numPartitions) {
+    String partitionPath = normalizePartitionPath(key.getPartitionPath());
+    int numBuckets = numBucketsFunction.getNumBuckets(partitionPath);
+    int curBucket = BucketIdentifier.getBucketId(key.getRecordKey(), indexKeyFields, numBuckets);
+    return getRemotePartition(getRemotePartitionHelper(), numBucketsFunction, partitionPath, curBucket, numPartitions);
+  }
+
+  public static int getRemotePartition(
+      RemotePartitionHelper remotePartitionHelper,
+      NumBucketsFunction numBucketsFunction,
+      String partitionPath,
+      int curBucket,
+      int partitionNum) {
+    String normalizedPartitionPath = normalizePartitionPath(partitionPath);
+    try {
+      int partition = remotePartitionHelper.getPartition(
+          numBucketsFunction.getNumBuckets(normalizedPartitionPath),
+          normalizedPartitionPath,
+          curBucket,
+          partitionNum);
+      if (partition < 0) {
+        throw new RuntimeException(
+            "Get remote partition succeeded, but the subtask id is negative: " + partition);
+      }
+      return partition;
+    } catch (Exception e) {
+      throw new RuntimeException("Get remote partition failed.", e);
+    }
+  }
+
+  private static String normalizePartitionPath(String partitionPath) {
+    return partitionPath == null ? "" : partitionPath;
+  }
+
+  private RemotePartitionHelper getRemotePartitionHelper() {
+    if (remotePartitionHelper == null) {
+      FileSystemViewStorageConfig viewStorageConfig =
+          ViewStorageProperties.loadFromProperties(conf.get(FlinkOptions.PATH), conf);
+      remotePartitionHelper = new RemotePartitionHelper(viewStorageConfig);
+    }
+    return remotePartitionHelper;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
@@ -62,14 +62,14 @@ public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partit
       NumBucketsFunction numBucketsFunction,
       String partitionPath,
       int curBucket,
-      int partitionNum) {
+      int numPartitions) {
     String normalizedPartitionPath = normalizePartitionPath(partitionPath);
     try {
       int partition = remotePartitionHelper.getPartition(
           numBucketsFunction.getNumBuckets(normalizedPartitionPath),
           normalizedPartitionPath,
           curBucket,
-          partitionNum);
+          numPartitions);
       if (partition < 0) {
         throw new RuntimeException(
             "Get remote partition succeeded, but the subtask id is negative: " + partition);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -142,7 +142,7 @@ public class Pipelines {
       }
       String indexKeys = OptionsResolver.getIndexKeyField(conf);
       Partitioner<HoodieKey> partitioner =
-          OptionsResolver.enableBucketRemotePartitioner(conf)
+          OptionsResolver.shouldUseBucketRemotePartitioner(conf)
               ? new BucketIndexRemotePartitioner<>(conf, indexKeys)
               : new BucketIndexPartitioner<>(conf, indexKeys);
       RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
@@ -378,7 +378,7 @@ public class Pipelines {
           // [HUDI-9036] BucketIndexPartitioner is also used in bulk insert mode,
           // keep use of HoodieKey here in partitionCustom for now
           Partitioner<HoodieKey> partitioner =
-              OptionsResolver.enableBucketRemotePartitioner(conf)
+              OptionsResolver.shouldUseBucketRemotePartitioner(conf)
                   ? new BucketIndexRemotePartitioner<>(conf, indexKeyFields)
                   : new BucketIndexPartitioner<>(conf, indexKeyFields);
           SingleOutputStreamOperator<RowData> bucketWriteStream = dataStream

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -55,8 +55,7 @@ import org.apache.hudi.sink.compact.CompactionCommitSink;
 import org.apache.hudi.sink.compact.CompactionPlanEvent;
 import org.apache.hudi.sink.compact.CompactionPlanOperator;
 import org.apache.hudi.sink.partitioner.BucketAssignFunction;
-import org.apache.hudi.sink.partitioner.BucketIndexPartitioner;
-import org.apache.hudi.sink.partitioner.BucketIndexRemotePartitioner;
+import org.apache.hudi.sink.partitioner.BucketIndexPartitionerFactory;
 import org.apache.hudi.sink.partitioner.DynamicBucketAssignFunction;
 import org.apache.hudi.sink.partitioner.DynamicBucketAssignOperator;
 import org.apache.hudi.sink.partitioner.GlobalRecordIndexPartitioner;
@@ -141,10 +140,7 @@ public class Pipelines {
             "Consistent hashing bucket index does not work with bulk insert using FLINK engine. Use simple bucket index or Spark engine.");
       }
       String indexKeys = OptionsResolver.getIndexKeyField(conf);
-      Partitioner<HoodieKey> partitioner =
-          OptionsResolver.shouldUseBucketRemotePartitioner(conf)
-              ? new BucketIndexRemotePartitioner<>(conf, indexKeys)
-              : new BucketIndexPartitioner<>(conf, indexKeys);
+      Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf, indexKeys);
       RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
       RowType rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
       InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(rowTypeWithFileId);
@@ -374,13 +370,9 @@ public class Pipelines {
       HoodieIndex.BucketIndexEngineType bucketIndexEngineType = OptionsResolver.getBucketEngineType(conf);
       switch (bucketIndexEngineType) {
         case SIMPLE:
-          String indexKeyFields = OptionsResolver.getIndexKeyField(conf);
           // [HUDI-9036] BucketIndexPartitioner is also used in bulk insert mode,
           // keep use of HoodieKey here in partitionCustom for now
-          Partitioner<HoodieKey> partitioner =
-              OptionsResolver.shouldUseBucketRemotePartitioner(conf)
-                  ? new BucketIndexRemotePartitioner<>(conf, indexKeyFields)
-                  : new BucketIndexPartitioner<>(conf, indexKeyFields);
+          Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf);
           SingleOutputStreamOperator<RowData> bucketWriteStream = dataStream
               .partitionCustom(
                   partitioner,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -56,6 +56,7 @@ import org.apache.hudi.sink.compact.CompactionPlanEvent;
 import org.apache.hudi.sink.compact.CompactionPlanOperator;
 import org.apache.hudi.sink.partitioner.BucketAssignFunction;
 import org.apache.hudi.sink.partitioner.BucketIndexPartitioner;
+import org.apache.hudi.sink.partitioner.BucketIndexRemotePartitioner;
 import org.apache.hudi.sink.partitioner.DynamicBucketAssignFunction;
 import org.apache.hudi.sink.partitioner.DynamicBucketAssignOperator;
 import org.apache.hudi.sink.partitioner.GlobalRecordIndexPartitioner;
@@ -140,7 +141,10 @@ public class Pipelines {
             "Consistent hashing bucket index does not work with bulk insert using FLINK engine. Use simple bucket index or Spark engine.");
       }
       String indexKeys = OptionsResolver.getIndexKeyField(conf);
-      BucketIndexPartitioner<HoodieKey> partitioner = new BucketIndexPartitioner<>(conf, indexKeys);
+      Partitioner<HoodieKey> partitioner =
+          OptionsResolver.enableBucketRemotePartitioner(conf)
+              ? new BucketIndexRemotePartitioner<>(conf, indexKeys)
+              : new BucketIndexPartitioner<>(conf, indexKeys);
       RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
       RowType rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
       InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(rowTypeWithFileId);
@@ -373,7 +377,10 @@ public class Pipelines {
           String indexKeyFields = OptionsResolver.getIndexKeyField(conf);
           // [HUDI-9036] BucketIndexPartitioner is also used in bulk insert mode,
           // keep use of HoodieKey here in partitionCustom for now
-          BucketIndexPartitioner<HoodieKey> partitioner = new BucketIndexPartitioner<>(conf, indexKeyFields);
+          Partitioner<HoodieKey> partitioner =
+              OptionsResolver.enableBucketRemotePartitioner(conf)
+                  ? new BucketIndexRemotePartitioner<>(conf, indexKeyFields)
+                  : new BucketIndexPartitioner<>(conf, indexKeyFields);
           SingleOutputStreamOperator<RowData> bucketWriteStream = dataStream
               .partitionCustom(
                   partitioner,

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
@@ -242,10 +242,10 @@ public class FlinkWriteClients {
                 .build())
             .withIndexConfig(StreamerUtil.getIndexConfig(conf))
             .withPayloadConfig(getPayloadConfig(conf))
-            .withProps(flinkConf2TypedProperties(conf))
-            .withEmbeddedTimelineServerEnabled(enableEmbeddedTimelineService)
             .withEmbeddedTimelineServerReuseEnabled(true) // make write client embedded timeline service singleton
             .withAllowOperationMetadataField(conf.get(FlinkOptions.CHANGELOG_ENABLED))
+            .withProps(flinkConf2TypedProperties(conf))
+            .withEmbeddedTimelineServerEnabled(enableEmbeddedTimelineService)
             .withSchema(getSourceSchema(conf).toString())
             .withWriteIgnoreFailed(conf.get(FlinkOptions.IGNORE_FAILED));
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
@@ -242,10 +242,10 @@ public class FlinkWriteClients {
                 .build())
             .withIndexConfig(StreamerUtil.getIndexConfig(conf))
             .withPayloadConfig(getPayloadConfig(conf))
+            .withProps(flinkConf2TypedProperties(conf))
             .withEmbeddedTimelineServerEnabled(enableEmbeddedTimelineService)
             .withEmbeddedTimelineServerReuseEnabled(true) // make write client embedded timeline service singleton
             .withAllowOperationMetadataField(conf.get(FlinkOptions.CHANGELOG_ENABLED))
-            .withProps(flinkConf2TypedProperties(conf))
             .withSchema(getSourceSchema(conf).toString())
             .withWriteIgnoreFailed(conf.get(FlinkOptions.IGNORE_FAILED));
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/FlinkWriteClients.java
@@ -245,6 +245,8 @@ public class FlinkWriteClients {
             .withEmbeddedTimelineServerReuseEnabled(true) // make write client embedded timeline service singleton
             .withAllowOperationMetadataField(conf.get(FlinkOptions.CHANGELOG_ENABLED))
             .withProps(flinkConf2TypedProperties(conf))
+            // Keep timeline service enablement controlled by the caller:
+            // coordinator-side clients enable it, while task-side clients disable it.
             .withEmbeddedTimelineServerEnabled(enableEmbeddedTimelineService)
             .withSchema(getSourceSchema(conf).toString())
             .withWriteIgnoreFailed(conf.get(FlinkOptions.IGNORE_FAILED));

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
@@ -218,6 +218,7 @@ public class StreamerUtil {
         .withRecordKeyField(conf.get(FlinkOptions.RECORD_KEY_FIELD))
         .withIndexKeyField(OptionsResolver.getIndexKeyField(conf))
         .withBucketIndexEngineType(OptionsResolver.getBucketEngineType(conf))
+        .enableBucketRemotePartitioner(OptionsResolver.isBucketRemotePartitionerEnabled(conf))
         .withEngineType(EngineType.FLINK)
         .build();
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
@@ -100,6 +100,30 @@ public class TestOptionsResolver {
   }
 
   @Test
+  void testEnableBucketRemotePartitioner() {
+    Configuration conf = getConf();
+    assertFalse(conf.get(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE));
+    assertFalse(OptionsResolver.isBucketRemotePartitionerEnabled(conf));
+    assertFalse(OptionsResolver.enableBucketRemotePartitioner(conf));
+
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.SIMPLE.name());
+    assertFalse(OptionsResolver.isBucketRemotePartitionerEnabled(conf));
+    assertFalse(OptionsResolver.enableBucketRemotePartitioner(conf));
+
+    conf.set(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE, true);
+    assertTrue(OptionsResolver.isBucketRemotePartitionerEnabled(conf));
+    assertTrue(OptionsResolver.enableBucketRemotePartitioner(conf));
+
+    conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "false");
+    assertFalse(OptionsResolver.enableBucketRemotePartitioner(conf));
+
+    conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "true");
+    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING.name());
+    assertFalse(OptionsResolver.enableBucketRemotePartitioner(conf));
+  }
+
+  @Test
   void testIsLazyFailedWritesCleanPolicy() {
     Configuration conf = new Configuration();
     // add any parameter

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/configuration/TestOptionsResolver.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.config.HoodieCleanConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
 
@@ -102,25 +103,23 @@ public class TestOptionsResolver {
   @Test
   void testEnableBucketRemotePartitioner() {
     Configuration conf = getConf();
-    assertFalse(conf.get(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE));
     assertFalse(OptionsResolver.isBucketRemotePartitionerEnabled(conf));
-    assertFalse(OptionsResolver.enableBucketRemotePartitioner(conf));
+    assertFalse(OptionsResolver.shouldUseBucketRemotePartitioner(conf));
 
     conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
     conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.SIMPLE.name());
     assertFalse(OptionsResolver.isBucketRemotePartitionerEnabled(conf));
-    assertFalse(OptionsResolver.enableBucketRemotePartitioner(conf));
+    assertFalse(OptionsResolver.shouldUseBucketRemotePartitioner(conf));
 
-    conf.set(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE, true);
+    conf.setString(HoodieIndexConfig.BUCKET_PARTITIONER.key(), "true");
     assertTrue(OptionsResolver.isBucketRemotePartitionerEnabled(conf));
-    assertTrue(OptionsResolver.enableBucketRemotePartitioner(conf));
+    assertTrue(OptionsResolver.shouldUseBucketRemotePartitioner(conf));
 
     conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "false");
-    assertFalse(OptionsResolver.enableBucketRemotePartitioner(conf));
+    assertTrue(OptionsResolver.shouldUseBucketRemotePartitioner(conf));
 
-    conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "true");
     conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.CONSISTENT_HASHING.name());
-    assertFalse(OptionsResolver.enableBucketRemotePartitioner(conf));
+    assertFalse(OptionsResolver.shouldUseBucketRemotePartitioner(conf));
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieIOException;
@@ -133,8 +134,8 @@ public class ITTestBucketStreamWrite {
     options.put(FlinkOptions.TABLE_TYPE.key(), FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
     options.put(FlinkOptions.INDEX_TYPE.key(), IndexType.BUCKET.name());
     options.put(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), "4");
-    options.put(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE.key(), "true");
-    options.put(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "true");
+    options.put(HoodieIndexConfig.BUCKET_PARTITIONER.key(), "true");
+    options.put(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "false");
     options.put(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_REUSE_ENABLED.key(), "false");
 
     String hoodieTableDDL = TestConfigurations.getCreateHoodieTableDDL("t1", options);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/bucket/ITTestBucketStreamWrite.java
@@ -25,7 +25,10 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.FileCreateUtilsLegacy;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieIndex.IndexType;
 import org.apache.hudi.storage.HoodieStorage;
@@ -35,10 +38,15 @@ import org.apache.hudi.utils.TestConfigurations;
 import org.apache.hudi.utils.TestData;
 import org.apache.hudi.utils.TestSQL;
 
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,6 +56,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +67,7 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Integration test cases for {@link BucketStreamWriteFunction}.
@@ -110,6 +120,66 @@ public class ITTestBucketStreamWrite {
       TestData.checkWrittenDataCOW(tempFile, EXPECTED_AS_LIST);
     } else {
       TestData.checkWrittenDataMOR(tempFile, EXPECTED, 4);
+    }
+  }
+
+  @Test
+  public void testRemotePartitioner() throws Exception {
+    String tablePath = tempFile.getAbsolutePath();
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment().setParallelism(4);
+    TableEnvironment tableEnv = StreamTableEnvironment.create(env);
+    Map<String, String> options = new HashMap<>();
+    options.put(FlinkOptions.PATH.key(), tablePath);
+    options.put(FlinkOptions.TABLE_TYPE.key(), FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
+    options.put(FlinkOptions.INDEX_TYPE.key(), IndexType.BUCKET.name());
+    options.put(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.key(), "4");
+    options.put(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE.key(), "true");
+    options.put(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "true");
+    options.put(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_REUSE_ENABLED.key(), "false");
+
+    String hoodieTableDDL = TestConfigurations.getCreateHoodieTableDDL("t1", options);
+    tableEnv.executeSql(hoodieTableDDL);
+    tableEnv.executeSql(TestSQL.INSERT_T1).await();
+    TimeUnit.SECONDS.sleep(3);
+
+    tableEnv.executeSql(TestSQL.INSERT_T1).await();
+    TimeUnit.SECONDS.sleep(3);
+
+    tableEnv.executeSql(TestSQL.INSERT_T1).await();
+    TimeUnit.SECONDS.sleep(3);
+
+    HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(tablePath);
+    HoodieTimeline commitsTimeline = metaClient.getActiveTimeline().getCommitsTimeline();
+    List<Pair<HoodieInstant, HoodieCommitMetadata>> instantAndMetadatas = commitsTimeline.filterCompletedInstants()
+        .getInstants().stream()
+        .sorted(Comparator.comparing(HoodieInstant::requestedTime).reversed())
+        .map(instant -> {
+          try {
+            HoodieCommitMetadata commitMetadata = commitsTimeline.readCommitMetadata(instant);
+            return Pair.of(instant, commitMetadata);
+          } catch (IOException e) {
+            throw new HoodieIOException(String.format("Failed to fetch HoodieCommitMetadata for instant (%s)", instant), e);
+          }
+        }).collect(Collectors.toList());
+    assertEquals(3, instantAndMetadatas.size());
+
+    HashMap<String, String> latestFileIdAndRelativePaths = instantAndMetadatas.get(0).getRight().getFileIdAndRelativePaths();
+    for (Pair<HoodieInstant, HoodieCommitMetadata> instantAndMetadata : instantAndMetadatas.subList(1, instantAndMetadatas.size())) {
+      HashMap<String, String> fileIdAndRelativePaths = instantAndMetadata.getRight().getFileIdAndRelativePaths();
+      for (String fileId : fileIdAndRelativePaths.keySet()) {
+        if (!latestFileIdAndRelativePaths.containsKey(fileId)) {
+          fail("FileID should exist and be the same.");
+        }
+      }
+    }
+
+    try (CloseableIterator<Row> rows = tableEnv.executeSql("select * from t1").collect()) {
+      int count = 0;
+      while (rows.hasNext()) {
+        rows.next();
+        count++;
+      }
+      assertEquals(8, count);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexPartitionerFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexPartitionerFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.index.HoodieIndex;
+
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Test cases for {@link BucketIndexPartitionerFactory}.
+ */
+class TestBucketIndexPartitionerFactory {
+
+  @Test
+  void testCreateLocalBucketIndexPartitioner() {
+    Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(getSimpleBucketConf(), "id");
+
+    assertInstanceOf(BucketIndexPartitioner.class, partitioner);
+  }
+
+  @Test
+  void testCreateRemoteBucketIndexPartitioner() {
+    Configuration conf = getSimpleBucketConf();
+    conf.setString(HoodieIndexConfig.BUCKET_PARTITIONER.key(), "true");
+
+    Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf, "id");
+
+    assertInstanceOf(BucketIndexRemotePartitioner.class, partitioner);
+  }
+
+  private static Configuration getSimpleBucketConf() {
+    Configuration conf = new Configuration();
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.SIMPLE.name());
+    return conf;
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexRemotePartitioner.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.partitioner;
+
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.RemotePartitionHelper;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.index.bucket.BucketIdentifier;
+import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
+
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link BucketIndexRemotePartitioner}.
+ */
+class TestBucketIndexRemotePartitioner {
+
+  @Test
+  void testGetRemotePartitionDelegatesWithNormalizedPartitionPath() throws Exception {
+    RemotePartitionHelper remotePartitionHelper = mock(RemotePartitionHelper.class);
+    NumBucketsFunction numBucketsFunction = new NumBucketsFunction(8);
+
+    when(remotePartitionHelper.getPartition(8, "", 2, 10)).thenReturn(5);
+
+    int partition = BucketIndexRemotePartitioner.getRemotePartition(
+        remotePartitionHelper, numBucketsFunction, null, 2, 10);
+
+    assertEquals(5, partition);
+    verify(remotePartitionHelper).getPartition(8, "", 2, 10);
+  }
+
+  @Test
+  void testGetRemotePartitionWrapsRemoteFailure() throws Exception {
+    RemotePartitionHelper remotePartitionHelper = mock(RemotePartitionHelper.class);
+    NumBucketsFunction numBucketsFunction = new NumBucketsFunction(4);
+
+    when(remotePartitionHelper.getPartition(4, "par1", 1, 6)).thenThrow(new Exception("remote unavailable"));
+
+    RuntimeException error = assertThrows(RuntimeException.class, () ->
+        BucketIndexRemotePartitioner.getRemotePartition(remotePartitionHelper, numBucketsFunction, "par1", 1, 6));
+
+    assertEquals("Get remote partition failed.", error.getMessage());
+    assertEquals("remote unavailable", error.getCause().getMessage());
+  }
+
+  @Test
+  void testGetRemotePartitionRejectsNegativePartition() throws Exception {
+    RemotePartitionHelper remotePartitionHelper = mock(RemotePartitionHelper.class);
+    NumBucketsFunction numBucketsFunction = new NumBucketsFunction(4);
+
+    when(remotePartitionHelper.getPartition(4, "par1", 1, 6)).thenReturn(-1);
+
+    RuntimeException error = assertThrows(RuntimeException.class, () ->
+        BucketIndexRemotePartitioner.getRemotePartition(remotePartitionHelper, numBucketsFunction, "par1", 1, 6));
+
+    assertEquals("Get remote partition failed.", error.getMessage());
+    assertTrue(error.getCause().getMessage().contains("negative"));
+  }
+
+  @Test
+  void testPartitionUsesRemotePartition() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS, 8);
+    RemotePartitionHelper remotePartitionHelper = mock(RemotePartitionHelper.class);
+    HoodieKey key = new HoodieKey("id1", "par1");
+    int currentBucket = BucketIdentifier.getBucketId(key.getRecordKey(), "id", 8);
+
+    when(remotePartitionHelper.getPartition(8, "par1", currentBucket, 16)).thenReturn(11);
+
+    BucketIndexRemotePartitioner<HoodieKey> partitioner = new BucketIndexRemotePartitioner<>(conf, "id");
+    setRemotePartitionHelper(partitioner, remotePartitionHelper);
+
+    assertEquals(11, partitioner.partition(key, 16));
+  }
+
+  private void setRemotePartitionHelper(
+      BucketIndexRemotePartitioner<HoodieKey> partitioner,
+      RemotePartitionHelper remotePartitionHelper) throws Exception {
+    Field field = BucketIndexRemotePartitioner.class.getDeclaredField("remotePartitionHelper");
+    field.setAccessible(true);
+    field.set(partitioner, remotePartitionHelper);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexRemotePartitioner.java
@@ -28,8 +28,6 @@ import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.flink.configuration.Configuration;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -92,17 +90,9 @@ class TestBucketIndexRemotePartitioner {
 
     when(remotePartitionHelper.getPartition(8, "", currentBucket, 16)).thenReturn(11);
 
-    BucketIndexRemotePartitioner<HoodieKey> partitioner = new BucketIndexRemotePartitioner<>(conf, "id");
-    setRemotePartitionHelper(partitioner, remotePartitionHelper);
+    BucketIndexRemotePartitioner<HoodieKey> partitioner =
+        new BucketIndexRemotePartitioner<>(conf, "id", remotePartitionHelper);
 
     assertEquals(11, partitioner.partition(key, 16));
-  }
-
-  private void setRemotePartitionHelper(
-      BucketIndexRemotePartitioner<HoodieKey> partitioner,
-      RemotePartitionHelper remotePartitionHelper) throws Exception {
-    Field field = BucketIndexRemotePartitioner.class.getDeclaredField("remotePartitionHelper");
-    field.setAccessible(true);
-    field.set(partitioner, remotePartitionHelper);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexRemotePartitioner.java
@@ -21,6 +21,7 @@ package org.apache.hudi.sink.partitioner;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.util.RemotePartitionHelper;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 
@@ -31,7 +32,6 @@ import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,7 +62,7 @@ class TestBucketIndexRemotePartitioner {
 
     when(remotePartitionHelper.getPartition(4, "par1", 1, 6)).thenThrow(new Exception("remote unavailable"));
 
-    RuntimeException error = assertThrows(RuntimeException.class, () ->
+    HoodieException error = assertThrows(HoodieException.class, () ->
         BucketIndexRemotePartitioner.getRemotePartition(remotePartitionHelper, numBucketsFunction, "par1", 1, 6));
 
     assertEquals("Get remote partition failed.", error.getMessage());
@@ -76,11 +76,10 @@ class TestBucketIndexRemotePartitioner {
 
     when(remotePartitionHelper.getPartition(4, "par1", 1, 6)).thenReturn(-1);
 
-    RuntimeException error = assertThrows(RuntimeException.class, () ->
+    HoodieException error = assertThrows(HoodieException.class, () ->
         BucketIndexRemotePartitioner.getRemotePartition(remotePartitionHelper, numBucketsFunction, "par1", 1, 6));
 
-    assertEquals("Get remote partition failed.", error.getMessage());
-    assertTrue(error.getCause().getMessage().contains("negative"));
+    assertEquals("Get remote partition succeeded, but the subtask id is negative: -1", error.getMessage());
   }
 
   @Test
@@ -88,10 +87,10 @@ class TestBucketIndexRemotePartitioner {
     Configuration conf = new Configuration();
     conf.set(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS, 8);
     RemotePartitionHelper remotePartitionHelper = mock(RemotePartitionHelper.class);
-    HoodieKey key = new HoodieKey("id1", "par1");
+    HoodieKey key = new HoodieKey("id1", null);
     int currentBucket = BucketIdentifier.getBucketId(key.getRecordKey(), "id", 8);
 
-    when(remotePartitionHelper.getPartition(8, "par1", currentBucket, 16)).thenReturn(11);
+    when(remotePartitionHelper.getPartition(8, "", currentBucket, 16)).thenReturn(11);
 
     BucketIndexRemotePartitioner<HoodieKey> partitioner = new BucketIndexRemotePartitioner<>(conf, "id");
     setRemotePartitionHelper(partitioner, remotePartitionHelper);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
@@ -37,7 +37,6 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.marker.MarkerType;
-import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.index.HoodieIndex;
@@ -114,20 +113,15 @@ public class TestFlinkWriteClients {
   }
 
   @Test
-  void testBucketRemotePartitionerConfig() {
-    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
-    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.SIMPLE.name());
-
+  void testUserConfiguredGlobalRecordIndexMinFileGroupCountIsNotOverridden() {
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX.name());
+    conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_MIN_FILE_GROUP_COUNT_PROP.key(), "12");
     HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
-    assertFalse(writeConfig.isUsingRemotePartitioner());
-
-    conf.setString(HoodieIndexConfig.BUCKET_PARTITIONER.key(), "true");
-    writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
-    assertTrue(writeConfig.isUsingRemotePartitioner());
+    assertEquals(12, writeConfig.getGlobalRecordLevelIndexMinFileGroupCount());
   }
 
   @Test
-  void testEmbeddedTimelineServerConfigUsesCallSiteFlag() {
+  void testHoodieClientConfigPrecedence() {
     conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "false");
     HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, true, false);
     assertTrue(writeConfig.isEmbeddedTimelineServerEnabled());
@@ -135,14 +129,15 @@ public class TestFlinkWriteClients {
     conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "true");
     writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
     assertFalse(writeConfig.isEmbeddedTimelineServerEnabled());
-  }
 
-  @Test
-  void testUserConfiguredGlobalRecordIndexMinFileGroupCountIsNotOverridden() {
-    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX.name());
-    conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_MIN_FILE_GROUP_COUNT_PROP.key(), "12");
-    HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
-    assertEquals(12, writeConfig.getGlobalRecordLevelIndexMinFileGroupCount());
+    conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_REUSE_ENABLED.key(), "false");
+    writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
+    assertFalse(writeConfig.isEmbeddedTimelineServerReuseEnabled());
+
+    conf.set(FlinkOptions.CHANGELOG_ENABLED, true);
+    conf.setString(HoodieWriteConfig.ALLOW_OPERATION_METADATA_FIELD.key(), "false");
+    writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
+    assertFalse(writeConfig.allowOperationMetadataField());
   }
 
   @ParameterizedTest

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
@@ -37,6 +37,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.index.HoodieIndex;
@@ -120,9 +121,20 @@ public class TestFlinkWriteClients {
     HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
     assertFalse(writeConfig.isUsingRemotePartitioner());
 
-    conf.set(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE, true);
+    conf.setString(HoodieIndexConfig.BUCKET_PARTITIONER.key(), "true");
     writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
     assertTrue(writeConfig.isUsingRemotePartitioner());
+  }
+
+  @Test
+  void testEmbeddedTimelineServerConfigUsesCallSiteFlag() {
+    conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "false");
+    HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, true, false);
+    assertTrue(writeConfig.isEmbeddedTimelineServerEnabled());
+
+    conf.setString(HoodieWriteConfig.EMBEDDED_TIMELINE_SERVER_ENABLE.key(), "true");
+    writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
+    assertFalse(writeConfig.isEmbeddedTimelineServerEnabled());
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
@@ -113,6 +113,19 @@ public class TestFlinkWriteClients {
   }
 
   @Test
+  void testBucketRemotePartitionerConfig() {
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.SIMPLE.name());
+
+    HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
+    assertFalse(writeConfig.isUsingRemotePartitioner());
+
+    conf.set(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE, true);
+    writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
+    assertTrue(writeConfig.isUsingRemotePartitioner());
+  }
+
+  @Test
   void testUserConfiguredGlobalRecordIndexMinFileGroupCountIsNotOverridden() {
     conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.GLOBAL_RECORD_LEVEL_INDEX.name());
     conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_MIN_FILE_GROUP_COUNT_PROP.key(), "12");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
@@ -28,9 +28,11 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.collection.Triple;
+import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.io.util.FileIOUtils;
 import org.apache.hudi.keygen.SimpleAvroKeyGenerator;
 import org.apache.hudi.util.StreamerUtil;
@@ -104,6 +106,18 @@ class TestStreamerUtil {
     assertEquals(RecordMergeMode.EVENT_TIME_ORDERING, mergeBehavior.getLeft());
     assertEquals(PartialUpdateAvroPayload.class.getName(), mergeBehavior.getMiddle());
     assertNull(mergeBehavior.getRight());
+  }
+
+  @Test
+  void testGetIndexConfigUsesFlinkBucketRemotePartitionerConfig() {
+    Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+    conf.set(FlinkOptions.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
+    conf.set(FlinkOptions.BUCKET_INDEX_ENGINE_TYPE, HoodieIndex.BucketIndexEngineType.SIMPLE.name());
+
+    assertFalse(StreamerUtil.getIndexConfig(conf).getBoolean(HoodieIndexConfig.BUCKET_PARTITIONER));
+
+    conf.set(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE, true);
+    assertTrue(StreamerUtil.getIndexConfig(conf).getBoolean(HoodieIndexConfig.BUCKET_PARTITIONER));
   }
 
   @Test
@@ -200,4 +214,3 @@ class TestStreamerUtil {
     }
   }
 }
-

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
@@ -116,7 +116,7 @@ class TestStreamerUtil {
 
     assertFalse(StreamerUtil.getIndexConfig(conf).getBoolean(HoodieIndexConfig.BUCKET_PARTITIONER));
 
-    conf.set(FlinkOptions.BUCKET_INDEX_REMOTE_PARTITIONER_ENABLE, true);
+    conf.setString(HoodieIndexConfig.BUCKET_PARTITIONER.key(), "true");
     assertTrue(StreamerUtil.getIndexConfig(conf).getBoolean(HoodieIndexConfig.BUCKET_PARTITIONER));
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  This PR wires Flink simple bucket index writes to the existing timeline-service-backed remote partitioner path.

  Today Flink simple bucket index routes records with local bucket-to-task mapping. When writer parallelism changes, bucket ownership can shift across subtasks, which can make the writer route records and load bucket file groups inconsistently. Hudi already has remote partition helper support in the timeline service and write config, but the Flink simple bucket index write pipeline does not use it.

  This PR enables Flink writers to use remote bucket partition assignment when `hoodie.bucket.index.remote.partitioner.enable=true`.

### Summary and Changelog

  This PR adds remote partitioner support for Flink simple bucket index.

  Changes:
  - Add Flink option `hoodie.bucket.index.remote.partitioner.enable`, backed by the existing core bucket remote partitioner config key.
  - Add Flink option resolution logic to enable remote partitioning only for simple bucket index with embedded timeline server enabled.
  - Add `BucketIndexRemotePartitioner` for Flink `partitionCustom`, using `RemotePartitionHelper` and `NumBucketsFunction`.
  - Wire the remote partitioner into Flink bulk insert and streaming write bucket index pipelines.
  - Make `BucketStreamWriteFunction` use remote partition assignment when deciding whether a bucket belongs to the current writer subtask.
  - Propagate the Flink option into `HoodieWriteConfig`.
  - Include the remote partitioner flag in `EmbeddedTimelineService` reuse identity to avoid sharing a timeline service across incompatible writer
  configs.
  - Add unit tests and an integration test covering the enabled remote partitioner path.

  No code was copied from external sources.

### Impact

  This is a user-facing Flink write feature, disabled by default.

  When `hoodie.bucket.index.remote.partitioner.enable=true`, Flink simple bucket index writers use the timeline service to determine bucket-to-task assignment. This change centralizes bucket-to-task assignment through the timeline service by reusing the existing remote partitioner capability. This makes the routing side and bucket-loading side use the same remote assignment source, instead of maintaining separate local assignment calculations.

  Public API/config impact:
  - Adds Flink support for `hoodie.bucket.index.remote.partitioner.enable`.

  Storage format impact:
  - None.

  Performance impact:
  - Remote partitioning introduces timeline-service lookups during bucket routing. The option is disabled by default and only applies to simple bucket index when embedded timeline server is enabled.

### Risk Level

  medium

  This changes Flink bucket index routing behavior when the new option is enabled. The default behavior is unchanged because the option defaults to `false`.

  Risk mitigation:
  - The feature is gated to simple bucket index.
  - The feature requires embedded timeline server to be enabled.
  - Added unit tests for option resolution, write config propagation, remote partition calculation, and Flink write client config.
  - Added an integration test for Flink bucket stream writes with remote partitioner enabled.

  Verification:
  - `mvn -pl hudi-flink-datasource/hudi-flink -am -Dcheckstyle.skip=true -DskipITs -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
  -Dtest=TestOptionsResolver,TestStreamerUtil,TestFlinkWriteClients,TestBucketIndexRemotePartitioner test`
  - `mvn -pl hudi-flink-datasource/hudi-flink -am -Dcheckstyle.skip=true -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
  -Dtest=ITTestBucketStreamWrite#testRemotePartitioner test`

### Documentation Update

  Required.

  The Hudi website/config documentation should be updated to describe Flink support for:

  - `hoodie.bucket.index.remote.partitioner.enable`

  The documentation should mention that this option applies to Flink simple bucket index writes, requires embedded timeline server, and defaults to `false`.

### Contributor's checklist

  - [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable