### PR TITLE
feat(hive-sync): batch and parallelize HMS partition operations

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncConfigHolder.java
@@ -122,6 +122,23 @@ public class HiveSyncConfigHolder {
       .defaultValue(1000)
       .markAdvanced()
       .withDocumentation("The number of partitions one batch when synchronous partitions to hive.");
+  public static final ConfigProperty<Boolean> HIVE_SYNC_BATCHING_ENABLED = ConfigProperty
+      .key("hoodie.datasource.hive_sync.batching.enabled")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("When true, HMS-mode partition operations (add/update/touch/drop) are split into "
+          + "batches of `hoodie.datasource.hive_sync.batch_num` and dispatched in parallel to a pool of "
+          + "IMetaStoreClient instances. Table-level operations (create/alter table, last commit time, "
+          + "writer version) continue to use the single session client. Default off; existing behavior "
+          + "is unchanged unless explicitly opted in.");
+  public static final ConfigProperty<Integer> HIVE_SYNC_BATCHING_THREADS = ConfigProperty
+      .key("hoodie.datasource.hive_sync.batching.threads")
+      .defaultValue(4)
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Pool size (number of IMetaStoreClient instances) and worker thread count used "
+          + "for parallel partition sync when `hoodie.datasource.hive_sync.batching.enabled` is true.");
   public static final ConfigProperty<String> HIVE_SYNC_MODE = ConfigProperty
       .key("hoodie.datasource.hive_sync.mode")
       .noDefaultValue()

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -37,6 +37,7 @@ import org.apache.hudi.hive.ddl.HiveQueryDDLExecutor;
 import org.apache.hudi.hive.ddl.HiveSyncMode;
 import org.apache.hudi.hive.ddl.JDBCBasedMetadataOperator;
 import org.apache.hudi.hive.ddl.JDBCExecutor;
+import org.apache.hudi.hive.util.IMetaStoreClientPool;
 import org.apache.hudi.hive.util.IMetaStoreClientUtil;
 import org.apache.hudi.hive.util.PartitionFilterGenerator;
 import org.apache.hudi.sync.common.HoodieSyncClient;
@@ -66,6 +67,8 @@ import static org.apache.hudi.hadoop.utils.HoodieHiveUtils.GLOBALLY_CONSISTENT_R
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getInputFormatClassName;
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getOutputFormatClassName;
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getSerDeClassName;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BATCHING_ENABLED;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BATCHING_THREADS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_MODE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_USE_SPARK_CATALOG;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_USE_JDBC;
@@ -86,6 +89,10 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
   private final Map<String, Table> initialTableByName = new HashMap<>();
   DDLExecutor ddlExecutor;
   private IMetaStoreClient client;
+  // Non-null only when HIVE_SYNC_BATCHING_ENABLED and sync mode is HMS. Owned by this
+  // class; closed in close() before Hive.closeCurrent(). Hands clients to HMSDDLExecutor
+  // for partition-row work only — see IMetaStoreClientPool javadoc.
+  private IMetaStoreClientPool partitionClientPool;
 
   /**
    * JDBC-based metadata operator, lazily initialized on first Thrift
@@ -121,7 +128,8 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
         HiveSyncMode syncMode = HiveSyncMode.of(config.getString(HIVE_SYNC_MODE));
         switch (syncMode) {
           case HMS:
-            ddlExecutor = new HMSDDLExecutor(config, this.client);
+            this.partitionClientPool = maybeBuildPartitionClientPool(config);
+            ddlExecutor = new HMSDDLExecutor(config, this.client, this.partitionClientPool);
             break;
           case HIVEQL:
             ddlExecutor = new HiveQueryDDLExecutor(config, this.client);
@@ -199,6 +207,22 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
     } catch (Exception e) {
       throw new HoodieHiveSyncException("Failed to create HiveMetaStoreClient", e);
     }
+  }
+
+  private IMetaStoreClientPool maybeBuildPartitionClientPool(HiveSyncConfig config) {
+    if (!config.getBooleanOrDefault(HIVE_SYNC_BATCHING_ENABLED)) {
+      return null;
+    }
+    if (config.getBooleanOrDefault(HIVE_SYNC_USE_SPARK_CATALOG)) {
+      // The Spark catalog client is constructed via reflection against a Spark-side
+      // class and isn't compatible with the direct RetryingMetaStoreClient pool path.
+      // Fall back to single-client sequential behavior rather than failing the sync.
+      log.warn("hive_sync.batching.enabled=true is not supported with use_spark_catalog=true; "
+          + "falling back to sequential partition sync.");
+      return null;
+    }
+    int size = config.getIntOrDefault(HIVE_SYNC_BATCHING_THREADS);
+    return new IMetaStoreClientPool(config, size);
   }
 
   private Table getInitialTable(String table) {
@@ -597,6 +621,17 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
   public void close() {
     try {
       ddlExecutor.close();
+      // Close the partition client pool before Hive.closeCurrent() so the
+      // RetryingMetaStoreClient instances held by the pool release their Thrift
+      // sockets without racing the ThreadLocal Hive cleanup.
+      if (partitionClientPool != null) {
+        try {
+          partitionClientPool.close();
+        } catch (Exception e) {
+          log.warn("Error closing IMetaStoreClient pool", e);
+        }
+        partitionClientPool = null;
+      }
       if (client != null) {
         Hive.closeCurrent();
         client = null;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
@@ -27,6 +27,7 @@ import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.HoodieHiveSyncException;
 import org.apache.hudi.hive.util.HivePartitionUtil;
 import org.apache.hudi.hive.util.HiveSchemaUtil;
+import org.apache.hudi.hive.util.IMetaStoreClientPool;
 import org.apache.hudi.storage.StorageSchemes;
 import org.apache.hudi.sync.common.model.PartitionValueExtractor;
 
@@ -46,13 +47,13 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.thrift.TException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
@@ -73,11 +74,21 @@ public class HMSDDLExecutor implements DDLExecutor {
   private final String databaseName;
   private final IMetaStoreClient client;
   private final PartitionValueExtractor partitionValueExtractor;
+  // Optional. When non-null, partition-row operations fan out across this pool;
+  // table-row operations always use the session `client` field above. See
+  // IMetaStoreClientPool javadoc for the usage contract.
+  private final IMetaStoreClientPool partitionClientPool;
 
   public HMSDDLExecutor(HiveSyncConfig syncConfig, IMetaStoreClient metaStoreClient) throws HiveException, MetaException {
+    this(syncConfig, metaStoreClient, null);
+  }
+
+  public HMSDDLExecutor(HiveSyncConfig syncConfig, IMetaStoreClient metaStoreClient,
+                        IMetaStoreClientPool partitionClientPool) throws HiveException, MetaException {
     this.syncConfig = syncConfig;
     this.databaseName = syncConfig.getStringOrDefault(META_SYNC_DATABASE_NAME);
     this.client = metaStoreClient;
+    this.partitionClientPool = partitionClientPool;
     try {
       this.partitionValueExtractor =
           (PartitionValueExtractor) Class.forName(syncConfig.getStringOrDefault(META_SYNC_PARTITION_EXTRACTOR_CLASS)).newInstance();
@@ -193,11 +204,14 @@ public class HMSDDLExecutor implements DDLExecutor {
     }
     log.info("Adding partitions {} to table {}", partitionsToAdd.size(), tableName);
     try {
+      // Fetch the table StorageDescriptor once on the session client. Each worker
+      // copies fields off it; the Thrift POJO is not mutated after this read.
       StorageDescriptor sd = client.getTable(databaseName, tableName).getSd();
       int batchSyncPartitionNum = syncConfig.getIntOrDefault(HIVE_BATCH_SYNC_PARTITION_NUM);
-      for (List<String> batch : CollectionUtils.batches(partitionsToAdd, batchSyncPartitionNum)) {
-        List<Partition> partitionList = new ArrayList<>();
-        batch.forEach(x -> {
+      List<List<String>> batches = CollectionUtils.batches(partitionsToAdd, batchSyncPartitionNum);
+      runBatches("add", tableName, batches, (poolClient, batch) -> {
+        List<Partition> partitionList = new ArrayList<>(batch.size());
+        for (String x : batch) {
           StorageDescriptor partitionSd = new StorageDescriptor();
           partitionSd.setCols(sd.getCols());
           partitionSd.setInputFormat(sd.getInputFormat());
@@ -208,11 +222,11 @@ public class HMSDDLExecutor implements DDLExecutor {
           List<String> partitionValues = partitionValueExtractor.extractPartitionValuesInPath(x);
           partitionSd.setLocation(fullPartitionPath);
           partitionList.add(new Partition(partitionValues, databaseName, tableName, 0, 0, partitionSd, null));
-        });
-        client.add_partitions(partitionList, true, false);
+        }
+        poolClient.add_partitions(partitionList, true, false);
         log.info("HMSDDLExecutor add a batch partitions done: {}", partitionList.size());
-      }
-    } catch (TException e) {
+      });
+    } catch (Exception e) {
       log.error("{}.{} add partition failed", databaseName, tableName, e);
       throw new HoodieHiveSyncException(databaseName + "." + tableName + " add partition failed", e);
     }
@@ -247,15 +261,22 @@ public class HMSDDLExecutor implements DDLExecutor {
 
     log.info("Drop partitions {} on {}", partitionsToDrop.size(), tableName);
     try {
-      for (String dropPartition : partitionsToDrop) {
-        if (HivePartitionUtil.partitionExists(client, tableName, dropPartition, partitionValueExtractor, syncConfig)) {
-          String partitionClause =
-              HivePartitionUtil.getPartitionClauseForDrop(dropPartition, partitionValueExtractor, syncConfig);
-          client.dropPartition(databaseName, tableName, partitionClause, false);
+      // HMS has no batch-drop primitive that matches dropPartition's semantics, so each
+      // worker still iterates its chunk one partition at a time. The win is fanning
+      // chunks across pooled clients.
+      int batchSyncPartitionNum = syncConfig.getIntOrDefault(HIVE_BATCH_SYNC_PARTITION_NUM);
+      List<List<String>> batches = CollectionUtils.batches(partitionsToDrop, batchSyncPartitionNum);
+      runBatches("drop", tableName, batches, (poolClient, batch) -> {
+        for (String dropPartition : batch) {
+          if (HivePartitionUtil.partitionExists(poolClient, tableName, dropPartition, partitionValueExtractor, syncConfig)) {
+            String partitionClause =
+                HivePartitionUtil.getPartitionClauseForDrop(dropPartition, partitionValueExtractor, syncConfig);
+            poolClient.dropPartition(databaseName, tableName, partitionClause, false);
+          }
+          log.info("Drop partition {} on {}", dropPartition, tableName);
         }
-        log.info("Drop partition {} on {}", dropPartition, tableName);
-      }
-    } catch (TException e) {
+      });
+    } catch (Exception e) {
       log.error("{}.{} drop partition failed", databaseName, tableName, e);
       throw new HoodieHiveSyncException(databaseName + "." + tableName + " drop partition failed", e);
     }
@@ -291,21 +312,71 @@ public class HMSDDLExecutor implements DDLExecutor {
 
   private void registerAlterPartitionEvent(String tableName, List<String> alteredPartitions) {
     try {
+      // Read the StorageDescriptor once on the session client; each worker deep-copies
+      // it per partition (alter_partitions semantics today).
       StorageDescriptor sd = client.getTable(databaseName, tableName).getSd();
-      List<Partition> partitionList = alteredPartitions.stream().map(partition -> {
-        Path partitionPath = HadoopFSUtils.constructAbsolutePathInHadoopPath(syncConfig.getString(META_SYNC_BASE_PATH), partition);
-        String partitionScheme = partitionPath.toUri().getScheme();
-        String fullPartitionPath = StorageSchemes.HDFS.getScheme().equals(partitionScheme)
-            ? HadoopFSUtils.getDFSFullPartitionPath(syncConfig.getHadoopFileSystem(), partitionPath) : partitionPath.toString();
-        List<String> partitionValues = partitionValueExtractor.extractPartitionValuesInPath(partition);
-        StorageDescriptor partitionSd = sd.deepCopy();
-        partitionSd.setLocation(fullPartitionPath);
-        return new Partition(partitionValues, databaseName, tableName, 0, 0, partitionSd, null);
-      }).collect(Collectors.toList());
-      client.alter_partitions(databaseName, tableName, partitionList, null);
-    } catch (TException e) {
+      int batchSyncPartitionNum = syncConfig.getIntOrDefault(HIVE_BATCH_SYNC_PARTITION_NUM);
+      List<List<String>> batches = CollectionUtils.batches(alteredPartitions, batchSyncPartitionNum);
+      runBatches("alter", tableName, batches, (poolClient, batch) -> {
+        List<Partition> partitionList = batch.stream().map(partition -> {
+          Path partitionPath = HadoopFSUtils.constructAbsolutePathInHadoopPath(syncConfig.getString(META_SYNC_BASE_PATH), partition);
+          String partitionScheme = partitionPath.toUri().getScheme();
+          String fullPartitionPath = StorageSchemes.HDFS.getScheme().equals(partitionScheme)
+              ? HadoopFSUtils.getDFSFullPartitionPath(syncConfig.getHadoopFileSystem(), partitionPath) : partitionPath.toString();
+          List<String> partitionValues = partitionValueExtractor.extractPartitionValuesInPath(partition);
+          StorageDescriptor partitionSd = sd.deepCopy();
+          partitionSd.setLocation(fullPartitionPath);
+          return new Partition(partitionValues, databaseName, tableName, 0, 0, partitionSd, null);
+        }).collect(Collectors.toList());
+        poolClient.alter_partitions(databaseName, tableName, partitionList, null);
+      });
+    } catch (Exception e) {
       log.error("{}.{} update partition failed", databaseName, tableName, e);
       throw new HoodieHiveSyncException(databaseName + "." + tableName + " update partition failed", e);
+    }
+  }
+
+  /**
+   * Dispatches partition batches either in parallel against the client pool (if
+   * configured) or sequentially against the session client. The sequential path
+   * preserves the exact behavior we had before the pool existed, including failure
+   * semantics where batch N+1 never runs if batch N throws.
+   */
+  @FunctionalInterface
+  private interface BatchAction {
+    void apply(IMetaStoreClient client, List<String> batch) throws Exception;
+  }
+
+  private void runBatches(String opName, String tableName, List<List<String>> batches, BatchAction action) throws Exception {
+    if (partitionClientPool == null) {
+      for (List<String> batch : batches) {
+        action.apply(client, batch);
+      }
+      return;
+    }
+    List<Future<Void>> futures = new ArrayList<>(batches.size());
+    for (List<String> batch : batches) {
+      futures.add(partitionClientPool.executor().submit(() ->
+          partitionClientPool.run(poolClient -> {
+            action.apply(poolClient, batch);
+            return null;
+          })
+      ));
+    }
+    Exception firstError = null;
+    for (Future<Void> f : futures) {
+      try {
+        f.get();
+      } catch (Exception e) {
+        if (firstError == null) {
+          firstError = e;
+        } else {
+          log.warn("Additional {} batch failed on {} (suppressed in favor of first error)", opName, tableName, e);
+        }
+      }
+    }
+    if (firstError != null) {
+      throw firstError;
     }
   }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/IMetaStoreClientPool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/IMetaStoreClientPool.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.util;
+
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.hive.HiveSyncConfig;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Pool of {@link IMetaStoreClient} instances for parallel partition sync.
+ *
+ * <p>Each pooled client wraps an independent Thrift connection to the Hive Metastore.
+ * Callers borrow a client via {@link #run(ClientAction)}, which blocks until a client
+ * is available, executes the action, and returns the client to the pool. A worker
+ * thread pool of the same size is exposed via {@link #executor()} so callers can fan
+ * out their batches to match the number of available clients.
+ *
+ * <p><b>Usage contract:</b> pool clients must be used <i>only</i> for partition-row
+ * operations — {@code add_partitions}, {@code alter_partitions}, {@code dropPartition},
+ * {@code getPartition}. Table-row operations ({@code createTable}, {@code alter_table},
+ * {@code getTable} used as the read half of a read-modify-write of table parameters)
+ * must continue to go through the session client held by
+ * {@code HoodieHiveSyncClient.client} on the sync driver thread. Mixing the two would
+ * risk lost updates on table parameters such as the last-commit-time-synced marker.
+ *
+ * <p>The pool is gated behind {@code hoodie.datasource.hive_sync.batching.enabled} and
+ * is constructed only for sync mode HMS.
+ */
+public class IMetaStoreClientPool implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IMetaStoreClientPool.class);
+
+  private final ArrayBlockingQueue<IMetaStoreClient> available;
+  private final List<IMetaStoreClient> all;
+  private final ExecutorService executor;
+  private final int size;
+  private volatile boolean closed;
+
+  public IMetaStoreClientPool(HiveSyncConfig config, int size) {
+    this(buildClients(config, size), size);
+  }
+
+  // Package-private for tests: accepts a pre-built list of clients so we can
+  // exercise borrow/return/close semantics without a live metastore.
+  IMetaStoreClientPool(List<IMetaStoreClient> clients, int size) {
+    if (size < 1) {
+      throw new IllegalArgumentException("Pool size must be >= 1, got " + size);
+    }
+    if (clients.size() != size) {
+      throw new IllegalArgumentException("Expected " + size + " clients, got " + clients.size());
+    }
+    this.size = size;
+    this.available = new ArrayBlockingQueue<>(size);
+    this.all = new ArrayList<>(clients);
+    this.available.addAll(clients);
+    this.executor = Executors.newFixedThreadPool(size, new PoolThreadFactory());
+    LOG.info("Initialized IMetaStoreClient pool with {} clients", size);
+  }
+
+  private static List<IMetaStoreClient> buildClients(HiveSyncConfig config, int size) {
+    if (size < 1) {
+      throw new IllegalArgumentException("Pool size must be >= 1, got " + size);
+    }
+    HiveConf hiveConf = config.getHiveConf();
+    List<IMetaStoreClient> clients = new ArrayList<>(size);
+    try {
+      for (int i = 0; i < size; i++) {
+        clients.add(newClient(hiveConf));
+      }
+      return clients;
+    } catch (Exception e) {
+      // Construction failed mid-way; close any clients we already built before
+      // surfacing the error so we don't leak Thrift sockets.
+      for (IMetaStoreClient c : clients) {
+        try {
+          c.close();
+        } catch (Exception ignore) {
+          // intentional: best-effort cleanup during failure
+        }
+      }
+      throw new HoodieException("Failed to construct IMetaStoreClient pool of size " + size, e);
+    }
+  }
+
+  private static IMetaStoreClient newClient(HiveConf hiveConf) {
+    try {
+      // RetryingMetaStoreClient.getProxy returns an independent IMetaStoreClient
+      // (one Thrift socket per call), bypassing the Hive thread-local cache that
+      // Hive.get(conf) would use. This is what gives us N truly independent clients.
+      return RetryingMetaStoreClient.getProxy(hiveConf, true);
+    } catch (Exception e) {
+      throw new HoodieException("Failed to create IMetaStoreClient for pool", e);
+    }
+  }
+
+  /**
+   * Borrows a client, runs the action, and returns the client to the pool.
+   * Blocks if all clients are in use until one becomes available.
+   */
+  public <T> T run(ClientAction<T> action) throws Exception {
+    if (closed) {
+      throw new IllegalStateException("Cannot borrow from a closed IMetaStoreClient pool");
+    }
+    IMetaStoreClient client = available.take();
+    try {
+      return action.apply(client);
+    } finally {
+      // Always return the client to the pool, even on failure. Thrift clients
+      // recover transparently from transactional errors at the HMS layer;
+      // RetryingMetaStoreClient handles transient socket failures internally.
+      if (!closed) {
+        available.offer(client);
+      }
+    }
+  }
+
+  /**
+   * Worker thread pool sized to match the client pool. Use this to fan out
+   * batches so the number of in-flight Thrift calls cannot exceed the
+   * number of pooled clients.
+   */
+  public ExecutorService executor() {
+    return executor;
+  }
+
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public void close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException ie) {
+      executor.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+    closeQuietly();
+  }
+
+  private void closeQuietly() {
+    for (IMetaStoreClient client : all) {
+      try {
+        client.close();
+      } catch (Exception e) {
+        LOG.warn("Error closing pooled IMetaStoreClient", e);
+      }
+    }
+    available.clear();
+    all.clear();
+  }
+
+  @FunctionalInterface
+  public interface ClientAction<T> {
+    T apply(IMetaStoreClient client) throws Exception;
+  }
+
+  private static final class PoolThreadFactory implements ThreadFactory {
+    private static final AtomicInteger POOL_ID = new AtomicInteger(0);
+    private final AtomicInteger threadId = new AtomicInteger(0);
+    private final String namePrefix = "hudi-hive-sync-pool-" + POOL_ID.incrementAndGet() + "-";
+
+    @Override
+    public Thread newThread(Runnable r) {
+      Thread t = new Thread(r, namePrefix + threadId.incrementAndGet());
+      t.setDaemon(true);
+      return t;
+    }
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -96,9 +96,12 @@ import static org.apache.hudi.hadoop.fs.HadoopFSUtils.getRelativePartitionPath;
 import static org.apache.hudi.hive.HiveSyncConfig.HIVE_SYNC_FILTER_PUSHDOWN_ENABLED;
 import static org.apache.hudi.hive.HiveSyncConfig.RECREATE_HIVE_TABLE_ON_ERROR;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_AUTO_CREATE_DATABASE;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_CREATE_MANAGED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_IGNORE_EXCEPTIONS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_AS_DATA_SOURCE_TABLE;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BATCHING_ENABLED;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BATCHING_THREADS;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_COMMENT;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_MODE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY;
@@ -327,6 +330,40 @@ public class TestHiveSyncTool {
     reSyncHiveTable();
     assertEquals(2, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
         "Table partitions should match the number of partitions we wrote");
+  }
+
+  /**
+   * Exercises HMS sync with parallel partition batching enabled. Forces multiple
+   * batches with a small batch_num against a partition set large enough to fan out
+   * across multiple pool clients, and asserts the resulting partition set matches.
+   */
+  @Test
+  public void testHMSSyncWithBatchingEnabled() throws Exception {
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), HiveSyncMode.HMS.name());
+    hiveSyncProps.setProperty(HIVE_SYNC_BATCHING_ENABLED.key(), "true");
+    hiveSyncProps.setProperty(HIVE_SYNC_BATCHING_THREADS.key(), "3");
+    // Small batch_num so we get multiple batches dispatched in parallel.
+    hiveSyncProps.setProperty(HIVE_BATCH_SYNC_PARTITION_NUM.key(), "3");
+
+    int partitionCount = 10;
+    HiveTestUtil.createCOWTable("100", partitionCount, true);
+
+    reInitHiveSyncClient();
+    assertFalse(hiveClient.tableExists(HiveTestUtil.TABLE_NAME),
+        "Table should not exist before initial sync");
+    reSyncHiveTable();
+    assertEquals(partitionCount, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
+        "All partitions should be added under parallel batching");
+
+    // Add more partitions, then sync again to exercise the parallel update path.
+    HiveTestUtil.addCOWPartition("2050/01/01", true, true, "101");
+    HiveTestUtil.addCOWPartition("2050/01/02", true, true, "102");
+    HiveTestUtil.addCOWPartition("2050/01/03", true, true, "103");
+    HiveTestUtil.addCOWPartition("2050/01/04", true, true, "104");
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+    assertEquals(partitionCount + 4, hiveClient.getAllPartitions(HiveTestUtil.TABLE_NAME).size(),
+        "Incremental add via parallel batching should sync the new partitions");
   }
 
   @ParameterizedTest

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/util/TestIMetaStoreClientPool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/util/TestIMetaStoreClientPool.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.util;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link IMetaStoreClientPool} borrow/return/close semantics. These tests
+ * never hit a real Hive Metastore — clients are mocked and injected via the package-
+ * private constructor.
+ */
+class TestIMetaStoreClientPool {
+
+  private static List<IMetaStoreClient> mockClients(int n) {
+    List<IMetaStoreClient> clients = new ArrayList<>(n);
+    for (int i = 0; i < n; i++) {
+      clients.add(mock(IMetaStoreClient.class));
+    }
+    return clients;
+  }
+
+  @Test
+  void runReturnsClientToPoolOnSuccess() throws Exception {
+    List<IMetaStoreClient> clients = mockClients(2);
+    IMetaStoreClientPool pool = new IMetaStoreClientPool(clients, 2);
+    try {
+      IMetaStoreClient borrowed = pool.run(c -> c);
+      // Both clients should be available again
+      Set<IMetaStoreClient> seen = new HashSet<>();
+      seen.add(pool.run(c -> c));
+      seen.add(pool.run(c -> c));
+      assertEquals(2, seen.size(), "Both clients should be reachable after returns");
+      assertTrue(seen.contains(borrowed));
+    } finally {
+      pool.close();
+    }
+  }
+
+  @Test
+  void runReturnsClientToPoolOnFailure() {
+    List<IMetaStoreClient> clients = mockClients(1);
+    IMetaStoreClientPool pool = new IMetaStoreClientPool(clients, 1);
+    try {
+      assertThrows(IllegalStateException.class, () -> pool.run(c -> {
+        throw new IllegalStateException("boom");
+      }));
+      // Pool should still be usable; the borrowed client was returned
+      try {
+        IMetaStoreClient again = pool.run(c -> c);
+        assertSame(clients.get(0), again);
+      } catch (Exception e) {
+        throw new AssertionError("Pool should still be usable after action failure", e);
+      }
+    } finally {
+      pool.close();
+    }
+  }
+
+  @Test
+  void concurrentBorrowsBlockUntilReturned() throws Exception {
+    int poolSize = 2;
+    int callers = 4;
+    List<IMetaStoreClient> clients = mockClients(poolSize);
+    IMetaStoreClientPool pool = new IMetaStoreClientPool(clients, poolSize);
+    AtomicInteger concurrent = new AtomicInteger(0);
+    AtomicInteger maxConcurrent = new AtomicInteger(0);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService threads = Executors.newFixedThreadPool(callers);
+    try {
+      List<java.util.concurrent.Future<?>> futures = new ArrayList<>();
+      for (int i = 0; i < callers; i++) {
+        futures.add(threads.submit(() -> {
+          start.await();
+          return pool.run(c -> {
+            int now = concurrent.incrementAndGet();
+            maxConcurrent.updateAndGet(prev -> Math.max(prev, now));
+            Thread.sleep(50);
+            concurrent.decrementAndGet();
+            return null;
+          });
+        }));
+      }
+      start.countDown();
+      for (java.util.concurrent.Future<?> f : futures) {
+        f.get(10, TimeUnit.SECONDS);
+      }
+      assertTrue(maxConcurrent.get() <= poolSize,
+          "Concurrent borrows must not exceed pool size, observed " + maxConcurrent.get());
+      assertTrue(maxConcurrent.get() >= 1, "At least one borrow must have occurred");
+    } finally {
+      threads.shutdownNow();
+      pool.close();
+    }
+  }
+
+  @Test
+  void closeReleasesAllClients() throws Exception {
+    int poolSize = 3;
+    List<IMetaStoreClient> clients = mockClients(poolSize);
+    IMetaStoreClientPool pool = new IMetaStoreClientPool(clients, poolSize);
+    pool.close();
+    for (IMetaStoreClient c : clients) {
+      verify(c).close();
+    }
+    // Subsequent borrow should fail
+    assertThrows(IllegalStateException.class, () -> pool.run(c -> c));
+  }
+
+  @Test
+  void closeIsIdempotent() throws Exception {
+    int poolSize = 2;
+    List<IMetaStoreClient> clients = mockClients(poolSize);
+    IMetaStoreClientPool pool = new IMetaStoreClientPool(clients, poolSize);
+    pool.close();
+    pool.close();
+    // verify still passes — close() called only once per client
+    for (IMetaStoreClient c : clients) {
+      verify(c).close();
+    }
+  }
+
+  @Test
+  void invalidSizeRejected() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new IMetaStoreClientPool(mockClients(0), 0));
+  }
+
+  @Test
+  void sizeMismatchRejected() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new IMetaStoreClientPool(mockClients(2), 3));
+  }
+
+  @Test
+  void executorSizedToPool() {
+    int poolSize = 4;
+    IMetaStoreClientPool pool = new IMetaStoreClientPool(mockClients(poolSize), poolSize);
+    try {
+      assertFalse(pool.executor().isShutdown());
+      assertEquals(poolSize, pool.size());
+    } finally {
+      pool.close();
+    }
+    assertTrue(pool.executor().isShutdown());
+  }
+}


### PR DESCRIPTION
## Summary
- Adds opt-in `IMetaStoreClientPool` for HMS partition sync (issue [#18331](https://github.com/apache/hudi/issues/18331))
- Batches ADD/TOUCH/UPDATE/DROP using the existing `hoodie.datasource.hive_sync.batch_num` (default 1000)
- Fans batches out across N pooled `RetryingMetaStoreClient` instances via a fixed-size executor
- Default off — existing behavior unchanged unless `hoodie.datasource.hive_sync.batching.enabled=true`

## Design invariant
Only partition-row operations (`add_partitions`, `alter_partitions`, `dropPartition`, `getPartition`) go through the pool. Table-row operations (`createTable`, `alter_table`, `updateLastCommitTimeSynced`, `updateHoodieWriterVersion`, `updateTableComments`) stay on the existing session `IMetaStoreClient` held by `HoodieHiveSyncClient`. The sync flow is therefore **serial → parallel → serial**:

1. Table setup (single client)
2. Partition fan-out across the pool
3. Table finalization (single client)

This eliminates lost-update risk on `Table.parameters` (the read-modify-write pattern used by `updateLastCommitTimeSynced` and `updateHoodieWriterVersion`).

## New configs
| Key | Default | Purpose |
|---|---|---|
| `hoodie.datasource.hive_sync.batching.enabled` | `false` | Master feature flag |
| `hoodie.datasource.hive_sync.batching.threads` | `4` | Pool size + worker thread count |

Reuses the existing `hoodie.datasource.hive_sync.batch_num` for batch sizing (no new batch-size config).

## Scope
HMS executor only — matches the branch name `hms-parallelize-calls`. HiveQL and JDBC executor parallelism is deferred (per-thread `SessionState`/`Driver` and JDBC `Connection` pools are bigger changes; gating on benchmarks of this PR first).

## Failure semantics
- **Today (sequential):** batch N fails → N+1..K never run. Predictable prefix.
- **New (parallel):** in-flight batches complete; first exception is thrown, remaining errors logged at WARN. Re-running sync is already idempotent (`add_partitions(list, ifNotExists=true)`, `partitionExists` guard before `dropPartition`, idempotent `alter_partitions`), so partial-state retry behavior matches today.

## Compatibility
When `HIVE_SYNC_USE_SPARK_CATALOG=true`, the pool path is skipped with a warning and we fall back to sequential — the reflection-built `SparkCatalogMetaStoreClient` isn't compatible with the direct `RetryingMetaStoreClient.getProxy` construction path.

## Test plan
- [x] `mvn compile` on `hudi-sync/hudi-hive-sync` — clean, 0 Checkstyle violations, 0 RAT issues
- [x] `mvn test` on `hudi-sync/hudi-hive-sync` — **296 tests, 0 failures, 0 errors**
- [x] `TestIMetaStoreClientPool` (new, 8 tests) — borrow/return on success, on failure, concurrent borrow bounded by pool size, idempotent close, executor lifecycle, size validation
- [x] `TestHiveSyncTool#testHMSSyncWithBatchingEnabled` (new) — end-to-end HMS sync with `batching.enabled=true`, `threads=3`, `batch_num=3`, 10 initial + 4 incremental partitions
- [ ] Manual benchmark on a 2k-partition table (planned before flipping default; not blocking this PR since flag is opt-in)

## Files touched
- `HiveSyncConfigHolder.java` — 2 new `ConfigProperty` constants
- `HoodieHiveSyncClient.java` — owns + closes the pool, builds it only for HMS mode with flag on
- `ddl/HMSDDLExecutor.java` — new constructor accepting the pool, `runBatches` helper shared across all four partition methods
- `util/IMetaStoreClientPool.java` — **new**; modeled on Iceberg's `HiveClientPool` but standalone (no Iceberg dep)
- `TestIMetaStoreClientPool.java` — **new**; mock-based unit tests
- `TestHiveSyncTool.java` — new end-to-end test method

## Follow-ups (separate PRs)
1. Respond to issue #18331 noting a minor inaccuracy: JDBC's DROP is already batched ([`JDBCExecutor.constructDropPartitions`](https://github.com/apache/hudi/blob/master/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/JDBCExecutor.java)). The real JDBC gap is `SET LOCATION` (UPDATE), which is one statement per partition with no batching.
2. After benchmarks, decide whether HiveQL + JDBC parallelism is worth the additional per-thread `SessionState`/`Connection` complexity.

Related: #18331

🤖 Generated with [Claude Code](https://claude.com/claude-code)