### PR TITLE
fix(flink): Close write client properly in DefaultCleanHandler

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/handler/DefaultCleanHandler.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/handler/DefaultCleanHandler.java
@@ -111,6 +111,6 @@ public class DefaultCleanHandler implements CleanHandler {
         throw new HoodieException("Failed to close executor of clean handler.", e);
       }
     }
-    this.writeClient.clean();
+    this.writeClient.close();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/compact/handler/TestDefaultCleanHandler.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/compact/handler/TestDefaultCleanHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.compact.handler;
+
+import org.apache.hudi.client.HoodieFlinkWriteClient;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+class TestDefaultCleanHandler {
+
+  @Test
+  void testCloseClosesWriteClientWithoutTriggeringClean() {
+    HoodieFlinkWriteClient writeClient = mock(HoodieFlinkWriteClient.class);
+    DefaultCleanHandler handler = new DefaultCleanHandler(writeClient);
+
+    handler.close();
+
+    verify(writeClient).close();
+    verifyNoMoreInteractions(writeClient);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`DefaultCleanHandler.close()` should release the underlying Flink write client when the clean handler is closed. The previous implementation incorrectly invoked `writeClient.clean()`, which could trigger an unintended clean operation during handler shutdown instead of closing client resources.

### Summary and Changelog

- Updated `DefaultCleanHandler.close()` to call `writeClient.close()` instead of `writeClient.clean()`.
- Added `TestDefaultCleanHandler` to verify the close lifecycle delegates to the write client close path without extra client interactions.

### Impact

Fixes clean-handler shutdown behavior so closing the handler no longer triggers an unintended clean operation.

### Risk Level

low. 

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable