### PR TITLE
docs: fix broken and outdated links across docs

### DIFF
--- a/website/docs/compaction.md
+++ b/website/docs/compaction.md
@@ -15,7 +15,7 @@ not applicable to Copy-on-Write (COW) tables and only applies to MOR tables.
 ### Why MOR tables need compaction?
 
 To understand the significance of compaction in MOR tables, it is helpful to understand the MOR table layout first. In Hudi,
-data is organized in terms of [file groups](https://hudi.apache.org/docs/file_layouts/). Each file group in a MOR table
+data is organized in terms of [file groups](https://hudi.apache.org/docs/storage_layouts/). Each file group in a MOR table
 consists of a base file and one or more log files. Typically, during writes, inserts are stored in the base file, and updates
 are appended to log files.
 

--- a/website/docs/comparison.md
+++ b/website/docs/comparison.md
@@ -50,5 +50,5 @@ of PrestoDB/SparkSQL/Hive for your queries.
 
 More advanced use cases revolve around the concepts of [incremental processing](https://www.oreilly.com/ideas/ubers-case-for-incremental-processing-on-hadoop), which effectively
 uses Hudi even inside the `processing` engine to speed up typical batch pipelines. For e.g: Hudi can be used as a state store inside a processing DAG (similar
-to how [rocksDB](https://ci.apache.org/projects/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
+to how [rocksDB](https://nightlies.apache.org/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
 and will eventually happen as a [Beam Runner](https://github.com/apache/hudi/issues/14452)

--- a/website/docs/s3_hoodie.md
+++ b/website/docs/s3_hoodie.md
@@ -88,7 +88,7 @@ AWS glue data libraries are needed if AWS glue data is used
 
 ## AWS S3 Versioned Bucket
 
-With versioned buckets any object deleted creates a [Delete Marker](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html), as Hudi cleans up files using [Cleaner utility](https://hudi.apache.org/docs/hoodie_cleaner) the number of Delete Markers increases over time.
+With versioned buckets any object deleted creates a [Delete Marker](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html), as Hudi cleans up files using [Cleaner utility](https://hudi.apache.org/docs/cleaning) the number of Delete Markers increases over time.
 It is important to configure the [Lifecycle Rule](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) correctly
 to clean up these delete markers as the List operation can choke if the number of delete markers reaches 1000.
 We recommend cleaning up Delete Markers after 1 day in Lifecycle Rule.

--- a/website/docs/sql_queries.md
+++ b/website/docs/sql_queries.md
@@ -917,7 +917,7 @@ for more details.
 ## Doris
 
 The Doris integration currently support Copy on Write and Merge On Read tables in Hudi since version 0.10.0. You can query Hudi tables via Doris from Doris version 2.0. Doris offers a multi-catalog, which is designed to make it easier to connect to external data catalogs to enhance Doris's data lake analysis and federated data query capabilities. Please refer
-to [Doris Hudi Catalog](https://doris.apache.org/docs/lakehouse/datalake-analytics/hudi/) for more details on the setup.
+to [Doris Hudi Catalog](https://doris.apache.org/docs/3.x/lakehouse/catalogs/hudi-catalog) for more details on the setup.
 
 :::note
 The current default supported version of Hudi is 0.10.0 ~ 0.13.1, and has not been tested in other versions. More versions will be supported in the future.

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -137,7 +137,7 @@ First of all, please confirm if you do indeed have duplicates **AFTER** ensuring
 
 ### Ingestion
 
-#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at [kafka.utils.Utils$.read](http://kafka.utils.Utils$.read)(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
+#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at `kafka.utils.Utils$.read`(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
 
 This might happen if you are ingesting from Kafka source, your cluster is ssl enabled by default and you are using some version of Hudi older than 0.5.1. Previous versions of Hudi were using spark-streaming-kafka-0-8 library. With the release of 0.5.1 version of Hudi, spark was upgraded to 2.4.4 and spark-streaming-kafka library was upgraded to spark-streaming-kafka-0-10. SSL support was introduced from spark-streaming-kafka-0-10. Please see here for reference.
 

--- a/website/versioned_docs/version-0.15.0/comparison.md
+++ b/website/versioned_docs/version-0.15.0/comparison.md
@@ -52,5 +52,5 @@ of PrestoDB/SparkSQL/Hive for your queries.
 
 More advanced use cases revolve around the concepts of [incremental processing](https://www.oreilly.com/ideas/ubers-case-for-incremental-processing-on-hadoop), which effectively
 uses Hudi even inside the `processing` engine to speed up typical batch pipelines. For e.g: Hudi can be used as a state store inside a processing DAG (similar
-to how [rocksDB](https://ci.apache.org/projects/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
+to how [rocksDB](https://nightlies.apache.org/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
 and will eventually happen as a [Beam Runner](https://github.com/apache/hudi/issues/14452)

--- a/website/versioned_docs/version-0.15.0/troubleshooting.md
+++ b/website/versioned_docs/version-0.15.0/troubleshooting.md
@@ -137,7 +137,7 @@ First of all, please confirm if you do indeed have duplicates **AFTER** ensuring
 
 ### Ingestion
 
-#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at [kafka.utils.Utils$.read](http://kafka.utils.Utils$.read)(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
+#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at `kafka.utils.Utils$.read`(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
 
 This might happen if you are ingesting from Kafka source, your cluster is ssl enabled by default and you are using some version of Hudi older than 0.5.1. Previous versions of Hudi were using spark-streaming-kafka-0-8 library. With the release of 0.5.1 version of Hudi, spark was upgraded to 2.4.4 and spark-streaming-kafka library was upgraded to spark-streaming-kafka-0-10. SSL support was introduced from spark-streaming-kafka-0-10. Please see here for reference.
 

--- a/website/versioned_docs/version-0.15.1/comparison.md
+++ b/website/versioned_docs/version-0.15.1/comparison.md
@@ -52,5 +52,5 @@ of PrestoDB/SparkSQL/Hive for your queries.
 
 More advanced use cases revolve around the concepts of [incremental processing](https://www.oreilly.com/ideas/ubers-case-for-incremental-processing-on-hadoop), which effectively
 uses Hudi even inside the `processing` engine to speed up typical batch pipelines. For e.g: Hudi can be used as a state store inside a processing DAG (similar
-to how [rocksDB](https://ci.apache.org/projects/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
+to how [rocksDB](https://nightlies.apache.org/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
 and will eventually happen as a [Beam Runner](https://github.com/apache/hudi/issues/14452)

--- a/website/versioned_docs/version-0.15.1/troubleshooting.md
+++ b/website/versioned_docs/version-0.15.1/troubleshooting.md
@@ -137,7 +137,7 @@ First of all, please confirm if you do indeed have duplicates **AFTER** ensuring
 
 ### Ingestion
 
-#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at [kafka.utils.Utils$.read](http://kafka.utils.Utils$.read)(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
+#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at `kafka.utils.Utils$.read`(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
 
 This might happen if you are ingesting from Kafka source, your cluster is ssl enabled by default and you are using some version of Hudi older than 0.5.1. Previous versions of Hudi were using spark-streaming-kafka-0-8 library. With the release of 0.5.1 version of Hudi, spark was upgraded to 2.4.4 and spark-streaming-kafka library was upgraded to spark-streaming-kafka-0-10. SSL support was introduced from spark-streaming-kafka-0-10. Please see here for reference.
 

--- a/website/versioned_docs/version-1.0.0/comparison.md
+++ b/website/versioned_docs/version-1.0.0/comparison.md
@@ -52,5 +52,5 @@ of PrestoDB/SparkSQL/Hive for your queries.
 
 More advanced use cases revolve around the concepts of [incremental processing](https://www.oreilly.com/ideas/ubers-case-for-incremental-processing-on-hadoop), which effectively
 uses Hudi even inside the `processing` engine to speed up typical batch pipelines. For e.g: Hudi can be used as a state store inside a processing DAG (similar
-to how [rocksDB](https://ci.apache.org/projects/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
+to how [rocksDB](https://nightlies.apache.org/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
 and will eventually happen as a [Beam Runner](https://github.com/apache/hudi/issues/14452)

--- a/website/versioned_docs/version-1.0.0/troubleshooting.md
+++ b/website/versioned_docs/version-1.0.0/troubleshooting.md
@@ -137,7 +137,7 @@ First of all, please confirm if you do indeed have duplicates **AFTER** ensuring
 
 ### Ingestion
 
-#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at [kafka.utils.Utils$.read](http://kafka.utils.Utils$.read)(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
+#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at `kafka.utils.Utils$.read`(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
 
 This might happen if you are ingesting from Kafka source, your cluster is ssl enabled by default and you are using some version of Hudi older than 0.5.1. Previous versions of Hudi were using spark-streaming-kafka-0-8 library. With the release of 0.5.1 version of Hudi, spark was upgraded to 2.4.4 and spark-streaming-kafka library was upgraded to spark-streaming-kafka-0-10. SSL support was introduced from spark-streaming-kafka-0-10. Please see here for reference.
 

--- a/website/versioned_docs/version-1.0.1/comparison.md
+++ b/website/versioned_docs/version-1.0.1/comparison.md
@@ -52,5 +52,5 @@ of PrestoDB/SparkSQL/Hive for your queries.
 
 More advanced use cases revolve around the concepts of [incremental processing](https://www.oreilly.com/ideas/ubers-case-for-incremental-processing-on-hadoop), which effectively
 uses Hudi even inside the `processing` engine to speed up typical batch pipelines. For e.g: Hudi can be used as a state store inside a processing DAG (similar
-to how [rocksDB](https://ci.apache.org/projects/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
+to how [rocksDB](https://nightlies.apache.org/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
 and will eventually happen as a [Beam Runner](https://github.com/apache/hudi/issues/14452)

--- a/website/versioned_docs/version-1.0.1/troubleshooting.md
+++ b/website/versioned_docs/version-1.0.1/troubleshooting.md
@@ -137,7 +137,7 @@ First of all, please confirm if you do indeed have duplicates **AFTER** ensuring
 
 ### Ingestion
 
-#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at [kafka.utils.Utils$.read](http://kafka.utils.Utils$.read)(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
+#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at `kafka.utils.Utils$.read`(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
 
 This might happen if you are ingesting from Kafka source, your cluster is ssl enabled by default and you are using some version of Hudi older than 0.5.1. Previous versions of Hudi were using spark-streaming-kafka-0-8 library. With the release of 0.5.1 version of Hudi, spark was upgraded to 2.4.4 and spark-streaming-kafka library was upgraded to spark-streaming-kafka-0-10. SSL support was introduced from spark-streaming-kafka-0-10. Please see here for reference.
 

--- a/website/versioned_docs/version-1.0.2/comparison.md
+++ b/website/versioned_docs/version-1.0.2/comparison.md
@@ -52,5 +52,5 @@ of PrestoDB/SparkSQL/Hive for your queries.
 
 More advanced use cases revolve around the concepts of [incremental processing](https://www.oreilly.com/ideas/ubers-case-for-incremental-processing-on-hadoop), which effectively
 uses Hudi even inside the `processing` engine to speed up typical batch pipelines. For e.g: Hudi can be used as a state store inside a processing DAG (similar
-to how [rocksDB](https://ci.apache.org/projects/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
+to how [rocksDB](https://nightlies.apache.org/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
 and will eventually happen as a [Beam Runner](https://github.com/apache/hudi/issues/14452)

--- a/website/versioned_docs/version-1.0.2/troubleshooting.md
+++ b/website/versioned_docs/version-1.0.2/troubleshooting.md
@@ -137,7 +137,7 @@ First of all, please confirm if you do indeed have duplicates **AFTER** ensuring
 
 ### Ingestion
 
-#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at [kafka.utils.Utils$.read](http://kafka.utils.Utils$.read)(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
+#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at `kafka.utils.Utils$.read`(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
 
 This might happen if you are ingesting from Kafka source, your cluster is ssl enabled by default and you are using some version of Hudi older than 0.5.1. Previous versions of Hudi were using spark-streaming-kafka-0-8 library. With the release of 0.5.1 version of Hudi, spark was upgraded to 2.4.4 and spark-streaming-kafka library was upgraded to spark-streaming-kafka-0-10. SSL support was introduced from spark-streaming-kafka-0-10. Please see here for reference.
 

--- a/website/versioned_docs/version-1.1.1/compaction.md
+++ b/website/versioned_docs/version-1.1.1/compaction.md
@@ -15,7 +15,7 @@ not applicable to Copy-on-Write (COW) tables and only applies to MOR tables.
 ### Why MOR tables need compaction?
 
 To understand the significance of compaction in MOR tables, it is helpful to understand the MOR table layout first. In Hudi,
-data is organized in terms of [file groups](https://hudi.apache.org/docs/file_layouts/). Each file group in a MOR table
+data is organized in terms of [file groups](https://hudi.apache.org/docs/storage_layouts/). Each file group in a MOR table
 consists of a base file and one or more log files. Typically, during writes, inserts are stored in the base file, and updates
 are appended to log files.
 

--- a/website/versioned_docs/version-1.1.1/comparison.md
+++ b/website/versioned_docs/version-1.1.1/comparison.md
@@ -50,5 +50,5 @@ of PrestoDB/SparkSQL/Hive for your queries.
 
 More advanced use cases revolve around the concepts of [incremental processing](https://www.oreilly.com/ideas/ubers-case-for-incremental-processing-on-hadoop), which effectively
 uses Hudi even inside the `processing` engine to speed up typical batch pipelines. For e.g: Hudi can be used as a state store inside a processing DAG (similar
-to how [rocksDB](https://ci.apache.org/projects/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
+to how [rocksDB](https://nightlies.apache.org/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
 and will eventually happen as a [Beam Runner](https://github.com/apache/hudi/issues/14452)

--- a/website/versioned_docs/version-1.1.1/s3_hoodie.md
+++ b/website/versioned_docs/version-1.1.1/s3_hoodie.md
@@ -88,7 +88,7 @@ AWS glue data libraries are needed if AWS glue data is used
 
 ## AWS S3 Versioned Bucket
 
-With versioned buckets any object deleted creates a [Delete Marker](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html), as Hudi cleans up files using [Cleaner utility](https://hudi.apache.org/docs/hoodie_cleaner) the number of Delete Markers increases over time.
+With versioned buckets any object deleted creates a [Delete Marker](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html), as Hudi cleans up files using [Cleaner utility](https://hudi.apache.org/docs/cleaning) the number of Delete Markers increases over time.
 It is important to configure the [Lifecycle Rule](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) correctly
 to clean up these delete markers as the List operation can choke if the number of delete markers reaches 1000.
 We recommend cleaning up Delete Markers after 1 day in Lifecycle Rule.

--- a/website/versioned_docs/version-1.1.1/sql_queries.md
+++ b/website/versioned_docs/version-1.1.1/sql_queries.md
@@ -709,7 +709,7 @@ for more details.
 ## Doris
 
 The Doris integration currently support Copy on Write and Merge On Read tables in Hudi since version 0.10.0. You can query Hudi tables via Doris from Doris version 2.0. Doris offers a multi-catalog, which is designed to make it easier to connect to external data catalogs to enhance Doris's data lake analysis and federated data query capabilities. Please refer
-to [Doris Hudi Catalog](https://doris.apache.org/docs/lakehouse/datalake-analytics/hudi/) for more details on the setup.
+to [Doris Hudi Catalog](https://doris.apache.org/docs/3.x/lakehouse/catalogs/hudi-catalog) for more details on the setup.
 
 :::note
 The current default supported version of Hudi is 0.10.0 ~ 0.13.1, and has not been tested in other versions. More versions will be supported in the future.

--- a/website/versioned_docs/version-1.1.1/troubleshooting.md
+++ b/website/versioned_docs/version-1.1.1/troubleshooting.md
@@ -137,7 +137,7 @@ First of all, please confirm if you do indeed have duplicates **AFTER** ensuring
 
 ### Ingestion
 
-#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at [kafka.utils.Utils$.read](http://kafka.utils.Utils$.read)(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
+#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at `kafka.utils.Utils$.read`(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
 
 This might happen if you are ingesting from Kafka source, your cluster is ssl enabled by default and you are using some version of Hudi older than 0.5.1. Previous versions of Hudi were using spark-streaming-kafka-0-8 library. With the release of 0.5.1 version of Hudi, spark was upgraded to 2.4.4 and spark-streaming-kafka library was upgraded to spark-streaming-kafka-0-10. SSL support was introduced from spark-streaming-kafka-0-10. Please see here for reference.
 

--- a/website/versioned_docs/version-1.2.0/compaction.md
+++ b/website/versioned_docs/version-1.2.0/compaction.md
@@ -15,7 +15,7 @@ not applicable to Copy-on-Write (COW) tables and only applies to MOR tables.
 ### Why MOR tables need compaction?
 
 To understand the significance of compaction in MOR tables, it is helpful to understand the MOR table layout first. In Hudi,
-data is organized in terms of [file groups](https://hudi.apache.org/docs/file_layouts/). Each file group in a MOR table
+data is organized in terms of [file groups](https://hudi.apache.org/docs/storage_layouts/). Each file group in a MOR table
 consists of a base file and one or more log files. Typically, during writes, inserts are stored in the base file, and updates
 are appended to log files.
 

--- a/website/versioned_docs/version-1.2.0/comparison.md
+++ b/website/versioned_docs/version-1.2.0/comparison.md
@@ -50,5 +50,5 @@ of PrestoDB/SparkSQL/Hive for your queries.
 
 More advanced use cases revolve around the concepts of [incremental processing](https://www.oreilly.com/ideas/ubers-case-for-incremental-processing-on-hadoop), which effectively
 uses Hudi even inside the `processing` engine to speed up typical batch pipelines. For e.g: Hudi can be used as a state store inside a processing DAG (similar
-to how [rocksDB](https://ci.apache.org/projects/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
+to how [rocksDB](https://nightlies.apache.org/flink/flink-docs-release-1.2/ops/state_backends.html#the-rocksdbstatebackend) is used by Flink). This is an item on the roadmap
 and will eventually happen as a [Beam Runner](https://github.com/apache/hudi/issues/14452)

--- a/website/versioned_docs/version-1.2.0/s3_hoodie.md
+++ b/website/versioned_docs/version-1.2.0/s3_hoodie.md
@@ -88,7 +88,7 @@ AWS glue data libraries are needed if AWS glue data is used
 
 ## AWS S3 Versioned Bucket
 
-With versioned buckets any object deleted creates a [Delete Marker](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html), as Hudi cleans up files using [Cleaner utility](https://hudi.apache.org/docs/hoodie_cleaner) the number of Delete Markers increases over time.
+With versioned buckets any object deleted creates a [Delete Marker](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html), as Hudi cleans up files using [Cleaner utility](https://hudi.apache.org/docs/cleaning) the number of Delete Markers increases over time.
 It is important to configure the [Lifecycle Rule](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) correctly
 to clean up these delete markers as the List operation can choke if the number of delete markers reaches 1000.
 We recommend cleaning up Delete Markers after 1 day in Lifecycle Rule.

--- a/website/versioned_docs/version-1.2.0/sql_queries.md
+++ b/website/versioned_docs/version-1.2.0/sql_queries.md
@@ -913,7 +913,7 @@ for more details.
 ## Doris
 
 The Doris integration currently support Copy on Write and Merge On Read tables in Hudi since version 0.10.0. You can query Hudi tables via Doris from Doris version 2.0. Doris offers a multi-catalog, which is designed to make it easier to connect to external data catalogs to enhance Doris's data lake analysis and federated data query capabilities. Please refer
-to [Doris Hudi Catalog](https://doris.apache.org/docs/lakehouse/datalake-analytics/hudi/) for more details on the setup.
+to [Doris Hudi Catalog](https://doris.apache.org/docs/3.x/lakehouse/catalogs/hudi-catalog) for more details on the setup.
 
 :::note
 The current default supported version of Hudi is 0.10.0 ~ 0.13.1, and has not been tested in other versions. More versions will be supported in the future.

--- a/website/versioned_docs/version-1.2.0/troubleshooting.md
+++ b/website/versioned_docs/version-1.2.0/troubleshooting.md
@@ -137,7 +137,7 @@ First of all, please confirm if you do indeed have duplicates **AFTER** ensuring
 
 ### Ingestion
 
-#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at [kafka.utils.Utils$.read](http://kafka.utils.Utils$.read)(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
+#### java.io.EOFException: Received -1 when reading from channel, socket has likely been closed. at `kafka.utils.Utils$.read`(Utils.scala:381) at kafka.network.BoundedByteBufferReceive.readFrom(BoundedByteBufferReceive.scala:54)
 
 This might happen if you are ingesting from Kafka source, your cluster is ssl enabled by default and you are using some version of Hudi older than 0.5.1. Previous versions of Hudi were using spark-streaming-kafka-0-8 library. With the release of 0.5.1 version of Hudi, spark was upgraded to 2.4.4 and spark-streaming-kafka library was upgraded to spark-streaming-kafka-0-10. SSL support was introduced from spark-streaming-kafka-0-10. Please see here for reference.
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Several links in the documentation are broken or outdated. A link scan across the docs surfaced internal links pointing to renamed pages (returning 404s), external links to pages that have moved or been deprecated, and a stack-trace class reference that was mistakenly formatted as a (broken) hyperlink. This PR fixes those so readers no longer hit dead links.

### Summary and Changelog

Fixes broken and outdated links across the documentation. No content or behavior changes beyond the corrected links/formatting.

Detailed changelog:

- docs/compaction.md: updated /docs/file_layouts/ to /docs/storage_layouts/ (the page was renamed).
- docs/s3_hoodie.md: updated /docs/hoodie_cleaner to /docs/cleaning (the page was renamed).
- docs/comparison.md: replaced the dead Flink RocksDB state-backend link (ci.apache.org) with the current nightlies.apache.org URL.
- docs/sql_queries.md: updated the Doris Hudi Catalog link to the current Doris 3.x docs path.
- docs/troubleshooting.md: rendered kafka.utils.Utils$.read as inline code instead of a broken hyperlink.

### Impact

Readers get working links instead of 404s. No public API, config, behavior, or performance impact.

### Risk Level

none

### Documentation Update

This PR is the documentation update. No new feature, config, or user-facing behavior is introduced, so no further docs changes are required.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
