### PR TITLE
fix(flink): reuse the preceeding avg size if there is no eligible estimation

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
@@ -93,7 +93,7 @@ public class DeltaWriteProfile extends WriteProfile {
 
   @Override
   protected long averageBytesPerRecord() {
-    long avgSize = config.getCopyOnWriteRecordSizeEstimate();
+    long avgSize = getAvgSize() > 0 ? getAvgSize() : config.getCopyOnWriteRecordSizeEstimate();
     HoodieTimeline commitTimeline = metaClient.getCommitTimeline().filterCompletedInstants();
     if (!commitTimeline.empty()) {
       long sizeFromCommitMetadata = calculateRecordSizeThroughCommitMetadata(commitTimeline, 1.0D);
@@ -109,7 +109,6 @@ public class DeltaWriteProfile extends WriteProfile {
         }
       }
     }
-    log.info("Refresh average bytes per record => " + avgSize);
     return avgSize;
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/DeltaWriteProfile.java
@@ -29,8 +29,6 @@ import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.action.commit.SmallFile;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,7 +39,6 @@ import java.util.stream.Collectors;
  *
  * <p>Note: assumes the index can always index log files for Flink write.
  */
-@Slf4j
 public class DeltaWriteProfile extends WriteProfile {
 
   public DeltaWriteProfile(HoodieWriteConfig config, HoodieFlinkEngineContext context) {
@@ -93,7 +90,7 @@ public class DeltaWriteProfile extends WriteProfile {
 
   @Override
   protected long averageBytesPerRecord() {
-    long avgSize = getAvgSize() > 0 ? getAvgSize() : config.getCopyOnWriteRecordSizeEstimate();
+    long avgSize = this.avgSize > 0 ? this.avgSize : config.getCopyOnWriteRecordSizeEstimate();
     HoodieTimeline commitTimeline = metaClient.getCommitTimeline().filterCompletedInstants();
     if (!commitTimeline.empty()) {
       long sizeFromCommitMetadata = calculateRecordSizeThroughCommitMetadata(commitTimeline, 1.0D);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
@@ -78,7 +78,7 @@ public class WriteProfile {
    * The average record size.
    */
   @Getter
-  private long avgSize = -1L;
+  protected long avgSize = -1L;
 
   /**
    * Total records to write for each bucket based on

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/profile/WriteProfile.java
@@ -134,7 +134,7 @@ public class WriteProfile {
    * records pack into one file.
    */
   protected long averageBytesPerRecord() {
-    long avgSize = config.getCopyOnWriteRecordSizeEstimate();
+    long avgSize = this.avgSize > 0 ? this.avgSize : config.getCopyOnWriteRecordSizeEstimate();
     HoodieTimeline commitTimeline = metaClient.getCommitTimeline().filterCompletedInstants();
     if (!commitTimeline.empty()) {
       long sizeFromCommitMetadata = calculateRecordSizeThroughCommitMetadata(commitTimeline, 1.0D);
@@ -142,7 +142,6 @@ public class WriteProfile {
         avgSize = sizeFromCommitMetadata;
       }
     }
-    log.info("Refresh average bytes per record => " + avgSize);
     return avgSize;
   }
 
@@ -238,8 +237,9 @@ public class WriteProfile {
 
   private void recordProfile() {
     this.avgSize = averageBytesPerRecord();
+    log.info("Refresh average bytes per record => {}", avgSize);
     this.recordsPerBucket = config.getParquetMaxFileSize() / avgSize;
-    log.info("Refresh insert records per bucket => " + recordsPerBucket);
+    log.info("Refresh insert records per bucket => {}", recordsPerBucket);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketAssigner.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/TestBucketAssigner.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
@@ -46,11 +47,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -445,6 +448,26 @@ public class TestBucketAssigner {
   }
 
   @Test
+  public void testWriteProfileReusesPreviousAvgSizeWhenNoEligibleCommitOnReload() throws Exception {
+    conf.set(FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE, 1);
+    conf.setString(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), "1024");
+    TestData.writeData(TestData.DATA_SET_INSERT, conf);
+
+    writeConfig = FlinkWriteClients.getHoodieClientConfig(conf);
+    setScriptedRecordSizes(512L, -1L);
+    WriteProfile writeProfile = new ScriptedRecordSizeWriteProfile(writeConfig, context);
+    assertThat("Average record size should use the profiled commit metadata",
+        writeProfile.getAvgSize(), is(512L));
+
+    writeProfile.reload(1);
+
+    assertThat("Average record size should reuse the previous estimate when no eligible commit metadata is found",
+        writeProfile.getAvgSize(), is(512L));
+    assertThat("Records per bucket should continue to use the previous estimate",
+        writeProfile.getRecordsPerBucket(), is(writeConfig.getParquetMaxFileSize() / 512L));
+  }
+
+  @Test
   public void testDeltaWriteProfileRecordsPerBucketUsesCompressionRatio() throws Exception {
     File morPath = new File(tempFile, "mor");
     Configuration morConf = TestConfigurations.getDefaultConf(morPath.getAbsolutePath());
@@ -505,6 +528,34 @@ public class TestBucketAssigner {
         writeProfile.getRecordsPerBucket(), is(morWriteConfig.getParquetMaxFileSize() / expectedAvgSize));
   }
 
+  @Test
+  public void testDeltaWriteProfileReusesPreviousAvgSizeWhenNoEligibleDeltaCommitOnReload() throws Exception {
+    File morPath = new File(tempFile, "mor_reuse_previous_avg");
+    Configuration morConf = TestConfigurations.getDefaultConf(morPath.getAbsolutePath());
+    morConf.set(FlinkOptions.TABLE_TYPE, HoodieTableType.MERGE_ON_READ.name());
+    morConf.set(FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE, 1);
+    morConf.setString(HoodieCompactionConfig.COPY_ON_WRITE_RECORD_SIZE_ESTIMATE.key(), "1024");
+    StreamerUtil.initTableIfNotExists(morConf);
+    TestData.writeData(TestData.DATA_SET_INSERT, morConf);
+
+    HoodieWriteConfig morWriteConfig = FlinkWriteClients.getHoodieClientConfig(morConf);
+    HoodieFlinkEngineContext morContext = new HoodieFlinkEngineContext(
+        HadoopFSUtils.getStorageConf(HadoopConfigurations.getHadoopConf(morConf)),
+        new FlinkTaskContextSupplier(null));
+
+    setScriptedRecordSizes(256L, -1L);
+    DeltaWriteProfile writeProfile = new ScriptedRecordSizeDeltaWriteProfile(morWriteConfig, morContext);
+    assertThat("Average record size should use the profiled delta commit metadata",
+        writeProfile.getAvgSize(), is(256L));
+
+    writeProfile.reload(1);
+
+    assertThat("Average record size should reuse the previous estimate when no eligible delta commit metadata is found",
+        writeProfile.getAvgSize(), is(256L));
+    assertThat("Records per bucket should continue to use the previous estimate",
+        writeProfile.getRecordsPerBucket(), is(morWriteConfig.getParquetMaxFileSize() / 256L));
+  }
+
   private static String getLastCompleteInstant(WriteProfile profile) {
     return StreamerUtil.getLastCompletedInstant(profile.getMetaClient());
   }
@@ -524,6 +575,40 @@ public class TestBucketAssigner {
       BucketType bucketType) {
     assertThat(bucketInfo.getPartitionPath(), is(partition));
     assertThat(bucketInfo.getBucketType(), is(bucketType));
+  }
+
+  private static Queue<Long> scriptedRecordSizes = new ArrayDeque<>();
+
+  private static void setScriptedRecordSizes(Long... recordSizes) {
+    scriptedRecordSizes = new ArrayDeque<>(Arrays.asList(recordSizes));
+  }
+
+  /**
+   * WriteProfile with scripted record size estimates.
+   */
+  static class ScriptedRecordSizeWriteProfile extends WriteProfile {
+    ScriptedRecordSizeWriteProfile(HoodieWriteConfig config, HoodieFlinkEngineContext context) {
+      super(config, context);
+    }
+
+    @Override
+    protected long calculateRecordSizeThroughCommitMetadata(HoodieTimeline commitTimeline, double fileSizeCalibrationRatio) {
+      return scriptedRecordSizes.remove();
+    }
+  }
+
+  /**
+   * DeltaWriteProfile with scripted record size estimates.
+   */
+  static class ScriptedRecordSizeDeltaWriteProfile extends DeltaWriteProfile {
+    ScriptedRecordSizeDeltaWriteProfile(HoodieWriteConfig config, HoodieFlinkEngineContext context) {
+      super(config, context);
+    }
+
+    @Override
+    protected long calculateRecordSizeThroughCommitMetadata(HoodieTimeline commitTimeline, double fileSizeCalibrationRatio) {
+      return scriptedRecordSizes.remove();
+    }
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink `WriteProfile` and `DeltaWriteProfile` refresh average record size from commit or delta-commit metadata. When the current timeline has no eligible commit metadata for size estimation, the refresh path could fall back to the configured default record size estimate, even if the profile had already learned a better value from a preceding eligible commit.

This can make `recordsPerBucket` jump back to the default estimate after a reload, affecting insert bucket sizing for Flink COW and MOR writes. This PR keeps the preceding profiled average size when a later refresh cannot derive a valid estimate from eligible commits or delta commits.

### Summary and Changelog

Flink write profiles now preserve the last successful average record size estimate across reloads when no eligible commit metadata is available for the current estimation pass.

- Updated `WriteProfile.averageBytesPerRecord()` to seed estimation from the existing `avgSize` once initialized, falling back to `COPY_ON_WRITE_RECORD_SIZE_ESTIMATE` only before any profiled value exists.
- Updated `DeltaWriteProfile.averageBytesPerRecord()` with the same reuse behavior for MOR commit and delta-commit estimation.
- Moved average-size logging into `WriteProfile.recordProfile()` so the refreshed value is logged once after the profile is updated.
- Added regression coverage in `TestBucketAssigner` for:
  - `testWriteProfileReusesPreviousAvgSizeWhenNoEligibleCommitOnReload`
  - `testDeltaWriteProfileReusesPreviousAvgSizeWhenNoEligibleDeltaCommitOnReload`

### Impact

This affects Flink write bucket sizing for COW and MOR tables when profile reloads encounter commits or delta commits that are not eligible for record-size estimation. The change avoids reverting to the configured default estimate after a better preceding estimate has already been learned.

There are no public API, config, storage format, or compatibility changes. Performance impact is negligible; the change only reuses an already cached in-memory value during profile refresh.

### Risk Level

low

The change is limited to Flink `WriteProfile` and `DeltaWriteProfile` average record size estimation. The main behavioral risk is retaining a stale estimate longer when no eligible metadata exists, but that is the intended behavior and is safer than reverting to a less accurate configured default. Once eligible commit metadata is available again, the estimate is refreshed from metadata as before.

Verified with:

`mvn -pl hudi-flink-datasource/hudi-flink -am -Dtest=TestBucketAssigner -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs`

Result: `TestBucketAssigner` ran 16 tests with 0 failures.

### Documentation Update

none

This is an internal Flink write profile estimation fix with no new user-facing configuration, API, or documented behavior change.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
