### PR TITLE
test(flink): retry short CollectSink reads to de-flake stream-read ITs

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -79,6 +79,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -126,6 +128,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @ExtendWith(FlinkMiniCluster.class)
 public class ITTestHoodieDataSource {
+  private static final Logger LOG = LoggerFactory.getLogger(ITTestHoodieDataSource.class);
+
+  // A streaming read collected via CollectTableSink is terminated by a forced SuccessException once it
+  // reaches its expected row count. A benign teardown race (see isAcceptableTerminalFailure) can instead
+  // close the source stream mid-read and terminate the job before all rows are emitted, leaving an
+  // incomplete result. Re-reading from the same (already committed) table is idempotent, so retry a few
+  // times before giving up. See fetchResultWithExpectedNum.
+  private static final int MAX_STREAM_READ_ATTEMPTS = 3;
+
   private TableEnvironment streamTableEnv;
   private TableEnvironment batchTableEnv;
 
@@ -560,7 +571,7 @@ public class ITTestHoodieDataSource {
         + "  'connector' = '" + CollectSinkTableFactory.FACTORY_ID + "',\n"
         + "  'sink-expected-row-num' = '2'"
         + ")";
-    List<Row> result = execSelectSqlWithExpectedNum(streamTableEnv, "select name, sum(age) from t1 group by name", sinkDDL);
+    List<Row> result = submitAndFetchWithRetry(streamTableEnv, "select name, sum(age) from t1 group by name", sinkDDL, 2);
     final String expected = "[+I(+I[Danny, 24]), +I(+I[Stephen, 34])]";
     assertRowsEquals(result, expected, true);
   }
@@ -3888,15 +3899,32 @@ public class ITTestHoodieDataSource {
     } else {
       sinkDDL = TestConfigurations.getCollectSinkDDLWithExpectedNum("sink", expectedNum);
     }
-    return execSelectSqlWithExpectedNum(tEnv, select, sinkDDL);
+    return submitAndFetchWithRetry(tEnv, select, sinkDDL, expectedNum);
   }
 
   /**
-   * Use CollectTableSink to collect results with expected row number.
+   * Submits a streaming select that collects into the {@link CollectSinkTableFactory} sink and returns
+   * the collected rows.
+   *
+   * <p>The streaming job is terminated by a forced {@link CollectSinkTableFactory.SuccessException} once
+   * {@code expectedNum} rows are collected. A benign teardown race (see {@link #isAcceptableTerminalFailure})
+   * can instead end the job before all rows are emitted, leaving a short result. Re-reading the already
+   * committed table is idempotent, so retry up to {@link #MAX_STREAM_READ_ATTEMPTS} times when the result
+   * is short; this keeps the race from surfacing as a confusing row-count assertion failure.
    */
-  private List<Row> execSelectSqlWithExpectedNum(TableEnvironment tEnv, String select, String sinkDDL) {
-    TableResult tableResult = submitSelectSql(tEnv, select, sinkDDL);
-    return fetchResultWithExpectedNum(tEnv, tableResult);
+  private List<Row> submitAndFetchWithRetry(TableEnvironment tEnv, String select, String sinkDDL, int expectedNum) {
+    List<Row> rows = Collections.emptyList();
+    for (int attempt = 1; attempt <= MAX_STREAM_READ_ATTEMPTS; attempt++) {
+      TableResult tableResult = submitSelectSql(tEnv, select, sinkDDL);
+      rows = fetchResultWithExpectedNum(tEnv, tableResult);
+      if (expectedNum <= 0 || rows.size() >= expectedNum) {
+        return rows;
+      }
+      LOG.warn("Streaming read collected {} of {} expected rows on attempt {}/{}; a tolerated teardown "
+              + "race ended the job before the read completed. Retrying. select=[{}]",
+          rows.size(), expectedNum, attempt, MAX_STREAM_READ_ATTEMPTS, select);
+    }
+    return rows;
   }
 
   private TableResult submitSelectSql(TableEnvironment tEnv, String select, String sinkDDL) {
@@ -3952,6 +3980,14 @@ public class ITTestHoodieDataSource {
       //      reason as (2), and likewise NOT mirrored in production code.
       if (!isAcceptableTerminalFailure(e)) {
         throw new AssertionError("Unexpected job failure", e);
+      }
+      // The races (2)/(3) usually fire after the sink has collected its expected rows, but can also fire
+      // before - ending the read with a short result. Log the tolerated cause so an incomplete read is
+      // diagnosable; submitAndFetchWithRetry re-reads when the collected count is below the expectation.
+      if (!isSuccessException(e)) {
+        LOG.warn("Streaming read terminated by a tolerated teardown race ({}); collected {} rows so far.",
+            describeTerminalCause(e),
+            CollectSinkTableFactory.RESULT.values().stream().mapToInt(List::size).sum());
       }
     }
     tEnv.executeSql("DROP TABLE IF EXISTS sink");
@@ -4011,5 +4047,29 @@ public class ITTestHoodieDataSource {
       }
     }
     return false;
+  }
+
+  /**
+   * Whether {@code e} (or any of its causes) is the normal {@link CollectSinkTableFactory.SuccessException}
+   * terminator (the happy path), as opposed to one of the tolerated teardown-race symptoms.
+   */
+  private static boolean isSuccessException(Throwable e) {
+    for (Throwable cur = e; cur != null; cur = cur.getCause()) {
+      if (cur instanceof CollectSinkTableFactory.SuccessException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Short description of {@code e}'s root cause, for logging which tolerated terminal failure fired.
+   */
+  private static String describeTerminalCause(Throwable e) {
+    Throwable root = e;
+    while (root.getCause() != null) {
+      root = root.getCause();
+    }
+    return root.getClass().getName() + ": " + root.getMessage();
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -134,7 +134,7 @@ public class ITTestHoodieDataSource {
   // reaches its expected row count. A benign teardown race (see isAcceptableTerminalFailure) can instead
   // close the source stream mid-read and terminate the job before all rows are emitted, leaving an
   // incomplete result. Re-reading from the same (already committed) table is idempotent, so retry a few
-  // times before giving up. See fetchResultWithExpectedNum.
+  // times before giving up. See submitAndFetchWithRetry.
   private static final int MAX_STREAM_READ_ATTEMPTS = 3;
 
   private TableEnvironment streamTableEnv;
@@ -4070,6 +4070,6 @@ public class ITTestHoodieDataSource {
     while (root.getCause() != null) {
       root = root.getCause();
     }
-    return root.getClass().getName() + ": " + root.getMessage();
+    return root.getClass().getSimpleName() + ": " + root.getMessage();
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`ITTestHoodieDataSource.testStreamReadFromSpecifiedCommitWithChangelog` is intermittently failing in CI with a streaming-read row-count mismatch, e.g. expecting the 11 merged rows but receiving 9, with the entire `par2` partition (`id3`, `id4`) missing. It surfaced on an unrelated PR's `test-flink-1 (flink2.1, 1.11.4, 1.15.2)` job: https://github.com/apache/hudi/actions/runs/27664812470/job/81816514280

These streaming reads are collected with `CollectTableSink` and terminated by a forced `SuccessException` once the expected row count is reached, with up to a 30s await. `fetchResultWithExpectedNum` tolerates a known benign teardown race (an `IOException("Stream is closed")`, or a `ParquetColumnarRowSplitReader#readNextRowGroup` NPE) that can fire when the source's `SplitFetcher` closes its stream during the job's cascading shutdown. That tolerance (added in #19019) assumed the race only fires after the sink has already collected its expected rows. Under CI load it can instead fire before the read completes, so the job ends with fewer rows than expected; the tolerated exception is then swallowed and the test asserts on the incomplete result, producing the confusing row-count mismatch.

### Summary and Changelog

`fetchResultWithExpectedNum` no longer assumes that a tolerated terminal failure implies a complete read. The submit-and-collect path is wrapped in a new `submitAndFetchWithRetry`, which re-reads (up to `MAX_STREAM_READ_ATTEMPTS = 3`) when the collected row count is below the expectation. Re-reading the already committed table is idempotent (the collect sink clears its global result on each submit), so a transient teardown race no longer leaks into the assertion. The swallowed non-`SuccessException` cause is now logged so an incomplete read is diagnosable. Behavior is unchanged on the happy path: a complete first read returns immediately with no retry.

The change is confined to the test harness in `ITTestHoodieDataSource`; no production code is touched.

### Impact

De-flakes `ITTestHoodieDataSource` streaming-read tests (and any test going through `execSelectSqlWithExpectedNum`). No public API, on-disk format, or production behavior change.

### Risk Level

low. Test-only change. The retry is a no-op on the happy path and only re-reads an idempotent, already-committed table when a read comes back short. Validated locally on JDK 11 / flink1.20: 60 consecutive runs of the failing parameterization pass, and a fault-injection run that truncates the first attempt (reproducing the exact 9-of-11 CI symptom) confirms the retry recovers the full result; the full test method (6 parameterizations) passes with 0 Checkstyle violations.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
