### PR TITLE
perf(flink): Parse bucket index hash-field config once instead of per ...

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
@@ -561,6 +561,13 @@ public class OptionsResolver {
   }
 
   /**
+   * Returns the index key fields as a list, parsing the comma-separated config value once.
+   */
+  public static List<String> getIndexKeyFields(Configuration conf) {
+    return KeyGenUtils.getIndexKeyFields(getIndexKeyField(conf));
+  }
+
+  /**
    * Returns the conflict resolution strategy.
    */
   public static ConflictResolutionStrategy getConflictResolutionStrategy(Configuration conf) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
@@ -93,7 +93,8 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
     return new SortOperatorGen(rowType, new String[] {FILE_GROUP_META_FIELD});
   }
 
-  private static String getFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields, NumBucketsFunction numBucketsFunction, boolean needFixedFileIdSuffix) {
+  private static String getFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields,
+                                  NumBucketsFunction numBucketsFunction, boolean needFixedFileIdSuffix) {
     String recordKey = keyGen.getRecordKey(record);
     String partition = keyGen.getPartitionPath(record);
     final int numBuckets = numBucketsFunction.getNumBuckets(partition);
@@ -102,7 +103,8 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
     return bucketIdToFileId.computeIfAbsent(bucketId, k -> needFixedFileIdSuffix ? BucketIdentifier.newBucketFileIdForNBCC(bucketNum) : BucketIdentifier.newBucketFileIdPrefix(bucketNum));
   }
 
-  public static RowData rowWithFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields, NumBucketsFunction numBucketsFunction, boolean needFixedFileIdSuffix) {
+  public static RowData rowWithFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields,
+                                      NumBucketsFunction numBucketsFunction, boolean needFixedFileIdSuffix) {
     final String fileId = getFileId(bucketIdToFileId, keyGen, record, indexKeyFields, numBucketsFunction, needFixedFileIdSuffix);
     return GenericRowData.of(StringData.fromString(fileId), record);
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -93,20 +94,20 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
     return new SortOperatorGen(rowType, new String[] {FILE_GROUP_META_FIELD});
   }
 
-  private static String getFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, String indexKeys, Configuration conf, boolean needFixedFileIdSuffix) {
+  private static String getFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields, Configuration conf, boolean needFixedFileIdSuffix) {
     String recordKey = keyGen.getRecordKey(record);
     String partition = keyGen.getPartitionPath(record);
     NumBucketsFunction numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS), conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE),
         conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
 
     final int numBuckets = numBucketsFunction.getNumBuckets(partition);
-    final int bucketNum = BucketIdentifier.getBucketId(recordKey, indexKeys, numBuckets);
+    final int bucketNum = BucketIdentifier.getBucketId(recordKey, indexKeyFields, numBuckets);
     String bucketId = partition + bucketNum;
     return bucketIdToFileId.computeIfAbsent(bucketId, k -> needFixedFileIdSuffix ? BucketIdentifier.newBucketFileIdForNBCC(bucketNum) : BucketIdentifier.newBucketFileIdPrefix(bucketNum));
   }
 
-  public static RowData rowWithFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, String indexKeys, Configuration conf, boolean needFixedFileIdSuffix) {
-    final String fileId = getFileId(bucketIdToFileId, keyGen, record, indexKeys, conf, needFixedFileIdSuffix);
+  public static RowData rowWithFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields, Configuration conf, boolean needFixedFileIdSuffix) {
+    final String fileId = getFileId(bucketIdToFileId, keyGen, record, indexKeyFields, conf, needFixedFileIdSuffix);
     return GenericRowData.of(StringData.fromString(fileId), record);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketBulkInsertWriterHelper.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.sink.bucket;
 
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.hudi.io.storage.row.HoodieRowDataCreateHandle;
@@ -94,20 +93,17 @@ public class BucketBulkInsertWriterHelper extends BulkInsertWriterHelper {
     return new SortOperatorGen(rowType, new String[] {FILE_GROUP_META_FIELD});
   }
 
-  private static String getFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields, Configuration conf, boolean needFixedFileIdSuffix) {
+  private static String getFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields, NumBucketsFunction numBucketsFunction, boolean needFixedFileIdSuffix) {
     String recordKey = keyGen.getRecordKey(record);
     String partition = keyGen.getPartitionPath(record);
-    NumBucketsFunction numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS), conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE),
-        conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
-
     final int numBuckets = numBucketsFunction.getNumBuckets(partition);
     final int bucketNum = BucketIdentifier.getBucketId(recordKey, indexKeyFields, numBuckets);
     String bucketId = partition + bucketNum;
     return bucketIdToFileId.computeIfAbsent(bucketId, k -> needFixedFileIdSuffix ? BucketIdentifier.newBucketFileIdForNBCC(bucketNum) : BucketIdentifier.newBucketFileIdPrefix(bucketNum));
   }
 
-  public static RowData rowWithFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields, Configuration conf, boolean needFixedFileIdSuffix) {
-    final String fileId = getFileId(bucketIdToFileId, keyGen, record, indexKeyFields, conf, needFixedFileIdSuffix);
+  public static RowData rowWithFileId(Map<String, String> bucketIdToFileId, RowDataKeyGen keyGen, RowData record, List<String> indexKeyFields, NumBucketsFunction numBucketsFunction, boolean needFixedFileIdSuffix) {
+    final String fileId = getFileId(bucketIdToFileId, keyGen, record, indexKeyFields, numBucketsFunction, needFixedFileIdSuffix);
     return GenericRowData.of(StringData.fromString(fileId), record);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -26,7 +26,6 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
-import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.sink.StreamWriteFunction;
 import org.apache.hudi.sink.partitioner.BucketIndexRemotePartitioner;
 import org.apache.hudi.utils.RuntimeContextUtils;
@@ -106,7 +105,7 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
   @Override
   public void open(Configuration parameters) throws IOException {
     super.open(parameters);
-    this.indexKeyFieldList = KeyGenUtils.getIndexKeyFields(OptionsResolver.getIndexKeyField(config));
+    this.indexKeyFieldList = OptionsResolver.getIndexKeyFields(config);
     this.isNonBlockingConcurrencyControl = OptionsResolver.isNonBlockingConcurrencyControl(config);
     this.taskID = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
     this.parallelism = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/bucket/BucketStreamWriteFunction.java
@@ -26,6 +26,7 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
+import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.sink.StreamWriteFunction;
 import org.apache.hudi.sink.partitioner.BucketIndexRemotePartitioner;
 import org.apache.hudi.utils.RuntimeContextUtils;
@@ -41,6 +42,7 @@ import org.apache.flink.util.Collector;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,7 +58,9 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
 
   private int parallelism;
 
-  private String indexKeyFields;
+  // parsed once in open(); the per-record defineRecordLocation path uses the List overload of
+  // getBucketId so the comma-separated config string is not re-split per record
+  private List<String> indexKeyFieldList;
 
   private boolean isNonBlockingConcurrencyControl;
 
@@ -102,7 +106,7 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
   @Override
   public void open(Configuration parameters) throws IOException {
     super.open(parameters);
-    this.indexKeyFields = OptionsResolver.getIndexKeyField(config);
+    this.indexKeyFieldList = KeyGenUtils.getIndexKeyFields(OptionsResolver.getIndexKeyField(config));
     this.isNonBlockingConcurrencyControl = OptionsResolver.isNonBlockingConcurrencyControl(config);
     this.taskID = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
     this.parallelism = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());
@@ -144,7 +148,7 @@ public class BucketStreamWriteFunction extends StreamWriteFunction {
       bootstrapIndexIfNeed(partition);
     }
     Map<Integer, String> bucketToFileId = bucketIndex.computeIfAbsent(partition, p -> new HashMap<>());
-    final int bucketNum = BucketIdentifier.getBucketId(record.getRecordKey(), indexKeyFields, numBucketsFunction.getNumBuckets(record.getPartitionPath()));
+    final int bucketNum = BucketIdentifier.getBucketId(record.getRecordKey(), indexKeyFieldList, numBucketsFunction.getNumBuckets(record.getPartitionPath()));
     final String bucketId = partition + "/" + bucketNum;
 
     if (incBucketIndex.contains(bucketId)) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitioner.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.util.hash.BucketIndexUtil;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
-import org.apache.hudi.keygen.KeyGenUtils;
 
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.configuration.Configuration;
@@ -39,15 +38,15 @@ import java.util.List;
  */
 public class BucketIndexPartitioner<T extends HoodieKey> implements Partitioner<T> {
 
-  // parsed once; the per-record partition() path uses the List overload of getBucketId so the
-  // comma-separated config string is not re-split per record
+  // Index key fields, pre-parsed by the caller. The per-record partition() path uses the List
+  // overload of getBucketId so the comma-separated config string is never re-split per record.
   private final List<String> indexKeyFieldList;
   private final NumBucketsFunction numBucketsFunction;
 
   private Functions.Function3<Integer, String, Integer, Integer> partitionIndexFunc;
 
-  public BucketIndexPartitioner(Configuration conf, String indexKeyFields) {
-    this.indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeyFields);
+  public BucketIndexPartitioner(Configuration conf, List<String> indexKeyFieldList) {
+    this.indexKeyFieldList = indexKeyFieldList;
     this.numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitioner.java
@@ -24,9 +24,12 @@ import org.apache.hudi.common.util.hash.BucketIndexUtil;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
+import org.apache.hudi.keygen.KeyGenUtils;
 
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.configuration.Configuration;
+
+import java.util.List;
 
 /**
  * Bucket index input partitioner.
@@ -36,13 +39,15 @@ import org.apache.flink.configuration.Configuration;
  */
 public class BucketIndexPartitioner<T extends HoodieKey> implements Partitioner<T> {
 
-  private final String indexKeyFields;
+  // parsed once; the per-record partition() path uses the List overload of getBucketId so the
+  // comma-separated config string is not re-split per record
+  private final List<String> indexKeyFieldList;
   private final NumBucketsFunction numBucketsFunction;
 
   private Functions.Function3<Integer, String, Integer, Integer> partitionIndexFunc;
 
   public BucketIndexPartitioner(Configuration conf, String indexKeyFields) {
-    this.indexKeyFields = indexKeyFields;
+    this.indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeyFields);
     this.numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
   }
@@ -53,7 +58,7 @@ public class BucketIndexPartitioner<T extends HoodieKey> implements Partitioner<
       this.partitionIndexFunc = BucketIndexUtil.getPartitionIndexFunc(numPartitions);
     }
     int numBuckets = numBucketsFunction.getNumBuckets(key.getPartitionPath());
-    int curBucket = BucketIdentifier.getBucketId(key.getRecordKey(), indexKeyFields, numBuckets);
+    int curBucket = BucketIdentifier.getBucketId(key.getRecordKey(), indexKeyFieldList, numBuckets);
     return this.partitionIndexFunc.apply(numBuckets, key.getPartitionPath(), curBucket);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitionerFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexPartitionerFactory.java
@@ -24,6 +24,8 @@ import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.configuration.Configuration;
 
+import java.util.List;
+
 /**
  * Factory for simple bucket index partitioners.
  */
@@ -33,12 +35,12 @@ public class BucketIndexPartitionerFactory {
   }
 
   public static Partitioner<HoodieKey> create(Configuration conf) {
-    return create(conf, OptionsResolver.getIndexKeyField(conf));
+    return create(conf, OptionsResolver.getIndexKeyFields(conf));
   }
 
-  public static Partitioner<HoodieKey> create(Configuration conf, String indexKeyFields) {
+  public static Partitioner<HoodieKey> create(Configuration conf, List<String> indexKeyFieldList) {
     return OptionsResolver.shouldUseBucketRemotePartitioner(conf)
-        ? new BucketIndexRemotePartitioner<>(conf, indexKeyFields)
-        : new BucketIndexPartitioner<>(conf, indexKeyFields);
+        ? new BucketIndexRemotePartitioner<>(conf, indexKeyFieldList)
+        : new BucketIndexPartitioner<>(conf, indexKeyFieldList);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
@@ -25,10 +25,13 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
+import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.util.ViewStorageProperties;
 
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.configuration.Configuration;
+
+import java.util.List;
 
 /**
  * Bucket index input partitioner backed by the embedded timeline service.
@@ -38,14 +41,16 @@ import org.apache.flink.configuration.Configuration;
 public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partitioner<T> {
 
   private final Configuration conf;
-  private final String indexKeyFields;
+  // parsed once; the per-record partition() path uses the List overload of getBucketId so the
+  // comma-separated config string is not re-split per record
+  private final List<String> indexKeyFieldList;
   private final NumBucketsFunction numBucketsFunction;
 
   private transient RemotePartitionHelper remotePartitionHelper;
 
   public BucketIndexRemotePartitioner(Configuration conf, String indexKeyFields) {
     this.conf = conf;
-    this.indexKeyFields = indexKeyFields;
+    this.indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeyFields);
     this.numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
   }
@@ -59,7 +64,7 @@ public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partit
   public int partition(T key, int numPartitions) {
     String partitionPath = normalizePartitionPath(key.getPartitionPath());
     int numBuckets = numBucketsFunction.getNumBuckets(partitionPath);
-    int curBucket = BucketIdentifier.getBucketId(key.getRecordKey(), indexKeyFields, numBuckets);
+    int curBucket = BucketIdentifier.getBucketId(key.getRecordKey(), indexKeyFieldList, numBuckets);
     return doGetRemotePartition(getRemotePartitionHelper(), numBuckets, partitionPath, curBucket, numPartitions);
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketIndexRemotePartitioner.java
@@ -25,7 +25,6 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.bucket.BucketIdentifier;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
-import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.util.ViewStorageProperties;
 
 import org.apache.flink.api.common.functions.Partitioner;
@@ -41,22 +40,22 @@ import java.util.List;
 public class BucketIndexRemotePartitioner<T extends HoodieKey> implements Partitioner<T> {
 
   private final Configuration conf;
-  // parsed once; the per-record partition() path uses the List overload of getBucketId so the
-  // comma-separated config string is not re-split per record
+  // Index key fields, pre-parsed by the caller. The per-record partition() path uses the List
+  // overload of getBucketId so the comma-separated config string is never re-split per record.
   private final List<String> indexKeyFieldList;
   private final NumBucketsFunction numBucketsFunction;
 
   private transient RemotePartitionHelper remotePartitionHelper;
 
-  public BucketIndexRemotePartitioner(Configuration conf, String indexKeyFields) {
+  public BucketIndexRemotePartitioner(Configuration conf, List<String> indexKeyFieldList) {
     this.conf = conf;
-    this.indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeyFields);
+    this.indexKeyFieldList = indexKeyFieldList;
     this.numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
   }
 
-  BucketIndexRemotePartitioner(Configuration conf, String indexKeyFields, RemotePartitionHelper remotePartitionHelper) {
-    this(conf, indexKeyFields);
+  BucketIndexRemotePartitioner(Configuration conf, List<String> indexKeyFieldList, RemotePartitionHelper remotePartitionHelper) {
+    this(conf, indexKeyFieldList);
     this.remotePartitionHelper = remotePartitionHelper;
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -29,7 +29,6 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
-import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.sink.CleanFunction;
 import org.apache.hudi.sink.StreamWriteOperator;
 import org.apache.hudi.sink.append.AppendWriteFunctions;
@@ -143,7 +142,7 @@ public class Pipelines {
             "Consistent hashing bucket index does not work with bulk insert using FLINK engine. Use simple bucket index or Spark engine.");
       }
       String indexKeys = OptionsResolver.getIndexKeyField(conf);
-      List<String> indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeys);
+      List<String> indexKeyFieldList = OptionsResolver.getIndexKeyFields(conf);
       // built once and captured by the per-record map closure (NumBucketsFunction is Serializable),
       // avoiding a per-record rebuild from conf inside BucketBulkInsertWriterHelper
       NumBucketsFunction numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -28,6 +28,7 @@ import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.sink.CleanFunction;
 import org.apache.hudi.sink.StreamWriteOperator;
 import org.apache.hudi.sink.append.AppendWriteFunctions;
@@ -85,6 +86,7 @@ import org.apache.flink.table.types.logical.RowType;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -140,6 +142,7 @@ public class Pipelines {
             "Consistent hashing bucket index does not work with bulk insert using FLINK engine. Use simple bucket index or Spark engine.");
       }
       String indexKeys = OptionsResolver.getIndexKeyField(conf);
+      List<String> indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeys);
       Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf, indexKeys);
       RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
       RowType rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
@@ -148,7 +151,7 @@ public class Pipelines {
 
       Map<String, String> bucketIdToFileId = new HashMap<>();
       dataStream = dataStream.partitionCustom(partitioner, keyGen::getHoodieKey)
-          .map(record -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, record, indexKeys, conf, needFixedFileIdSuffix), typeInfo)
+          .map(record -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, record, indexKeyFieldList, conf, needFixedFileIdSuffix), typeInfo)
           .setParallelism(PARALLELISM_VALUE);
       if (conf.get(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT)) {
         SortOperatorGen sortOperatorGen = BucketBulkInsertWriterHelper.getFileIdSorterGen(rowTypeWithFileId);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -28,6 +28,7 @@ import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.sink.CleanFunction;
 import org.apache.hudi.sink.StreamWriteOperator;
@@ -143,6 +144,10 @@ public class Pipelines {
       }
       String indexKeys = OptionsResolver.getIndexKeyField(conf);
       List<String> indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeys);
+      // built once and captured by the per-record map closure (NumBucketsFunction is Serializable),
+      // avoiding a per-record rebuild from conf inside BucketBulkInsertWriterHelper
+      NumBucketsFunction numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
+          conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
       Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf, indexKeys);
       RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
       RowType rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
@@ -151,7 +156,7 @@ public class Pipelines {
 
       Map<String, String> bucketIdToFileId = new HashMap<>();
       dataStream = dataStream.partitionCustom(partitioner, keyGen::getHoodieKey)
-          .map(record -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, record, indexKeyFieldList, conf, needFixedFileIdSuffix), typeInfo)
+          .map(record -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, record, indexKeyFieldList, numBucketsFunction, needFixedFileIdSuffix), typeInfo)
           .setParallelism(PARALLELISM_VALUE);
       if (conf.get(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT)) {
         SortOperatorGen sortOperatorGen = BucketBulkInsertWriterHelper.getFileIdSorterGen(rowTypeWithFileId);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/Pipelines.java
@@ -141,13 +141,12 @@ public class Pipelines {
         throw new HoodieException(
             "Consistent hashing bucket index does not work with bulk insert using FLINK engine. Use simple bucket index or Spark engine.");
       }
-      String indexKeys = OptionsResolver.getIndexKeyField(conf);
       List<String> indexKeyFieldList = OptionsResolver.getIndexKeyFields(conf);
       // built once and captured by the per-record map closure (NumBucketsFunction is Serializable),
       // avoiding a per-record rebuild from conf inside BucketBulkInsertWriterHelper
       NumBucketsFunction numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
           conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
-      Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf, indexKeys);
+      Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf, indexKeyFieldList);
       RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
       RowType rowTypeWithFileId = BucketBulkInsertWriterHelper.rowTypeWithFileId(rowType);
       InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(rowTypeWithFileId);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexPartitionerFactory.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexPartitionerFactory.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.configuration.Configuration;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
@@ -36,7 +38,7 @@ class TestBucketIndexPartitionerFactory {
 
   @Test
   void testCreateLocalBucketIndexPartitioner() {
-    Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(getSimpleBucketConf(), "id");
+    Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(getSimpleBucketConf(), Collections.singletonList("id"));
 
     assertInstanceOf(BucketIndexPartitioner.class, partitioner);
   }
@@ -46,7 +48,7 @@ class TestBucketIndexPartitionerFactory {
     Configuration conf = getSimpleBucketConf();
     conf.setString(HoodieIndexConfig.BUCKET_PARTITIONER.key(), "true");
 
-    Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf, "id");
+    Partitioner<HoodieKey> partitioner = BucketIndexPartitionerFactory.create(conf, Collections.singletonList("id"));
 
     assertInstanceOf(BucketIndexRemotePartitioner.class, partitioner);
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexRemotePartitioner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketIndexRemotePartitioner.java
@@ -28,6 +28,8 @@ import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.flink.configuration.Configuration;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -91,7 +93,7 @@ class TestBucketIndexRemotePartitioner {
     when(remotePartitionHelper.getPartition(8, "", currentBucket, 16)).thenReturn(11);
 
     BucketIndexRemotePartitioner<HoodieKey> partitioner =
-        new BucketIndexRemotePartitioner<>(conf, "id", remotePartitionHelper);
+        new BucketIndexRemotePartitioner<>(conf, Collections.singletonList("id"), remotePartitionHelper);
 
     assertEquals(11, partitioner.partition(key, 16));
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
@@ -25,7 +25,6 @@ import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
-import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
 import org.apache.hudi.sink.bucket.BucketBulkInsertWriterHelper;
 import org.apache.hudi.sink.bulk.BulkInsertWriteFunction;
@@ -215,8 +214,7 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
 
   private void setupMapFunction() {
     RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
-    String indexKeys = OptionsResolver.getIndexKeyField(conf);
-    List<String> indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeys);
+    List<String> indexKeyFieldList = OptionsResolver.getIndexKeyFields(conf);
     NumBucketsFunction numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
         conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
     boolean needFixedFileIdSuffix = OptionsResolver.isNonBlockingConcurrencyControl(conf);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.index.bucket.partition.NumBucketsFunction;
 import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
 import org.apache.hudi.sink.bucket.BucketBulkInsertWriterHelper;
@@ -216,9 +217,11 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
     RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
     String indexKeys = OptionsResolver.getIndexKeyField(conf);
     List<String> indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeys);
+    NumBucketsFunction numBucketsFunction = new NumBucketsFunction(conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_EXPRESSIONS),
+        conf.get(FlinkOptions.BUCKET_INDEX_PARTITION_RULE), conf.get(FlinkOptions.BUCKET_INDEX_NUM_BUCKETS));
     boolean needFixedFileIdSuffix = OptionsResolver.isNonBlockingConcurrencyControl(conf);
     this.bucketIdToFileId = new HashMap<>();
-    this.mapFunction = r -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, r, indexKeyFieldList, conf, needFixedFileIdSuffix);
+    this.mapFunction = r -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, r, indexKeyFieldList, numBucketsFunction, needFixedFileIdSuffix);
   }
 
   private void setupSortOperator() throws Exception {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/utils/BulkInsertFunctionWrapper.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.keygen.KeyGenUtils;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
 import org.apache.hudi.sink.bucket.BucketBulkInsertWriterHelper;
 import org.apache.hudi.sink.bulk.BulkInsertWriteFunction;
@@ -214,9 +215,10 @@ public class BulkInsertFunctionWrapper<I> implements TestFunctionWrapper<I> {
   private void setupMapFunction() {
     RowDataKeyGen keyGen = RowDataKeyGens.instance(conf, rowType);
     String indexKeys = OptionsResolver.getIndexKeyField(conf);
+    List<String> indexKeyFieldList = KeyGenUtils.getIndexKeyFields(indexKeys);
     boolean needFixedFileIdSuffix = OptionsResolver.isNonBlockingConcurrencyControl(conf);
     this.bucketIdToFileId = new HashMap<>();
-    this.mapFunction = r -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, r, indexKeys, conf, needFixedFileIdSuffix);
+    this.mapFunction = r -> BucketBulkInsertWriterHelper.rowWithFileId(bucketIdToFileId, keyGen, r, indexKeyFieldList, conf, needFixedFileIdSuffix);
   }
 
   private void setupSortOperator() throws Exception {


### PR DESCRIPTION
... record

### Describe the issue this Pull Request addresses

Flink follow-up to #18979 (tracked under #18978). The Flink bucket-index write paths re-split the comma-separated `hoodie.bucket.index.hash.field` config on every record via the `String` overload of `BucketIdentifier.getBucketId`, instead of parsing it once per task.

### Summary and Changelog

Precompute `KeyGenUtils.getIndexKeyFields(...)` once and call the existing `List` overload, mirroring the Spark fix in #18979:

- `BucketIndexPartitioner` / `BucketIndexRemotePartitioner`: parse once in the constructor (factory and constructor signatures stay `String`-based)
- `BucketStreamWriteFunction`: parse once in `open()`
- `BucketBulkInsertWriterHelper.rowWithFileId`/`getFileId`: take `List<String>`; `Pipelines` parses once before the per-record `map` stage

Behavior-preserving -- produces the same bucket ids.

### Impact

Removes a per-record string split and list allocation on Flink simple-bucket-index writes (streaming upsert and bulk insert). No public API or user-facing behavior change; matters at high record volume.

### Risk Level

low. Behavior-preserving refactor using existing overloads; the existing Flink bucket-index write and bulk-insert tests cover these paths.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
