### PR TITLE
fix(flink): fix the mor small file record size estimation

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
@@ -86,6 +86,11 @@ public class DeltaWriteProfile extends WriteProfile {
     return smallFileLocations;
   }
 
+  @Override
+  protected double fileSizeParquetCompressionRatio() {
+    return config.getLogFileToParquetCompressionRatio();
+  }
+
   protected SyncableFileSystemView getFileSystemView() {
     return (SyncableFileSystemView) getTable().getSliceView();
   }
@@ -98,5 +103,4 @@ public class DeltaWriteProfile extends WriteProfile {
     long totalSize = getTotalFileSize(fileSlice);
     return totalSize < config.getParquetMaxFileSize();
   }
-
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
@@ -29,6 +29,8 @@ import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.action.commit.SmallFile;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,7 +41,9 @@ import java.util.stream.Collectors;
  *
  * <p>Note: assumes the index can always index log files for Flink write.
  */
+@Slf4j
 public class DeltaWriteProfile extends WriteProfile {
+
   public DeltaWriteProfile(HoodieWriteConfig config, HoodieFlinkEngineContext context) {
     super(config, context);
   }
@@ -88,8 +92,25 @@ public class DeltaWriteProfile extends WriteProfile {
   }
 
   @Override
-  protected double fileSizeCalibrationRatio() {
-    return logFileToParquetCompressionRatio();
+  protected long averageBytesPerRecord() {
+    long avgSize = config.getCopyOnWriteRecordSizeEstimate();
+    HoodieTimeline commitTimeline = metaClient.getCommitTimeline().filterCompletedInstants();
+    if (!commitTimeline.empty()) {
+      long sizeFromCommitMetadata = calculateRecordSizeThroughCommitMetadata(commitTimeline, 1.0D);
+      if (sizeFromCommitMetadata > 0) {
+        avgSize = sizeFromCommitMetadata;
+      }
+    } else {
+      HoodieTimeline deltaCommitTimeline = metaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants();
+      if (!deltaCommitTimeline.empty()) {
+        long sizeFromCommitMetadata = calculateRecordSizeThroughCommitMetadata(deltaCommitTimeline, logFileToParquetCompressionRatio());
+        if (sizeFromCommitMetadata > 0) {
+          avgSize = sizeFromCommitMetadata;
+        }
+      }
+    }
+    log.info("Refresh average bytes per record => " + avgSize);
+    return avgSize;
   }
 
   protected SyncableFileSystemView getFileSystemView() {
@@ -106,9 +127,10 @@ public class DeltaWriteProfile extends WriteProfile {
   }
 
   private double logFileToParquetCompressionRatio() {
-    return config.getLogDataBlockFormat()
-        .map(logBlockType -> logBlockType == HoodieLogBlock.HoodieLogBlockType.PARQUET_DATA_BLOCK
-            ? 1D : config.getLogFileToParquetCompressionRatio())
-        .orElse(config.getLogFileToParquetCompressionRatio());
+    if (config.getLogDataBlockFormat().isPresent()
+        && config.getLogDataBlockFormat().get() == HoodieLogBlock.HoodieLogBlockType.PARQUET_DATA_BLOCK) {
+      return 1D;
+    }
+    return config.getLogFileToParquetCompressionRatio();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
@@ -22,6 +22,7 @@ import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.SyncableFileSystemView;
@@ -87,8 +88,8 @@ public class DeltaWriteProfile extends WriteProfile {
   }
 
   @Override
-  protected double fileSizeParquetCompressionRatio() {
-    return config.getLogFileToParquetCompressionRatio();
+  protected double fileSizeCalibrationRatio() {
+    return logFileToParquetCompressionRatio();
   }
 
   protected SyncableFileSystemView getFileSystemView() {
@@ -96,11 +97,18 @@ public class DeltaWriteProfile extends WriteProfile {
   }
 
   private long getTotalFileSize(FileSlice fileSlice) {
-    return fileSlice.getTotalFileSizeAsParquetFormat(config.getLogFileToParquetCompressionRatio());
+    return fileSlice.getTotalFileSizeAsParquetFormat(logFileToParquetCompressionRatio());
   }
 
   private boolean isSmallFile(FileSlice fileSlice) {
     long totalSize = getTotalFileSize(fileSlice);
     return totalSize < config.getParquetMaxFileSize();
+  }
+
+  private double logFileToParquetCompressionRatio() {
+    return config.getLogDataBlockFormat()
+        .map(logBlockType -> logBlockType == HoodieLogBlock.HoodieLogBlockType.PARQUET_DATA_BLOCK
+            ? 1D : config.getLogFileToParquetCompressionRatio())
+        .orElse(config.getLogFileToParquetCompressionRatio());
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
@@ -154,13 +154,17 @@ public class WriteProfile {
         long totalBytesWritten = commitMetadata.fetchTotalBytesWritten();
         long totalRecordsWritten = commitMetadata.fetchTotalRecordsWritten();
         if (totalBytesWritten > fileSizeThreshold && totalRecordsWritten > 0) {
-          avgSize = (long) Math.ceil((1.0 * totalBytesWritten) / totalRecordsWritten);
+          avgSize = (long) Math.ceil((fileSizeParquetCompressionRatio() * totalBytesWritten) / totalRecordsWritten);
           break;
         }
       }
     }
     log.info("Refresh average bytes per record => " + avgSize);
     return avgSize;
+  }
+
+  protected double fileSizeParquetCompressionRatio() {
+    return 1;
   }
 
   /**
@@ -228,10 +232,8 @@ public class WriteProfile {
 
   private void recordProfile() {
     this.avgSize = averageBytesPerRecord();
-    if (config.shouldAllowMultiWriteOnSameInstant()) {
-      this.recordsPerBucket = config.getParquetMaxFileSize() / avgSize;
-      log.info("Refresh insert records per bucket => " + recordsPerBucket);
-    }
+    this.recordsPerBucket = config.getParquetMaxFileSize() / avgSize;
+    log.info("Refresh insert records per bucket => " + recordsPerBucket);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
@@ -117,7 +117,6 @@ public class WriteProfile {
     this.context = context;
     this.basePath = new Path(config.getBasePath());
     this.smallFilesMap = new HashMap<>();
-    this.recordsPerBucket = config.getCopyOnWriteInsertSplitSize();
     this.metaClient = StreamerUtil.createMetaClient(
         config.getBasePath(), context.getStorageConf().unwrapAs(Configuration.class));
     this.metadataCache = new HashMap<>();
@@ -134,37 +133,44 @@ public class WriteProfile {
    * Obtains the average record size based on records written during previous commits. Used for estimating how many
    * records pack into one file.
    */
-  private long averageBytesPerRecord() {
+  protected long averageBytesPerRecord() {
     long avgSize = config.getCopyOnWriteRecordSizeEstimate();
-    long fileSizeThreshold = (long) (config.getRecordSizeEstimationThreshold() * config.getParquetSmallFileLimit());
-    HoodieTimeline commitTimeline = metaClient.getCommitsTimeline().filterCompletedInstants();
+    HoodieTimeline commitTimeline = metaClient.getCommitTimeline().filterCompletedInstants();
     if (!commitTimeline.empty()) {
-      // Go over the reverse ordered commits to get a more recent estimate of average record size.
-      Iterator<HoodieInstant> instants = commitTimeline.getReverseOrderedInstants().iterator();
-      while (instants.hasNext()) {
-        HoodieInstant instant = instants.next();
-        final HoodieCommitMetadata commitMetadata =
-            this.metadataCache.computeIfAbsent(
-                instant.requestedTime(),
-                k -> WriteProfiles.getCommitMetadataSafely(config.getTableName(), basePath, instant, commitTimeline)
-                    .orElse(null));
-        if (commitMetadata == null) {
-          continue;
-        }
-        long totalBytesWritten = commitMetadata.fetchTotalBytesWritten();
-        long totalRecordsWritten = commitMetadata.fetchTotalRecordsWritten();
-        if (totalBytesWritten > fileSizeThreshold && totalRecordsWritten > 0) {
-          avgSize = (long) Math.ceil((fileSizeCalibrationRatio() * totalBytesWritten) / totalRecordsWritten);
-          break;
-        }
+      long sizeFromCommitMetadata = calculateRecordSizeThroughCommitMetadata(commitTimeline, 1.0D);
+      if (sizeFromCommitMetadata > 0) {
+        avgSize = sizeFromCommitMetadata;
       }
     }
     log.info("Refresh average bytes per record => " + avgSize);
     return avgSize;
   }
 
-  protected double fileSizeCalibrationRatio() {
-    return 1D;
+  protected long calculateRecordSizeThroughCommitMetadata(HoodieTimeline commitTimeline, double fileSizeCalibrationRatio) {
+    long fileSizeThreshold = recordSizeEstimationFileSizeThreshold();
+    // Go over the reverse ordered commits to get a more recent estimate of average record size.
+    Iterator<HoodieInstant> instants = commitTimeline.getReverseOrderedInstants().iterator();
+    while (instants.hasNext()) {
+      HoodieInstant instant = instants.next();
+      final HoodieCommitMetadata commitMetadata =
+          this.metadataCache.computeIfAbsent(
+              instant.requestedTime(),
+              k -> WriteProfiles.getCommitMetadataSafely(config.getTableName(), basePath, instant, commitTimeline)
+                  .orElse(null));
+      if (commitMetadata == null) {
+        continue;
+      }
+      long totalBytesWritten = commitMetadata.fetchTotalBytesWritten();
+      long totalRecordsWritten = commitMetadata.fetchTotalRecordsWritten();
+      if (totalBytesWritten > fileSizeThreshold && totalRecordsWritten > 0) {
+        return (long) Math.ceil((fileSizeCalibrationRatio * totalBytesWritten) / totalRecordsWritten);
+      }
+    }
+    return -1L;
+  }
+
+  private long recordSizeEstimationFileSizeThreshold() {
+    return (long) (0.1D * config.getParquetSmallFileLimit());
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
@@ -154,7 +154,7 @@ public class WriteProfile {
         long totalBytesWritten = commitMetadata.fetchTotalBytesWritten();
         long totalRecordsWritten = commitMetadata.fetchTotalRecordsWritten();
         if (totalBytesWritten > fileSizeThreshold && totalRecordsWritten > 0) {
-          avgSize = (long) Math.ceil((fileSizeParquetCompressionRatio() * totalBytesWritten) / totalRecordsWritten);
+          avgSize = (long) Math.ceil((fileSizeCalibrationRatio() * totalBytesWritten) / totalRecordsWritten);
           break;
         }
       }
@@ -163,8 +163,8 @@ public class WriteProfile {
     return avgSize;
   }
 
-  protected double fileSizeParquetCompressionRatio() {
-    return 1;
+  protected double fileSizeCalibrationRatio() {
+    return 1D;
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketAssigner.java
@@ -424,6 +424,27 @@ public class TestBucketAssigner {
   }
 
   @Test
+  public void testWriteProfileRecordsPerBucketUsesProfiledRecordSizeWithSmallEstimationThreshold() throws Exception {
+    conf.set(FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE, 1);
+    conf.setString(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(1024 * 1024));
+    conf.setString(HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key(), "1");
+    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+
+    writeConfig = FlinkWriteClients.getHoodieClientConfig(conf);
+    WriteProfile writeProfile = new WriteProfile(writeConfig, context);
+    String latestInstant = getLastCompleteInstant(writeProfile);
+    HoodieCommitMetadata commitMetadata = writeProfile.getMetadataCache().get(latestInstant);
+    assertNotNull(commitMetadata);
+    long expectedAvgSize = (long) Math.ceil(
+        1.0 * commitMetadata.fetchTotalBytesWritten() / commitMetadata.fetchTotalRecordsWritten());
+
+    assertThat("Average record size should use commit metadata when it is large enough relative to small file limit",
+        writeProfile.getAvgSize(), is(expectedAvgSize));
+    assertThat("Records per bucket should use the profiled record size",
+        writeProfile.getRecordsPerBucket(), is(writeConfig.getParquetMaxFileSize() / expectedAvgSize));
+  }
+
+  @Test
   public void testDeltaWriteProfileRecordsPerBucketUsesCompressionRatio() throws Exception {
     File morPath = new File(tempFile, "mor");
     Configuration morConf = TestConfigurations.getDefaultConf(morPath.getAbsolutePath());

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketAssigner.java
@@ -453,6 +453,37 @@ public class TestBucketAssigner {
         writeProfile.getRecordsPerBucket(), is(morWriteConfig.getParquetMaxFileSize() / expectedAvgSize));
   }
 
+  @Test
+  public void testDeltaWriteProfileRecordsPerBucketSkipsCompressionRatioForParquetLogBlocks() throws Exception {
+    File morPath = new File(tempFile, "mor_parquet_logs");
+    Configuration morConf = TestConfigurations.getDefaultConf(morPath.getAbsolutePath());
+    morConf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.MERGE_ON_READ.name());
+    morConf.set(FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE, 1);
+    morConf.setString(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), "1024");
+    morConf.setString(HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key(), "1");
+    morConf.setString(HoodieStorageConfig.LOGFILE_TO_PARQUET_COMPRESSION_RATIO_FRACTION.key(), "0.5");
+    morConf.setString(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "parquet");
+    StreamerUtil.initTableIfNotExists(morConf);
+    TestData.writeData(TestData.DATA_SET_INSERT, morConf);
+
+    HoodieWriteConfig morWriteConfig = FlinkWriteClients.getHoodieClientConfig(morConf);
+    HoodieFlinkEngineContext morContext = new HoodieFlinkEngineContext(
+        HadoopFSUtils.getStorageConf(HadoopConfigurations.getHadoopConf(morConf)),
+        new FlinkTaskContextSupplier(null));
+
+    DeltaWriteProfile writeProfile = new DeltaWriteProfile(morWriteConfig, morContext);
+    String latestInstant = getLastCompleteInstant(writeProfile);
+    HoodieCommitMetadata commitMetadata = writeProfile.getMetadataCache().get(latestInstant);
+    assertNotNull(commitMetadata);
+    long expectedAvgSize = (long) Math.ceil(
+        1.0 * commitMetadata.fetchTotalBytesWritten() / commitMetadata.fetchTotalRecordsWritten());
+
+    assertThat("Average record size from parquet log blocks should not be corrected again",
+        writeProfile.getAvgSize(), is(expectedAvgSize));
+    assertThat("Records per bucket should use the uncorrected parquet log block average record size",
+        writeProfile.getRecordsPerBucket(), is(morWriteConfig.getParquetMaxFileSize() / expectedAvgSize));
+  }
+
   private static String getLastCompleteInstant(WriteProfile profile) {
     return StreamerUtil.getLastCompletedInstant(profile.getMetaClient());
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketAssigner.java
@@ -19,11 +19,16 @@
 package org.apache.hudi.sink.partitioner;
 
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
+import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecordLocation;
+import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.sink.partitioner.profile.DeltaWriteProfile;
 import org.apache.hudi.sink.partitioner.profile.WriteProfile;
 import org.apache.hudi.table.action.commit.BucketInfo;
 import org.apache.hudi.table.action.commit.BucketType;
@@ -151,7 +156,8 @@ public class TestBucketAssigner {
 
   @Test
   public void testInsertOverBucketAssigned() {
-    conf.setString(HoodieCompactionConfig.COPY_ON_WRITE_INSERT_SPLIT_SIZE.key(), "2");
+    conf.set(FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE, 1);
+    conf.setString(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(512 * 1024));
     writeConfig = FlinkWriteClients.getHoodieClientConfig(conf);
 
     MockBucketAssigner mockBucketAssigner = new MockBucketAssigner(context, writeConfig);
@@ -400,6 +406,51 @@ public class TestBucketAssigner {
     writeProfile.getSmallFiles("par1");
     assertThat("The metadata should be reused",
         writeProfile.getMetadataCache().size(), is(3));
+  }
+
+  @Test
+  public void testWriteProfileRecordsPerBucketUsesProfiledRecordSize() {
+    conf.set(FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE, 1);
+    conf.setString(HoodieCompactionConfig.COPY_ON_WRITE_INSERT_SPLIT_SIZE.key(), "2");
+    conf.setString(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), "1024");
+    writeConfig = FlinkWriteClients.getHoodieClientConfig(conf);
+
+    WriteProfile writeProfile = new WriteProfile(writeConfig, context);
+
+    assertThat("Average record size should use the configured estimate for an empty table",
+        writeProfile.getAvgSize(), is(1024L));
+    assertThat("Records per bucket should be derived from the max parquet file size",
+        writeProfile.getRecordsPerBucket(), is(1024L));
+  }
+
+  @Test
+  public void testDeltaWriteProfileRecordsPerBucketUsesCompressionRatio() throws Exception {
+    File morPath = new File(tempFile, "mor");
+    Configuration morConf = TestConfigurations.getDefaultConf(morPath.getAbsolutePath());
+    morConf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.MERGE_ON_READ.name());
+    morConf.set(FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE, 1);
+    morConf.setString(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), "1024");
+    morConf.setString(HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key(), "1");
+    morConf.setString(HoodieStorageConfig.LOGFILE_TO_PARQUET_COMPRESSION_RATIO_FRACTION.key(), "0.5");
+    StreamerUtil.initTableIfNotExists(morConf);
+    TestData.writeData(TestData.DATA_SET_INSERT, morConf);
+
+    HoodieWriteConfig morWriteConfig = FlinkWriteClients.getHoodieClientConfig(morConf);
+    HoodieFlinkEngineContext morContext = new HoodieFlinkEngineContext(
+        HadoopFSUtils.getStorageConf(HadoopConfigurations.getHadoopConf(morConf)),
+        new FlinkTaskContextSupplier(null));
+
+    DeltaWriteProfile writeProfile = new DeltaWriteProfile(morWriteConfig, morContext);
+    String latestInstant = getLastCompleteInstant(writeProfile);
+    HoodieCommitMetadata commitMetadata = writeProfile.getMetadataCache().get(latestInstant);
+    assertNotNull(commitMetadata);
+    long expectedAvgSize = (long) Math.ceil(
+        0.5 * commitMetadata.fetchTotalBytesWritten() / commitMetadata.fetchTotalRecordsWritten());
+
+    assertThat("Average record size from commit metadata should be corrected for MOR log-to-parquet compression",
+        writeProfile.getAvgSize(), is(expectedAvgSize));
+    assertThat("Records per bucket should use the corrected MOR average record size",
+        writeProfile.getRecordsPerBucket(), is(morWriteConfig.getParquetMaxFileSize() / expectedAvgSize));
   }
 
   private static String getLastCompleteInstant(WriteProfile profile) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestDynamicBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestDynamicBucketStreamWrite.java
@@ -166,8 +166,12 @@ public class ITTestDynamicBucketStreamWrite {
   @ParameterizedTest
   @EnumSource(value = HoodieTableType.class)
   void testBucketScalesUpWithContinuousWrites(HoodieTableType tableType) {
+    Map<String, String> smallBucketOptions = Map.of(
+        HoodieCompactionConfig.COPY_ON_WRITE_INSERT_SPLIT_SIZE.key(), "1",
+        FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE.key(), "1",
+        HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(1024 * 1024));
     streamTableEnv.executeSql(getTableDDL(
-        "t1", tableType, Collections.singletonMap(HoodieCompactionConfig.COPY_ON_WRITE_INSERT_SPLIT_SIZE.key(), "1"), true));
+        "t1", tableType, smallBucketOptions, true));
 
     execInsertSql(streamTableEnv, "insert into t1 values\n"
         + "('id1','Danny',23,TIMESTAMP '1970-01-01 00:00:01','par_scale'),\n"

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestDynamicBucketStreamWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestDynamicBucketStreamWrite.java
@@ -169,6 +169,7 @@ public class ITTestDynamicBucketStreamWrite {
     Map<String, String> smallBucketOptions = Map.of(
         HoodieCompactionConfig.COPY_ON_WRITE_INSERT_SPLIT_SIZE.key(), "1",
         FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE.key(), "1",
+        HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key(), "1",
         HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), String.valueOf(1024 * 1024));
     streamTableEnv.executeSql(getTableDDL(
         "t1", tableType, smallBucketOptions, true));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink `MERGE_ON_READ` write profiling estimates how many records can fit into small-file and insert buckets based on average record size. For MOR tables, commit metadata may include log-file bytes, which need to be normalized to estimated parquet size using `hoodie.logfile.to.parquet.compression.ratio`. Without that adjustment, Flink can overestimate record size and under-fill buckets.

The write profile also only refreshed `recordsPerBucket` from profiled average record size when multi-write-on-same-instant was enabled. That made normal writes continue using the configured split-size fallback instead of the current profile-derived capacity.

### Summary and Changelog

This PR updates Flink write profiling so MOR average record size uses the existing log-to-parquet compression ratio, and insert bucket capacity is refreshed from profiled record size consistently.

- Added a `fileSizeParquetCompressionRatio()` hook in `WriteProfile`, defaulting to `1`.
- Overrode the hook in `DeltaWriteProfile` to use `config.getLogFileToParquetCompressionRatio()`.
- Applied the ratio when computing average bytes per record from commit metadata.
- Refreshed `recordsPerBucket` from `parquetMaxFileSize / avgSize` unconditionally during profile construction/reload.
- Updated `TestBucketAssigner` to cover profile-derived bucket sizing and MOR commit-metadata sizing with compression ratio.

### Impact

This affects Flink sink bucket assignment for Hudi write profiles, especially `MERGE_ON_READ` tables. MOR small-file and insert bucket sizing should better reflect estimated compacted parquet size.

There is no public API change, storage format change, config rename, or compatibility break. Existing configuration is reused.

### Risk Level

medium

The change is in Flink write-path sizing logic and can affect how records are assigned to insert buckets and small files. The risk is mitigated by targeted coverage in `TestBucketAssigner`, including a real MOR write commit and validation that average record size and records-per-bucket use the compression-adjusted metadata estimate.

Validated with:

```bash
mvn -pl hudi-flink-datasource/hudi-flink -am -Dtest=TestBucketAssigner -Dsurefire.failIfNoSpecifiedTests=false test
```

### Documentation Update

none

- No new config, API, or user-facing option is introduced.
- This PR corrects internal use of the existing MOR sizing configuration.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
