### PR TITLE
fix: Add input records caching to HoodieGlobalSimpleIndex

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieGlobalSimpleIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/simple/HoodieGlobalSimpleIndex.java
@@ -68,13 +68,20 @@ public class HoodieGlobalSimpleIndex extends HoodieSimpleIndex {
   protected <R> HoodieData<HoodieRecord<R>> tagLocationInternal(
       HoodieData<HoodieRecord<R>> inputRecords, HoodieEngineContext context,
       HoodieTable hoodieTable) {
+    if (config.getSimpleIndexUseCaching()) {
+      inputRecords.persist(config.getSimpleIndexInputStorageLevel());
+    }
     List<Pair<String, HoodieBaseFile>> latestBaseFiles = getAllBaseFilesInTable(context, hoodieTable);
     HoodiePairData<String, HoodieRecordGlobalLocation> allKeysAndLocations =
         fetchRecordGlobalLocations(context, hoodieTable, latestBaseFiles);
     boolean mayContainDuplicateLookup = hoodieTable.getMetaClient().getTableType() == MERGE_ON_READ;
     boolean shouldUpdatePartitionPath = config.getGlobalSimpleIndexUpdatePartitionPath() && hoodieTable.isPartitioned();
-    return tagGlobalLocationBackToRecords(inputRecords, allKeysAndLocations,
+    HoodieData<HoodieRecord<R>> taggedRecords = tagGlobalLocationBackToRecords(inputRecords, allKeysAndLocations,
         mayContainDuplicateLookup, shouldUpdatePartitionPath, config, hoodieTable);
+    if (config.getSimpleIndexUseCaching()) {
+      inputRecords.unpersist();
+    }
+    return taggedRecords;
   }
 
   private HoodiePairData<String, HoodieRecordGlobalLocation> fetchRecordGlobalLocations(


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18922

`HoodieGlobalSimpleIndex.tagLocationInternal` overrides the parent `HoodieSimpleIndex.tagLocationInternal` but was missing the `persist`/`unpersist` caching guard. `inputRecords` is referenced multiple times across the lazy RDD DAG (once for the key-based join and once per branch in `mergeForPartitionUpdatesAndDeletionsIfNeeded`). Without caching, Spark recomputes the full source lineage for each downstream evaluation, causing the same data to be re-read from the source multiple times within a single upsert.

### Summary and Changelog

- Add `inputRecords.persist(config.getSimpleIndexInputStorageLevel())` at the start of `HoodieGlobalSimpleIndex.tagLocationInternal` when `hoodie.simple.index.use.caching` is enabled
- Call `inputRecords.unpersist()` after `tagGlobalLocationBackToRecords` returns

Mirrors the identical pattern already present in `HoodieSimpleIndex.tagLocationInternal` (parent class) and `SparkMetadataTableGlobalRecordLevelIndex.tagLocation`.

### Impact

Performance improvement for writes using `GLOBAL_SIMPLE` index — avoids redundant recomputation of the incoming records RDD lineage within a single upsert operation. No API or behavior change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable