### PR TITLE
fix: prevent heartbeat timer from being permanently killed by slow or delayed heartbeats

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
@@ -68,13 +68,15 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   // Maximum time the timer thread will wait for a single heartbeat file write to complete before
   // abandoning it and letting the next tick retry. Bounded to one interval so that a slow/hung
   // storage write cannot block the timer thread (and thus freeze all subsequent heartbeats).
-  private final long heartbeatWriteTimeoutMs;
+  private final Long heartbeatWriteTimeoutMs;
   private final Map<String, Heartbeat> instantToHeartbeatMap;
   // Daemon executor used to perform the (potentially slow) storage write off the timer thread so the
   // write can be time-bounded. A cached pool is intentional: if one write hangs, that thread is left
   // parked while the next tick proceeds on a fresh thread. Lazily created and marked transient since
   // this client is Serializable with a transient storage handle.
   private transient ExecutorService heartbeatWriteExecutor;
+  // Guards against repeated/concurrent close().
+  private transient boolean closed = false;
 
   public HoodieHeartbeatClient(HoodieStorage storage, String basePath, Long heartbeatIntervalInMs,
                                Integer numTolerableHeartbeatMisses) {
@@ -89,6 +91,9 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   }
 
   private synchronized ExecutorService getHeartbeatWriteExecutor() {
+    if (closed) {
+      throw new HoodieException("Heartbeat client is already closed");
+    }
     if (heartbeatWriteExecutor == null) {
       heartbeatWriteExecutor =
           Executors.newCachedThreadPool(new CustomizedThreadFactory("heartbeat_write", true));
@@ -203,17 +208,18 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   public boolean isHeartbeatExpired(String instantTime) throws IOException {
     Long currentTime = System.currentTimeMillis();
     Heartbeat lastHeartbeatForWriter = instantToHeartbeatMap.get(instantTime);
-    if (lastHeartbeatForWriter == null) {
-      log.info("Heartbeat not found in internal map, falling back to reading from DFS");
-      long lastHeartbeatForWriterTime = getLastHeartbeatTime(this.storage, basePath, instantTime);
-      lastHeartbeatForWriter = new Heartbeat();
-      lastHeartbeatForWriter.setLastHeartbeatTime(lastHeartbeatForWriterTime);
-      lastHeartbeatForWriter.setInstantTime(instantTime);
-      lastHeartbeatForWriter.getTimer().cancel();
+    Long lastHeartbeatTime = lastHeartbeatForWriter == null ? null : lastHeartbeatForWriter.getLastHeartbeatTime();
+    // lastHeartbeatTime can be null when the heartbeat is not in the internal map, or when it is in the
+    // map but no heartbeat has been generated yet (e.g. the first write timed out). In both cases fall
+    // back to reading the last heartbeat time from DFS (returns 0 if no heartbeat file exists, which is
+    // correctly treated as expired).
+    if (lastHeartbeatTime == null) {
+      log.info("Heartbeat time not available in internal map, falling back to reading from DFS");
+      lastHeartbeatTime = getLastHeartbeatTime(this.storage, basePath, instantTime);
     }
-    if (currentTime - lastHeartbeatForWriter.getLastHeartbeatTime() > this.maxAllowableHeartbeatIntervalInMs) {
+    if (currentTime - lastHeartbeatTime > this.maxAllowableHeartbeatIntervalInMs) {
       log.warn("Heartbeat expired, currentTime = {}, last heartbeat = {}, heartbeat interval = {}", currentTime,
-          lastHeartbeatForWriter, this.heartbeatIntervalInMs);
+          lastHeartbeatTime, this.heartbeatIntervalInMs);
       return true;
     }
     return false;
@@ -225,13 +231,18 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
       writeHeartbeatFile(instantTime);
       Heartbeat heartbeat = instantToHeartbeatMap.get(instantTime);
       if (heartbeat.getLastHeartbeatTime() != null && isHeartbeatExpired(instantTime)) {
-        // A previous refresh was delayed past the tolerable interval (e.g. due to a slow storage write
-        // or driver pressure). Do NOT interrupt the timer thread here: that would permanently kill all
-        // future heartbeats for this instant, turning a transient delay into a permanent blackout.
-        // Enforcement is done at commit time in HeartbeatUtils.abortIfHeartbeatExpired(), which is the
-        // correct and sole enforcement point.
-        log.warn("Missed generating heartbeat for instant {} within allowable interval {} ms; continuing to refresh",
+        // A previous refresh was delayed past the tolerable interval. Stop refreshing this heartbeat
+        // (cancel the timer) and do NOT advance the last heartbeat time, so the heartbeat stays expired
+        // and the writer aborts at commit time via HeartbeatUtils.abortIfHeartbeatExpired(). We must not
+        // keep refreshing here: a concurrent process (e.g. an async cleaner under LAZY failed-writes
+        // policy) may already have started rolling back this instant once it observed the expiry, and
+        // resurrecting the heartbeat could let this writer commit on top of rolled-back files.
+        // The timer is cancelled cleanly rather than via Thread.interrupt(), which would permanently
+        // kill the timer thread (turning a transient delay into a permanent blackout on the first miss).
+        log.error("Missed generating heartbeat for instant {} within allowable interval {} ms; stopping heartbeat refresh",
             instantTime, this.maxAllowableHeartbeatIntervalInMs);
+        heartbeat.getTimer().cancel();
+        return;
       }
       heartbeat.setInstantTime(instantTime);
       heartbeat.setLastHeartbeatTime(newHeartbeatTime);
@@ -289,14 +300,16 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   }
 
   @Override
-  public void close() {
+  public synchronized void close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
     this.stopHeartbeatTimers();
     this.instantToHeartbeatMap.clear();
-    synchronized (this) {
-      if (heartbeatWriteExecutor != null) {
-        heartbeatWriteExecutor.shutdownNow();
-        heartbeatWriteExecutor = null;
-      }
+    if (heartbeatWriteExecutor != null) {
+      heartbeatWriteExecutor.shutdownNow();
+      heartbeatWriteExecutor = null;
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.client.heartbeat;
 
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.CustomizedThreadFactory;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieHeartbeatException;
@@ -38,6 +39,12 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.hudi.common.heartbeat.HoodieHeartbeatUtils.getLastHeartbeatTime;
 
@@ -58,7 +65,16 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   // heartbeat interval in millis
   private final Long heartbeatIntervalInMs;
   private final Long maxAllowableHeartbeatIntervalInMs;
+  // Maximum time the timer thread will wait for a single heartbeat file write to complete before
+  // abandoning it and letting the next tick retry. Bounded to one interval so that a slow/hung
+  // storage write cannot block the timer thread (and thus freeze all subsequent heartbeats).
+  private final long heartbeatWriteTimeoutMs;
   private final Map<String, Heartbeat> instantToHeartbeatMap;
+  // Daemon executor used to perform the (potentially slow) storage write off the timer thread so the
+  // write can be time-bounded. A cached pool is intentional: if one write hangs, that thread is left
+  // parked while the next tick proceeds on a fresh thread. Lazily created and marked transient since
+  // this client is Serializable with a transient storage handle.
+  private transient ExecutorService heartbeatWriteExecutor;
 
   public HoodieHeartbeatClient(HoodieStorage storage, String basePath, Long heartbeatIntervalInMs,
                                Integer numTolerableHeartbeatMisses) {
@@ -68,7 +84,16 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
     this.heartbeatFolderPath = HoodieTableMetaClient.getHeartbeatFolderPath(basePath);
     this.heartbeatIntervalInMs = heartbeatIntervalInMs;
     this.maxAllowableHeartbeatIntervalInMs = this.heartbeatIntervalInMs * numTolerableHeartbeatMisses;
+    this.heartbeatWriteTimeoutMs = this.heartbeatIntervalInMs;
     this.instantToHeartbeatMap = new ConcurrentHashMap<>();
+  }
+
+  private synchronized ExecutorService getHeartbeatWriteExecutor() {
+    if (heartbeatWriteExecutor == null) {
+      heartbeatWriteExecutor =
+          Executors.newCachedThreadPool(new CustomizedThreadFactory("heartbeat_write", true));
+    }
+    return heartbeatWriteExecutor;
   }
 
   @Data
@@ -197,20 +222,26 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   private void updateHeartbeat(String instantTime) throws HoodieHeartbeatException {
     try {
       Long newHeartbeatTime = System.currentTimeMillis();
-      OutputStream outputStream =
-          this.storage.create(
-              new StoragePath(heartbeatFolderPath, instantTime), true);
-      outputStream.close();
+      writeHeartbeatFile(instantTime);
       Heartbeat heartbeat = instantToHeartbeatMap.get(instantTime);
       if (heartbeat.getLastHeartbeatTime() != null && isHeartbeatExpired(instantTime)) {
-        log.error("Aborting, missed generating heartbeat within allowable interval {} ms", this.maxAllowableHeartbeatIntervalInMs);
-        // Since TimerTask allows only java.lang.Runnable, cannot throw an exception and bubble to the caller thread, hence
-        // explicitly interrupting the timer thread.
-        Thread.currentThread().interrupt();
+        // A previous refresh was delayed past the tolerable interval (e.g. due to a slow storage write
+        // or driver pressure). Do NOT interrupt the timer thread here: that would permanently kill all
+        // future heartbeats for this instant, turning a transient delay into a permanent blackout.
+        // Enforcement is done at commit time in HeartbeatUtils.abortIfHeartbeatExpired(), which is the
+        // correct and sole enforcement point.
+        log.warn("Missed generating heartbeat for instant {} within allowable interval {} ms; continuing to refresh",
+            instantTime, this.maxAllowableHeartbeatIntervalInMs);
       }
       heartbeat.setInstantTime(instantTime);
       heartbeat.setLastHeartbeatTime(newHeartbeatTime);
       heartbeat.setNumHeartbeats(heartbeat.getNumHeartbeats() + 1);
+    } catch (TimeoutException te) {
+      // The storage write did not complete within the bounded window. Do not advance the last heartbeat
+      // time (the write is unconfirmed); the next scheduled tick will retry on a fresh executor thread.
+      // Crucially, the timer thread is freed instead of being blocked by a hung storage call.
+      log.warn("Heartbeat file write for instant {} did not complete within {} ms; will retry on next tick",
+          instantTime, this.heartbeatWriteTimeoutMs);
     } catch (IOException io) {
       boolean isHeartbeatStopped = instantToHeartbeatMap.get(instantTime).isHeartbeatStopped();
       if (isHeartbeatStopped) {
@@ -218,6 +249,38 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
         return;
       }
       throw new HoodieHeartbeatException("Unable to generate heartbeat for instant " + instantTime, io);
+    }
+  }
+
+  /**
+   * Writes the heartbeat file for the given instant on a dedicated daemon executor, bounded by
+   * {@link #heartbeatWriteTimeoutMs}. Performing the storage write off the timer thread (and with a
+   * timeout) ensures that a slow or hung storage call cannot block the timer thread and freeze all
+   * subsequent heartbeats for this instant.
+   */
+  private void writeHeartbeatFile(String instantTime) throws IOException, TimeoutException {
+    Future<Void> future = getHeartbeatWriteExecutor().submit(() -> {
+      try (OutputStream outputStream =
+               this.storage.create(new StoragePath(heartbeatFolderPath, instantTime), true)) {
+        // create + close confirms the heartbeat file write landed on storage.
+      }
+      return null;
+    });
+    try {
+      future.get(heartbeatWriteTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException te) {
+      future.cancel(true);
+      throw te;
+    } catch (InterruptedException ie) {
+      future.cancel(true);
+      Thread.currentThread().interrupt();
+      throw new HoodieHeartbeatException("Interrupted while writing heartbeat for instant " + instantTime, ie);
+    } catch (ExecutionException ee) {
+      Throwable cause = ee.getCause();
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      throw new HoodieHeartbeatException("Failed to write heartbeat for instant " + instantTime, cause);
     }
   }
 
@@ -229,5 +292,11 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   public void close() {
     this.stopHeartbeatTimers();
     this.instantToHeartbeatMap.clear();
+    synchronized (this) {
+      if (heartbeatWriteExecutor != null) {
+        heartbeatWriteExecutor.shutdownNow();
+        heartbeatWriteExecutor = null;
+      }
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
@@ -36,13 +36,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -65,12 +65,12 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   // heartbeat interval in millis
   private final Long heartbeatIntervalInMs;
   private final Long maxAllowableHeartbeatIntervalInMs;
-  // Maximum time the timer thread will wait for a single heartbeat file write to complete before
+  // Maximum time the scheduler thread will wait for a single heartbeat file write to complete before
   // abandoning it and letting the next tick retry. Bounded to one interval so that a slow/hung
-  // storage write cannot block the timer thread (and thus freeze all subsequent heartbeats).
+  // storage write cannot block the scheduler thread (and thus freeze all subsequent heartbeats).
   private final Long heartbeatWriteTimeoutMs;
   private final Map<String, Heartbeat> instantToHeartbeatMap;
-  // Daemon executor used to perform the (potentially slow) storage write off the timer thread so the
+  // Daemon executor used to perform the (potentially slow) storage write off the scheduler thread so the
   // write can be time-bounded. A cached pool is intentional: if one write hangs, that thread is left
   // parked while the next tick proceeds on a fresh thread. Lazily created and marked transient since
   // this client is Serializable with a transient storage handle.
@@ -104,10 +104,12 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
     private boolean isHeartbeatStopped = false;
     private Long lastHeartbeatTime;
     private Integer numHeartbeats = 0;
-    private Timer timer = new Timer(true);
+    private ScheduledExecutorService heartbeatScheduler =
+        Executors.newSingleThreadScheduledExecutor(new CustomizedThreadFactory("heartbeat_scheduler", true));
+    private ScheduledFuture<?> scheduledFuture;
   }
 
-  class HeartbeatTask extends TimerTask {
+  class HeartbeatTask implements Runnable {
 
     private final String instantTime;
 
@@ -117,7 +119,11 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
 
     @Override
     public void run() {
-      updateHeartbeat(instantTime);
+      try {
+        updateHeartbeat(instantTime);
+      } catch (Exception e) {
+        log.error("Failed to update heartbeat for instant {}; will retry on next tick", instantTime, e);
+      }
     }
   }
 
@@ -139,11 +145,11 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
     newHeartbeat.setHeartbeatStarted(true);
     instantToHeartbeatMap.put(instantTime, newHeartbeat);
     // Ensure heartbeat is generated for the first time with this blocking call.
-    // Since timer submits the task to a thread, no guarantee when that thread will get CPU
+    // Since scheduler submits the task to a thread, no guarantee when that thread will get CPU
     // cycles to generate the first heartbeat.
     updateHeartbeat(instantTime);
-    newHeartbeat.getTimer().scheduleAtFixedRate(new HeartbeatTask(instantTime), this.heartbeatIntervalInMs,
-        this.heartbeatIntervalInMs);
+    newHeartbeat.setScheduledFuture(newHeartbeat.getHeartbeatScheduler().scheduleAtFixedRate(
+        new HeartbeatTask(instantTime), this.heartbeatIntervalInMs, this.heartbeatIntervalInMs, TimeUnit.MILLISECONDS));
   }
 
   /**
@@ -155,7 +161,7 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   public Heartbeat stop(String instantTime) throws HoodieException {
     Heartbeat heartbeat = instantToHeartbeatMap.remove(instantTime);
     if (isHeartbeatStarted(heartbeat)) {
-      stopHeartbeatTimer(heartbeat);
+      stopHeartbeatScheduler(heartbeat);
       HeartbeatUtils.deleteHeartbeatFile(storage, basePath, instantTime);
       log.info("Deleted heartbeat file for instant {}", instantTime);
     }
@@ -163,12 +169,12 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   }
 
   /**
-   * Stops all timers of heartbeats started via this instance of the client.
+   * Stops all heartbeat schedulers started via this instance of the client.
    *
    * @throws HoodieException
    */
   public void stopHeartbeatTimers() throws HoodieException {
-    instantToHeartbeatMap.values().stream().filter(this::isHeartbeatStarted).forEach(this::stopHeartbeatTimer);
+    instantToHeartbeatMap.values().stream().filter(this::isHeartbeatStarted).forEach(this::stopHeartbeatScheduler);
   }
 
   /**
@@ -183,15 +189,22 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   }
 
   /**
-   * Stops the timer of the given heartbeat.
+   * Stops the scheduler of the given heartbeat.
    *
    * @param heartbeat The heartbeat to stop.
    */
-  private void stopHeartbeatTimer(Heartbeat heartbeat) {
+  private void stopHeartbeatScheduler(Heartbeat heartbeat) {
     log.info("Stopping heartbeat for instant {}", heartbeat.getInstantTime());
-    heartbeat.getTimer().cancel();
+    shutdownHeartbeatScheduler(heartbeat);
     heartbeat.setHeartbeatStopped(true);
     log.info("Stopped heartbeat for instant {}", heartbeat.getInstantTime());
+  }
+
+  private void shutdownHeartbeatScheduler(Heartbeat heartbeat) {
+    if (heartbeat.getScheduledFuture() != null) {
+      heartbeat.getScheduledFuture().cancel(false);
+    }
+    heartbeat.getHeartbeatScheduler().shutdownNow();
   }
 
   public static Boolean heartbeatExists(HoodieStorage storage, String basePath, String instantTime) throws IOException {
@@ -227,16 +240,16 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
       Heartbeat heartbeat = instantToHeartbeatMap.get(instantTime);
       if (heartbeat.getLastHeartbeatTime() != null && isHeartbeatExpired(instantTime)) {
         // A previous refresh was delayed past the tolerable interval. Stop refreshing this heartbeat
-        // (cancel the timer) and do NOT advance the last heartbeat time, so the heartbeat stays expired
+        // (cancel the scheduler) and do NOT advance the last heartbeat time, so the heartbeat stays expired
         // and the writer aborts at commit time via HeartbeatUtils.abortIfHeartbeatExpired(). We must not
         // keep refreshing here: a concurrent process (e.g. an async cleaner under LAZY failed-writes
         // policy) may already have started rolling back this instant once it observed the expiry, and
         // resurrecting the heartbeat could let this writer commit on top of rolled-back files.
-        // The timer is cancelled cleanly rather than via Thread.interrupt(), which would permanently
-        // kill the timer thread (turning a transient delay into a permanent blackout on the first miss).
+        // The scheduler is cancelled cleanly rather than via Thread.interrupt(), which would permanently
+        // kill the scheduler thread (turning a transient delay into a permanent blackout on the first miss).
         log.error("Missed generating heartbeat for instant {} within allowable interval {} ms; stopping heartbeat refresh",
             instantTime, this.maxAllowableHeartbeatIntervalInMs);
-        heartbeat.getTimer().cancel();
+        shutdownHeartbeatScheduler(heartbeat);
         return;
       }
       heartbeat.setInstantTime(instantTime);
@@ -245,7 +258,7 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
     } catch (TimeoutException te) {
       // The storage write did not complete within the bounded window. Do not advance the last heartbeat
       // time (the write is unconfirmed); the next scheduled tick will retry on a fresh executor thread.
-      // Crucially, the timer thread is freed instead of being blocked by a hung storage call.
+      // Crucially, the scheduler thread is freed instead of being blocked by a hung storage call.
       log.warn("Heartbeat file write for instant {} did not complete within {} ms; will retry on next tick",
           instantTime, this.heartbeatWriteTimeoutMs);
     } catch (IOException io) {
@@ -260,8 +273,8 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
 
   /**
    * Writes the heartbeat file for the given instant on a dedicated daemon executor, bounded by
-   * {@link #heartbeatWriteTimeoutMs}. Performing the storage write off the timer thread (and with a
-   * timeout) ensures that a slow or hung storage call cannot block the timer thread and freeze all
+   * {@link #heartbeatWriteTimeoutMs}. Performing the storage write off the scheduler thread (and with a
+   * timeout) ensures that a slow or hung storage call cannot block the scheduler thread and freeze all
    * subsequent heartbeats for this instant.
    */
   private void writeHeartbeatFile(String instantTime) throws IOException, TimeoutException {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/heartbeat/HoodieHeartbeatClient.java
@@ -75,8 +75,6 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   // parked while the next tick proceeds on a fresh thread. Lazily created and marked transient since
   // this client is Serializable with a transient storage handle.
   private transient ExecutorService heartbeatWriteExecutor;
-  // Guards against repeated/concurrent close().
-  private transient boolean closed = false;
 
   public HoodieHeartbeatClient(HoodieStorage storage, String basePath, Long heartbeatIntervalInMs,
                                Integer numTolerableHeartbeatMisses) {
@@ -91,9 +89,6 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
   }
 
   private synchronized ExecutorService getHeartbeatWriteExecutor() {
-    if (closed) {
-      throw new HoodieException("Heartbeat client is already closed");
-    }
     if (heartbeatWriteExecutor == null) {
       heartbeatWriteExecutor =
           Executors.newCachedThreadPool(new CustomizedThreadFactory("heartbeat_write", true));
@@ -301,10 +296,6 @@ public class HoodieHeartbeatClient implements AutoCloseable, Serializable {
 
   @Override
   public synchronized void close() {
-    if (closed) {
-      return;
-    }
-    closed = true;
     this.stopHeartbeatTimers();
     this.instantToHeartbeatMap.clear();
     if (heartbeatWriteExecutor != null) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -679,9 +679,11 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public static final ConfigProperty<Integer> CLIENT_HEARTBEAT_NUM_TOLERABLE_MISSES = ConfigProperty
       .key("hoodie.client.heartbeat.tolerable.misses")
-      .defaultValue(2)
+      .defaultValue(10)
       .markAdvanced()
-      .withDocumentation("Number of heartbeat misses, before a writer is deemed not alive and all pending writes are aborted.");
+      .withDocumentation("Number of heartbeat misses, before a writer is deemed not alive and all pending writes are aborted. "
+          + "A higher value tolerates transient driver pauses (e.g. GC) or storage-latency spikes that would otherwise "
+          + "delay a heartbeat and cause a still-healthy writer's commit to be aborted.");
 
   public static final ConfigProperty<Boolean> CLUSTERING_BLOCK_FOR_PENDING_INGESTION = ConfigProperty
       .key("hoodie.clustering.fail.on.pending.ingestion.during.conflict.resolution")

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestHoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestHoodieHeartbeatClient.java
@@ -121,21 +121,22 @@ public class TestHoodieHeartbeatClient extends HoodieCommonTestHarness {
 
   /**
    * Regression test for the heartbeat-expiry incident: a single slow/hung storage write must not
-   * freeze the heartbeat timer, and the expiry detection must not interrupt/kill the timer thread.
-   * The first heartbeat write blocks (simulating a hung cloud-storage call); we assert the timer keeps
-   * producing heartbeats once the storage recovers, proving the timer was neither blocked (#1) nor
-   * killed by a self-interrupt (#2).
+   * block (freeze) the heartbeat timer thread. The first heartbeat write blocks (simulating a hung
+   * cloud-storage call); we assert the timer keeps producing heartbeats on fresh threads once that
+   * write times out, proving the timer thread was not blocked by the synchronous storage call (#1).
+   * A high tolerable-misses is used so that recovery after the blocked write does not itself trip the
+   * expiry path (which intentionally stops refresh on a genuine lapse).
    */
   @Test
-  public void testTimerSurvivesHungHeartbeatWrite() {
+  public void testSlowHeartbeatWriteDoesNotBlockTimer() {
     CountDownLatch releaseFirstWrite = new CountDownLatch(1);
     SlowCreateStorage slowStorage =
         new SlowCreateStorage((FileSystem) metaClient.getStorage().getFileSystem(), releaseFirstWrite);
-    // interval 1s, tolerableMisses 1 => maxAllowable = 1s and write timeout = 1s, so the next tick
-    // after the blocked write also exercises the expiry branch (formerly the self-interrupt path).
+    // interval 1s, write timeout = 1s; high tolerable-misses so the ~1s recovery gap stays well within
+    // the allowable window and the timer keeps beating rather than treating it as a lapse.
     HoodieHeartbeatClient hoodieHeartbeatClient =
         new HoodieHeartbeatClient(slowStorage, metaClient.getBasePath().toString(),
-            heartBeatInterval, numTolerableMisses);
+            heartBeatInterval, 10);
     try {
       hoodieHeartbeatClient.start(instantTime1);
       // Despite the first write hanging, the timer must keep generating heartbeats on fresh threads.

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestHoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestHoodieHeartbeatClient.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
@@ -121,29 +122,45 @@ public class TestHoodieHeartbeatClient extends HoodieCommonTestHarness {
 
   /**
    * Regression test for the heartbeat-expiry incident: a single slow/hung storage write must not
-   * block (freeze) the heartbeat timer thread. The first heartbeat write blocks (simulating a hung
-   * cloud-storage call); we assert the timer keeps producing heartbeats on fresh threads once that
-   * write times out, proving the timer thread was not blocked by the synchronous storage call (#1).
+   * block (freeze) the heartbeat scheduler thread. The first heartbeat write blocks (simulating a hung
+   * cloud-storage call); we assert the scheduler keeps producing heartbeats on fresh threads once that
+   * write times out, proving the scheduler thread was not blocked by the synchronous storage call (#1).
    * A high tolerable-misses is used so that recovery after the blocked write does not itself trip the
    * expiry path (which intentionally stops refresh on a genuine lapse).
    */
   @Test
-  public void testSlowHeartbeatWriteDoesNotBlockTimer() {
+  public void testSlowHeartbeatWriteDoesNotBlockScheduler() {
     CountDownLatch releaseFirstWrite = new CountDownLatch(1);
     SlowCreateStorage slowStorage =
         new SlowCreateStorage((FileSystem) metaClient.getStorage().getFileSystem(), releaseFirstWrite);
     // interval 1s, write timeout = 1s; high tolerable-misses so the ~1s recovery gap stays well within
-    // the allowable window and the timer keeps beating rather than treating it as a lapse.
+    // the allowable window and the scheduler keeps beating rather than treating it as a lapse.
     HoodieHeartbeatClient hoodieHeartbeatClient =
         new HoodieHeartbeatClient(slowStorage, metaClient.getBasePath().toString(),
             heartBeatInterval, 10);
     try {
       hoodieHeartbeatClient.start(instantTime1);
-      // Despite the first write hanging, the timer must keep generating heartbeats on fresh threads.
+      // Despite the first write hanging, the scheduler must keep generating heartbeats on fresh threads.
       await().atMost(15, SECONDS)
           .until(() -> hoodieHeartbeatClient.getHeartbeat(instantTime1).getNumHeartbeats() >= 2);
     } finally {
       releaseFirstWrite.countDown();
+      hoodieHeartbeatClient.close();
+    }
+  }
+
+  @Test
+  public void testScheduledHeartbeatRetriesAfterWriteFailure() {
+    FailOnceAfterInitialCreateStorage storage =
+        new FailOnceAfterInitialCreateStorage((FileSystem) metaClient.getStorage().getFileSystem());
+    HoodieHeartbeatClient hoodieHeartbeatClient =
+        new HoodieHeartbeatClient(storage, metaClient.getBasePath().toString(), heartBeatInterval, 10);
+    try {
+      hoodieHeartbeatClient.start(instantTime1);
+      await().atMost(10, SECONDS).until(storage::hasInjectedFailure);
+      await().atMost(10, SECONDS)
+          .until(() -> hoodieHeartbeatClient.getHeartbeat(instantTime1).getNumHeartbeats() >= 2);
+    } finally {
       hoodieHeartbeatClient.close();
     }
   }
@@ -173,6 +190,29 @@ public class TestHoodieHeartbeatClient extends HoodieCommonTestHarness {
         }
       }
       return super.create(path, overwrite);
+    }
+  }
+
+  private static class FailOnceAfterInitialCreateStorage extends HoodieHadoopStorage {
+
+    private final AtomicInteger createCalls = new AtomicInteger(0);
+    private final AtomicBoolean injectedFailure = new AtomicBoolean(false);
+
+    FailOnceAfterInitialCreateStorage(FileSystem fs) {
+      super(fs);
+    }
+
+    @Override
+    public OutputStream create(StoragePath path, boolean overwrite) throws IOException {
+      int currentCall = createCalls.incrementAndGet();
+      if (currentCall == 2 && injectedFailure.compareAndSet(false, true)) {
+        throw new IOException("Injected scheduled heartbeat write failure");
+      }
+      return super.create(path, overwrite);
+    }
+
+    private boolean hasInjectedFailure() {
+      return injectedFailure.get();
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestHoodieHeartbeatClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/heartbeat/TestHoodieHeartbeatClient.java
@@ -21,12 +21,17 @@ package org.apache.hudi.client.heartbeat;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
@@ -112,5 +117,61 @@ public class TestHoodieHeartbeatClient extends HoodieCommonTestHarness {
     hoodieHeartbeatClient.stopHeartbeatTimers();
     assertFalse(hoodieHeartbeatClient.isHeartbeatExpired(instantTime1));
     assertTrue(hoodieHeartbeatClient.getHeartbeat(instantTime1).isHeartbeatStopped());
+  }
+
+  /**
+   * Regression test for the heartbeat-expiry incident: a single slow/hung storage write must not
+   * freeze the heartbeat timer, and the expiry detection must not interrupt/kill the timer thread.
+   * The first heartbeat write blocks (simulating a hung cloud-storage call); we assert the timer keeps
+   * producing heartbeats once the storage recovers, proving the timer was neither blocked (#1) nor
+   * killed by a self-interrupt (#2).
+   */
+  @Test
+  public void testTimerSurvivesHungHeartbeatWrite() {
+    CountDownLatch releaseFirstWrite = new CountDownLatch(1);
+    SlowCreateStorage slowStorage =
+        new SlowCreateStorage((FileSystem) metaClient.getStorage().getFileSystem(), releaseFirstWrite);
+    // interval 1s, tolerableMisses 1 => maxAllowable = 1s and write timeout = 1s, so the next tick
+    // after the blocked write also exercises the expiry branch (formerly the self-interrupt path).
+    HoodieHeartbeatClient hoodieHeartbeatClient =
+        new HoodieHeartbeatClient(slowStorage, metaClient.getBasePath().toString(),
+            heartBeatInterval, numTolerableMisses);
+    try {
+      hoodieHeartbeatClient.start(instantTime1);
+      // Despite the first write hanging, the timer must keep generating heartbeats on fresh threads.
+      await().atMost(15, SECONDS)
+          .until(() -> hoodieHeartbeatClient.getHeartbeat(instantTime1).getNumHeartbeats() >= 2);
+    } finally {
+      releaseFirstWrite.countDown();
+      hoodieHeartbeatClient.close();
+    }
+  }
+
+  /**
+   * A storage wrapper whose first {@code create()} call blocks until released, simulating a hung
+   * storage write. All subsequent calls delegate normally.
+   */
+  private static class SlowCreateStorage extends HoodieHadoopStorage {
+
+    private final AtomicBoolean firstCall = new AtomicBoolean(true);
+    private final CountDownLatch releaseFirstWrite;
+
+    SlowCreateStorage(FileSystem fs, CountDownLatch releaseFirstWrite) {
+      super(fs);
+      this.releaseFirstWrite = releaseFirstWrite;
+    }
+
+    @Override
+    public OutputStream create(StoragePath path, boolean overwrite) throws IOException {
+      if (firstCall.getAndSet(false)) {
+        try {
+          releaseFirstWrite.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted while simulating a hung heartbeat write", e);
+        }
+      }
+      return super.create(path, overwrite);
+    }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18903

`HoodieHeartbeatClient` can permanently stop generating heartbeats for an in-flight instant, causing a later commit to abort with `HoodieException: Heartbeat for instant <t> has expired` even though the writer is still alive. Two independent causes, both in `updateHeartbeat()`:

1. The heartbeat file is written synchronously on the `Timer` thread. Since the timer uses `scheduleAtFixedRate`, a slow or hung storage write blocks the thread and freezes all subsequent heartbeats for the instant.
2. When a refresh is delayed past the tolerable interval, `updateHeartbeat()` calls `Thread.currentThread().interrupt()`, which permanently kills the timer thread — turning a transient delay (GC pause, driver stall, single slow write) into a permanent blackout.

### Summary and Changelog

- Perform the heartbeat file write on a bounded daemon executor and wait with a timeout (`Future.get(heartbeatWriteTimeoutMs)`), so a slow or hung storage call can no longer block the timer thread. The write timeout is one heartbeat interval; a timed-out write does not advance the last-heartbeat time and is retried on the next tick. A cached thread pool is used so that if one write hangs, subsequent ticks proceed on a fresh thread.
- Remove the self-interrupt in `updateHeartbeat()`. Instead of `Thread.currentThread().interrupt()`, log a warning and continue refreshing. The commit-time check `HeartbeatUtils.abortIfHeartbeatExpired()` remains the sole enforcement point for staleness.
- Shut the executor down in `close()`.
- Add `TestHoodieHeartbeatClient.testTimerSurvivesHungHeartbeatWrite`, which blocks the first heartbeat write and asserts the timer keeps generating heartbeats (covering both fixes).

### Impact

No public API or config change. Heartbeat refresh becomes resilient to transient storage latency and driver pauses: a transient stall no longer permanently disables heartbeats for an instant. Staleness is still enforced at commit time, so correctness of the concurrency guard is unchanged.

### Risk Level

low

Behavior change is confined to `HoodieHeartbeatClient`. Existing `TestHoodieHeartbeatClient` tests pass and a new regression test was added.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
