### PR TITLE
fix(clustering): retain missing partitions in selected/regex incremental scheduling

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/ClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/ClusteringPlanStrategy.java
@@ -147,7 +147,7 @@ public abstract class ClusteringPlanStrategy<T,I,K,O> implements Serializable {
   protected List<String> getMissingPartitionsFromCurrentWindow(List<String> partitionsToSchedule,
                                                                List<String> partitionsInCurrentWindow) {
     if (!getWriteConfig().isIncrementalTableServiceEnabled()) {
-      return Collections.emptyList();
+      return new ArrayList<>();
     }
     Set<String> missingPartitions = new LinkedHashSet<>(partitionsInCurrentWindow);
     missingPartitions.removeAll(new HashSet<>(partitionsToSchedule));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/ClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/ClusteringPlanStrategy.java
@@ -141,27 +141,16 @@ public abstract class ClusteringPlanStrategy<T,I,K,O> implements Serializable {
   protected abstract Map<String, String> getStrategyParams();
 
   /**
-   * When users manually select partitions for clustering, keep the rest of the current scheduling window
-   * in missing partitions so those partitions are picked up by later schedules, while removing the selected
-   * partitions since this plan is explicitly handling them now.
+   * Keep partitions from the current scheduling window that are not scheduled in this plan as missing
+   * partitions so that they can be picked up by later incremental clustering schedules.
    */
-  protected List<String> getMissingPartitionsForSelectedPartitions(List<String> selectedPartitions,
-                                                                   List<String> partitionsInCurrentWindow) {
+  protected List<String> getMissingPartitionsFromCurrentWindow(List<String> partitionsToSchedule,
+                                                               List<String> partitionsInCurrentWindow) {
     if (!getWriteConfig().isIncrementalTableServiceEnabled()) {
       return Collections.emptyList();
     }
     Set<String> missingPartitions = new LinkedHashSet<>(partitionsInCurrentWindow);
-    missingPartitions.removeAll(new HashSet<>(selectedPartitions));
-    return new ArrayList<>(missingPartitions);
-  }
-
-  protected List<String> getMissingPartitionsForRegexFilteredPartitions(List<String> matchedPartitions,
-                                                                        List<String> partitionsInCurrentWindow) {
-    if (!getWriteConfig().isIncrementalTableServiceEnabled()) {
-      return Collections.emptyList();
-    }
-    Set<String> missingPartitions = new LinkedHashSet<>(partitionsInCurrentWindow);
-    missingPartitions.removeAll(new HashSet<>(matchedPartitions));
+    missingPartitions.removeAll(new HashSet<>(partitionsToSchedule));
     return new ArrayList<>(missingPartitions);
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/ClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/ClusteringPlanStrategy.java
@@ -41,8 +41,11 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -136,6 +139,31 @@ public abstract class ClusteringPlanStrategy<T,I,K,O> implements Serializable {
    * context from schedule to run step.
    */
   protected abstract Map<String, String> getStrategyParams();
+
+  /**
+   * When users manually select partitions for clustering, keep the rest of the current scheduling window
+   * in missing partitions so those partitions are picked up by later schedules, while removing the selected
+   * partitions since this plan is explicitly handling them now.
+   */
+  protected List<String> getMissingPartitionsForSelectedPartitions(List<String> selectedPartitions,
+                                                                   List<String> partitionsInCurrentWindow) {
+    if (!getWriteConfig().isIncrementalTableServiceEnabled()) {
+      return Collections.emptyList();
+    }
+    Set<String> missingPartitions = new LinkedHashSet<>(partitionsInCurrentWindow);
+    missingPartitions.removeAll(new HashSet<>(selectedPartitions));
+    return new ArrayList<>(missingPartitions);
+  }
+
+  protected List<String> getMissingPartitionsForRegexFilteredPartitions(List<String> matchedPartitions,
+                                                                        List<String> partitionsInCurrentWindow) {
+    if (!getWriteConfig().isIncrementalTableServiceEnabled()) {
+      return Collections.emptyList();
+    }
+    Set<String> missingPartitions = new LinkedHashSet<>(partitionsInCurrentWindow);
+    missingPartitions.removeAll(new HashSet<>(matchedPartitions));
+    return new ArrayList<>(missingPartitions);
+  }
 
   /**
    * Returns any specific parameters to be stored as part of clustering metadata.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -24,7 +24,6 @@ import org.apache.hudi.avro.model.HoodieClusteringStrategy;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.FileSlice;
-import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -41,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -169,13 +169,15 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
 
     if (StringUtils.isNullOrEmpty(partitionSelected)) {
       // get matched partitions if set
-      partitionPaths = getRegexPatternMatchedPartitions(config, partitions.get());
+      // partitionsInCurrentWindow = incremental partitions + missing partitions in last plan
+      List<String> partitionsInCurrentWindow = partitions.get();
+      partitionPaths = getRegexPatternMatchedPartitions(config, partitionsInCurrentWindow);
+      missingPartitions = getMissingPartitionsForRegexFilteredPartitions(partitionPaths, partitionsInCurrentWindow);
       // filter the partition paths if needed to reduce list status
     } else {
       partitionPaths = Arrays.asList(partitionSelected.split(","));
-      // Users may temporarily set specific partitions for clustering.
-      // Ensure the coherence of the missing partitions.
-      missingPartitions = (List<String>)executor.fetchMissingPartitions(TableServiceType.CLUSTER).getRight();
+      missingPartitions = getMissingPartitionsForSelectedPartitions(partitionPaths,
+          config.isIncrementalTableServiceEnabled() ? partitions.get() : Collections.emptyList());
     }
 
     Pair<List<String>, List<String>> partitionsPair = filterPartitionPaths(getWriteConfig(), partitionPaths);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -172,11 +172,11 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
       // partitionsInCurrentWindow = incremental partitions + missing partitions in last plan
       List<String> partitionsInCurrentWindow = partitions.get();
       partitionPaths = getRegexPatternMatchedPartitions(config, partitionsInCurrentWindow);
-      missingPartitions = getMissingPartitionsForRegexFilteredPartitions(partitionPaths, partitionsInCurrentWindow);
+      missingPartitions = getMissingPartitionsFromCurrentWindow(partitionPaths, partitionsInCurrentWindow);
       // filter the partition paths if needed to reduce list status
     } else {
       partitionPaths = Arrays.asList(partitionSelected.split(","));
-      missingPartitions = getMissingPartitionsForSelectedPartitions(partitionPaths,
+      missingPartitions = getMissingPartitionsFromCurrentWindow(partitionPaths,
           config.isIncrementalTableServiceEnabled() ? partitions.get() : Collections.emptyList());
     }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestPartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestPartitionAwareClusteringPlanStrategy.java
@@ -93,11 +93,8 @@ public class TestPartitionAwareClusteringPlanStrategy {
     DummyPartitionAwareClusteringPlanStrategy incrementalStrategy =
         new DummyPartitionAwareClusteringPlanStrategy(table, context, incrementalConfig);
 
-    assertEquals(Arrays.asList("p3", "p4"),
-        incrementalStrategy.resolveMissingPartitionsForSelectedPartitions(
-            Arrays.asList("p1", "p2"), Arrays.asList("p1", "p3", "p4")));
     assertEquals(Arrays.asList("p2", "p4"),
-        incrementalStrategy.resolveMissingPartitionsForRegexFilteredPartitions(
+        incrementalStrategy.resolveMissingPartitionsFromCurrentWindow(
             Arrays.asList("p1", "p3"), Arrays.asList("p1", "p2", "p3", "p4")));
 
     HoodieWriteConfig nonIncrementalConfig = mock(HoodieWriteConfig.class);
@@ -105,9 +102,7 @@ public class TestPartitionAwareClusteringPlanStrategy {
     DummyPartitionAwareClusteringPlanStrategy nonIncrementalStrategy =
         new DummyPartitionAwareClusteringPlanStrategy(table, context, nonIncrementalConfig);
 
-    assertTrue(nonIncrementalStrategy.resolveMissingPartitionsForSelectedPartitions(
-        Arrays.asList("p1", "p2"), Arrays.asList("p1", "p3", "p4")).isEmpty());
-    assertTrue(nonIncrementalStrategy.resolveMissingPartitionsForRegexFilteredPartitions(
+    assertTrue(nonIncrementalStrategy.resolveMissingPartitionsFromCurrentWindow(
         Arrays.asList("p1", "p3"), Arrays.asList("p1", "p2", "p3", "p4")).isEmpty());
   }
 
@@ -155,14 +150,9 @@ public class TestPartitionAwareClusteringPlanStrategy {
       super(table, engineContext, writeConfig);
     }
 
-    List<String> resolveMissingPartitionsForSelectedPartitions(List<String> selectedPartitions,
-                                                               List<String> partitionsInCurrentWindow) {
-      return getMissingPartitionsForSelectedPartitions(selectedPartitions, partitionsInCurrentWindow);
-    }
-
-    List<String> resolveMissingPartitionsForRegexFilteredPartitions(List<String> matchedPartitions,
-                                                                    List<String> partitionsInCurrentWindow) {
-      return getMissingPartitionsForRegexFilteredPartitions(matchedPartitions, partitionsInCurrentWindow);
+    List<String> resolveMissingPartitionsFromCurrentWindow(List<String> partitionsToSchedule,
+                                                           List<String> partitionsInCurrentWindow) {
+      return getMissingPartitionsFromCurrentWindow(partitionsToSchedule, partitionsInCurrentWindow);
     }
 
     @Override

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestPartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestPartitionAwareClusteringPlanStrategy.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -40,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestPartitionAwareClusteringPlanStrategy {
 
@@ -84,6 +87,31 @@ public class TestPartitionAwareClusteringPlanStrategy {
   }
 
   @Test
+  public void testResolveMissingPartitionsFromCurrentWindow() {
+    HoodieWriteConfig incrementalConfig = mock(HoodieWriteConfig.class);
+    when(incrementalConfig.isIncrementalTableServiceEnabled()).thenReturn(true);
+    DummyPartitionAwareClusteringPlanStrategy incrementalStrategy =
+        new DummyPartitionAwareClusteringPlanStrategy(table, context, incrementalConfig);
+
+    assertEquals(Arrays.asList("p3", "p4"),
+        incrementalStrategy.resolveMissingPartitionsForSelectedPartitions(
+            Arrays.asList("p1", "p2"), Arrays.asList("p1", "p3", "p4")));
+    assertEquals(Arrays.asList("p2", "p4"),
+        incrementalStrategy.resolveMissingPartitionsForRegexFilteredPartitions(
+            Arrays.asList("p1", "p3"), Arrays.asList("p1", "p2", "p3", "p4")));
+
+    HoodieWriteConfig nonIncrementalConfig = mock(HoodieWriteConfig.class);
+    when(nonIncrementalConfig.isIncrementalTableServiceEnabled()).thenReturn(false);
+    DummyPartitionAwareClusteringPlanStrategy nonIncrementalStrategy =
+        new DummyPartitionAwareClusteringPlanStrategy(table, context, nonIncrementalConfig);
+
+    assertTrue(nonIncrementalStrategy.resolveMissingPartitionsForSelectedPartitions(
+        Arrays.asList("p1", "p2"), Arrays.asList("p1", "p3", "p4")).isEmpty());
+    assertTrue(nonIncrementalStrategy.resolveMissingPartitionsForRegexFilteredPartitions(
+        Arrays.asList("p1", "p3"), Arrays.asList("p1", "p2", "p3", "p4")).isEmpty());
+  }
+
+  @Test
   public void testResolveEngineContextUsesLocalWhenEnabled() {
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(new HadoopStorageConfiguration(false));
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder()
@@ -125,6 +153,16 @@ public class TestPartitionAwareClusteringPlanStrategy {
 
     public DummyPartitionAwareClusteringPlanStrategy(HoodieTable table, HoodieEngineContext engineContext, HoodieWriteConfig writeConfig) {
       super(table, engineContext, writeConfig);
+    }
+
+    List<String> resolveMissingPartitionsForSelectedPartitions(List<String> selectedPartitions,
+                                                               List<String> partitionsInCurrentWindow) {
+      return getMissingPartitionsForSelectedPartitions(selectedPartitions, partitionsInCurrentWindow);
+    }
+
+    List<String> resolveMissingPartitionsForRegexFilteredPartitions(List<String> matchedPartitions,
+                                                                    List<String> partitionsInCurrentWindow) {
+      return getMissingPartitionsForRegexFilteredPartitions(matchedPartitions, partitionsInCurrentWindow);
     }
 
     @Override

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestPartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/cluster/strategy/TestPartitionAwareClusteringPlanStrategy.java
@@ -32,6 +32,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -102,8 +103,11 @@ public class TestPartitionAwareClusteringPlanStrategy {
     DummyPartitionAwareClusteringPlanStrategy nonIncrementalStrategy =
         new DummyPartitionAwareClusteringPlanStrategy(table, context, nonIncrementalConfig);
 
-    assertTrue(nonIncrementalStrategy.resolveMissingPartitionsFromCurrentWindow(
-        Arrays.asList("p1", "p3"), Arrays.asList("p1", "p2", "p3", "p4")).isEmpty());
+    List<String> nonIncrementalMissingPartitions = nonIncrementalStrategy.resolveMissingPartitionsFromCurrentWindow(
+        Arrays.asList("p1", "p3"), Arrays.asList("p1", "p2", "p3", "p4"));
+    assertTrue(nonIncrementalMissingPartitions.isEmpty());
+    nonIncrementalMissingPartitions.addAll(Collections.singletonList("p5"));
+    assertEquals(Collections.singletonList("p5"), nonIncrementalMissingPartitions);
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/cluster/TestIncrementalClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/action/cluster/TestIncrementalClustering.java
@@ -131,8 +131,8 @@ public class TestIncrementalClustering extends SparkClientFunctionalTestHarness 
 
     switch (mode) {
       case NONE: {
-        // For partitions filtered out by the regex expression, they will not be recorded in the missingPartitions
-        assertEquals(0, clusteringPlan.getMissingSchedulePartitions().size());
+        assertEquals(1, clusteringPlan.getMissingSchedulePartitions().size());
+        assertTrue(clusteringPlan.getMissingSchedulePartitions().contains(YESTERDAY));
         break;
       }
       case SELECTED_PARTITIONS: {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  Incremental clustering builds its scheduling window from partitions changed by new commits plus `missingSchedulePartitions` recorded in the last clustering plan.

  When clustering only schedules part of that current window, the unscheduled partitions need to be written back to `missingSchedulePartitions` so that later schedules can pick them up. Today, partitions filtered out by the
  clustering partition regex are dropped from the current window without being recorded as missing. Similarly, when users temporarily set `hoodie.clustering.plan.strategy.target.partitions`, the strategy reads the previous
  plan's missing partitions instead of deriving missing partitions from the current scheduling window.

  This can cause partitions to be skipped by incremental clustering if they do not receive new writes later.


### Summary and Changelog

  This change retains unscheduled partitions from the current incremental clustering window as missing partitions.

  Changes:
  - Added a common helper in `ClusteringPlanStrategy` to compute `currentWindow - partitionsToSchedule`.
  - Updated `PartitionAwareClusteringPlanStrategy` to record regex-filtered partitions as `missingSchedulePartitions`.
  - Updated `PartitionAwareClusteringPlanStrategy` to compute missing partitions for manually selected partitions from the current scheduling window.
  - Used insertion-order preserving de-duplication for deterministic missing partition output.
  - Added unit coverage for missing partition calculation with incremental table service enabled and disabled.
  - Updated incremental clustering regression coverage to verify regex-filtered partitions are retained as missing.

  No code was copied.

### Impact

  No public API, storage format, or config changes.

  This changes incremental clustering scheduling behavior for partition-filtered plans: partitions in the current incremental scheduling window that are not selected by regex or manual target partition selection are retained
  in `missingSchedulePartitions` for future scheduling instead of being dropped.

  No performance impact is expected beyond small in-memory set operations over the current scheduling window.

### Risk Level

  low

  The change is limited to clustering plan generation metadata. It does not change executor incremental window calculation or clustering execution.

  Verification:
  - `git diff --check`
  - `mvn -pl hudi-client/hudi-client-common -am -DskipITs -Dcheckstyle.skip=true -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TestPartitionAwareClusteringPlanStrategy test`

### Documentation Update

  none

  No new config, API, or user-facing feature is added.

### Contributor's checklist

  - [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable