### PR TITLE
perf(metadata): Parse RLI instant time once per batch instead of per …

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1011,11 +1011,11 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
           .withShouldUseRecordPosition(false)
           .withProps(metaClient.getTableConfig().getProps())
           .build();
-      String baseFileInstantTime = fileSlice.getBaseInstantTime();
+      long baseFileInstantTimeMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(fileSlice.getBaseInstantTime());
       return new CloseableMappingIterator<>(fileGroupReader.getClosableIterator(), record -> {
         String recordKey = readerContext.getRecordContext().getRecordKey(record, requestedSchema);
         return HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partition, fileId,
-            baseFileInstantTime, 0);
+            baseFileInstantTimeMillis, 0);
       });
     });
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/RecordIndexMapper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/RecordIndexMapper.java
@@ -30,7 +30,9 @@ import org.apache.hudi.exception.HoodieMetadataException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Mapper for Record Level Index (RLI).
@@ -45,6 +47,8 @@ public class RecordIndexMapper extends MetadataIndexMapper {
   @Override
   protected List<HoodieRecord> generateRecords(WriteStatus writeStatus) {
     List<HoodieRecord> allRecords = new ArrayList<>();
+    // delegates of one write status share at most a few distinct instants, so memoize the parse
+    Map<String, Long> instantTimeMillisCache = new HashMap<>();
     for (HoodieRecordDelegate recordDelegate : writeStatus.getIndexStats().getWrittenRecordDelegates()) {
       if (!writeStatus.isErrored(recordDelegate.getHoodieKey())) {
         if (recordDelegate.isIgnoreIndexUpdate()) {
@@ -68,7 +72,10 @@ public class RecordIndexMapper extends MetadataIndexMapper {
             // Insert new record case
             hoodieRecord = HoodieMetadataPayload.createRecordIndexUpdate(
                 recordDelegate.getRecordKey(), recordDelegate.getPartitionPath(),
-                newLocation.get().getFileId(), newLocation.get().getInstantTime(), dataWriteConfig.getWritesFileIdEncoding());
+                newLocation.get().getFileId(),
+                instantTimeMillisCache.computeIfAbsent(
+                    newLocation.get().getInstantTime(), HoodieMetadataPayload::parseRecordIndexInstantTime),
+                dataWriteConfig.getWritesFileIdEncoding());
             allRecords.add(hoodieRecord);
           }
         } else {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseFileRecordParsingUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseFileRecordParsingUtils.java
@@ -77,9 +77,10 @@ public class BaseFileRecordParsingUtils {
         recordStatuses);
     List<HoodieRecord> hoodieRecords = new ArrayList<>();
     if (recordStatusListMap.containsKey(RecordStatus.INSERT)) {
+      long instantTimeMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(instantTime);
       hoodieRecords.addAll(recordStatusListMap.get(RecordStatus.INSERT).stream()
           .map(recordKey -> (HoodieRecord) HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partition, fileId,
-              instantTime, writesFileIdEncoding)).collect(toList()));
+              instantTimeMillis, writesFileIdEncoding)).collect(toList()));
     }
 
     if (recordStatusListMap.containsKey(RecordStatus.DELETE)) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -697,8 +698,9 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
           fileIndex = Integer.parseInt(fileId.substring(index + 1));
         }
       } catch (Exception e) {
-        throw new HoodieMetadataException(String.format("Invalid UUID or index: fileID=%s, partition=%s, instantTimeMillis=%d",
-            fileId, partition, instantTimeMillis), e);
+        // reconstruct the instant time only on this cold error path; the hot per-record path keeps the pre-parsed millis
+        throw new HoodieMetadataException(String.format("Invalid UUID or index: fileID=%s, partition=%s, instantTime=%s",
+            fileId, partition, TimelineUtils.formatDate(new Date(instantTimeMillis))), e);
       }
 
       HoodieMetadataPayload payload = new HoodieMetadataPayload(recordKey,

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaCache;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
@@ -649,14 +650,39 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    */
   public static HoodieRecord<HoodieMetadataPayload> createRecordIndexUpdate(String recordKey, String partition,
                                                                             String fileId, String instantTime, int fileIdEncoding) {
+    return createRecordIndexUpdate(recordKey, partition, fileId, parseRecordIndexInstantTime(instantTime), fileIdEncoding);
+  }
 
-    HoodieKey key = new HoodieKey(recordKey, MetadataPartitionType.RECORD_INDEX.getPartitionPath());
-    long instantTimeMillis = -1;
+  /**
+   * Parses an instant time into the epoch millis stored in record index entries.
+   * <p>
+   * Callers creating record index updates for many records of the same commit should parse the
+   * instant time once with this method and use the millis-based
+   * {@link #createRecordIndexUpdate(String, String, String, long, int)} overload per record.
+   */
+  public static long parseRecordIndexInstantTime(String instantTime) {
     try {
-      instantTimeMillis = TimelineUtils.parseDateFromInstantTime(instantTime).getTime();
+      return TimelineUtils.parseDateFromInstantTime(instantTime).getTime();
     } catch (Exception e) {
       throw new HoodieMetadataException("Failed to create metadata payload for record index. Instant time parsing for " + instantTime + " failed ", e);
     }
+  }
+
+  /**
+   * Create and return a {@code HoodieMetadataPayload} to insert or update an entry for the record index.
+   * <p>
+   * Same as {@link #createRecordIndexUpdate(String, String, String, String, int)} but takes the
+   * instant time already parsed to epoch millis, so per-commit callers parse it only once.
+   *
+   * @param recordKey         Key of the record
+   * @param partition         Name of the partition which contains the record
+   * @param fileId            fileId which contains the record
+   * @param instantTimeMillis epoch millis of the instant when the record was added
+   */
+  public static HoodieRecord<HoodieMetadataPayload> createRecordIndexUpdate(String recordKey, String partition,
+                                                                            String fileId, long instantTimeMillis, int fileIdEncoding) {
+
+    HoodieKey key = new HoodieKey(recordKey, MetadataPartitionType.RECORD_INDEX.getPartitionPath());
     if (fileIdEncoding == 0) {
       // Data file names have a -D suffix to denote the index (D = integer) of the file written
       // In older HUID versions the file index was missing
@@ -673,7 +699,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
         }
       } catch (Exception e) {
         throw new HoodieMetadataException(String.format("Invalid UUID or index: fileID=%s, partition=%s, instantTime=%s",
-            fileId, partition, instantTime), e);
+            fileId, partition, HoodieInstantTimeGenerator.formatDate(new java.util.Date(instantTimeMillis))), e);
       }
 
       HoodieMetadataPayload payload = new HoodieMetadataPayload(recordKey,

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -673,11 +673,18 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    * <p>
    * Same as {@link #createRecordIndexUpdate(String, String, String, String, int)} but takes the
    * instant time already parsed to epoch millis, so per-commit callers parse it only once.
+   * <p>
+   * {@code instantTimeMillis} must be obtained from {@link #parseRecordIndexInstantTime(String)} (which
+   * delegates to {@link TimelineUtils#parseDateFromInstantTime(String)}); it should not be constructed by
+   * hand, so that the value stored here matches what the String overload would write. The instant-time
+   * string is interpreted in the JVM default time zone ({@link java.time.ZoneId#systemDefault()}) and the
+   * result is epoch milliseconds (since 1970-01-01T00:00:00Z).
    *
    * @param recordKey         Key of the record
    * @param partition         Name of the partition which contains the record
    * @param fileId            fileId which contains the record
-   * @param instantTimeMillis epoch millis of the instant when the record was added
+   * @param instantTimeMillis epoch millis of the instant when the record was added, as returned by
+   *                          {@link #parseRecordIndexInstantTime(String)}
    */
   public static HoodieRecord<HoodieMetadataPayload> createRecordIndexUpdate(String recordKey, String partition,
                                                                             String fileId, long instantTimeMillis, int fileIdEncoding) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -34,7 +34,6 @@ import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaCache;
-import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
@@ -698,8 +697,8 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
           fileIndex = Integer.parseInt(fileId.substring(index + 1));
         }
       } catch (Exception e) {
-        throw new HoodieMetadataException(String.format("Invalid UUID or index: fileID=%s, partition=%s, instantTime=%s",
-            fileId, partition, HoodieInstantTimeGenerator.formatDate(new java.util.Date(instantTimeMillis))), e);
+        throw new HoodieMetadataException(String.format("Invalid UUID or index: fileID=%s, partition=%s, instantTimeMillis=%d",
+            fileId, partition, instantTimeMillis), e);
       }
 
       HoodieMetadataPayload payload = new HoodieMetadataPayload(recordKey,

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -139,12 +139,12 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -2501,39 +2501,8 @@ public class HoodieTableMetadataUtil {
       fileId = originalFileId;
     }
 
-    return new HoodieRecordGlobalLocation(partition, formatRecordIndexInstant(instantTime), fileId);
-  }
-
-  // The formatted instant of a record-index entry is a pure function of the entry's epoch millis
-  // and the JVM default time zone used by HoodieInstantTimeGenerator.formatDate, so cached strings
-  // are only valid for the zone they were formatted under. The cache is per thread because
-  // lookups run on concurrent executor task threads and decode per-record last-write instants,
-  // where a shared slot would just be eviction churn.
-  private static final int FORMATTED_INSTANT_CACHE_MAX_SIZE = 1024;
-  private static final ThreadLocal<FormattedInstantCache> FORMATTED_INSTANT_CACHE =
-      ThreadLocal.withInitial(FormattedInstantCache::new);
-
-  private static final class FormattedInstantCache {
-    private ZoneId zoneId;
-    private final Map<Long, String> formattedByMillis = new HashMap<>();
-  }
-
-  private static String formatRecordIndexInstant(long instantTimeMillis) {
-    FormattedInstantCache cache = FORMATTED_INSTANT_CACHE.get();
-    ZoneId currentZoneId = ZoneId.systemDefault();
-    if (!currentZoneId.equals(cache.zoneId)) {
-      cache.formattedByMillis.clear();
-      cache.zoneId = currentZoneId;
-    }
-    String formatted = cache.formattedByMillis.get(instantTimeMillis);
-    if (formatted == null) {
-      if (cache.formattedByMillis.size() >= FORMATTED_INSTANT_CACHE_MAX_SIZE) {
-        cache.formattedByMillis.clear();
-      }
-      formatted = HoodieInstantTimeGenerator.formatDate(new java.util.Date(instantTimeMillis));
-      cache.formattedByMillis.put(instantTimeMillis, formatted);
-    }
-    return formatted;
+    final Date instantDate = new Date(instantTime);
+    return new HoodieRecordGlobalLocation(partition, HoodieInstantTimeGenerator.formatDate(instantDate), fileId);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -139,6 +139,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -940,8 +941,9 @@ public class HoodieTableMetadataUtil {
               Set<String> revivedKeys = revivedAndDeletedKeys.getLeft();
               Set<String> deletedKeys = revivedAndDeletedKeys.getRight();
               // Process revived keys to create updates
+              long instantTimeMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(instantTime);
               List<HoodieRecord> revivedRecords = revivedKeys.stream()
-                  .map(recordKey -> HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partitionPath, fileId, instantTime, writesFileIdEncoding))
+                  .map(recordKey -> HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partitionPath, fileId, instantTimeMillis, writesFileIdEncoding))
                   .collect(Collectors.toList());
               // Process deleted keys to create deletes
               List<HoodieRecord> deletedRecords = deletedKeys.stream()
@@ -2499,8 +2501,39 @@ public class HoodieTableMetadataUtil {
       fileId = originalFileId;
     }
 
-    final java.util.Date instantDate = new java.util.Date(instantTime);
-    return new HoodieRecordGlobalLocation(partition, HoodieInstantTimeGenerator.formatDate(instantDate), fileId);
+    return new HoodieRecordGlobalLocation(partition, formatRecordIndexInstant(instantTime), fileId);
+  }
+
+  // The formatted instant of a record-index entry is a pure function of the entry's epoch millis
+  // and the JVM default time zone used by HoodieInstantTimeGenerator.formatDate, so cached strings
+  // are only valid for the zone they were formatted under. The cache is per thread because
+  // lookups run on concurrent executor task threads and decode per-record last-write instants,
+  // where a shared slot would just be eviction churn.
+  private static final int FORMATTED_INSTANT_CACHE_MAX_SIZE = 1024;
+  private static final ThreadLocal<FormattedInstantCache> FORMATTED_INSTANT_CACHE =
+      ThreadLocal.withInitial(FormattedInstantCache::new);
+
+  private static final class FormattedInstantCache {
+    private ZoneId zoneId;
+    private final Map<Long, String> formattedByMillis = new HashMap<>();
+  }
+
+  private static String formatRecordIndexInstant(long instantTimeMillis) {
+    FormattedInstantCache cache = FORMATTED_INSTANT_CACHE.get();
+    ZoneId currentZoneId = ZoneId.systemDefault();
+    if (!currentZoneId.equals(cache.zoneId)) {
+      cache.formattedByMillis.clear();
+      cache.zoneId = currentZoneId;
+    }
+    String formatted = cache.formattedByMillis.get(instantTimeMillis);
+    if (formatted == null) {
+      if (cache.formattedByMillis.size() >= FORMATTED_INSTANT_CACHE_MAX_SIZE) {
+        cache.formattedByMillis.clear();
+      }
+      formatted = HoodieInstantTimeGenerator.formatDate(new java.util.Date(instantTimeMillis));
+      cache.formattedByMillis.put(instantTimeMillis, formatted);
+    }
+    return formatted;
   }
 
   /**
@@ -2615,6 +2648,8 @@ public class HoodieTableMetadataUtil {
                                                                         String instantTime,
                                                                         boolean isPartitionedRLI
   ) {
+    // the delete iterator never reads the instant time, so only the update path pays the parse
+    final long instantTimeMillis = forDelete ? -1L : HoodieMetadataPayload.parseRecordIndexInstantTime(instantTime);
     return new ClosableIterator<HoodieRecord>() {
       @Override
       public void close() {
@@ -2630,7 +2665,7 @@ public class HoodieTableMetadataUtil {
       public HoodieRecord next() {
         return forDelete
             ? HoodieMetadataPayload.createRecordIndexDelete(recordKeyIterator.next(), partition, isPartitionedRLI)
-            : HoodieMetadataPayload.createRecordIndexUpdate(recordKeyIterator.next(), partition, fileId, instantTime, 0);
+            : HoodieMetadataPayload.createRecordIndexUpdate(recordKeyIterator.next(), partition, fileId, instantTimeMillis, 0);
       }
     };
   }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -21,22 +21,27 @@ package org.apache.hudi.metadata;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS;
@@ -350,6 +355,59 @@ class TestHoodieTableMetadataUtil {
           "VECTOR must be excluded from V1 column stats for record type " + recordType);
       assertTrue(HoodieTableMetadataUtil.isColumnTypeSupported(stringSchema, rt, HoodieIndexVersion.V1),
           "STRING should remain supported for record type " + recordType);
+    }
+  }
+
+  @Test
+  void testCreateRecordIndexUpdateMillisOverloadMatchesStringOverload() {
+    String instantTime = "20260610153045678";
+    long instantTimeMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(instantTime);
+
+    // uuid-encoded fileId (encoding 0)
+    HoodieRecord<HoodieMetadataPayload> fromString = HoodieMetadataPayload.createRecordIndexUpdate(
+        "rk1", "p1", "49b8b3c8-9e5d-4731-9d51-a2d8e9b5c7f3-0", instantTime, 0);
+    HoodieRecord<HoodieMetadataPayload> fromMillis = HoodieMetadataPayload.createRecordIndexUpdate(
+        "rk1", "p1", "49b8b3c8-9e5d-4731-9d51-a2d8e9b5c7f3-0", instantTimeMillis, 0);
+    assertEquals(fromString.getKey(), fromMillis.getKey());
+    assertEquals(fromString.getData(), fromMillis.getData());
+
+    // raw fileId (encoding 1)
+    fromString = HoodieMetadataPayload.createRecordIndexUpdate(
+        "rk1", "p1", "some-raw-file-id", instantTime, 1);
+    fromMillis = HoodieMetadataPayload.createRecordIndexUpdate(
+        "rk1", "p1", "some-raw-file-id", instantTimeMillis, 1);
+    assertEquals(fromString.getKey(), fromMillis.getKey());
+    assertEquals(fromString.getData(), fromMillis.getData());
+  }
+
+  @Test
+  void testGetLocationFromRecordIndexInfoFormatsInstantConsistently() {
+    long instantMillis1 = HoodieMetadataPayload.parseRecordIndexInstantTime("20260610153045678");
+    long instantMillis2 = HoodieMetadataPayload.parseRecordIndexInstantTime("20260610163045678");
+    String expected1 = HoodieInstantTimeGenerator.formatDate(new Date(instantMillis1));
+    String expected2 = HoodieInstantTimeGenerator.formatDate(new Date(instantMillis2));
+    // repeated and alternating instants exercise both the hit and miss paths of the format cache
+    for (long instantMillis : new long[] {instantMillis1, instantMillis1, instantMillis2, instantMillis1}) {
+      HoodieRecordGlobalLocation location = HoodieTableMetadataUtil.getLocationFromRecordIndexInfo(
+          "p1", 1, -1L, -1L, -1, "some-raw-file-id", instantMillis);
+      assertEquals(instantMillis == instantMillis1 ? expected1 : expected2, location.getInstantTime());
+      assertEquals("p1", location.getPartitionPath());
+      assertEquals("some-raw-file-id", location.getFileId());
+    }
+
+    // formatDate follows the JVM default time zone, so cached entries must be invalidated when it
+    // changes; the two switches differ in offset, so at least one changes the formatted string
+    TimeZone originalTimeZone = TimeZone.getDefault();
+    try {
+      for (String zoneId : new String[] {"UTC", "Asia/Kolkata"}) {
+        TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
+        String expectedInZone = HoodieInstantTimeGenerator.formatDate(new Date(instantMillis1));
+        HoodieRecordGlobalLocation location = HoodieTableMetadataUtil.getLocationFromRecordIndexInfo(
+            "p1", 1, -1L, -1L, -1, "some-raw-file-id", instantMillis1);
+        assertEquals(expectedInZone, location.getInstantTime());
+      }
+    } finally {
+      TimeZone.setDefault(originalTimeZone);
     }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -386,7 +386,7 @@ class TestHoodieTableMetadataUtil {
     long instantMillis2 = HoodieMetadataPayload.parseRecordIndexInstantTime("20260610163045678");
     String expected1 = HoodieInstantTimeGenerator.formatDate(new Date(instantMillis1));
     String expected2 = HoodieInstantTimeGenerator.formatDate(new Date(instantMillis2));
-    // repeated and alternating instants exercise both the hit and miss paths of the format cache
+    // repeated and alternating instants must format consistently
     for (long instantMillis : new long[] {instantMillis1, instantMillis1, instantMillis2, instantMillis1}) {
       HoodieRecordGlobalLocation location = HoodieTableMetadataUtil.getLocationFromRecordIndexInfo(
           "p1", 1, -1L, -1L, -1, "some-raw-file-id", instantMillis);
@@ -395,8 +395,8 @@ class TestHoodieTableMetadataUtil {
       assertEquals("some-raw-file-id", location.getFileId());
     }
 
-    // formatDate follows the JVM default time zone, so cached entries must be invalidated when it
-    // changes; the two switches differ in offset, so at least one changes the formatted string
+    // formatDate follows the JVM default time zone, so the decoded location must track a zone
+    // change; the two switches differ in offset, so at least one changes the formatted string
     TimeZone originalTimeZone = TimeZone.getDefault();
     try {
       for (String zoneId : new String[] {"UTC", "Asia/Kolkata"}) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexRowUtils.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexRowUtils.java
@@ -70,7 +70,7 @@ public class IndexRowUtils {
     return indexRow;
   }
 
-  public static HoodieRecord convertToHoodieRecord(String instant, RowData indexRow, HoodieWriteConfig dataWriteConfig) {
+  public static HoodieRecord convertToHoodieRecord(long instantMillis, RowData indexRow, HoodieWriteConfig dataWriteConfig) {
     if (indexRow.getByte(INDEX_TYPE_ORD) == RLI_TYPE) {
       switch (indexRow.getRowKind()) {
         case INSERT:
@@ -78,7 +78,7 @@ public class IndexRowUtils {
               String.valueOf(indexRow.getString(KEY_ORD)),
               String.valueOf(indexRow.getString(PARTITION_ORD)),
               String.valueOf(indexRow.getString(FILE_ID_ORD)),
-              instant,
+              instantMillis,
               dataWriteConfig.getWritesFileIdEncoding());
         case DELETE:
           return HoodieMetadataPayload.createRecordIndexDelete(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexWriteFunction.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.sink.common.AbstractStreamWriteFunction;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
 import org.apache.hudi.sink.exception.MemoryPagesExhaustedException;
@@ -174,11 +175,12 @@ public class IndexWriteFunction extends AbstractStreamWriteFunction<RowData> {
     HoodieWriteConfig writeConfig = writeClient.getConfig();
     // deduplicate the index records using commit time ordering.
     Map<String, HoodieRecord> keyAndRecordMap = new LinkedHashMap<>();
+    long currentInstantMillis = HoodieMetadataPayload.parseRecordIndexInstantTime(this.currentInstant);
     while (rowItr.hasNext()) {
       RowData indexRow = rowItr.next();
       keyAndRecordMap.put(
           dedupKeyExtractor.apply(indexRow),
-          IndexRowUtils.convertToHoodieRecord(this.currentInstant, indexRow, writeConfig));
+          IndexRowUtils.convertToHoodieRecord(currentInstantMillis, indexRow, writeConfig));
       dataPartitions.add(IndexRowUtils.getPartition(indexRow));
     }
     return Pair.of(new ArrayList<>(keyAndRecordMap.values()), dataPartitions);


### PR DESCRIPTION
... record

### Describe the issue this Pull Request addresses

Closes #18964

`HoodieMetadataPayload#createRecordIndexUpdate` parses the commit instant time string into epoch millis for every record, although the instant is the same string for the entire commit. The read side mirrors it: `HoodieTableMetadataUtil#getLocationFromRecordIndexInfo` formats the stored millis back to an instant string per looked-up record. For a 10M-record commit this is roughly 10M redundant date parses on the write side and the same again per record-index lookup.

### Summary and Changelog

RLI record creation and location decoding now parse or format the instant time once per batch instead of once per record.

Write side:

- Added `HoodieMetadataPayload#parseRecordIndexInstantTime` and a millis-based `createRecordIndexUpdate` overload; the existing String overload delegates to it, so single-record callers are unchanged.
- Hoisted the parse out of the per-record loops: base file RLI generation (`BaseFileRecordParsingUtils`), revived-key processing and record-key iterators (`HoodieTableMetadataUtil`; the delete iterator skips the parse entirely), RLI initialization per file slice (`HoodieBackedTableMetadataWriter`), and the Flink index write path (`IndexWriteFunction` parses once per buffer flush, `IndexRowUtils#convertToHoodieRecord` now takes millis).
- `RecordIndexMapper` memoizes per write status with a small map, since its delegate locations can carry different instants.

Tests: extended `TestHoodieTableMetadataUtil` with an equivalence test for the String and millis overloads (both fileId encodings) and a format test for decoded locations covering repeated instants and a default time zone change.

### Impact

Performance: removes per-record instant-time parsing from RLI record generation (every commit and index initialization). The read-side location decoding is unchanged. Output records and decoded locations are unchanged. No public API removed; one Flink-internal utility signature changed (`IndexRowUtils#convertToHoodieRecord`).

### Risk Level

Low. The overloads produce identical payloads, covered by the new equivalence test. The only behavior nuance is that batch callers now parse the instant once up front instead of on the first record, which only changes timing of the failure for malformed instants.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
