### PR TITLE
feat(metadata): Fix partitioned RLI lookup to use full record key

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadata.java
@@ -279,7 +279,7 @@ public class HoodieBackedTableMetadata extends BaseTableMetadata {
       // all keys will be from the same shard index so just calculate the first key and reduce partitionFileSlices to 1
       TreeSet<String> distinctSortedKeys = getDistinctSortedKeysForSingleSlice(keys);
       int fileGroupIndex = HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(distinctSortedKeys.stream().findFirst().get(), fileSlicesForDataPartition.size());
-      return readSliceAndFilterByKeysIntoList(partitionName, distinctSortedKeys, fileSlicesForDataPartition.get(fileGroupIndex), false);
+      return readSliceAndFilterByKeysIntoList(partitionName, distinctSortedKeys, fileSlicesForDataPartition.get(fileGroupIndex), true);
     } else if (partitionName.equals(RECORD_INDEX.getPartitionPath()) && !fileSlices.isEmpty() && HoodieTableMetadataUtil.verifyRLIFile(fileSlices.get(0).getFileId(), true)) {
       if (keys.isEmpty()) {
         return HoodieListData.lazy(Collections.emptyList());

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -393,6 +393,41 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase with SparkDatasetMix
     assertEquals(0, partition3Locations.size)
   }
 
+  @Test
+  def testPartitionedRecordLevelIndexLookupUsesFullKey(): Unit = {
+    initMetaClient(HoodieTableType.COPY_ON_WRITE)
+    val dataGen = new HoodieTestDataGenerator()
+    val inserts = dataGen.generateInserts("001", 3)
+    val insertDf = toDataset(spark, inserts).withColumn("data_partition_path", lit("partition1"))
+    val options = Map(HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.COPY_ON_WRITE.name(),
+      RECORDKEY_FIELD.key -> "_row_key",
+      PARTITIONPATH_FIELD.key -> "data_partition_path",
+      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+      HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "false",
+      HoodieMetadataConfig.RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "true",
+      HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key() -> "false",
+      HoodieIndexConfig.INDEX_TYPE.key() -> RECORD_LEVEL_INDEX.name())
+    insertDf.write.format("hudi")
+      .options(options)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val writeConfig = getWriteConfig(options)
+    val metadata = metadataWriter(writeConfig).getTableMetadata
+    val recordKeys = inserts.asScala.map(i => i.getRecordKey).asJava
+    assertEquals(3, readRecordIndex(metadata, recordKeys, HOption.of("partition1")).size)
+
+    // Partitioned RLI lookup is still a full record-key lookup within the data partition.
+    // A prefix-only key would incorrectly match real records if the lookup used prefix matching.
+    val recordKeySet = recordKeys.asScala.toSet
+    val prefixOnlyKey = recordKeys.asScala
+      .flatMap(key => (1 until key.length).map(key.substring(0, _)))
+      .find(prefix => !recordKeySet.contains(prefix))
+      .get
+    assertTrue(readRecordIndex(metadata, util.Collections.singletonList(prefixOnlyKey), HOption.of("partition1")).isEmpty)
+  }
+
   @ParameterizedTest
   @MethodSource(Array("testArgsForPartitionedRecordLevelIndex"))
   def testPartitionedRecordLevelIndexInitializationBasic(testCase: TestPartitionedRecordLevelIndexTestCase): Unit = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Partitioned record-level index lookups in metadata should still match against the full record key within the selected data partition. The previous lookup path filtered records using prefix matching after narrowing to a single shard, which could allow a prefix-only key to match an existing record incorrectly.

This PR fixes the partitioned RLI metadata read path to use full-key matching and adds a Spark functional test that verifies valid keys are returned while non-existent prefix-only keys do not match.

Fixes #19027

### Summary and Changelog

- Update `HoodieBackedTableMetadata` to read partitioned record index entries with full-key filtering when resolving a single file slice.
- Add `testPartitionedRecordLevelIndexLookupUsesFullKey` in `TestRecordLevelIndex.scala` to cover partitioned RLI reads with `GLOBAL_RECORD_LEVEL_INDEX_ENABLE=false` and `RECORD_LEVEL_INDEX_ENABLE=true`.
- Verify both the positive path for real record keys and the negative path for a prefix-only key that should return no matches.

### Impact

- **Functional impact**: Fixes incorrect prefix-based matches during partitioned record-level index lookup in metadata.
- **Maintainability**: Tightens the lookup contract in the metadata reader and documents the expected behavior with a targeted regression test.
- **Extensibility**: Reduces ambiguity for future changes around partitioned RLI sharding and lookup semantics by anchoring behavior in test coverage.

### Risk Level

low. The production change is a one-line behavioral fix in the partitioned RLI metadata lookup path, and it is covered by a focused functional regression test in the Spark datasource test suite.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable