### PR TITLE
perf(kafka-connect): reuse AvroConvertor across records in the connect writer

### DIFF
--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/AbstractConnectWriter.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/AbstractConnectWriter.java
@@ -53,6 +53,10 @@ public abstract class AbstractConnectWriter implements ConnectWriter<WriteStatus
   private final KeyGenerator keyGenerator;
   private final SchemaProvider schemaProvider;
   protected final KafkaConnectConfigs connectConfigs;
+  private final String kafkaValueConverter;
+  // Reused across all records of this writer (one writer is created per commit, single-threaded),
+  // instead of re-parsing the schema and rebuilding the converter on every record.
+  private AvroConvertor convertor;
 
   public AbstractConnectWriter(KafkaConnectConfigs connectConfigs,
                                KeyGenerator keyGenerator,
@@ -61,23 +65,26 @@ public abstract class AbstractConnectWriter implements ConnectWriter<WriteStatus
     this.keyGenerator = keyGenerator;
     this.schemaProvider = schemaProvider;
     this.instantTime = instantTime;
+    this.kafkaValueConverter = connectConfigs.getKafkaValueConverter();
   }
 
   @Override
   public void writeRecord(SinkRecord record) throws IOException {
-    AvroConvertor convertor = new AvroConvertor(schemaProvider.getSourceHoodieSchema());
     Option<GenericRecord> avroRecord;
-    switch (connectConfigs.getKafkaValueConverter()) {
+    switch (kafkaValueConverter) {
       case KAFKA_AVRO_CONVERTER:
         avroRecord = Option.of((GenericRecord) record.value());
         break;
       case KAFKA_STRING_CONVERTER:
+        if (convertor == null) {
+          convertor = new AvroConvertor(schemaProvider.getSourceHoodieSchema());
+        }
         avroRecord = Option.of(convertor.fromJson((String) record.value()));
         break;
       case KAFKA_JSON_CONVERTER:
         throw new UnsupportedEncodingException("Currently JSON objects are not supported");
       default:
-        throw new IOException("Unsupported Kafka Format type (" + connectConfigs.getKafkaValueConverter() + ")");
+        throw new IOException("Unsupported Kafka Format type (" + kafkaValueConverter + ")");
     }
 
     // Tag records with a file ID based on kafka partition and hudi partition.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`AbstractConnectWriter.writeRecord` allocates a new `AvroConvertor` on every record via `new AvroConvertor(schemaProvider.getSourceHoodieSchema())`. The `AvroConvertor(HoodieSchema)` constructor serializes the schema to a string, and on the `StringConverter` path the first use of each convertor lazily parses the schema (`HoodieSchema.parse`) and builds a new `MercifulJsonConverter`. Since a fresh convertor is created per record, this work repeats on every record of the hot write path.

### Summary and Changelog

Build the `AvroConvertor` once per writer and reuse it across all records, and read the configured value converter into a `final` field instead of looking it up per record. A writer is created per commit and `writeRecord` runs on a single thread, so the convertor is created lazily on first use in the `StringConverter` branch and reused for the remainder of the commit; the Avro path no longer allocates a convertor at all (previously it was created but never used). The produced `HoodieRecord`s and record keys are unchanged.

### Impact

Performance only; no public API or behavior change. Local JMH micro-benchmark of `writeRecord` (AverageTime mode, gc profiler, with a caching schema provider so the numbers are conservative), measured against master:

| Path | Baseline ns/op | After ns/op | Baseline B/op | After B/op |
|------|---------------:|------------:|--------------:|-----------:|
| StringConverter (JSON) | 18419 | 2495 (-86%, 7.4x) | 33040 | 3951 (-88%) |
| AvroConverter | 2574 | 792 (-69%, 3.25x) | 10602 | 1306 (-88%) |

Per-record CPU time and garbage on the connect write path drop by roughly 7-8x. Benchmark code is not included in this PR.

### Risk Level

low

Behavior-preserving reuse of an object that is already meant to be reused (`AvroConvertor` is constructed once per partition elsewhere in Hudi). Covered by the existing `hudi-kafka-connect` unit tests; `TestAbstractConnectWriter` exercises both the Avro and JSON paths and passes.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
