### PR TITLE
test(flink): de-flake testStreamReadMorTableWithCompactionFromEarliest

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -3941,6 +3941,15 @@ public class ITTestHoodieDataSource {
       //      fail the job on stream-closed-mid-read (the right behavior for real I/O
       //      failures), so this tolerance is scoped to the SuccessException-based test
       //      pattern below and is NOT mirrored in production code.
+      //   3. NullPointerException from ParquetColumnarRowSplitReader#readNextRowGroup: the
+      //      same benign teardown race as (2), observed with different timing. When the
+      //      SplitFetcher's close() fully completes first, ParquetColumnarRowSplitReader#close
+      //      nulls out its `reader` field, so the in-flight row-group read on the task thread
+      //      surfaces as a NullPointerException (reader.readNextRowGroup() on a null reader)
+      //      instead of an IOException("Stream is closed!"). Same functional outcome - the
+      //      sink has already collected the expected rows - only the error symptom differs.
+      //      Tolerated narrowly (an NPE originating from that exact frame) for the same
+      //      reason as (2), and likewise NOT mirrored in production code.
       if (!isAcceptableTerminalFailure(e)) {
         throw new AssertionError("Unexpected job failure", e);
       }
@@ -3966,7 +3975,40 @@ public class ITTestHoodieDataSource {
       if (msg != null && msg.contains("Stream is closed")) {
         return true;
       }
+      // The NPE twin of the "Stream is closed!" teardown race (cause #3 at the call site):
+      // a NullPointerException whose own stack trace originates from
+      // ParquetColumnarRowSplitReader#readNextRowGroup, i.e. reader.readNextRowGroup() ran on a
+      // null `reader` that ParquetColumnarRowSplitReader#close had just nulled out. Scoped to
+      // that exact frame so genuine NPEs - and the legitimate IOException("expecting more
+      // rows...") thrown from the same method - still fail the test.
+      if (isNullPointerException(cur) && readsNextRowGroup(cur)) {
+        return true;
+      }
       cur = cur.getCause();
+    }
+    return false;
+  }
+
+  /**
+   * True for a real {@link NullPointerException} as well as one wrapped in Flink's
+   * {@code SerializedThrowable} when the failure is propagated back from the cluster (its
+   * {@code toString()} preserves the original {@code java.lang.NullPointerException} prefix).
+   */
+  private static boolean isNullPointerException(Throwable t) {
+    return t instanceof NullPointerException
+        || t.toString().startsWith("java.lang.NullPointerException");
+  }
+
+  /**
+   * Whether {@code t}'s stack trace (preserved even through {@code SerializedThrowable})
+   * contains a {@code ParquetColumnarRowSplitReader#readNextRowGroup} frame.
+   */
+  private static boolean readsNextRowGroup(Throwable t) {
+    for (StackTraceElement frame : t.getStackTrace()) {
+      if (frame.getClassName().endsWith("ParquetColumnarRowSplitReader")
+          && "readNextRowGroup".equals(frame.getMethodName())) {
+        return true;
+      }
     }
     return false;
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -3981,7 +3981,7 @@ public class ITTestHoodieDataSource {
       // null `reader` that ParquetColumnarRowSplitReader#close had just nulled out. Scoped to
       // that exact frame so genuine NPEs - and the legitimate IOException("expecting more
       // rows...") thrown from the same method - still fail the test.
-      if (isNullPointerException(cur) && readsNextRowGroup(cur)) {
+      if (isNullPointerException(cur) && containsReadNextRowGroupFrame(cur)) {
         return true;
       }
       cur = cur.getCause();
@@ -3996,14 +3996,14 @@ public class ITTestHoodieDataSource {
    */
   private static boolean isNullPointerException(Throwable t) {
     return t instanceof NullPointerException
-        || t.toString().startsWith("java.lang.NullPointerException");
+        || t.toString().startsWith(NullPointerException.class.getName());
   }
 
   /**
    * Whether {@code t}'s stack trace (preserved even through {@code SerializedThrowable})
    * contains a {@code ParquetColumnarRowSplitReader#readNextRowGroup} frame.
    */
-  private static boolean readsNextRowGroup(Throwable t) {
+  private static boolean containsReadNextRowGroupFrame(Throwable t) {
     for (StackTraceElement frame : t.getStackTrace()) {
       if (frame.getClassName().endsWith("ParquetColumnarRowSplitReader")
           && "readNextRowGroup".equals(frame.getMethodName())) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Flink streaming-read integration test `ITTestHoodieDataSource#testStreamReadMorTableWithCompactionFromEarliest` is intermittently flaky in CI. It surfaced on an unrelated PR run with `java.lang.NullPointerException` at `ParquetColumnarRowSplitReader.readNextRowGroup`, reported as "Unexpected job failure". Originating failure: https://github.com/apache/hudi/actions/runs/27597833446/job/81591777608

### Summary and Changelog

The test drives a continuous streaming read and terminates it by having `CollectSink` throw `SuccessException` once the expected row count is collected. During that cascading shutdown the source's `SplitFetcher` calls `close()` down to `ParquetColumnarRowSplitReader#close`, which nulls out its `reader` field, while the task-thread mailbox is still draining a `BatchRecords` batch queued earlier for the same split. Depending on exact timing the in-flight row-group read surfaces either as `IOException("Stream is closed!")` or, when `close()` fully completes first, as a `NullPointerException` from `reader.readNextRowGroup()` on the now-null `reader`. Both are the same benign teardown race: the sink has already collected all expected rows by then, so the functional outcome is unchanged and only the reported failure cause differs. Splits are read strictly sequentially and `reader` is nulled only by `close()` (reachable here only on job teardown), so this is not a steady-state correctness/data-loss issue.

`fetchResultWithExpectedNum` already documents and tolerates the `IOException("Stream is closed!")` variant via `isAcceptableTerminalFailure`. This change extends that same test-only tolerance to the `NullPointerException` variant, scoped narrowly to an NPE whose stack trace originates from `ParquetColumnarRowSplitReader#readNextRowGroup` (robust to Flink's `SerializedThrowable` wrapping), so that genuine NPEs and the legitimate `IOException("expecting more rows...")` thrown from the same method still fail the test. The call-site rationale comment is extended to document the second manifestation. The flaky test was introduced by #18848.

### Impact

Test-only change; no production code is modified. It reduces flakiness of the Flink streaming-read IT. The tolerance stays scoped to the `SuccessException`-based test termination pattern and is deliberately not mirrored in production code, where failing the job on a stream-closed-mid-read is the correct behavior for real I/O failures.

### Risk Level

low

Verified by building the `hudi-flink` module (`test-compile`) with 0 checkstyle violations and running `ITTestHoodieDataSource#testStreamReadMorTableWithCompactionFromEarliest` (both `useSourceV2` parameterizations) to a clean pass. The change only adds a branch inside the existing teardown-failure catch path, so it cannot affect the happy path.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
