### PR TITLE
Support column stats for Lance base files

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/LanceUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/LanceUtils.java
@@ -24,6 +24,8 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
@@ -32,6 +34,7 @@ import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -40,12 +43,15 @@ import org.apache.avro.generic.GenericRecord;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 public class LanceUtils extends FileFormatUtils {
 
@@ -175,7 +181,30 @@ public class LanceUtils extends FileFormatUtils {
                                                                                   StoragePath filePath,
                                                                                   List<String> columnList,
                                                                                   HoodieIndexVersion indexVersion) {
-    throw new UnsupportedOperationException("readColumnStatsFromMetadata is not yet supported for Lance format");
+    try {
+      HoodieSchema fileSchema = readSchema(storage, filePath);
+      List<Pair<String, HoodieSchemaField>> fieldsToIndex = columnList.stream()
+          .map(columnName -> HoodieSchemaUtils.getNestedField(fileSchema, columnName))
+          .filter(Option::isPresent)
+          .map(Option::get)
+          .collect(Collectors.toList());
+      if (fieldsToIndex.isEmpty()) {
+        return Collections.emptyList();
+      }
+
+      HoodieSchema readSchema = HoodieSchemaUtils.projectSchema(
+          fileSchema, fieldsToIndex.stream().map(Pair::getKey).collect(Collectors.toList()));
+      try (HoodieFileReader fileReader = HoodieIOFactory.getIOFactory(storage)
+          .getReaderFactory(HoodieRecord.HoodieRecordType.SPARK)
+          .getFileReader(ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER, filePath, HoodieFileFormat.LANCE);
+           ClosableIterator<HoodieRecord> recordIterator = fileReader.getRecordIterator(readSchema)) {
+        Map<String, HoodieColumnRangeMetadata<Comparable>> columnRangeMetadata =
+            HoodieTableMetadataUtil.collectColumnRangeMetadata(recordIterator, fieldsToIndex, filePath.getName(), readSchema, storage.getConf(), indexVersion);
+        return new ArrayList<>(columnRangeMetadata.values());
+      }
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to read column stats from Lance file " + filePath, e);
+    }
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -1771,6 +1771,10 @@ public class HoodieTableMetadataUtil {
         return HoodieIOFactory.getIOFactory(datasetMetaClient.getStorage())
             .getFileFormatUtils(HoodieFileFormat.PARQUET)
             .readColumnStatsFromMetadata(datasetMetaClient.getStorage(), fullFilePath, columnsToIndex, indexVersion);
+      } else if (partitionPathFileName.endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
+        return HoodieIOFactory.getIOFactory(datasetMetaClient.getStorage())
+            .getFileFormatUtils(HoodieFileFormat.LANCE)
+            .readColumnStatsFromMetadata(datasetMetaClient.getStorage(), fullFilePath, columnsToIndex, indexVersion);
       } else if (FSUtils.isLogFile(fileName)) {
         Option<HoodieSchema> writerSchemaOpt = tryResolveSchemaForTable(datasetMetaClient);
         log.info("Reading log file: {}, to build column range metadata.", partitionPathFileName);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceReader.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceReader.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
 import org.apache.hudi.common.bloom.SimpleBloomFilter;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
@@ -33,6 +34,8 @@ import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -64,7 +67,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.bloom.BloomFilterTypeCode.DYNAMIC_V0;
@@ -380,6 +386,38 @@ public class TestHoodieSparkLanceReader {
   }
 
   @Test
+  public void testReadColumnStatsFromMetadata() throws Exception {
+    StructType schema = new StructType()
+        .add("id", DataTypes.IntegerType, false)
+        .add("name", DataTypes.StringType, true)
+        .add("age", DataTypes.LongType, true)
+        .add("score", DataTypes.DoubleType, true);
+
+    List<InternalRow> rows = Arrays.asList(
+        createRow(1, "Alice", 20L, 10.5),
+        createRow(2, "Bob", 25L, null),
+        createRow(3, null, null, 5.25),
+        createRow(4, "Dora", 30L, 20.0)
+    );
+
+    StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_column_stats.lance");
+    try (HoodieSparkLanceReader ignored = writeAndCreateReader(path, schema, rows)) {
+      List<HoodieColumnRangeMetadata<Comparable>> columnStats = HoodieIOFactory.getIOFactory(storage)
+          .getFileFormatUtils(HoodieFileFormat.LANCE)
+          .readColumnStatsFromMetadata(storage, path, Arrays.asList("id", "name", "age", "score", "missing"), HoodieIndexVersion.V2);
+
+      Map<String, HoodieColumnRangeMetadata<Comparable>> statsByColumn = columnStats.stream()
+          .collect(Collectors.toMap(HoodieColumnRangeMetadata::getColumnName, Function.identity()));
+
+      assertEquals(Set.of("id", "name", "age", "score"), statsByColumn.keySet());
+      assertColumnStats(statsByColumn.get("id"), 1, 4, 0L, 4L);
+      assertColumnStats(statsByColumn.get("name"), "Alice", "Dora", 1L, 4L);
+      assertColumnStats(statsByColumn.get("age"), 20L, 30L, 1L, 4L);
+      assertColumnStats(statsByColumn.get("score"), 5.25, 20.0, 1L, 4L);
+    }
+  }
+
+  @Test
   public void testFilterRowKeysWithCandidates() throws Exception {
     // Create schema with all 5 Hudi metadata fields
     StructType schema = new StructType()
@@ -423,6 +461,18 @@ public class TestHoodieSparkLanceReader {
         Arguments.of(Collections.emptySet()),
         Arguments.of((Set<String>) null)
     );
+  }
+
+  private static void assertColumnStats(HoodieColumnRangeMetadata<Comparable> columnStats,
+                                        Comparable expectedMinValue,
+                                        Comparable expectedMaxValue,
+                                        long expectedNullCount,
+                                        long expectedValueCount) {
+    assertNotNull(columnStats);
+    assertEquals(expectedMinValue, columnStats.getMinValue());
+    assertEquals(expectedMaxValue, columnStats.getMaxValue());
+    assertEquals(expectedNullCount, columnStats.getNullCount());
+    assertEquals(expectedValueCount, columnStats.getValueCount());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18758.

### Summary and Changelog

This adds column range stats support for Lance base files.

- Implement `LanceUtils.readColumnStatsFromMetadata` by reading projected Lance columns and collecting Hudi column range metadata from Spark records.
- Route `.lance` base files through `HoodieTableMetadataUtil.readColumnRangeMetadataFrom`, so column stats and partition stats generation can use Lance files.
- Add a Spark Lance reader test covering min, max, null count, value count, and ignored missing columns.

### Impact

Enables metadata column stats and partition stats generation for Lance base files. No new public config or API.

### Risk Level

Low. The change is scoped to Lance file-format stats reads and uses the existing Hudi column range metadata collector.

Local verification:

- `git diff --check`
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home/bin:$PATH mvn -pl hudi-common -am -DskipTests compile`

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
