### PR TITLE
fix(spark): support consistent hashing clustering on non-partitioned tables

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SingleSparkJobConsistentHashingExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SingleSparkJobConsistentHashingExecutionStrategy.java
@@ -114,7 +114,8 @@ public class SingleSparkJobConsistentHashingExecutionStrategy<T> extends SingleS
     Option<Map<String, String>> extraMetadata = clusteringGroup.getExtraMetadata();
     ValidationUtils.checkArgument(extraMetadata.isPresent(), "Extra metadata should be present for consistent hashing operations");
     String partition = extraMetadata.get().get(BaseConsistentHashingBucketClusteringPlanStrategy.METADATA_PARTITION_KEY);
-    ValidationUtils.checkArgument(!StringUtils.isNullOrEmpty(partition), "Partition should not be null or empty");
+    // Note: partition can be an empty string for non-partitioned tables, so only check for null here.
+    ValidationUtils.checkArgument(partition != null, "Partition should not be null");
     List<ConsistentHashingNode> nodes = decodeConsistentHashingNodes(clusteringGroup);
     Option<ConsistentHashingNode> newBucket = Option.fromJavaOptional(nodes.stream().filter(node -> node.getTag() == ConsistentHashingNode.NodeTag.REPLACE).findFirst());
     ValidationUtils.checkArgument(newBucket.isPresent(), "New bucket should be present for merge operation");
@@ -200,7 +201,8 @@ public class SingleSparkJobConsistentHashingExecutionStrategy<T> extends SingleS
     Option<Map<String, String>> extraMetadata = clusteringGroup.getExtraMetadata();
     ValidationUtils.checkArgument(extraMetadata.isPresent(), "Extra metadata should be present for consistent hashing operations");
     String partition = extraMetadata.get().get(BaseConsistentHashingBucketClusteringPlanStrategy.METADATA_PARTITION_KEY);
-    ValidationUtils.checkArgument(!StringUtils.isNullOrEmpty(partition), "Partition should not be null or empty");
+    // Note: partition can be an empty string for non-partitioned tables, so only check for null here.
+    ValidationUtils.checkArgument(partition != null, "Partition should not be null");
     List<ConsistentHashingNode> nodes = decodeConsistentHashingNodes(clusteringGroup);
     Integer seqNo = Integer.parseInt(extraMetadata.get().get(BaseConsistentHashingBucketClusteringPlanStrategy.METADATA_SEQUENCE_NUMBER_KEY));
     HoodieConsistentHashingMetadata metadata = new HoodieConsistentHashingMetadata((short) 0, partition, instantTime, 0, seqNo + 1, Collections.emptyList());

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkConsistentBucketClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkConsistentBucketClustering.java
@@ -143,16 +143,21 @@ public class TestSparkConsistentBucketClustering extends HoodieSparkClientTestHa
   }
 
   /**
-   * Test resizing with bucket number upper bound and lower bound
+   * Test resizing with bucket number upper bound and lower bound, on both partitioned and non-partitioned tables.
+   *
+   * <p>Non-partitioned coverage guards GitHub issue #18161: consistent hashing clustering used to fail on
+   * non-partitioned tables because the empty partition path was rejected by the execution strategy. For a
+   * non-partitioned table {@code dataGen.getPartitionPaths()} returns the single empty partition path, so the
+   * assertions below cover both cases without branching.
    *
    * @throws IOException
    */
   @ParameterizedTest
-  @MethodSource("configParams")
-  public void testResizing(boolean isSplit, boolean rowWriterEnable, boolean single) throws IOException {
+  @MethodSource("resizingConfigParams")
+  public void testResizing(boolean isSplit, boolean rowWriterEnable, boolean single, boolean nonPartitioned) throws IOException {
     final int maxFileSize = isSplit ? 5120 : 128 * 1024 * 1024;
     final int targetBucketNum = isSplit ? 14 : 4;
-    setup(maxFileSize, Collections.emptyMap(), single);
+    setup(maxFileSize, Collections.emptyMap(), single, nonPartitioned);
     config.setValue("hoodie.datasource.write.row.writer.enable", String.valueOf(rowWriterEnable));
     config.setValue("hoodie.metadata.enable", "false");
     writeData(2000, true);
@@ -172,41 +177,6 @@ public class TestSparkConsistentBucketClustering extends HoodieSparkClientTestHa
         Assertions.assertTrue(fs.getBaseFile().isPresent());
         Assertions.assertTrue(fs.getLogFiles().count() == 0);
       });
-    });
-  }
-
-  /**
-   * Test bucket resizing (split / merge) on a non-partitioned table, covering both the single-job and
-   * multi-job execution strategies. See HUDI-18161 / issue #18161: consistent hashing clustering used to
-   * fail on non-partitioned tables because the empty partition path was rejected by the execution strategy.
-   *
-   * @throws IOException
-   */
-  @ParameterizedTest
-  @MethodSource("configParams")
-  public void testResizingNonPartitioned(boolean isSplit, boolean rowWriterEnable, boolean single) throws IOException {
-    final int maxFileSize = isSplit ? 5120 : 128 * 1024 * 1024;
-    final int targetBucketNum = isSplit ? 14 : 4;
-    setup(maxFileSize, Collections.emptyMap(), single, true);
-    config.setValue("hoodie.datasource.write.row.writer.enable", String.valueOf(rowWriterEnable));
-    config.setValue("hoodie.metadata.enable", "false");
-    writeData(2000, true);
-    String clusteringTime = (String) writeClient.scheduleClustering(Option.empty()).get();
-    writeClient.cluster(clusteringTime, true);
-
-    metaClient = HoodieTableMetaClient.reload(metaClient);
-    final HoodieTable table = HoodieSparkTable.create(config, context, metaClient);
-    Assertions.assertEquals(2000, readRecords().size());
-
-    // Non-partitioned table has a single empty partition path.
-    String partition = HoodieTestDataGenerator.NO_PARTITION_PATH;
-    HoodieConsistentHashingMetadata metadata = ConsistentBucketIndexUtils.loadMetadata(table, partition).get();
-    Assertions.assertEquals(targetBucketNum, metadata.getNodes().size());
-
-    // The file slice has no log files after clustering.
-    table.getSliceView().getLatestFileSlices(partition).forEach(fs -> {
-      Assertions.assertTrue(fs.getBaseFile().isPresent());
-      Assertions.assertEquals(0, fs.getLogFiles().count());
     });
   }
 
@@ -430,6 +400,16 @@ public class TestSparkConsistentBucketClustering extends HoodieSparkClientTestHa
         Arguments.of(true, true, false),
         Arguments.of(false, true, false)
     );
+  }
+
+  // configParams crossed with the partitioned / non-partitioned dimension (isSplit, rowWriterEnable, single, nonPartitioned).
+  private static Stream<Arguments> resizingConfigParams() {
+    return configParams().flatMap(args -> {
+      Object[] a = args.get();
+      return Stream.of(
+          Arguments.of(a[0], a[1], a[2], false),
+          Arguments.of(a[0], a[1], a[2], true));
+    });
   }
 
   private static Stream<Arguments> configParamsForSorting() {

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkConsistentBucketClustering.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestSparkConsistentBucketClustering.java
@@ -34,6 +34,7 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
@@ -49,6 +50,7 @@ import org.apache.hudi.execution.bulkinsert.BulkInsertSortMode;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.bucket.ConsistentBucketIndexUtils;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.keygen.constant.KeyGeneratorType;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
@@ -102,6 +104,10 @@ public class TestSparkConsistentBucketClustering extends HoodieSparkClientTestHa
   }
 
   public void setup(int maxFileSize, Map<String, String> options, boolean singleJob) throws IOException {
+    setup(maxFileSize, options, singleJob, false);
+  }
+
+  public void setup(int maxFileSize, Map<String, String> options, boolean singleJob, boolean nonPartitioned) throws IOException {
     initPath();
     initSparkContexts();
     initTestDataGenerator();
@@ -109,6 +115,13 @@ public class TestSparkConsistentBucketClustering extends HoodieSparkClientTestHa
     Properties props = getPropertiesForKeyGen(true);
     props.putAll(options);
     props.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+    if (nonPartitioned) {
+      // Non-partitioned tables produce records with an empty partition path and use the non-partition key generator.
+      dataGen = new HoodieTestDataGenerator(new String[] {HoodieTestDataGenerator.NO_PARTITION_PATH});
+      props.setProperty(HoodieWriteConfig.KEYGENERATOR_TYPE.key(), KeyGeneratorType.NON_PARTITION.name());
+      props.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "");
+      props.remove(HoodieTableConfig.PARTITION_FIELDS.key());
+    }
     metaClient = HoodieTestUtils.init(storageConf, basePath, HoodieTableType.MERGE_ON_READ, props);
     config = getConfigBuilder().withProps(props)
         .withIndexConfig(HoodieIndexConfig.newBuilder().fromProperties(props)
@@ -159,6 +172,41 @@ public class TestSparkConsistentBucketClustering extends HoodieSparkClientTestHa
         Assertions.assertTrue(fs.getBaseFile().isPresent());
         Assertions.assertTrue(fs.getLogFiles().count() == 0);
       });
+    });
+  }
+
+  /**
+   * Test bucket resizing (split / merge) on a non-partitioned table, covering both the single-job and
+   * multi-job execution strategies. See HUDI-18161 / issue #18161: consistent hashing clustering used to
+   * fail on non-partitioned tables because the empty partition path was rejected by the execution strategy.
+   *
+   * @throws IOException
+   */
+  @ParameterizedTest
+  @MethodSource("configParams")
+  public void testResizingNonPartitioned(boolean isSplit, boolean rowWriterEnable, boolean single) throws IOException {
+    final int maxFileSize = isSplit ? 5120 : 128 * 1024 * 1024;
+    final int targetBucketNum = isSplit ? 14 : 4;
+    setup(maxFileSize, Collections.emptyMap(), single, true);
+    config.setValue("hoodie.datasource.write.row.writer.enable", String.valueOf(rowWriterEnable));
+    config.setValue("hoodie.metadata.enable", "false");
+    writeData(2000, true);
+    String clusteringTime = (String) writeClient.scheduleClustering(Option.empty()).get();
+    writeClient.cluster(clusteringTime, true);
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    final HoodieTable table = HoodieSparkTable.create(config, context, metaClient);
+    Assertions.assertEquals(2000, readRecords().size());
+
+    // Non-partitioned table has a single empty partition path.
+    String partition = HoodieTestDataGenerator.NO_PARTITION_PATH;
+    HoodieConsistentHashingMetadata metadata = ConsistentBucketIndexUtils.loadMetadata(table, partition).get();
+    Assertions.assertEquals(targetBucketNum, metadata.getNodes().size());
+
+    // The file slice has no log files after clustering.
+    table.getSliceView().getLatestFileSlices(partition).forEach(fs -> {
+      Assertions.assertTrue(fs.getBaseFile().isPresent());
+      Assertions.assertEquals(0, fs.getLogFiles().count());
     });
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Consistent hashing bucket-index clustering (bucket resizing) fails on **non-partitioned** tables.

For a non-partitioned table the partition path stored in the clustering group metadata is an empty string (`""`). `SingleSparkJobConsistentHashingExecutionStrategy` validated the partition with a "not null **or empty**" guard and threw `IllegalArgumentException: Partition should not be null or empty` before any clustering work could run, so split/merge resizing was impossible on non-partitioned tables.

GitHub issue: https://github.com/apache/hudi/issues/18161

### Summary and Changelog

- Relax the partition guard in `SingleSparkJobConsistentHashingExecutionStrategy` (both the merge and split paths) from `!StringUtils.isNullOrEmpty(partition)` to `partition != null`. An empty partition path is valid for non-partitioned tables; a genuinely absent metadata key (`null`) is still rejected.
- Add a parameterized test `testResizingNonPartitioned` in `TestSparkConsistentBucketClustering`, mirroring the existing `testResizing`, covering split and merge resizing on a non-partitioned table across the single-job and multi-job execution strategies and the row-writer on/off paths. A `setup(..., boolean nonPartitioned)` overload configures the non-partition key generator and an empty partition-path field.

### Impact

Consistent hashing clustering now works on non-partitioned tables. No behavior change for partitioned tables — when the partition path is non-empty (every partitioned table), the guard evaluates identically and the code path is unchanged. No public API or config changes.

### Risk Level

low

Partitioned-table behavior is byte-for-byte identical (the relaxed guard only differs when the partition path is the empty string). Verified via the new parameterized test and an end-to-end `spark-shell` run on Spark 4.0.2 against a non-partitioned MOR table with consistent-hashing bucket index: a follow-up write triggered inline split clustering through `SingleSparkJobConsistentHashingExecutionStrategy`, increasing the bucket count from 2 to 4 with all records preserved.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

