### PR TITLE
 fix(flink): relocate org.apache.flink.dropwizard

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -203,7 +203,7 @@
                        DropwizardHistogramWrapper(com.codahale.metrics.Histogram). -->
                 <relocation>
                   <pattern>org.apache.flink.dropwizard.</pattern>
-                  <shadedPattern>org.apache.hudi.org.apache.flink.dropwizard.</shadedPattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.flink.dropwizard.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.beust.jcommander.</pattern>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -196,6 +196,15 @@
                   <pattern>com.codahale.metrics.</pattern>
                   <shadedPattern>org.apache.hudi.com.codahale.metrics.</shadedPattern>
                 </relocation>
+                <!-- Relocate the bundled flink-metrics-dropwizard bridge into the hudi namespace.
+                       It is recompiled against the relocated com.codahale.metrics above, so leaving it
+                       at the real Flink FQN shadows the genuine wrapper and breaks any consumer that
+                       also depends on flink-metrics-dropwizard with a NoSuchMethodError on
+                       DropwizardHistogramWrapper(com.codahale.metrics.Histogram). -->
+                <relocation>
+                  <pattern>org.apache.flink.dropwizard.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.flink.dropwizard.</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>com.beust.jcommander.</pattern>
                   <shadedPattern>${flink.bundle.shade.prefix}com.beust.jcommander.</shadedPattern>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18981

`hudi-flink-bundle` ships a half-shaded copy of the Flink Dropwizard metrics bridge. Since #18730 it relocates `com.codahale.metrics` → `org.apache.hudi.com.codahale.metrics` but does not relocate `org.apache.flink.dropwizard`, while still bundling `org.apache.flink:flink-metrics-dropwizard`. Shade rewrites the bundled `DropwizardHistogramWrapper`'s bytecode references to the relocated codahale but leaves the class at the real Flink FQN, so the shaded jar exposes a `DropwizardHistogramWrapper` whose only constructor is `(org.apache.hudi.com.codahale.metrics.Histogram)`. Any application with both `hudi-flink-bundle` and the real `flink-metrics-dropwizard` on the classpath then fails at runtime with `NoSuchMethodError` on `new DropwizardHistogramWrapper(new com.codahale.metrics.Histogram(...))`.
  
### Summary and Changelog

Relocate `org.apache.flink.dropwizard` alongside the existing codahale relocation in `packaging/hudi-flink-bundle/pom.xml` (`${flink.bundle.shade.prefix}org.apache.flink.dropwizard.`), so the bundled bridge moves into the hudi namespace. Shade rewrites Hudi's own references to the relocated class, and the genuine `org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper` FQN is left intact for other consumers. Shade-config only — no source changes.
  
### Impact
  
Fixes a runtime `NoSuchMethodError` for jobs that combine `hudi-flink-bundle` with `flink-metrics-dropwizard`. No public API or behavior change for Hudi's own metrics (they follow the relocation).

### Risk Level
  
low
  
Shade-config-only change scoped to `hudi-flink-bundle`; Hudi's own (shaded) metrics reporting continues to resolve the relocated wrapper.

### Documentation Update
  
none
  
### Contributor's checklist

  - [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable