### PR TITLE
feat: support Lance metadata stats

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/LanceUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/LanceUtils.java
@@ -24,6 +24,8 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
@@ -32,6 +34,7 @@ import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -40,12 +43,15 @@ import org.apache.avro.generic.GenericRecord;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 public class LanceUtils extends FileFormatUtils {
 
@@ -175,7 +181,42 @@ public class LanceUtils extends FileFormatUtils {
                                                                                   StoragePath filePath,
                                                                                   List<String> columnList,
                                                                                   HoodieIndexVersion indexVersion) {
-    throw new UnsupportedOperationException("readColumnStatsFromMetadata is not yet supported for Lance format");
+    if (columnList == null || columnList.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    try (HoodieFileReader fileReader =
+             HoodieIOFactory.getIOFactory(storage)
+                 .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+                 .getFileReader(
+                     ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER,
+                     filePath,
+                     HoodieFileFormat.LANCE)) {
+      HoodieSchema fileSchema = fileReader.getSchema();
+      List<Pair<String, HoodieSchemaField>> fieldsToIndex = columnList.stream()
+          .map(columnName -> HoodieSchemaUtils.getNestedField(fileSchema, columnName))
+          .filter(Option::isPresent)
+          .map(Option::get)
+          .collect(Collectors.toList());
+      if (fieldsToIndex.isEmpty()) {
+        return Collections.emptyList();
+      }
+
+      List<String> projectedColumns = fieldsToIndex.stream()
+          .map(Pair::getKey)
+          .collect(Collectors.toList());
+      HoodieSchema projectedSchema = HoodieSchemaUtils.projectSchema(fileSchema, projectedColumns);
+      try (ClosableIterator<HoodieRecord> recordIterator = fileReader.getRecordIterator(projectedSchema)) {
+        Map<String, HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataMap =
+            HoodieTableMetadataUtil.collectColumnRangeMetadata(
+                recordIterator, fieldsToIndex, filePath.getName(), projectedSchema, storage.getConf(), indexVersion);
+        return fieldsToIndex.stream()
+            .map(field -> columnRangeMetadataMap.get(field.getKey()))
+            .collect(Collectors.toCollection(ArrayList::new));
+      }
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read column stats from Lance file " + filePath, e);
+    }
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/LanceUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/LanceUtils.java
@@ -43,7 +43,6 @@ import org.apache.avro.generic.GenericRecord;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -212,7 +211,7 @@ public class LanceUtils extends FileFormatUtils {
                 recordIterator, fieldsToIndex, filePath.getName(), projectedSchema, storage.getConf(), indexVersion);
         return fieldsToIndex.stream()
             .map(field -> columnRangeMetadataMap.get(field.getKey()))
-            .collect(Collectors.toCollection(ArrayList::new));
+            .collect(Collectors.toList());
       }
     } catch (IOException e) {
       throw new HoodieIOException("Failed to read column stats from Lance file " + filePath, e);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1771,6 +1771,10 @@ public class HoodieTableMetadataUtil {
         return HoodieIOFactory.getIOFactory(datasetMetaClient.getStorage())
             .getFileFormatUtils(HoodieFileFormat.PARQUET)
             .readColumnStatsFromMetadata(datasetMetaClient.getStorage(), fullFilePath, columnsToIndex, indexVersion);
+      } else if (partitionPathFileName.endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
+        return HoodieIOFactory.getIOFactory(datasetMetaClient.getStorage())
+            .getFileFormatUtils(HoodieFileFormat.LANCE)
+            .readColumnStatsFromMetadata(datasetMetaClient.getStorage(), fullFilePath, columnsToIndex, indexVersion);
       } else if (FSUtils.isLogFile(fileName)) {
         Option<HoodieSchema> writerSchemaOpt = tryResolveSchemaForTable(datasetMetaClient);
         log.info("Reading log file: {}, to build column range metadata.", partitionPathFileName);

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -25,7 +25,6 @@ import org.apache.hudi.avro.model.HoodieRecordIndexInfo;
 import org.apache.hudi.avro.model.HoodieSecondaryIndexInfo;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.function.SerializableBiFunction;
-import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -109,11 +108,7 @@ public enum MetadataPartitionType {
   COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-", 3) {
     @Override
     public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
-      // Lance base files do not yet emit column-range metadata, so per-file column stats
-      // aggregate as empty entries and silently prune everything on read. Disable until
-      // HoodieTableMetadataUtil#readColumnRangeMetadataFrom has a LANCE branch.
-      return tableConfig.getBaseFileFormat() != HoodieFileFormat.LANCE
-          && metadataConfig.isColumnStatsIndexEnabled();
+      return metadataConfig.isColumnStatsIndexEnabled();
     }
 
     @Override
@@ -245,11 +240,7 @@ public enum MetadataPartitionType {
   PARTITION_STATS(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, "partition-stats-", 6) {
     @Override
     public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
-      // Partition stats aggregate per-file column ranges. Lance base files contribute none
-      // (see HoodieTableMetadataUtil#readColumnRangeMetadataFrom), so partition records end
-      // up with empty ranges and the partition stats index prunes everything on read.
-      return tableConfig.getBaseFileFormat() != HoodieFileFormat.LANCE
-          && tableConfig.isTablePartitioned() && metadataConfig.isPartitionStatsIndexEnabled();
+      return tableConfig.isTablePartitioned() && metadataConfig.isPartitionStatsIndexEnabled();
     }
 
     @Override

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -20,7 +20,6 @@
 package org.apache.hudi.metadata;
 
 import org.apache.hudi.common.config.HoodieMetadataConfig;
-import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -115,7 +114,6 @@ public class TestMetadataPartitionType {
   @Test
   public void testColumnAndPartitionStatsEnabledForLanceTables() {
     HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
-    Mockito.when(tableConfig.getBaseFileFormat()).thenReturn(HoodieFileFormat.LANCE);
     Mockito.when(tableConfig.isTablePartitioned()).thenReturn(true);
     HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
         .enable(true)

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.metadata;
 
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -109,6 +110,20 @@ public class TestMetadataPartitionType {
     // Verify partition type is enabled due to config
     assertEquals(expectedEnabledPartitions, enabledPartitions.size());
     assertTrue(enabledPartitions.contains(partitionType) || MetadataPartitionType.ALL_PARTITIONS.equals(partitionType));
+  }
+
+  @Test
+  public void testColumnAndPartitionStatsEnabledForLanceTables() {
+    HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
+    Mockito.when(tableConfig.getBaseFileFormat()).thenReturn(HoodieFileFormat.LANCE);
+    Mockito.when(tableConfig.isTablePartitioned()).thenReturn(true);
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+        .enable(true)
+        .withMetadataIndexColumnStats(true)
+        .build();
+
+    assertTrue(MetadataPartitionType.COLUMN_STATS.isMetadataPartitionEnabled(metadataConfig, tableConfig));
+    assertTrue(MetadataPartitionType.PARTITION_STATS.isMetadataPartitionEnabled(metadataConfig, tableConfig));
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceReader.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceReader.java
@@ -30,9 +30,12 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.LanceUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -64,7 +67,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.bloom.BloomFilterTypeCode.DYNAMIC_V0;
@@ -134,6 +140,33 @@ public class TestHoodieSparkLanceReader {
 
       assertTrue(actualRows.get(3).isNullAt(1), "Fourth row name should be null");
       assertTrue(actualRows.get(3).isNullAt(2), "Fourth row value should be null");
+    }
+  }
+
+  @Test
+  public void testReadColumnStatsFromMetadata() throws Exception {
+    StructType schema = new StructType()
+        .add("id", DataTypes.IntegerType, false)
+        .add("name", DataTypes.StringType, true)
+        .add("age", DataTypes.LongType, true);
+
+    List<InternalRow> rows = new ArrayList<>();
+    rows.add(createRow(1, "Alice", 30L));
+    rows.add(createRow(2, null, 25L));
+    rows.add(createRow(3, "Charlie", 35L));
+
+    StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_column_stats.lance");
+    try (HoodieSparkLanceReader ignored = writeAndCreateReader(path, schema, rows)) {
+      List<HoodieColumnRangeMetadata<Comparable>> stats = new LanceUtils()
+          .readColumnStatsFromMetadata(storage, path, Arrays.asList("id", "name", "age"), HoodieIndexVersion.V1);
+
+      Map<String, HoodieColumnRangeMetadata<Comparable>> statsByColumn = stats.stream()
+          .collect(Collectors.toMap(HoodieColumnRangeMetadata::getColumnName, Function.identity()));
+
+      assertEquals(3, statsByColumn.size());
+      assertColumnStats(statsByColumn.get("id"), 1, 3, 0, 3);
+      assertColumnStats(statsByColumn.get("name"), "Alice", "Charlie", 1, 3);
+      assertColumnStats(statsByColumn.get("age"), 25L, 35L, 0, 3);
     }
   }
 
@@ -593,6 +626,18 @@ public class TestHoodieSparkLanceReader {
       }
     }
     return new HoodieSparkLanceReader(path);
+  }
+
+  private void assertColumnStats(HoodieColumnRangeMetadata<Comparable> stats,
+                                 Comparable minValue,
+                                 Comparable maxValue,
+                                 long nullCount,
+                                 long valueCount) {
+    assertNotNull(stats);
+    assertEquals(minValue, stats.getMinValue());
+    assertEquals(maxValue, stats.getMaxValue());
+    assertEquals(nullCount, stats.getNullCount());
+    assertEquals(valueCount, stats.getValueCount());
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -1690,15 +1690,14 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     assertEquals(HoodieFileFormat.LANCE, baseFileFormat,
                  "Table should use Lance base file format")
 
-    // Column stats and partition stats indices are gated off for Lance base files in
-    // MetadataPartitionType — per-file column ranges aren't emitted for Lance yet, and
-    // empty ranges would silently prune everything on read. Confirm the metadata table
-    // never initialized these partitions.
+    // Column stats now read per-file ranges from Lance base files, so the metadata table
+    // should initialize column stats for Lance tables. Partition stats remain available
+    // only when the table itself is partitioned.
     val tableConfig = metaClient.getTableConfig
-    assertFalse(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.COLUMN_STATS),
-      "Column stats metadata partition must not be initialized for Lance tables")
-    assertFalse(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.PARTITION_STATS),
-      "Partition stats metadata partition must not be initialized for Lance tables")
+    assertTrue(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.COLUMN_STATS),
+      "Column stats metadata partition must be initialized for Lance tables")
+    assertEquals(isPartitioned, tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.PARTITION_STATS),
+      "Partition stats metadata partition availability should match table partitioning")
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18758.

### Summary and Changelog

Adds Lance support for metadata column statistics so Lance base files can contribute column ranges to the metadata table.

Changes:
- Implement `LanceUtils.readColumnStatsFromMetadata` by reading projected Lance columns and collecting `HoodieColumnRangeMetadata` with the existing metadata utility.
- Route `.lance` base files through the column-range metadata reader.
- Enable column stats and partition stats metadata partitions for Lance tables now that Lance column ranges can be produced.
- Add focused regression coverage for Lance column range metadata and Lance metadata partition enablement.

No code was copied.

### Impact

Lance base files can now populate metadata column stats. Partition stats can also be enabled for partitioned Lance tables because they aggregate per-file column stats. No public API, storage format, or config key changes are introduced.

### Risk Level

medium

This changes metadata-table behavior for Lance tables by enabling existing stats indexes for that file format. Verification covers the Lance stats reader path and the metadata partition enablement gate.

### Documentation Update

none

No new config is added; this enables existing column/partition stats behavior for Lance.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

Local verification:

- `mvn test -q -Punit-tests -pl hudi-spark-datasource/hudi-spark -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TestHoodieSparkLanceReader#testReadColumnStatsFromMetadata -DwildcardSuites=abc -Dspark3.5 -Dlance.skip.tests=false -Dmaven.repo.local=/private/tmp/hudi-18758-m2`
- `mvn test -q -Punit-tests -pl hudi-common -am -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TestMetadataPartitionType#testColumnAndPartitionStatsEnabledForLanceTables -DwildcardSuites=abc -Dmaven.repo.local=/private/tmp/hudi-18758-m2`
- `git diff --check`
