### PR TITLE
fix(mdt): Propagate bloom filter config to HFile reader correctly

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -860,6 +860,8 @@ public class ConfigUtils {
         metadataConfig.getStringOrDefault(HoodieReaderConfig.HFILE_BLOCK_CACHE_TTL_MINUTES));
     props.setProperty(HoodieMetadataConfig.METADATA_FILE_CACHE_MAX_SIZE_MB.key(),
         metadataConfig.getStringOrDefault(HoodieMetadataConfig.METADATA_FILE_CACHE_MAX_SIZE_MB));
+    props.setProperty(HoodieMetadataConfig.BLOOM_FILTER_ENABLE.key(),
+        metadataConfig.getStringOrDefault(HoodieMetadataConfig.BLOOM_FILTER_ENABLE));
     return props;
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
@@ -458,9 +458,10 @@ public class TestConfigUtils {
   }
 
   @Test
-  void testBuildFileGroupReaderPropertiesIncludesMetadataFileCacheConfig() {
+  void testBuildFileGroupReaderPropertiesIncludesMetadataReaderConfigs() {
     TypedProperties metadataProps = new TypedProperties();
     metadataProps.setProperty(HoodieMetadataConfig.METADATA_FILE_CACHE_MAX_SIZE_MB.key(), "123");
+    metadataProps.setProperty(HoodieMetadataConfig.BLOOM_FILTER_ENABLE.key(), "true");
     metadataProps.setProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_ENABLED.key(), "false");
     metadataProps.setProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_SIZE.key(), "200000");
     metadataProps.setProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_TTL_MINUTES.key(), "7");
@@ -472,6 +473,7 @@ public class TestConfigUtils {
     TypedProperties fileGroupReaderProps = ConfigUtils.buildFileGroupReaderProperties(metadataConfig, false);
 
     assertEquals("123", fileGroupReaderProps.getProperty(HoodieMetadataConfig.METADATA_FILE_CACHE_MAX_SIZE_MB.key()));
+    assertEquals("true", fileGroupReaderProps.getProperty(HoodieMetadataConfig.BLOOM_FILTER_ENABLE.key()));
     assertEquals("false", fileGroupReaderProps.getProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_ENABLED.key()));
     assertEquals("200000", fileGroupReaderProps.getProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_SIZE.key()));
     assertEquals("7", fileGroupReaderProps.getProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_TTL_MINUTES.key()));

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileReaderFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileReaderFactory.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.io.storage.hadoop;
 
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.io.storage.HFileReaderFactory;
@@ -51,8 +52,7 @@ public class HoodieAvroFileReaderFactory extends HoodieFileReaderFactory {
     HFileReaderFactory readerFactory = HFileReaderFactory.builder()
         .withStorage(storage).withProps(hoodieConfig.getProps())
         .withPath(path).build();
-    return HoodieNativeAvroHFileReader.builder()
-        .readerFactory(readerFactory).path(path).schema(schemaOption).build();
+    return newNativeHFileReader(hoodieConfig, readerFactory, path, schemaOption);
   }
 
   protected HoodieFileReader newHFileFileReader(HoodieConfig hoodieConfig, StoragePathInfo pathInfo,
@@ -60,8 +60,7 @@ public class HoodieAvroFileReaderFactory extends HoodieFileReaderFactory {
     HFileReaderFactory readerFactory = HFileReaderFactory.builder()
         .withStorage(storage).withProps(hoodieConfig.getProps())
         .withPath(pathInfo.getPath()).withFileSize(pathInfo.getLength()).build();
-    return HoodieNativeAvroHFileReader.builder()
-        .readerFactory(readerFactory).path(pathInfo.getPath()).schema(schemaOption).build();
+    return newNativeHFileReader(hoodieConfig, readerFactory, pathInfo.getPath(), schemaOption);
   }
 
   @Override
@@ -73,8 +72,19 @@ public class HoodieAvroFileReaderFactory extends HoodieFileReaderFactory {
     HFileReaderFactory.Builder readerFactoryBuilder = HFileReaderFactory.builder()
         .withStorage(storage).withProps(hoodieConfig.getProps())
         .withContent(content);
+    return newNativeHFileReader(hoodieConfig, readerFactoryBuilder.build(), path, schemaOption);
+  }
+
+  private HoodieNativeAvroHFileReader newNativeHFileReader(HoodieConfig hoodieConfig,
+                                                           HFileReaderFactory readerFactory,
+                                                           StoragePath path,
+                                                           Option<HoodieSchema> schemaOption) {
     return HoodieNativeAvroHFileReader.builder()
-        .readerFactory(readerFactoryBuilder.build()).path(path).schema(schemaOption).build();
+        .readerFactory(readerFactory)
+        .path(path)
+        .schema(schemaOption)
+        .useBloomFilter(hoodieConfig.getBoolean(HoodieMetadataConfig.BLOOM_FILTER_ENABLE))
+        .build();
   }
 
   @Override

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieAvroFileReaderFactory.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieAvroFileReaderFactory.java
@@ -19,22 +19,34 @@
 
 package org.apache.hudi.io.hadoop;
 
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.io.storage.HoodieNativeAvroHFileReader;
 import org.apache.hudi.io.storage.hadoop.HoodieAvroOrcReader;
 import org.apache.hudi.io.storage.hadoop.HoodieAvroParquetReader;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 
 import static org.apache.hudi.common.util.ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,6 +56,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestHoodieAvroFileReaderFactory {
   @TempDir
   public java.nio.file.Path tempDir;
+
+  private static final StoragePath HFILE_PATH = new StoragePath("/partition/path/f1_1-0-1_000.hfile");
 
   @Test
   public void testGetFileReader() throws IOException {
@@ -69,5 +83,57 @@ public class TestHoodieAvroFileReaderFactory {
         .getReaderFactory(HoodieRecordType.AVRO)
         .getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, orcPath);
     assertTrue(orcReader instanceof HoodieAvroOrcReader);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testHFileReaderPassesBloomFilterConfig(boolean bloomFilterEnabled)
+      throws IOException, ReflectiveOperationException {
+    HoodieStorage storage = HoodieTestUtils.getDefaultStorage();
+    HoodieFileReaderFactory readerFactory = HoodieIOFactory.getIOFactory(storage)
+        .getReaderFactory(HoodieRecordType.AVRO);
+    HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+        .withProperties(DEFAULT_HUDI_CONFIG_FOR_READER.getProps())
+        .withProperties(bloomFilterProps(bloomFilterEnabled))
+        .build();
+
+    assertBloomFilterConfig(readerFactory.getFileReader(metadataConfig, HFILE_PATH),
+        bloomFilterEnabled);
+    assertBloomFilterConfig(readerFactory.getFileReader(metadataConfig,
+        new StoragePathInfo(HFILE_PATH, 100, false, (short) 0, 0, 0), HoodieFileFormat.HFILE,
+        Option.<HoodieSchema>empty()), bloomFilterEnabled);
+    assertBloomFilterConfig(readerFactory.getContentReader(metadataConfig, HFILE_PATH, HoodieFileFormat.HFILE,
+        storage, new byte[0], Option.<HoodieSchema>empty()),
+        bloomFilterEnabled);
+  }
+
+  @Test
+  public void testHFileReaderDoesNotUseBloomFilterByDefault()
+      throws IOException, ReflectiveOperationException {
+    HoodieStorage storage = HoodieTestUtils.getDefaultStorage();
+    HoodieFileReaderFactory readerFactory = HoodieIOFactory.getIOFactory(storage)
+        .getReaderFactory(HoodieRecordType.AVRO);
+
+    assertBloomFilterConfig(readerFactory.getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, HFILE_PATH), false);
+    assertBloomFilterConfig(readerFactory.getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER,
+        new StoragePathInfo(HFILE_PATH, 100, false, (short) 0, 0, 0), HoodieFileFormat.HFILE,
+        Option.<HoodieSchema>empty()), false);
+    assertBloomFilterConfig(readerFactory.getContentReader(DEFAULT_HUDI_CONFIG_FOR_READER, HFILE_PATH,
+        HoodieFileFormat.HFILE, storage, new byte[0], Option.<HoodieSchema>empty()),
+        false);
+  }
+
+  private static TypedProperties bloomFilterProps(boolean enableBloomFilter) {
+    TypedProperties properties = new TypedProperties();
+    properties.setProperty(HoodieMetadataConfig.BLOOM_FILTER_ENABLE.key(), Boolean.toString(enableBloomFilter));
+    return properties;
+  }
+
+  private static void assertBloomFilterConfig(HoodieFileReader reader, boolean expectedBloomFilterEnabled)
+      throws ReflectiveOperationException {
+    HoodieNativeAvroHFileReader hfileReader = assertInstanceOf(HoodieNativeAvroHFileReader.class, reader);
+    Field useBloomFilterField = HoodieNativeAvroHFileReader.class.getDeclaredField("useBloomFilter");
+    useBloomFilterField.setAccessible(true);
+    assertEquals(expectedBloomFilterEnabled, useBloomFilterField.getBoolean(hfileReader));
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`hoodie.metadata.bloom.filter.enable` was not fully propagated through the metadata table read path. As a result, metadata file-group readers and HFile readers could be constructed without enabling the native HFile bloom filter lookup optimization, even when the metadata bloom filter config was set.

This PR wires the existing metadata bloom filter config through the file-group reader properties and HFile reader factory so metadata table lookups, including record index reads, can correctly enable bloom-filter-backed full-key lookup.

Fixes #18918.

### Summary and Changelog

- Added `HoodieMetadataConfig.BLOOM_FILTER_ENABLE` to `ConfigUtils.buildFileGroupReaderProperties` so metadata reader configs carry the bloom filter setting into file-group readers.
- Updated `HoodieAvroFileReaderFactory` to pass the bloom filter setting into `HoodieNativeAvroHFileReader` for path, `StoragePathInfo`, and in-memory content reader creation paths.
- Added tests in `TestConfigUtils` and `TestHoodieAvroFileReaderFactory` covering config propagation, explicit true/false values, default behavior, and all HFile reader creation paths.

### Impact

Existing `hoodie.metadata.bloom.filter.enable=true` settings now correctly enable native HFile bloom filter usage for metadata HFile full-key lookup paths.

### Risk Level

low. The change is scoped to metadata reader config propagation and HFile reader construction, with tests covering the new config path and default disabled behavior.

### Documentation Update

none. This fixes propagation for an existing config and does not introduce a new user-facing option.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable