### PR TITLE
perf(kafka-connect): memoize file id per partition path in the connect writer

### DIFF
--- a/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/AbstractConnectWriter.java
+++ b/hudi-kafka-connect/src/main/java/org/apache/hudi/connect/writers/AbstractConnectWriter.java
@@ -35,7 +35,9 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Base Hudi Writer that manages reading the raw Kafka records and
@@ -57,6 +59,9 @@ public abstract class AbstractConnectWriter implements ConnectWriter<WriteStatus
   // Reused across all records of this writer (one writer is created per commit, single-threaded),
   // instead of re-parsing the schema and rebuilding the converter on every record.
   private AvroConvertor convertor;
+  // Cache fileId per partition path; kafkaPartition is invariant for a writer (the participant is
+  // bound to a single TopicPartition), so the digest input is stable for a given partition path.
+  private final Map<String, String> fileIdByPartitionPath = new HashMap<>();
 
   public AbstractConnectWriter(KafkaConnectConfigs connectConfigs,
                                KeyGenerator keyGenerator,
@@ -89,7 +94,12 @@ public abstract class AbstractConnectWriter implements ConnectWriter<WriteStatus
 
     // Tag records with a file ID based on kafka partition and hudi partition.
     HoodieRecord<?> hoodieRecord = new HoodieAvroRecord<>(keyGenerator.getKey(avroRecord.get()), new HoodieAvroPayload(avroRecord));
-    String fileId = KafkaConnectUtils.hashDigest(String.format("%s-%s", record.kafkaPartition(), hoodieRecord.getPartitionPath()));
+    String partitionPath = hoodieRecord.getPartitionPath();
+    String fileId = fileIdByPartitionPath.get(partitionPath);
+    if (fileId == null) {
+      fileId = KafkaConnectUtils.hashDigest(record.kafkaPartition() + "-" + partitionPath);
+      fileIdByPartitionPath.put(partitionPath, fileId);
+    }
     hoodieRecord.unseal();
     hoodieRecord.setCurrentLocation(new HoodieRecordLocation(instantTime, fileId));
     hoodieRecord.setNewLocation(new HoodieRecordLocation(instantTime, fileId));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`AbstractConnectWriter.writeRecord` computes the Hudi file id per record via `KafkaConnectUtils.hashDigest(String.format("%s-%s", record.kafkaPartition(), partitionPath))`, which builds a formatted string, runs `MessageDigest.getInstance("MD5")`, digests, and hex-encodes on every record. The file id depends only on `(kafkaPartition, partitionPath)`, and `kafkaPartition` is invariant for a given writer because a participant is bound to a single `TopicPartition`, so the same digest is recomputed redundantly for every record that shares a partition path.

### Summary and Changelog

Memoize the file id in a `HashMap` keyed by partition path, computing the MD5 digest only on the first record seen for each partition path and reusing it afterwards. The hashed input stays `kafkaPartition + "-" + partitionPath` (concatenation, byte-identical to the previous `String.format("%s-%s", ...)`), so the produced file id, which determines on-disk file grouping, is unchanged. The cache lives on the writer instance, which is created per commit and used by a single thread, so no synchronization is needed. This change is independent of #19015 (AvroConvertor reuse); both touch `writeRecord`, so whichever merges second needs a trivial rebase.

### Impact

Performance only; no public API or behavior change. Local JMH micro-benchmark of `writeRecord` (AverageTime mode, gc profiler, caching schema provider), measured independently against master:

| Path | Baseline ns/op | After ns/op | Baseline B/op | After B/op |
|------|---------------:|------------:|--------------:|-----------:|
| AvroConverter | 2574 | 1807 (-30%) | 10602 | 9698 (-904 B) |
| StringConverter (JSON) | 18419 | 17279 (-6%) | 33040 | 32136 (-904 B) |

The change removes a fixed ~767 ns and ~904 B per record (the MD5 digest, the hex string, and the `String.format` temporaries). With a typical low-cardinality partition layout the digest collapses to one computation per partition path. Benchmark code is not included in this PR.

### Risk Level

low

The file id string is byte-identical to before, and the cache is scoped to a single-threaded, per-commit writer so it needs no synchronization. Covered by the existing `hudi-kafka-connect` unit tests; `TestAbstractConnectWriter` validates the produced record keys for both the Avro and JSON paths and passes.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
