### PR TITLE
perf(io): Derive log file size from AppendResult on append-handle close

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -572,7 +572,8 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
       // object stores.
       for (WriteStatus status : statuses) {
         HoodieDeltaWriteStat stat = (HoodieDeltaWriteStat) status.getStat();
-        stat.setFileSizeInBytes(stat.getLogOffset() + stat.getFileSizeInBytes());
+        long appendedBytes = stat.getFileSizeInBytes();
+        stat.setFileSizeInBytes(stat.getLogOffset() + appendedBytes);
       }
 
       // generate Secondary index stats if streaming writes is enabled.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -564,14 +564,15 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
         writer = null;
       }
 
-      // update final size, once for all log files
-      // TODO we can actually deduce file size purely from AppendResult (based on offset and size
-      //      of the appended block)
+      // Set the final on-disk size of each log file. Appends within an append handle are contiguous,
+      // so a log file's length equals its start offset plus the total bytes appended to it. That is
+      // exactly what fs.getFileStatus().getLength() returns, and both values are already captured by
+      // the AppendResult stats (logOffset and the accumulated fileSizeInBytes). Deriving the size this
+      // way avoids a getPathInfo/HEAD per log file, which is a remote round trip per file group on
+      // object stores.
       for (WriteStatus status : statuses) {
-        long logFileSize = storage.getPathInfo(
-            new StoragePath(config.getBasePath(), status.getStat().getPath()))
-            .getLength();
-        status.getStat().setFileSizeInBytes(logFileSize);
+        HoodieDeltaWriteStat stat = (HoodieDeltaWriteStat) status.getStat();
+        stat.setFileSizeInBytes(stat.getLogOffset() + stat.getFileSizeInBytes());
       }
 
       // generate Secondary index stats if streaming writes is enabled.

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/common/table/log/TestLogReaderUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/common/table/log/TestLogReaderUtils.java
@@ -43,6 +43,8 @@ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.List;
@@ -132,16 +134,28 @@ public class TestLogReaderUtils extends SparkClientFunctionalTestHarness {
     }
   }
 
-  @Test
-  public void testLogFileWriteStatSizeMatchesOnDisk() throws Exception {
-    // HoodieAppendHandle records each log file's size by deriving it from AppendResult
+  @ParameterizedTest
+  @ValueSource(ints = {6, 9}) // SIX appends to the existing log file (logOffset > 0); NINE writes fresh files (logOffset == 0)
+  public void testLogFileWriteStatSizeMatchesOnDisk(int writeTableVersion) throws Exception {
+    // HoodieAppendHandle derives each log file's on-disk size from the AppendResult
     // (logOffset + accumulated appended bytes) instead of a getPathInfo per file. Validate that the
-    // derived size in the write stat matches the actual on-disk log file length, across multiple
-    // appends to the same log file (two upsert commits with no compaction / small-file packing).
-    HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, new Properties());
+    // derived size in the write stat matches the actual on-disk log file length.
+    //
+    // The "logOffset +" term only contributes when a delta commit appends to a pre-existing log file:
+    //   - table version >= EIGHT (e.g. NINE): each delta commit writes a fresh instant-named log file
+    //     from offset 0, so logOffset is always 0;
+    //   - table version SIX: the second upsert appends to the first commit's log file, so logOffset
+    //     is > 0 and the derived sum is actually exercised.
+    // Running both covers the derivation with and without a non-zero offset.
+    Properties props = new Properties();
+    props.setProperty(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), String.valueOf(writeTableVersion));
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(
+        storageConf(), basePath(), props, HoodieTableType.MERGE_ON_READ);
 
     HoodieWriteConfig config = getConfigBuilder(true)
         .withPath(basePath())
+        .withWriteTableVersion(writeTableVersion)
+        .withAutoUpgradeVersion(false)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
             .withInlineCompaction(false)
             .compactionSmallFileSize(0)
@@ -158,7 +172,8 @@ public class TestLogReaderUtils extends SparkClientFunctionalTestHarness {
       assertNoWriteErrors(insertRdd.collect());
       client.commit(firstCommit, insertRdd);
 
-      // Upsert across two commits so each log file accumulates multiple appends through the handle
+      // Two upsert commits. Under version SIX the second commit appends to the first's log file
+      // (logOffset > 0); under version >= EIGHT each commit writes a fresh log file (logOffset == 0).
       for (String commitTime : new String[] {"002", "003"}) {
         WriteClientTestUtils.startCommitWithTime(client, commitTime);
         JavaRDD<WriteStatus> upsertRdd = client.upsert(jsc().parallelize(dataGen.generateUpdates(commitTime, 50), 1), commitTime);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/common/table/log/TestLogReaderUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/common/table/log/TestLogReaderUtils.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+import static org.apache.hudi.testutils.Assertions.assertFileSizesEqual;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -128,6 +129,48 @@ public class TestLogReaderUtils extends SparkClientFunctionalTestHarness {
       assertNotNull(allLogFiles);
       assertTrue(allLogFiles.size() >= logFilesWithMaxCommit.size(),
           "Should have same or more log files when including third commit");
+    }
+  }
+
+  @Test
+  public void testLogFileWriteStatSizeMatchesOnDisk() throws Exception {
+    // HoodieAppendHandle records each log file's size by deriving it from AppendResult
+    // (logOffset + accumulated appended bytes) instead of a getPathInfo per file. Validate that the
+    // derived size in the write stat matches the actual on-disk log file length, across multiple
+    // appends to the same log file (two upsert commits with no compaction / small-file packing).
+    HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, new Properties());
+
+    HoodieWriteConfig config = getConfigBuilder(true)
+        .withPath(basePath())
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withInlineCompaction(false)
+            .compactionSmallFileSize(0)
+            .build())
+        .build();
+
+    HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
+
+    try (SparkRDDWriteClient client = getHoodieWriteClient(config)) {
+      // First commit - insert data (base files)
+      String firstCommit = "001";
+      WriteClientTestUtils.startCommitWithTime(client, firstCommit);
+      JavaRDD<WriteStatus> insertRdd = client.insert(jsc().parallelize(dataGen.generateInserts(firstCommit, 100), 1), firstCommit);
+      assertNoWriteErrors(insertRdd.collect());
+      client.commit(firstCommit, insertRdd);
+
+      // Upsert across two commits so each log file accumulates multiple appends through the handle
+      for (String commitTime : new String[] {"002", "003"}) {
+        WriteClientTestUtils.startCommitWithTime(client, commitTime);
+        JavaRDD<WriteStatus> upsertRdd = client.upsert(jsc().parallelize(dataGen.generateUpdates(commitTime, 50), 1), commitTime);
+        List<WriteStatus> statuses = upsertRdd.collect();
+        assertNoWriteErrors(statuses);
+        assertLogFilesProduced(statuses);
+        client.commit(commitTime, upsertRdd);
+        // Derived log file size (logOffset + appended bytes) must equal the actual on-disk length
+        assertFileSizesEqual(statuses, status -> FSUtils.getFileSize(
+            metaClient.getStorage(),
+            new StoragePath(config.getBasePath(), status.getStat().getPath())));
+      }
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19001. `HoodieAppendHandle.close()` issued `storage.getPathInfo(<logFile>).getLength()` for every `WriteStatus` to record the final log file size -- a remote HEAD per log file per file group on object stores, purely to read a size the handle already knows.

### Summary and Changelog

`HoodieLogFormatWriter.appendBlocks` reports, via `AppendResult`, the start offset and the total bytes appended (covering every on-disk byte: magic, header, content, footers, reverse-pointer long); these already populate the delta write stat's `logOffset` and accumulated `fileSizeInBytes`. Appends within a handle are contiguous and `closeStream()` appends no trailer, so a log file's on-disk length equals `logOffset + fileSizeInBytes`. `close()` now sets the final size from those fields instead of issuing a `getPathInfo`/HEAD per file.

### Impact

Removes one remote round trip per log file per file group on the MOR write path (a commit touching K file groups dropped K HEAD requests). The recorded size is byte-identical to `getFileStatus().getLength()`. Same class of change as the merged clean-path getPathInfo removal (#18963). No public API or user-facing behavior change.

### Risk Level

low. The derived size is byte-identical: `AppendResult.size()` is the full on-disk byte delta of each `appendBlocks` call, any pre-block bytes are absorbed into `logOffset`, and `closeStream()` only `sync()`s (no trailer). Behaviorally covered by the existing MOR functional suite (writes log files via the append handle, then reads/compacts them). Note: the harness's precise `assertFileSizesEqual` (write-stat size vs on-disk length) is currently dormant/unused; reviving it for the MOR path is a reasonable follow-up.

### Documentation Update

none.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
