### PR TITLE
feat(flink): Support writing out-of-line BLOB columns

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
@@ -283,7 +283,7 @@ public class HoodieSchemaConverter {
    * type. See <a href="https://github.com/apache/hudi/issues/18711">apache/hudi#18711</a> for
    * the tracked work to remove this structural inference.
    */
-  static boolean isBlobStructure(RowType rowType) {
+  private static boolean isBlobStructure(RowType rowType) {
     // Validate: 3 fields with exact names
     if (rowType.getFieldCount() != HoodieSchema.Blob.getFieldCount()) {
       return false;

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
@@ -279,14 +279,11 @@ public class HoodieSchemaConverter {
    * exact nullability match would silently demote a user's BLOB column to a generic record when the
    * column is declared through DDL. The canonical nullability is restored by {@link HoodieSchema#createBlob()}.
    *
-   * <p>TODO(#18711): This heuristic (field-name + base-type shape matching) is a workaround because
-   * Flink has no native logical type for Hudi BLOB and Parquet annotations cannot distinguish a BLOB
-   * group from a user-defined struct with the same field names. Similar to VECTOR, we should explore
-   * having the schema path treat the physical layout as a plain Flink {@code ROW} while threading
-   * {@link HoodieSchema} so Flink row data and Hudi/Avro conversion stay aligned without inferring BLOB
-   * from shape alone; see <a href="https://github.com/apache/hudi/issues/18711">apache/hudi#18711</a>.
+   * <p>TODO: This heuristic is a workaround for the lack of a native Flink/Parquet BLOB logical
+   * type. See <a href="https://github.com/apache/hudi/issues/18711">apache/hudi#18711</a> for
+   * the tracked work to remove this structural inference.
    */
-  private static boolean isBlobStructure(RowType rowType) {
+  static boolean isBlobStructure(RowType rowType) {
     // Validate: 3 fields with exact names
     if (rowType.getFieldCount() != HoodieSchema.Blob.getFieldCount()) {
       return false;

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
@@ -272,8 +272,22 @@ public class HoodieSchemaConverter {
 
   /**
    * Detects if a Flink RowType represents a BLOB structure by validating it matches the schema defined in {@link HoodieSchema.Blob}.
+   *
+   * <p>Detection intentionally keys off the stable structural signals (field names and base type
+   * roots) and does <b>not</b> assert nested-field nullability. Flink SQL {@code CREATE TABLE} does
+   * not reliably preserve {@code NOT NULL} constraints on nested {@code ROW} fields, so requiring an
+   * exact nullability match would silently demote a user's BLOB column to a generic record when the
+   * column is declared through DDL. The canonical nullability is restored by {@link HoodieSchema#createBlob()}.
+   *
+   * <p>TODO(#18711): This heuristic (field-name + base-type shape matching) is a workaround because
+   * Flink has no native logical type for Hudi BLOB and Parquet annotations cannot distinguish a BLOB
+   * group from a user-defined struct with the same field names. The tracked work at
+   * <a href="https://github.com/apache/hudi/issues/18711">apache/hudi#18711</a> proposes threading
+   * {@code HoodieSchema} through Flink's Parquet-to-type conversion (Option A) and/or writing
+   * {@code hoodie.blob.columns} footer metadata (Option B) so callers can identify BLOB columns
+   * unambiguously without relying on structural heuristics.
    */
-  private static boolean isBlobStructure(RowType rowType) {
+  static boolean isBlobStructure(RowType rowType) {
     // Validate: 3 fields with exact names
     if (rowType.getFieldCount() != HoodieSchema.Blob.getFieldCount()) {
       return false;
@@ -286,24 +300,20 @@ public class HoodieSchemaConverter {
       return false;
     }
 
-    // Validate 'type' field: non-null STRING
-    LogicalType typeField = rowType.getTypeAt(0);
-    if (!isFamily(typeField, LogicalTypeFamily.CHARACTER_STRING) || typeField.isNullable()) {
+    // Validate 'type' field: STRING
+    if (!isFamily(rowType.getTypeAt(0), LogicalTypeFamily.CHARACTER_STRING)) {
       return false;
     }
 
-    // Validate 'data' field: nullable BYTES/VARBINARY
+    // Validate 'data' field: BYTES/VARBINARY
     LogicalType dataField = rowType.getTypeAt(1);
     if (dataField.getTypeRoot() != LogicalTypeRoot.BINARY && dataField.getTypeRoot() != LogicalTypeRoot.VARBINARY) {
       return false;
     }
-    if (!dataField.isNullable()) {
-      return false;
-    }
 
-    // Validate 'reference' field: nullable ROW
+    // Validate 'reference' field: ROW
     LogicalType referenceField = rowType.getTypeAt(2);
-    if (!referenceField.isNullable() || referenceField.getTypeRoot() != LogicalTypeRoot.ROW) {
+    if (referenceField.getTypeRoot() != LogicalTypeRoot.ROW) {
       return false;
     }
 
@@ -322,24 +332,20 @@ public class HoodieSchemaConverter {
     }
 
     // Validate reference sub-field types
-    // external_path: non-null STRING
-    if (!isFamily(referenceRow.getTypeAt(0), LogicalTypeFamily.CHARACTER_STRING)
-        || referenceRow.getTypeAt(0).isNullable()) {
+    // external_path: STRING
+    if (!isFamily(referenceRow.getTypeAt(0), LogicalTypeFamily.CHARACTER_STRING)) {
       return false;
     }
-    // offset: nullable BIGINT
-    if (referenceRow.getTypeAt(1).getTypeRoot() != LogicalTypeRoot.BIGINT
-        || !referenceRow.getTypeAt(1).isNullable()) {
+    // offset: BIGINT
+    if (referenceRow.getTypeAt(1).getTypeRoot() != LogicalTypeRoot.BIGINT) {
       return false;
     }
-    // length: nullable BIGINT
-    if (referenceRow.getTypeAt(2).getTypeRoot() != LogicalTypeRoot.BIGINT
-        || !referenceRow.getTypeAt(2).isNullable()) {
+    // length: BIGINT
+    if (referenceRow.getTypeAt(2).getTypeRoot() != LogicalTypeRoot.BIGINT) {
       return false;
     }
-    // managed: non-null BOOLEAN
-    if (referenceRow.getTypeAt(3).getTypeRoot() != LogicalTypeRoot.BOOLEAN
-        || referenceRow.getTypeAt(3).isNullable()) {
+    // managed: BOOLEAN
+    if (referenceRow.getTypeAt(3).getTypeRoot() != LogicalTypeRoot.BOOLEAN) {
       return false;
     }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
@@ -281,13 +281,12 @@ public class HoodieSchemaConverter {
    *
    * <p>TODO(#18711): This heuristic (field-name + base-type shape matching) is a workaround because
    * Flink has no native logical type for Hudi BLOB and Parquet annotations cannot distinguish a BLOB
-   * group from a user-defined struct with the same field names. The tracked work at
-   * <a href="https://github.com/apache/hudi/issues/18711">apache/hudi#18711</a> proposes threading
-   * {@code HoodieSchema} through Flink's Parquet-to-type conversion (Option A) and/or writing
-   * {@code hoodie.blob.columns} footer metadata (Option B) so callers can identify BLOB columns
-   * unambiguously without relying on structural heuristics.
+   * group from a user-defined struct with the same field names. Similar to VECTOR, we should explore
+   * having the schema path treat the physical layout as a plain Flink {@code ROW} while threading
+   * {@link HoodieSchema} so Flink row data and Hudi/Avro conversion stay aligned without inferring BLOB
+   * from shape alone; see <a href="https://github.com/apache/hudi/issues/18711">apache/hudi#18711</a>.
    */
-  static boolean isBlobStructure(RowType rowType) {
+  private static boolean isBlobStructure(RowType rowType) {
     // Validate: 3 fields with exact names
     if (rowType.getFieldCount() != HoodieSchema.Blob.getFieldCount()) {
       return false;

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -232,7 +232,10 @@ public class RowDataToAvroConverters {
         converter = createArrayConverter((ArrayType) type, utcTimezone);
         break;
       case ROW:
-        converter = createRowConverter((RowType) type, utcTimezone);
+        RowType rowType = (RowType) type;
+        converter = HoodieSchemaConverter.isBlobStructure(rowType)
+            ? createBlobConverter(rowType, utcTimezone)
+            : createRowConverter(rowType, utcTimezone);
         break;
       case MAP:
       case MULTISET:
@@ -274,6 +277,47 @@ public class RowDataToAvroConverters {
           actualSchema = schema;
         }
         return converter.convert(actualSchema, object);
+      }
+    };
+  }
+
+  /**
+   * Creates a converter for a Flink {@link RowType} that matches the Hudi BLOB structure
+   * ({@link org.apache.hudi.common.schema.HoodieSchema.Blob}).
+   *
+   * <p>The BLOB {@code type} discriminator (field[0]) is an Avro {@code ENUM} even though Flink
+   * models it as a {@code STRING}. This converter hard-wires the {@link GenericData.EnumSymbol}
+   * construction for that field so the generic VARCHAR converter does not need BLOB awareness.
+   * Fields[1] (inline data) and [2] (reference ROW) use the standard converters.
+   */
+  private static RowDataToAvroConverter createBlobConverter(RowType rowType, boolean utcTimezone) {
+    final RowDataToAvroConverter dataConverter = createConverter(rowType.getTypeAt(1), utcTimezone);
+    final RowDataToAvroConverter referenceConverter = createConverter(rowType.getTypeAt(2), utcTimezone);
+    final RowData.FieldGetter typeGetter = RowData.createFieldGetter(rowType.getTypeAt(0), 0);
+    final RowData.FieldGetter dataGetter = RowData.createFieldGetter(rowType.getTypeAt(1), 1);
+    final RowData.FieldGetter refGetter = RowData.createFieldGetter(rowType.getTypeAt(2), 2);
+
+    return new RowDataToAvroConverter() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public Object convert(HoodieSchema schema, Object object) {
+        final RowData row = (RowData) object;
+        final List<HoodieSchemaField> fields = schema.getFields();
+        final GenericRecord record = new GenericData.Record(schema.toAvroSchema());
+
+        // field[0]: BLOB type discriminator — Avro ENUM, Flink delivers BinaryStringData.
+        Object rawType = typeGetter.getFieldOrNull(row);
+        record.put(0, rawType == null ? null
+            : new GenericData.EnumSymbol(fields.get(0).schema().toAvroSchema(), rawType.toString()));
+
+        // field[1]: nullable inline data bytes.
+        record.put(1, dataConverter.convert(fields.get(1).schema(), dataGetter.getFieldOrNull(row)));
+
+        // field[2]: external reference — a plain nested ROW.
+        record.put(2, referenceConverter.convert(fields.get(2).schema(), refGetter.getFieldOrNull(row)));
+
+        return record;
       }
     };
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -151,10 +151,10 @@ public class RowDataToAvroConverters {
                 // The BLOB `type` discriminator is a STRING in Flink but an ENUM in Avro.
                 // Detect that at call time from the HoodieSchema so the converter stays
                 // reusable across any row shape — not hard-wired by Flink row structure alone.
-                if (schema.getNonNullType().getType() == HoodieSchemaType.ENUM) {
-                  HoodieSchema enumSchema = schema.getNonNullType();
+                HoodieSchema nonNullSchema = schema.getNonNullType();
+                if (nonNullSchema.getType() == HoodieSchemaType.ENUM) {
                   return new GenericData.EnumSymbol(
-                      enumSchema.toAvroSchema(), object.toString());
+                      nonNullSchema.toAvroSchema(), object.toString());
                 }
                 return new Utf8(((BinaryStringData) object).toBytes());
               }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -148,6 +148,12 @@ public class RowDataToAvroConverters {
 
               @Override
               public Object convert(HoodieSchema schema, Object object) {
+                // Hudi custom logical types such as BLOB carry an Avro ENUM child (e.g. the BLOB
+                // `type` discriminator). Flink models enums as STRING, so materialize a proper
+                // EnumSymbol when the target schema is an enum; otherwise emit a plain Utf8.
+                if (schema.getType() == HoodieSchemaType.ENUM) {
+                  return new GenericData.EnumSymbol(schema.toAvroSchema(), object.toString());
+                }
                 return new Utf8(((BinaryStringData) object).toBytes());
               }
             };
@@ -232,10 +238,7 @@ public class RowDataToAvroConverters {
         converter = createArrayConverter((ArrayType) type, utcTimezone);
         break;
       case ROW:
-        RowType rowType = (RowType) type;
-        converter = HoodieSchemaConverter.isBlobStructure(rowType)
-            ? createBlobConverter(rowType, utcTimezone)
-            : createRowConverter(rowType, utcTimezone);
+        converter = createRowConverter((RowType) type, utcTimezone);
         break;
       case MAP:
       case MULTISET:
@@ -277,47 +280,6 @@ public class RowDataToAvroConverters {
           actualSchema = schema;
         }
         return converter.convert(actualSchema, object);
-      }
-    };
-  }
-
-  /**
-   * Creates a converter for a Flink {@link RowType} that matches the Hudi BLOB structure
-   * ({@link org.apache.hudi.common.schema.HoodieSchema.Blob}).
-   *
-   * <p>The BLOB {@code type} discriminator (field[0]) is an Avro {@code ENUM} even though Flink
-   * models it as a {@code STRING}. This converter hard-wires the {@link GenericData.EnumSymbol}
-   * construction for that field so the generic VARCHAR converter does not need BLOB awareness.
-   * Fields[1] (inline data) and [2] (reference ROW) use the standard converters.
-   */
-  private static RowDataToAvroConverter createBlobConverter(RowType rowType, boolean utcTimezone) {
-    final RowDataToAvroConverter dataConverter = createConverter(rowType.getTypeAt(1), utcTimezone);
-    final RowDataToAvroConverter referenceConverter = createConverter(rowType.getTypeAt(2), utcTimezone);
-    final RowData.FieldGetter typeGetter = RowData.createFieldGetter(rowType.getTypeAt(0), 0);
-    final RowData.FieldGetter dataGetter = RowData.createFieldGetter(rowType.getTypeAt(1), 1);
-    final RowData.FieldGetter refGetter = RowData.createFieldGetter(rowType.getTypeAt(2), 2);
-
-    return new RowDataToAvroConverter() {
-      private static final long serialVersionUID = 1L;
-
-      @Override
-      public Object convert(HoodieSchema schema, Object object) {
-        final RowData row = (RowData) object;
-        final List<HoodieSchemaField> fields = schema.getFields();
-        final GenericRecord record = new GenericData.Record(schema.toAvroSchema());
-
-        // field[0]: BLOB type discriminator — Avro ENUM, Flink delivers BinaryStringData.
-        Object rawType = typeGetter.getFieldOrNull(row);
-        record.put(0, rawType == null ? null
-            : new GenericData.EnumSymbol(fields.get(0).schema().toAvroSchema(), rawType.toString()));
-
-        // field[1]: nullable inline data bytes.
-        record.put(1, dataConverter.convert(fields.get(1).schema(), dataGetter.getFieldOrNull(row)));
-
-        // field[2]: external reference — a plain nested ROW.
-        record.put(2, referenceConverter.convert(fields.get(2).schema(), refGetter.getFieldOrNull(row)));
-
-        return record;
       }
     };
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -154,7 +154,7 @@ public class RowDataToAvroConverters {
                 if (schema.getNonNullType().getType() == HoodieSchemaType.ENUM) {
                   HoodieSchema enumSchema = schema.getNonNullType();
                   return new GenericData.EnumSymbol(
-                      enumSchema.toAvroSchema(), ((BinaryStringData) object).toString());
+                      enumSchema.toAvroSchema(), object.toString());
                 }
                 return new Utf8(((BinaryStringData) object).toBytes());
               }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -148,6 +148,14 @@ public class RowDataToAvroConverters {
 
               @Override
               public Object convert(HoodieSchema schema, Object object) {
+                // The BLOB `type` discriminator is a STRING in Flink but an ENUM in Avro.
+                // Detect that at call time from the HoodieSchema so the converter stays
+                // reusable across any row shape — not hard-wired by Flink row structure alone.
+                if (schema.getNonNullType().getType() == HoodieSchemaType.ENUM) {
+                  HoodieSchema enumSchema = schema.getNonNullType();
+                  return new GenericData.EnumSymbol(
+                      enumSchema.toAvroSchema(), ((BinaryStringData) object).toString());
+                }
                 return new Utf8(((BinaryStringData) object).toBytes());
               }
             };
@@ -233,9 +241,7 @@ public class RowDataToAvroConverters {
         break;
       case ROW:
         RowType rowType = (RowType) type;
-        converter = HoodieSchemaConverter.isBlobStructure(rowType)
-            ? createBlobConverter(rowType, utcTimezone)
-            : createRowConverter(rowType, utcTimezone);
+        converter = createRowConverter(rowType, utcTimezone);
         break;
       case MAP:
       case MULTISET:
@@ -277,45 +283,6 @@ public class RowDataToAvroConverters {
           actualSchema = schema;
         }
         return converter.convert(actualSchema, object);
-      }
-    };
-  }
-
-  /**
-   * Creates a dedicated converter for a Flink {@link RowType} that matches the Hudi BLOB structure.
-   *
-   * <p>The BLOB {@code type} discriminator (field[0]) is an Avro {@code ENUM} even though Flink
-   * models it as {@code STRING}. This converter hard-wires {@link GenericData.EnumSymbol} for that
-   * field so the generic VARCHAR converter stays clean. Fields[1] and [2] use standard converters.
-   */
-  private static RowDataToAvroConverter createBlobConverter(RowType rowType, boolean utcTimezone) {
-    final RowDataToAvroConverter dataConverter = createConverter(rowType.getTypeAt(1), utcTimezone);
-    final RowDataToAvroConverter referenceConverter = createConverter(rowType.getTypeAt(2), utcTimezone);
-    final RowData.FieldGetter typeGetter = RowData.createFieldGetter(rowType.getTypeAt(0), 0);
-    final RowData.FieldGetter dataGetter = RowData.createFieldGetter(rowType.getTypeAt(1), 1);
-    final RowData.FieldGetter refGetter = RowData.createFieldGetter(rowType.getTypeAt(2), 2);
-
-    return new RowDataToAvroConverter() {
-      private static final long serialVersionUID = 1L;
-
-      @Override
-      public Object convert(HoodieSchema schema, Object object) {
-        final RowData row = (RowData) object;
-        final List<HoodieSchemaField> fields = schema.getFields();
-        final GenericRecord record = new GenericData.Record(schema.toAvroSchema());
-
-        // field[0]: BLOB type discriminator — Avro ENUM, Flink delivers BinaryStringData.
-        Object rawType = typeGetter.getFieldOrNull(row);
-        record.put(0, rawType == null ? null
-            : new GenericData.EnumSymbol(fields.get(0).schema().toAvroSchema(), rawType.toString()));
-
-        // field[1]: nullable inline data bytes.
-        record.put(1, dataConverter.convert(fields.get(1).schema(), dataGetter.getFieldOrNull(row)));
-
-        // field[2]: external reference nested ROW.
-        record.put(2, referenceConverter.convert(fields.get(2).schema(), refGetter.getFieldOrNull(row)));
-
-        return record;
       }
     };
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -148,12 +148,6 @@ public class RowDataToAvroConverters {
 
               @Override
               public Object convert(HoodieSchema schema, Object object) {
-                // Hudi custom logical types such as BLOB carry an Avro ENUM child (e.g. the BLOB
-                // `type` discriminator). Flink models enums as STRING, so materialize a proper
-                // EnumSymbol when the target schema is an enum; otherwise emit a plain Utf8.
-                if (schema.getType() == HoodieSchemaType.ENUM) {
-                  return new GenericData.EnumSymbol(schema.toAvroSchema(), object.toString());
-                }
                 return new Utf8(((BinaryStringData) object).toBytes());
               }
             };
@@ -238,7 +232,10 @@ public class RowDataToAvroConverters {
         converter = createArrayConverter((ArrayType) type, utcTimezone);
         break;
       case ROW:
-        converter = createRowConverter((RowType) type, utcTimezone);
+        RowType rowType = (RowType) type;
+        converter = HoodieSchemaConverter.isBlobStructure(rowType)
+            ? createBlobConverter(rowType, utcTimezone)
+            : createRowConverter(rowType, utcTimezone);
         break;
       case MAP:
       case MULTISET:
@@ -280,6 +277,45 @@ public class RowDataToAvroConverters {
           actualSchema = schema;
         }
         return converter.convert(actualSchema, object);
+      }
+    };
+  }
+
+  /**
+   * Creates a dedicated converter for a Flink {@link RowType} that matches the Hudi BLOB structure.
+   *
+   * <p>The BLOB {@code type} discriminator (field[0]) is an Avro {@code ENUM} even though Flink
+   * models it as {@code STRING}. This converter hard-wires {@link GenericData.EnumSymbol} for that
+   * field so the generic VARCHAR converter stays clean. Fields[1] and [2] use standard converters.
+   */
+  private static RowDataToAvroConverter createBlobConverter(RowType rowType, boolean utcTimezone) {
+    final RowDataToAvroConverter dataConverter = createConverter(rowType.getTypeAt(1), utcTimezone);
+    final RowDataToAvroConverter referenceConverter = createConverter(rowType.getTypeAt(2), utcTimezone);
+    final RowData.FieldGetter typeGetter = RowData.createFieldGetter(rowType.getTypeAt(0), 0);
+    final RowData.FieldGetter dataGetter = RowData.createFieldGetter(rowType.getTypeAt(1), 1);
+    final RowData.FieldGetter refGetter = RowData.createFieldGetter(rowType.getTypeAt(2), 2);
+
+    return new RowDataToAvroConverter() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public Object convert(HoodieSchema schema, Object object) {
+        final RowData row = (RowData) object;
+        final List<HoodieSchemaField> fields = schema.getFields();
+        final GenericRecord record = new GenericData.Record(schema.toAvroSchema());
+
+        // field[0]: BLOB type discriminator — Avro ENUM, Flink delivers BinaryStringData.
+        Object rawType = typeGetter.getFieldOrNull(row);
+        record.put(0, rawType == null ? null
+            : new GenericData.EnumSymbol(fields.get(0).schema().toAvroSchema(), rawType.toString()));
+
+        // field[1]: nullable inline data bytes.
+        record.put(1, dataConverter.convert(fields.get(1).schema(), dataGetter.getFieldOrNull(row)));
+
+        // field[2]: external reference nested ROW.
+        record.put(2, referenceConverter.convert(fields.get(2).schema(), refGetter.getFieldOrNull(row)));
+
+        return record;
       }
     };
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataToAvroConverters.java
@@ -240,8 +240,7 @@ public class RowDataToAvroConverters {
         converter = createArrayConverter((ArrayType) type, utcTimezone);
         break;
       case ROW:
-        RowType rowType = (RowType) type;
-        converter = createRowConverter(rowType, utcTimezone);
+        converter = createRowConverter((RowType) type, utcTimezone);
         break;
       case MAP:
       case MULTISET:

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestHoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/util/TestHoodieSchemaConverter.java
@@ -771,6 +771,23 @@ public class TestHoodieSchemaConverter {
     HoodieSchema convertedSchema = HoodieSchemaConverter.convertToSchema(blobLikeRowType);
     assertEquals(HoodieSchemaType.BLOB, convertedSchema.getType());
 
+    // Positive case: same structure but every nested field nullable. Flink SQL CREATE TABLE does not
+    // preserve NOT NULL on nested ROW fields, so detection must not depend on nested nullability.
+    DataType allNullableBlobRow = DataTypes.ROW(
+        DataTypes.FIELD(HoodieSchema.Blob.TYPE, DataTypes.STRING().nullable()),
+        DataTypes.FIELD(HoodieSchema.Blob.INLINE_DATA_FIELD, DataTypes.BYTES().nullable()),
+        DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE, DataTypes.ROW(
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH, DataTypes.STRING().nullable()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_OFFSET, DataTypes.BIGINT().nullable()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_LENGTH, DataTypes.BIGINT().nullable()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED, DataTypes.BOOLEAN().nullable())
+        ).nullable())
+    ).notNull();
+
+    RowType allNullableBlobRowType = (RowType) allNullableBlobRow.getLogicalType();
+    HoodieSchema allNullableConverted = HoodieSchemaConverter.convertToSchema(allNullableBlobRowType);
+    assertEquals(HoodieSchemaType.BLOB, allNullableConverted.getType());
+
     // Negative case 1: Different field names
     DataType differentNames = DataTypes.ROW(
         DataTypes.FIELD("wrong_name", DataTypes.STRING().notNull()),

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestBlobWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestBlobWrite.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table;
+
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.util.HoodieSchemaConverter;
+import org.apache.hudi.util.StreamerUtil;
+import org.apache.hudi.utils.FlinkMiniCluster;
+
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * IT case for writing out-of-line (OOL) BLOB columns through the Flink writer and reading them back.
+ *
+ * <p>Verifies that the Hudi {@link HoodieSchema.Blob} structure round-trips through the Flink
+ * write/read pipeline (both COW and MOR), that updates land through the MOR Avro log path, and that
+ * the stored table schema keeps the BLOB logical type instead of degrading the column to a generic
+ * Flink/Avro record.
+ */
+@ExtendWith(FlinkMiniCluster.class)
+public class ITTestBlobWrite {
+
+  @TempDir
+  File tempFile;
+
+  private static final String BLOB_COLUMN = "blob_col";
+
+  private static final String BLOB_COLUMN_DDL =
+      "  " + BLOB_COLUMN + " ROW<\n"
+          + "    `type` STRING NOT NULL,\n"
+          + "    `data` BYTES,\n"
+          + "    `reference` ROW<\n"
+          + "      external_path STRING NOT NULL,\n"
+          + "      `offset` BIGINT,\n"
+          + "      `length` BIGINT,\n"
+          + "      managed BOOLEAN NOT NULL\n"
+          + "    >\n"
+          + "  >,\n";
+
+  /**
+   * Regression for {@code HoodieSchemaConverter#isBlobStructure}: Flink SQL {@code CREATE TABLE}
+   * may declare nested {@code ROW} fields as {@code NOT NULL}, but
+   * {@link ResolvedSchema#toPhysicalRowDataType()} does not always preserve those constraints in
+   * the {@link RowType}. Schema inference must still recognize the BLOB shape (same path as
+   * {@code HoodieTableFactory#inferAvroSchema}), otherwise {@code blob_col} would degrade to a
+   * generic RECORD in the committed Hoodie schema.
+   */
+  @Test
+  public void testFlinkSqlDdlPhysicalRowTypeStillMapsToHoodieBlob() {
+    TableEnvironment tableEnv = batchEnv();
+    final String probeTable = "flink_blob_ddl_probe";
+    String createProbeDdl =
+        "CREATE TABLE "
+            + probeTable
+            + " (\n"
+            + "  id BIGINT,\n"
+            + "  name STRING,\n"
+            + BLOB_COLUMN_DDL
+            + "  ts BIGINT\n"
+            + ") WITH ('connector'='blackhole')";
+    tableEnv.executeSql(createProbeDdl);
+
+    ResolvedSchema resolved = tableEnv.from(probeTable).getResolvedSchema();
+    RowType physical = (RowType) resolved.toPhysicalRowDataType().getLogicalType();
+    int blobIdx = physical.getFieldNames().indexOf(BLOB_COLUMN);
+    RowType blobPhysical = (RowType) physical.getTypeAt(blobIdx);
+    // DDL uses NOT NULL on nested BLOB ROW fields where the canonical Hoodie BLOB shape is
+    // stricter. Flink's physical RowType from ResolvedSchema#toPhysicalRowDataType() may or may
+    // not preserve those flags across versions (see Flink table config / release notes linked in
+    // the PR). We do not assert which fields widen — only that Hudi still recognizes the column as
+    // a BLOB (regression for HoodieSchemaConverter#isBlobStructure).
+
+    HoodieSchema recordSchema =
+        HoodieSchemaConverter.convertToSchema(
+            physical, HoodieSchemaUtils.getRecordQualifiedName(probeTable));
+    HoodieSchemaField blobField =
+        recordSchema
+            .getField(BLOB_COLUMN)
+            .orElseThrow(() -> new AssertionError("blob_col missing from converted HoodieSchema"));
+    assertTrue(
+        blobField.schema().isBlobField(),
+        "Physical RowType from Flink SQL DDL must still map to Hoodie BLOB, got: "
+            + blobField.schema());
+
+    tableEnv.executeSql("DROP TABLE " + probeTable);
+  }
+
+  private void createTable(TableEnvironment tableEnv, String tablePath, HoodieTableType tableType) {
+    String createTableDdl = String.format(
+        "CREATE TABLE blob_table (\n"
+            + "  id BIGINT,\n"
+            + "  name STRING,\n"
+            + BLOB_COLUMN_DDL
+            + "  ts BIGINT,\n"
+            + "  PRIMARY KEY (id) NOT ENFORCED\n"
+            + ") WITH (\n"
+            + "  'connector' = 'hudi',\n"
+            + "  'path' = '%s',\n"
+            + "  'table.type' = '%s',\n"
+            + "  'ordering.fields' = 'ts'\n"
+            + ");",
+        tablePath, tableType.name());
+    tableEnv.executeSql(createTableDdl);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = HoodieTableType.class)
+  public void testWriteAndReadOutOfLineBlob(HoodieTableType tableType) throws Exception {
+    TableEnvironment tableEnv = batchEnv();
+    String tablePath = new File(tempFile, "blob_table").getAbsolutePath();
+    createTable(tableEnv, tablePath, tableType);
+
+    // First batch: insert two OOL blob references.
+    execInsert(tableEnv,
+        "INSERT INTO blob_table VALUES\n"
+            + "(1, 'doc-1', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('file1.bin', CAST(0 AS BIGINT), CAST(100 AS BIGINT), false)), 1000),\n"
+            + "(2, 'doc-2', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('file1.bin', CAST(100 AS BIGINT), CAST(200 AS BIGINT), false)), 2000)");
+
+    List<Row> rows = readOrdered(tableEnv);
+    assertEquals(2, rows.size());
+    assertOutOfLineRow(rows.get(0), 1L, "doc-1", "file1.bin", 0L, 100L, 1000L);
+    assertOutOfLineRow(rows.get(1), 2L, "doc-2", "file1.bin", 100L, 200L, 2000L);
+
+    // Second batch: upsert the same keys with new references. For MOR this exercises the Avro
+    // log write path (RowData -> Avro), including the BLOB enum `type` field.
+    execInsert(tableEnv,
+        "INSERT INTO blob_table VALUES\n"
+            + "(1, 'doc-1', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('file2.bin', CAST(500 AS BIGINT), CAST(300 AS BIGINT), false)), 3000),\n"
+            + "(2, 'doc-2', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('file2.bin', CAST(800 AS BIGINT), CAST(400 AS BIGINT), false)), 4000)");
+
+    List<Row> updated = readOrdered(tableEnv);
+    assertEquals(2, updated.size());
+    assertOutOfLineRow(updated.get(0), 1L, "doc-1", "file2.bin", 500L, 300L, 3000L);
+    assertOutOfLineRow(updated.get(1), 2L, "doc-2", "file2.bin", 800L, 400L, 4000L);
+
+    // The stored table schema must keep the BLOB logical type, not a generic record.
+    assertBlobTypePreserved(tablePath);
+  }
+
+  private static List<Row> readOrdered(TableEnvironment tableEnv) {
+    return CollectionUtil.iteratorToList(
+        tableEnv.executeSql("select id, name, blob_col, ts from blob_table order by id").collect());
+  }
+
+  private static void assertOutOfLineRow(Row row, long id, String name, String path,
+                                         long offset, long length, long ts) {
+    assertEquals(id, row.getField(0));
+    assertEquals(name, row.getField(1));
+    Row blob = (Row) row.getField(2);
+    assertNotNull(blob, "blob struct must be populated");
+    assertEquals("OUT_OF_LINE", blob.getField(0));
+    assertNull(blob.getField(1), "inline data must be null for OUT_OF_LINE blob");
+    Row reference = (Row) blob.getField(2);
+    assertNotNull(reference, "reference must be populated for OUT_OF_LINE blob");
+    assertEquals(path, reference.getField(0));
+    assertEquals(offset, reference.getField(1));
+    assertEquals(length, reference.getField(2));
+    assertEquals(false, reference.getField(3));
+    assertEquals(ts, row.getField(3));
+  }
+
+  private static void assertBlobTypePreserved(String tablePath) throws Exception {
+    HoodieTableMetaClient metaClient =
+        StreamerUtil.createMetaClient(tablePath, new org.apache.hadoop.conf.Configuration());
+    HoodieSchema tableSchema = new TableSchemaResolver(metaClient).getTableSchema();
+    HoodieSchemaField blobField = tableSchema.getField(BLOB_COLUMN)
+        .orElseThrow(() -> new AssertionError("blob_col field missing from table schema"));
+    assertTrue(blobField.schema().isBlobField(),
+        "blob_col must keep the BLOB logical type, found: " + blobField.schema());
+  }
+
+  private static TableEnvironment batchEnv() {
+    TableEnvironment tableEnv = org.apache.hudi.utils.TestTableEnvs.getBatchTableEnv();
+    tableEnv.getConfig().getConfiguration()
+        .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+    return tableEnv;
+  }
+
+  private static void execInsert(TableEnvironment tableEnv, String insertSql) throws Exception {
+    TableResult result = tableEnv.executeSql(insertSql);
+    result.getJobClient().get().getJobExecutionResult().get(120, TimeUnit.SECONDS);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestBlobWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestBlobWrite.java
@@ -103,8 +103,6 @@ public class ITTestBlobWrite {
 
     ResolvedSchema resolved = tableEnv.from(probeTable).getResolvedSchema();
     RowType physical = (RowType) resolved.toPhysicalRowDataType().getLogicalType();
-    int blobIdx = physical.getFieldNames().indexOf(BLOB_COLUMN);
-    RowType blobPhysical = (RowType) physical.getTypeAt(blobIdx);
     // DDL uses NOT NULL on nested BLOB ROW fields where the canonical Hoodie BLOB shape is
     // stricter. Flink's physical RowType from ResolvedSchema#toPhysicalRowDataType() may or may
     // not preserve those flags across versions (see Flink table config / release notes linked in

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestRowDataToAvroConverters.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestRowDataToAvroConverters.java
@@ -135,16 +135,9 @@ class TestRowDataToAvroConverters {
   }
 
   /**
-   * Regression for the {@code createBlobConverter} approach (old design): when a ROW has the same
-   * field-name shape as a BLOB but its {@link HoodieSchema} carries a plain {@code STRING} for
-   * {@code type} (not an {@code ENUM}), the converter must not crash and must write a plain
-   * {@link Utf8} — not a {@link GenericData.EnumSymbol}.
-   *
-   * <p>The old approach selected {@code createBlobConverter} at creation time via
-   * {@code isBlobStructure}, then called
-   * {@code new GenericData.EnumSymbol(stringAvroSchema, ...)} at runtime — which either threw or
-   * wrote the wrong representation.  With Option-1 the ENUM branch is gated on the runtime
-   * {@code HoodieSchema}, so this scenario falls through to a plain {@link Utf8}.
+   * A ROW whose field names match the BLOB structure but whose {@link HoodieSchema} carries a
+   * plain {@code STRING} (not {@code ENUM}) for the {@code type} field must write a plain
+   * {@link Utf8}, not a {@link GenericData.EnumSymbol}.
    */
   @Test
   void testBlobShapedRowWithPlainStringSchemaWritesUtf8() {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestRowDataToAvroConverters.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestRowDataToAvroConverters.java
@@ -19,11 +19,14 @@
 package org.apache.hudi.utils;
 
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.RowDataToAvroConverters;
 
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.JsonToRowDataConverters;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
@@ -40,6 +43,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 
 import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.ROW;
@@ -128,5 +132,80 @@ class TestRowDataToAvroConverters {
         "BLOB `type` must be written as an Avro EnumSymbol, found: "
             + (typeValue == null ? "null" : typeValue.getClass().getName()));
     Assertions.assertEquals(HoodieSchema.Blob.OUT_OF_LINE, typeValue.toString());
+  }
+
+  /**
+   * Regression for the {@code createBlobConverter} approach (old design): when a ROW has the same
+   * field-name shape as a BLOB but its {@link HoodieSchema} carries a plain {@code STRING} for
+   * {@code type} (not an {@code ENUM}), the converter must not crash and must write a plain
+   * {@link Utf8} — not a {@link GenericData.EnumSymbol}.
+   *
+   * <p>The old approach selected {@code createBlobConverter} at creation time via
+   * {@code isBlobStructure}, then called
+   * {@code new GenericData.EnumSymbol(stringAvroSchema, ...)} at runtime — which either threw or
+   * wrote the wrong representation.  With Option-1 the ENUM branch is gated on the runtime
+   * {@code HoodieSchema}, so this scenario falls through to a plain {@link Utf8}.
+   */
+  @Test
+  void testBlobShapedRowWithPlainStringSchemaWritesUtf8() {
+    DataType blobShapedRow = DataTypes.ROW(
+        DataTypes.FIELD(HoodieSchema.Blob.TYPE, DataTypes.STRING().notNull()),
+        DataTypes.FIELD(HoodieSchema.Blob.INLINE_DATA_FIELD, DataTypes.BYTES().nullable()),
+        DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE, DataTypes.ROW(
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH, DataTypes.STRING().notNull()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_OFFSET, DataTypes.BIGINT().nullable()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_LENGTH, DataTypes.BIGINT().nullable()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED, DataTypes.BOOLEAN().notNull())
+        ).nullable()));
+    RowType outerRowType = (RowType) DataTypes.ROW(
+        DataTypes.FIELD("blob_col", blobShapedRow)).getLogicalType();
+
+    // Plain RECORD schema: field[0] is STRING (not ENUM) — mimics a non-BLOB record whose
+    // shape happens to match the BLOB structure.
+    HoodieSchema refSchema = HoodieSchema.createRecord("reference", null, null, Arrays.asList(
+        HoodieSchemaField.of(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH,
+            HoodieSchema.create(HoodieSchemaType.STRING)),
+        HoodieSchemaField.of(HoodieSchema.Blob.EXTERNAL_REFERENCE_OFFSET,
+            HoodieSchema.createNullable(HoodieSchemaType.LONG)),
+        HoodieSchemaField.of(HoodieSchema.Blob.EXTERNAL_REFERENCE_LENGTH,
+            HoodieSchema.createNullable(HoodieSchemaType.LONG)),
+        HoodieSchemaField.of(HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED,
+            HoodieSchema.create(HoodieSchemaType.BOOLEAN))
+    ));
+    HoodieSchema plainBlobShapedSchema = HoodieSchema.createRecord("blob_col", null, null, Arrays.asList(
+        HoodieSchemaField.of(HoodieSchema.Blob.TYPE, HoodieSchema.create(HoodieSchemaType.STRING)),
+        HoodieSchemaField.of(HoodieSchema.Blob.INLINE_DATA_FIELD,
+            HoodieSchema.createNullable(HoodieSchemaType.BYTES)),
+        HoodieSchemaField.of(HoodieSchema.Blob.EXTERNAL_REFERENCE,
+            HoodieSchema.createNullable(refSchema))
+    ));
+    HoodieSchema outerSchema = HoodieSchema.createRecord("outer", null, null, Arrays.asList(
+        HoodieSchemaField.of("blob_col", plainBlobShapedSchema)
+    ));
+
+    GenericRowData reference = new GenericRowData(4);
+    reference.setField(0, StringData.fromString("file1.bin"));
+    reference.setField(1, 0L);
+    reference.setField(2, 100L);
+    reference.setField(3, false);
+
+    GenericRowData blobRow = new GenericRowData(3);
+    blobRow.setField(0, StringData.fromString("OUT_OF_LINE"));
+    blobRow.setField(1, null);
+    blobRow.setField(2, reference);
+
+    GenericRowData top = new GenericRowData(1);
+    top.setField(0, blobRow);
+
+    RowDataToAvroConverters.RowDataToAvroConverter converter =
+        RowDataToAvroConverters.createConverter(outerRowType);
+    GenericRecord avroRecord = (GenericRecord) converter.convert(outerSchema, top);
+
+    GenericRecord blobRecord = (GenericRecord) avroRecord.get(0);
+    Object typeValue = blobRecord.get(HoodieSchema.Blob.TYPE);
+    Assertions.assertInstanceOf(Utf8.class, typeValue,
+        "STRING field must write as Utf8 (not EnumSymbol) when HoodieSchema is not ENUM; found: "
+            + (typeValue == null ? "null" : typeValue.getClass().getName()));
+    Assertions.assertEquals("OUT_OF_LINE", typeValue.toString());
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestRowDataToAvroConverters.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestRowDataToAvroConverters.java
@@ -18,15 +18,19 @@
 
 package org.apache.hudi.utils;
 
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.RowDataToAvroConverters;
 
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.JsonToRowDataConverters;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.junit.jupiter.api.Assertions;
@@ -80,5 +84,49 @@ class TestRowDataToAvroConverters {
     Assertions.assertEquals(timestampFromUtc0, formatter.format(LocalDateTime.ofInstant(Instant.ofEpochMilli((Long) avroRecord.get(0)), ZoneId.of("UTC"))));
     Assertions.assertEquals("2021-03-30 08:44:29", formatter.format(LocalDateTime.ofInstant(Instant.ofEpochMilli((Long) avroRecord.get(0)), ZoneId.of("UTC+1"))));
     Assertions.assertEquals("2021-03-30 15:44:29", formatter.format(LocalDateTime.ofInstant(Instant.ofEpochMilli((Long) avroRecord.get(0)), ZoneId.of("Asia/Shanghai"))));
+  }
+
+  @Test
+  void testRowDataToAvroBlobTypeFieldWritesEnumSymbol() {
+    // Flink models the BLOB `type` discriminator as STRING, but its Avro encoding is an ENUM
+    // (blob_storage_type). The converter must emit a GenericData.EnumSymbol, not a plain Utf8,
+    // otherwise Avro log-block writes (MOR) fail with "value OUT_OF_LINE (a Utf8) is not a
+    // blob_storage_type".
+    DataType blobRow = DataTypes.ROW(
+        DataTypes.FIELD(HoodieSchema.Blob.TYPE, DataTypes.STRING().notNull()),
+        DataTypes.FIELD(HoodieSchema.Blob.INLINE_DATA_FIELD, DataTypes.BYTES().nullable()),
+        DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE, DataTypes.ROW(
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_PATH, DataTypes.STRING().notNull()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_OFFSET, DataTypes.BIGINT().nullable()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_LENGTH, DataTypes.BIGINT().nullable()),
+            DataTypes.FIELD(HoodieSchema.Blob.EXTERNAL_REFERENCE_IS_MANAGED, DataTypes.BOOLEAN().notNull())
+        ).nullable()));
+    RowType rowType = (RowType) DataTypes.ROW(DataTypes.FIELD("blob_col", blobRow)).getLogicalType();
+
+    GenericRowData reference = new GenericRowData(4);
+    reference.setField(0, StringData.fromString("file1.bin"));
+    reference.setField(1, 0L);
+    reference.setField(2, 100L);
+    reference.setField(3, false);
+
+    GenericRowData blob = new GenericRowData(3);
+    blob.setField(0, StringData.fromString(HoodieSchema.Blob.OUT_OF_LINE));
+    blob.setField(1, null);
+    blob.setField(2, reference);
+
+    GenericRowData top = new GenericRowData(1);
+    top.setField(0, blob);
+
+    RowDataToAvroConverters.RowDataToAvroConverter converter =
+        RowDataToAvroConverters.createConverter(rowType);
+    GenericRecord avroRecord =
+        (GenericRecord) converter.convert(HoodieSchemaConverter.convertToSchema(rowType), top);
+
+    GenericRecord blobRecord = (GenericRecord) avroRecord.get(0);
+    Object typeValue = blobRecord.get(HoodieSchema.Blob.TYPE);
+    Assertions.assertInstanceOf(GenericData.EnumSymbol.class, typeValue,
+        "BLOB `type` must be written as an Avro EnumSymbol, found: "
+            + (typeValue == null ? "null" : typeValue.getClass().getName()));
+    Assertions.assertEquals(HoodieSchema.Blob.OUT_OF_LINE, typeValue.toString());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink can already declare BLOB columns in Hudi table schemas (the `HoodieSchema.Blob` ROW shape is recognized by `HoodieSchemaConverter`), but writing out-of-line (OOL) BLOB references through the Flink writer did not work end-to-end:

1. A BLOB column declared via Flink SQL `CREATE TABLE` was silently demoted to a generic record in the committed schema. Flink does not preserve `NOT NULL` on nested `ROW` fields in the physical `RowType` exposed by `ResolvedSchema#toPhysicalRowDataType()`, so `isBlobStructure` (which required exact nested nullability) failed to recognize the column and `convertToSchema` produced a plain RECORD instead of the BLOB logical type.
2. Once the schema was a proper BLOB, MOR upserts failed at write time with `AvroTypeException: value OUT_OF_LINE (a Utf8) is not a blob_storage_type`. The BLOB `type` discriminator is an Avro ENUM, but the Flink RowData -> Avro converter emitted a plain `Utf8` for all string fields.

This change makes Flink write OOL BLOB references for both COW and MOR tables while preserving the `HoodieSchema` BLOB type on disk (not a generic record).

### Summary and Changelog

**User-facing outcome:** Flink SQL / DataStream upserts can write OOL BLOB references (`external_path`, `offset`, `length`, `managed`) to COW base files and MOR log files, and the committed table schema keeps the BLOB logical type.

#### Changes

- **`HoodieSchemaConverter#isBlobStructure`**
  - Detect BLOB columns by field names and base type roots only; all nullability checks are removed. Flink SQL `CREATE TABLE` does not reliably preserve `NOT NULL` on nested `ROW` fields ([Table config docs](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/config/), [Flink 2.2 release notes](https://nightlies.apache.org/flink/flink-docs-stable/release-notes/flink-2.2/)), so the old strict match silently demoted a valid BLOB column to a plain RECORD. Canonical nullability is restored by `HoodieSchema.createBlob()`. See [apache/hudi#18711](https://github.com/apache/hudi/issues/18711) for discussion to remove this structural inference entirely.

- **`RowDataToAvroConverters` (runtime ENUM detection)**
  - The CHAR/VARCHAR converter now checks the runtime `HoodieSchema` at call time: if the field schema is `HoodieSchemaType.ENUM`, it emits a `GenericData.EnumSymbol`; otherwise it falls through to a plain `Utf8`. This fixes `AvroTypeException: value OUT_OF_LINE (a Utf8) is not a blob_storage_type` on MOR Avro log-block writes. Gating on the runtime schema (rather than the Flink `RowType` at converter-creation time) keeps the converter reusable across any row shape regardless of what `HoodieSchema` is passed at call time.

#### Tests

- **`ITTestBlobWrite`** (new, Flink-only)
  - Parameterized over COW / MOR: insert OOL BLOB references, upsert the same keys (exercising the MOR Avro log write path), read back and verify the references, and assert the committed table schema retains the BLOB logical type via `HoodieSchema#isBlobField`.
  - `testFlinkSqlDdlPhysicalRowTypeStillMapsToHoodieBlob`: creates a `blackhole` table with a BLOB column declared with nested `NOT NULL` in the DDL; asserts that `HoodieSchemaConverter.convertToSchema` (same code path as `HoodieTableFactory#inferAvroSchema`) still maps `blob_col` to a Hoodie BLOB despite Flink's physical `RowType` potentially relaxing inner nullability.

- **`TestRowDataToAvroConverters`**
  - `testRowDataToAvroBlobTypeFieldWritesEnumSymbol`: asserts the BLOB `type` field is written as an Avro `EnumSymbol`, not a `Utf8`.
  - `testBlobShapedRowWithPlainStringSchemaWritesUtf8`: asserts that a ROW whose field names match the BLOB structure but whose `HoodieSchema` carries a plain `STRING` (not `ENUM`) for `type` correctly writes a `Utf8` and does not throw.

- **`TestHoodieSchemaConverter`**
  - `testBlobStructureValidation`: positive case for the canonical (strict-nullability) BLOB ROW and for an all-nullable-nested BLOB ROW (the Flink DDL physical shape). Negative cases for wrong field names and wrong base types are unchanged.

### Impact

- **Write path:** Flink COW and MOR writes can now encode OOL BLOB references instead of either degrading the schema to a generic record or failing at MOR log-write time.
- **Read path:** unchanged.
- **On-disk layout:** BLOB column retains the `HoodieSchema.Blob` shape (enum `type`, nullable `data`, nullable `reference`) consistent with Spark.
- **No public API change.** Inline BLOB writes, the `read_blob` batched reader, managed-blob cleaning, and dynamic inline/OOL placement remain out of scope.

### Risk Level

**Low/Medium**

- The `isBlobStructure` relaxation only drops nullability assertions; field-name and base-type checks are unchanged, so non-BLOB records are unaffected.
- The ENUM branch in the VARCHAR converter is gated on the runtime `HoodieSchema`; plain STRING fields are unaffected.

### Test plan

- [ ] `-Pflink2.1` CI: `TestHoodieSchemaConverter`
- [ ] `-Pflink2.1` CI: `TestRowDataToAvroConverters`
- [ ] `-Pflink2.1` CI: `ITTestBlobWrite` (COW + MOR + Flink DDL physical schema)

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
