### PR TITLE
fix(spark): preserve Spark's native unresolved-column errors in HoodieAnalysis

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSparkBaseAnalysis.scala
@@ -185,7 +185,14 @@ case class ResolveReferences(spark: SparkSession) extends Rule[LogicalPlan]
       val sourceTable = if (sourceTableO.resolved) sourceTableO else analyzer.execute(sourceTableO)
       val m = mO.asInstanceOf[MergeIntoTable].copy(targetTable = targetTable, sourceTable = sourceTable)
       // END: custom Hudi change
-      EliminateSubqueryAliases(targetTable) match {
+      // If the source table still has unresolved references (e.g. a non-existent
+      // column in the source query, or a missing source table), return the
+      // partially-resolved MIT and let Spark's CheckAnalysis surface the error.
+      // Continuing into the resolve-assignments path would either lose the column
+      // context or throw a less informative UnresolvedException.
+      if (!sourceTable.resolved) {
+        m
+      } else EliminateSubqueryAliases(targetTable) match {
         case r: NamedRelation if r.skipSchemaResolution =>
           // Do not resolve the expression if the target table accepts any schema.
           // This allows data sources to customize their own resolution logic using

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieAnalysis.scala
@@ -309,7 +309,12 @@ object HoodieAnalysis extends SparkAdapterSupport {
           analyzer.execute(plan)
         }
 
-        if (resolved.output.exists(attr => isMetaField(attr.name))) {
+        // If the plan is still not fully resolved (e.g., it references non-existent
+        // tables or columns), fall through. Spark's CheckAnalysis runs later and
+        // produces precise UNRESOLVED_COLUMN / TABLE_OR_VIEW_NOT_FOUND errors with
+        // "did you mean" suggestions; intercepting UnresolvedException here would
+        // discard that context. Only inspect the output once the plan is resolved.
+        if (resolved.resolved && resolved.output.exists(attr => isMetaField(attr.name))) {
           Some(resolved.output)
         } else {
           None

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodieAnalysisErrorHandling.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodieAnalysisErrorHandling.scala
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+
+/**
+ * Regression tests covering how Hudi's analysis surface unresolved references in
+ * Spark SQL queries. Hudi's [[ProducesHudiMetaFields]] extractor and the MERGE INTO
+ * resolution path in [[HoodieSparkBaseAnalysis]] used to swallow the
+ * [[org.apache.spark.sql.catalyst.analysis.UnresolvedException]] and rewrite it as a
+ * generic Hudi error, which lost Spark's "did you mean" suggestions. Both sites now
+ * fall through to Spark's CheckAnalysis so the user-facing error remains
+ * Spark-native (e.g. `UNRESOLVED_COLUMN.WITH_SUGGESTION`).
+ */
+class TestHoodieAnalysisErrorHandling extends HoodieSparkSqlTestBase {
+
+  test("MERGE INTO with unresolved column in source query surfaces Spark's native error") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  price DOUBLE,
+           |  ts INT
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           |)
+           """.stripMargin)
+
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'a1', 10.0, 1000)")
+
+      // Source query references a non-existent column. Spark's analyzer
+      // should produce a precise error naming the missing column.
+      val ex = intercept[AnalysisException] {
+        spark.sql(
+          s"""
+             |MERGE INTO $tableName AS target
+             |USING (
+             |  SELECT 1 AS id, 'updated' AS name, 20.0 AS price, 2000 AS ts, nonexistent_column AS extra
+             |) AS source
+             |ON target.id = source.id
+             |WHEN MATCHED THEN UPDATE SET *
+             |WHEN NOT MATCHED THEN INSERT *
+             """.stripMargin)
+      }
+      val msg = ex.getMessage
+      assertNativeUnresolvedColumn(msg, "nonexistent_column")
+      assertNoHudiGenericRewrite(msg)
+    }
+  }
+
+  test("INSERT INTO from non-existent source table surfaces Spark's native error") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id INT,
+           |  name STRING,
+           |  price DOUBLE,
+           |  ts INT
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts'
+           |)
+           """.stripMargin)
+
+      val ex = intercept[AnalysisException] {
+        spark.sql(
+          s"""
+             |INSERT INTO $tableName
+             |SELECT * FROM nonexistent_source_table
+             """.stripMargin)
+      }
+      val msg = ex.getMessage
+      assertNativeTableNotFound(msg, "nonexistent_source_table")
+      assertNoHudiGenericRewrite(msg)
+    }
+  }
+
+  test("MERGE INTO with unresolved column in ON predicate surfaces Spark's native error") {
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |CREATE TABLE $tableName (
+           |  id INT, name STRING, price DOUBLE, ts INT
+           |) USING hudi
+           |LOCATION '${tmp.getCanonicalPath}'
+           |TBLPROPERTIES (primaryKey = 'id', preCombineField = 'ts')
+           """.stripMargin)
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'a1', 10.0, 1000)")
+
+      val ex = intercept[AnalysisException] {
+        spark.sql(
+          s"""
+             |MERGE INTO $tableName AS target
+             |USING (SELECT 1 AS id, 'u' AS name, 20.0 AS price, 2000 AS ts) AS source
+             |ON target.nonexistent_id = source.id
+             |WHEN MATCHED THEN UPDATE SET *
+             |WHEN NOT MATCHED THEN INSERT *
+             """.stripMargin)
+      }
+      val msg = ex.getMessage
+      assertNativeUnresolvedColumn(msg, "nonexistent_id")
+      assertNoHudiGenericRewrite(msg)
+    }
+  }
+
+  /**
+   * Match Spark's native "column not resolved" error. Spark 3.4+ uses the
+   * `UNRESOLVED_COLUMN.WITH_SUGGESTION` error class with a phrase like
+   * "A column or function parameter with name ... cannot be resolved"; older
+   * Spark just says "cannot be resolved". Accept either, but also require the
+   * specific column name appears so we know the right column was reported.
+   */
+  private def assertNativeUnresolvedColumn(msg: String, columnName: String): Unit = {
+    val hasCannotResolve =
+      msg.contains("cannot be resolved") ||
+        msg.contains("UNRESOLVED_COLUMN")
+    assert(hasCannotResolve,
+      s"Expected Spark's native unresolved-column error; got: $msg")
+    assert(msg.contains(columnName),
+      s"Expected error to mention column '$columnName'; got: $msg")
+  }
+
+  private def assertNativeTableNotFound(msg: String, tableName: String): Unit = {
+    val hasTableNotFound =
+      msg.contains("TABLE_OR_VIEW_NOT_FOUND") ||
+        msg.toLowerCase.contains("table or view not found") ||
+        msg.contains("cannot be resolved")
+    assert(hasTableNotFound,
+      s"Expected Spark's native table-not-found error; got: $msg")
+    assert(msg.contains(tableName),
+      s"Expected error to mention table '$tableName'; got: $msg")
+  }
+
+  /**
+   * The earlier version of this PR caught UnresolvedException and rewrote it as
+   * "Failed to resolve query. The query contains unresolved columns or tables.
+   *  Please check for: (1) typos ...". Make sure we no longer mask Spark's
+   * native message with that generic Hudi wrapper.
+   */
+  private def assertNoHudiGenericRewrite(msg: String): Unit = {
+    assert(!msg.contains("Failed to resolve query"),
+      s"Hudi should not rewrap Spark's analysis error; got: $msg")
+    assert(!msg.contains("Please check for: (1) typos"),
+      s"Hudi should not rewrap Spark's analysis error; got: $msg")
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodieAnalysisErrorHandling.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/analysis/TestHoodieAnalysisErrorHandling.scala
@@ -19,6 +19,8 @@
 
 package org.apache.spark.sql.hudi.analysis
 
+import org.apache.hudi.HoodieSparkUtils
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
@@ -134,29 +136,47 @@ class TestHoodieAnalysisErrorHandling extends HoodieSparkSqlTestBase {
   }
 
   /**
-   * Match Spark's native "column not resolved" error. Spark 3.4+ uses the
-   * `UNRESOLVED_COLUMN.WITH_SUGGESTION` error class with a phrase like
-   * "A column or function parameter with name ... cannot be resolved"; older
-   * Spark just says "cannot be resolved". Accept either, but also require the
-   * specific column name appears so we know the right column was reported.
+   * Assert the failure is Spark's native unresolved-column error and not a Hudi rewrite.
+   *
+   * On Spark 3.4+ we require the structured `UNRESOLVED_COLUMN` error-class token. That
+   * token is produced only by Spark's own `CheckAnalysis`; the pre-PR Hudi path rewrote
+   * the failure as a generic "Failed to resolve query ..." message that never carried it,
+   * so requiring the token here actually distinguishes the new behavior from the old (the
+   * looser "cannot be resolved" substring would have matched either way — see
+   * https://github.com/apache/hudi/pull/18147#discussion_r2795763747). On Spark 3.3, which
+   * predates error classes, the phrasing varies by code path — accept the legacy
+   * "cannot resolve" / "cannot be resolved" forms as well as "Column '...' does not exist"
+   * (what Spark 3.3 emits for the unresolved references in these queries).
+   *
+   * In all cases require the offending column name to appear, so we know the precise
+   * column was reported rather than some unrelated resolution failure.
    */
   private def assertNativeUnresolvedColumn(msg: String, columnName: String): Unit = {
-    val hasCannotResolve =
-      msg.contains("cannot be resolved") ||
-        msg.contains("UNRESOLVED_COLUMN")
-    assert(hasCannotResolve,
-      s"Expected Spark's native unresolved-column error; got: $msg")
+    if (HoodieSparkUtils.gteqSpark3_4) {
+      assert(msg.contains("UNRESOLVED_COLUMN"),
+        s"Expected Spark's structured UNRESOLVED_COLUMN error class; got: $msg")
+    } else {
+      assert(msg.contains("cannot resolve") || msg.contains("cannot be resolved") ||
+        msg.contains("does not exist"),
+        s"Expected Spark's native unresolved-column error; got: $msg")
+    }
     assert(msg.contains(columnName),
       s"Expected error to mention column '$columnName'; got: $msg")
   }
 
+  /**
+   * Assert the failure is Spark's native table-not-found error. On Spark 3.4+ require the
+   * structured `TABLE_OR_VIEW_NOT_FOUND` error-class token (same reasoning as
+   * [[assertNativeUnresolvedColumn]]); on Spark 3.3 fall back to the legacy phrasing.
+   */
   private def assertNativeTableNotFound(msg: String, tableName: String): Unit = {
-    val hasTableNotFound =
-      msg.contains("TABLE_OR_VIEW_NOT_FOUND") ||
-        msg.toLowerCase.contains("table or view not found") ||
-        msg.contains("cannot be resolved")
-    assert(hasTableNotFound,
-      s"Expected Spark's native table-not-found error; got: $msg")
+    if (HoodieSparkUtils.gteqSpark3_4) {
+      assert(msg.contains("TABLE_OR_VIEW_NOT_FOUND"),
+        s"Expected Spark's structured TABLE_OR_VIEW_NOT_FOUND error class; got: $msg")
+    } else {
+      assert(msg.toLowerCase.contains("table or view not found"),
+        s"Expected Spark's native table-not-found error; got: $msg")
+    }
     assert(msg.contains(tableName),
       s"Expected error to mention table '$tableName'; got: $msg")
   }


### PR DESCRIPTION
Ports apache/hudi#18147 onto current master and addresses the remaining review feedback.

Closes #18151.

### What & why

When a Spark SQL query against a Hudi table contained unresolved references (typos in column names, missing source tables, etc.), Hudi's analysis layer was masking Spark's own error reporting — discarding the structured `UNRESOLVED_COLUMN.WITH_SUGGESTION` / `TABLE_OR_VIEW_NOT_FOUND` errors (including "did you mean" hints) that Spark already produces.

Two guarded one-line fall-throughs now let Spark's `CheckAnalysis` surface its native error, per @yihua's suggestion in https://github.com/apache/hudi/pull/18147#discussion_r2796386493:

- `HoodieAnalysis.ProducesHudiMetaFields.unapply` — gate the output check on `resolved.resolved`; if the plan is still unresolved, return `None` and let the pattern-match fall through. Spark's `CheckAnalysis` then runs in its normal phase. (Inspecting `resolved.output` on an unresolved plan could otherwise throw `UnresolvedException` and lose context.)
- `HoodieSparkBaseAnalysis.ResolveReferences` (MERGE INTO) — if the source table is still unresolved after the analyzer pass, return the partially-resolved `MergeIntoTable` instead of descending into `resolveAssignments`. Spark's downstream rules already know how to report the precise error.

### On top of the original commit

The original commit (credit: @nada-attia / @nsivabalan) is preserved as-is. Added one commit addressing @yihua's test-assertion note (https://github.com/apache/hudi/pull/18147#discussion_r2795763747): the assertions used loose substrings like `"cannot be resolved"` that match Spark's output even without this change. On Spark 3.4+ they now require the structured error-class token (`UNRESOLVED_COLUMN` / `TABLE_OR_VIEW_NOT_FOUND`) that only Spark's `CheckAnalysis` emits and the old Hudi rewrite never carried, with a Spark 3.3 legacy-phrasing fallback (branching on `HoodieSparkUtils.gteqSpark3_4`, matching the existing `HoodieSparkSqlTestBase` pattern). The specific column/table name is still required.

### Risk

**Low** — both source changes are guarded fall-throughs in the resolution path; existing query-resolution behavior is unchanged for plans that fully resolve. The meta-field projection simply defers to a later fixed-point analyzer iteration.

### Verification

Build verified locally: `mvn install -pl hudi-spark-datasource/hudi-spark -am -DskipTests -Dspark3.5 -Dscala-2.12` (0 errors, including scalastyle). Tests (`TestHoodieAnalysisErrorHandling`) to be run by reviewer / CI.

Opened as draft.
