### PR TITLE
refactor(variant): self-align log-block variant rows, drop buffer-level projection hook

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -148,14 +148,14 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
   }
 
   /**
-   * Variant overload. {@code structSchema} is the requested Spark schema, which may carry
+   * Variant overload. {@code projectedStructSchema} is the requested Spark schema, which may carry
    * a Spark 4.1 PushVariantIntoScan variant projection (per-field {@code VariantMetadata}) that
    * {@link HoodieSchema} cannot represent. Using it as the requested schema makes parquet-mr decode
    * variant columns into the projected struct shape natively (mirroring the base-file read path)
    * rather than returning the full {@code VariantType}. {@code requestedSchema} is still used for
    * vector-column detection (orthogonal to variants) and the timestamp-repair MessageType.
    */
-  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType structSchema, List<Filter> readFilters) throws IOException {
+  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType projectedStructSchema, List<Filter> readFilters) throws IOException {
     HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
 
     // Detect vector columns: ordinal → Vector schema
@@ -164,8 +164,8 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
     // For vector columns, replace ArrayType(FloatType) with BinaryType in the read schema
     // so SparkBasicSchemaEvolution sees matching types (file has FIXED_LEN_BYTE_ARRAY → BinaryType)
     StructType readStructSchema = vectorColumnInfo.isEmpty()
-        ? structSchema
-        : VectorConversionUtils.replaceVectorColumnsWithBinary(structSchema, vectorColumnInfo);
+        ? projectedStructSchema
+        : VectorConversionUtils.replaceVectorColumnsWithBinary(projectedStructSchema, vectorColumnInfo);
 
     Option<MessageType> messageSchema = Option.of(getAvroSchemaConverter(storage.getConf().unwrapAs(Configuration.class)).convert(nonNullSchema));
     boolean enableTimestampFieldRepair = storage.getConf().getBoolean(ENABLE_LOGICAL_TIMESTAMP_REPAIR, true);
@@ -215,7 +215,7 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
 
     if (!vectorColumnInfo.isEmpty()) {
       // Post-process: convert binary VECTOR columns back to typed arrays
-      UnsafeProjection vectorProjection = UnsafeProjection.create(structSchema);
+      UnsafeProjection vectorProjection = UnsafeProjection.create(projectedStructSchema);
       Function<InternalRow, InternalRow> mapper =
           VectorConversionUtils.buildRowMapper(readStructSchema, vectorColumnInfo, vectorProjection::apply);
       CloseableMappingIterator<UnsafeRow, UnsafeRow> vectorIterator =

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -148,16 +148,15 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
   }
 
   /**
-   * Variant overload. {@code projectedRequestedStruct} is the requested Spark schema, which may carry
+   * Variant overload. {@code structSchema} is the requested Spark schema, which may carry
    * a Spark 4.1 PushVariantIntoScan variant projection (per-field {@code VariantMetadata}) that
    * {@link HoodieSchema} cannot represent. Using it as the requested schema makes parquet-mr decode
    * variant columns into the projected struct shape natively (mirroring the base-file read path)
    * rather than returning the full {@code VariantType}. {@code requestedSchema} is still used for
    * vector-column detection (orthogonal to variants) and the timestamp-repair MessageType.
    */
-  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType projectedRequestedStruct, List<Filter> readFilters) throws IOException {
+  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType structSchema, List<Filter> readFilters) throws IOException {
     HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
-    StructType structSchema = projectedRequestedStruct;
 
     // Detect vector columns: ordinal → Vector schema
     Map<Integer, HoodieSchema.Vector> vectorColumnInfo = HoodieVectorUtils.detectVectorColumns(nonNullSchema);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -144,7 +144,20 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
    */
   public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, List<Filter> readFilters) throws IOException {
     HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
-    StructType structSchema = HoodieInternalRowUtils.getCachedSchema(nonNullSchema);
+    return getUnsafeRowIterator(nonNullSchema, HoodieInternalRowUtils.getCachedSchema(nonNullSchema), readFilters);
+  }
+
+  /**
+   * Variant overload. {@code projectedRequestedStruct} is the requested Spark schema, which may carry
+   * a Spark 4.1 PushVariantIntoScan variant projection (per-field {@code VariantMetadata}) that
+   * {@link HoodieSchema} cannot represent. Using it as the requested schema makes parquet-mr decode
+   * variant columns into the projected struct shape natively (mirroring the base-file read path)
+   * rather than returning the full {@code VariantType}. {@code requestedSchema} is still used for
+   * vector-column detection (orthogonal to variants) and the timestamp-repair MessageType.
+   */
+  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType projectedRequestedStruct, List<Filter> readFilters) throws IOException {
+    HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
+    StructType structSchema = projectedRequestedStruct;
 
     // Detect vector columns: ordinal → Vector schema
     Map<Integer, HoodieSchema.Vector> vectorColumnInfo = HoodieVectorUtils.detectVectorColumns(nonNullSchema);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -149,12 +149,13 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
   }
 
   /**
-   * Variant overload. {@code projectedStructSchema} is the requested Spark schema, which may carry
-   * a Spark 4.1 PushVariantIntoScan variant projection (per-field {@code VariantMetadata}) that
-   * {@link HoodieSchema} cannot represent. Using it as the requested schema makes parquet-mr decode
-   * variant columns into the projected struct shape natively (mirroring the base-file read path)
-   * rather than returning the full {@code VariantType}. {@code requestedSchema} is still used for
-   * vector-column detection (orthogonal to variants) and the timestamp-repair MessageType.
+   * Returns an unsafe-row iterator that uses {@code projectedStructSchema} as the Spark read schema
+   * directly, preserving any Spark 4.1 PushVariantIntoScan variant projection (per-field
+   * {@code VariantMetadata}) that {@link HoodieSchema} cannot represent. Using it as the requested
+   * schema makes parquet-mr decode variant columns into the projected struct shape natively
+   * (mirroring the base-file read path) rather than returning the full {@code VariantType}.
+   * {@code requestedSchema} is still used for vector-column detection (orthogonal to variants) and
+   * the timestamp-repair MessageType.
    */
   public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType projectedStructSchema, List<Filter> readFilters) throws IOException {
     HoodieSchema nonNullSchema = requestedSchema.getNonNullType();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -149,16 +149,15 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
   }
 
   /**
-   * Variant overload. {@code projectedRequestedStruct} is the requested Spark schema, which may carry
+   * Variant overload. {@code structSchema} is the requested Spark schema, which may carry
    * a Spark 4.1 PushVariantIntoScan variant projection (per-field {@code VariantMetadata}) that
    * {@link HoodieSchema} cannot represent. Using it as the requested schema makes parquet-mr decode
    * variant columns into the projected struct shape natively (mirroring the base-file read path)
    * rather than returning the full {@code VariantType}. {@code requestedSchema} is still used for
    * vector-column detection (orthogonal to variants) and the timestamp-repair MessageType.
    */
-  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType projectedRequestedStruct, List<Filter> readFilters) throws IOException {
+  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType structSchema, List<Filter> readFilters) throws IOException {
     HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
-    StructType structSchema = projectedRequestedStruct;
 
     // Detect vector columns: ordinal → Vector schema
     Map<Integer, HoodieSchema.Vector> vectorColumnInfo = HoodieVectorUtils.detectVectorColumns(nonNullSchema);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -145,7 +145,20 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
    */
   public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, List<Filter> readFilters) throws IOException {
     HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
-    StructType structSchema = HoodieInternalRowUtils.getCachedSchema(nonNullSchema);
+    return getUnsafeRowIterator(nonNullSchema, HoodieInternalRowUtils.getCachedSchema(nonNullSchema), readFilters);
+  }
+
+  /**
+   * Variant overload. {@code projectedRequestedStruct} is the requested Spark schema, which may carry
+   * a Spark 4.1 PushVariantIntoScan variant projection (per-field {@code VariantMetadata}) that
+   * {@link HoodieSchema} cannot represent. Using it as the requested schema makes parquet-mr decode
+   * variant columns into the projected struct shape natively (mirroring the base-file read path)
+   * rather than returning the full {@code VariantType}. {@code requestedSchema} is still used for
+   * vector-column detection (orthogonal to variants) and the timestamp-repair MessageType.
+   */
+  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType projectedRequestedStruct, List<Filter> readFilters) throws IOException {
+    HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
+    StructType structSchema = projectedRequestedStruct;
 
     // Detect vector columns: ordinal → Vector schema
     Map<Integer, HoodieSchema.Vector> vectorColumnInfo = HoodieVectorUtils.detectVectorColumns(nonNullSchema);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetReader.java
@@ -149,14 +149,14 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
   }
 
   /**
-   * Variant overload. {@code structSchema} is the requested Spark schema, which may carry
+   * Variant overload. {@code projectedStructSchema} is the requested Spark schema, which may carry
    * a Spark 4.1 PushVariantIntoScan variant projection (per-field {@code VariantMetadata}) that
    * {@link HoodieSchema} cannot represent. Using it as the requested schema makes parquet-mr decode
    * variant columns into the projected struct shape natively (mirroring the base-file read path)
    * rather than returning the full {@code VariantType}. {@code requestedSchema} is still used for
    * vector-column detection (orthogonal to variants) and the timestamp-repair MessageType.
    */
-  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType structSchema, List<Filter> readFilters) throws IOException {
+  public ClosableIterator<UnsafeRow> getUnsafeRowIterator(HoodieSchema requestedSchema, StructType projectedStructSchema, List<Filter> readFilters) throws IOException {
     HoodieSchema nonNullSchema = requestedSchema.getNonNullType();
 
     // Detect vector columns: ordinal → Vector schema
@@ -165,8 +165,8 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
     // For vector columns, replace ArrayType(FloatType) with BinaryType in the read schema
     // so SparkBasicSchemaEvolution sees matching types (file has FIXED_LEN_BYTE_ARRAY → BinaryType)
     StructType readStructSchema = vectorColumnInfo.isEmpty()
-        ? structSchema
-        : VectorConversionUtils.replaceVectorColumnsWithBinary(structSchema, vectorColumnInfo);
+        ? projectedStructSchema
+        : VectorConversionUtils.replaceVectorColumnsWithBinary(projectedStructSchema, vectorColumnInfo);
 
     Option<MessageType> messageSchema = Option.of(getAvroSchemaConverter(storage.getConf().unwrapAs(Configuration.class)).convert(nonNullSchema));
     boolean enableTimestampFieldRepair = storage.getConf().getBoolean(ENABLE_LOGICAL_TIMESTAMP_REPAIR, true);
@@ -217,7 +217,7 @@ public class HoodieSparkParquetReader implements HoodieSparkFileReader {
 
     if (!vectorColumnInfo.isEmpty()) {
       // Post-process: convert binary VECTOR columns back to typed arrays
-      UnsafeProjection vectorProjection = UnsafeProjection.create(structSchema);
+      UnsafeProjection vectorProjection = UnsafeProjection.create(projectedStructSchema);
       Function<InternalRow, InternalRow> mapper =
           VectorConversionUtils.buildRowMapper(readStructSchema, vectorColumnInfo, vectorProjection::apply);
       CloseableMappingIterator<UnsafeRow, UnsafeRow> vectorIterator =

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -24,13 +24,14 @@ import org.apache.hudi.SparkFileFormatInternalRowReaderContext.{filterIsSafeForB
 import org.apache.hudi.common.engine.HoodieReaderContext
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieFileFormat, HoodieRecord}
+import org.apache.hudi.common.model.HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
 import org.apache.hudi.common.util.HoodieVectorUtils
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.common.util.ValidationUtils.checkState
-import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, Pair => HPair}
+import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, CloseableMappingIterator, Pair => HPair}
 import org.apache.hudi.io.storage.{HoodieSparkFileReaderFactory, HoodieSparkParquetReader, VectorConversionUtils}
 import org.apache.hudi.storage.{HoodieStorage, StorageConfiguration, StoragePath}
 import org.apache.hudi.util.CloseableInternalRowIterator
@@ -86,6 +87,14 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
 
   // For each field of `target`, replace its dataType with the matching field's projected
   // variant struct from `source` (when present). Non-matching fields pass through.
+  //
+  // Why a parallel `sparkRequiredSchema` overlay exists at all (#18739 sub-task 4): a Spark 4.1
+  // PushVariantIntoScan projection carries per-field `VariantMetadata` (extraction path / timezone /
+  // failOnError) that `HoodieSchema` has nowhere to store — `HoodieSparkSchemaConverters` collapses
+  // the projected struct back to a plain VARIANT and the reverse can't reconstruct the metadata. So
+  // the engine must keep the projected Spark schema alongside the HoodieSchema; it cannot be
+  // recovered from a HoodieSchema round-trip. Kept Spark-side on purpose so the engine-neutral schema
+  // model stays free of Spark-4.1 variant concepts.
   private def overlayVariantProjections(target: StructType, source: StructType): StructType = {
     StructType(target.fields.map { f =>
       SparkFileFormatInternalRowReaderContext.findFieldByName(source, f.name).map(_.dataType) match {
@@ -96,29 +105,45 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     })
   }
 
-  // Aligns log-block records with the PushVariantIntoScan-projected variant shape before
-  // they reach the merger. Preserves merger metadata cols (_hoodie_record_key,
-  // _tmp_metadata_row_index) which the merger reads by ordinal — projecting down to the
-  // bare required schema would drop them and the merger would read garbage offsets.
-  override def getLogBlockRecordProjection(
-      dataBlockSchema: HoodieSchema): HOption[JFunction[InternalRow, InternalRow]] = {
-    val needsProjection = sparkRequiredSchema.exists(_.fields.exists(f => f.dataType match {
+  // True only when there is a Spark 4.1 PushVariantIntoScan projection to apply AND the table is
+  // not using a custom (payload-based) merger. Payload-based tables round-trip records through
+  // PayloadUpdateProcessor.convertToAvroRecord against a schema that still types variant fields as
+  // VariantType, so a row already rewritten into the projected struct shape would be mis-decoded.
+  // Single source of truth for both reader paths (parquet native projection + avro rewrite).
+  private def shouldProjectVariants: Boolean = {
+    val hasVariantProjection = sparkRequiredSchema.exists(_.fields.exists(_.dataType match {
       case st: StructType => sparkAdapter.isVariantProjectionStruct(st)
       case _ => false
     }))
-    if (!needsProjection) {
-      return HOption.empty[JFunction[InternalRow, InternalRow]]()
+    hasVariantProjection && {
+      val merger = getRecordMerger()
+      !(merger != null && merger.isPresent && merger.get.getMergingStrategy == PAYLOAD_BASED_MERGE_STRATEGY_UUID)
+    }
+  }
+
+  // Aligns avro log-block records with the PushVariantIntoScan-projected variant shape before
+  // they reach the merger. Preserves merger metadata cols (_hoodie_record_key,
+  // _tmp_metadata_row_index) which the merger reads by ordinal — projecting down to the bare
+  // required schema would drop them and the merger would read garbage offsets. Parquet log blocks
+  // project natively in getFileRecordIterator, so only the avro log reader calls this hook.
+  override def projectLogBlockRecords(
+      recordIterator: ClosableIterator[InternalRow],
+      dataBlockSchema: HoodieSchema): ClosableIterator[InternalRow] = {
+    if (!shouldProjectVariants) {
+      return recordIterator
     }
     val req = sparkRequiredSchema.get
     val dataStruct = HoodieInternalRowUtils.getCachedSchema(dataBlockSchema)
     val targetStruct = overlayVariantProjections(dataStruct, req)
     sparkAdapter.buildVariantProjector(dataStruct, targetStruct) match {
-      case Some(p) => HOption.of(new JFunction[InternalRow, InternalRow] {
-        // .copy() because the buffer stores rows into ExternalSpillableMap and
-        // UnsafeProjection reuses a single output buffer.
-        override def apply(r: InternalRow): InternalRow = p(r).copy()
-      })
-      case None => HOption.empty[JFunction[InternalRow, InternalRow]]()
+      case Some(p) =>
+        new CloseableMappingIterator[InternalRow, InternalRow](recordIterator,
+          new JFunction[InternalRow, InternalRow] {
+            // .copy() because the buffer stores rows into ExternalSpillableMap and
+            // UnsafeProjection reuses a single output buffer.
+            override def apply(r: InternalRow): InternalRow = p(r).copy()
+          })
+      case None => recordIterator
     }
   }
 
@@ -159,11 +184,18 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
 
     val (readSchema, readFilters) = getSchemaAndFiltersForRead(parquetReadStructType, hasRowIndexField)
     if (FSUtils.isLogFile(filePath)) {
-      // NOTE: now only primary key based filtering is supported for log files
-      // Variant alignment happens later via getLogBlockRecordProjection in the merge buffer.
-      new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
-        .asInstanceOf[HoodieSparkParquetReader].getUnsafeRowIterator(requiredSchema, readFilters.asJava)
-        .asInstanceOf[ClosableIterator[InternalRow]]
+      // NOTE: now only primary key based filtering is supported for log files.
+      val reader = new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
+        .asInstanceOf[HoodieSparkParquetReader]
+      val rawIterator = if (shouldProjectVariants) {
+        // Thread the variant-overlaid struct (carrying VariantMetadata that HoodieSchema can't
+        // represent) so parquet-mr decodes variants into the projected struct shape natively,
+        // mirroring the base-file branch below. Gated so payload-based tables keep full variants.
+        reader.getUnsafeRowIterator(requiredSchema, structType, readFilters.asJava)
+      } else {
+        reader.getUnsafeRowIterator(requiredSchema, readFilters.asJava)
+      }
+      rawIterator.asInstanceOf[ClosableIterator[InternalRow]]
     } else {
       // partition value is empty because the spark parquet reader will append the partition columns to
       // each row if they are given. That is the only usage of the partition values in the reader.

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -133,9 +133,9 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     if (!shouldProjectVariants) {
       return recordIterator
     }
-    val req = sparkRequiredSchema.get
+    val requiredStruct = sparkRequiredSchema.get
     val dataStruct = HoodieInternalRowUtils.getCachedSchema(dataBlockSchema)
-    val targetStruct = overlayVariantProjections(dataStruct, req)
+    val targetStruct = overlayVariantProjections(dataStruct, requiredStruct)
     sparkAdapter.buildVariantProjector(dataStruct, targetStruct) match {
       case Some(p) =>
         new CloseableMappingIterator[InternalRow, InternalRow](recordIterator,

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -115,10 +115,9 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
       case st: StructType => sparkAdapter.isVariantProjectionStruct(st)
       case _ => false
     }))
-    hasVariantProjection && {
-      val merger = getRecordMerger()
-      !(merger != null && merger.isPresent && merger.get.getMergingStrategy == PAYLOAD_BASED_MERGE_STRATEGY_UUID)
-    }
+    val merger = getRecordMerger()
+    val isPayloadBased = merger != null && merger.isPresent && merger.get.getMergingStrategy == PAYLOAD_BASED_MERGE_STRATEGY_UUID
+    hasVariantProjection && !isPayloadBased
   }
 
   // Aligns avro log-block records with the PushVariantIntoScan-projected variant shape before

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -115,6 +115,8 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
       case st: StructType => sparkAdapter.isVariantProjectionStruct(st)
       case _ => false
     }))
+    // getRecordMerger() is a Lombok getter over a field initialized to null (not Option.empty());
+    // it stays null until setRecordMerger() runs during reader init, so the null guard is required.
     val merger = getRecordMerger()
     val isPayloadBased = merger != null && merger.isPresent && merger.get.getMergingStrategy == PAYLOAD_BASED_MERGE_STRATEGY_UUID
     hasVariantProjection && !isPayloadBased

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -111,7 +111,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
   // PayloadUpdateProcessor.convertToAvroRecord against a schema that still types variant fields as
   // VariantType, so a row already rewritten into the projected struct shape would be mis-decoded.
   // Single source of truth for both reader paths (parquet native projection + avro rewrite).
-  private def shouldProjectVariants: Boolean = {
+  private def shouldProjectVariants(): Boolean = {
     val hasVariantProjection = sparkRequiredSchema.exists(_.fields.exists(_.dataType match {
       case st: StructType => sparkAdapter.isVariantProjectionStruct(st)
       case _ => false
@@ -131,7 +131,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
   override def projectLogBlockRecords(
       recordIterator: ClosableIterator[InternalRow],
       dataBlockSchema: HoodieSchema): ClosableIterator[InternalRow] = {
-    if (!shouldProjectVariants) {
+    if (!shouldProjectVariants()) {
       return recordIterator
     }
     val requiredStruct = sparkRequiredSchema.get
@@ -232,7 +232,7 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
         case HoodieFileFormat.PARQUET =>
           val reader = new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
             .asInstanceOf[HoodieSparkParquetReader]
-          val rawIterator = if (shouldProjectVariants) {
+          val rawIterator = if (shouldProjectVariants()) {
             // Thread the variant-overlaid struct (carrying VariantMetadata that HoodieSchema can't
             // represent) so parquet-mr decodes variants into the projected struct shape natively,
             // mirroring the base-file branch below. Gated so payload-based tables keep full variants.

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -24,13 +24,14 @@ import org.apache.hudi.SparkFileFormatInternalRowReaderContext.{filterIsSafeForB
 import org.apache.hudi.common.engine.HoodieReaderContext
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieFileFormat, HoodieRecord}
+import org.apache.hudi.common.model.HoodieRecordMerger.PAYLOAD_BASED_MERGE_STRATEGY_UUID
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
 import org.apache.hudi.common.util.HoodieVectorUtils
 import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.common.util.ValidationUtils.checkState
-import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, Pair => HPair}
+import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, CloseableMappingIterator, Pair => HPair}
 import org.apache.hudi.io.storage.{HoodieSparkFileReaderFactory, HoodieSparkParquetReader, VectorConversionUtils}
 import org.apache.hudi.storage.{HoodieStorage, StorageConfiguration, StoragePath}
 import org.apache.hudi.util.CloseableInternalRowIterator
@@ -86,6 +87,14 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
 
   // For each field of `target`, replace its dataType with the matching field's projected
   // variant struct from `source` (when present). Non-matching fields pass through.
+  //
+  // Why a parallel `sparkRequiredSchema` overlay exists at all (#18739 sub-task 4): a Spark 4.1
+  // PushVariantIntoScan projection carries per-field `VariantMetadata` (extraction path / timezone /
+  // failOnError) that `HoodieSchema` has nowhere to store — `HoodieSparkSchemaConverters` collapses
+  // the projected struct back to a plain VARIANT and the reverse can't reconstruct the metadata. So
+  // the engine must keep the projected Spark schema alongside the HoodieSchema; it cannot be
+  // recovered from a HoodieSchema round-trip. Kept Spark-side on purpose so the engine-neutral schema
+  // model stays free of Spark-4.1 variant concepts.
   private def overlayVariantProjections(target: StructType, source: StructType): StructType = {
     StructType(target.fields.map { f =>
       SparkFileFormatInternalRowReaderContext.findFieldByName(source, f.name).map(_.dataType) match {
@@ -96,29 +105,45 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     })
   }
 
-  // Aligns log-block records with the PushVariantIntoScan-projected variant shape before
-  // they reach the merger. Preserves merger metadata cols (_hoodie_record_key,
-  // _tmp_metadata_row_index) which the merger reads by ordinal — projecting down to the
-  // bare required schema would drop them and the merger would read garbage offsets.
-  override def getLogBlockRecordProjection(
-      dataBlockSchema: HoodieSchema): HOption[JFunction[InternalRow, InternalRow]] = {
-    val needsProjection = sparkRequiredSchema.exists(_.fields.exists(f => f.dataType match {
+  // True only when there is a Spark 4.1 PushVariantIntoScan projection to apply AND the table is
+  // not using a custom (payload-based) merger. Payload-based tables round-trip records through
+  // PayloadUpdateProcessor.convertToAvroRecord against a schema that still types variant fields as
+  // VariantType, so a row already rewritten into the projected struct shape would be mis-decoded.
+  // Single source of truth for both reader paths (parquet native projection + avro rewrite).
+  private def shouldProjectVariants: Boolean = {
+    val hasVariantProjection = sparkRequiredSchema.exists(_.fields.exists(_.dataType match {
       case st: StructType => sparkAdapter.isVariantProjectionStruct(st)
       case _ => false
     }))
-    if (!needsProjection) {
-      return HOption.empty[JFunction[InternalRow, InternalRow]]()
+    hasVariantProjection && {
+      val merger = getRecordMerger()
+      !(merger != null && merger.isPresent && merger.get.getMergingStrategy == PAYLOAD_BASED_MERGE_STRATEGY_UUID)
+    }
+  }
+
+  // Aligns avro log-block records with the PushVariantIntoScan-projected variant shape before
+  // they reach the merger. Preserves merger metadata cols (_hoodie_record_key,
+  // _tmp_metadata_row_index) which the merger reads by ordinal — projecting down to the bare
+  // required schema would drop them and the merger would read garbage offsets. Parquet log blocks
+  // project natively in getFileRecordIterator, so only the avro log reader calls this hook.
+  override def projectLogBlockRecords(
+      recordIterator: ClosableIterator[InternalRow],
+      dataBlockSchema: HoodieSchema): ClosableIterator[InternalRow] = {
+    if (!shouldProjectVariants) {
+      return recordIterator
     }
     val req = sparkRequiredSchema.get
     val dataStruct = HoodieInternalRowUtils.getCachedSchema(dataBlockSchema)
     val targetStruct = overlayVariantProjections(dataStruct, req)
     sparkAdapter.buildVariantProjector(dataStruct, targetStruct) match {
-      case Some(p) => HOption.of(new JFunction[InternalRow, InternalRow] {
-        // .copy() because the buffer stores rows into ExternalSpillableMap and
-        // UnsafeProjection reuses a single output buffer.
-        override def apply(r: InternalRow): InternalRow = p(r).copy()
-      })
-      case None => HOption.empty[JFunction[InternalRow, InternalRow]]()
+      case Some(p) =>
+        new CloseableMappingIterator[InternalRow, InternalRow](recordIterator,
+          new JFunction[InternalRow, InternalRow] {
+            // .copy() because the buffer stores rows into ExternalSpillableMap and
+            // UnsafeProjection reuses a single output buffer.
+            override def apply(r: InternalRow): InternalRow = p(r).copy()
+          })
+      case None => recordIterator
     }
   }
 
@@ -194,7 +219,6 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
       // record of the block. Pushing filters into the scan can physically drop records (e.g. with
       // parquet record-level filtering) and misalign that pairing, so push no filters in that case.
       val logReadFilters = if (getShouldMergeUseRecordPosition) Seq.empty[Filter] else readFilters
-      // Variant alignment happens later via getLogBlockRecordProjection in the merge buffer.
       // Log files reach this method either as an inline parquet data block or as a native log file.
       // Inline paths do not carry the parquet extension, so resolve them by the log block contract.
       val fileFormat = if (isInlineLog) {
@@ -204,9 +228,17 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
       }
       fileFormat match {
         case HoodieFileFormat.PARQUET =>
-          new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
-            .asInstanceOf[HoodieSparkParquetReader].getUnsafeRowIterator(requiredSchema, logReadFilters.asJava)
-            .asInstanceOf[ClosableIterator[InternalRow]]
+          val reader = new HoodieSparkFileReaderFactory(storage).newParquetFileReader(filePath)
+            .asInstanceOf[HoodieSparkParquetReader]
+          val rawIterator = if (shouldProjectVariants) {
+            // Thread the variant-overlaid struct (carrying VariantMetadata that HoodieSchema can't
+            // represent) so parquet-mr decodes variants into the projected struct shape natively,
+            // mirroring the base-file branch below. Gated so payload-based tables keep full variants.
+            reader.getUnsafeRowIterator(requiredSchema, structType, logReadFilters.asJava)
+          } else {
+            reader.getUnsafeRowIterator(requiredSchema, logReadFilters.asJava)
+          }
+          rawIterator.asInstanceOf[ClosableIterator[InternalRow]]
         case _ =>
           val fileInfo = sparkAdapter.getSparkPartitionedFileUtils
             .createPartitionedFile(InternalRow.empty, filePath, start, length)

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -29,7 +29,6 @@ import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
 import org.apache.hudi.common.util.HoodieVectorUtils
-import org.apache.hudi.common.util.{Option => HOption}
 import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.hudi.common.util.collection.{CachingIterator, ClosableIterator, CloseableMappingIterator, Pair => HPair}
 import org.apache.hudi.io.storage.{HoodieSparkFileReaderFactory, HoodieSparkParquetReader, VectorConversionUtils}
@@ -117,7 +116,8 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
       case _ => false
     }))
     // getRecordMerger() is a Lombok getter over a field initialized to null (not Option.empty());
-    // it stays null until setRecordMerger() runs during reader init, so the null guard is required.
+    // it stays null until HoodieReaderContext.initRecordMerger runs (HoodieFileGroupReader calls it
+    // from its constructor), so the null guard is required.
     val merger = getRecordMerger()
     val isPayloadBased = merger != null && merger.isPresent && merger.get.getMergingStrategy == PAYLOAD_BASED_MERGE_STRATEGY_UUID
     hasVariantProjection && !isPayloadBased

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -62,6 +62,14 @@ import scala.collection.JavaConverters._
  *                          not required for reading a file group with only log files.
  * @param filters           spark filters that might be pushed down into the reader
  * @param requiredFilters   filters that are required and should always be used, even in merging situations
+ * @param sparkRequiredSchema the query's Spark-side required schema, when the caller has one. It travels
+ *                            alongside the engine's [[HoodieSchema]] because a Spark 4.1 PushVariantIntoScan
+ *                            projection carries per-field VariantMetadata (extraction path / timezone /
+ *                            failOnError) that HoodieSchema has nowhere to store: HoodieSparkSchemaConverters
+ *                            collapses the projected struct back to a plain VARIANT, so the projected Spark
+ *                            schema cannot be recovered from a HoodieSchema round-trip (#18739 sub-task 4).
+ *                            Kept Spark-side so the engine-neutral schema model stays free of Spark 4.1
+ *                            variant concepts.
  */
 class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileReader,
                                               filters: Seq[Filter],
@@ -86,15 +94,8 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
   private lazy val allFilters = filters ++ requiredFilters
 
   // For each field of `target`, replace its dataType with the matching field's projected
-  // variant struct from `source` (when present). Non-matching fields pass through.
-  //
-  // Why a parallel `sparkRequiredSchema` overlay exists at all (#18739 sub-task 4): a Spark 4.1
-  // PushVariantIntoScan projection carries per-field `VariantMetadata` (extraction path / timezone /
-  // failOnError) that `HoodieSchema` has nowhere to store — `HoodieSparkSchemaConverters` collapses
-  // the projected struct back to a plain VARIANT and the reverse can't reconstruct the metadata. So
-  // the engine must keep the projected Spark schema alongside the HoodieSchema; it cannot be
-  // recovered from a HoodieSchema round-trip. Kept Spark-side on purpose so the engine-neutral schema
-  // model stays free of Spark-4.1 variant concepts.
+  // variant struct from `source` (when present). Non-matching fields pass through. Why a parallel
+  // `sparkRequiredSchema` overlay exists at all is documented on that constructor parameter.
   private def overlayVariantProjections(target: StructType, source: StructType): StructType = {
     StructType(target.fields.map { f =>
       SparkFileFormatInternalRowReaderContext.findFieldByName(source, f.name).map(_.dataType) match {

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -60,7 +60,6 @@ import lombok.experimental.Accessors;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_DEPRECATED_WRITE_CONFIG_KEY;
 import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_WRITE_CONFIG_KEY;
@@ -317,12 +316,18 @@ public abstract class HoodieReaderContext<T> {
                                                             List<Pair<String, Object>> requiredPartitionFieldAndValues);
 
   /**
-   * Optional per-row transformer applied to log-block records before they reach the merger.
-   * Engines override this to align records with a projected read schema (e.g. Spark 4.1's
-   * PushVariantIntoScan). Default is no projection.
+   * Wraps a log-block record iterator to align its rows with a projected read schema before they
+   * reach the merger (e.g. Spark 4.1's PushVariantIntoScan rewrites variant columns into struct
+   * extractions on the base-file side, so avro log rows must be rewritten to match). Default is a
+   * no-op pass-through; the parquet log path projects natively via the reader, so only engines
+   * whose avro log reader needs an explicit row rewrite (currently the Spark reader context)
+   * override this.
+   *
+   * @param recordIterator the deserialized log-block records in {@code dataBlockSchema} shape
+   * @param dataBlockSchema the schema the records are in
    */
-  public Option<Function<T, T>> getLogBlockRecordProjection(HoodieSchema dataBlockSchema) {
-    return Option.empty();
+  public ClosableIterator<T> projectLogBlockRecords(ClosableIterator<T> recordIterator, HoodieSchema dataBlockSchema) {
+    return recordIterator;
   }
 
   public Option<Pair<String, String>> getPayloadClasses(TypedProperties props) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
@@ -62,7 +62,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_DEPRECATED_WRITE_CONFIG_KEY;
 import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_WRITE_CONFIG_KEY;
@@ -348,12 +347,18 @@ public abstract class HoodieReaderContext<T> {
                                                             List<Pair<String, Object>> requiredPartitionFieldAndValues);
 
   /**
-   * Optional per-row transformer applied to log-block records before they reach the merger.
-   * Engines override this to align records with a projected read schema (e.g. Spark 4.1's
-   * PushVariantIntoScan). Default is no projection.
+   * Wraps a log-block record iterator to align its rows with a projected read schema before they
+   * reach the merger (e.g. Spark 4.1's PushVariantIntoScan rewrites variant columns into struct
+   * extractions on the base-file side, so avro log rows must be rewritten to match). Default is a
+   * no-op pass-through; the parquet log path projects natively via the reader, so only engines
+   * whose avro log reader needs an explicit row rewrite (currently the Spark reader context)
+   * override this.
+   *
+   * @param recordIterator the deserialized log-block records in {@code dataBlockSchema} shape
+   * @param dataBlockSchema the schema the records are in
    */
-  public Option<Function<T, T>> getLogBlockRecordProjection(HoodieSchema dataBlockSchema) {
-    return Option.empty();
+  public ClosableIterator<T> projectLogBlockRecords(ClosableIterator<T> recordIterator, HoodieSchema dataBlockSchema) {
+    return recordIterator;
   }
 
   public Option<Pair<String, String>> getPayloadClasses(TypedProperties props) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
@@ -169,7 +169,10 @@ public class HoodieAvroDataBlock extends HoodieDataBlock {
   protected <T> ClosableIterator<T> deserializeRecords(HoodieReaderContext<T> readerContext, byte[] content) throws IOException {
     checkState(this.readerSchema != null, "Reader's schema has to be non-null");
     RecordIterator iterator = RecordIterator.getInstance(this, content, readerContext.enableLogicalTimestampFieldRepair());
-    return new CloseableMappingIterator<>(iterator, data -> readerContext.getRecordContext().convertAvroRecord(data));
+    ClosableIterator<T> records = new CloseableMappingIterator<>(iterator, data -> readerContext.getRecordContext().convertAvroRecord(data));
+    // Align records with the engine's projected read schema (e.g. Spark 4.1 PushVariantIntoScan).
+    // No-op for engines/queries that don't need it. Parquet log blocks project natively in the reader.
+    return readerContext.projectLogBlockRecords(records, this.readerSchema);
   }
 
   private static class RecordIterator implements ClosableIterator<IndexedRecord> {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieAvroDataBlock.java
@@ -170,7 +170,10 @@ public class HoodieAvroDataBlock extends HoodieDataBlock {
   protected <T> ClosableIterator<T> deserializeRecords(HoodieReaderContext<T> readerContext, byte[] content) throws IOException {
     checkState(this.readerSchema != null, "Reader's schema has to be non-null");
     RecordIterator iterator = RecordIterator.getInstance(this, content, readerContext.enableLogicalTimestampFieldRepair());
-    return new CloseableMappingIterator<>(iterator, data -> readerContext.getRecordContext().convertAvroRecord(data));
+    ClosableIterator<T> records = new CloseableMappingIterator<>(iterator, data -> readerContext.getRecordContext().convertAvroRecord(data));
+    // Align records with the engine's projected read schema (e.g. Spark 4.1 PushVariantIntoScan).
+    // No-op for engines/queries that don't need it. Parquet log blocks project natively in the reader.
+    return readerContext.projectLogBlockRecords(records, this.readerSchema);
   }
 
   private static class RecordIterator implements ClosableIterator<IndexedRecord> {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
@@ -199,8 +199,8 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
       } else {
         blockRecordsIterator = dataBlock.getEngineRecordIterator(readerContext);
       }
-      Pair<Function<T, T>, HoodieSchema> projectedTransformer = getProjectedTransformer(dataBlock);
-      return Pair.of(new CloseableMappingIterator<>(blockRecordsIterator, projectedTransformer.getLeft()), projectedTransformer.getRight());
+      Pair<Function<T, T>, HoodieSchema> schemaTransformer = getSchemaTransformerWithEvolvedSchema(dataBlock);
+      return Pair.of(new CloseableMappingIterator<>(blockRecordsIterator, schemaTransformer.getLeft()), schemaTransformer.getRight());
     } catch (IOException e) {
       throw new HoodieIOException("Failed to deser records from log files ", e);
     }
@@ -278,28 +278,6 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
 
     HoodieSchema evolvedSchema = schemaEvolutionTransformerOpt.map(Pair::getRight).orElseGet(dataBlock::getSchema);
     return Pair.of(transformer, evolvedSchema);
-  }
-
-  /**
-   * Composes schema evolution then the engine's optional log-block record projection
-   * (currently only Spark 4.1's PushVariantIntoScan). Returns the evolved data-block schema
-   * — the projector preserves field shape, only rewriting variant fields, so merger
-   * metadata cols (read by ordinal) stay intact.
-   *
-   * <p>Skipped when a custom payload class is configured: {@code PayloadUpdateProcessor}
-   * round-trips through {@code convertToAvroRecord} against a schema that still types
-   * variant fields as {@code VariantType}, which would mis-decode rewritten rows.
-   */
-  protected Pair<Function<T, T>, HoodieSchema> getProjectedTransformer(HoodieDataBlock dataBlock) {
-    Pair<Function<T, T>, HoodieSchema> evolved = getSchemaTransformerWithEvolvedSchema(dataBlock);
-    if (payloadClasses.isPresent()) {
-      return evolved;
-    }
-    Option<Function<T, T>> logProjOpt = readerContext.getLogBlockRecordProjection(evolved.getRight());
-    if (!logProjOpt.isPresent()) {
-      return evolved;
-    }
-    return Pair.of(evolved.getLeft().andThen(logProjOpt.get()), evolved.getRight());
   }
 
   private static class LogRecordIterator<T> implements ClosableIterator<BufferedRecord<T>> {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/FileGroupRecordBuffer.java
@@ -184,8 +184,8 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
       } else {
         blockRecordsIterator = dataBlock.getEngineRecordIterator(readerContext);
       }
-      Pair<Function<T, T>, HoodieSchema> projectedTransformer = getProjectedTransformer(dataBlock);
-      return Pair.of(new CloseableMappingIterator<>(blockRecordsIterator, projectedTransformer.getLeft()), projectedTransformer.getRight());
+      Pair<Function<T, T>, HoodieSchema> schemaTransformer = getSchemaTransformerWithEvolvedSchema(dataBlock);
+      return Pair.of(new CloseableMappingIterator<>(blockRecordsIterator, schemaTransformer.getLeft()), schemaTransformer.getRight());
     } catch (IOException e) {
       throw new HoodieIOException("Failed to deser records from log files ", e);
     }
@@ -246,28 +246,6 @@ abstract class FileGroupRecordBuffer<T> implements HoodieFileGroupRecordBuffer<T
 
     HoodieSchema evolvedSchema = schemaEvolutionTransformerOpt.map(Pair::getRight).orElseGet(dataBlock::getSchema);
     return Pair.of(transformer, evolvedSchema);
-  }
-
-  /**
-   * Composes schema evolution then the engine's optional log-block record projection
-   * (currently only Spark 4.1's PushVariantIntoScan). Returns the evolved data-block schema
-   * — the projector preserves field shape, only rewriting variant fields, so merger
-   * metadata cols (read by ordinal) stay intact.
-   *
-   * <p>Skipped when a custom payload class is configured: {@code PayloadUpdateProcessor}
-   * round-trips through {@code convertToAvroRecord} against a schema that still types
-   * variant fields as {@code VariantType}, which would mis-decode rewritten rows.
-   */
-  protected Pair<Function<T, T>, HoodieSchema> getProjectedTransformer(HoodieDataBlock dataBlock) {
-    Pair<Function<T, T>, HoodieSchema> evolved = getSchemaTransformerWithEvolvedSchema(dataBlock);
-    if (payloadClasses.isPresent()) {
-      return evolved;
-    }
-    Option<Function<T, T>> logProjOpt = readerContext.getLogBlockRecordProjection(evolved.getRight());
-    if (!logProjOpt.isPresent()) {
-      return evolved;
-    }
-    return Pair.of(evolved.getLeft().andThen(logProjOpt.get()), evolved.getRight());
   }
 
   private static class LogRecordIterator<T> implements ClosableIterator<BufferedRecord<T>> {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
@@ -126,9 +126,9 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
           partialUpdateModeOpt);
     }
 
-    Pair<Function<T, T>, HoodieSchema> projectedTransformer = getProjectedTransformer(dataBlock);
+    Pair<Function<T, T>, HoodieSchema> schemaTransformer = getSchemaTransformerWithEvolvedSchema(dataBlock);
 
-    HoodieSchema schema = HoodieSchemaCache.intern(projectedTransformer.getRight());
+    HoodieSchema schema = HoodieSchemaCache.intern(schemaTransformer.getRight());
 
     // TODO: Return an iterator that can generate sequence number with the record.
     //       Then we can hide this logic into data block.
@@ -144,9 +144,9 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
         }
 
         long recordPosition = recordPositions.get(recordIndex++);
-        T projectedNextRecord = projectedTransformer.getLeft().apply(nextRecord);
-        boolean isDelete = readerContext.getRecordContext().isDeleteRecord(projectedNextRecord, deleteContext);
-        BufferedRecord<T> bufferedRecord = BufferedRecords.fromEngineRecord(projectedNextRecord, schema, readerContext.getRecordContext(), orderingFieldNames, isDelete);
+        T transformedNextRecord = schemaTransformer.getLeft().apply(nextRecord);
+        boolean isDelete = readerContext.getRecordContext().isDeleteRecord(transformedNextRecord, deleteContext);
+        BufferedRecord<T> bufferedRecord = BufferedRecords.fromEngineRecord(transformedNextRecord, schema, readerContext.getRecordContext(), orderingFieldNames, isDelete);
         processNextDataRecord(bufferedRecord, recordPosition);
       }
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/PositionBasedFileGroupRecordBuffer.java
@@ -122,9 +122,9 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
           partialUpdateModeOpt);
     }
 
-    Pair<Function<T, T>, HoodieSchema> projectedTransformer = getProjectedTransformer(dataBlock);
+    Pair<Function<T, T>, HoodieSchema> schemaTransformer = getSchemaTransformerWithEvolvedSchema(dataBlock);
 
-    HoodieSchema schema = HoodieSchemaCache.intern(projectedTransformer.getRight());
+    HoodieSchema schema = HoodieSchemaCache.intern(schemaTransformer.getRight());
 
     // TODO: Return an iterator that can generate sequence number with the record.
     //       Then we can hide this logic into data block.
@@ -140,9 +140,9 @@ public class PositionBasedFileGroupRecordBuffer<T> extends KeyBasedFileGroupReco
         }
 
         long recordPosition = recordPositions.get(recordIndex++);
-        T projectedNextRecord = projectedTransformer.getLeft().apply(nextRecord);
-        boolean isDelete = readerContext.getRecordContext().isDeleteRecord(projectedNextRecord, deleteContext);
-        BufferedRecord<T> bufferedRecord = BufferedRecords.fromEngineRecord(projectedNextRecord, schema, readerContext.getRecordContext(), orderingFieldNames, isDelete);
+        T transformedNextRecord = schemaTransformer.getLeft().apply(nextRecord);
+        boolean isDelete = readerContext.getRecordContext().isDeleteRecord(transformedNextRecord, deleteContext);
+        BufferedRecord<T> bufferedRecord = BufferedRecords.fromEngineRecord(transformedNextRecord, schema, readerContext.getRecordContext(), orderingFieldNames, isDelete);
         processNextDataRecord(bufferedRecord, recordPosition);
       }
       if (recordIndex != recordPositions.size()) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
-import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.getLastCommitMetadata
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.{getLastCommitMetadata, getMetaClientAndFileSystemView}
 import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, LongType, MapType, MetadataBuilder, StringType, StructField, StructType}
 
 import scala.collection.JavaConverters._

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -22,11 +22,14 @@ package org.apache.spark.sql.hudi.dml.schema
 import org.apache.hudi.{DataSourceReadOptions, HoodieSparkUtils}
 import org.apache.hudi.common.avro.VariantShreddingRuntime
 import org.apache.hudi.common.fs.FSUtils
+import org.apache.hudi.common.model.HoodieLogFile
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
 import org.apache.hudi.common.model.WriteOperationType
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.schema.internal.HoodieSchemaException
 import org.apache.hudi.common.table.TableSchemaResolver
+import org.apache.hudi.common.table.log.HoodieLogFormat
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType
 import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.testutils.DataSourceTestUtils
@@ -129,6 +132,76 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
         )
       })
     }
+  }
+
+  test("Test MOR Table with Variant Data Type and Avro log blocks") {
+    // Variant type is only supported in Spark 4.0+
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    // On the current table version the append handle writes native parquet log files and ignores
+    // hoodie.logfile.data.block.format, so the AVRO leg of the MOR cases above never produces an
+    // avro data block. Pin a pre-native table version so the update below lands in a
+    // HoodieAvroDataBlock and the read goes through projectLogBlockRecords (Spark 4.1+ applies the
+    // PushVariantIntoScan rewrite there; Spark 4.0 reads the block unprojected).
+    withRecordType(Seq(HoodieRecordType.AVRO))(withTempDir { tmp =>
+      val tableName = generateTableName
+      val tablePath = tmp.getCanonicalPath
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '$tablePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'mor',
+           |  preCombineField = 'ts',
+           |  hoodie.write.table.version = '9'
+           | )
+       """.stripMargin)
+
+      spark.sql(
+        s"""
+           |insert into $tableName
+           |values
+           |  (1, 'row1', parse_json('{"key": "value1", "num": 1}'), 1000),
+           |  (2, 'row2', parse_json('{"key": "value2", "list": [1, 2, 3]}'), 1000)
+         """.stripMargin)
+      checkAnswer(s"select id, name, cast(v as string), ts from $tableName order by id")(
+        Seq(1, "row1", "{\"key\":\"value1\",\"num\":1}", 1000),
+        Seq(2, "row2", "{\"key\":\"value2\",\"list\":[1,2,3]}", 1000)
+      )
+
+      // The update is what produces the log block; the insert above only wrote base files.
+      spark.sql(
+        s"""
+           |update $tableName
+           |set v = parse_json('{"updated": true, "new_field": 123}')
+           |where id = 1
+         """.stripMargin)
+
+      // Pin the log format. A table version that routed the update through the native log writer
+      // would turn this leg back into a parquet one and pass without touching projectLogBlockRecords.
+      val blockTypes = listLogBlockTypes(tablePath)
+      assert(blockTypes.contains(HoodieLogBlockType.AVRO_DATA_BLOCK),
+        s"expected an avro data block in the log files, found: $blockTypes")
+      assert(!blockTypes.contains(HoodieLogBlockType.PARQUET_DATA_BLOCK),
+        s"table version 9 with the avro block format must not write parquet data blocks, found: $blockTypes")
+
+      // Merged read: row 1 comes from the avro log block, row 2 from the parquet base file.
+      checkAnswer(s"select id, name, cast(v as string), ts from $tableName order by id")(
+        Seq(1, "row1", "{\"new_field\":123,\"updated\":true}", 1000),
+        Seq(2, "row2", "{\"key\":\"value2\",\"list\":[1,2,3]}", 1000)
+      )
+
+      spark.sql(s"delete from $tableName where id = 2")
+      checkAnswer(s"select id, name, cast(v as string), ts from $tableName order by id")(
+        Seq(1, "row1", "{\"new_field\":123,\"updated\":true}", 1000)
+      )
+    })
   }
 
   test("Test Query Log Only MOR Table With VARIANT column triggers compaction") {
@@ -1528,6 +1601,31 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
   /**
    * Lists data parquet files in the table directory, excluding Hudi metadata files.
    */
+  /**
+   * Block types of every log block in the table, read from the log files themselves. Tests that pin
+   * a log format assert on this rather than on file names: native logs carry a .log.parquet suffix,
+   * but an inline log file is named the same whether its data blocks are avro or parquet.
+   */
+  private def listLogBlockTypes(tablePath: String): Seq[HoodieLogBlockType] = {
+    val (metaClient, fsView) = getMetaClientAndFileSystemView(tablePath)
+    val schema = new TableSchemaResolver(metaClient).getTableSchema
+    val logFiles = fsView.getAllFileSlices("").iterator().asScala
+      .flatMap(slice => HoodieTestUtils.getLogFileListFromFileSlice(slice).asScala).toSeq
+    assert(logFiles.nonEmpty, "expected at least one log file")
+    logFiles.flatMap { path =>
+      val reader = HoodieLogFormat.newReader(metaClient, new HoodieLogFile(path), schema)
+      try {
+        val types = scala.collection.mutable.ArrayBuffer[HoodieLogBlockType]()
+        while (reader.hasNext) {
+          types += reader.next().getBlockType
+        }
+        types.toSeq
+      } finally {
+        reader.close()
+      }
+    }
+  }
+
   private def listDataParquetFiles(tablePath: String): Seq[String] = {
     val conf = spark.sparkContext.hadoopConfiguration
     val fs = FileSystem.get(new HadoopPath(tablePath).toUri, conf)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -1601,6 +1601,21 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
   /**
    * Lists data parquet files in the table directory, excluding Hudi metadata files.
    */
+  private def listDataParquetFiles(tablePath: String): Seq[String] = {
+    val conf = spark.sparkContext.hadoopConfiguration
+    val fs = FileSystem.get(new HadoopPath(tablePath).toUri, conf)
+    val iter = fs.listFiles(new HadoopPath(tablePath), true)
+    val files = scala.collection.mutable.ArrayBuffer[String]()
+    while (iter.hasNext) {
+      val file = iter.next()
+      val path = file.getPath.toString
+      if (path.endsWith(".parquet") && !path.contains(".hoodie")) {
+        files += path
+      }
+    }
+    files.toSeq
+  }
+
   /**
    * Block types of every log block in the table, read from the log files themselves. Tests that pin
    * a log format assert on this rather than on file names: native logs carry a .log.parquet suffix,
@@ -1624,21 +1639,6 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
         reader.close()
       }
     }
-  }
-
-  private def listDataParquetFiles(tablePath: String): Seq[String] = {
-    val conf = spark.sparkContext.hadoopConfiguration
-    val fs = FileSystem.get(new HadoopPath(tablePath).toUri, conf)
-    val iter = fs.listFiles(new HadoopPath(tablePath), true)
-    val files = scala.collection.mutable.ArrayBuffer[String]()
-    while (iter.hasNext) {
-      val file = iter.next()
-      val path = file.getPath.toString
-      if (path.endsWith(".parquet") && !path.contains(".hoodie")) {
-        files += path
-      }
-    }
-    files.toSeq
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Addresses #18739.

PR #18674 aligned Spark 4.1+ MOR variant reads via `HoodieReaderContext.getLogBlockRecordProjection`, a per-row projector run inside the engine-neutral `FileGroupRecordBuffer`. That leaked Spark `PushVariantIntoScan` concerns into format-agnostic merge code. This PR pushes variant projection down into the log readers so the buffer no longer knows about variants.

### Summary and Changelog

Each log reader now emits rows already aligned to the projected read schema; the buffer-level projection hook is removed.

- Remove `FileGroupRecordBuffer.getProjectedTransformer` and `HoodieReaderContext.getLogBlockRecordProjection`. The buffers (`FileGroupRecordBuffer`, `PositionBasedFileGroupRecordBuffer`) now call `getSchemaTransformerWithEvolvedSchema` directly and keep returning the unprojected evolved schema (merger reads metadata cols by ordinal).
- Add a no-op `HoodieReaderContext.projectLogBlockRecords(iter, dataBlockSchema)`. `HoodieAvroDataBlock.deserializeRecords` invokes it; the Spark reader context overrides it to apply the `VariantGet` rewrite (relocated from the old hook).
- Parquet log blocks: new `HoodieSparkParquetReader.getUnsafeRowIterator(HoodieSchema, StructType, filters)` overload threads the projected struct so `SPARK_ROW_REQUESTED_SCHEMA` carries `VariantMetadata` and parquet-mr projects natively (mirrors the base-file path).
- Single `shouldProjectVariants` gate (variant projection present AND merger not `PAYLOAD_BASED`) drives both paths, preserving the previous custom-payload skip.

No code copied. `buildVariantProjector` / `isVariantProjectionStruct` are unchanged (caller moved).

Spark version scope: the projection engages on every Spark version whose adapter reports a `PushVariantIntoScan` projection struct, which today is Spark 4.1 and 4.2 (`Spark4_1Adapter` and `Spark4_2Adapter` implement `isVariantProjectionStruct` / `buildVariantProjector` identically). Spark 4.0 and 3.x adapters return false and take the unprojected path. No per-version code in this PR.

Rebase notes (2026-08-25, over #18961): the parquet-log leg now sits in the PARQUET arm of the log-file format dispatch from #19118/#19283 (Lance native logs keep going through `baseFileReader.read` with the overlaid schema) and uses the position-merge filter guard from #19583; the other five files merged clean.

### Impact

Internal change to the `HoodieReaderContext` extension point (`getLogBlockRecordProjection` -> `projectLogBlockRecords`); the new hook is a no-op by default. No new configs. No user-facing behavior change for non-Spark engines or Spark < 4.1; Spark 4.1 and 4.2 variant MOR reads are unchanged in result, only the alignment moves out of the buffer.

### Risk Level

Medium. Touches the engine-neutral merge buffer and the reader-context API. Mitigations: the new hook is a no-op default (non-Spark engines and Spark < 4.1 unaffected); projection is gated by `shouldProjectVariants` (custom-payload tables skip it); the buffer still returns the unprojected evolved schema, so the merger's ordinal-based metadata access is unchanged. Verified with `TestVariantDataType` on Spark 4.0, 4.1 and 4.2 (cow + mor: insert / update / delete / merge-into, `cast(v as string)` selects) across key-based, position-based, and unmerged paths, plus a custom-payload variant MOR case. The 4.2 run is on the rebased head (975b68747ce7, Spark 4.2.0): 19 passed, 0 failed, the 3 Spark 3.x-only cases canceled by their version guard; it includes the log-only MOR query, MOR compaction with auto-inferred shredding, CDC and clustering cases added after #18961. CI runs the same suite on Spark 4.2 through the `test-spark-java17-scala-dml-tests` lane (the only 4.x version in the CI matrix). The dedicated shredded-native-log MOR legs in `TestVariantShreddingMixedLayouts` still run once #19687 lands.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable


