### PR TITLE
feat(spark): add repair_clustering_plan procedure for requested clustering plans

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/HoodieProcedures.scala
@@ -41,6 +41,7 @@ object HoodieProcedures {
       ,(RollbackToInstantTimeProcedure.NAME, RollbackToInstantTimeProcedure.builder)
       ,(RestoreToInstantProcedure.NAME, RestoreToInstantProcedure.builder)
       ,(RunClusteringProcedure.NAME, RunClusteringProcedure.builder)
+      ,(RepairClusteringPlanProcedure.NAME, RepairClusteringPlanProcedure.builder)
       ,(ShowClusteringProcedure.NAME, ShowClusteringProcedure.builder)
       ,(ShowCommitsProcedure.NAME, ShowCommitsProcedure.builder)
       ,(ShowCommitsMetadataProcedure.NAME, ShowCommitsMetadataProcedure.builder)

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairClusteringPlanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RepairClusteringPlanProcedure.scala
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.command.procedures
+
+import org.apache.hudi.HoodieCLIUtils
+import org.apache.hudi.avro.model.{HoodieClusteringPlan, HoodieRequestedReplaceMetadata}
+import org.apache.hudi.client.SparkRDDWriteClient
+import org.apache.hudi.common.model.WriteOperationType
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+import org.apache.hudi.common.util.{ClusteringUtils, Option => HOption}
+import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.hadoop.fs.HadoopFSUtils
+import org.apache.hudi.io.util.FileIOUtils
+import org.apache.hudi.storage.StoragePath
+
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GROUPS
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.apache.spark.util.SerializableConfiguration
+
+import java.util
+import java.util.Locale
+import java.util.function.Supplier
+
+import scala.collection.JavaConverters._
+
+class RepairClusteringPlanProcedure extends BaseProcedure with ProcedureBuilder with Logging {
+
+  private val PARAMETERS = Array[ProcedureParameter](
+    ProcedureParameter.optional(0, "table", DataTypes.StringType),
+    ProcedureParameter.optional(1, "path", DataTypes.StringType),
+    ProcedureParameter.required(2, "instant", DataTypes.StringType),
+    ProcedureParameter.optional(3, "op", DataTypes.StringType),
+    ProcedureParameter.optional(4, "invalid_parquet_files", DataTypes.StringType, ""),
+    ProcedureParameter.optional(5, "validation_parallelism", DataTypes.IntegerType, 100),
+    ProcedureParameter.optional(6, "need_delete", DataTypes.BooleanType, false),
+    ProcedureParameter.optional(7, "dry_run", DataTypes.BooleanType, true),
+    ProcedureParameter.optional(8, "backup", DataTypes.BooleanType, true),
+    ProcedureParameter.optional(9, "allow_empty_plan", DataTypes.BooleanType, false),
+    ProcedureParameter.optional(10, "options", DataTypes.StringType, "")
+  )
+
+  private val OUTPUT_TYPE = new StructType(Array[StructField](
+    StructField("instant", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("path", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("action", DataTypes.StringType, nullable = true, Metadata.empty),
+    StructField("deleted", DataTypes.BooleanType, nullable = true, Metadata.empty),
+    StructField("reason", DataTypes.StringType, nullable = true, Metadata.empty)
+  ))
+
+  override def parameters: Array[ProcedureParameter] = PARAMETERS
+
+  override def outputType: StructType = OUTPUT_TYPE
+
+  override def call(args: ProcedureArgs): Seq[Row] = {
+    super.checkArgs(PARAMETERS, args)
+
+    val tableName = getArgValueOrDefault(args, PARAMETERS(0))
+    val tablePath = getArgValueOrDefault(args, PARAMETERS(1))
+    val instantTime = getArgValueOrDefault(args, PARAMETERS(2)).get.toString
+    val invalidParquetFiles = getArgValueOrDefault(args, PARAMETERS(4)).map(_.toString).getOrElse("")
+    val operation = getOperation(getArgValueOrDefault(args, PARAMETERS(3)), invalidParquetFiles)
+    val parallelism = getArgValueOrDefault(args, PARAMETERS(5)).get.asInstanceOf[Int]
+    val needDelete = getArgValueOrDefault(args, PARAMETERS(6)).get.asInstanceOf[Boolean]
+    val dryRun = getArgValueOrDefault(args, PARAMETERS(7)).get.asInstanceOf[Boolean]
+    val shouldBackup = getArgValueOrDefault(args, PARAMETERS(8)).get.asInstanceOf[Boolean]
+    val allowEmptyPlan = getArgValueOrDefault(args, PARAMETERS(9)).get.asInstanceOf[Boolean]
+    val options = getArgValueOrDefault(args, PARAMETERS(10)).map(_.toString).getOrElse("")
+
+    val basePath = getBasePath(tableName, tablePath)
+    val metaClient = createMetaClient(jsc, basePath)
+    val (_, clusteringPlan) = RepairClusteringPlanProcedure.getRequestedClusteringPlan(metaClient, instantTime)
+    val candidates = getRepairCandidates(operation, invalidParquetFiles, clusteringPlan, parallelism)
+    if (candidates.isEmpty) {
+      Seq.empty
+    } else {
+      val candidatePaths = candidates.map(_.path).toSet
+      if (!allowEmptyPlan && !RepairClusteringPlanProcedure.hasRetainedInputGroup(clusteringPlan, candidatePaths)) {
+        throw new HoodieException(
+          s"Repairing clustering instant $instantTime would remove all input groups. "
+            + "Set allow_empty_plan => true to allow this operation.")
+      }
+
+      if (dryRun) {
+        candidates.map(candidate =>
+          Row(instantTime, candidate.path, RepairClusteringPlanProcedure.WOULD_REMOVE_FROM_PLAN, false, candidate.reason))
+      } else {
+        var client: SparkRDDWriteClient[_] = null
+        var repairedPaths = Set.empty[String]
+        val confs = if (options.trim.isEmpty) Map.empty[String, String] else HoodieCLIUtils.extractOptions(options)
+        val tableNameOpt = tableName.map(_.toString)
+        try {
+          client = HoodieCLIUtils.createHoodieWriteClient(sparkSession, basePath, confs, tableNameOpt)
+          val transactionOwner = HOption.of(metaClient.getInstantGenerator.createNewInstant(
+            HoodieInstant.State.REQUESTED,
+            clusteringPlanAction(metaClient, instantTime),
+            instantTime))
+          val txnManager = client.getTransactionManager
+          txnManager.beginStateChange(transactionOwner, metaClient.reloadActiveTimeline().filterCompletedInstants().lastInstant())
+          try {
+            val latestMetaClient = createMetaClient(jsc, basePath)
+            val (latestInstant, latestPlan) = RepairClusteringPlanProcedure.getRequestedClusteringPlan(latestMetaClient, instantTime)
+            val latestPlanFiles = RepairClusteringPlanProcedure.getPlanDataFiles(latestPlan).toSet
+            val filesToRepair = candidatePaths.intersect(latestPlanFiles)
+            if (filesToRepair.nonEmpty) {
+              if (!allowEmptyPlan && !RepairClusteringPlanProcedure.hasRetainedInputGroup(latestPlan, filesToRepair)) {
+                throw new HoodieException(
+                  s"Repairing clustering instant $instantTime would remove all input groups. "
+                    + "Set allow_empty_plan => true to allow this operation.")
+              }
+
+              val repairedPlan = RepairClusteringPlanProcedure.pruneClusteringPlan(latestPlan, filesToRepair)
+              RepairClusteringPlanProcedure.rewriteRequestedClusteringPlan(
+                latestMetaClient, latestInstant, repairedPlan, latestPlan.getExtraMetadata, shouldBackup)
+              repairedPaths = filesToRepair
+            }
+          } finally {
+            txnManager.endStateChange(transactionOwner)
+          }
+        } finally {
+          if (client != null) {
+            client.close()
+          }
+        }
+
+        val deleteResults = if (needDelete) {
+          deletePhysicalFiles(repairedPaths.toSeq)
+        } else {
+          Map.empty[String, Boolean]
+        }
+
+        candidates.map { candidate =>
+          val repaired = repairedPaths.contains(candidate.path)
+          Row(
+            instantTime,
+            candidate.path,
+            if (repaired) RepairClusteringPlanProcedure.REMOVED_FROM_PLAN else RepairClusteringPlanProcedure.NOT_FOUND_IN_PLAN,
+            deleteResults.getOrElse(candidate.path, false),
+            candidate.reason)
+        }
+      }
+    }
+  }
+
+  private def getOperation(operationArg: Option[Any], invalidParquetFiles: String): String = {
+    operationArg
+      .map(_.toString.trim)
+      .filter(_.nonEmpty)
+      .getOrElse {
+        if (invalidParquetFiles.trim.nonEmpty) {
+          RepairClusteringPlanProcedure.DELETE_OPERATION
+        } else {
+          RepairClusteringPlanProcedure.VALIDATE_DELETE_OPERATION
+        }
+      }
+      .toLowerCase(Locale.ROOT)
+  }
+
+  private def getRepairCandidates(operation: String,
+                                  invalidParquetFiles: String,
+                                  clusteringPlan: HoodieClusteringPlan,
+                                  parallelism: Int): Seq[RepairCandidate] = {
+    operation match {
+      case RepairClusteringPlanProcedure.DELETE_OPERATION =>
+        parseInvalidFiles(invalidParquetFiles).map(path =>
+          RepairCandidate(path, RepairClusteringPlanProcedure.USER_REQUESTED))
+      case RepairClusteringPlanProcedure.VALIDATE_DELETE_OPERATION | RepairClusteringPlanProcedure.CHECK_AND_DELETE_OPERATION =>
+        validateInvalidParquetFiles(clusteringPlan, parallelism).map(path =>
+          RepairCandidate(path, RepairClusteringPlanProcedure.NOT_PARQUET_FILE))
+      case unsupported =>
+        throw new UnsupportedOperationException(
+          s"Unsupported operation: '$unsupported'. Supported operations: delete, validate_delete, checkanddelete")
+    }
+  }
+
+  private def parseInvalidFiles(filesParam: String): Seq[String] = {
+    require(filesParam != null && filesParam.trim.nonEmpty,
+      "Please set the files to be removed from the clustering plan via the parameter invalid_parquet_files.")
+
+    filesParam.split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .distinct
+      .toSeq
+  }
+
+  private def validateInvalidParquetFiles(clusteringPlan: HoodieClusteringPlan,
+                                          parallelism: Int): Seq[String] = {
+    val allFiles = RepairClusteringPlanProcedure.getPlanDataFiles(clusteringPlan).toSeq
+    if (allFiles.isEmpty) {
+      Seq.empty
+    } else {
+      val serHadoopConf = new SerializableConfiguration(jsc.hadoopConfiguration())
+      val rddParallelism = Math.max(1, Math.min(allFiles.size, parallelism))
+      jsc.parallelize(allFiles.asJava, rddParallelism).rdd.filter { path =>
+        var isInvalid = false
+        if (path.endsWith(".parquet")) {
+          try {
+            ParquetFileReader.readFooter(serHadoopConf.value, new Path(path), SKIP_ROW_GROUPS).getFileMetaData
+          } catch {
+            case e: Exception =>
+              isInvalid = Option(e.getMessage).exists(_.contains("is not a Parquet file"))
+          }
+        }
+        isInvalid
+      }.collect().toSeq
+    }
+  }
+
+  private def deletePhysicalFiles(filesToDelete: Seq[String]): Map[String, Boolean] = {
+    val storageConf = HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration())
+    filesToDelete.map { filePath =>
+      val path = new Path(filePath)
+      val fs = HadoopFSUtils.getFs(path, storageConf.unwrap())
+      val deleted = if (fs.exists(path)) {
+        if (!fs.delete(path, false)) {
+          throw new HoodieException(s"Failed to delete invalid parquet file after repairing clustering plan: $filePath")
+        }
+        true
+      } else {
+        false
+      }
+      filePath -> deleted
+    }.toMap
+  }
+
+  private def clusteringPlanAction(metaClient: HoodieTableMetaClient, instantTime: String): String = {
+    RepairClusteringPlanProcedure.getRequestedClusteringPlan(metaClient, instantTime)._1.getAction
+  }
+
+  override def build: Procedure = new RepairClusteringPlanProcedure()
+}
+
+object RepairClusteringPlanProcedure {
+  val NAME = "repair_clustering_plan"
+
+  val DELETE_OPERATION = "delete"
+  val VALIDATE_DELETE_OPERATION = "validate_delete"
+  val CHECK_AND_DELETE_OPERATION = "checkanddelete"
+
+  val WOULD_REMOVE_FROM_PLAN = "WOULD_REMOVE_FROM_PLAN"
+  val REMOVED_FROM_PLAN = "REMOVED_FROM_PLAN"
+  val NOT_FOUND_IN_PLAN = "NOT_FOUND_IN_PLAN"
+  val USER_REQUESTED = "USER_REQUESTED"
+  val NOT_PARQUET_FILE = "NOT_PARQUET_FILE"
+
+  def builder: Supplier[ProcedureBuilder] = new Supplier[ProcedureBuilder] {
+    override def get(): ProcedureBuilder = new RepairClusteringPlanProcedure()
+  }
+
+  private def getRequestedClusteringPlan(metaClient: HoodieTableMetaClient,
+                                         instantTime: String): (HoodieInstant, HoodieClusteringPlan) = {
+    val pendingPlan = ClusteringUtils.getAllPendingClusteringPlans(metaClient).iterator().asScala
+      .find(plan => plan.getLeft.requestedTime == instantTime && plan.getLeft.isRequested)
+      .getOrElse {
+        throw new HoodieException(
+          s"The requested clustering plan for instant $instantTime does not exist. Modifications are not supported.")
+      }
+
+    (pendingPlan.getLeft, pendingPlan.getRight)
+  }
+
+  private def getPlanDataFiles(plan: HoodieClusteringPlan): Iterable[String] = {
+    Option(plan.getInputGroups)
+      .map(_.asScala)
+      .getOrElse(Seq.empty)
+      .flatMap(group => Option(group.getSlices).map(_.asScala).getOrElse(Seq.empty))
+      .map(_.getDataFilePath)
+      .filter(path => path != null && path.nonEmpty)
+  }
+
+  private def hasRetainedInputGroup(plan: HoodieClusteringPlan, filesToRemove: Set[String]): Boolean = {
+    Option(plan.getInputGroups)
+      .map(_.asScala)
+      .getOrElse(Seq.empty)
+      .exists { group =>
+        Option(group.getSlices)
+          .map(_.asScala)
+          .getOrElse(Seq.empty)
+          .exists(slice => !filesToRemove.contains(slice.getDataFilePath))
+      }
+  }
+
+  private def pruneClusteringPlan(plan: HoodieClusteringPlan,
+                                  filesToRemove: Set[String]): HoodieClusteringPlan = {
+    val retainedGroups = Option(plan.getInputGroups)
+      .map(_.asScala)
+      .getOrElse(Seq.empty)
+      .map { group =>
+        val retainedSlices = Option(group.getSlices)
+          .map(_.asScala)
+          .getOrElse(Seq.empty)
+          .filter(slice => !filesToRemove.contains(slice.getDataFilePath))
+          .asJava
+        group.setSlices(retainedSlices)
+        group
+      }
+      .filter(group => group.getSlices != null && !group.getSlices.isEmpty)
+      .asJava
+
+    plan.setInputGroups(retainedGroups)
+    plan
+  }
+
+  private def rewriteRequestedClusteringPlan(metaClient: HoodieTableMetaClient,
+                                             clusteringInstant: HoodieInstant,
+                                             clusteringPlan: HoodieClusteringPlan,
+                                             extraMetadata: util.Map[String, String],
+                                             shouldBackup: Boolean): Unit = {
+    val activeTimeline = metaClient.getActiveTimeline
+    val instantFileName = metaClient.getInstantFileNameGenerator.getFileName(clusteringInstant)
+    val instantPath = new StoragePath(metaClient.getTimelinePath, instantFileName)
+    val backupDir = new StoragePath(
+      metaClient.getMetaPath,
+      s".repair/repair_clustering_plan/${clusteringInstant.requestedTime}/${System.currentTimeMillis()}")
+    val backupPath = new StoragePath(backupDir, instantFileName)
+
+    try {
+      if (shouldBackup) {
+        activeTimeline.copyInstant(clusteringInstant, backupDir)
+      }
+      activeTimeline.deleteInstantFileIfExists(clusteringInstant)
+
+      val requestedReplaceMetadata = HoodieRequestedReplaceMetadata.newBuilder
+        .setOperationType(WriteOperationType.CLUSTER.name())
+        .setExtraMetadata(Option(extraMetadata).getOrElse(new util.HashMap[String, String]()))
+        .setClusteringPlan(clusteringPlan)
+        .build()
+
+      clusteringInstant.getAction match {
+        case HoodieTimeline.CLUSTERING_ACTION =>
+          activeTimeline.saveToPendingClusterCommit(clusteringInstant, requestedReplaceMetadata)
+        case HoodieTimeline.REPLACE_COMMIT_ACTION =>
+          activeTimeline.saveToPendingReplaceCommit(clusteringInstant, requestedReplaceMetadata)
+        case action =>
+          throw new HoodieException(s"Unsupported clustering instant action: $action")
+      }
+
+      if (!metaClient.getStorage.exists(instantPath)) {
+        throw new HoodieException(s"Failed to rewrite requested clustering instant: $clusteringInstant")
+      }
+    } catch {
+      case e: Exception =>
+        restoreRequestedInstantIfNeeded(metaClient, instantPath, backupPath, shouldBackup)
+        throw new HoodieException(s"Failed to repair clustering plan for instant ${clusteringInstant.requestedTime}", e)
+    }
+  }
+
+  private def restoreRequestedInstantIfNeeded(metaClient: HoodieTableMetaClient,
+                                              instantPath: StoragePath,
+                                              backupPath: StoragePath,
+                                              shouldBackup: Boolean): Unit = {
+    if (shouldBackup && !metaClient.getStorage.exists(instantPath) && metaClient.getStorage.exists(backupPath)) {
+      FileIOUtils.copy(metaClient.getStorage, backupPath, metaClient.getStorage, instantPath, false, false)
+    }
+  }
+}
+
+case class RepairCandidate(path: String, reason: String)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairClusteringPlanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairClusteringPlanProcedure.scala
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.procedure
+
+import org.apache.hudi.avro.model.HoodieClusteringPlan
+import org.apache.hudi.common.table.timeline.HoodieTimeline
+import org.apache.hudi.common.util.ClusteringUtils
+import org.apache.hudi.storage.StoragePath
+import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.replaceWithEmptyFile
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
+
+import scala.collection.JavaConverters._
+
+class TestRepairClusteringPlanProcedure extends HoodieSparkProcedureTestBase {
+
+  test("Test repair_clustering_plan dry run, delete and validate delete") {
+    withTempDir { tmp =>
+      withSQLConf("hoodie.parquet.small.file.limit" -> "0") {
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long,
+             |  dt string
+             |) using hudi
+             | tblproperties (
+             |  primaryKey = 'id',
+             |  type = 'cow',
+             |  orderingFields = 'ts',
+             |  hoodie.metadata.enable = 'false'
+             | )
+             | partitioned by (dt)
+             | location '$basePath'
+             |""".stripMargin)
+
+        insertRows(tableName, "2026-01-27", 1)
+        insertRows(tableName, "2026-01-27", 4)
+        insertRows(tableName, "2026-01-27", 7)
+
+        runClustering(tableName, "schedule")
+        var metadata = getLatestRequestedClusteringPlan(basePath)
+        val instant1 = metadata.getLeft
+        val plannedFiles = getPlanDataFiles(metadata.getRight)
+        assertTrue(plannedFiles.size > 1, s"Expected more than one planned file, but got $plannedFiles")
+
+        val fileToRemove = plannedFiles.head
+        val dryRunRows = spark.sql(
+          s"call repair_clustering_plan(table => '$tableName', instant => '${instant1.requestedTime}', " +
+            s"op => 'delete', invalid_parquet_files => '$fileToRemove')").collect()
+        assertRepairResult(dryRunRows, instant1.requestedTime, fileToRemove, "WOULD_REMOVE_FROM_PLAN", deleted = false, "USER_REQUESTED")
+        assertTrue(getPlanDataFiles(getLatestRequestedClusteringPlan(basePath).getRight).contains(fileToRemove))
+
+        val deleteRows = spark.sql(
+          s"call repair_clustering_plan(table => '$tableName', instant => '${instant1.requestedTime}', " +
+            s"op => 'delete', invalid_parquet_files => '$fileToRemove', dry_run => false)").collect()
+        assertRepairResult(deleteRows, instant1.requestedTime, fileToRemove, "REMOVED_FROM_PLAN", deleted = false, "USER_REQUESTED")
+
+        metadata = getLatestRequestedClusteringPlan(basePath)
+        assertFalse(getPlanDataFiles(metadata.getRight).contains(fileToRemove))
+
+        var metaClient = createMetaClient(spark, basePath)
+        assertTrue(metaClient.getStorage.exists(new StoragePath(fileToRemove)))
+        assertTrue(metaClient.getStorage.exists(new StoragePath(metaClient.getMetaPath, ".repair")))
+
+        runClustering(tableName, "execute", Some(instant1.requestedTime))
+        assertClusteringCompleted(basePath, instant1.requestedTime)
+        assertEquals(9, spark.sql(s"select id from $tableName where dt = '2026-01-27'").collect().length)
+
+        checkExceptionContain(
+          s"call repair_clustering_plan(table => '$tableName', instant => '${instant1.requestedTime}', " +
+            s"op => 'delete', invalid_parquet_files => '$fileToRemove', dry_run => false)")(
+          "does not exist")
+
+        insertRows(tableName, "2026-01-28", 10)
+        insertRows(tableName, "2026-01-28", 13)
+        insertRows(tableName, "2026-01-28", 16)
+
+        runClustering(tableName, "schedule")
+        metadata = getLatestRequestedClusteringPlan(basePath)
+        val instant2 = metadata.getLeft
+        val corruptFile = getPlanDataFiles(metadata.getRight).head
+        metaClient = createMetaClient(spark, basePath)
+        replaceWithEmptyFile(metaClient.getStorage, new StoragePath(corruptFile))
+
+        val validateRows = spark.sql(
+          s"call repair_clustering_plan(table => '$tableName', instant => '${instant2.requestedTime}', " +
+            s"op => 'validate_delete', need_delete => true, dry_run => false)").collect()
+        assertRepairResult(validateRows, instant2.requestedTime, corruptFile, "REMOVED_FROM_PLAN", deleted = true, "NOT_PARQUET_FILE")
+
+        metadata = getLatestRequestedClusteringPlan(basePath)
+        assertFalse(getPlanDataFiles(metadata.getRight).contains(corruptFile))
+        metaClient = createMetaClient(spark, basePath)
+        assertFalse(metaClient.getStorage.exists(new StoragePath(corruptFile)))
+      }
+    }
+  }
+
+  test("Test repair_clustering_plan is registered") {
+    assertNotNull(org.apache.spark.sql.hudi.command.procedures.HoodieProcedures.newBuilder("repair_clustering_plan"))
+  }
+
+  private def runClustering(tableName: String,
+                            operation: String,
+                            instant: Option[String] = None): Unit = {
+    val instantClause = instant.map(value => s", instants => '$value'").getOrElse("")
+    spark.sql(s"call run_clustering(table => '$tableName', op => '$operation'$instantClause)").collect()
+  }
+
+  private def insertRows(tableName: String, dt: String, startId: Int): Unit = {
+    spark.sql(
+      s"""
+         |insert into $tableName values
+         | (${startId}, 'a${startId}', ${startId}.0, ${startId * 1000L}, '$dt'),
+         | (${startId + 1}, 'a${startId + 1}', ${startId + 1}.0, ${(startId + 1) * 1000L}, '$dt'),
+         | (${startId + 2}, 'a${startId + 2}', ${startId + 2}.0, ${(startId + 2) * 1000L}, '$dt')
+         |""".stripMargin)
+  }
+
+  private def getLatestRequestedClusteringPlan(basePath: String) = {
+    val metaClient = createMetaClient(spark, basePath)
+    val plans = ClusteringUtils.getAllPendingClusteringPlans(metaClient).iterator().asScala
+      .filter(_.getLeft.isRequested)
+      .toSeq
+    assertTrue(plans.nonEmpty)
+    plans.maxBy(_.getLeft.requestedTime)
+  }
+
+  private def getPlanDataFiles(plan: HoodieClusteringPlan): Seq[String] = {
+    plan.getInputGroups.asScala
+      .flatMap(_.getSlices.asScala)
+      .map(_.getDataFilePath)
+      .filter(path => path != null && path.nonEmpty)
+      .toSeq
+  }
+
+  private def assertRepairResult(rows: Array[Row],
+                                 instant: String,
+                                 file: String,
+                                 action: String,
+                                 deleted: Boolean,
+                                 reason: String): Unit = {
+    assertTrue(rows.exists { row =>
+      row.getString(0) == instant &&
+        row.getString(1) == file &&
+        row.getString(2) == action &&
+        row.getBoolean(3) == deleted &&
+        row.getString(4) == reason
+    }, s"Expected repair result to contain ($instant, $file, $action, $deleted, $reason), but got ${rows.mkString("[", ", ", "]")}")
+  }
+
+  private def assertClusteringCompleted(basePath: String, instantTime: String): Unit = {
+    val metaClient = createMetaClient(spark, basePath)
+    val instants = metaClient.reloadActiveTimeline().getInstants.iterator().asScala
+      .filter(instant => instant.requestedTime == instantTime
+        && (instant.getAction == HoodieTimeline.REPLACE_COMMIT_ACTION || instant.getAction == HoodieTimeline.CLUSTERING_ACTION))
+      .toSeq
+
+    assertTrue(instants.exists(_.isCompleted), s"Expected clustering instant $instantTime to be completed")
+    assertFalse(instants.exists(instant => instant.isRequested || instant.isInflight),
+      s"Expected clustering instant $instantTime to have no pending state, but got ${instants.mkString("[", ", ", "]")}")
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

  Clustering execution can fail when a requested clustering plan references data files that are no longer valid, for example corrupted parquet files or files that operators explicitly need to remove from the pending plan.

  This PR adds a Spark SQL procedure to repair a requested clustering plan by pruning selected invalid file slices from the plan before clustering execution.

### Summary and Changelog

  This PR adds `repair_clustering_plan`, a Spark SQL procedure for repairing pending requested clustering plans.

  Changes:
  - Add `repair_clustering_plan` procedure.
  - Support dry-run mode by default, returning the files that would be removed from the requested clustering plan.
  - Support user-specified file removal through `op => 'delete'` and `invalid_parquet_files`.
  - Support parquet validation through `op => 'validate_delete'`, which scans files referenced by the clustering plan and detects invalid parquet files.
  - Support optional physical file deletion through `need_delete => true`.
  - Rewrite the requested clustering/replace instant metadata with the repaired clustering plan.
  - Create a backup of the original requested instant metadata by default before rewriting.
  - Prevent removing all input groups by default unless `allow_empty_plan => true` is explicitly set.
  - Register the procedure in `HoodieProcedures`.
  - Add tests covering dry-run, plan repair, backup creation, clustering execution after repair, invalid parquet validation, optional physical deletion, and procedure registration.

  No code was copied.

### Impact

  This adds a new user-facing Spark SQL procedure:

  ```sql
  call repair_clustering_plan(
    table => '<table>',
    instant => '<requested_clustering_instant>',
    op => 'delete',
    invalid_parquet_files => '<file1,file2>',
    dry_run => false
  )
```
  The change does not affect normal read/write/clustering behavior unless the procedure is explicitly invoked.

  The procedure can rewrite pending requested clustering metadata and can delete physical files when need_delete => true is set. Dry-run is enabled by default to avoid accidental mutation.

  Validation mode scans files referenced by the requested clustering plan. The scan parallelism is controlled by validation_parallelism.


### Risk Level

  medium

  The procedure performs metadata repair on requested clustering instants and optionally deletes physical files, so misuse could remove entries from a pending clustering plan. The risk is mitigated by:

  - dry_run defaulting to true.
  - metadata backup enabled by default.
  - explicit instant selection.
  - refusing to remove all input groups unless allow_empty_plan => true.
  - tests covering dry-run, actual repair, post-repair clustering execution, invalid parquet detection, and physical deletion.

### Documentation Update

  Required.

  This PR adds a new user-facing Spark SQL procedure. The Hudi website procedure documentation should be updated to describe repair_clustering_plan, including parameters, default values, dry-run behavior, backup behavior, and examples for manual deletion and validation-based repair.

  No new configs are added and no existing config defaults are changed.

### Contributor's checklist

  - [x] Read through contributor's guide (https://hudi.apache.org/contribute/how-to-contribute)
  - [x] Enough context is provided in the sections above
  - [x] Adequate tests were added if applicable