### PR TITLE
perf(metadata): Resolve column-stats field schemas once per collection instead of per record

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -277,12 +277,10 @@ public class HoodieTableMetadataUtil {
     properties.setProperty(HoodieStorageConfig.WRITE_UTC_TIMEZONE.key(),
         storageConfig.getString(HoodieStorageConfig.WRITE_UTC_TIMEZONE.key(), HoodieStorageConfig.WRITE_UTC_TIMEZONE.defaultValue().toString()));
     // getNonNullType() rebuilds the union-member wrappers for nullable fields and depends only on the
-    // (fixed) target fields, so resolve it once per field instead of once per record per field. Holding
-    // a stable HoodieSchema instance also lets its toAvroSchema() memoize across records.
-    List<Pair<String, HoodieSchema>> nonNullFieldSchemas = new ArrayList<>(targetFields.size());
-    for (Pair<String, HoodieSchemaField> fieldNameFieldPair : targetFields) {
-      nonNullFieldSchemas.add(Pair.of(fieldNameFieldPair.getKey(), fieldNameFieldPair.getValue().schema().getNonNullType()));
-    }
+    // (fixed) target fields, so resolve it once per field instead of once per record per field.
+    List<Pair<String, HoodieSchema>> nonNullFieldSchemas = targetFields.stream()
+        .map(p -> Pair.of(p.getKey(), p.getValue().schema().getNonNullType()))
+        .collect(Collectors.toList());
     // Collect stats for all columns by iterating through records while accounting
     // corresponding stats
     records.forEachRemaining((record) -> {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -276,15 +276,21 @@ public class HoodieTableMetadataUtil {
     final Properties properties = new Properties();
     properties.setProperty(HoodieStorageConfig.WRITE_UTC_TIMEZONE.key(),
         storageConfig.getString(HoodieStorageConfig.WRITE_UTC_TIMEZONE.key(), HoodieStorageConfig.WRITE_UTC_TIMEZONE.defaultValue().toString()));
+    // getNonNullType() rebuilds the union-member wrappers for nullable fields and depends only on the
+    // (fixed) target fields, so resolve it once per field instead of once per record per field. Holding
+    // a stable HoodieSchema instance also lets its toAvroSchema() memoize across records.
+    List<Pair<String, HoodieSchema>> nonNullFieldSchemas = new ArrayList<>(targetFields.size());
+    for (Pair<String, HoodieSchemaField> fieldNameFieldPair : targetFields) {
+      nonNullFieldSchemas.add(Pair.of(fieldNameFieldPair.getKey(), fieldNameFieldPair.getValue().schema().getNonNullType()));
+    }
     // Collect stats for all columns by iterating through records while accounting
     // corresponding stats
     records.forEachRemaining((record) -> {
       // For each column (field) we have to index update corresponding column stats
       // with the values from this record
-      targetFields.forEach(fieldNameFieldPair -> {
-        String fieldName = fieldNameFieldPair.getKey();
-        HoodieSchemaField field = fieldNameFieldPair.getValue();
-        HoodieSchema fieldSchema = field.schema().getNonNullType();
+      nonNullFieldSchemas.forEach(fieldNameSchemaPair -> {
+        String fieldName = fieldNameSchemaPair.getKey();
+        HoodieSchema fieldSchema = fieldNameSchemaPair.getValue();
         if (!isColumnTypeSupported(fieldSchema, Option.of(record.getRecordType()), indexVersion)) {
           return;
         }


### PR DESCRIPTION
…n instead of per record

### Describe the issue this Pull Request addresses

Closes #18999. `HoodieTableMetadataUtil#collectColumnRangeMetadata` recomputes per-field schema invariants once per record per target column on the column-stats write path (per appended log block in `HoodieAppendHandle`, and per log file in `getLogFileColumnRangeMetadata`).

### Summary and Changelog

For every record and every target field, the loop recomputed `field.schema().getNonNullType()`, which rebuilds the union-member wrappers for nullable fields (a fresh `HoodieSchema` per call) even though it depends only on the fixed target field list.

Resolve the non-null `HoodieSchema` once per target field before the record loop and iterate that precomputed list. The per-record work (type-support check, value extraction, min / max / null / value counts) is unchanged, so results are identical.

### Impact

Removes _O(N*F)_ redundant schema-wrapper rebuilds (N records, F indexed columns) plus their transient allocations on the column-stats write path. No public API or user-facing behavior change.

### Risk Level

low. Behavior-preserving hoist of values that are pure functions of the fixed target fields (`getNonNullType()`); min / max / counts are order-independent. Covered by the existing column-stats functional tests (`TestColumnStatsIndex`, `TestColStatsRecordWithMetadataRecord`, `TestDataSkippingWithMORColstats`).

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable

