### PR TITLE
docs(datasource): START_COMMIT is exclusive, not inclusive

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -114,20 +114,20 @@ object DataSourceReadOptions {
     .noDefaultValue()
     .sinceVersion("0.9.0")
     .withDocumentation("Required when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL + "`. "
-      + "Represents the start point (exclusive) to begin incrementally pulling data from. Interpreted as completion time for "
-      + "table version 8 and later, or as requested time (instant time) for earlier table versions. The value need not "
-      + "necessarily correspond to an instant on the timeline. New data written strictly after START_COMMIT are fetched out. "
-      + "For e.g: ‘20170901080000’ will get all new data written strictly after Sep 1, 2017 08:00AM.")
+      + "The start point (exclusive) to begin incrementally pulling data from. For source tables at version 8 or later this is "
+      + "a completion time; for earlier source table versions (e.g., version 6) it is a requested time (instant time). The "
+      + "value need not necessarily correspond to an instant on the timeline. New data written strictly after START_COMMIT are "
+      + "fetched out. For e.g. ‘20170901080000’ will get all new data written strictly after Sep 1, 2017 08:00AM.")
 
   val END_COMMIT: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.end.instanttime")
     .noDefaultValue()
     .sinceVersion("0.9.0")
     .withDocumentation("Used when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL
-      + "`. Represents the completion time to limit incrementally fetched data to. When not specified latest commit "
-      + "completion time from timeline is assumed by default. When specified, new data written with "
-      + "completion_time <= END_COMMIT are fetched out. "
-      + "Point in time type queries make more sense with begin and end completion times specified.")
+      + "`. The end point (inclusive) to limit incrementally fetched data to. For source tables at version 8 or later this is "
+      + "a completion time; for earlier source table versions (e.g., version 6) it is a requested time (instant time). When "
+      + "not specified, the latest committed instant from the timeline is used. Point in time type queries make more sense "
+      + "with both begin and end specified.")
 
   val STREAMING_READ_TABLE_VERSION: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.streaming.table.version")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -114,8 +114,9 @@ object DataSourceReadOptions {
     .noDefaultValue()
     .sinceVersion("0.9.0")
     .withDocumentation("Required when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL + "`. "
-      + "Represents the completion time to start incrementally pulling data from (exclusive). The completion time here need not "
-      + "necessarily correspond to an instant on the timeline. New data written with completion_time > START_COMMIT are fetched out. "
+      + "Represents the start point (exclusive) to begin incrementally pulling data from. Interpreted as completion time for "
+      + "table version 8 and later, or as requested time (instant time) for earlier table versions. The value need not "
+      + "necessarily correspond to an instant on the timeline. New data written strictly after START_COMMIT are fetched out. "
       + "For e.g: ‘20170901080000’ will get all new data written strictly after Sep 1, 2017 08:00AM.")
 
   val END_COMMIT: ConfigProperty[String] = ConfigProperty

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -114,9 +114,9 @@ object DataSourceReadOptions {
     .noDefaultValue()
     .sinceVersion("0.9.0")
     .withDocumentation("Required when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL + "`. "
-      + "Represents the completion time to start incrementally pulling data from. The completion time here need not necessarily "
-      + "correspond to an instant on the timeline. New data written with completion_time >= START_COMMIT are fetched out. "
-      + "For e.g: ‘20170901080000’ will get all new data written on or after Sep 1, 2017 08:00AM.")
+      + "Represents the completion time to start incrementally pulling data from (exclusive). The completion time here need not "
+      + "necessarily correspond to an instant on the timeline. New data written with completion_time > START_COMMIT are fetched out. "
+      + "For e.g: ‘20170901080000’ will get all new data written strictly after Sep 1, 2017 08:00AM.")
 
   val END_COMMIT: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.end.instanttime")

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -114,32 +114,40 @@ object DataSourceReadOptions {
     .noDefaultValue()
     .sinceVersion("0.9.0")
     .withDocumentation("Required when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL + "`. "
-      + "The start point (exclusive) to begin incrementally pulling data from. For source tables at version 8 or later this is "
-      + "a completion time; for earlier source table versions (e.g., version 6) it is a requested time (instant time). The "
-      + "value need not necessarily correspond to an instant on the timeline. New data written strictly after START_COMMIT are "
-      + "fetched out. For e.g. ‘20170901080000’ will get all new data written strictly after Sep 1, 2017 08:00AM.")
+      + "The start point (exclusive) to begin incrementally pulling data from. The semantics depend on the effective table "
+      + "version (overridable via `hoodie.datasource.read.incr.table.version` for incremental reads or "
+      + "`hoodie.datasource.read.streaming.table.version` for streaming reads; otherwise the source table's actual version): "
+      + "version 8 or later treats this as a completion time, earlier versions (e.g., version 6) treat it as a requested time "
+      + "(instant time). The value need not necessarily correspond to an instant on the timeline. New data written strictly "
+      + "after START_COMMIT are fetched out. For e.g. ‘20170901080000’ will get all new data written strictly after Sep 1, "
+      + "2017 08:00AM.")
 
   val END_COMMIT: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.end.instanttime")
     .noDefaultValue()
     .sinceVersion("0.9.0")
     .withDocumentation("Used when `" + QUERY_TYPE.key() + "` is set to `" + QUERY_TYPE_INCREMENTAL_OPT_VAL
-      + "`. The end point (inclusive) to limit incrementally fetched data to. For source tables at version 8 or later this is "
-      + "a completion time; for earlier source table versions (e.g., version 6) it is a requested time (instant time). When "
-      + "not specified, the latest committed instant from the timeline is used. Point in time type queries make more sense "
-      + "with both begin and end specified.")
+      + "`. The end point (inclusive) to limit incrementally fetched data to. Same time-semantics rules as START_COMMIT: "
+      + "version 8 or later treats this as a completion time, earlier versions (e.g., version 6) treat it as a requested time "
+      + "(overridable via `hoodie.datasource.read.incr.table.version` or `hoodie.datasource.read.streaming.table.version`). "
+      + "When not specified, the latest committed instant from the timeline is used. Point in time type queries make more "
+      + "sense with both begin and end specified.")
 
   val STREAMING_READ_TABLE_VERSION: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.streaming.table.version")
     .noDefaultValue()
     .sinceVersion("1.0.0")
-    .withDocumentation("The table version assumed for streaming read")
+    .withDocumentation("Overrides the table version assumed for streaming reads. Version 8+ selects HoodieStreamSourceV2 "
+      + "(completion-time based START_COMMIT/END_COMMIT); earlier versions select HoodieStreamSourceV1 (requested-time based). "
+      + "If unset, the source table's actual version is used.")
 
   val INCREMENTAL_READ_TABLE_VERSION: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.incr.table.version")
     .noDefaultValue()
     .sinceVersion("1.0.0")
-    .withDocumentation("The table version assumed for incremental read")
+    .withDocumentation("Overrides the table version assumed for incremental reads. Version 8+ selects the V2 incremental "
+      + "relation (completion-time based START_COMMIT/END_COMMIT); earlier versions select the V1 relation (requested-time "
+      + "based). If unset, the source table's actual version is used.")
 
   val INCREMENTAL_READ_SCHEMA_USE_END_INSTANTTIME: ConfigProperty[String] = ConfigProperty
     .key("hoodie.datasource.read.schema.use.end.instanttime")


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The doc for `hoodie.datasource.read.begin.instanttime` (config alias `START_COMMIT`) currently states `New data written with completion_time >= START_COMMIT are fetched out`, with the example phrased `on or after`. This is inconsistent with the actual implementation, which treats `START_COMMIT` as **exclusive**:

- V1 relation: timeline is filtered via `findInstantsInRange(start, end)` which is `(start, end]` (start-exclusive). See `InstantComparison.isInRange`.
- V2 relation: defaults to `RangeType.OPEN_CLOSED` (start-exclusive) after `31166ce6f1 fix(query): Change start commit time to be exclusive in incremental query on Spark`.

### Summary and Changelog

Updates the `START_COMMIT` config description to use `>` instead of `>=`, and rephrases the example from `on or after` to `strictly after`, matching the runtime behavior of both V1 and V2 incremental relations.

### Impact

Documentation only. No code behavior change.

### Risk Level

none

### Documentation Update

This PR is the documentation update. A companion PR will update the published configuration pages on the Hudi docs site.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable