### PR TITLE
feat: add lance format for Flink MOR table

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -55,7 +55,7 @@ public enum HoodieFileFormat {
           + "and designed for ML and AI workloads")
   LANCE(".lance");
 
-  public static final String LANCE_SPARK_ONLY_ERROR_MSG =
+  public static final String LANCE_UNSUPPORTED_ERROR_MSG =
       "Lance base file format is not supported by this reader or writer path. "
           + "Please use an engine-specific Lance reader/writer, or use Parquet, ORC, or HFile.";
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -56,8 +56,8 @@ public enum HoodieFileFormat {
   LANCE(".lance");
 
   public static final String LANCE_SPARK_ONLY_ERROR_MSG =
-      "Lance base file format is currently only supported with the Spark engine. "
-          + "Please use Parquet, ORC, or HFile for non-Spark engines (Flink, Hive, Presto, Trino).";
+      "Lance base file format is not supported by this reader or writer path. "
+          + "Please use an engine-specific Lance reader/writer, or use Parquet, ORC, or HFile.";
 
   public static final Set<String> BASE_FILE_EXTENSIONS = Arrays.stream(HoodieFileFormat.values())
       .map(HoodieFileFormat::getFileExtension)

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReaderFactory.java
@@ -134,7 +134,7 @@ public class HoodieFileReaderFactory {
   }
 
   protected HoodieFileReader newLanceFileReader(HoodieConfig hoodieConfig, StoragePath path) {
-    throw new UnsupportedOperationException(HoodieFileFormat.LANCE_SPARK_ONLY_ERROR_MSG);
+    throw new UnsupportedOperationException(HoodieFileFormat.LANCE_UNSUPPORTED_ERROR_MSG);
   }
 
   public HoodieFileReader newBootstrapFileReader(HoodieFileReader skeletonFileReader,

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
@@ -114,7 +114,7 @@ public class HoodieFileWriterFactory {
   protected HoodieFileWriter newLanceFileWriter(
       String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier) throws IOException {
-    throw new UnsupportedOperationException(HoodieFileFormat.LANCE_SPARK_ONLY_ERROR_MSG);
+    throw new UnsupportedOperationException(HoodieFileFormat.LANCE_UNSUPPORTED_ERROR_MSG);
   }
 
   public static BloomFilter createBloomFilter(HoodieConfig config) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
@@ -44,10 +44,8 @@ import org.apache.hudi.source.reader.BatchRecords;
 import org.apache.hudi.source.reader.HoodieRecordWithPosition;
 import org.apache.hudi.source.split.HoodieCdcSourceSplit;
 import org.apache.hudi.source.split.HoodieSourceSplit;
-import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.FormatUtils;
-import org.apache.hudi.table.format.HoodieRowDataLanceReader;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
 import org.apache.hudi.table.format.cdc.CdcImageManager;
@@ -55,18 +53,15 @@ import org.apache.hudi.table.format.cdc.CdcInputFormat;
 import org.apache.hudi.table.format.cdc.CdcIterators;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
 import org.apache.hudi.table.format.mor.MergeOnReadTableState;
-import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.StreamerUtil;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -287,19 +282,8 @@ public class HoodieCdcSplitReaderFunction extends AbstractSplitReaderFunction {
   /** Reads a CDC base file returning required-schema records. */
   private ClosableIterator<RowData> getBaseFileIterator(String path) throws IOException {
     if (path.endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
-      DataType selectedDataType = DataTypes.ROW(Arrays.stream(tableState.getRequiredPositions())
-              .mapToObj(i -> DataTypes.FIELD(tableState.getRowType().getFieldNames().get(i), fieldTypes.get(i)))
-              .toArray(DataTypes.Field[]::new))
-          .bridgedTo(RowData.class);
-      HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(selectedDataType.getLogicalType());
-      HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(
-          new StoragePath(path), StreamerUtil.getLanceReadConfig(getHadoopConf()));
-      try {
-        return reader.getRowDataIterator(selectedDataType, requestedSchema);
-      } catch (RuntimeException e) {
-        reader.close();
-        throw e;
-      }
+      return FormatUtils.getLanceRecordIterator(
+          path, tableState.getRowType().getFieldNames(), fieldTypes, tableState.getRequiredPositions(), getHadoopConf());
     }
 
     String[] fieldNames = tableState.getRowType().getFieldNames().toArray(new String[0]);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
@@ -20,6 +20,7 @@ package org.apache.hudi.source.reader.function;
 
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -43,8 +44,10 @@ import org.apache.hudi.source.reader.BatchRecords;
 import org.apache.hudi.source.reader.HoodieRecordWithPosition;
 import org.apache.hudi.source.split.HoodieCdcSourceSplit;
 import org.apache.hudi.source.split.HoodieSourceSplit;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.FormatUtils;
+import org.apache.hudi.table.format.HoodieRowDataLanceReader;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
 import org.apache.hudi.table.format.cdc.CdcImageManager;
@@ -52,15 +55,18 @@ import org.apache.hudi.table.format.cdc.CdcInputFormat;
 import org.apache.hudi.table.format.cdc.CdcIterators;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
 import org.apache.hudi.table.format.mor.MergeOnReadTableState;
+import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.StreamerUtil;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -278,8 +284,24 @@ public class HoodieCdcSplitReaderFunction extends AbstractSplitReaderFunction {
     }
   }
 
-  /** Reads a parquet CDC base file returning required-schema records. */
+  /** Reads a CDC base file returning required-schema records. */
   private ClosableIterator<RowData> getBaseFileIterator(String path) throws IOException {
+    if (path.endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
+      DataType selectedDataType = DataTypes.ROW(Arrays.stream(tableState.getRequiredPositions())
+              .mapToObj(i -> DataTypes.FIELD(tableState.getRowType().getFieldNames().get(i), fieldTypes.get(i)))
+              .toArray(DataTypes.Field[]::new))
+          .bridgedTo(RowData.class);
+      HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(selectedDataType.getLogicalType());
+      HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(
+          new StoragePath(path), StreamerUtil.getLanceReadConfig(getHadoopConf()));
+      try {
+        return reader.getRowDataIterator(selectedDataType, requestedSchema);
+      } catch (RuntimeException e) {
+        reader.close();
+        throw e;
+      }
+    }
+
     String[] fieldNames = tableState.getRowType().getFieldNames().toArray(new String[0]);
     DataType[] fieldTypesArray = fieldTypes.toArray(new DataType[0]);
     LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
@@ -216,7 +216,7 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
   }
 
   /**
-   * Validate the base file format. Flink Lance support is scoped to COW tables.
+   * Validate the base file format.
    */
   private void checkBaseFileFormatForRead(Configuration conf) {
     checkLanceBaseFileFormat(conf);
@@ -229,9 +229,6 @@ public class HoodieTableFactory implements DynamicTableSourceFactory, DynamicTab
   private void checkLanceBaseFileFormat(Configuration conf) {
     if (!isLanceBaseFileFormat(conf)) {
       return;
-    }
-    if (OptionsResolver.isMorTable(conf)) {
-      throw new HoodieValidationException("Flink Lance base-file support is only available for COPY_ON_WRITE tables.");
     }
     if (OptionsResolver.isSchemaEvolutionEnabled(conf)) {
       throw new HoodieValidationException("Flink Lance base-file support does not support schema evolution. Set '"

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/HoodieHiveCatalog.java
@@ -639,7 +639,7 @@ public class HoodieHiveCatalog extends AbstractCatalog {
     HoodieFileFormat baseFileFormat = HoodieFileFormat.PARQUET;
     String baseFileFormatStr = properties.get(HoodieTableConfig.BASE_FILE_FORMAT.key());
     if (baseFileFormatStr != null && HoodieFileFormat.LANCE.name().equalsIgnoreCase(baseFileFormatStr)) {
-      throw new HoodieValidationException(HoodieFileFormat.LANCE_SPARK_ONLY_ERROR_MSG);
+      throw new HoodieValidationException(HoodieFileFormat.LANCE_UNSUPPORTED_ERROR_MSG);
     }
     //ignore uber input Format
     String inputFormatClassName = HoodieInputFormatUtils.getInputFormatClassName(baseFileFormat, useRealTimeInputFormat);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FlinkRowDataReaderContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FlinkRowDataReaderContext.java
@@ -104,7 +104,8 @@ public class FlinkRowDataReaderContext extends HoodieReaderContext<RowData> {
     InternalSchemaManager schemaManager = isLogFile ? InternalSchemaManager.DISABLED : internalSchemaManager.get();
 
     if (filePath.getName().endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
-      if (schemaManager != InternalSchemaManager.DISABLED) {
+      if (schemaManager != InternalSchemaManager.DISABLED
+          && !schemaManager.getMergeSchema(filePath.getName()).isEmptySchema()) {
         throw new HoodieValidationException("Flink Lance base-file support does not support schema evolution.");
       }
       HoodieRowDataLanceReader rowDataLanceReader =

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FormatUtils.java
@@ -30,18 +30,25 @@ import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.table.read.HoodieFileGroupReader;
 import org.apache.hudi.common.util.DefaultSizeEstimator;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.source.ExpressionPredicates;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.FlinkClientUtil;
+import org.apache.hudi.util.HoodieSchemaConverter;
+import org.apache.hudi.util.StreamerUtil;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;
@@ -69,6 +76,27 @@ public class FormatUtils {
 
   private static Object getVal(IndexedRecord record, int pos) {
     return pos == -1 ? null : record.get(pos);
+  }
+
+  public static ClosableIterator<RowData> getLanceRecordIterator(
+      String path,
+      List<String> fieldNames,
+      List<DataType> fieldTypes,
+      int[] selectedFields,
+      Configuration hadoopConf) {
+    DataType selectedDataType = DataTypes.ROW(Arrays.stream(selectedFields)
+            .mapToObj(i -> DataTypes.FIELD(fieldNames.get(i), fieldTypes.get(i)))
+            .toArray(DataTypes.Field[]::new))
+        .bridgedTo(RowData.class);
+    HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(selectedDataType.getLogicalType());
+    HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(
+        new StoragePath(path), StreamerUtil.getLanceReadConfig(hadoopConf));
+    try {
+      return reader.getRowDataIterator(selectedDataType, requestedSchema);
+    } catch (RuntimeException e) {
+      reader.close();
+      throw new HoodieException("Failed to get iterator from Lance reader: " + path, e);
+    }
   }
 
   public static ExternalSpillableMap<String, byte[]> spillableMap(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.table.format.cow;
 
 import org.apache.hudi.common.model.HoodieFileFormat;
-import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -21,16 +21,12 @@ package org.apache.hudi.table.format.cow;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.collection.ClosableIterator;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
-import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.FilePathUtils;
-import org.apache.hudi.table.format.HoodieRowDataLanceReader;
+import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
-import org.apache.hudi.util.HoodieSchemaConverter;
-import org.apache.hudi.util.StreamerUtil;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.io.FileInputFormat;
@@ -40,7 +36,6 @@ import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.utils.SerializableConfiguration;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.hadoop.conf.Configuration;
@@ -154,18 +149,8 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
   }
 
   private ClosableIterator<RowData> getLanceRecordIterator(Path path) {
-    DataType selectedDataType = DataTypes.ROW(Arrays.stream(selectedFields)
-            .mapToObj(i -> DataTypes.FIELD(fullFieldNames[i], fullFieldTypes[i]))
-            .toArray(DataTypes.Field[]::new))
-        .bridgedTo(RowData.class);
-    HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(selectedDataType.getLogicalType());
-    HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(new StoragePath(path.toString()), StreamerUtil.getLanceReadConfig(conf.conf()));
-    try {
-      return reader.getRowDataIterator(selectedDataType, requestedSchema);
-    } catch (RuntimeException e) {
-      reader.close();
-      throw new HoodieException("Failed to get iterator from lance reader", e);
-    }
+    return FormatUtils.getLanceRecordIterator(
+        path.toString(), Arrays.asList(fullFieldNames), Arrays.asList(fullFieldTypes), selectedFields, conf.conf());
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -34,14 +34,11 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
-import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.FormatUtils;
-import org.apache.hudi.table.format.HoodieRowDataLanceReader;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
 import org.apache.hudi.util.FlinkWriteClients;
-import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.StreamerUtil;
 
 import lombok.Getter;
@@ -51,12 +48,10 @@ import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplitAssigner;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -277,19 +272,7 @@ public class MergeOnReadInputFormat
 
   protected ClosableIterator<RowData> getBaseFileIterator(String path) throws IOException {
     if (path.endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
-      DataType selectedDataType = DataTypes.ROW(Arrays.stream(requiredPos)
-              .mapToObj(i -> DataTypes.FIELD(fieldNames.get(i), fieldTypes.get(i)))
-              .toArray(DataTypes.Field[]::new))
-          .bridgedTo(RowData.class);
-      HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(selectedDataType.getLogicalType());
-      HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(
-          new StoragePath(path), StreamerUtil.getLanceReadConfig(hadoopConf));
-      try {
-        return reader.getRowDataIterator(selectedDataType, requestedSchema);
-      } catch (RuntimeException e) {
-        reader.close();
-        throw e;
-      }
+      return FormatUtils.getLanceRecordIterator(path, fieldNames, fieldTypes, requiredPos, hadoopConf);
     }
 
     LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -20,6 +20,7 @@ package org.apache.hudi.table.format.mor;
 
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.schema.HoodieSchema;
@@ -33,11 +34,14 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.FormatUtils;
+import org.apache.hudi.table.format.HoodieRowDataLanceReader;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.RecordIterators;
 import org.apache.hudi.util.FlinkWriteClients;
+import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.StreamerUtil;
 
 import lombok.Getter;
@@ -47,10 +51,12 @@ import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplitAssigner;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -270,6 +276,22 @@ public class MergeOnReadInputFormat
   }
 
   protected ClosableIterator<RowData> getBaseFileIterator(String path) throws IOException {
+    if (path.endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
+      DataType selectedDataType = DataTypes.ROW(Arrays.stream(requiredPos)
+              .mapToObj(i -> DataTypes.FIELD(fieldNames.get(i), fieldTypes.get(i)))
+              .toArray(DataTypes.Field[]::new))
+          .bridgedTo(RowData.class);
+      HoodieSchema requestedSchema = HoodieSchemaConverter.convertToSchema(selectedDataType.getLogicalType());
+      HoodieRowDataLanceReader reader = new HoodieRowDataLanceReader(
+          new StoragePath(path), StreamerUtil.getLanceReadConfig(hadoopConf));
+      try {
+        return reader.getRowDataIterator(selectedDataType, requestedSchema);
+      } catch (RuntimeException e) {
+        reader.close();
+        throw e;
+      }
+    }
+
     LinkedHashMap<String, Object> partObjects = FilePathUtils.generatePartitionSpecs(
         path,
         fieldNames,

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -1683,6 +1683,34 @@ public class ITTestHoodieDataSource {
     assertRowsEquals(updatedRows, TestData.DATA_SET_SOURCE_MERGED);
   }
 
+  @Test
+  void testLanceFormatMergeOnReadUpsertWriteAndRead() {
+    String createHoodieTable = sql("t1")
+        .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+        .options(getDefaultKeys())
+        .option(FlinkOptions.TABLE_TYPE, FlinkOptions.TABLE_TYPE_MERGE_ON_READ)
+        .option(FlinkOptions.COMPACTION_SCHEDULE_ENABLED, true)
+        .option(FlinkOptions.COMPACTION_ASYNC_ENABLED, true)
+        .option(FlinkOptions.COMPACTION_DELTA_COMMITS, 1)
+        .option("hoodie.table.base.file.format", "LANCE")
+        .end();
+    batchTableEnv.executeSql(createHoodieTable);
+
+    execInsertSql(batchTableEnv, TestSQL.INSERT_T1);
+    assertTrue(TestUtils.hasCompleteCompactionInstant(tempFile.getAbsolutePath()),
+        "The first MOR insert should have complete compaction");
+
+    List<Row> rows = CollectionUtil.iteratorToList(
+        batchTableEnv.executeSql("select * from t1").collect());
+    assertRowsEquals(rows, TestData.DATA_SET_SOURCE_INSERT);
+
+    execInsertSql(batchTableEnv, TestSQL.UPDATE_INSERT_T1);
+
+    List<Row> updatedRows = CollectionUtil.iteratorToList(
+        batchTableEnv.executeSql("select * from t1").collect());
+    assertRowsEquals(updatedRows, TestData.DATA_SET_SOURCE_MERGED);
+  }
+
   @ParameterizedTest
   @EnumSource(value = ExecMode.class)
   void testWriteAndReadDebeziumJson(ExecMode execMode) throws Exception {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
@@ -788,7 +788,7 @@ public class TestHoodieTableFactory {
   }
 
   @Test
-  void testLanceFormatSupportedForCopyOnWriteTables() {
+  void testLanceFormatSupportedForFlinkTables() {
     Configuration lanceConf = new Configuration();
     lanceConf.set(FlinkOptions.PATH, new File(tempFile, "lance").getAbsolutePath());
     lanceConf.set(FlinkOptions.TABLE_NAME, "lance_t1");
@@ -807,9 +807,7 @@ public class TestHoodieTableFactory {
     Configuration morConf = new Configuration(lanceConf);
     morConf.set(FlinkOptions.TABLE_TYPE, FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
     final MockContext morContext = MockContext.getInstance(morConf, appendOnlySchema, "f2");
-    HoodieValidationException morEx = assertThrows(HoodieValidationException.class,
-        () -> new HoodieTableFactory().createDynamicTableSink(morContext));
-    assertThat(morEx.getMessage(), is("Flink Lance base-file support is only available for COPY_ON_WRITE tables."));
+    assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSink(morContext));
 
     Configuration schemaEvolutionConf = new Configuration(lanceConf);
     schemaEvolutionConf.setString(HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE.key(), "true");

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
@@ -401,7 +401,7 @@ public class TestHoodieHiveCatalog extends BaseTestHoodieCatalog {
     HoodieCatalogException ex = assertThrows(HoodieCatalogException.class,
         () -> hoodieCatalog.createTable(tablePath, table, false));
     assertThat(ex.getCause(), instanceOf(HoodieValidationException.class));
-    assertThat(ex.getCause().getMessage(), containsString("Lance base file format is currently only supported with the Spark engine"));
+    assertThat(ex.getCause().getMessage(), containsString("Lance base file format is not supported by this reader or writer path"));
   }
 
   @ParameterizedTest

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -954,14 +954,16 @@ public class TestInputFormat {
     testReadChangelogInternal(commits);
   }
 
-  @Test
-  void testReadChangelogIncrementallyForMorWithCompaction() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {"PARQUET", "LANCE"})
+  void testReadChangelogIncrementallyForMorWithCompaction(String baseFileFormat) throws Exception {
     Map<String, String> options = new HashMap<>();
     options.put(FlinkOptions.QUERY_TYPE.key(), FlinkOptions.QUERY_TYPE_INCREMENTAL);
     options.put(FlinkOptions.CDC_ENABLED.key(), "true");
     options.put(FlinkOptions.COMPACTION_ASYNC_ENABLED.key(), "true");
     options.put(FlinkOptions.COMPACTION_DELTA_COMMITS.key(), "1");   // compact for every commit
     options.put(FlinkOptions.INDEX_BOOTSTRAP_ENABLED.key(), "true"); // for batch update
+    options.put("hoodie.table.base.file.format", baseFileFormat);
     beforeEach(HoodieTableType.MERGE_ON_READ, options);
 
     // write 3 commits first

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -170,9 +170,12 @@ public class TestInputFormat {
     assertThat(actual, is(expected));
   }
 
-  @Test
-  void testReadBaseAndLogFiles() throws Exception {
-    beforeEach(HoodieTableType.MERGE_ON_READ);
+  @ParameterizedTest
+  @ValueSource(strings = {"PARQUET", "LANCE"})
+  void testReadBaseAndLogFiles(String baseFileFormat) throws Exception {
+    Map<String, String> options = new HashMap<>();
+    options.put("hoodie.table.base.file.format", baseFileFormat);
+    beforeEach(HoodieTableType.MERGE_ON_READ, options);
 
     // write base first with compaction
     conf.set(FlinkOptions.COMPACTION_ASYNC_ENABLED, true);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestUtils.java
@@ -123,6 +123,12 @@ public class TestUtils {
         .orElse(null);
   }
 
+  public static boolean hasCompleteCompactionInstant(String basePath) {
+    final HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(
+        new HadoopStorageConfiguration(HadoopConfigurations.getHadoopConf(new Configuration())), basePath);
+    return metaClient.getActiveTimeline().filterCompletedInstants().getCommitTimeline().lastInstant().isPresent();
+  }
+
   @Nullable
   public static String getNthArchivedInstant(String basePath, int n) {
     final HoodieTableMetaClient metaClient = HoodieTestUtils.createMetaClient(

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveHoodieReaderContext.java
@@ -130,7 +130,7 @@ public class HiveHoodieReaderContext extends HoodieReaderContext<ArrayWritable> 
   private ClosableIterator<ArrayWritable> getFileRecordIterator(StoragePath filePath, String[] hosts, long start, long length, HoodieSchema dataSchema,
                                                                 HoodieSchema requiredSchema, HoodieStorage storage) throws IOException {
     if (filePath.toString().endsWith(HoodieFileFormat.LANCE.getFileExtension())) {
-      throw new UnsupportedOperationException(HoodieFileFormat.LANCE_SPARK_ONLY_ERROR_MSG);
+      throw new UnsupportedOperationException(HoodieFileFormat.LANCE_UNSUPPORTED_ERROR_MSG);
     }
     // mdt file schema irregular and does not work with this logic. Also, log file evolution is handled inside the log block
     boolean isParquetOrOrc = filePath.getFileExtension().equals(HoodieFileFormat.PARQUET.getFileExtension())


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This closes #18907 .

Flink Lance base-file support was previously scoped away from merge-on-read tables, so MOR write/read flows could not use Lance base files even when the Flink path had Lance-specific readers available. This blocked users from combining Lance base files with MOR log-file merging, CDC base-file reads, and async compaction in Flink SQL pipelines.

This PR expands the Flink Lance path to support merge-on-read writes and reads while keeping the existing schema-evolution restriction for Lance files.

### Summary and Changelog

This PR enables Lance base files for Flink merge-on-read tables, wires Lance readers into MOR and CDC base-file reads, and updates tests to cover both Parquet and Lance MOR base/log-file reads.

#### Working tree: Support Flink Lance MOR write and read path
- Allows `hoodie.table.base.file.format = LANCE` for Flink merge-on-read tables by removing the previous MOR rejection in `HoodieTableFactory`.
- Adds Lance base-file handling in `MergeOnReadInputFormat` using `HoodieRowDataLanceReader` and requested-schema projection.
- Adds Lance base-file handling in `HoodieCdcSplitReaderFunction` so CDC split reads can load Lance base files.
- Narrows `FlinkRowDataReaderContext` schema-evolution rejection to only fail when a non-empty merge schema is required, while still rejecting actual Lance schema evolution.
- Updates the Lance unsupported-path error message to avoid saying Lance is Spark-only.

#### Working tree: Tests and validation
- Adds `ITTestHoodieDataSource.testLanceFormatMergeOnReadUpsertWriteAndRead` for Flink SQL MOR upsert/write/read with Lance base files and async compaction enabled through SQL table options.
- Parameterizes `TestInputFormat.testReadBaseAndLogFiles` to run for both `PARQUET` and `LANCE`.
- Updates table-factory and Hive catalog assertions for the new Lance support boundary.
- Adds a test utility helper for checking completed compaction timeline state.
- Validation run:
  - `mvn -pl hudi-flink-datasource/hudi-flink -am -DskipITs -DskipIT -Dcheckstyle.skip -Drat.skip=true -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TestInputFormat#testReadBaseAndLogFiles test`
  - `mvn -pl hudi-flink-datasource/hudi-flink -am -DskipITs=false -DskipIT=false -Dcheckstyle.skip -Drat.skip=true -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=ITTestHoodieDataSource#testLanceFormatMergeOnReadUpsertWriteAndRead test`

### Impact

This expands Flink user-facing behavior by allowing Lance base files with merge-on-read tables and by enabling MOR/CDC read paths to read Lance base files. Schema evolution for Flink Lance base files remains unsupported. There is no new public API, but the accepted configuration surface changes because Flink MOR tables can now use `hoodie.table.base.file.format = LANCE`.

### Risk Level

medium

This touches Flink MOR read/write behavior, CDC split reads, table factory validation, and a storage-format-specific reader path. Risk is mitigated by targeted unit and integration coverage for Lance MOR SQL writes/reads, MOR base/log-file reads, and table factory validation. One targeted IT run completed successfully with Surefire retry after an initial transient row assertion mismatch.

### Documentation Update

Required. The Flink/base-file-format support matrix or configuration documentation should be updated to note that Lance base files are supported for Flink merge-on-read tables, with schema evolution still unsupported.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable