### PR TITLE
chore(test): document macOS-specific cleaner consistency-guard slowness (#17714)

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/action/clean/TestCleanerInsertAndCleanByVersions.java
@@ -133,6 +133,10 @@ public class TestCleanerInsertAndCleanByVersions extends SparkClientFunctionalTe
         .withBulkInsertParallelism(PARALLELISM)
         .withFinalizeWriteParallelism(PARALLELISM)
         .withDeleteParallelism(PARALLELISM)
+        // #17714: enabling the consistency check makes this test slow on macOS local file://. The cleaner's
+        // getFileStatus calls the guard's waitTillFileAppears, which misses the translated path and burns the
+        // full ~25.2s backoff per deleted file. Does NOT reproduce on CI (Linux), where the path resolves and
+        // it stays fast, so this gotcha is only visible locally.
         .withConsistencyGuardConfig(ConsistencyGuardConfig.newBuilder().withConsistencyCheckEnabled(true).build())
         .build();
     try (final SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17714.

`TestCleanerInsertAndCleanByVersions` runs for minutes on macOS local `file://`. Root cause: the cleaner's `getPathInfo` -> `HoodieWrapperFileSystem.getFileStatus` calls `FailSafeConsistencyGuard.waitTillFileAppears`, which on macOS misses the translated path and runs the full ~25.2s exponential backoff per deleted file before swallowing the `TimeoutException` (`// pass`). The file is still deleted correctly - it is purely wasted time.

It does **not** reproduce on CI/Linux. A verbose CI run (`-Pwarn-log` dropped, `-Dsurefire.useFile=false`) showed 0 tasks at ~25s and a slowest task of ~2.9s, with the delete path confirmed exercised - so this is specific to macOS local-FS path translation, not a code defect. Full investigation is in the issue.

This PR documents the gotcha inline in the test so the next person hitting a slow local run knows why. No behavior change.

### Summary and Changelog

- `[MINOR]` `TestCleanerInsertAndCleanByVersions`: inline comment next to `withConsistencyCheckEnabled(true)` explaining the macOS-only slowness (full ~25.2s `waitTillFileAppears` backoff per deleted file) and that it is invisible on CI.

### Impact

None. Comment-only change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
