### PR TITLE
fix(spark): align CTAS partition fields by table partition order

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -451,6 +451,7 @@ case class ResolveImplementationsEarly(spark: SparkSession) extends Rule[Logical
       val alreadyAligned = partitionColumns.zip(partitionAttrs).forall {
         case (partition, attr) => resolver(partition, attr.name)
       }
+      // Avoid adding a redundant Project when partition columns are already in the table-defined order.
       if (alreadyAligned) {
         query
       } else {

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -410,7 +410,8 @@ case class ResolveImplementationsEarly(spark: SparkSession) extends Rule[Logical
       // Convert to CreateHoodieTableAsSelectCommand
       case ct @ CreateTable(table, mode, Some(query))
         if sparkAdapter.isHoodieTable(table) && ct.query.forall(_.resolved) =>
-        val alignedQuery = stripMetaFieldAttributes(query)
+        val alignedQuery = alignCtasQueryByPartitionOrder(
+          stripMetaFieldAttributes(query), table.partitionColumnNames)
         CreateHoodieTableAsSelectCommand(table, mode, alignedQuery)
 
       case ct: CreateTable =>
@@ -430,6 +431,36 @@ case class ResolveImplementationsEarly(spark: SparkSession) extends Rule[Logical
         plan
 
       case _ => plan
+    }
+  }
+
+  private def alignCtasQueryByPartitionOrder(query: LogicalPlan, partitionColumns: Seq[String]): LogicalPlan = {
+    if (partitionColumns.isEmpty) {
+      query
+    } else {
+      val resolver = spark.sessionState.conf.resolver
+      val (dataAttrs, partitionAttrs) = query.output.partition { attr =>
+        !partitionColumns.exists(partition => resolver(partition, attr.name))
+      }
+
+      if (partitionAttrs.size != partitionColumns.size) {
+        throw new HoodieAnalysisException(s"Partition columns ${partitionColumns.mkString("[", ", ", "]")} " +
+          s"do not match query output ${query.output.map(_.name).mkString("[", ", ", "]")}")
+      }
+
+      val alreadyAligned = partitionColumns.zip(partitionAttrs).forall {
+        case (partition, attr) => resolver(partition, attr.name)
+      }
+      if (alreadyAligned) {
+        query
+      } else {
+        val orderedPartitionAttrs = partitionColumns.map { partition =>
+          partitionAttrs.find(attr => resolver(partition, attr.name)).getOrElse {
+            throw new HoodieAnalysisException(s"Cannot resolve partition column $partition in CTAS query output")
+          }
+        }
+        Project(dataAttrs ++ orderedPartitionAttrs, query)
+      }
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -416,6 +416,46 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
           Seq(1, "a1", 10, "2021-04-01")
         )
 
+        // Create table with multi-level partition
+        val tableNameMultiLevelPartition = generateTableName
+        spark.sql(
+          s"""
+             | create table $tableNameMultiLevelPartition using hudi
+             | partitioned by (year, month, day)
+             | tblproperties(
+             |    primaryKey = 'id',
+             |    type = '$tableType'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableNameMultiLevelPartition'
+             | AS
+             | select 1 as id, 'a1' as name, 10 as price, '2021' as year, '04' as month, '01' as day
+         """.stripMargin
+        )
+
+        checkAnswer(s"select id, name, price, year, month, day from $tableNameMultiLevelPartition")(
+          Seq(1, "a1", 10, "2021", "04", "01")
+        )
+
+        // Create table with multi-level partition and out-of-order partition columns
+        val tableNameMultiLevelPartitionDisorder = generateTableName
+        spark.sql(
+          s"""
+             | create table $tableNameMultiLevelPartitionDisorder using hudi
+             | partitioned by (year, month, day)
+             | tblproperties(
+             |    primaryKey = 'id',
+             |    type = '$tableType'
+             | )
+             | location '${tmp.getCanonicalPath}/$tableNameMultiLevelPartitionDisorder'
+             | AS
+             | select 1 as id, 'a1' as name, 10 as price, '04' as month, '01' as day, '2021' as year
+         """.stripMargin
+        )
+
+        checkAnswer(s"select id, name, price, year, month, day from $tableNameMultiLevelPartitionDisorder")(
+          Seq(1, "a1", 10, "2021", "04", "01")
+        )
+
         // Create Partitioned table with timestamp data type
         val tableName3 = generateTableName
         // CTAS failed with null primaryKey


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  Spark SQL CTAS for Hudi tables can write incorrect values for multi-level partition fields when the partition columns in the SELECT output are not ordered the same as the table partition spec.

  For example, a table created with:

  ```sql
  partitioned by (year, month, day)
  ```

  can receive a CTAS query whose output is:

  ```sql
  select ..., month, day, year
  ```

  The CTAS path currently forwards the resolved query output as-is, so the downstream write path may interpret partition field values by position instead of the declared table partition order.

  This PR fixes the issue inline.

### Summary and Changelog

  This change aligns CTAS query output with the Hudi table partition field order before creating `CreateHoodieTableAsSelectCommand`.

  Changes:
  - Reorder CTAS partition attributes according to `table.partitionColumnNames` in `ResolveImplementationsEarly`.
  - Preserve non-partition columns in their original query output order.
  - Use Spark's session resolver for partition field matching.
  - Avoid adding a projection when the CTAS output is already aligned.
  - Add Spark SQL DDL tests for multi-level partition CTAS with both ordered and out-of-order partition columns.

### Impact

  No public API, config, or storage format changes.

  This fixes Spark SQL CTAS behavior for Hudi partitioned tables. CTAS now correctly handles multi-level partition columns even when the SELECT list orders partition fields differently from the `PARTITIONED BY` clause.

### Risk Level

  low

  The change is scoped to Hudi Spark SQL CTAS analysis for resolved Hudi tables. Non-partitioned CTAS and already-aligned CTAS plans keep the existing behavior. Verification was added for both COW and MOR table types
  through the existing `TestCreateTable` CTAS coverage.

### Documentation Update

  none

  This is a bug fix with no new feature, config, or public API change.

### Contributor's checklist

  - [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable