### PR TITLE
[MINOR] Disable codecov-commenter PR comment (comment: false)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -47,13 +47,7 @@ ignore:
   - "hudi-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/HoodieInputFormat.java"
   - "hudi-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeInputFormat.java"
 
-comment:
-  layout: "diff, flags, files"
-  behavior: new
-  require_changes: false
-  require_base: false
-  require_head: true
-  hide_project_coverage: false
+comment: false
 
 flags:
   hudicli:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

On every commit to a PR, the Codecov bot posts a burst of comments and triggers a flood of email notifications. This was raised in https://github.com/apache/hudi/discussions/18992 ("Let's turn the codecov-commenter OFF"), where a single PR review with 6 commits produced roughly 100 emails.

The root cause is a combination of three things in the current setup: `behavior: new` in `.codecov.yml` (Codecov deletes and re-posts the PR comment on every upload, and each re-post is a new comment that emails subscribers), ~14 separate coverage uploads per CI run (one `Upload coverage to Codecov` step per test job in `.github/workflows/bot.yml`, each with its own `flags:`), and no `after_n_builds` setting (so Codecov comments as uploads arrive instead of once at the end). Together this produces roughly 14 comment/email events per commit.

### Summary and Changelog

Set `comment: false` in `.codecov.yml`. This is the Codecov shorthand that disables the PR comment entirely, so the bot no longer comments on pull requests and no longer generates the per-commit email notifications.

This is a config-only change: the previous `comment:` block (`layout`, `behavior: new`, `require_*`, `hide_project_coverage`) is replaced by the single line `comment: false`. The `coverage`, `ignore`, and `flags` sections are unchanged.

### Impact

No public API or user-facing product change. Coverage is still uploaded to Codecov and the `codecov/project` / `codecov/patch` status checks are unaffected, so merge gating is not impacted. The only behavior change is that Codecov stops posting comments (and the associated emails) on PRs. The change is trivially reversible by restoring the `comment:` block.

### Risk Level

none. The change touches only Codecov comment rendering in `.codecov.yml` and does not affect builds, tests, or coverage status checks.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
