### PR TITLE
[MINOR] Wait for ZK connection in lock provider to de-flake direct-marker detection test

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/BaseZookeeperBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/BaseZookeeperBasedLockProvider.java
@@ -68,6 +68,7 @@ public abstract class BaseZookeeperBasedLockProvider implements LockProvider<Int
     this.lockConfiguration = lockConfiguration;
     zkBasePath = getZkBasePath(lockConfiguration);
     lockKey = getLockKey(lockConfiguration);
+    int connectionTimeoutMs = ConfigUtils.getIntWithAltKeys(lockConfiguration.getConfig(), ZK_CONNECTION_TIMEOUT_MS);
     this.curatorFrameworkClient = CuratorFrameworkFactory.builder()
         .connectString(ConfigUtils.getStringWithAltKeys(lockConfiguration.getConfig(), ZK_CONNECT_URL))
         .retryPolicy(new BoundedExponentialBackoffRetry(
@@ -75,19 +76,32 @@ public abstract class BaseZookeeperBasedLockProvider implements LockProvider<Int
             ConfigUtils.getIntWithAltKeys(lockConfiguration.getConfig(), LOCK_ACQUIRE_RETRY_MAX_WAIT_TIME_IN_MILLIS),
             ConfigUtils.getIntWithAltKeys(lockConfiguration.getConfig(), LOCK_ACQUIRE_NUM_RETRIES)))
         .sessionTimeoutMs(ConfigUtils.getIntWithAltKeys(lockConfiguration.getConfig(), ZK_SESSION_TIMEOUT_MS))
-        .connectionTimeoutMs(ConfigUtils.getIntWithAltKeys(lockConfiguration.getConfig(), ZK_CONNECTION_TIMEOUT_MS))
+        .connectionTimeoutMs(connectionTimeoutMs)
         .build();
     this.curatorFrameworkClient.start();
+    // Once started, the Curator client owns background threads. If anything below throws, the
+    // constructor never returns the instance, so the caller can never invoke close() - clean up here.
     try {
-      int connectionTimeoutMs = ConfigUtils.getIntWithAltKeys(lockConfiguration.getConfig(), ZK_CONNECTION_TIMEOUT_MS);
       if (!this.curatorFrameworkClient.blockUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)) {
         throw new HoodieLockException("Failed to connect to ZooKeeper within " + connectionTimeoutMs + " ms");
       }
+      createPathIfNotExists();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      closeQuietly();
       throw new HoodieLockException("Interrupted while waiting to connect to ZooKeeper", e);
+    } catch (RuntimeException e) {
+      closeQuietly();
+      throw e;
     }
-    createPathIfNotExists();
+  }
+
+  private void closeQuietly() {
+    try {
+      this.curatorFrameworkClient.close();
+    } catch (Exception ex) {
+      log.warn("Failed to close ZooKeeper client after failed initialization", ex);
+    }
   }
 
   protected abstract String getZkBasePath(LockConfiguration lockConfiguration);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/BaseZookeeperBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/BaseZookeeperBasedLockProvider.java
@@ -78,6 +78,15 @@ public abstract class BaseZookeeperBasedLockProvider implements LockProvider<Int
         .connectionTimeoutMs(ConfigUtils.getIntWithAltKeys(lockConfiguration.getConfig(), ZK_CONNECTION_TIMEOUT_MS))
         .build();
     this.curatorFrameworkClient.start();
+    try {
+      int connectionTimeoutMs = ConfigUtils.getIntWithAltKeys(lockConfiguration.getConfig(), ZK_CONNECTION_TIMEOUT_MS);
+      if (!this.curatorFrameworkClient.blockUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)) {
+        throw new HoodieLockException("Failed to connect to ZooKeeper within " + connectionTimeoutMs + " ms");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new HoodieLockException("Interrupted while waiting to connect to ZooKeeper", e);
+    }
     createPathIfNotExists();
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestZookeeperBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestZookeeperBasedLockProvider.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -193,5 +194,25 @@ public class TestZookeeperBasedLockProvider {
   public void testUnlockWithoutLock() {
     ZookeeperBasedLockProvider zookeeperBasedLockProvider = new ZookeeperBasedLockProvider(zkConfWithZkBasePathAndLockKeyLock, null);
     zookeeperBasedLockProvider.unlock();
+  }
+
+  @Test
+  public void testFailFastWhenZkUnreachable() {
+    Properties properties = new Properties();
+    // Nothing listens on 127.0.0.1:1, so the connect-wait must time out instead of hanging.
+    properties.setProperty(ZK_CONNECT_URL_PROP_KEY, "127.0.0.1:1");
+    properties.setProperty(ZK_BASE_PATH_PROP_KEY, basePath);
+    properties.setProperty(ZK_LOCK_KEY_PROP_KEY, key);
+    properties.setProperty(LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY, "100");
+    properties.setProperty(LOCK_ACQUIRE_RETRY_MAX_WAIT_TIME_IN_MILLIS_PROP_KEY, "300");
+    properties.setProperty(LOCK_ACQUIRE_NUM_RETRIES_PROP_KEY, "1");
+    properties.setProperty(ZK_SESSION_TIMEOUT_MS_PROP_KEY, "1000");
+    properties.setProperty(ZK_CONNECTION_TIMEOUT_MS_PROP_KEY, "1000");
+    LockConfiguration unreachable = new LockConfiguration(properties);
+    // Construction must fail fast (seconds, bounded by the connection timeout) with a
+    // HoodieLockException instead of being amplified into a multi-minute retry hang.
+    Assertions.assertTimeoutPreemptively(Duration.ofSeconds(15), () ->
+        Assertions.assertThrows(HoodieLockException.class,
+            () -> new ZookeeperBasedLockProvider(unreachable, null)));
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockProvider.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockProvider.java
@@ -51,9 +51,16 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
+import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_CLIENT_NUM_RETRIES_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_NUM_RETRIES_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_RETRY_MAX_WAIT_TIME_IN_MILLIS_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.ZK_BASE_PATH_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.ZK_CONNECTION_TIMEOUT_MS_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.ZK_CONNECT_URL_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.ZK_LOCK_KEY_PROP_KEY;
+import static org.apache.hudi.common.config.LockConfiguration.ZK_SESSION_TIMEOUT_MS_PROP_KEY;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -82,6 +89,15 @@ public class TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockPr
     properties.setProperty(ZK_CONNECT_URL_PROP_KEY, server.getConnectString());
     properties.setProperty(ZK_BASE_PATH_PROP_KEY, server.getTempDirectory().getAbsolutePath());
     properties.setProperty(ZK_LOCK_KEY_PROP_KEY, "key");
+    // Bound lock retries and ZK timeouts so a transient connection failure fails fast in seconds
+    // instead of being amplified by the production-default retry layers into a multi-minute hang.
+    properties.setProperty(LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY, "1000");
+    properties.setProperty(LOCK_ACQUIRE_RETRY_MAX_WAIT_TIME_IN_MILLIS_PROP_KEY, "3000");
+    properties.setProperty(LOCK_ACQUIRE_CLIENT_NUM_RETRIES_PROP_KEY, "3");
+    properties.setProperty(LOCK_ACQUIRE_NUM_RETRIES_PROP_KEY, "3");
+    properties.setProperty(ZK_SESSION_TIMEOUT_MS_PROP_KEY, "10000");
+    properties.setProperty(ZK_CONNECTION_TIMEOUT_MS_PROP_KEY, "10000");
+    properties.setProperty(LOCK_ACQUIRE_WAIT_TIMEOUT_MS_PROP_KEY, "1000");
 
     config = getConfigBuilder()
         .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
@@ -104,10 +120,15 @@ public class TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockPr
 
   @AfterEach
   public void clean() throws IOException {
-    cleanupResources();
-    FileIOUtils.deleteDirectory(new File(basePath));
-    if (server != null) {
-      server.close();
+    try {
+      cleanupResources();
+      FileIOUtils.deleteDirectory(new File(basePath));
+    } finally {
+      // Always stop the embedded ZooKeeper server, even if resource cleanup or directory
+      // deletion above throws, so the server is not leaked across parameterized runs.
+      if (server != null) {
+        server.close();
+      }
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockProvider` is flaky on Azure CI (for example [Azure build 14697](https://dev.azure.com/apachehudi/a1a51da7-8592-47d4-88dc-fd67bed336bb/_build/results?buildId=14697), where the `UT FT client` job hit it as a spurious failure on the unrelated PR #18693): one parameterization has hung for ~7 minutes (422s) and failed the job with `CuratorConnectionLossException` thrown from `BaseZookeeperBasedLockProvider.<init>` during `createPathIfNotExists`. The root cause is amplification of a single transient ZooKeeper `ConnectionLoss` by two nested retry layers - the Curator `BoundedExponentialBackoffRetry` inside the lock provider constructor and `LockManager`'s `RetryHelper` around provider creation - because the test inherits the production-default retry counts (client retries 50, Curator retries 15) instead of bounding them like the sibling `TestZookeeperBasedLockProvider`.

### Summary and Changelog

- `BaseZookeeperBasedLockProvider`: after `curatorFrameworkClient.start()` and before the first `exists`/`create`, block until the client is connected (bounded by the existing `ZK_CONNECTION_TIMEOUT_MS`). The first ZooKeeper operation no longer races asynchronous connection setup, so a healthy server connects cleanly and a genuinely unreachable one fails deterministically after one connection timeout instead of throwing `ConnectionLoss` into the retry storm.
- `TestSimpleTransactionDirectMarkerBasedDetectionStrategyWithZKLockProvider`: bound the lock-acquire retries and ZooKeeper timeouts, mirroring the non-flaky `TestZookeeperBasedLockProvider`, so a transient failure fails fast (seconds) instead of being amplified into a multi-minute hang. The `@AfterEach` now closes the embedded `TestingServer` in a `finally` so it is not leaked if resource cleanup or directory deletion throws.

### Impact

ZooKeeper-based lock acquisition waits for the client connection before its first operation. Early conflict detection and any `ZookeeperBasedLockProvider` user now fail fast and deterministically against an unreachable ZooKeeper instead of retrying a `ConnectionLoss` for minutes. No public API or configuration change.

### Risk Level

low

The change reuses the already-configured `ZK_CONNECTION_TIMEOUT_MS` and adds no new config. Verified locally: the touched modules compile with 0 checkstyle violations, and `TestZookeeperBasedLockProvider` (8/8) passes - it constructs `BaseZookeeperBasedLockProvider` against a real embedded ZooKeeper and exercises the new connect-wait path.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
