### PR TITLE
feat(client): enrich write commit callback message and fire it for table-service commits

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/HoodieWriteCommitCallbackUtil.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/HoodieWriteCommitCallbackUtil.java
@@ -17,15 +17,27 @@
 
 package org.apache.hudi.callback;
 
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
+import org.apache.hudi.common.model.BaseFile;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieCommitCallbackException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Util helps to prepare callback message.
  */
+@Slf4j
 public class HoodieWriteCommitCallbackUtil {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -41,4 +53,46 @@ public class HoodieWriteCommitCallbackUtil {
     }
   }
 
+  /**
+   * Resolve the previous base file (and bootstrap base file, if any) for every
+   * {@link HoodieWriteStat} that represents an update, using a populated
+   * {@link BaseFileOnlyView}. The lookup is O(1) per stat against the cached view, so
+   * this adds no I/O on top of what the writer already paid.
+   *
+   * <p>Feeds {@link org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage#getPrevFilePaths()}
+   * so the callback message can ship actual file paths rather than forcing each callback
+   * impl to rebuild a {@code FileSystemView}.
+   */
+  public static Map<String, PrevFilePaths> resolvePrevFilePaths(List<HoodieWriteStat> stats,
+                                                                BaseFileOnlyView fsView) {
+    Map<String, PrevFilePaths> pathsByFileId = new HashMap<>();
+    if (stats == null || fsView == null) {
+      return pathsByFileId;
+    }
+    for (HoodieWriteStat stat : stats) {
+      String prevCommit = stat.getPrevCommit();
+      if (StringUtils.isNullOrEmpty(prevCommit) || HoodieWriteStat.NULL_COMMIT.equals(prevCommit)) {
+        continue;
+      }
+      Option<HoodieBaseFile> prev;
+      try {
+        prev = fsView.getBaseFileOn(stat.getPartitionPath(), prevCommit, stat.getFileId());
+      } catch (Exception e) {
+        // Best-effort: a remote view 4xx/5xx, a stale view, or a replaced file group must not
+        // fail the commit. Drop the prev path for this stat and keep going.
+        log.warn("Could not resolve prev base file for fileId={} prevCommit={}; skipping",
+            stat.getFileId(), prevCommit, e);
+        continue;
+      }
+      if (!prev.isPresent()) {
+        continue;
+      }
+      HoodieBaseFile prevBaseFile = prev.get();
+      Option<BaseFile> bootstrapBaseFile = prevBaseFile.getBootstrapBaseFile();
+      String prevPath = prevBaseFile.getPath();
+      String bootstrapPath = bootstrapBaseFile.isPresent() ? bootstrapBaseFile.get().getPath() : null;
+      pathsByFileId.put(stat.getFileId(), new PrevFilePaths(prevPath, bootstrapPath));
+    }
+    return pathsByFileId;
+  }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
@@ -26,6 +26,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -69,10 +70,54 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
    */
   private final Option<Map<String, String>> extraMetadata;
 
+  /**
+   * Previous base file paths keyed by fileId. Populated by the write client
+   * using the cached FileSystemView so that callback implementations don't
+   * have to rebuild a view. Empty for inserts and for callers that don't
+   * pre-resolve.
+   */
+  private final Map<String, PrevFilePaths> prevFilePaths;
+
+  /**
+   * Free-form context that producers can attach for downstream callback consumers.
+   * The OSS write client populates this as empty; specialized callsites or wrappers
+   * may populate it with whatever context their callbacks need. Mirrors the
+   * optional shape of {@link #extraMetadata}.
+   */
+  private final Map<String, String> extraContext;
+
   public HoodieWriteCommitCallbackMessage(String commitTime,
                                           String tableName,
                                           String basePath,
                                           List<HoodieWriteStat> hoodieWriteStat) {
-    this(commitTime, tableName, basePath, hoodieWriteStat, Option.empty(), Option.empty());
+    this(commitTime, tableName, basePath, hoodieWriteStat, Option.empty(), Option.empty(),
+        Collections.emptyMap(), Collections.emptyMap());
+  }
+
+  public HoodieWriteCommitCallbackMessage(String commitTime,
+                                          String tableName,
+                                          String basePath,
+                                          List<HoodieWriteStat> hoodieWriteStat,
+                                          Option<String> commitActionType,
+                                          Option<Map<String, String>> extraMetadata) {
+    this(commitTime, tableName, basePath, hoodieWriteStat, commitActionType, extraMetadata,
+        Collections.emptyMap(), Collections.emptyMap());
+  }
+
+  /**
+   * Container for previously-existing file paths associated with a single fileId in a
+   * commit. {@link #prevBaseFilePath} is the base file the new write replaces, and
+   * {@link #bootstrapBaseFilePath} is the bootstrap-source file the previous
+   * base file referenced (null for non-bootstrap tables).
+   */
+  public static class PrevFilePaths implements Serializable {
+    private static final long serialVersionUID = 1L;
+    public final String prevBaseFilePath;
+    public final String bootstrapBaseFilePath;
+
+    public PrevFilePaths(String prevBaseFilePath, String bootstrapBaseFilePath) {
+      this.prevBaseFilePath = prevBaseFilePath;
+      this.bootstrapBaseFilePath = bootstrapBaseFilePath;
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
@@ -159,18 +159,18 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
 
   /**
    * Container for previously-existing file paths associated with a single fileId in a
-   * commit. {@link #prevBaseFilePath} is the base file the new write replaces, and
+   * commit. {@link #baseFilePath} is the base file the new write replaces, and
    * {@link #bootstrapBaseFilePath} is the bootstrap-source file the previous
    * base file referenced (null for non-bootstrap tables).
    */
   @Getter
   public static class PrevFilePaths implements Serializable {
     private static final long serialVersionUID = 1L;
-    private final String prevBaseFilePath;
+    private final String baseFilePath;
     private final String bootstrapBaseFilePath;
 
-    public PrevFilePaths(String prevBaseFilePath, String bootstrapBaseFilePath) {
-      this.prevBaseFilePath = prevBaseFilePath;
+    public PrevFilePaths(String baseFilePath, String bootstrapBaseFilePath) {
+      this.baseFilePath = baseFilePath;
       this.bootstrapBaseFilePath = bootstrapBaseFilePath;
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
@@ -22,18 +22,20 @@ import org.apache.hudi.PublicAPIClass;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.util.Option;
 
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Getter;
 
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Base callback message, which contains commitTime and tableName only for now.
  */
-@AllArgsConstructor
 @Getter
 @PublicAPIClass(maturity = ApiMaturityLevel.EVOLVING)
 public class HoodieWriteCommitCallbackMessage implements Serializable {
@@ -71,27 +73,57 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
   private final Option<Map<String, String>> extraMetadata;
 
   /**
-   * Previous base file paths keyed by fileId. Populated by the write client
-   * using the cached FileSystemView so that callback implementations don't
-   * have to rebuild a view. Empty for inserts and for callers that don't
-   * pre-resolve.
+   * Previous base file paths keyed by fileId, resolved lazily. Populated by the write
+   * client from the cached FileSystemView so that callback implementations don't have to
+   * rebuild a view. Empty for inserts and for callers that don't pre-resolve.
+   *
+   * <p>Resolution is deferred to the {@code prevFilePathsSupplier} and only triggered on the
+   * first {@link #getPrevFilePaths()} call: a callback that never reads the previous paths
+   * pays nothing (no FileSystemView access). The resolved value is memoized here and is the
+   * form that gets serialized (see {@link #writeObject}).
    */
-  private final Map<String, PrevFilePaths> prevFilePaths;
+  private Map<String, PrevFilePaths> prevFilePaths;
+
+  /**
+   * Lazily resolves {@link #prevFilePaths}. Transient because it may capture a
+   * FileSystemView (not serializable); excluded from the generated getters so it never
+   * leaks into JSON/Java serialization. The resolved map is memoized into
+   * {@link #prevFilePaths}.
+   */
+  @Getter(AccessLevel.NONE)
+  private final transient Supplier<Map<String, PrevFilePaths>> prevFilePathsSupplier;
 
   /**
    * Free-form context that producers can attach for downstream callback consumers.
    * The OSS write client populates this as empty; specialized callsites or wrappers
-   * may populate it with whatever context their callbacks need. Mirrors the
-   * optional shape of {@link #extraMetadata}.
+   * may populate it with whatever context their callbacks need.
    */
   private final Map<String, String> extraContext;
 
   public HoodieWriteCommitCallbackMessage(String commitTime,
                                           String tableName,
                                           String basePath,
+                                          List<HoodieWriteStat> hoodieWriteStat,
+                                          Option<String> commitActionType,
+                                          Option<Map<String, String>> extraMetadata,
+                                          Supplier<Map<String, PrevFilePaths>> prevFilePathsSupplier,
+                                          Map<String, String> extraContext) {
+    this.commitTime = commitTime;
+    this.tableName = tableName;
+    this.basePath = basePath;
+    this.hoodieWriteStat = hoodieWriteStat;
+    this.commitActionType = commitActionType;
+    this.extraMetadata = extraMetadata;
+    this.prevFilePathsSupplier = prevFilePathsSupplier;
+    this.extraContext = extraContext;
+  }
+
+  public HoodieWriteCommitCallbackMessage(String commitTime,
+                                          String tableName,
+                                          String basePath,
                                           List<HoodieWriteStat> hoodieWriteStat) {
     this(commitTime, tableName, basePath, hoodieWriteStat, Option.empty(), Option.empty(),
-        Collections.emptyMap(), Collections.emptyMap());
+        Collections::emptyMap, Collections.emptyMap());
   }
 
   public HoodieWriteCommitCallbackMessage(String commitTime,
@@ -101,7 +133,28 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
                                           Option<String> commitActionType,
                                           Option<Map<String, String>> extraMetadata) {
     this(commitTime, tableName, basePath, hoodieWriteStat, commitActionType, extraMetadata,
-        Collections.emptyMap(), Collections.emptyMap());
+        Collections::emptyMap, Collections.emptyMap());
+  }
+
+  /**
+   * Returns the previous base file paths keyed by fileId, resolving them on first access.
+   * A consumer that never calls this triggers no FileSystemView lookup. Never null.
+   */
+  public Map<String, PrevFilePaths> getPrevFilePaths() {
+    if (prevFilePaths == null) {
+      prevFilePaths = prevFilePathsSupplier != null
+          ? prevFilePathsSupplier.get() : Collections.emptyMap();
+    }
+    return prevFilePaths;
+  }
+
+  /**
+   * Force lazy resolution before serialization so the resolved map (not the transient
+   * supplier) is what gets written.
+   */
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    getPrevFilePaths();
+    out.defaultWriteObject();
   }
 
   /**
@@ -110,10 +163,11 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
    * {@link #bootstrapBaseFilePath} is the bootstrap-source file the previous
    * base file referenced (null for non-bootstrap tables).
    */
+  @Getter
   public static class PrevFilePaths implements Serializable {
     private static final long serialVersionUID = 1L;
-    public final String prevBaseFilePath;
-    public final String bootstrapBaseFilePath;
+    private final String prevBaseFilePath;
+    private final String bootstrapBaseFilePath;
 
     public PrevFilePaths(String prevBaseFilePath, String bootstrapBaseFilePath) {
       this.prevBaseFilePath = prevBaseFilePath;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
@@ -19,16 +19,15 @@ package org.apache.hudi.callback.common;
 
 import org.apache.hudi.ApiMaturityLevel;
 import org.apache.hudi.PublicAPIClass;
+import org.apache.hudi.callback.HoodieWriteCommitCallbackUtil;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.common.util.Option;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -75,18 +74,19 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
   private final Option<Map<String, String>> extraMetadata;
 
   /**
-   * Previous base file paths keyed by fileId, resolved lazily. Populated by the write
-   * client from the cached FileSystemView so that callback implementations don't have to
-   * rebuild a view. Empty for inserts and for callers that don't pre-resolve.
+   * Previous base file paths keyed by fileId, derived lazily from {@link #hoodieWriteStat} and
+   * the {@link BaseFileOnlyView} handed over by the write client, so that callback
+   * implementations don't have to rebuild a view themselves. Empty for inserts and for
+   * callers that don't supply a view.
    *
    * <p>Resolution is deferred until the first {@link #getPrevFilePaths()} call: a callback
    * that never reads the previous paths pays nothing (no FileSystemView access). Transient
-   * because the initializer may capture a FileSystemView (not serializable); the resolved
-   * map is what crosses Java serialization (see {@link #writeObject}/{@link #readObject}).
+   * because it captures a FileSystemView supplier, which is not serializable - these paths
+   * are JVM-local derived state, so a message restored from Java serialization reports none.
    * Excluded from the generated getters so the {@link Lazy} wrapper never leaks into JSON.
    */
   @Getter(AccessLevel.NONE)
-  private transient Lazy<Map<String, PrevFilePaths>> prevFilePaths;
+  private final transient Lazy<Map<String, PrevFilePaths>> prevFilePaths;
 
   /**
    * Free-form context that producers can attach for downstream callback consumers.
@@ -101,7 +101,7 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
                                           List<HoodieWriteStat> hoodieWriteStat,
                                           Option<String> commitActionType,
                                           Option<Map<String, String>> extraMetadata,
-                                          Supplier<Map<String, PrevFilePaths>> prevFilePathsSupplier,
+                                          Supplier<BaseFileOnlyView> fsViewSupplier,
                                           Map<String, String> extraContext) {
     this.commitTime = commitTime;
     this.tableName = tableName;
@@ -109,8 +109,8 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
     this.hoodieWriteStat = hoodieWriteStat;
     this.commitActionType = commitActionType;
     this.extraMetadata = extraMetadata;
-    this.prevFilePaths = Lazy.lazily(
-        prevFilePathsSupplier != null ? prevFilePathsSupplier : Collections::emptyMap);
+    this.prevFilePaths = Lazy.lazily(() -> HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(
+        hoodieWriteStat, fsViewSupplier == null ? null : fsViewSupplier.get()));
     this.extraContext = extraContext;
   }
 
@@ -119,7 +119,7 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
                                           String basePath,
                                           List<HoodieWriteStat> hoodieWriteStat) {
     this(commitTime, tableName, basePath, hoodieWriteStat, Option.empty(), Option.empty(),
-        Collections::emptyMap, Collections.emptyMap());
+        null, Collections.emptyMap());
   }
 
   public HoodieWriteCommitCallbackMessage(String commitTime,
@@ -129,30 +129,18 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
                                           Option<String> commitActionType,
                                           Option<Map<String, String>> extraMetadata) {
     this(commitTime, tableName, basePath, hoodieWriteStat, commitActionType, extraMetadata,
-        Collections::emptyMap, Collections.emptyMap());
+        null, Collections.emptyMap());
   }
 
   /**
-   * Returns the previous base file paths keyed by fileId, resolving them on first access.
-   * A consumer that never calls this triggers no FileSystemView lookup. Never null.
+   * Returns the previous base file paths keyed by fileId, resolving them from the file-system
+   * view on first access. A consumer that never calls this triggers no FileSystemView lookup.
+   * Never null: empty when no view was supplied, when the commit only inserted, or when this
+   * message was restored from Java serialization.
    */
   public Map<String, PrevFilePaths> getPrevFilePaths() {
-    return prevFilePaths.get();
-  }
-
-  /**
-   * Force lazy resolution before serialization so the resolved map (not the transient
-   * {@link Lazy} holder, which is not serializable) is what gets written.
-   */
-  private void writeObject(ObjectOutputStream out) throws IOException {
-    out.defaultWriteObject();
-    out.writeObject(getPrevFilePaths());
-  }
-
-  @SuppressWarnings("unchecked")
-  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-    in.defaultReadObject();
-    prevFilePaths = Lazy.eagerly((Map<String, PrevFilePaths>) in.readObject());
+    // Null only on an instance restored from Java serialization, since the holder is transient.
+    return prevFilePaths == null ? Collections.emptyMap() : prevFilePaths.get();
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
@@ -28,6 +28,8 @@ import org.apache.hudi.common.util.Option;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -74,19 +76,29 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
   private final Option<Map<String, String>> extraMetadata;
 
   /**
-   * Previous base file paths keyed by fileId, derived lazily from {@link #hoodieWriteStat} and
-   * the {@link BaseFileOnlyView} handed over by the write client, so that callback
+   * Previous base file paths keyed by fileId, derived from {@link #hoodieWriteStat} and the
+   * {@link BaseFileOnlyView} handed over by the write client, so that callback
    * implementations don't have to rebuild a view themselves. Empty for inserts and for
    * callers that don't supply a view.
    *
-   * <p>Resolution is deferred until the first {@link #getPrevFilePaths()} call: a callback
-   * that never reads the previous paths pays nothing (no FileSystemView access). Transient
-   * because it captures a FileSystemView supplier, which is not serializable - these paths
-   * are JVM-local derived state, so a message restored from Java serialization reports none.
-   * Excluded from the generated getters so the {@link Lazy} wrapper never leaks into JSON.
+   * <p>Holds the resolved map once {@link #getPrevFilePaths()} has run, and stays null until
+   * then. Not transient: this is the copy that crosses Java serialization, which is why
+   * {@link #writeObject} forces resolution before writing. Excluded from the generated
+   * getters so it is published only through {@link #getPrevFilePaths()}.
    */
   @Getter(AccessLevel.NONE)
-  private final transient Lazy<Map<String, PrevFilePaths>> prevFilePaths;
+  private volatile Map<String, PrevFilePaths> prevFilePaths;
+
+  /**
+   * Resolves {@link #prevFilePaths} on demand. Resolution is deferred until the first
+   * {@link #getPrevFilePaths()} call, so a callback that never reads the previous paths pays
+   * nothing (no FileSystemView access at all). Transient because it captures a
+   * FileSystemView supplier, which is not serializable: on a deserialized instance this is
+   * null and the already-resolved {@link #prevFilePaths} is used instead. Excluded from the
+   * generated getters so the {@link Lazy} wrapper never leaks into JSON.
+   */
+  @Getter(AccessLevel.NONE)
+  private final transient Lazy<Map<String, PrevFilePaths>> prevFilePathsResolver;
 
   /**
    * Free-form context that producers can attach for downstream callback consumers.
@@ -109,7 +121,7 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
     this.hoodieWriteStat = hoodieWriteStat;
     this.commitActionType = commitActionType;
     this.extraMetadata = extraMetadata;
-    this.prevFilePaths = Lazy.lazily(() -> HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(
+    this.prevFilePathsResolver = Lazy.lazily(() -> HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(
         hoodieWriteStat, fsViewSupplier == null ? null : fsViewSupplier.get()));
     this.extraContext = extraContext;
   }
@@ -134,13 +146,28 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
 
   /**
    * Returns the previous base file paths keyed by fileId, resolving them from the file-system
-   * view on first access. A consumer that never calls this triggers no FileSystemView lookup.
-   * Never null: empty when no view was supplied, when the commit only inserted, or when this
-   * message was restored from Java serialization.
+   * view on first access and memoizing the result. A consumer that never calls this triggers
+   * no FileSystemView lookup. Never null: empty when no view was supplied and when the commit
+   * only inserted.
    */
   public Map<String, PrevFilePaths> getPrevFilePaths() {
-    // Null only on an instance restored from Java serialization, since the holder is transient.
-    return prevFilePaths == null ? Collections.emptyMap() : prevFilePaths.get();
+    Map<String, PrevFilePaths> paths = prevFilePaths;
+    if (paths == null) {
+      // The resolver is null only on an instance restored from Java serialization, and there
+      // the resolved map has already been read back into prevFilePaths (see writeObject).
+      paths = prevFilePathsResolver == null ? Collections.emptyMap() : prevFilePathsResolver.get();
+      prevFilePaths = paths;
+    }
+    return paths;
+  }
+
+  /**
+   * A {@link BaseFileOnlyView} cannot cross a serialization boundary, so materialize the
+   * paths at the last possible moment and let the resolved map travel in their place.
+   */
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    getPrevFilePaths();
+    out.defaultWriteObject();
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/callback/common/HoodieWriteCommitCallbackMessage.java
@@ -20,12 +20,14 @@ package org.apache.hudi.callback.common;
 import org.apache.hudi.ApiMaturityLevel;
 import org.apache.hudi.PublicAPIClass;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.common.util.Option;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Collections;
@@ -77,21 +79,14 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
    * client from the cached FileSystemView so that callback implementations don't have to
    * rebuild a view. Empty for inserts and for callers that don't pre-resolve.
    *
-   * <p>Resolution is deferred to the {@code prevFilePathsSupplier} and only triggered on the
-   * first {@link #getPrevFilePaths()} call: a callback that never reads the previous paths
-   * pays nothing (no FileSystemView access). The resolved value is memoized here and is the
-   * form that gets serialized (see {@link #writeObject}).
-   */
-  private Map<String, PrevFilePaths> prevFilePaths;
-
-  /**
-   * Lazily resolves {@link #prevFilePaths}. Transient because it may capture a
-   * FileSystemView (not serializable); excluded from the generated getters so it never
-   * leaks into JSON/Java serialization. The resolved map is memoized into
-   * {@link #prevFilePaths}.
+   * <p>Resolution is deferred until the first {@link #getPrevFilePaths()} call: a callback
+   * that never reads the previous paths pays nothing (no FileSystemView access). Transient
+   * because the initializer may capture a FileSystemView (not serializable); the resolved
+   * map is what crosses Java serialization (see {@link #writeObject}/{@link #readObject}).
+   * Excluded from the generated getters so the {@link Lazy} wrapper never leaks into JSON.
    */
   @Getter(AccessLevel.NONE)
-  private final transient Supplier<Map<String, PrevFilePaths>> prevFilePathsSupplier;
+  private transient Lazy<Map<String, PrevFilePaths>> prevFilePaths;
 
   /**
    * Free-form context that producers can attach for downstream callback consumers.
@@ -114,7 +109,8 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
     this.hoodieWriteStat = hoodieWriteStat;
     this.commitActionType = commitActionType;
     this.extraMetadata = extraMetadata;
-    this.prevFilePathsSupplier = prevFilePathsSupplier;
+    this.prevFilePaths = Lazy.lazily(
+        prevFilePathsSupplier != null ? prevFilePathsSupplier : Collections::emptyMap);
     this.extraContext = extraContext;
   }
 
@@ -141,20 +137,22 @@ public class HoodieWriteCommitCallbackMessage implements Serializable {
    * A consumer that never calls this triggers no FileSystemView lookup. Never null.
    */
   public Map<String, PrevFilePaths> getPrevFilePaths() {
-    if (prevFilePaths == null) {
-      prevFilePaths = prevFilePathsSupplier != null
-          ? prevFilePathsSupplier.get() : Collections.emptyMap();
-    }
-    return prevFilePaths;
+    return prevFilePaths.get();
   }
 
   /**
    * Force lazy resolution before serialization so the resolved map (not the transient
-   * supplier) is what gets written.
+   * {@link Lazy} holder, which is not serializable) is what gets written.
    */
   private void writeObject(ObjectOutputStream out) throws IOException {
-    getPrevFilePaths();
     out.defaultWriteObject();
+    out.writeObject(getPrevFilePaths());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    prevFilePaths = Lazy.eagerly((Map<String, PrevFilePaths>) in.readObject());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -69,6 +69,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.config.HoodieWriteConfig.APPLICATION_ID;
@@ -486,11 +487,11 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
    * <p>Best-effort: catches and logs any exception from the user-supplied callback so a
    * misbehaving observer cannot fail the commit.
    */
-  protected void fireCommitCallback(String commitTime,
-                                    String commitActionType,
-                                    List<HoodieWriteStat> stats,
-                                    BaseFileOnlyView fsView,
-                                    Option<Map<String, String>> extraMetadata) {
+  protected void fireCommitCallbackIfNecessary(String commitTime,
+                                               String commitActionType,
+                                               List<HoodieWriteStat> stats,
+                                               Supplier<BaseFileOnlyView> fsViewSupplier,
+                                               Option<Map<String, String>> extraMetadata) {
     if (!config.writeCommitCallbackOn()) {
       return;
     }
@@ -500,7 +501,8 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       }
       commitCallback.call(new HoodieWriteCommitCallbackMessage(
           commitTime, config.getTableName(), config.getBasePath(),
-          stats, Option.of(commitActionType), extraMetadata, resolvePrevFilePaths(stats, fsView),
+          stats, Option.of(commitActionType), extraMetadata,
+          resolvePrevFilePaths(stats, fsViewSupplier.get()),
           Collections.emptyMap()));
     } catch (Exception e) {
       log.warn("HoodieWriteCommitCallback failed for commit {} ({}); ignoring",
@@ -514,7 +516,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
    * {@link BaseFileOnlyView}. The lookup is O(1) per stat against the cached view, so
    * this adds no I/O on top of what the writer already paid.
    *
-   * <p>Used by {@link #fireCommitCallback} call sites so the callback message ships
+   * <p>Used by {@link #fireCommitCallbackIfNecessary} call sites so the callback message ships
    * actual file paths rather than forcing each callback impl to rebuild a
    * {@code FileSystemView}.
    */

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -20,12 +20,17 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.callback.HoodieClientInitCallback;
+import org.apache.hudi.callback.HoodieWriteCommitCallback;
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
+import org.apache.hudi.callback.util.HoodieCommitCallbackFactory;
 import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.client.transaction.TransactionUtils;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -34,6 +39,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimeGenerator;
 import org.apache.hudi.common.table.timeline.TimeGenerators;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
+import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
@@ -86,6 +92,14 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
   protected final HoodieHeartbeatClient heartbeatClient;
   protected final TransactionManager txnManager;
   protected final TimeGenerator timeGenerator;
+
+  /**
+   * Lazily-initialized commit callback (HoodieWriteCommitCallback). Lifted from
+   * {@link BaseHoodieWriteClient} so that {@link BaseHoodieTableServiceClient} can also
+   * fire callbacks for compaction and clustering completions. Transient is fine
+   * because the callback is only ever invoked from the driver after a commit.
+   */
+  protected transient HoodieWriteCommitCallback commitCallback;
 
   /**
    * Timeline Server has the same lifetime as that of Client. Any operations done on the same timeline service will be
@@ -461,5 +475,79 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
 
   protected Option<Map<String, String>> updateExtraMetadata(Option<Map<String, String>> extraMetadata) {
     return CommitMetadataProperties.enrich(extraMetadata, config, context);
+  }
+
+  /**
+   * Fire {@link HoodieWriteCommitCallback} for a commit, if enabled. Shared by
+   * {@link BaseHoodieWriteClient#postCommit} (regular auto- and explicit-commit paths)
+   * and {@link BaseHoodieTableServiceClient} (compaction and clustering completions).
+   * Lazily constructs the callback instance from {@code hoodie.write.commit.callback.class}.
+   *
+   * <p>Best-effort: catches and logs any exception from the user-supplied callback so a
+   * misbehaving observer cannot fail the commit.
+   */
+  protected void fireCommitCallback(String commitTime,
+                                    String commitActionType,
+                                    List<HoodieWriteStat> stats,
+                                    BaseFileOnlyView fsView,
+                                    Option<Map<String, String>> extraMetadata) {
+    if (!config.writeCommitCallbackOn()) {
+      return;
+    }
+    try {
+      if (commitCallback == null) {
+        commitCallback = HoodieCommitCallbackFactory.create(config);
+      }
+      commitCallback.call(new HoodieWriteCommitCallbackMessage(
+          commitTime, config.getTableName(), config.getBasePath(),
+          stats, Option.of(commitActionType), extraMetadata, resolvePrevFilePaths(stats, fsView),
+          Collections.emptyMap()));
+    } catch (Exception e) {
+      log.warn("HoodieWriteCommitCallback failed for commit {} ({}); ignoring",
+          commitTime, commitActionType, e);
+    }
+  }
+
+  /**
+   * Pre-resolve the previous base file (and bootstrap base file, if any) for every
+   * {@link HoodieWriteStat} that represents an update, using a populated
+   * {@link BaseFileOnlyView}. The lookup is O(1) per stat against the cached view, so
+   * this adds no I/O on top of what the writer already paid.
+   *
+   * <p>Used by {@link #fireCommitCallback} call sites so the callback message ships
+   * actual file paths rather than forcing each callback impl to rebuild a
+   * {@code FileSystemView}.
+   */
+  protected static Map<String, PrevFilePaths> resolvePrevFilePaths(List<HoodieWriteStat> stats,
+                                                                   BaseFileOnlyView fsView) {
+    Map<String, PrevFilePaths> out = new HashMap<>();
+    if (stats == null || fsView == null) {
+      return out;
+    }
+    for (HoodieWriteStat stat : stats) {
+      String prevCommit = stat.getPrevCommit();
+      if (StringUtils.isNullOrEmpty(prevCommit) || HoodieWriteStat.NULL_COMMIT.equals(prevCommit)) {
+        continue;
+      }
+      Option<HoodieBaseFile> prev;
+      try {
+        prev = fsView.getBaseFileOn(stat.getPartitionPath(), prevCommit, stat.getFileId());
+      } catch (Exception e) {
+        // Best-effort: a remote view 4xx/5xx, a stale view, or a replaced file group must not
+        // fail the commit. Drop the prev path for this stat and keep going.
+        log.warn("Could not resolve prev base file for fileId={} prevCommit={}; skipping",
+            stat.getFileId(), prevCommit, e);
+        continue;
+      }
+      if (!prev.isPresent()) {
+        continue;
+      }
+      String prevPath = prev.get().getPath();
+      String bootstrapPath = prev.get().getBootstrapBaseFile().isPresent()
+          ? prev.get().getBootstrapBaseFile().get().getPath()
+          : null;
+      out.put(stat.getFileId(), new PrevFilePaths(prevPath, bootstrapPath));
+    }
+    return out;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -20,10 +20,10 @@ package org.apache.hudi.client;
 
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.callback.HoodieClientInitCallback;
+import org.apache.hudi.callback.HoodieCommitCallbackFactory;
 import org.apache.hudi.callback.HoodieWriteCommitCallback;
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
-import org.apache.hudi.callback.util.HoodieCommitCallbackFactory;
 import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
@@ -523,9 +523,9 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
    */
   protected static Map<String, PrevFilePaths> resolvePrevFilePaths(List<HoodieWriteStat> stats,
                                                                    BaseFileOnlyView fsView) {
-    Map<String, PrevFilePaths> out = new HashMap<>();
+    Map<String, PrevFilePaths> pathsByFileId = new HashMap<>();
     if (stats == null || fsView == null) {
-      return out;
+      return pathsByFileId;
     }
     for (HoodieWriteStat stat : stats) {
       String prevCommit = stat.getPrevCommit();
@@ -549,8 +549,8 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       Option<BaseFile> bootstrapBaseFile = prevBaseFile.getBootstrapBaseFile();
       String prevPath = prevBaseFile.getPath();
       String bootstrapPath = bootstrapBaseFile.isPresent() ? bootstrapBaseFile.get().getPath() : null;
-      out.put(stat.getFileId(), new PrevFilePaths(prevPath, bootstrapPath));
+      pathsByFileId.put(stat.getFileId(), new PrevFilePaths(prevPath, bootstrapPath));
     }
-    return out;
+    return pathsByFileId;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -30,6 +30,7 @@ import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.client.transaction.TransactionUtils;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
@@ -502,7 +503,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       commitCallback.call(new HoodieWriteCommitCallbackMessage(
           commitTime, config.getTableName(), config.getBasePath(),
           stats, Option.of(commitActionType), extraMetadata,
-          resolvePrevFilePaths(stats, fsViewSupplier.get()),
+          () -> resolvePrevFilePaths(stats, fsViewSupplier.get()),
           Collections.emptyMap()));
     } catch (Exception e) {
       log.warn("HoodieWriteCommitCallback failed for commit {} ({}); ignoring",
@@ -544,10 +545,10 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       if (!prev.isPresent()) {
         continue;
       }
-      String prevPath = prev.get().getPath();
-      String bootstrapPath = prev.get().getBootstrapBaseFile().isPresent()
-          ? prev.get().getBootstrapBaseFile().get().getPath()
-          : null;
+      HoodieBaseFile prevBaseFile = prev.get();
+      Option<BaseFile> bootstrapBaseFile = prevBaseFile.getBootstrapBaseFile();
+      String prevPath = prevBaseFile.getPath();
+      String bootstrapPath = bootstrapBaseFile.isPresent() ? bootstrapBaseFile.get().getPath() : null;
       out.put(stat.getFileId(), new PrevFilePaths(prevPath, bootstrapPath));
     }
     return out;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -22,7 +22,6 @@ import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.callback.HoodieClientInitCallback;
 import org.apache.hudi.callback.HoodieCommitCallbackFactory;
 import org.apache.hudi.callback.HoodieWriteCommitCallback;
-import org.apache.hudi.callback.HoodieWriteCommitCallbackUtil;
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
@@ -501,7 +500,7 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       commitCallback.call(new HoodieWriteCommitCallbackMessage(
           commitTime, config.getTableName(), config.getBasePath(),
           stats, Option.of(commitActionType), extraMetadata,
-          () -> HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(stats, fsViewSupplier.get()),
+          fsViewSupplier,
           Collections.emptyMap()));
     } catch (Exception e) {
       log.warn("HoodieWriteCommitCallback failed for commit {} ({}); ignoring",

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieClient.java
@@ -22,16 +22,14 @@ import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.callback.HoodieClientInitCallback;
 import org.apache.hudi.callback.HoodieCommitCallbackFactory;
 import org.apache.hudi.callback.HoodieWriteCommitCallback;
+import org.apache.hudi.callback.HoodieWriteCommitCallbackUtil;
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
-import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
 import org.apache.hudi.client.embedded.EmbeddedTimelineServerHelper;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.heartbeat.HoodieHeartbeatClient;
 import org.apache.hudi.client.transaction.TransactionManager;
 import org.apache.hudi.client.transaction.TransactionUtils;
 import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.common.model.BaseFile;
-import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -503,54 +501,11 @@ public abstract class BaseHoodieClient implements Serializable, AutoCloseable {
       commitCallback.call(new HoodieWriteCommitCallbackMessage(
           commitTime, config.getTableName(), config.getBasePath(),
           stats, Option.of(commitActionType), extraMetadata,
-          () -> resolvePrevFilePaths(stats, fsViewSupplier.get()),
+          () -> HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(stats, fsViewSupplier.get()),
           Collections.emptyMap()));
     } catch (Exception e) {
       log.warn("HoodieWriteCommitCallback failed for commit {} ({}); ignoring",
           commitTime, commitActionType, e);
     }
-  }
-
-  /**
-   * Pre-resolve the previous base file (and bootstrap base file, if any) for every
-   * {@link HoodieWriteStat} that represents an update, using a populated
-   * {@link BaseFileOnlyView}. The lookup is O(1) per stat against the cached view, so
-   * this adds no I/O on top of what the writer already paid.
-   *
-   * <p>Used by {@link #fireCommitCallbackIfNecessary} call sites so the callback message ships
-   * actual file paths rather than forcing each callback impl to rebuild a
-   * {@code FileSystemView}.
-   */
-  protected static Map<String, PrevFilePaths> resolvePrevFilePaths(List<HoodieWriteStat> stats,
-                                                                   BaseFileOnlyView fsView) {
-    Map<String, PrevFilePaths> pathsByFileId = new HashMap<>();
-    if (stats == null || fsView == null) {
-      return pathsByFileId;
-    }
-    for (HoodieWriteStat stat : stats) {
-      String prevCommit = stat.getPrevCommit();
-      if (StringUtils.isNullOrEmpty(prevCommit) || HoodieWriteStat.NULL_COMMIT.equals(prevCommit)) {
-        continue;
-      }
-      Option<HoodieBaseFile> prev;
-      try {
-        prev = fsView.getBaseFileOn(stat.getPartitionPath(), prevCommit, stat.getFileId());
-      } catch (Exception e) {
-        // Best-effort: a remote view 4xx/5xx, a stale view, or a replaced file group must not
-        // fail the commit. Drop the prev path for this stat and keep going.
-        log.warn("Could not resolve prev base file for fileId={} prevCommit={}; skipping",
-            stat.getFileId(), prevCommit, e);
-        continue;
-      }
-      if (!prev.isPresent()) {
-        continue;
-      }
-      HoodieBaseFile prevBaseFile = prev.get();
-      Option<BaseFile> bootstrapBaseFile = prevBaseFile.getBootstrapBaseFile();
-      String prevPath = prevBaseFile.getPath();
-      String bootstrapPath = bootstrapBaseFile.isPresent() ? bootstrapBaseFile.get().getPath() : null;
-      pathsByFileId.put(stat.getFileId(), new PrevFilePaths(prevPath, bootstrapPath));
-    }
-    return pathsByFileId;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -424,6 +424,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
         );
       }
       log.info("Compacted successfully on commit {}", compactionCommitTime);
+      fireCommitCallback(compactionCommitTime, HoodieTimeline.COMMIT_ACTION,
+          writeStats, table.getBaseFileOnlyView(), Option.empty());
     } finally {
       if (config.getWriteConcurrencyMode().supportsMultiWriter()) {
         this.heartbeatClient.stop(compactionCommitTime);
@@ -640,6 +642,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       heartbeatClient.stop(clusteringCommitTime);
     }
     log.info("Clustering successfully on commit {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
+    fireCommitCallback(clusteringCommitTime, HoodieTimeline.REPLACE_COMMIT_ACTION,
+        writeStats, table.getBaseFileOnlyView(), Option.empty());
   }
 
   protected void runTableServicesInline(HoodieTable table, HoodieCommitMetadata metadata, Option<Map<String, String>> extraMetadata) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -424,8 +424,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
         );
       }
       log.info("Compacted successfully on commit {}", compactionCommitTime);
-      fireCommitCallback(compactionCommitTime, HoodieTimeline.COMMIT_ACTION,
-          writeStats, table.getBaseFileOnlyView(), Option.empty());
+      fireCommitCallbackIfNecessary(compactionCommitTime, HoodieTimeline.COMMIT_ACTION,
+          writeStats, table::getBaseFileOnlyView, Option.empty());
     } finally {
       if (config.getWriteConcurrencyMode().supportsMultiWriter()) {
         this.heartbeatClient.stop(compactionCommitTime);
@@ -642,8 +642,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       heartbeatClient.stop(clusteringCommitTime);
     }
     log.info("Clustering successfully on commit {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
-    fireCommitCallback(clusteringCommitTime, HoodieTimeline.REPLACE_COMMIT_ACTION,
-        writeStats, table.getBaseFileOnlyView(), Option.empty());
+    fireCommitCallbackIfNecessary(clusteringCommitTime, HoodieTimeline.REPLACE_COMMIT_ACTION,
+        writeStats, table::getBaseFileOnlyView, Option.empty());
   }
 
   protected void runTableServicesInline(HoodieTable table, HoodieCommitMetadata metadata, Option<Map<String, String>> extraMetadata) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -498,6 +498,8 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       );
     }
     log.info("Log Compacted successfully on commit {}", logCompactionCommitTime);
+    fireCommitCallbackIfNecessary(logCompactionCommitTime, HoodieTimeline.DELTA_COMMIT_ACTION,
+        writeStats, table::getBaseFileOnlyView, Option.empty());
   }
 
   /**
@@ -642,7 +644,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       heartbeatClient.stop(clusteringCommitTime);
     }
     log.info("Clustering successfully on commit {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
-    fireCommitCallbackIfNecessary(clusteringCommitTime, HoodieTimeline.REPLACE_COMMIT_ACTION,
+    fireCommitCallbackIfNecessary(clusteringCommitTime, clusteringInstant.getAction(),
         writeStats, table::getBaseFileOnlyView, Option.empty());
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -670,10 +670,10 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       metrics.updateTableServiceInstantMetrics(table.getActiveTimeline());
       // Fire write commit callback if a callback class is registered. postCommit() is reached
       // by both auto-commit and explicit-commit paths; compaction and clustering have their own
-      // explicit fireCommitCallback call sites in BaseHoodieTableServiceClient.
+      // explicit fireCommitCallbackIfNecessary call sites in BaseHoodieTableServiceClient.
       List<HoodieWriteStat> stats = metadata.getWriteStats();
-      fireCommitCallback(instantTime, commitActionType, stats,
-          table.getBaseFileOnlyView(), extraMetadata);
+      fireCommitCallbackIfNecessary(instantTime, commitActionType, stats,
+          table::getBaseFileOnlyView, extraMetadata);
     } finally {
       this.heartbeatClient.stop(instantTime);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -24,9 +24,6 @@ import org.apache.hudi.avro.model.HoodieIndexPlan;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
-import org.apache.hudi.callback.HoodieCommitCallbackFactory;
-import org.apache.hudi.callback.HoodieWriteCommitCallback;
-import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.callback.common.WriteStatusValidator;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.client.heartbeat.WriterHeartbeatUtils;
@@ -149,7 +146,6 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
   @Getter
   @Setter
   private transient WriteOperationType operationType;
-  private transient HoodieWriteCommitCallback commitCallback;
 
   protected transient Timer.Context writeTimer = null;
 
@@ -290,7 +286,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     boolean postCommitStatus = true;
     HoodieTimer postCommitTimer = HoodieTimer.start();
     try {
-      postCommit(table, metadata, instantTime, extraMetadata);
+      postCommit(table, metadata, instantTime, commitActionType, extraMetadata);
       mayBeCleanAndArchive(table);
       runTableServicesInline(table, metadata, extraMetadata);
     } catch (Exception e) {
@@ -306,15 +302,6 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
     }
 
     emitCommitMetrics(instantTime, metadata, commitActionType);
-
-    // callback if needed.
-    if (config.writeCommitCallbackOn()) {
-      if (null == commitCallback) {
-        commitCallback = HoodieCommitCallbackFactory.create(config);
-      }
-      commitCallback.call(new HoodieWriteCommitCallbackMessage(
-          instantTime, config.getTableName(), config.getBasePath(), tableWriteStats.getDataTableWriteStats(), Option.of(commitActionType), extraMetadata));
-    }
     return true;
   }
 
@@ -645,7 +632,8 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       boolean postCommitStatus = true;
       HoodieTimer postCommitTimer = HoodieTimer.start();
       try {
-        postCommit(hoodieTable, result.getCommitMetadata().get(), instantTime, Option.empty());
+        postCommit(hoodieTable, result.getCommitMetadata().get(), instantTime,
+            hoodieTable.getMetaClient().getCommitActionType(), Option.empty());
         mayBeCleanAndArchive(hoodieTable);
       } catch (Exception e) {
         postCommitStatus = false;
@@ -672,7 +660,7 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
    * @param instantTime   Instant Time
    * @param extraMetadata Additional Metadata passed by user
    */
-  protected void postCommit(HoodieTable table, HoodieCommitMetadata metadata, String instantTime, Option<Map<String, String>> extraMetadata) {
+  protected void postCommit(HoodieTable table, HoodieCommitMetadata metadata, String instantTime, String commitActionType, Option<Map<String, String>> extraMetadata) {
     try {
       context.setJobStatus(this.getClass().getSimpleName(), "Cleaning up marker directories for commit " + instantTime + " in table "
           + config.getTableName());
@@ -680,6 +668,12 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       WriteMarkersFactory.get(config.getMarkersType(), table, instantTime)
           .quietDeleteMarkerDir(context, config.getMarkersDeleteParallelism());
       metrics.updateTableServiceInstantMetrics(table.getActiveTimeline());
+      // Fire write commit callback if a callback class is registered. postCommit() is reached
+      // by both auto-commit and explicit-commit paths; compaction and clustering have their own
+      // explicit fireCommitCallback call sites in BaseHoodieTableServiceClient.
+      List<HoodieWriteStat> stats = metadata.getWriteStats();
+      fireCommitCallback(instantTime, commitActionType, stats,
+          table.getBaseFileOnlyView(), extraMetadata);
     } finally {
       this.heartbeatClient.stop(instantTime);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieWriteClient.java
@@ -632,8 +632,9 @@ public abstract class BaseHoodieWriteClient<T, I, K, O> extends BaseHoodieClient
       boolean postCommitStatus = true;
       HoodieTimer postCommitTimer = HoodieTimer.start();
       try {
+        String commitActionType = CommitUtils.getCommitActionType(operationType, hoodieTable.getMetaClient().getTableType());
         postCommit(hoodieTable, result.getCommitMetadata().get(), instantTime,
-            hoodieTable.getMetaClient().getCommitActionType(), Option.empty());
+            commitActionType, Option.empty());
         mayBeCleanAndArchive(hoodieTable);
       } catch (Exception e) {
         postCommitStatus = false;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/TestHoodieWriteCommitCallbackUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/TestHoodieWriteCommitCallbackUtil.java
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 
-package org.apache.hudi.client;
+package org.apache.hudi.callback;
 
-import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -32,8 +31,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,14 +42,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for the post-commit write-callback plumbing added to {@link BaseHoodieClient}:
- * {@link BaseHoodieClient#resolvePrevFilePaths(List, BaseFileOnlyView)} and the
- * {@link HoodieWriteCommitCallbackMessage} contract it feeds. {@code resolvePrevFilePaths}
+ * Unit tests for
+ * {@link HoodieWriteCommitCallbackUtil#resolvePrevFilePaths(List, BaseFileOnlyView)}, which
  * pre-resolves the previous base file (and bootstrap source, if any) for each updated file
  * group from a cached {@link BaseFileOnlyView}, so callback implementations receive the
  * read/write file pairing without rebuilding a file-system view.
  */
-public class TestBaseHoodieClient {
+public class TestHoodieWriteCommitCallbackUtil {
 
   private static final String PARTITION = "2024/01/01";
   private static final String PREV_COMMIT = "001";
@@ -68,9 +64,9 @@ public class TestBaseHoodieClient {
   @Test
   public void resolvePrevFilePathsReturnsEmptyForNullInputs() {
     BaseFileOnlyView view = mock(BaseFileOnlyView.class);
-    assertTrue(BaseHoodieClient.resolvePrevFilePaths(null, view).isEmpty(),
+    assertTrue(HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(null, view).isEmpty(),
         "null stats must yield an empty map");
-    assertTrue(BaseHoodieClient.resolvePrevFilePaths(
+    assertTrue(HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(
         Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), null).isEmpty(),
         "null file-system view must yield an empty map");
   }
@@ -83,7 +79,8 @@ public class TestBaseHoodieClient {
         stat("f-empty", PARTITION, ""),
         stat("f-nullcommit", PARTITION, HoodieWriteStat.NULL_COMMIT));
 
-    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(inserts, view);
+    Map<String, PrevFilePaths> resolved =
+        HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(inserts, view);
 
     assertTrue(resolved.isEmpty(), "inserts (no prevCommit) must not resolve a prev base file");
     // The view must not even be consulted for inserts.
@@ -97,7 +94,7 @@ public class TestBaseHoodieClient {
     HoodieBaseFile prevBase = new HoodieBaseFile("/tbl/" + PARTITION + "/f0_0-1-1_" + PREV_COMMIT + ".parquet");
     when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0")).thenReturn(Option.of(prevBase));
 
-    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
+    Map<String, PrevFilePaths> resolved = HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(
         Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
 
     assertEquals(1, resolved.size());
@@ -112,7 +109,7 @@ public class TestBaseHoodieClient {
     HoodieBaseFile prevBase = new HoodieBaseFile("/tbl/" + PARTITION + "/f0_0-1-1_" + PREV_COMMIT + ".parquet", bootstrap);
     when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0")).thenReturn(Option.of(prevBase));
 
-    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
+    Map<String, PrevFilePaths> resolved = HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(
         Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
 
     assertEquals(prevBase.getPath(), resolved.get("f0").getBaseFilePath());
@@ -125,7 +122,7 @@ public class TestBaseHoodieClient {
     BaseFileOnlyView view = mock(BaseFileOnlyView.class);
     when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0")).thenReturn(Option.empty());
 
-    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
+    Map<String, PrevFilePaths> resolved = HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(
         Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
 
     assertTrue(resolved.isEmpty(), "a missing prev base file must be skipped, not mapped to null");
@@ -139,61 +136,11 @@ public class TestBaseHoodieClient {
     HoodieBaseFile prevBase = new HoodieBaseFile("/tbl/" + PARTITION + "/ok_0-1-1_" + PREV_COMMIT + ".parquet");
     when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "ok")).thenReturn(Option.of(prevBase));
 
-    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
+    Map<String, PrevFilePaths> resolved = HoodieWriteCommitCallbackUtil.resolvePrevFilePaths(
         Arrays.asList(stat("boom", PARTITION, PREV_COMMIT), stat("ok", PARTITION, PREV_COMMIT)), view);
 
     // The failing file group is dropped; resolution continues for the rest (must not fail the commit).
     assertFalse(resolved.containsKey("boom"));
     assertEquals(prevBase.getPath(), resolved.get("ok").getBaseFilePath());
-  }
-
-  @Test
-  public void callbackMessageDefaultsCollectionsToEmpty() {
-    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
-        PREV_COMMIT, "table", "/base", Collections.emptyList());
-
-    assertFalse(message.getCommitActionType().isPresent());
-    assertFalse(message.getExtraMetadata().isPresent());
-    assertTrue(message.getPrevFilePaths().isEmpty(), "prevFilePaths must default to an empty map, never null");
-    assertTrue(message.getExtraContext().isEmpty(), "extraContext must default to an empty map, never null");
-  }
-
-  @Test
-  public void callbackMessageRetainsPrevFilePathsAndContext() {
-    Map<String, PrevFilePaths> prevFilePaths =
-        Collections.singletonMap("f0", new PrevFilePaths("/tbl/prev.parquet", null));
-    Map<String, String> extraContext = Collections.singletonMap("file_id", "f0");
-
-    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
-        PREV_COMMIT, "table", "/base", Collections.emptyList(),
-        Option.of("commit"), Option.empty(), () -> prevFilePaths, extraContext);
-
-    assertEquals("commit", message.getCommitActionType().get());
-    assertEquals(prevFilePaths, message.getPrevFilePaths());
-    assertEquals(extraContext, message.getExtraContext());
-  }
-
-  @Test
-  public void prevFilePathsAreResolvedLazilyAndMemoized() {
-    AtomicInteger resolveCalls = new AtomicInteger();
-    Map<String, PrevFilePaths> resolved =
-        Collections.singletonMap("f0", new PrevFilePaths("/tbl/prev.parquet", null));
-    Supplier<Map<String, PrevFilePaths>> supplier = () -> {
-      resolveCalls.incrementAndGet();
-      return resolved;
-    };
-
-    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
-        PREV_COMMIT, "table", "/base", Collections.emptyList(),
-        Option.empty(), Option.empty(), supplier, Collections.emptyMap());
-
-    // Constructing the message must not resolve prev file paths (no FileSystemView access).
-    assertEquals(0, resolveCalls.get(),
-        "prevFilePaths must not be resolved until a consumer reads them");
-
-    assertEquals(resolved, message.getPrevFilePaths());
-    // A second read must reuse the memoized result rather than resolve again.
-    assertEquals(resolved, message.getPrevFilePaths());
-    assertEquals(1, resolveCalls.get(), "prevFilePaths must be resolved at most once and memoized");
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/TestHoodieWriteCommitCallbackUtil.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/TestHoodieWriteCommitCallbackUtil.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -84,8 +85,7 @@ public class TestHoodieWriteCommitCallbackUtil {
 
     assertTrue(resolved.isEmpty(), "inserts (no prevCommit) must not resolve a prev base file");
     // The view must not even be consulted for inserts.
-    verify(view, never()).getBaseFileOn(org.mockito.ArgumentMatchers.anyString(),
-        org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+    verify(view, never()).getBaseFileOn(anyString(), anyString(), anyString());
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/common/TestHoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/common/TestHoodieWriteCommitCallbackMessage.java
@@ -18,7 +18,9 @@
 
 package org.apache.hudi.callback.common;
 
+import org.apache.hudi.callback.HoodieWriteCommitCallbackUtil;
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
+import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
@@ -49,8 +51,8 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for the {@link HoodieWriteCommitCallbackMessage} contract: default (never-null)
  * collections, lazy one-shot resolution of {@code prevFilePaths} off the supplied file-system
- * view, and the Java-serialization round trip (the paths are JVM-local derived state, so they
- * are not carried across, but the getter still must not blow up).
+ * view, and the Java-serialization round trip (the view cannot be shipped, so the resolved
+ * paths must be materialized at the boundary and carried across in its place).
  */
 public class TestHoodieWriteCommitCallbackMessage {
 
@@ -58,6 +60,7 @@ public class TestHoodieWriteCommitCallbackMessage {
   private static final String PARTITION = "2024/01/01";
   private static final String PREV_COMMIT = "001";
   private static final String PREV_PATH = "/tbl/" + PARTITION + "/f0_0-1-1_" + PREV_COMMIT + ".parquet";
+  private static final String BOOTSTRAP_PATH = "/bootstrap/source/f0.parquet";
 
   private static List<HoodieWriteStat> updateStat() {
     HoodieWriteStat writeStat = new HoodieWriteStat();
@@ -71,6 +74,13 @@ public class TestHoodieWriteCommitCallbackMessage {
     BaseFileOnlyView view = mock(BaseFileOnlyView.class);
     when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0"))
         .thenReturn(Option.of(new HoodieBaseFile(prevBaseFilePath)));
+    return view;
+  }
+
+  private static BaseFileOnlyView viewResolvingWithBootstrap(String prevBaseFilePath, String bootstrapPath) {
+    BaseFileOnlyView view = mock(BaseFileOnlyView.class);
+    when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0"))
+        .thenReturn(Option.of(new HoodieBaseFile(prevBaseFilePath, new BaseFile(bootstrapPath))));
     return view;
   }
 
@@ -135,20 +145,44 @@ public class TestHoodieWriteCommitCallbackMessage {
   }
 
   @Test
-  public void javaSerializationRoundTripsWithoutPrevFilePaths() throws IOException, ClassNotFoundException {
-    // The view supplier is not serializable: it must not be shipped, and the restored message
-    // must report no previous paths rather than fail.
+  public void javaSerializationResolvesAndPreservesPrevFilePaths() throws IOException, ClassNotFoundException {
+    AtomicInteger viewLookups = new AtomicInteger();
+    // The view supplier cannot be shipped, so writeObject has to materialize the paths first.
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        COMMIT_TIME, "table", "/base", updateStat(),
+        Option.of("commit"), Option.empty(),
+        () -> {
+          viewLookups.incrementAndGet();
+          return viewResolvingWithBootstrap(PREV_PATH, BOOTSTRAP_PATH);
+        },
+        Collections.emptyMap());
+
+    assertEquals(0, viewLookups.get(), "building the message must not touch the file-system view");
+
+    HoodieWriteCommitCallbackMessage roundTripped = serializeAndDeserialize(message);
+
+    assertEquals(1, viewLookups.get(), "serialization must force resolution exactly once");
+    assertEquals(COMMIT_TIME, roundTripped.getCommitTime());
+    assertEquals("commit", roundTripped.getCommitActionType().get());
+    assertEquals(1, roundTripped.getHoodieWriteStat().size());
+    assertEquals(PREV_PATH, roundTripped.getPrevFilePaths().get("f0").getBaseFilePath());
+    assertEquals(BOOTSTRAP_PATH, roundTripped.getPrevFilePaths().get("f0").getBootstrapBaseFilePath(),
+        "the bootstrap source path must survive the round trip too");
+  }
+
+  @Test
+  public void jsonPayloadExposesPrevFilePathsAndNotTheResolver() {
     HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
         COMMIT_TIME, "table", "/base", updateStat(),
         Option.of("commit"), Option.empty(), () -> viewResolving(PREV_PATH), Collections.emptyMap());
 
-    HoodieWriteCommitCallbackMessage roundTripped = serializeAndDeserialize(message);
+    // This is the payload the built-in HTTP/Kafka/Pulsar callbacks put on the wire.
+    String json = HoodieWriteCommitCallbackUtil.convertToJsonString(message);
 
-    assertEquals(COMMIT_TIME, roundTripped.getCommitTime());
-    assertEquals("commit", roundTripped.getCommitActionType().get());
-    assertEquals(1, roundTripped.getHoodieWriteStat().size());
-    assertTrue(roundTripped.getPrevFilePaths().isEmpty(),
-        "prevFilePaths is JVM-local derived state; a deserialized message must report an empty map, never null");
+    assertTrue(json.contains("\"prevFilePaths\""), "prevFilePaths must be part of the callback payload");
+    assertTrue(json.contains(PREV_PATH), "Jackson must see the resolved paths, not the lazy holder");
+    assertFalse(json.contains("prevFilePathsResolver"),
+        "the lazy resolver is an implementation detail and must never reach the payload");
   }
 
   private static HoodieWriteCommitCallbackMessage serializeAndDeserialize(

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/common/TestHoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/common/TestHoodieWriteCommitCallbackMessage.java
@@ -19,6 +19,9 @@
 package org.apache.hudi.callback.common;
 
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
 import org.apache.hudi.common.util.Option;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +32,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -36,15 +40,39 @@ import java.util.function.Supplier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link HoodieWriteCommitCallbackMessage} contract: default (never-null)
- * collections, lazy one-shot resolution of {@code prevFilePaths}, and the Java-serialization
- * round trip that has to carry the resolved paths across (the lazy holder itself is transient).
+ * collections, lazy one-shot resolution of {@code prevFilePaths} off the supplied file-system
+ * view, and the Java-serialization round trip (the paths are JVM-local derived state, so they
+ * are not carried across, but the getter still must not blow up).
  */
 public class TestHoodieWriteCommitCallbackMessage {
 
-  private static final String COMMIT_TIME = "001";
+  private static final String COMMIT_TIME = "002";
+  private static final String PARTITION = "2024/01/01";
+  private static final String PREV_COMMIT = "001";
+  private static final String PREV_PATH = "/tbl/" + PARTITION + "/f0_0-1-1_" + PREV_COMMIT + ".parquet";
+
+  private static List<HoodieWriteStat> updateStat() {
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId("f0");
+    writeStat.setPartitionPath(PARTITION);
+    writeStat.setPrevCommit(PREV_COMMIT);
+    return Collections.singletonList(writeStat);
+  }
+
+  private static BaseFileOnlyView viewResolving(String prevBaseFilePath) {
+    BaseFileOnlyView view = mock(BaseFileOnlyView.class);
+    when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0"))
+        .thenReturn(Option.of(new HoodieBaseFile(prevBaseFilePath)));
+    return view;
+  }
 
   @Test
   public void callbackMessageDefaultsCollectionsToEmpty() {
@@ -58,69 +86,69 @@ public class TestHoodieWriteCommitCallbackMessage {
   }
 
   @Test
-  public void callbackMessageRetainsPrevFilePathsAndContext() {
-    Map<String, PrevFilePaths> prevFilePaths =
-        Collections.singletonMap("f0", new PrevFilePaths("/tbl/prev.parquet", null));
+  public void callbackMessageResolvesPrevFilePathsFromViewAndRetainsContext() {
     Map<String, String> extraContext = Collections.singletonMap("file_id", "f0");
 
     HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
-        COMMIT_TIME, "table", "/base", Collections.emptyList(),
-        Option.of("commit"), Option.empty(), () -> prevFilePaths, extraContext);
+        COMMIT_TIME, "table", "/base", updateStat(),
+        Option.of("commit"), Option.empty(), () -> viewResolving(PREV_PATH), extraContext);
 
     assertEquals("commit", message.getCommitActionType().get());
-    assertEquals(prevFilePaths, message.getPrevFilePaths());
+    PrevFilePaths resolved = message.getPrevFilePaths().get("f0");
+    assertEquals(PREV_PATH, resolved.getBaseFilePath());
     assertEquals(extraContext, message.getExtraContext());
   }
 
   @Test
-  public void prevFilePathsAreResolvedLazilyAndMemoized() {
-    AtomicInteger resolveCalls = new AtomicInteger();
-    Map<String, PrevFilePaths> resolved =
-        Collections.singletonMap("f0", new PrevFilePaths("/tbl/prev.parquet", null));
-    Supplier<Map<String, PrevFilePaths>> supplier = () -> {
-      resolveCalls.incrementAndGet();
-      return resolved;
-    };
-
+  public void nullFileSystemViewSupplierYieldsEmptyPrevFilePaths() {
     HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
-        COMMIT_TIME, "table", "/base", Collections.emptyList(),
-        Option.empty(), Option.empty(), supplier, Collections.emptyMap());
+        COMMIT_TIME, "table", "/base", updateStat(),
+        Option.of("commit"), Option.empty(), null, Collections.emptyMap());
 
-    // Constructing the message must not resolve prev file paths (no FileSystemView access).
-    assertEquals(0, resolveCalls.get(),
-        "prevFilePaths must not be resolved until a consumer reads them");
-
-    assertEquals(resolved, message.getPrevFilePaths());
-    // A second read must reuse the memoized result rather than resolve again.
-    assertEquals(resolved, message.getPrevFilePaths());
-    assertEquals(1, resolveCalls.get(), "prevFilePaths must be resolved at most once and memoized");
+    assertTrue(message.getPrevFilePaths().isEmpty(),
+        "a message built without a file-system view must yield an empty map, never null");
   }
 
   @Test
-  public void prevFilePathsSurviveJavaSerialization() throws IOException, ClassNotFoundException {
-    Map<String, PrevFilePaths> prevFilePaths = Collections.singletonMap(
-        "f0", new PrevFilePaths("/tbl/prev.parquet", "/bootstrap/source/f0.parquet"));
-    // A supplier that is itself unserializable: writeObject must resolve it away, not ship it.
+  public void prevFilePathsAreResolvedLazilyAndMemoized() {
+    AtomicInteger viewLookups = new AtomicInteger();
+    BaseFileOnlyView view = viewResolving(PREV_PATH);
+    Supplier<BaseFileOnlyView> viewSupplier = () -> {
+      viewLookups.incrementAndGet();
+      return view;
+    };
+
     HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
-        COMMIT_TIME, "table", "/base", Collections.emptyList(),
-        Option.of("commit"), Option.empty(), () -> prevFilePaths, Collections.emptyMap());
+        COMMIT_TIME, "table", "/base", updateStat(),
+        Option.empty(), Option.empty(), viewSupplier, Collections.emptyMap());
+
+    // Constructing the message must not touch the file-system view.
+    assertEquals(0, viewLookups.get(),
+        "prevFilePaths must not be resolved until a consumer reads them");
+    verify(view, never()).getBaseFileOn(anyString(), anyString(), anyString());
+
+    assertEquals(PREV_PATH, message.getPrevFilePaths().get("f0").getBaseFilePath());
+    // A second read must reuse the memoized result rather than resolve again.
+    assertEquals(PREV_PATH, message.getPrevFilePaths().get("f0").getBaseFilePath());
+    assertEquals(1, viewLookups.get(), "prevFilePaths must be resolved at most once and memoized");
+    verify(view).getBaseFileOn(PARTITION, PREV_COMMIT, "f0");
+  }
+
+  @Test
+  public void javaSerializationRoundTripsWithoutPrevFilePaths() throws IOException, ClassNotFoundException {
+    // The view supplier is not serializable: it must not be shipped, and the restored message
+    // must report no previous paths rather than fail.
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        COMMIT_TIME, "table", "/base", updateStat(),
+        Option.of("commit"), Option.empty(), () -> viewResolving(PREV_PATH), Collections.emptyMap());
 
     HoodieWriteCommitCallbackMessage roundTripped = serializeAndDeserialize(message);
 
     assertEquals(COMMIT_TIME, roundTripped.getCommitTime());
-    assertEquals(1, roundTripped.getPrevFilePaths().size());
-    assertEquals("/tbl/prev.parquet", roundTripped.getPrevFilePaths().get("f0").getBaseFilePath());
-    assertEquals("/bootstrap/source/f0.parquet",
-        roundTripped.getPrevFilePaths().get("f0").getBootstrapBaseFilePath());
-  }
-
-  @Test
-  public void unresolvedPrevFilePathsSerializeAsEmpty() throws IOException, ClassNotFoundException {
-    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
-        COMMIT_TIME, "table", "/base", Collections.emptyList());
-
-    assertTrue(serializeAndDeserialize(message).getPrevFilePaths().isEmpty(),
-        "a message with nothing to resolve must round trip to an empty map, never null");
+    assertEquals("commit", roundTripped.getCommitActionType().get());
+    assertEquals(1, roundTripped.getHoodieWriteStat().size());
+    assertTrue(roundTripped.getPrevFilePaths().isEmpty(),
+        "prevFilePaths is JVM-local derived state; a deserialized message must report an empty map, never null");
   }
 
   private static HoodieWriteCommitCallbackMessage serializeAndDeserialize(

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/common/TestHoodieWriteCommitCallbackMessage.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/callback/common/TestHoodieWriteCommitCallbackMessage.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.callback.common;
+
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the {@link HoodieWriteCommitCallbackMessage} contract: default (never-null)
+ * collections, lazy one-shot resolution of {@code prevFilePaths}, and the Java-serialization
+ * round trip that has to carry the resolved paths across (the lazy holder itself is transient).
+ */
+public class TestHoodieWriteCommitCallbackMessage {
+
+  private static final String COMMIT_TIME = "001";
+
+  @Test
+  public void callbackMessageDefaultsCollectionsToEmpty() {
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        COMMIT_TIME, "table", "/base", Collections.emptyList());
+
+    assertFalse(message.getCommitActionType().isPresent());
+    assertFalse(message.getExtraMetadata().isPresent());
+    assertTrue(message.getPrevFilePaths().isEmpty(), "prevFilePaths must default to an empty map, never null");
+    assertTrue(message.getExtraContext().isEmpty(), "extraContext must default to an empty map, never null");
+  }
+
+  @Test
+  public void callbackMessageRetainsPrevFilePathsAndContext() {
+    Map<String, PrevFilePaths> prevFilePaths =
+        Collections.singletonMap("f0", new PrevFilePaths("/tbl/prev.parquet", null));
+    Map<String, String> extraContext = Collections.singletonMap("file_id", "f0");
+
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        COMMIT_TIME, "table", "/base", Collections.emptyList(),
+        Option.of("commit"), Option.empty(), () -> prevFilePaths, extraContext);
+
+    assertEquals("commit", message.getCommitActionType().get());
+    assertEquals(prevFilePaths, message.getPrevFilePaths());
+    assertEquals(extraContext, message.getExtraContext());
+  }
+
+  @Test
+  public void prevFilePathsAreResolvedLazilyAndMemoized() {
+    AtomicInteger resolveCalls = new AtomicInteger();
+    Map<String, PrevFilePaths> resolved =
+        Collections.singletonMap("f0", new PrevFilePaths("/tbl/prev.parquet", null));
+    Supplier<Map<String, PrevFilePaths>> supplier = () -> {
+      resolveCalls.incrementAndGet();
+      return resolved;
+    };
+
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        COMMIT_TIME, "table", "/base", Collections.emptyList(),
+        Option.empty(), Option.empty(), supplier, Collections.emptyMap());
+
+    // Constructing the message must not resolve prev file paths (no FileSystemView access).
+    assertEquals(0, resolveCalls.get(),
+        "prevFilePaths must not be resolved until a consumer reads them");
+
+    assertEquals(resolved, message.getPrevFilePaths());
+    // A second read must reuse the memoized result rather than resolve again.
+    assertEquals(resolved, message.getPrevFilePaths());
+    assertEquals(1, resolveCalls.get(), "prevFilePaths must be resolved at most once and memoized");
+  }
+
+  @Test
+  public void prevFilePathsSurviveJavaSerialization() throws IOException, ClassNotFoundException {
+    Map<String, PrevFilePaths> prevFilePaths = Collections.singletonMap(
+        "f0", new PrevFilePaths("/tbl/prev.parquet", "/bootstrap/source/f0.parquet"));
+    // A supplier that is itself unserializable: writeObject must resolve it away, not ship it.
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        COMMIT_TIME, "table", "/base", Collections.emptyList(),
+        Option.of("commit"), Option.empty(), () -> prevFilePaths, Collections.emptyMap());
+
+    HoodieWriteCommitCallbackMessage roundTripped = serializeAndDeserialize(message);
+
+    assertEquals(COMMIT_TIME, roundTripped.getCommitTime());
+    assertEquals(1, roundTripped.getPrevFilePaths().size());
+    assertEquals("/tbl/prev.parquet", roundTripped.getPrevFilePaths().get("f0").getBaseFilePath());
+    assertEquals("/bootstrap/source/f0.parquet",
+        roundTripped.getPrevFilePaths().get("f0").getBootstrapBaseFilePath());
+  }
+
+  @Test
+  public void unresolvedPrevFilePathsSerializeAsEmpty() throws IOException, ClassNotFoundException {
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        COMMIT_TIME, "table", "/base", Collections.emptyList());
+
+    assertTrue(serializeAndDeserialize(message).getPrevFilePaths().isEmpty(),
+        "a message with nothing to resolve must round trip to an empty map, never null");
+  }
+
+  private static HoodieWriteCommitCallbackMessage serializeAndDeserialize(
+      HoodieWriteCommitCallbackMessage message) throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(message);
+    }
+    try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (HoodieWriteCommitCallbackMessage) in.readObject();
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieClient.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client;
+
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage.PrevFilePaths;
+import org.apache.hudi.common.model.BaseFile;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.view.TableFileSystemView.BaseFileOnlyView;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the post-commit write-callback plumbing added to {@link BaseHoodieClient}:
+ * {@link BaseHoodieClient#resolvePrevFilePaths(List, BaseFileOnlyView)} and the
+ * {@link HoodieWriteCommitCallbackMessage} contract it feeds. {@code resolvePrevFilePaths}
+ * pre-resolves the previous base file (and bootstrap source, if any) for each updated file
+ * group from a cached {@link BaseFileOnlyView}, so callback implementations receive the
+ * read/write file pairing without rebuilding a file-system view.
+ */
+public class TestBaseHoodieClient {
+
+  private static final String PARTITION = "2024/01/01";
+  private static final String PREV_COMMIT = "001";
+
+  private static HoodieWriteStat stat(String fileId, String partitionPath, String prevCommit) {
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setFileId(fileId);
+    writeStat.setPartitionPath(partitionPath);
+    writeStat.setPrevCommit(prevCommit);
+    return writeStat;
+  }
+
+  @Test
+  public void resolvePrevFilePathsReturnsEmptyForNullInputs() {
+    BaseFileOnlyView view = mock(BaseFileOnlyView.class);
+    assertTrue(BaseHoodieClient.resolvePrevFilePaths(null, view).isEmpty(),
+        "null stats must yield an empty map");
+    assertTrue(BaseHoodieClient.resolvePrevFilePaths(
+        Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), null).isEmpty(),
+        "null file-system view must yield an empty map");
+  }
+
+  @Test
+  public void resolvePrevFilePathsSkipsStatsWithoutAPrevCommit() {
+    BaseFileOnlyView view = mock(BaseFileOnlyView.class);
+    List<HoodieWriteStat> inserts = Arrays.asList(
+        stat("f-null", PARTITION, null),
+        stat("f-empty", PARTITION, ""),
+        stat("f-nullcommit", PARTITION, HoodieWriteStat.NULL_COMMIT));
+
+    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(inserts, view);
+
+    assertTrue(resolved.isEmpty(), "inserts (no prevCommit) must not resolve a prev base file");
+    // The view must not even be consulted for inserts.
+    verify(view, never()).getBaseFileOn(org.mockito.ArgumentMatchers.anyString(),
+        org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  public void resolvePrevFilePathsResolvesUpdatePrevBaseFile() {
+    BaseFileOnlyView view = mock(BaseFileOnlyView.class);
+    HoodieBaseFile prevBase = new HoodieBaseFile("/tbl/" + PARTITION + "/f0_0-1-1_" + PREV_COMMIT + ".parquet");
+    when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0")).thenReturn(Option.of(prevBase));
+
+    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
+        Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
+
+    assertEquals(1, resolved.size());
+    assertEquals(prevBase.getPath(), resolved.get("f0").prevBaseFilePath);
+    assertNull(resolved.get("f0").bootstrapBaseFilePath, "non-bootstrap update has no bootstrap path");
+  }
+
+  @Test
+  public void resolvePrevFilePathsCapturesBootstrapBaseFile() {
+    BaseFileOnlyView view = mock(BaseFileOnlyView.class);
+    BaseFile bootstrap = new BaseFile("/bootstrap/source/f0.parquet");
+    HoodieBaseFile prevBase = new HoodieBaseFile("/tbl/" + PARTITION + "/f0_0-1-1_" + PREV_COMMIT + ".parquet", bootstrap);
+    when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0")).thenReturn(Option.of(prevBase));
+
+    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
+        Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
+
+    assertEquals(prevBase.getPath(), resolved.get("f0").prevBaseFilePath);
+    assertEquals(bootstrap.getPath(), resolved.get("f0").bootstrapBaseFilePath,
+        "bootstrap source path must be carried through for bootstrapped file groups");
+  }
+
+  @Test
+  public void resolvePrevFilePathsSkipsWhenBaseFileAbsent() {
+    BaseFileOnlyView view = mock(BaseFileOnlyView.class);
+    when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "f0")).thenReturn(Option.empty());
+
+    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
+        Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
+
+    assertTrue(resolved.isEmpty(), "a missing prev base file must be skipped, not mapped to null");
+  }
+
+  @Test
+  public void resolvePrevFilePathsIsBestEffortOnViewFailure() {
+    BaseFileOnlyView view = mock(BaseFileOnlyView.class);
+    when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "boom"))
+        .thenThrow(new RuntimeException("stale or remote view error"));
+    HoodieBaseFile prevBase = new HoodieBaseFile("/tbl/" + PARTITION + "/ok_0-1-1_" + PREV_COMMIT + ".parquet");
+    when(view.getBaseFileOn(PARTITION, PREV_COMMIT, "ok")).thenReturn(Option.of(prevBase));
+
+    Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
+        Arrays.asList(stat("boom", PARTITION, PREV_COMMIT), stat("ok", PARTITION, PREV_COMMIT)), view);
+
+    // The failing file group is dropped; resolution continues for the rest (must not fail the commit).
+    assertFalse(resolved.containsKey("boom"));
+    assertEquals(prevBase.getPath(), resolved.get("ok").prevBaseFilePath);
+  }
+
+  @Test
+  public void callbackMessageDefaultsCollectionsToEmpty() {
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        PREV_COMMIT, "table", "/base", Collections.emptyList());
+
+    assertFalse(message.getCommitActionType().isPresent());
+    assertFalse(message.getExtraMetadata().isPresent());
+    assertTrue(message.getPrevFilePaths().isEmpty(), "prevFilePaths must default to an empty map, never null");
+    assertTrue(message.getExtraContext().isEmpty(), "extraContext must default to an empty map, never null");
+  }
+
+  @Test
+  public void callbackMessageRetainsPrevFilePathsAndContext() {
+    Map<String, PrevFilePaths> prevFilePaths =
+        Collections.singletonMap("f0", new PrevFilePaths("/tbl/prev.parquet", null));
+    Map<String, String> extraContext = Collections.singletonMap("file_id", "f0");
+
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        PREV_COMMIT, "table", "/base", Collections.emptyList(),
+        Option.of("commit"), Option.empty(), prevFilePaths, extraContext);
+
+    assertEquals("commit", message.getCommitActionType().get());
+    assertEquals(prevFilePaths, message.getPrevFilePaths());
+    assertEquals(extraContext, message.getExtraContext());
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieClient.java
@@ -101,7 +101,7 @@ public class TestBaseHoodieClient {
         Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
 
     assertEquals(1, resolved.size());
-    assertEquals(prevBase.getPath(), resolved.get("f0").getPrevBaseFilePath());
+    assertEquals(prevBase.getPath(), resolved.get("f0").getBaseFilePath());
     assertNull(resolved.get("f0").getBootstrapBaseFilePath(), "non-bootstrap update has no bootstrap path");
   }
 
@@ -115,7 +115,7 @@ public class TestBaseHoodieClient {
     Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
         Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
 
-    assertEquals(prevBase.getPath(), resolved.get("f0").getPrevBaseFilePath());
+    assertEquals(prevBase.getPath(), resolved.get("f0").getBaseFilePath());
     assertEquals(bootstrap.getPath(), resolved.get("f0").getBootstrapBaseFilePath(),
         "bootstrap source path must be carried through for bootstrapped file groups");
   }
@@ -144,7 +144,7 @@ public class TestBaseHoodieClient {
 
     // The failing file group is dropped; resolution continues for the rest (must not fail the commit).
     assertFalse(resolved.containsKey("boom"));
-    assertEquals(prevBase.getPath(), resolved.get("ok").getPrevBaseFilePath());
+    assertEquals(prevBase.getPath(), resolved.get("ok").getBaseFilePath());
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieClient.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/TestBaseHoodieClient.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -99,8 +101,8 @@ public class TestBaseHoodieClient {
         Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
 
     assertEquals(1, resolved.size());
-    assertEquals(prevBase.getPath(), resolved.get("f0").prevBaseFilePath);
-    assertNull(resolved.get("f0").bootstrapBaseFilePath, "non-bootstrap update has no bootstrap path");
+    assertEquals(prevBase.getPath(), resolved.get("f0").getPrevBaseFilePath());
+    assertNull(resolved.get("f0").getBootstrapBaseFilePath(), "non-bootstrap update has no bootstrap path");
   }
 
   @Test
@@ -113,8 +115,8 @@ public class TestBaseHoodieClient {
     Map<String, PrevFilePaths> resolved = BaseHoodieClient.resolvePrevFilePaths(
         Collections.singletonList(stat("f0", PARTITION, PREV_COMMIT)), view);
 
-    assertEquals(prevBase.getPath(), resolved.get("f0").prevBaseFilePath);
-    assertEquals(bootstrap.getPath(), resolved.get("f0").bootstrapBaseFilePath,
+    assertEquals(prevBase.getPath(), resolved.get("f0").getPrevBaseFilePath());
+    assertEquals(bootstrap.getPath(), resolved.get("f0").getBootstrapBaseFilePath(),
         "bootstrap source path must be carried through for bootstrapped file groups");
   }
 
@@ -142,7 +144,7 @@ public class TestBaseHoodieClient {
 
     // The failing file group is dropped; resolution continues for the rest (must not fail the commit).
     assertFalse(resolved.containsKey("boom"));
-    assertEquals(prevBase.getPath(), resolved.get("ok").prevBaseFilePath);
+    assertEquals(prevBase.getPath(), resolved.get("ok").getPrevBaseFilePath());
   }
 
   @Test
@@ -164,10 +166,34 @@ public class TestBaseHoodieClient {
 
     HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
         PREV_COMMIT, "table", "/base", Collections.emptyList(),
-        Option.of("commit"), Option.empty(), prevFilePaths, extraContext);
+        Option.of("commit"), Option.empty(), () -> prevFilePaths, extraContext);
 
     assertEquals("commit", message.getCommitActionType().get());
     assertEquals(prevFilePaths, message.getPrevFilePaths());
     assertEquals(extraContext, message.getExtraContext());
+  }
+
+  @Test
+  public void prevFilePathsAreResolvedLazilyAndMemoized() {
+    AtomicInteger resolveCalls = new AtomicInteger();
+    Map<String, PrevFilePaths> resolved =
+        Collections.singletonMap("f0", new PrevFilePaths("/tbl/prev.parquet", null));
+    Supplier<Map<String, PrevFilePaths>> supplier = () -> {
+      resolveCalls.incrementAndGet();
+      return resolved;
+    };
+
+    HoodieWriteCommitCallbackMessage message = new HoodieWriteCommitCallbackMessage(
+        PREV_COMMIT, "table", "/base", Collections.emptyList(),
+        Option.empty(), Option.empty(), supplier, Collections.emptyMap());
+
+    // Constructing the message must not resolve prev file paths (no FileSystemView access).
+    assertEquals(0, resolveCalls.get(),
+        "prevFilePaths must not be resolved until a consumer reads them");
+
+    assertEquals(resolved, message.getPrevFilePaths());
+    // A second read must reuse the memoized result rather than resolve again.
+    assertEquals(resolved, message.getPrevFilePaths());
+    assertEquals(1, resolveCalls.get(), "prevFilePaths must be resolved at most once and memoized");
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -100,7 +100,6 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
         }
       }
       log.info("Compacted successfully on commit {}", compactionCommitTime);
-      log.info("Compacted successfully on commit " + compactionCommitTime);
       fireCommitCallbackIfNecessary(compactionCommitTime, HoodieActiveTimeline.COMMIT_ACTION,
           metadata.getWriteStats(), table::getBaseFileOnlyView, Option.empty());
     } finally {
@@ -163,7 +162,6 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       }
     }
     log.info("Clustering successfully on commit {}", clusteringCommitTime);
-    log.info("Clustering successfully on commit " + clusteringCommitTime);
     fireCommitCallbackIfNecessary(clusteringCommitTime, clusteringInstant.getAction(),
         writeStats, table::getBaseFileOnlyView, Option.empty());
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -100,6 +100,9 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
         }
       }
       log.info("Compacted successfully on commit {}", compactionCommitTime);
+      log.info("Compacted successfully on commit " + compactionCommitTime);
+      fireCommitCallbackIfNecessary(compactionCommitTime, HoodieActiveTimeline.COMMIT_ACTION,
+          metadata.getWriteStats(), table::getBaseFileOnlyView, Option.empty());
     } finally {
       if (config.getWriteConcurrencyMode().supportsMultiWriter()) {
         this.heartbeatClient.stop(compactionCommitTime);
@@ -160,6 +163,9 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       }
     }
     log.info("Clustering successfully on commit {}", clusteringCommitTime);
+    log.info("Clustering successfully on commit " + clusteringCommitTime);
+    fireCommitCallbackIfNecessary(clusteringCommitTime, clusteringInstant.getAction(),
+        writeStats, table::getBaseFileOnlyView, Option.empty());
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
@@ -18,14 +18,21 @@
 
 package org.apache.hudi.client.functional;
 
+import org.apache.hudi.callback.HoodieWriteCommitCallback;
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.client.HoodieJavaWriteClient;
 import org.apache.hudi.client.WriteClientTestUtils;
+import org.apache.hudi.client.clustering.plan.strategy.JavaSizeBasedClusteringPlanStrategy;
+import org.apache.hudi.client.clustering.run.strategy.JavaSortAndSizeExecutionStrategy;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestTable;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieClusteringConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieWriteCommitCallbackConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
@@ -37,12 +44,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.TIMELINE_FACTORY;
 import static org.apache.hudi.testutils.GenericRecordValidationTestUtils.assertDataInMORTable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTestHarness {
@@ -178,6 +189,116 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
   @Override
   protected HoodieTableType getTableType() {
     return HoodieTableType.MERGE_ON_READ;
+  }
+
+  @Test
+  public void testWriteCommitCallbackFiresOnCompaction() throws Exception {
+    RecordingCommitCallback.MESSAGES.clear();
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+        HoodieIndex.IndexType.INMEMORY)
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build())
+        .withCallbackConfig(HoodieWriteCommitCallbackConfig.newBuilder()
+            .writeCommitCallbackOn("true")
+            .withCallbackClass(RecordingCommitCallback.class.getName())
+            .build())
+        .build();
+    HoodieJavaWriteClient client = getHoodieWriteClient(config);
+
+    // Two delta commits through the auto-commit path.
+    String commitTime = WriteClientTestUtils.createNewInstantTime();
+    insertBatch(config, client, commitTime, "000", 100, HoodieJavaWriteClient::insert,
+        false, false, 100, 100, 1, Option.empty(), INSTANT_GENERATOR);
+    String prevCommit = commitTime;
+    commitTime = WriteClientTestUtils.createNewInstantTime();
+    updateBatch(config, client, commitTime, prevCommit,
+        Option.of(Arrays.asList(prevCommit)), "000", 50, HoodieJavaWriteClient::upsert,
+        false, false, 5, 100, 2, config.populateMetaFields(), INSTANT_GENERATOR);
+
+    // The callback must fire for the auto-committed delta commits with the deltacommit action.
+    assertTrue(RecordingCommitCallback.MESSAGES.stream().anyMatch(m ->
+            HoodieTimeline.DELTA_COMMIT_ACTION.equals(m.getCommitActionType().orElse(null))),
+        "callback must fire for delta commits");
+
+    // Schedule, execute and commit compaction.
+    Option<String> compactionTime = client.scheduleCompaction(Option.empty());
+    assertTrue(compactionTime.isPresent());
+    HoodieWriteMetadata writeMetadata = client.compact(compactionTime.get());
+    client.commitCompaction(compactionTime.get(), writeMetadata, Option.empty());
+    assertTrue(metaClient.reloadActiveTimeline().filterCompletedInstants().containsInstant(compactionTime.get()));
+
+    // The callback must fire exactly once for the compaction completion, reporting the completed
+    // timeline action (commit).
+    List<HoodieWriteCommitCallbackMessage> compactionMessages = RecordingCommitCallback.MESSAGES.stream()
+        .filter(m -> m.getCommitTime().equals(compactionTime.get()))
+        .collect(Collectors.toList());
+    assertEquals(1, compactionMessages.size(), "callback must fire once for the compaction commit");
+    assertEquals(HoodieTimeline.COMMIT_ACTION, compactionMessages.get(0).getCommitActionType().orElse(null));
+    assertNotNull(compactionMessages.get(0).getPrevFilePaths(), "prevFilePaths must never be null");
+  }
+
+  @Test
+  public void testWriteCommitCallbackFiresOnClustering() throws Exception {
+    RecordingCommitCallback.MESSAGES.clear();
+    HoodieClusteringConfig clusteringConfig = HoodieClusteringConfig.newBuilder()
+        .withClusteringMaxNumGroups(10)
+        .withClusteringSortColumns("_row_key")
+        .withClusteringTargetPartitions(0)
+        .withClusteringPlanStrategyClass(JavaSizeBasedClusteringPlanStrategy.class.getName())
+        .withClusteringExecutionStrategyClass(JavaSortAndSizeExecutionStrategy.class.getName())
+        .build();
+    HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
+        HoodieIndex.IndexType.INMEMORY)
+        .withClusteringConfig(clusteringConfig)
+        .withCallbackConfig(HoodieWriteCommitCallbackConfig.newBuilder()
+            .writeCommitCallbackOn("true")
+            .withCallbackClass(RecordingCommitCallback.class.getName())
+            .build())
+        .build();
+    HoodieJavaWriteClient client = getHoodieWriteClient(config);
+
+    // Two inserts create base-file groups that clustering can rewrite.
+    String commitTime = WriteClientTestUtils.createNewInstantTime();
+    insertBatch(config, client, commitTime, "000", 100, HoodieJavaWriteClient::insert,
+        false, false, 100, 100, 1, Option.empty(), INSTANT_GENERATOR);
+    commitTime = WriteClientTestUtils.createNewInstantTime();
+    insertBatch(config, client, commitTime, "001", 100, HoodieJavaWriteClient::insert,
+        false, false, 100, 200, 2, Option.empty(), INSTANT_GENERATOR);
+
+    // Schedule and execute clustering inline (shouldComplete = true completes the commit).
+    Option<String> clusteringTime = client.scheduleClustering(Option.empty());
+    assertTrue(clusteringTime.isPresent(), "expected a clustering plan to be scheduled");
+    client.cluster(clusteringTime.get(), true);
+    assertTrue(metaClient.reloadActiveTimeline().filterCompletedInstants().containsInstant(clusteringTime.get()));
+
+    // The callback must fire once for the clustering completion, reporting the action actually on
+    // the timeline (replacecommit for table version < 8, clustering for 8+).
+    List<HoodieWriteCommitCallbackMessage> clusteringMessages = RecordingCommitCallback.MESSAGES.stream()
+        .filter(m -> m.getCommitTime().equals(clusteringTime.get()))
+        .collect(Collectors.toList());
+    assertEquals(1, clusteringMessages.size(), "callback must fire once for the clustering commit");
+    String action = clusteringMessages.get(0).getCommitActionType().orElse(null);
+    assertTrue(HoodieTimeline.REPLACE_COMMIT_ACTION.equals(action) || HoodieTimeline.CLUSTERING_ACTION.equals(action),
+        "clustering callback must report the timeline action, got: " + action);
+  }
+
+  /**
+   * A recording {@link HoodieWriteCommitCallback} that captures every fired message so tests can
+   * assert the callback fires for table-service (compaction/clustering) commits with the expected
+   * action type. Loaded reflectively from the write config, so it needs a public
+   * {@code (HoodieWriteConfig)} constructor.
+   */
+  public static class RecordingCommitCallback implements HoodieWriteCommitCallback {
+
+    static final List<HoodieWriteCommitCallbackMessage> MESSAGES = new CopyOnWriteArrayList<>();
+
+    public RecordingCommitCallback(HoodieWriteConfig config) {
+      // config arg required for reflective instantiation
+    }
+
+    @Override
+    public void call(HoodieWriteCommitCallbackMessage callbackMessage) {
+      MESSAGES.add(callbackMessage);
+    }
   }
 
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Today the write commit callback (`HoodieWriteCommitCallback`) has two limitations that make it awkward for consumers that want to react to what a commit actually changed on storage:

1. The callback message doesn't say which files a commit replaced. `HoodieWriteCommitCallbackMessage` carries the write stats, but a consumer that wants to correlate each newly written base file with the existing base file (and bootstrap source) it superseded has to rebuild a `FileSystemView` itself, duplicating I/O the write client already paid for.
2. The callback only fires for data commits. Compaction, log compaction and clustering completions never invoke the callback, so consumers get no signal for table-service commits.

This PR addresses both, backward-compatibly (no breaking change to the public API).

### Summary and Changelog

What users gain: callback implementations now receive, per updated file group, the previous base file path (and bootstrap source path, if any), pre-resolved by the write client without rebuilding a file-system view — and resolved lazily, so a callback that never reads them pays nothing. The callback also fires on compaction, log compaction and clustering completions, not just data commits.

**`hudi-client-common`**

- `HoodieWriteCommitCallbackMessage`: two new optional fields.
  - `prevFilePaths`: `Map<fileId, PrevFilePaths>`, where `PrevFilePaths` holds `baseFilePath` and `bootstrapBaseFilePath`. The all-args ctor takes a `Supplier<BaseFileOnlyView>`; the message derives the map itself from the write stats it already holds, on the first `getPrevFilePaths()` call, and memoizes it — a consumer that never reads it triggers no `FileSystemView` access at all. The resolver is a `transient Lazy` that never leaks into JSON; the resolved map is an ordinary field, and `writeObject` materializes it at the last moment so Java serialization carries the paths across even though the view itself cannot be shipped.
  - `extraContext`: `Map<String,String>` for producer-attached context.

  Both default to empty maps (never null). The existing 4-arg and 6-arg ctors are preserved; the new all-args ctor takes the supplier.
- `BaseHoodieClient`: lifted the `commitCallback` field up from `BaseHoodieWriteClient` and added one shared method, `fireCommitCallbackIfNecessary(commitTime, commitActionType, stats, Supplier<BaseFileOnlyView>, extraMetadata)` — lazily constructs the callback from `hoodie.write.commit.callback.class`, builds the message and invokes it. The fs-view supplier is handed to the message untouched and is only dereferenced if a consumer actually reads `prevFilePaths`.
- `HoodieWriteCommitCallbackUtil`: new `resolvePrevFilePaths(stats, BaseFileOnlyView)` — for each update stat, looks up the previous base file via the cached view (`getBaseFileOn`), capturing its path and bootstrap path. Invoked from the message's lazy resolver, so it runs on demand and at most once per message.
- `BaseHoodieWriteClient`: removed the inline callback block from `commitStats`; the callback now fires from `postCommit`, which covers both the explicit-commit and the executor auto-commit path. `postCommit` takes the resolved `commitActionType`, and `postWrite` derives it via `CommitUtils.getCommitActionType(operationType, tableType)` so the message reports the action actually committed (e.g. `replacecommit` for `insert_overwrite`) rather than the table's base action type.
- `BaseHoodieTableServiceClient`: fires the callback on compaction (`commit`), log compaction (`deltacommit`, matching how a log-compaction instant completes) and clustering (`clusteringInstant.getAction()` — `clustering` on table version 8+, `replacecommit` on older versions).

**`hudi-flink-client`**

- `HoodieFlinkTableServiceClient` overrides `completeCompaction`/`completeClustering` without delegating to the base class, so both now fire the callback as well — otherwise Flink users would not see the new table-service callbacks.

**Tests**

- `TestHoodieWriteCommitCallbackUtil` (new, 6 unit tests): `resolvePrevFilePaths` — null inputs, inserts skipped, update resolution, bootstrap capture, skip when the base file is absent, and best-effort behaviour when the view throws.
- `TestHoodieWriteCommitCallbackMessage` (new, 6 unit tests): never-null collection defaults, resolution off the supplied view, empty map when no view is supplied, lazy resolution + memoization, the Java-serialization round trip (resolution forced at the boundary; base and bootstrap paths preserved), and the JSON payload shape (`prevFilePaths` present, the lazy resolver absent).
- `TestHoodieJavaClientOnMergeOnReadStorage` (2 new functional tests): `testWriteCommitCallbackFiresOnCompaction` / `testWriteCommitCallbackFiresOnClustering` register a recording callback and assert it fires with the expected action type. The Java client uses the base `completeCompaction`/`completeClustering`, so these exercise the real fire sites.

No code was copied from third-party sources.

### Impact

- **Public API**: `HoodieWriteCommitCallbackMessage` is `@PublicAPIClass(EVOLVING)`. The change is additive and backward compatible: existing ctors and getters are unchanged and the new fields default to empty maps. Existing callback implementations compile and run unchanged.
- **More callbacks**: the callback now also fires for (a) the executor auto-commit path and (b) compaction, log compaction and clustering completions — none of which fired before. Consumers that assumed the callback fired only for explicit data commits will see additional invocations.
- **Ordering**: the callback now fires inside `postCommit`, before `mayBeCleanAndArchive` and `runTableServicesInline`. Previously it fired after both, outside the post-commit try block. Two consequences:
  - A consumer can now receive a successful-commit callback even if post-commit cleanup (cleaning, archiving, inline table services) subsequently throws; previously the callback was skipped in that case when `canIgnorePostCommitFailures=false`. `commitStats` still propagates the exception exactly as before — only callback delivery changed. This is intentional: the commit is already durable at that point, so the callback correctly reports a committed write.
  - With inline table services enabled, the data-commit callback is now delivered *before* the callbacks for the inline compaction/clustering that commit triggers (previously the data-commit callback came last). This is the causal order, but consumers keying off arrival order should be aware of the change.
- **Callback payload**: the message now carries `metadata.getWriteStats()` (the reconciled commit metadata) rather than the raw `tableWriteStats.getDataTableWriteStats()` list. For MOR tables the two can differ — `MarkerBasedCommitMetadataResolver` adds write stats for missing log files during reconciliation, so the callback may now see a superset of what it saw before. This matches what is actually recorded on the timeline.
- **Performance**: prev-file resolution is lazy, and when triggered it reuses the already-cached fs view, so there is no additional I/O beyond what the writer already performed. Resolution and callback invocation are best-effort and never fail the write.

### Risk Level

low

Changes are confined to the callback path in `hudi-client-common` plus the two Flink table-service overrides. All callback and resolution failures are caught and logged, so a misbehaving callback or a stale/remote view cannot fail a commit. The behavior changes listed above (extra invocations, ordering, reconciled stats) are the intended semantics and are called out explicitly for consumers.

- Added unit tests (`TestHoodieWriteCommitCallbackUtil`, `TestHoodieWriteCommitCallbackMessage`) and functional tests covering the compaction and clustering fire sites.
- Repo-wide check confirms all existing `HoodieWriteCommitCallbackMessage` ctor/getter call sites remain compatible.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable