### PR TITLE
feat(writer): add COMMIT_TIME_ONLY meta-fields mode for incremental queries on minimal-meta-fields tables

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1774,6 +1774,24 @@ public class HoodieWriteConfig extends HoodieConfig {
   }
 
   /**
+   * @return true when the writer is configured to additionally populate {@code _hoodie_commit_time}
+   * even though {@link HoodieTableConfig#POPULATE_META_FIELDS} is {@code false}. Only meaningful
+   * when {@code populateMetaFields()} is {@code false}; ignored otherwise. See
+   * {@link HoodieTableConfig#isCommitTimeOnlyMetaFieldsMode()}.
+   */
+  public boolean isCommitTimeOnlyMetaFieldsMode() {
+    return !populateMetaFields()
+        && getBooleanOrDefault(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED);
+  }
+
+  /**
+   * @return true when {@code _hoodie_commit_time} is physically populated on every row.
+   */
+  public boolean isCommitTimePopulated() {
+    return populateMetaFields() || isCommitTimeOnlyMetaFieldsMode();
+  }
+
+  /**
    * compaction properties.
    */
 
@@ -3574,6 +3592,11 @@ public class HoodieWriteConfig extends HoodieConfig {
       return this;
     }
 
+    public Builder withMetaFieldsCommitTimeEnabled(boolean enabled) {
+      writeConfig.setValue(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED, Boolean.toString(enabled));
+      return this;
+    }
+
     public Builder withAllowOperationMetadataField(boolean allowOperationMetadataField) {
       writeConfig.setValue(ALLOW_OPERATION_METADATA_FIELD, Boolean.toString(allowOperationMetadataField));
       return this;
@@ -3861,6 +3884,17 @@ public class HoodieWriteConfig extends HoodieConfig {
       checkArgument(lookbackCommits >= 0,
           String.format("%s must be non-negative, but was %d",
               ROLLING_METADATA_TIMELINE_LOOKBACK_COMMITS.key(), lookbackCommits));
+
+      // COMMIT_TIME_ONLY mode is an additive opt-in on top of populate.meta.fields=false. Setting
+      // both flags to true is ambiguous (the COMMIT_TIME_ONLY flag has no effect when all meta
+      // fields are already populated) so reject it explicitly rather than silently ignore.
+      boolean populateMetaFields = writeConfig.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS);
+      boolean commitTimeEnabled = writeConfig.getBooleanOrDefault(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED);
+      checkArgument(!(populateMetaFields && commitTimeEnabled),
+          String.format("%s=true is only meaningful when %s=false. Disable populate.meta.fields or "
+                  + "drop the commit-time-only opt-in.",
+              HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED.key(),
+              HoodieTableConfig.POPULATE_META_FIELDS.key()));
     }
 
     public HoodieWriteConfig build() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfigMetaFieldsMode.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfigMetaFieldsMode.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates the writer-side accessors and validation guard for the three meta-field-population
+ * modes (ALL / NONE / COMMIT_TIME_ONLY) on {@link HoodieWriteConfig}. The companion test for the
+ * {@link org.apache.hudi.common.table.HoodieTableConfig} accessors lives in {@code
+ * TestHoodieMetaFieldsMode}; this test covers the writer-builder surface and the cross-flag
+ * validation that runs at {@code build()} time.
+ */
+class TestHoodieWriteConfigMetaFieldsMode {
+
+  private static HoodieWriteConfig.Builder baseBuilder() {
+    return HoodieWriteConfig.newBuilder().withPath("file:///tmp/test_hudi_meta_fields_mode");
+  }
+
+  @Test
+  void defaultsToAllMode() {
+    HoodieWriteConfig cfg = baseBuilder().build();
+    assertTrue(cfg.populateMetaFields());
+    assertFalse(cfg.isCommitTimeOnlyMetaFieldsMode());
+    assertTrue(cfg.isCommitTimePopulated());
+  }
+
+  @Test
+  void explicitNoneModeBuilds() {
+    HoodieWriteConfig cfg = baseBuilder().withPopulateMetaFields(false).build();
+    assertFalse(cfg.populateMetaFields());
+    assertFalse(cfg.isCommitTimeOnlyMetaFieldsMode());
+    assertFalse(cfg.isCommitTimePopulated());
+  }
+
+  @Test
+  void commitTimeOnlyModeBuildsAndIsAdditiveOverNone() {
+    HoodieWriteConfig cfg = baseBuilder()
+        .withPopulateMetaFields(false)
+        .withMetaFieldsCommitTimeEnabled(true)
+        .build();
+    assertFalse(cfg.populateMetaFields());
+    assertTrue(cfg.isCommitTimeOnlyMetaFieldsMode(),
+        "COMMIT_TIME_ONLY must engage when populate.meta.fields=false and commit.time.enabled=true");
+    assertTrue(cfg.isCommitTimePopulated(),
+        "incremental query semantics depend on _hoodie_commit_time being populated in this mode");
+  }
+
+  @Test
+  void commitTimeFlagIgnoredWhenPopulateMetaFieldsIsTrueByConstruction() {
+    // The validation guard rejects the combination at build() time, so the only way to observe
+    // both flags being truthy together is to bypass the builder's validate() — i.e., the
+    // accessor must still report ALL semantics rather than COMMIT_TIME_ONLY if the bad combo
+    // ever leaks through (defensive correctness).
+    HoodieWriteConfig cfg = baseBuilder()
+        .withPopulateMetaFields(true)
+        // commit.time.enabled defaults to false; setting it false is allowed.
+        .withMetaFieldsCommitTimeEnabled(false)
+        .build();
+    assertTrue(cfg.populateMetaFields());
+    assertFalse(cfg.isCommitTimeOnlyMetaFieldsMode());
+  }
+
+  @Test
+  void rejectsIncompatibleCombination() {
+    // populate.meta.fields=true together with the COMMIT_TIME_ONLY opt-in is ambiguous (the new
+    // flag has no effect when all meta fields are already populated); reject loudly.
+    HoodieWriteConfig.Builder builder = baseBuilder()
+        .withPopulateMetaFields(true)
+        .withMetaFieldsCommitTimeEnabled(true);
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, builder::build);
+    assertTrue(ex.getMessage().contains("hoodie.meta.fields.commit.time.enabled"),
+        "exception must name the new property: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("hoodie.populate.meta.fields"),
+        "exception must name the legacy property too: " + ex.getMessage());
+  }
+
+  @Test
+  void noneModeWithCommitTimeFlagFalseExplicitIsStillNone() {
+    HoodieWriteConfig cfg = baseBuilder()
+        .withPopulateMetaFields(false)
+        .withMetaFieldsCommitTimeEnabled(false)
+        .build();
+    assertEquals(false, cfg.populateMetaFields());
+    assertEquals(false, cfg.isCommitTimeOnlyMetaFieldsMode());
+    assertEquals(false, cfg.isCommitTimePopulated());
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -54,6 +54,8 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
       String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier) throws IOException {
     boolean populateMetaFields = config.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS);
+    boolean commitTimeOnly = !populateMetaFields
+        && config.getBooleanOrDefault(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED);
 
     Pair<StorageConfiguration, HoodieConfig> injectedConfigs = HoodieParquetConfigInjector.applyConfigInjector(path, storage.getConf(), config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
@@ -77,7 +79,7 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
         hoodieConfig.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED));
     parquetConfig.getHadoopConf().addResource(writeSupport.getHadoopConf());
 
-    return new HoodieSparkParquetWriter(path, parquetConfig, instantTime, taskContextSupplier, populateMetaFields);
+    return new HoodieSparkParquetWriter(path, parquetConfig, instantTime, taskContextSupplier, populateMetaFields, commitTimeOnly);
   }
 
   protected HoodieFileWriter newParquetFileWriter(OutputStream outputStream, HoodieConfig config,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
@@ -44,6 +44,10 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
   private final UTF8String instantTime;
 
   private final boolean populateMetaFields;
+  // True when only _hoodie_commit_time (and seq id) should be populated even though
+  // populateMetaFields is false. Used by the COMMIT_TIME_ONLY mode so incremental queries keep
+  // working on otherwise-minimal-meta-field tables.
+  private final boolean commitTimeOnly;
 
   private final HoodieRowParquetWriteSupport writeSupport;
 
@@ -54,11 +58,21 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
                                   String instantTime,
                                   TaskContextSupplier taskContextSupplier,
                                   boolean populateMetaFields) throws IOException {
+    this(file, parquetConfig, instantTime, taskContextSupplier, populateMetaFields, false);
+  }
+
+  public HoodieSparkParquetWriter(StoragePath file,
+                                  HoodieRowParquetConfig parquetConfig,
+                                  String instantTime,
+                                  TaskContextSupplier taskContextSupplier,
+                                  boolean populateMetaFields,
+                                  boolean commitTimeOnly) throws IOException {
     super(file, parquetConfig);
     this.writeSupport = parquetConfig.getWriteSupport();
     this.fileName = UTF8String.fromString(file.getName());
     this.instantTime = UTF8String.fromString(instantTime);
     this.populateMetaFields = populateMetaFields;
+    this.commitTimeOnly = commitTimeOnly && !populateMetaFields;
     this.seqIdGenerator = recordIndex -> {
       Integer partitionId = taskContextSupplier.getPartitionIdSupplier().get();
       return HoodieRecord.generateSequenceId(instantTime, partitionId, recordIndex);
@@ -73,6 +87,15 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
 
       super.write(row);
       writeSupport.add(recordKey);
+    } else if (commitTimeOnly) {
+      // COMMIT_TIME_ONLY: populate only _hoodie_commit_time + seq id. The other three meta columns
+      // (record key, partition path, file name) stay at whatever their default unset state is. We
+      // do NOT register the record key with writeSupport — that would feed the parquet bloom
+      // filter, which has no meaning when the record key column is unpopulated.
+      row.update(COMMIT_TIME_METADATA_FIELD.ordinal(), instantTime);
+      row.update(COMMIT_SEQNO_METADATA_FIELD.ordinal(),
+          UTF8String.fromString(seqIdGenerator.apply(getWrittenRecordCount())));
+      super.write(row);
     } else {
       super.write(row);
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
@@ -67,6 +67,9 @@ public class HoodieRowCreateHandle implements Serializable {
   private final String fileId;
 
   private final boolean populateMetaFields;
+  // True when the writer is in COMMIT_TIME_ONLY mode (populateMetaFields is false but
+  // _hoodie_commit_time and seq id are still populated so incremental queries remain functional).
+  private final boolean commitTimeOnly;
 
   private final UTF8String fileName;
   private final UTF8String commitTime;
@@ -119,6 +122,7 @@ public class HoodieRowCreateHandle implements Serializable {
     this.path = makeNewPath(storage, partitionPath, fileName, writeConfig);
 
     this.populateMetaFields = writeConfig.populateMetaFields();
+    this.commitTimeOnly = writeConfig.isCommitTimeOnlyMetaFieldsMode();
     this.fileName = UTF8String.fromString(path.getName());
     this.commitTime = UTF8String.fromString(instantTime);
     this.seqIdGenerator = (id) -> HoodieRecord.generateSequenceId(instantTime, taskPartitionId, id);
@@ -160,8 +164,36 @@ public class HoodieRowCreateHandle implements Serializable {
   public void write(InternalRow row) throws IOException {
     if (populateMetaFields) {
       writeRow(row);
+    } else if (commitTimeOnly) {
+      writeRowCommitTimeOnly(row);
     } else {
       writeRowNoMetaFields(row);
+    }
+  }
+
+  /**
+   * COMMIT_TIME_ONLY write path: populate only {@code _hoodie_commit_time} (and the derived
+   * sequence id) so incremental queries keep working. The other three meta columns (record key,
+   * partition path, file name) stay null on disk. We do not register the record key with the
+   * write support — that would feed the parquet bloom filter, which has no meaning when the
+   * record key column is unpopulated.
+   */
+  private void writeRowCommitTimeOnly(InternalRow row) {
+    try {
+      UTF8String[] metaFields = new UTF8String[5];
+      metaFields[HoodieRecord.COMMIT_TIME_METADATA_FIELD_ORD] = shouldPreserveHoodieMetadata
+          ? row.getUTF8String(HoodieRecord.COMMIT_TIME_METADATA_FIELD_ORD) : commitTime;
+      metaFields[HoodieRecord.COMMIT_SEQNO_METADATA_FIELD_ORD] = shouldPreserveHoodieMetadata
+          ? row.getUTF8String(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD_ORD)
+          : UTF8String.fromString(seqIdGenerator.apply(GLOBAL_SEQ_NO.getAndIncrement()));
+      // metaFields[2/3/4] (record key / partition path / file name) intentionally left null —
+      // Parquet stores nulls as definition-level flags (zero data bytes).
+      InternalRow updatedRow = SparkAdapterSupport$.MODULE$.sparkAdapter().createInternalRow(metaFields, row, true);
+      fileWriter.writeRow(updatedRow);
+      writeStatus.markSuccess((HoodieRecordDelegate) null, Option.empty());
+    } catch (Exception e) {
+      writeStatus.setGlobalError(e);
+      throw new HoodieException("Exception thrown while writing spark InternalRows to file ", e);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -324,6 +324,14 @@ public class HoodieTableConfig extends HoodieConfig {
       .withDocumentation("When enabled, populates all meta fields. When disabled, no meta fields are populated "
           + "and incremental queries will not be functional. This is only meant to be used for append only/immutable data for batch processing");
 
+  public static final ConfigProperty<Boolean> META_FIELDS_COMMIT_TIME_ENABLED = ConfigProperty
+      .key("hoodie.meta.fields.commit.time.enabled")
+      .defaultValue(false)
+      .withDocumentation("Only meaningful when " + "hoodie.populate.meta.fields=false. When set to true, the writer "
+          + "additionally populates _hoodie_commit_time on every row so that incremental queries remain functional "
+          + "while the other meta columns are still skipped. Has no effect when "
+          + "hoodie.populate.meta.fields=true (all meta fields are populated unconditionally in that case).");
+
   public static final ConfigProperty<String> KEY_GENERATOR_CLASS_NAME = ConfigProperty
       .key("hoodie.table.keygenerator.class")
       .noDefaultValue()
@@ -1193,6 +1201,34 @@ public class HoodieTableConfig extends HoodieConfig {
    */
   public boolean populateMetaFields() {
     return Boolean.parseBoolean(getStringOrDefault(POPULATE_META_FIELDS));
+  }
+
+  /**
+   * @return true when the writer is configured for the COMMIT_TIME_ONLY mode: i.e.,
+   * {@link #POPULATE_META_FIELDS} is {@code false} and {@link #META_FIELDS_COMMIT_TIME_ENABLED} is
+   * {@code true}. This is the additive opt-in that keeps incremental queries functional while the
+   * other four meta columns stay null on disk.
+   */
+  public boolean isCommitTimeOnlyMetaFieldsMode() {
+    return !populateMetaFields() && Boolean.parseBoolean(getStringOrDefault(META_FIELDS_COMMIT_TIME_ENABLED));
+  }
+
+  /**
+   * @return true when the {@code _hoodie_commit_time} meta column is physically populated on disk —
+   * i.e., either all meta fields are populated, or the table is in the COMMIT_TIME_ONLY mode.
+   */
+  public boolean isCommitTimePopulated() {
+    return populateMetaFields() || isCommitTimeOnlyMetaFieldsMode();
+  }
+
+  /**
+   * @return true when the {@code _hoodie_record_key} meta column is physically populated on disk.
+   * Currently this exactly mirrors {@link #populateMetaFields()} but is exposed as a separate
+   * predicate so callers that specifically care about the record-key column do not need to be
+   * updated again if the mode set is extended.
+   */
+  public boolean isRecordKeyPopulated() {
+    return populateMetaFields();
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
@@ -1069,6 +1069,7 @@ public class HoodieTableMetaClient implements Serializable {
     private String bootstrapBasePath;
     private Boolean bootstrapIndexEnable;
     private Boolean populateMetaFields;
+    private Boolean metaFieldsCommitTimeEnabled;
     private String keyGeneratorClassProp;
     private String partitionValueExtractorClass;
     private String keyGeneratorType;
@@ -1226,6 +1227,11 @@ public class HoodieTableMetaClient implements Serializable {
 
     public TableBuilder setPopulateMetaFields(boolean populateMetaFields) {
       this.populateMetaFields = populateMetaFields;
+      return this;
+    }
+
+    public TableBuilder setMetaFieldsCommitTimeEnabled(boolean enabled) {
+      this.metaFieldsCommitTimeEnabled = enabled;
       return this;
     }
 
@@ -1443,6 +1449,9 @@ public class HoodieTableMetaClient implements Serializable {
       if (hoodieConfig.contains(HoodieTableConfig.POPULATE_META_FIELDS)) {
         setPopulateMetaFields(hoodieConfig.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS));
       }
+      if (hoodieConfig.contains(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED)) {
+        setMetaFieldsCommitTimeEnabled(hoodieConfig.getBoolean(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED));
+      }
       if (hoodieConfig.contains(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME)) {
         setKeyGeneratorClassProp(hoodieConfig.getString(HoodieTableConfig.KEY_GENERATOR_CLASS_NAME));
       } else if (hoodieConfig.contains(HoodieTableConfig.KEY_GENERATOR_TYPE)) {
@@ -1580,6 +1589,9 @@ public class HoodieTableMetaClient implements Serializable {
       }
       if (null != populateMetaFields) {
         tableConfig.setValue(HoodieTableConfig.POPULATE_META_FIELDS, Boolean.toString(populateMetaFields));
+      }
+      if (null != metaFieldsCommitTimeEnabled) {
+        tableConfig.setValue(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED, Boolean.toString(metaFieldsCommitTimeEnabled));
       }
       if (null != keyGeneratorClassProp) {
         KeyGeneratorType type = KeyGeneratorType.fromClassName(keyGeneratorClassProp);

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroFileWriterFactory.java
@@ -67,6 +67,8 @@ public class HoodieAvroFileWriterFactory extends HoodieFileWriterFactory {
       String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier) throws IOException {
     boolean populateMetaFields = config.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS);
+    boolean commitTimeOnly = !populateMetaFields
+        && config.getBooleanOrDefault(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED);
 
     Pair<StorageConfiguration, HoodieConfig> injectedConfigs = HoodieParquetConfigInjector.applyConfigInjector(path, storage.getConf(), config);
     StorageConfiguration storageConfiguration = injectedConfigs.getLeft();
@@ -86,7 +88,7 @@ public class HoodieAvroFileWriterFactory extends HoodieFileWriterFactory {
         hoodieConfig.getLongOrDefault(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE),
         storageConfiguration, hoodieConfig.getDoubleOrDefault(HoodieStorageConfig.PARQUET_COMPRESSION_RATIO_FRACTION),
         hoodieConfig.getBooleanOrDefault(HoodieStorageConfig.PARQUET_DICTIONARY_ENABLED));
-    return new HoodieAvroParquetWriter(path, parquetConfig, instantTime, taskContextSupplier, populateMetaFields);
+    return new HoodieAvroParquetWriter(path, parquetConfig, instantTime, taskContextSupplier, populateMetaFields, commitTimeOnly);
   }
 
   protected HoodieFileWriter newParquetFileWriter(

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroParquetWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroParquetWriter.java
@@ -19,10 +19,12 @@
 
 package org.apache.hudi.io.storage.hadoop;
 
+import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.avro.HoodieAvroWriteSupport;
 import org.apache.hudi.common.config.HoodieParquetConfig;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.io.hadoop.HoodieBaseParquetWriter;
 import org.apache.hudi.io.storage.HoodieAvroFileWriter;
 import org.apache.hudi.storage.StoragePath;
@@ -48,6 +50,10 @@ public class HoodieAvroParquetWriter
   private final String instantTime;
   private final TaskContextSupplier taskContextSupplier;
   private final boolean populateMetaFields;
+  // True when the writer should additionally populate _hoodie_commit_time (and seqId) even though
+  // populateMetaFields is false. This is the COMMIT_TIME_ONLY mode used to keep incremental queries
+  // functional on otherwise-minimal-meta-field tables. Ignored when populateMetaFields is true.
+  private final boolean commitTimeOnly;
   private final HoodieAvroWriteSupport writeSupport;
 
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -56,12 +62,23 @@ public class HoodieAvroParquetWriter
                                  String instantTime,
                                  TaskContextSupplier taskContextSupplier,
                                  boolean populateMetaFields) throws IOException {
+    this(file, parquetConfig, instantTime, taskContextSupplier, populateMetaFields, false);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public HoodieAvroParquetWriter(StoragePath file,
+                                 HoodieParquetConfig<HoodieAvroWriteSupport> parquetConfig,
+                                 String instantTime,
+                                 TaskContextSupplier taskContextSupplier,
+                                 boolean populateMetaFields,
+                                 boolean commitTimeOnly) throws IOException {
     super(file, (HoodieParquetConfig) parquetConfig);
     this.fileName = file.getName();
     this.writeSupport = parquetConfig.getWriteSupport();
     this.instantTime = instantTime;
     this.taskContextSupplier = taskContextSupplier;
     this.populateMetaFields = populateMetaFields;
+    this.commitTimeOnly = commitTimeOnly && !populateMetaFields;
   }
 
   @Override
@@ -71,6 +88,16 @@ public class HoodieAvroParquetWriter
           taskContextSupplier.getPartitionIdSupplier().get(), getWrittenRecordCount(), fileName);
       super.write(avroRecord);
       writeSupport.add(key.getRecordKey());
+    } else if (commitTimeOnly) {
+      // COMMIT_TIME_ONLY: populate only _hoodie_commit_time (and seq id derived from it) so
+      // incremental queries keep working. The other four meta columns stay null on disk, which
+      // Parquet stores as definition-level flags (zero data bytes). Bloom filter / record-key
+      // index population is intentionally skipped — that requires the record-key column.
+      String seqId = HoodieRecord.generateSequenceId(instantTime,
+          taskContextSupplier.getPartitionIdSupplier().get(), getWrittenRecordCount());
+      HoodieAvroUtils.addCommitMetadataToRecord(
+          (org.apache.avro.generic.GenericRecord) avroRecord, instantTime, seqId);
+      super.write(avroRecord);
     } else {
       super.write(avroRecord);
     }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieMetaFieldsMode.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieMetaFieldsMode.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.hudi.common.config.HoodieConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the three meta-field-population modes exposed by {@link HoodieTableConfig}:
+ *
+ * <ul>
+ *   <li>ALL — {@code populate.meta.fields=true} (default). All five meta columns populated.</li>
+ *   <li>NONE — {@code populate.meta.fields=false} and {@code meta.fields.commit.time.enabled=false}.
+ *   No meta columns populated; incremental queries rejected.</li>
+ *   <li>COMMIT_TIME_ONLY — {@code populate.meta.fields=false} and
+ *   {@code meta.fields.commit.time.enabled=true}. Only {@code _hoodie_commit_time} populated so
+ *   incremental queries keep working. Additive layer on top of the NONE mode.</li>
+ * </ul>
+ *
+ * <p>This test fixture exercises the {@link HoodieTableConfig} accessors directly without
+ * touching the storage layer; integration coverage lives in the per-engine writer tests.
+ */
+class TestHoodieMetaFieldsMode {
+
+  private static HoodieTableConfig configOf(Boolean populate, Boolean commitTime) {
+    HoodieTableConfig cfg = new HoodieTableConfig();
+    if (populate != null) {
+      cfg.setValue(HoodieTableConfig.POPULATE_META_FIELDS, String.valueOf(populate));
+    }
+    if (commitTime != null) {
+      cfg.setValue(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED, String.valueOf(commitTime));
+    }
+    return cfg;
+  }
+
+  @Test
+  void defaultsResolveToAllMode() {
+    // No properties set on a fresh config — defaults must keep today's behavior (ALL).
+    HoodieTableConfig cfg = configOf(null, null);
+    assertTrue(cfg.populateMetaFields(), "populateMetaFields default must remain true");
+    assertFalse(cfg.isCommitTimeOnlyMetaFieldsMode(),
+        "isCommitTimeOnlyMetaFieldsMode must be false when populate.meta.fields is true");
+    assertTrue(cfg.isCommitTimePopulated(), "commit time must be populated in ALL mode");
+    assertTrue(cfg.isRecordKeyPopulated(), "record key must be populated in ALL mode");
+  }
+
+  @Test
+  void allModeWhenPopulateExplicitlyTrue() {
+    HoodieTableConfig cfg = configOf(true, false);
+    assertTrue(cfg.populateMetaFields());
+    assertFalse(cfg.isCommitTimeOnlyMetaFieldsMode());
+    assertTrue(cfg.isCommitTimePopulated());
+    assertTrue(cfg.isRecordKeyPopulated());
+  }
+
+  @Test
+  void noneModeWhenPopulateFalseAndCommitTimeFalse() {
+    HoodieTableConfig cfg = configOf(false, false);
+    assertFalse(cfg.populateMetaFields());
+    assertFalse(cfg.isCommitTimeOnlyMetaFieldsMode());
+    assertFalse(cfg.isCommitTimePopulated(),
+        "commit time must not be populated under NONE — incremental queries are unsupported");
+    assertFalse(cfg.isRecordKeyPopulated());
+  }
+
+  @Test
+  void noneModeWhenPopulateFalseAndCommitTimeUnset() {
+    // The new property defaults to false; an existing populate.meta.fields=false table without
+    // the new prop set must still resolve to NONE.
+    HoodieTableConfig cfg = configOf(false, null);
+    assertFalse(cfg.populateMetaFields());
+    assertFalse(cfg.isCommitTimeOnlyMetaFieldsMode());
+    assertFalse(cfg.isCommitTimePopulated());
+    assertFalse(cfg.isRecordKeyPopulated());
+  }
+
+  @Test
+  void commitTimeOnlyModeWhenPopulateFalseAndCommitTimeTrue() {
+    HoodieTableConfig cfg = configOf(false, true);
+    assertFalse(cfg.populateMetaFields());
+    assertTrue(cfg.isCommitTimeOnlyMetaFieldsMode(),
+        "COMMIT_TIME_ONLY mode must engage when populate=false and commit.time.enabled=true");
+    assertTrue(cfg.isCommitTimePopulated(),
+        "_hoodie_commit_time must be populated under COMMIT_TIME_ONLY so incremental queries work");
+    assertFalse(cfg.isRecordKeyPopulated(),
+        "_hoodie_record_key remains unpopulated under COMMIT_TIME_ONLY");
+  }
+
+  @Test
+  void commitTimeFlagIgnoredWhenPopulateMetaFieldsIsTrue() {
+    // When all meta fields are populated, the commit-time-enabled flag has no semantic
+    // effect — the table is in ALL mode regardless. isCommitTimeOnlyMetaFieldsMode must report
+    // false so callers do not mistakenly drop into the COMMIT_TIME_ONLY write path.
+    HoodieTableConfig cfg = configOf(true, true);
+    assertTrue(cfg.populateMetaFields());
+    assertFalse(cfg.isCommitTimeOnlyMetaFieldsMode());
+    assertTrue(cfg.isCommitTimePopulated());
+    assertTrue(cfg.isRecordKeyPopulated());
+  }
+
+  @Test
+  void hoodieConfigViewProducesIdenticalSemantics() {
+    // Verifies the accessors do not depend on instance state; a HoodieConfig view of the same
+    // properties yields the same answers.
+    HoodieTableConfig cfg = configOf(false, true);
+    HoodieConfig view = new HoodieConfig(cfg.getProps());
+    assertTrue(view.getBooleanOrDefault(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED));
+    assertFalse(view.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS));
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -384,7 +384,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   @Test
   void testDefinedTableConfigs() {
     List<ConfigProperty<?>> configProperties = HoodieTableConfig.definedTableConfigs();
-    assertEquals(44, configProperties.size());
+    assertEquals(45, configProperties.size());
     configProperties.forEach(c -> {
       assertNotNull(c);
       assertFalse(c.doc().isEmpty());

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -284,6 +284,7 @@ class HoodieSparkSqlWriterInternal {
         val baseFileFormat = hoodieConfig.getStringOrDefault(HoodieTableConfig.BASE_FILE_FORMAT)
         val archiveLogFolder = hoodieConfig.getStringOrDefault(HoodieTableConfig.TIMELINE_HISTORY_PATH)
         val populateMetaFields = hoodieConfig.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS)
+        val metaFieldsCommitTimeEnabled = hoodieConfig.getBooleanOrDefault(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED)
         val useBaseFormatMetaFile = hoodieConfig.getBooleanOrDefault(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT);
         val payloadClass = hoodieConfig.getString(DataSourceWriteOptions.PAYLOAD_CLASS_NAME)
         val recordMergeStrategyId = hoodieConfig.getString(DataSourceWriteOptions.RECORD_MERGE_STRATEGY_ID)
@@ -308,6 +309,7 @@ class HoodieSparkSqlWriterInternal {
           .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(optParams.asJava))
           .setPartitionFields(partitionColumnsForKeyGenerator)
           .setPopulateMetaFields(populateMetaFields)
+          .setMetaFieldsCommitTimeEnabled(metaFieldsCommitTimeEnabled)
           .setRecordKeyFields(hoodieConfig.getString(RECORDKEY_FIELD))
           .setSecondaryKeyFields(hoodieConfig.getString(SECONDARYKEY_COLUMN_NAME))
           .setCDCEnabled(hoodieConfig.getBooleanOrDefault(HoodieTableConfig.CDC_ENABLED))
@@ -754,6 +756,10 @@ class HoodieSparkSqlWriterInternal {
           HoodieTableConfig.POPULATE_META_FIELDS.key(),
           String.valueOf(HoodieTableConfig.POPULATE_META_FIELDS.defaultValue())
         ))
+        val metaFieldsCommitTimeEnabled = java.lang.Boolean.parseBoolean(parameters.getOrElse(
+          HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED.key(),
+          String.valueOf(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED.defaultValue())
+        ))
         val baseFileFormat = hoodieConfig.getStringOrDefault(HoodieTableConfig.BASE_FILE_FORMAT)
         val useBaseFormatMetaFile = java.lang.Boolean.parseBoolean(parameters.getOrElse(
           HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
@@ -780,6 +786,7 @@ class HoodieSparkSqlWriterInternal {
           .setCDCEnabled(hoodieConfig.getBooleanOrDefault(HoodieTableConfig.CDC_ENABLED))
           .setCDCSupplementalLoggingMode(hoodieConfig.getStringOrDefault(HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE))
           .setPopulateMetaFields(populateMetaFields)
+          .setMetaFieldsCommitTimeEnabled(metaFieldsCommitTimeEnabled)
           .setKeyGeneratorClassProp(keyGenProp)
           .setPartitionValueExtractorClass(partitionValueExtractorClassName)
           .set(timestampKeyGeneratorConfigs.asJava.asInstanceOf[java.util.Map[String, Object]])

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelationV1.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelationV1.scala
@@ -88,8 +88,9 @@ class IncrementalRelationV1(val sqlContext: SQLContext,
       s"option ${DataSourceReadOptions.START_COMMIT.key}")
   }
 
-  if (!metaClient.getTableConfig.populateMetaFields()) {
-    throw new HoodieException("Incremental queries are not supported when meta fields are disabled")
+  if (!metaClient.getTableConfig.isCommitTimePopulated()) {
+    throw new HoodieException("Incremental queries are not supported when _hoodie_commit_time is not populated. "
+      + "Either keep hoodie.populate.meta.fields=true or set hoodie.meta.fields.commit.time.enabled=true.")
   }
 
   private val useEndInstantSchema = optParams.getOrElse(INCREMENTAL_READ_SCHEMA_USE_END_INSTANTTIME.key,

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelationV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/IncrementalRelationV2.scala
@@ -77,8 +77,9 @@ class IncrementalRelationV2(val sqlContext: SQLContext,
       s"option ${DataSourceReadOptions.START_COMMIT.key}")
   }
 
-  if (!metaClient.getTableConfig.populateMetaFields()) {
-    throw new HoodieException("Incremental queries are not supported when meta fields are disabled")
+  if (!metaClient.getTableConfig.isCommitTimePopulated()) {
+    throw new HoodieException("Incremental queries are not supported when _hoodie_commit_time is not populated. "
+      + "Either keep hoodie.populate.meta.fields=true or set hoodie.meta.fields.commit.time.enabled=true.")
   }
 
   private val queryContext: IncrementalQueryAnalyzer.QueryContext =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV1.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV1.scala
@@ -267,8 +267,9 @@ trait HoodieIncrementalRelationV1Trait extends HoodieBaseRelation {
         s"option ${DataSourceReadOptions.START_COMMIT.key}")
     }
 
-    if (!this.tableConfig.populateMetaFields()) {
-      throw new HoodieException("Incremental queries are not supported when meta fields are disabled")
+    if (!this.tableConfig.isCommitTimePopulated()) {
+      throw new HoodieException("Incremental queries are not supported when _hoodie_commit_time is not populated. "
+        + "Either keep hoodie.populate.meta.fields=true or set hoodie.meta.fields.commit.time.enabled=true.")
     }
 
     if (hollowCommitHandling == USE_TRANSITION_TIME && fullTableScan) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
@@ -257,8 +257,9 @@ trait HoodieIncrementalRelationV2Trait extends HoodieBaseRelation {
         s"option ${DataSourceReadOptions.START_COMMIT.key}")
     }
 
-    if (!this.tableConfig.populateMetaFields()) {
-      throw new HoodieException("Incremental queries are not supported when meta fields are disabled")
+    if (!this.tableConfig.isCommitTimePopulated()) {
+      throw new HoodieException("Incremental queries are not supported when _hoodie_commit_time is not populated. "
+        + "Either keep hoodie.populate.meta.fields=true or set hoodie.meta.fields.commit.time.enabled=true.")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsCommitTimeOnly.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestMetaFieldsCommitTimeOnly.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.functional;
+
+import org.apache.hudi.DataSourceWriteOptions;
+import org.apache.hudi.SparkAdapterSupport$;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
+
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Spark-datasource tests for the COMMIT_TIME_ONLY meta-fields-population mode.
+ *
+ * <p>The mode is an additive layer on top of the existing NONE mode
+ * ({@code hoodie.populate.meta.fields=false}): it additionally populates
+ * {@code _hoodie_commit_time} so incremental queries remain functional. The remaining four meta
+ * columns stay null on disk, giving the storage saving while keeping incremental-query semantics.
+ *
+ * <p>This test fixture covers:
+ * <ul>
+ *   <li>The persisted table-config flag is set correctly when the writer opts into the mode.</li>
+ *   <li>The {@code HoodieTableConfig} accessors correctly report the mode after a write/reread.</li>
+ *   <li>The ambiguous combination ({@code populate.meta.fields=true} together with
+ *   {@code meta.fields.commit.time.enabled=true}) is rejected at writer init.</li>
+ *   <li>The ALL mode (default) is not regressed.</li>
+ * </ul>
+ *
+ * <p>End-to-end snapshot/incremental query semantics that depend on Spark's schema-selection
+ * pathway are exercised in follow-up integration tests; the writer-engine-level coverage of the
+ * COMMIT_TIME_ONLY branch lives in {@code TestHoodieSparkParquetWriter}-style unit tests.
+ */
+class TestMetaFieldsCommitTimeOnly extends SparkClientFunctionalTestHarness {
+
+  // ---- helpers ------------------------------------------------------------
+
+  private static StructType simpleSchema() {
+    return DataTypes.createStructType(new StructField[]{
+        DataTypes.createStructField("column1", DataTypes.StringType, true),
+        DataTypes.createStructField("column2", DataTypes.StringType, true),
+        DataTypes.createStructField("column3", DataTypes.StringType, true)
+    }).asNullable();
+  }
+
+  private Map<String, String> baseOptions() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "column1");
+    opts.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "column2");
+    opts.put(DataSourceWriteOptions.ORDERING_FIELDS().key(), "column3");
+    opts.put(HoodieTableConfig.NAME.key(), "test_commit_time_only");
+    opts.put(DataSourceWriteOptions.TABLE_TYPE().key(), "COPY_ON_WRITE");
+    opts.put(HoodieMetadataConfig.ENABLE.key(), "false");
+    return opts;
+  }
+
+  private void writeRows(List<Row> records, StructType schema, Map<String, String> options, String path, SaveMode mode) {
+    spark().createDataset(records,
+            SparkAdapterSupport$.MODULE$.sparkAdapter().getCatalystExpressionUtils().getEncoder(schema))
+        .write()
+        .format("hudi")
+        .options(options)
+        .mode(mode)
+        .save(path);
+  }
+
+  // ---- tests --------------------------------------------------------------
+
+  /**
+   * COMMIT_TIME_ONLY mode: writer succeeds, persists both legacy and new properties on
+   * {@code hoodie.properties}, and the read-back table config correctly reports the mode via the
+   * three accessors.
+   */
+  @Test
+  void commitTimeOnlyModePersistsPropertiesAndReportsMode() {
+    String path = basePath();
+    Map<String, String> options = baseOptions();
+    options.put(HoodieTableConfig.POPULATE_META_FIELDS.key(), "false");
+    options.put(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED.key(), "true");
+    options.put(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+
+    writeRows(Collections.singletonList(RowFactory.create("k1", "p1", "v1")), simpleSchema(), options, path, SaveMode.Overwrite);
+
+    HoodieTableMetaClient metaClient =
+        HoodieTableMetaClient.builder().setBasePath(path).setConf(storageConf()).build();
+    HoodieTableConfig tc = metaClient.getTableConfig();
+
+    assertEquals("false", tc.getProps().getProperty(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+        "populate.meta.fields=false must be persisted");
+    assertEquals("true", tc.getProps().getProperty(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED.key()),
+        "meta.fields.commit.time.enabled=true must be persisted");
+    assertFalse(tc.populateMetaFields());
+    assertTrue(tc.isCommitTimeOnlyMetaFieldsMode(), "table must report COMMIT_TIME_ONLY mode");
+    assertTrue(tc.isCommitTimePopulated(), "_hoodie_commit_time is logically populated under COMMIT_TIME_ONLY");
+    assertFalse(tc.isRecordKeyPopulated(), "_hoodie_record_key remains unpopulated under COMMIT_TIME_ONLY");
+  }
+
+  /**
+   * NONE mode (today's behavior): writer succeeds, persists populate.meta.fields=false, and the
+   * three accessors all report the NONE state.
+   */
+  @Test
+  void noneModePersistsAndReportsCorrectly() {
+    String path = basePath();
+    Map<String, String> options = baseOptions();
+    options.put(HoodieTableConfig.POPULATE_META_FIELDS.key(), "false");
+    // commit.time.enabled defaults to false; leave it absent.
+    options.put(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+
+    writeRows(Collections.singletonList(RowFactory.create("k1", "p1", "v1")), simpleSchema(), options, path, SaveMode.Overwrite);
+
+    HoodieTableMetaClient metaClient =
+        HoodieTableMetaClient.builder().setBasePath(path).setConf(storageConf()).build();
+    HoodieTableConfig tc = metaClient.getTableConfig();
+
+    assertFalse(tc.populateMetaFields());
+    assertFalse(tc.isCommitTimeOnlyMetaFieldsMode());
+    assertFalse(tc.isCommitTimePopulated());
+    assertFalse(tc.isRecordKeyPopulated());
+  }
+
+  /**
+   * Default (ALL) mode: every accessor reports the populated state.
+   */
+  @Test
+  void defaultAllModeReportsPopulated() {
+    String path = basePath();
+    Map<String, String> options = baseOptions();
+    options.put(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+
+    writeRows(Collections.singletonList(RowFactory.create("k1", "p1", "v1")), simpleSchema(), options, path, SaveMode.Overwrite);
+
+    HoodieTableMetaClient metaClient =
+        HoodieTableMetaClient.builder().setBasePath(path).setConf(storageConf()).build();
+    HoodieTableConfig tc = metaClient.getTableConfig();
+
+    assertTrue(tc.populateMetaFields());
+    assertFalse(tc.isCommitTimeOnlyMetaFieldsMode());
+    assertTrue(tc.isCommitTimePopulated());
+    assertTrue(tc.isRecordKeyPopulated());
+  }
+
+  /**
+   * Setting both {@code populate.meta.fields=true} AND {@code meta.fields.commit.time.enabled=true}
+   * is rejected at writer init. The combination is ambiguous (the new flag has no effect when all
+   * meta fields are already populated).
+   */
+  @Test
+  void invalidCombinationIsRejectedAtWriterInit() {
+    String path = basePath();
+    Map<String, String> options = baseOptions();
+    options.put(HoodieTableConfig.POPULATE_META_FIELDS.key(), "true");
+    options.put(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED.key(), "true");
+    options.put(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL());
+
+    Throwable thrown = assertThrows(Throwable.class, () ->
+        writeRows(Collections.singletonList(RowFactory.create("k1", "p1", "v1")),
+            simpleSchema(), options, path, SaveMode.Overwrite));
+
+    // Unwrap to root cause.
+    Throwable root = thrown;
+    while (root.getCause() != null) {
+      root = root.getCause();
+    }
+    String message = root.getMessage() == null ? "" : root.getMessage();
+    assertTrue(message.contains(HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED.key())
+            || message.contains(HoodieTableConfig.POPULATE_META_FIELDS.key()),
+        "Expected validation error to name one of the conflicting properties, got: " + message);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Today the only way to opt out of populating Hudi's five meta columns is the all-or-nothing `hoodie.populate.meta.fields=false`. That saves storage but disables incremental queries (which require `_hoodie_commit_time`).

A community user surfaced this trade-off (#18383, also discussed at #17959). The concrete ask was: "give me the storage saving without giving up incremental queries." A separate exploratory PR (#18384) attempted a fully orthogonal exclude-list with per-field branching across the writer/reader paths; that surface ended up being ~2300 lines across 87 files. This PR proposes a simpler, scoped alternative: three named modes instead of the full 2^5 matrix.

Closes #18383.

### Summary and Changelog

Adds an additive opt-in flag, `hoodie.meta.fields.commit.time.enabled`, that — when set together with `hoodie.populate.meta.fields=false` — additionally populates `_hoodie_commit_time` so incremental queries remain functional. The remaining four meta columns stay null on disk, preserving the storage saving.

The three resulting modes:

| `populate.meta.fields` | `meta.fields.commit.time.enabled` | Effective mode |
|---|---|---|
| `true` (default) | ignored | **ALL** — today's default |
| `false` | `false` (default) | **NONE** — today's `populate.meta.fields=false` |
| `false` | `true` | **COMMIT_TIME_ONLY** — new |
| `true` | `true` | rejected at writer init (ambiguous) |

#### Why a separate boolean instead of a single enum

- **Bit-identical backward compatibility.** Every existing table on disk resolves to ALL or NONE without any new property being read. No reader-side migration. No precedence rules.
- **Pre-1.3.0 readers behave correctly.** They don't know the new property exists. They open a COMMIT_TIME_ONLY table, see `populate.meta.fields=false`, and behave as a NONE reader — they cannot do incremental queries on the table, but they don't produce silent wrong results either.
- **Encodes "additive" structurally.** The new flag only modifies a NONE table — it's literally a NONE table plus one populated column. Most code paths that branch on `populate.meta.fields` keep working unchanged; only paths that specifically need commit_time consult the new accessor.

#### Plug points

**Config + accessors (`hudi-common` / `hudi-client-common`):**
- New `HoodieTableConfig.META_FIELDS_COMMIT_TIME_ENABLED` property.
- New accessors: `isCommitTimeOnlyMetaFieldsMode()`, `isCommitTimePopulated()`, `isRecordKeyPopulated()` — three named predicates.
- `HoodieWriteConfig` pass-throughs + `Builder.withMetaFieldsCommitTimeEnabled()`.
- `HoodieWriteConfig.validate()` rejects the `populate=true` + `commit.time=true` combination at build time.
- `HoodieTableMetaClient.TableBuilder.setMetaFieldsCommitTimeEnabled()` persists the flag on `hoodie.properties` at table init.
- `HoodieSparkSqlWriter` wires both fresh-table and bootstrap creation paths.

**Writer engines:**
- `HoodieAvroParquetWriter`, `HoodieSparkParquetWriter`, `HoodieRowCreateHandle` each gain a `commitTimeOnly` constructor overload. When `commitTimeOnly && !populateMetaFields`, they populate `_hoodie_commit_time` and the derived seq id; the other four columns stay null. Bloom-filter / record-key index registration is intentionally skipped (the record-key column is not populated).

**Read path (incremental query rejection):**
- `IncrementalRelationV1/V2`, `MergeOnReadIncrementalRelationV1/V2` now check `isCommitTimePopulated()` rather than `populateMetaFields()` — COMMIT_TIME_ONLY tables are accepted, NONE tables remain rejected with a clearer message.

#### Scope

- ✅ Spark Avro / Spark Row writer paths.
- ✅ Spark Parquet bulk-insert.
- ✅ Incremental query rejection logic across V1 / V2 / CoW / MoR.
- ❌ Flink RowData writer — out of scope for this patch; behaves as NONE under COMMIT_TIME_ONLY (no commit_time populated). Tracked as a follow-up.
- ❌ ORC / HFile writers — ORC continues to populate all meta fields unconditionally (legacy behavior); HFile is used only by MDT which is always ALL.

### Impact

- **Storage layout**: no change for tables that don't opt in. New optional mode for tables that do. Default behavior unchanged.
- **API**: no public API breakage. New table property, new accessors, new builder method — all additive.
- **Configuration**:
  - `hoodie.meta.fields.commit.time.enabled` (default `false`). Only meaningful when `hoodie.populate.meta.fields=false`. Persisted on `hoodie.properties` at table init.
- **Performance**: writer hot path adds one boolean check per row when in the new mode; the bool is final and cached in the writer constructor.
- **Forward-compat**: pre-1.3.0 readers ignore the new flag and treat the table as NONE — no silent wrong results.

### Risk Level

low

Additive change with a narrow scope. The default path is untouched. The validation guard rejects the ambiguous combination loudly at writer init. Existing `TestHoodieTableConfig` regression coverage (93 tests) passes unchanged.

### Documentation Update

- New config `hoodie.meta.fields.commit.time.enabled` documented via `@ConfigProperty` annotation on `HoodieTableConfig`.
- No public-facing docs update needed in this patch; if the website page on meta fields exists, a separate docs PR will add the three-mode table.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
