### PR TITLE
docs(site): Add new committers to the Team page

### DIFF
--- a/website/community/team.md
+++ b/website/community/team.md
@@ -40,6 +40,7 @@ Here is the list of PMC and Committers who have contributed to the project. For 
 | Name                 | Github Username     | Apache ID                                                                           |
 |----------------------|---------------------|-------------------------------------------------------------------------------------|
 | Alexey Kudinkin      | alexeykudinkin      | [akudinkin](https://people.apache.org/committer-index.html#akudinkin)               |
+| Chaoyang Liu         | TheR1sing3un        | [chaoyang](https://people.apache.org/committer-index.html#chaoyang)                 |
 | Forward Xu           | XuQianJin-Stars     | [forwardxu](https://people.apache.org/committer-index.html#forwardxu)               |
 | Hui An               | boneanxs            | [rexan](https://people.apache.org/committer-index.html#rexan)                       |
 | Jonathan Vexler      | jonvex              | [jonvex](https://people.apache.org/committer-index.html#jonvex)                     |


### PR DESCRIPTION
1. add chaoyang as the new committer to the Team page

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
