### PR TITLE
docs: Fix Lance project URL in storage_layouts

### DIFF
--- a/website/docs/storage_layouts.md
+++ b/website/docs/storage_layouts.md
@@ -34,7 +34,7 @@ base file formats.
 
 #### Lance base file format {#lance-base-file-format}
 
-[Lance](https://lancedb.github.io/lance/) is a pluggable base file format selected per table via
+[Lance](https://github.com/lance-format/lance) is a pluggable base file format selected per table via
 `hoodie.table.base.file.format = 'lance'`. Hudi manages the table layer
 (timeline, metadata, schema, file groups, table services); Lance is the on-disk file format for
 base files. Log files for MOR tables remain Avro; log compaction merges Avro logs into Lance base

--- a/website/versioned_docs/version-1.2.0/storage_layouts.md
+++ b/website/versioned_docs/version-1.2.0/storage_layouts.md
@@ -34,7 +34,7 @@ base file formats.
 
 #### Lance base file format {#lance-base-file-format}
 
-[Lance](https://lancedb.github.io/lance/) is a pluggable base file format selected per table via
+[Lance](https://github.com/lance-format/lance) is a pluggable base file format selected per table via
 `hoodie.table.base.file.format = 'lance'`. Hudi manages the table layer
 (timeline, metadata, schema, file groups, table services); Lance is the on-disk file format for
 base files. Log files for MOR tables remain Avro; log compaction merges Avro logs into Lance base


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Lance file format docs link to `https://lancedb.github.io/lance/`, which is not the right home for the Lance project. Update the link to the canonical project URL `https://github.com/lance-format/lance`.

### Summary and Changelog

- Update Lance project URL in `website/docs/storage_layouts.md` (latest)
- Update Lance project URL in `website/versioned_docs/version-1.2.0/storage_layouts.md` (1.2.0 docs)

### Impact

Documentation link fix; users following the Lance link now land on the canonical project repo.

### Risk Level

low.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable