### PR TITLE
perf(clean): Avoid extra getPathInfo RPC per file during clean execution

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -106,37 +106,38 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     }
   }
 
-  private static boolean deletePathAndGetResult(HoodieStorage storage, String deletePathStr) {
-    StoragePath deletePath = new StoragePath(deletePathStr);
-    log.debug("Working on delete path: {}", deletePath);
+  private static boolean deleteDirAndGetResult(HoodieStorage storage, String deleteDirStr) {
+    StoragePath deleteDir = new StoragePath(deleteDirStr);
+    log.debug("Working on deleting directory: {}", deleteDir);
     try {
-      boolean deleteResult = storage.getPathInfo(deletePath).isDirectory()
-          ? storage.deleteDirectory(deletePath)
-          : storage.deleteFile(deletePath);
+      // Only partition directories are handled here, so delete recursively without probing
+      // getPathInfo for the path type first.
+      boolean deleteResult = storage.deleteDirectory(deleteDir);
       if (deleteResult) {
-        log.debug("Cleaned path: {}", deletePath);
-      } else {
-        if (storage.exists(deletePath)) {
-          throw new HoodieIOException("Failed to delete path during clean execution " + deletePath);
-        } else {
-          log.debug("Already cleaned up path: {}", deletePath);
-        }
+        log.debug("Cleaned directory: {}", deleteDir);
+        return true;
       }
-      return deleteResult;
+      if (storage.exists(deleteDir)) {
+        throw new HoodieIOException("Failed to delete directory during clean execution " + deleteDir);
+      }
+      // Hadoop file systems report a missing path by returning false from delete instead of
+      // throwing FileNotFoundException, so this is the regular retried-clean case below.
+      log.debug("Already cleaned up directory: {}", deleteDir);
+      return true;
     } catch (FileNotFoundException fio) {
-      // With cleanPlan being used for retried cleaning operations, its possible to clean a path twice if a path to be
-      // deleted is not found, treat it as a success.
+      // With cleanPlan being used for retried cleaning operations, its possible to clean a directory twice if the
+      // directory to be deleted is not found, treat it as a success.
       return true;
     } catch (IOException e) {
       try {
-        if (storage.exists(deletePath)) {
-          log.error("Delete path failed: {} and path still exists", deletePath, e);
+        if (storage.exists(deleteDir)) {
+          log.error("Delete directory failed: {} and directory still exists", deleteDir, e);
           throw new HoodieIOException(e.getMessage(), e);
         }
-        log.warn("Delete path failed: {} but path does not exist", deletePath, e);
+        log.warn("Delete directory failed: {} but directory does not exist", deleteDir, e);
         return false;
       } catch (IOException ex) {
-        log.error("Delete path failed: {} with exception: {} and existence check also failed", deletePath, e, ex);
+        log.error("Delete directory failed: {} with exception: {} and existence check also failed", deleteDir, e, ex);
         throw new HoodieIOException(ex.getMessage(), ex);
       }
     }
@@ -198,7 +199,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         : Collections.emptyList();
     partitionsToBeDeleted.forEach(entry -> {
       if (!isNullOrEmpty(entry)) {
-        deletePathAndGetResult(table.getStorage(), table.getMetaClient().getBasePath() + "/" + entry);
+        deleteDirAndGetResult(table.getStorage(), table.getMetaClient().getBasePath() + "/" + entry);
       }
     });
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -72,19 +72,20 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     StoragePath deletePath = new StoragePath(deletePathStr);
     log.debug("Working on delete path: {}", deletePath);
     try {
-      boolean deleteResult = storage.getPathInfo(deletePath).isDirectory()
-          ? storage.deleteDirectory(deletePath)
-          : storage.deleteFile(deletePath);
+      // Plan entries handled here are always base/log/bootstrap file paths (never directories),
+      // so delete directly instead of paying an extra getPathInfo RPC per file.
+      boolean deleteResult = storage.deleteFile(deletePath);
       if (deleteResult) {
         log.debug("Cleaned file at path: {}", deletePath);
-      } else {
-        if (storage.exists(deletePath)) {
-          throw new HoodieIOException("Failed to delete path during clean execution " + deletePath);
-        } else {
-          log.debug("Already cleaned up file at path: {}", deletePath);
-        }
+        return true;
       }
-      return deleteResult;
+      if (storage.exists(deletePath)) {
+        throw new HoodieIOException("Failed to delete path during clean execution " + deletePath);
+      }
+      // Hadoop file systems report a missing path by returning false from delete instead of
+      // throwing FileNotFoundException, so this is the regular retried-clean case below.
+      log.debug("Already cleaned up file at path: {}", deletePath);
+      return true;
     } catch (FileNotFoundException fio) {
       // With cleanPlan being used for retried cleaning operations, its possible to clean a file twice if a file to be
       // deleted is not found, treat it as a success.  In other words, there is nothing else to be cleaned up on the
@@ -100,6 +101,42 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         return false;
       } catch (IOException ex) {
         log.error("Delete file failed: {} with exception: {} and existence check also failed", deletePath, e, ex);
+        throw new HoodieIOException(ex.getMessage(), ex);
+      }
+    }
+  }
+
+  private static boolean deletePathAndGetResult(HoodieStorage storage, String deletePathStr) {
+    StoragePath deletePath = new StoragePath(deletePathStr);
+    log.debug("Working on delete path: {}", deletePath);
+    try {
+      boolean deleteResult = storage.getPathInfo(deletePath).isDirectory()
+          ? storage.deleteDirectory(deletePath)
+          : storage.deleteFile(deletePath);
+      if (deleteResult) {
+        log.debug("Cleaned path: {}", deletePath);
+      } else {
+        if (storage.exists(deletePath)) {
+          throw new HoodieIOException("Failed to delete path during clean execution " + deletePath);
+        } else {
+          log.debug("Already cleaned up path: {}", deletePath);
+        }
+      }
+      return deleteResult;
+    } catch (FileNotFoundException fio) {
+      // With cleanPlan being used for retried cleaning operations, its possible to clean a path twice if a path to be
+      // deleted is not found, treat it as a success.
+      return true;
+    } catch (IOException e) {
+      try {
+        if (storage.exists(deletePath)) {
+          log.error("Delete path failed: {} and path still exists", deletePath, e);
+          throw new HoodieIOException(e.getMessage(), e);
+        }
+        log.warn("Delete path failed: {} but path does not exist", deletePath, e);
+        return false;
+      } catch (IOException ex) {
+        log.error("Delete path failed: {} with exception: {} and existence check also failed", deletePath, e, ex);
         throw new HoodieIOException(ex.getMessage(), ex);
       }
     }
@@ -161,7 +198,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         : Collections.emptyList();
     partitionsToBeDeleted.forEach(entry -> {
       if (!isNullOrEmpty(entry)) {
-        deleteFileAndGetResult(table.getStorage(), table.getMetaClient().getBasePath() + "/" + entry);
+        deletePathAndGetResult(table.getStorage(), table.getMetaClient().getBasePath() + "/" + entry);
       }
     });
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanActionExecutor.java
@@ -68,76 +68,45 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
     this.txnManager = new TransactionManager(config, table.getStorage());
   }
 
-  private static boolean deleteFileAndGetResult(HoodieStorage storage, String deletePathStr) {
+  /**
+   * Deletes the given path and returns whether it is gone afterwards. Cleaner plan file entries
+   * are always base/log/bootstrap file paths and partition deletions are always directories, so
+   * the caller passes the path type explicitly and no getPathInfo probe is needed.
+   *
+   * @param isDirectory true for a partition directory (deleted recursively), false for a file
+   */
+  private static boolean deleteAndGetResult(HoodieStorage storage, String deletePathStr, boolean isDirectory) {
     StoragePath deletePath = new StoragePath(deletePathStr);
-    log.debug("Working on delete path: {}", deletePath);
+    String pathType = isDirectory ? "directory" : "file";
+    log.debug("Working on deleting {}: {}", pathType, deletePath);
     try {
-      // Plan entries handled here are always base/log/bootstrap file paths (never directories),
-      // so delete directly instead of paying an extra getPathInfo RPC per file.
-      boolean deleteResult = storage.deleteFile(deletePath);
+      boolean deleteResult = isDirectory ? storage.deleteDirectory(deletePath) : storage.deleteFile(deletePath);
       if (deleteResult) {
-        log.debug("Cleaned file at path: {}", deletePath);
+        log.debug("Cleaned {}: {}", pathType, deletePath);
         return true;
       }
       if (storage.exists(deletePath)) {
-        throw new HoodieIOException("Failed to delete path during clean execution " + deletePath);
+        throw new HoodieIOException("Failed to delete " + pathType + " during clean execution " + deletePath);
       }
       // Hadoop file systems report a missing path by returning false from delete instead of
       // throwing FileNotFoundException, so this is the regular retried-clean case below.
-      log.debug("Already cleaned up file at path: {}", deletePath);
+      log.debug("Already cleaned up {}: {}", pathType, deletePath);
       return true;
     } catch (FileNotFoundException fio) {
-      // With cleanPlan being used for retried cleaning operations, its possible to clean a file twice if a file to be
+      // With cleanPlan being used for retried cleaning operations, its possible to clean a path twice if a path to be
       // deleted is not found, treat it as a success.  In other words, there is nothing else to be cleaned up on the
       // FileSystem, except for updating the MDT.  By returning success, we would remove the entry from MDT.
       return true;
     } catch (IOException e) {
       try {
         if (storage.exists(deletePath)) {
-          log.error("Delete file failed: {} and file still exists", deletePath, e);
+          log.error("Delete {} failed: {} and it still exists", pathType, deletePath, e);
           throw new HoodieIOException(e.getMessage(), e);
         }
-        log.warn("Delete file failed: {} but file does not exist", deletePath, e);
+        log.warn("Delete {} failed: {} but it does not exist", pathType, deletePath, e);
         return false;
       } catch (IOException ex) {
-        log.error("Delete file failed: {} with exception: {} and existence check also failed", deletePath, e, ex);
-        throw new HoodieIOException(ex.getMessage(), ex);
-      }
-    }
-  }
-
-  private static boolean deleteDirAndGetResult(HoodieStorage storage, String deleteDirStr) {
-    StoragePath deleteDir = new StoragePath(deleteDirStr);
-    log.debug("Working on deleting directory: {}", deleteDir);
-    try {
-      // Only partition directories are handled here, so delete recursively without probing
-      // getPathInfo for the path type first.
-      boolean deleteResult = storage.deleteDirectory(deleteDir);
-      if (deleteResult) {
-        log.debug("Cleaned directory: {}", deleteDir);
-        return true;
-      }
-      if (storage.exists(deleteDir)) {
-        throw new HoodieIOException("Failed to delete directory during clean execution " + deleteDir);
-      }
-      // Hadoop file systems report a missing path by returning false from delete instead of
-      // throwing FileNotFoundException, so this is the regular retried-clean case below.
-      log.debug("Already cleaned up directory: {}", deleteDir);
-      return true;
-    } catch (FileNotFoundException fio) {
-      // With cleanPlan being used for retried cleaning operations, its possible to clean a directory twice if the
-      // directory to be deleted is not found, treat it as a success.
-      return true;
-    } catch (IOException e) {
-      try {
-        if (storage.exists(deleteDir)) {
-          log.error("Delete directory failed: {} and directory still exists", deleteDir, e);
-          throw new HoodieIOException(e.getMessage(), e);
-        }
-        log.warn("Delete directory failed: {} but directory does not exist", deleteDir, e);
-        return false;
-      } catch (IOException ex) {
-        log.error("Delete directory failed: {} with exception: {} and existence check also failed", deleteDir, e, ex);
+        log.error("Delete {} failed: {} with exception: {} and existence check also failed", pathType, deletePath, e, ex);
         throw new HoodieIOException(ex.getMessage(), ex);
       }
     }
@@ -151,7 +120,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
       String partitionPath = partitionDelFileTuple.getLeft();
       StoragePath deletePath = new StoragePath(partitionDelFileTuple.getRight().getFilePath());
       String deletePathStr = deletePath.toString();
-      boolean deletedFileResult = deleteFileAndGetResult(storage, deletePathStr);
+      boolean deletedFileResult = deleteAndGetResult(storage, deletePathStr, false);
       final PartitionCleanStat partitionCleanStat =
           partitionCleanStatMap.computeIfAbsent(partitionPath, k -> new PartitionCleanStat(partitionPath));
       boolean isBootstrapBasePathFile = partitionDelFileTuple.getRight().isBootstrapBaseFile();
@@ -199,7 +168,7 @@ public class CleanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I, K,
         : Collections.emptyList();
     partitionsToBeDeleted.forEach(entry -> {
       if (!isNullOrEmpty(entry)) {
-        deleteDirAndGetResult(table.getStorage(), table.getMetaClient().getBasePath() + "/" + entry);
+        deleteAndGetResult(table.getStorage(), table.getMetaClient().getBasePath() + "/" + entry, true);
       }
     });
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestCleanActionExecutor.java
@@ -66,7 +66,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -161,23 +163,26 @@ public class TestCleanActionExecutor {
 
     CleanActionExecutor cleanActionExecutor = new CleanActionExecutor(context, config, mockHoodieTable, "002");
     if (failureType == CleanFailureType.TRUE_ON_DELETE) {
-      assertCleanExecutionSuccess(cleanActionExecutor, filePath);
+      assertCleanExecutionSuccess(cleanActionExecutor, filePath, true);
     } else if (failureType == CleanFailureType.FALSE_ON_DELETE_IS_EXISTS_FALSE) {
-      assertCleanExecutionSuccess(cleanActionExecutor, filePath);
+      // a missing file on a retried clean counts as a successful delete so its MDT entry is removed
+      assertCleanExecutionSuccess(cleanActionExecutor, filePath, true);
     } else if (failureType == CleanFailureType.FALSE_ON_DELETE_IS_EXISTS_TRUE) {
       assertCleanExecutionFailure(cleanActionExecutor);
     } else if (failureType == CleanFailureType.FILE_NOT_FOUND_EXC_ON_DELETE) {
-      assertCleanExecutionSuccess(cleanActionExecutor, filePath);
+      assertCleanExecutionSuccess(cleanActionExecutor, filePath, true);
     } else if (failureType == CleanFailureType.IO_EXCEPTION) {
       assertCleanExecutionFailure(cleanActionExecutor);
     } else if (failureType == CleanFailureType.IO_EXCEPTION_AND_EXISTS) {
       assertCleanExecutionFailure(cleanActionExecutor);
     } else if (failureType == CleanFailureType.IO_EXCEPTION_BUT_NOT_EXISTS) {
-      assertCleanExecutionSuccess(cleanActionExecutor, filePath);
+      assertCleanExecutionSuccess(cleanActionExecutor, filePath, false);
     } else {
       // run time exception
       assertCleanExecutionFailure(cleanActionExecutor);
     }
+    // file deletions must not stat the path first; deletes go straight to storage
+    verify(storage, never()).getPathInfo(filePath);
   }
 
   private void assertCleanExecutionFailure(CleanActionExecutor cleanActionExecutor) {
@@ -186,11 +191,16 @@ public class TestCleanActionExecutor {
     });
   }
 
-  private void assertCleanExecutionSuccess(CleanActionExecutor cleanActionExecutor, StoragePath filePath) {
+  private void assertCleanExecutionSuccess(CleanActionExecutor cleanActionExecutor, StoragePath filePath, boolean expectFileDeleteSuccess) {
     HoodieCleanMetadata cleanMetadata = cleanActionExecutor.execute();
     assertTrue(cleanMetadata.getPartitionMetadata().containsKey(PARTITION1));
     HoodieCleanPartitionMetadata cleanPartitionMetadata = cleanMetadata.getPartitionMetadata().get(PARTITION1);
     assertTrue(cleanPartitionMetadata.getDeletePathPatterns().contains(filePath.getName()));
+    if (expectFileDeleteSuccess) {
+      assertTrue(cleanPartitionMetadata.getSuccessDeleteFiles().contains(filePath.getName()));
+    } else {
+      assertTrue(cleanPartitionMetadata.getFailedDeleteFiles().contains(filePath.getName()));
+    }
   }
 
   private static HoodieWriteConfig getCleanByCommitsConfig() {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18962

Clean execution pays a `storage.getPathInfo` RPC per file just to test `isDirectory` before deleting, even though cleaner plan file entries are always base, log or bootstrap base file paths and never directories. On cloud storage this doubles the request count of the clean execution phase.

### Summary and Changelog

Cleaning now issues a single delete RPC per file instead of stat plus delete.

- `CleanActionExecutor#deleteFileAndGetResult` calls `storage.deleteFile` directly and drops the `getPathInfo` check.
- A `false` delete result with the file absent (how Hadoop file systems report a missing path) is now treated as success, so retried cleans remove the corresponding MDT entry instead of recording a failed delete.
- Directory-capable deletion is kept as `deletePathAndGetResult` and used only for `partitionsToBeDeleted` entries, which can be directories.
- Extended `TestCleanActionExecutor` to assert the success and failed delete lists per failure type and to verify `getPathInfo` is never called when deleting files.

### Impact

Performance: halves cleaner storage RPCs for file deletions. No public API change.

### Risk Level

Low. Covered by existing and extended functional tests in `TestCleanActionExecutor`.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable