### PR TITLE
[MINOR] Forward spark.hoodie.* SparkConf to write path (parity with read path)

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -1034,29 +1034,46 @@ object DataSourceOptionsHelper {
   private val log = LoggerFactory.getLogger(DataSourceOptionsHelper.getClass)
 
   // Prefix constants for config normalization
+  private val HOODIE_PREFIX = "hoodie."
   private val SPARK_HOODIE_PREFIX = "spark.hoodie."
   private val SPARK_PREFIX = "spark."
 
   /**
-   * Collects `hoodie.*` and `spark.hoodie.*` configs from the SparkConf and merges them
-   * with explicit DataFrame options. Explicit options win over SparkConf.
+   * Collects `hoodie.*` and `spark.hoodie.*` configs from the SparkConf, normalizes the
+   * `spark.hoodie.*` keys to canonical `hoodie.*`, and merges with explicit DataFrame
+   * options. Explicit options win over SparkConf.
    *
    * Use this from both read and write entry points so SparkConf-level Hudi configs are
    * forwarded consistently. Without this, only the read path picks up SparkConf, and
    * write/hive_sync configs set via `--conf spark.hoodie.X=Y` are silently dropped.
+   *
+   * Example (SparkConf has both prefixes set; explicit options override):
+   * {{{
+   *   SparkConf:  spark.hoodie.X = "a", hoodie.Y = "b"
+   *   optParams:  hoodie.X = "c"
+   *   result:     hoodie.X = "c"   // explicit wins over both prefixes
+   *               hoodie.Y = "b"
+   * }}}
    */
   def collectHoodieAndSparkHoodieConfs(sqlContext: SQLContext,
                                        optParams: Map[String, String]): Map[String, String] = {
     val sparkConfs = sqlContext.getAllConfs.filter {
-      case (key, _) => key.startsWith("hoodie.") || key.startsWith(SPARK_HOODIE_PREFIX)
+      case (key, _) => key.startsWith(HOODIE_PREFIX) || key.startsWith(SPARK_HOODIE_PREFIX)
     }
-    sparkConfs ++ optParams
+    normalizeSparkHoodiePrefix(sparkConfs) ++ optParams
   }
 
   /**
    * Strips the `spark.` prefix from `spark.hoodie.*` keys so downstream code only sees
    * canonical `hoodie.*` keys. If both `spark.hoodie.X` and `hoodie.X` are present, the
    * latter wins (explicit options/configs override the SparkConf-prefixed form).
+   *
+   * The function is idempotent: running it on an already-normalized map is a no-op.
+   * Both `collectHoodieAndSparkHoodieConfs` (the entry-point helper) and
+   * `parametersWithReadDefaults` / `parametersWithWriteDefaults` (the per-path defaulting
+   * helpers) call it; this defense-in-depth ensures callers that bypass
+   * `collectHoodieAndSparkHoodieConfs` (e.g., SQL `ALTER TABLE` paths) still get
+   * normalized configs.
    */
   def normalizeSparkHoodiePrefix(parameters: Map[String, String]): Map[String, String] = {
     val normalized = parameters.collect {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -35,6 +35,7 @@ import org.apache.hudi.keygen.factory.HoodieSparkKeyGeneratorFactory.{getKeyGene
 import org.apache.hudi.sync.common.HoodieSyncConfig
 import org.apache.hudi.util.{JFunction, SparkConfigUtils}
 
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.execution.datasources.{DataSourceUtils => SparkDataSourceUtils}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
 import org.slf4j.LoggerFactory
@@ -1036,6 +1037,36 @@ object DataSourceOptionsHelper {
   private val SPARK_HOODIE_PREFIX = "spark.hoodie."
   private val SPARK_PREFIX = "spark."
 
+  /**
+   * Collects `hoodie.*` and `spark.hoodie.*` configs from the SparkConf and merges them
+   * with explicit DataFrame options. Explicit options win over SparkConf.
+   *
+   * Use this from both read and write entry points so SparkConf-level Hudi configs are
+   * forwarded consistently. Without this, only the read path picks up SparkConf, and
+   * write/hive_sync configs set via `--conf spark.hoodie.X=Y` are silently dropped.
+   */
+  def collectHoodieAndSparkHoodieConfs(sqlContext: SQLContext,
+                                       optParams: Map[String, String]): Map[String, String] = {
+    val sparkConfs = sqlContext.getAllConfs.filter {
+      case (key, _) => key.startsWith("hoodie.") || key.startsWith(SPARK_HOODIE_PREFIX)
+    }
+    sparkConfs ++ optParams
+  }
+
+  /**
+   * Strips the `spark.` prefix from `spark.hoodie.*` keys so downstream code only sees
+   * canonical `hoodie.*` keys. If both `spark.hoodie.X` and `hoodie.X` are present, the
+   * latter wins (explicit options/configs override the SparkConf-prefixed form).
+   */
+  def normalizeSparkHoodiePrefix(parameters: Map[String, String]): Map[String, String] = {
+    val normalized = parameters.collect {
+      case (key, value) if key.startsWith(SPARK_HOODIE_PREFIX) =>
+        (key.stripPrefix(SPARK_PREFIX), value)
+    }
+    val nonSparkHoodie = parameters.filterNot(_._1.startsWith(SPARK_HOODIE_PREFIX))
+    normalized ++ nonSparkHoodie
+  }
+
   // put all the configs with alternatives here
   private val allConfigsWithAlternatives = List(
     DataSourceReadOptions.QUERY_TYPE,
@@ -1132,13 +1163,8 @@ object DataSourceOptionsHelper {
     // 2) spark.hoodie.* (normalized to hoodie.*)
     // 3) hoodie.* / explicit data source options
     // NOTE: If both spark.hoodie.X and hoodie.X are set, hoodie.X wins.
-    val normalizedSparkHoodieConfigs = parameters.collect {
-      case (key, value) if key.startsWith(SPARK_HOODIE_PREFIX) => (key.stripPrefix(SPARK_PREFIX), value)
-    }
-    val paramsWithoutSparkHoodie = parameters.filterNot(_._1.startsWith(SPARK_HOODIE_PREFIX))
-    val paramsWithGlobalProps = DFSPropertiesConfiguration.getGlobalProps.asScala.toMap ++
-      normalizedSparkHoodieConfigs ++
-      paramsWithoutSparkHoodie
+    val normalized = normalizeSparkHoodiePrefix(parameters)
+    val paramsWithGlobalProps = DFSPropertiesConfiguration.getGlobalProps.asScala.toMap ++ normalized
     val queryType = paramsWithGlobalProps.get(IS_QUERY_AS_RO_TABLE)
       .map(is => if (is.toBoolean) QUERY_TYPE_READ_OPTIMIZED_OPT_VAL else QUERY_TYPE_SNAPSHOT_OPT_VAL)
       .getOrElse(paramsWithGlobalProps.getOrElse(QUERY_TYPE.key, QUERY_TYPE.defaultValue()))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -1076,12 +1076,12 @@ object DataSourceOptionsHelper {
    * normalized configs.
    */
   def normalizeSparkHoodiePrefix(parameters: Map[String, String]): Map[String, String] = {
-    val normalized = parameters.collect {
+    val rekeyedSparkHoodie = parameters.collect {
       case (key, value) if key.startsWith(SPARK_HOODIE_PREFIX) =>
         (key.stripPrefix(SPARK_PREFIX), value)
     }
     val nonSparkHoodie = parameters.filterNot(_._1.startsWith(SPARK_HOODIE_PREFIX))
-    normalized ++ nonSparkHoodie
+    rekeyedSparkHoodie ++ nonSparkHoodie
   }
 
   // put all the configs with alternatives here

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -1043,9 +1043,10 @@ object DataSourceOptionsHelper {
    * `spark.hoodie.*` keys to canonical `hoodie.*`, and merges with explicit DataFrame
    * options. Explicit options win over SparkConf.
    *
-   * Use this from both read and write entry points so SparkConf-level Hudi configs are
-   * forwarded consistently. Without this, only the read path picks up SparkConf, and
-   * write/hive_sync configs set via `--conf spark.hoodie.X=Y` are silently dropped.
+   * This is the read-path entry point: reads have always picked up session-level `hoodie.*`
+   * confs (e.g. `hoodie.datasource.query.type`), so both prefixes are forwarded here.
+   * Do NOT use this for writes — see `collectSparkHoodieConfs` for why ambient `hoodie.*`
+   * confs must not be forwarded to the write path.
    *
    * Example (SparkConf has both prefixes set; explicit options override):
    * {{{
@@ -1056,9 +1057,39 @@ object DataSourceOptionsHelper {
    * }}}
    */
   def collectHoodieAndSparkHoodieConfs(sqlContext: SQLContext,
-                                       optParams: Map[String, String]): Map[String, String] = {
+                                       optParams: Map[String, String]): Map[String, String] =
+    collectConfsByPrefix(sqlContext, optParams, includeHoodiePrefix = true)
+
+  /**
+   * Collects only `spark.hoodie.*` configs from the SparkConf, normalizes them to canonical
+   * `hoodie.*`, and merges with explicit DataFrame options. Explicit options win over SparkConf.
+   *
+   * This is the write-path entry point. It deliberately does NOT forward bare `hoodie.*`
+   * session confs: unlike reads, the DataFrame write path historically honored only the
+   * explicit `.option(...)` map, so injecting ambient `hoodie.*` session state (e.g. a
+   * session-level `hoodie.datasource.write.operation` or `hoodie.logfile.data.block.format`)
+   * would silently change every `df.write`. The bug this addresses (HUDI-#18649) is about
+   * `--conf spark.hoodie.X=Y` being dropped on writes, which only requires forwarding the
+   * `spark.hoodie.*` form.
+   *
+   * Example:
+   * {{{
+   *   SparkConf:  spark.hoodie.X = "a", hoodie.Y = "b"   // bare hoodie.Y is NOT forwarded
+   *   optParams:  hoodie.Z = "c"
+   *   result:     hoodie.X = "a"
+   *               hoodie.Z = "c"
+   * }}}
+   */
+  def collectSparkHoodieConfs(sqlContext: SQLContext,
+                              optParams: Map[String, String]): Map[String, String] =
+    collectConfsByPrefix(sqlContext, optParams, includeHoodiePrefix = false)
+
+  private def collectConfsByPrefix(sqlContext: SQLContext,
+                                   optParams: Map[String, String],
+                                   includeHoodiePrefix: Boolean): Map[String, String] = {
     val sparkConfs = sqlContext.getAllConfs.filter {
-      case (key, _) => key.startsWith(HOODIE_PREFIX) || key.startsWith(SPARK_HOODIE_PREFIX)
+      case (key, _) =>
+        key.startsWith(SPARK_HOODIE_PREFIX) || (includeHoodiePrefix && key.startsWith(HOODIE_PREFIX))
     }
     normalizeSparkHoodiePrefix(sparkConfs) ++ optParams
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -107,9 +107,6 @@ class DefaultSource extends RelationProvider
       throw new HoodieException("Glob paths are not supported for read paths as of Hudi 1.2.0")
     }
 
-    val hoodieAndSparkHoodieSqlConfs = sqlContext.getAllConfs.filter {
-      case (key, _) => key.startsWith("hoodie.") || key.startsWith("spark.hoodie.")
-    }
     // Add default options for unspecified read options keys.
     // Effective precedence (low -> high):
     // 1) global DFS props
@@ -117,7 +114,7 @@ class DefaultSource extends RelationProvider
     // 3) hoodie.* SQL confs
     // 4) explicit DataFrame/DataSource options
     val parameters = DataSourceOptionsHelper.parametersWithReadDefaults(
-      hoodieAndSparkHoodieSqlConfs ++ optParams)
+      DataSourceOptionsHelper.collectHoodieAndSparkHoodieConfs(sqlContext, optParams))
 
     // Get the table base path
     val tablePath = DataSourceUtils.getTablePath(storage, Seq(new StoragePath(path.get)).asJava)
@@ -159,11 +156,18 @@ class DefaultSource extends RelationProvider
                               mode: SaveMode,
                               optParams: Map[String, String],
                               df: DataFrame): BaseRelation = {
+    // Pull `hoodie.*` and `spark.hoodie.*` from SparkConf and merge with explicit options
+    // (explicit options win). This mirrors what the read createRelation already does, so
+    // configs like `--conf spark.hoodie.datasource.hive_sync.use_spark_catalog=true` are
+    // honored on writes too. The spark.* prefix is stripped downstream in
+    // parametersWithWriteDefaults.
+    val effectiveOpts =
+      DataSourceOptionsHelper.collectHoodieAndSparkHoodieConfs(sqlContext, optParams)
     try {
-      if (optParams.get(OPERATION.key).contains(BOOTSTRAP_OPERATION_OPT_VAL)) {
-        HoodieSparkSqlWriter.bootstrap(sqlContext, mode, optParams, df)
+      if (effectiveOpts.get(OPERATION.key).contains(BOOTSTRAP_OPERATION_OPT_VAL)) {
+        HoodieSparkSqlWriter.bootstrap(sqlContext, mode, effectiveOpts, df)
       } else {
-        val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sqlContext, mode, optParams, df)
+        val (success, _, _, _, _, _) = HoodieSparkSqlWriter.write(sqlContext, mode, effectiveOpts, df)
         if (!success) {
           throw new HoodieException("Failed to write to Hudi")
         }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -156,13 +156,15 @@ class DefaultSource extends RelationProvider
                               mode: SaveMode,
                               optParams: Map[String, String],
                               df: DataFrame): BaseRelation = {
-    // Pull `hoodie.*` and `spark.hoodie.*` from SparkConf, normalize `spark.hoodie.*` to
-    // canonical `hoodie.*`, and merge with explicit options (explicit options win). This
-    // mirrors what the read createRelation already does, so configs like
+    // Pull `spark.hoodie.*` from SparkConf, normalize to canonical `hoodie.*`, and merge
+    // with explicit options (explicit options win), so configs like
     // `--conf spark.hoodie.datasource.hive_sync.use_spark_catalog=true` are honored on
-    // writes too. `HoodieSparkSqlWriter` and downstream callers see only canonical keys.
+    // writes too. Unlike the read path, we deliberately do NOT forward bare `hoodie.*`
+    // session confs here: the DataFrame write path historically honored only the explicit
+    // `.option(...)` map, and injecting ambient session `hoodie.*` state would silently
+    // change every write. `HoodieSparkSqlWriter` and downstream callers see only canonical keys.
     val effectiveOpts =
-      DataSourceOptionsHelper.collectHoodieAndSparkHoodieConfs(sqlContext, optParams)
+      DataSourceOptionsHelper.collectSparkHoodieConfs(sqlContext, optParams)
     try {
       if (effectiveOpts.get(OPERATION.key).contains(BOOTSTRAP_OPERATION_OPT_VAL)) {
         HoodieSparkSqlWriter.bootstrap(sqlContext, mode, effectiveOpts, df)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -110,7 +110,7 @@ class DefaultSource extends RelationProvider
     // Add default options for unspecified read options keys.
     // Effective precedence (low -> high):
     // 1) global DFS props
-    // 2) spark.hoodie.* SQL confs (normalized in parametersWithReadDefaults)
+    // 2) spark.hoodie.* SQL confs (normalized to hoodie.* in collectHoodieAndSparkHoodieConfs)
     // 3) hoodie.* SQL confs
     // 4) explicit DataFrame/DataSource options
     val parameters = DataSourceOptionsHelper.parametersWithReadDefaults(
@@ -156,11 +156,11 @@ class DefaultSource extends RelationProvider
                               mode: SaveMode,
                               optParams: Map[String, String],
                               df: DataFrame): BaseRelation = {
-    // Pull `hoodie.*` and `spark.hoodie.*` from SparkConf and merge with explicit options
-    // (explicit options win). This mirrors what the read createRelation already does, so
-    // configs like `--conf spark.hoodie.datasource.hive_sync.use_spark_catalog=true` are
-    // honored on writes too. The spark.* prefix is stripped downstream in
-    // parametersWithWriteDefaults.
+    // Pull `hoodie.*` and `spark.hoodie.*` from SparkConf, normalize `spark.hoodie.*` to
+    // canonical `hoodie.*`, and merge with explicit options (explicit options win). This
+    // mirrors what the read createRelation already does, so configs like
+    // `--conf spark.hoodie.datasource.hive_sync.use_spark_catalog=true` are honored on
+    // writes too. `HoodieSparkSqlWriter` and downstream callers see only canonical keys.
     val effectiveOpts =
       DataSourceOptionsHelper.collectHoodieAndSparkHoodieConfs(sqlContext, optParams)
     try {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
@@ -53,8 +53,12 @@ object HoodieWriterUtils {
    * Add default options for unspecified write options keys.
    */
   def parametersWithWriteDefaults(parameters: Map[String, String]): Map[String, String] = {
+    // Strip the `spark.` prefix from `spark.hoodie.*` keys so write/hive_sync configs
+    // forwarded from SparkConf reach Hudi under their canonical names. Mirrors what
+    // parametersWithReadDefaults does for the read path.
+    val normalizedParams = DataSourceOptionsHelper.normalizeSparkHoodiePrefix(parameters)
     val globalProps = DFSPropertiesConfiguration.getGlobalProps.asScala
-    val props = TypedProperties.fromMap(parameters.asJava)
+    val props = TypedProperties.fromMap(normalizedParams.asJava)
     val hoodieConfig: HoodieConfig = new HoodieConfig(props)
     hoodieConfig.setDefaultValue(OPERATION)
     hoodieConfig.setDefaultValue(TABLE_TYPE)
@@ -87,7 +91,7 @@ object HoodieWriterUtils {
     hoodieConfig.setDefaultValue(RECONCILE_SCHEMA)
     hoodieConfig.setDefaultValue(DROP_PARTITION_COLUMNS)
     hoodieConfig.setDefaultValue(KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED)
-    Map() ++ hoodieConfig.getProps.asScala ++ globalProps ++ DataSourceOptionsHelper.translateConfigurations(parameters)
+    Map() ++ hoodieConfig.getProps.asScala ++ globalProps ++ DataSourceOptionsHelper.translateConfigurations(normalizedParams)
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestDataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestDataSourceOptions.scala
@@ -167,6 +167,39 @@ class TestDataSourceOptions {
   }
 
   @Test
+  def testCollectSparkHoodieConfsForwardsOnlySparkPrefix(): Unit = {
+    val sqlContext = mock(classOf[SQLContext])
+    when(sqlContext.getAllConfs).thenReturn(Map(
+      "spark.hoodie.datasource.hive_sync.use_spark_catalog" -> "true", // forwarded (the --conf use case)
+      "hoodie.logfile.data.block.format" -> "parquet",                 // bare hoodie.* must NOT leak into writes
+      "hoodie.datasource.write.operation" -> "bulk_insert",            // bare hoodie.* must NOT leak into writes
+      "spark.sql.shuffle.partitions" -> "200"                          // non-hoodie, filtered out
+    ))
+
+    val result = DataSourceOptionsHelper.collectSparkHoodieConfs(sqlContext, Map.empty)
+
+    assertEquals("true", result("hoodie.datasource.hive_sync.use_spark_catalog"))
+    assertFalse(result.contains("hoodie.logfile.data.block.format"))
+    assertFalse(result.contains("hoodie.datasource.write.operation"))
+    assertFalse(result.contains("spark.sql.shuffle.partitions"))
+  }
+
+  @Test
+  def testCollectSparkHoodieConfsExplicitOptionsWin(): Unit = {
+    val sqlContext = mock(classOf[SQLContext])
+    when(sqlContext.getAllConfs).thenReturn(Map(
+      "spark.hoodie.datasource.write.operation" -> "insert"
+    ))
+
+    val result = DataSourceOptionsHelper.collectSparkHoodieConfs(sqlContext, Map(
+      "hoodie.datasource.write.operation" -> "upsert" // explicit overrides spark.hoodie.*
+    ))
+
+    assertEquals("upsert", result("hoodie.datasource.write.operation"))
+    assertFalse(result.contains("spark.hoodie.datasource.write.operation"))
+  }
+
+  @Test
   def testWriteDefaultsSupportSparkHoodieConfigs(): Unit = {
     val params = HoodieWriterUtils.parametersWithWriteDefaults(Map(
       "spark.hoodie.datasource.write.operation" -> "upsert"

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestDataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/hudi/TestDataSourceOptions.scala
@@ -22,9 +22,11 @@ package org.apache.hudi
 import org.apache.hudi.common.config.{DFSPropertiesConfiguration, HoodieCommonConfig}
 import org.apache.hudi.common.table.HoodieTableConfig
 
+import org.apache.spark.sql.SQLContext
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.{mock, when}
 
 class TestDataSourceOptions {
   @Test
@@ -89,6 +91,100 @@ class TestDataSourceOptions {
       "hoodie.datasource.query.type" -> DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL
     ))
     assertEquals(DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL, params3(DataSourceReadOptions.QUERY_TYPE.key))
+  }
+
+  @Test
+  def testNormalizeSparkHoodiePrefixStripsSparkPrefix(): Unit = {
+    val result = DataSourceOptionsHelper.normalizeSparkHoodiePrefix(Map(
+      "spark.hoodie.datasource.query.type" -> "snapshot",
+      "spark.hoodie.datasource.hive_sync.use_spark_catalog" -> "true",
+      "non.hoodie.key" -> "ignored"
+    ))
+
+    assertEquals("snapshot", result("hoodie.datasource.query.type"))
+    assertEquals("true", result("hoodie.datasource.hive_sync.use_spark_catalog"))
+    assertEquals("ignored", result("non.hoodie.key"))
+    assertFalse(result.contains("spark.hoodie.datasource.query.type"))
+    assertFalse(result.contains("spark.hoodie.datasource.hive_sync.use_spark_catalog"))
+  }
+
+  @Test
+  def testNormalizeSparkHoodiePrefixPrefersHoodieOverSparkHoodie(): Unit = {
+    val result = DataSourceOptionsHelper.normalizeSparkHoodiePrefix(Map(
+      "spark.hoodie.datasource.query.type" -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+      "hoodie.datasource.query.type" -> DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL
+    ))
+
+    assertEquals(DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL,
+      result("hoodie.datasource.query.type"))
+    assertFalse(result.contains("spark.hoodie.datasource.query.type"))
+  }
+
+  @Test
+  def testNormalizeSparkHoodiePrefixIsIdempotent(): Unit = {
+    val once = DataSourceOptionsHelper.normalizeSparkHoodiePrefix(Map(
+      "spark.hoodie.datasource.query.type" -> "snapshot",
+      "hoodie.other.key" -> "v"
+    ))
+    val twice = DataSourceOptionsHelper.normalizeSparkHoodiePrefix(once)
+
+    assertEquals(once, twice)
+  }
+
+  @Test
+  def testCollectHoodieAndSparkHoodieConfsReturnsCanonicalKeys(): Unit = {
+    val sqlContext = mock(classOf[SQLContext])
+    when(sqlContext.getAllConfs).thenReturn(Map(
+      "spark.hoodie.datasource.query.type" -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+      "hoodie.datasource.write.operation" -> "upsert",
+      "spark.sql.shuffle.partitions" -> "200" // non-hoodie, must be filtered out
+    ))
+
+    val result = DataSourceOptionsHelper.collectHoodieAndSparkHoodieConfs(sqlContext, Map.empty)
+
+    assertEquals(DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+      result("hoodie.datasource.query.type"))
+    assertEquals("upsert", result("hoodie.datasource.write.operation"))
+    assertFalse(result.contains("spark.hoodie.datasource.query.type"))
+    assertFalse(result.contains("spark.sql.shuffle.partitions"))
+  }
+
+  @Test
+  def testCollectHoodieAndSparkHoodieConfsExplicitOptionsWin(): Unit = {
+    val sqlContext = mock(classOf[SQLContext])
+    when(sqlContext.getAllConfs).thenReturn(Map(
+      "spark.hoodie.datasource.write.operation" -> "insert",
+      "hoodie.datasource.write.precombine.field" -> "ts_from_conf"
+    ))
+
+    val result = DataSourceOptionsHelper.collectHoodieAndSparkHoodieConfs(sqlContext, Map(
+      "hoodie.datasource.write.operation" -> "upsert",                  // explicit overrides spark.hoodie.*
+      "hoodie.datasource.write.precombine.field" -> "ts_from_options"   // explicit overrides hoodie.*
+    ))
+
+    assertEquals("upsert", result("hoodie.datasource.write.operation"))
+    assertEquals("ts_from_options", result("hoodie.datasource.write.precombine.field"))
+  }
+
+  @Test
+  def testWriteDefaultsSupportSparkHoodieConfigs(): Unit = {
+    val params = HoodieWriterUtils.parametersWithWriteDefaults(Map(
+      "spark.hoodie.datasource.write.operation" -> "upsert"
+    ))
+
+    assertEquals("upsert", params(DataSourceWriteOptions.OPERATION.key))
+    assertFalse(params.contains("spark.hoodie.datasource.write.operation"))
+  }
+
+  @Test
+  def testWriteDefaultsPreferHoodieOverSparkHoodieWhenBothSet(): Unit = {
+    val params = HoodieWriterUtils.parametersWithWriteDefaults(Map(
+      "spark.hoodie.datasource.write.operation" -> "insert",
+      "hoodie.datasource.write.operation" -> "upsert"
+    ))
+
+    assertEquals("upsert", params(DataSourceWriteOptions.OPERATION.key))
+    assertFalse(params.contains("spark.hoodie.datasource.write.operation"))
   }
 
   @AfterEach


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18649. Ports #18650 (original fix by @prashantwason; review follow-up by @nsivabalan) onto current `master`, with a deep-review fix and a CI-regression fix on top.

`--conf spark.hoodie.X=Y` configs reached the **read** path but were silently dropped on **writes** (e.g. `hoodie.datasource.hive_sync.use_spark_catalog`). This brings the write path to parity for that case.

### Summary and Changelog

Hudi configs arrive either as explicit `.option(...)` or ambiently via SparkConf (`sqlContext.getAllConfs`), where `--conf` requires a `spark.` prefix that must be stripped back to the canonical `hoodie.*` key.

Helpers in `DataSourceOptionsHelper`:
- `normalizeSparkHoodiePrefix` — strips `spark.` from `spark.hoodie.*`; on conflict canonical `hoodie.*` wins; idempotent.
- `collectHoodieAndSparkHoodieConfs` (**read**) — collects `hoodie.*` + `spark.hoodie.*` from SparkConf, normalizes, merges with explicit options.
- `collectSparkHoodieConfs` (**write**) — collects **only** `spark.hoodie.*`, normalizes, merges with explicit options.

Wiring: read/write `createRelation` use the respective helper; `parametersWith{Read,Write}Defaults` call `normalizeSparkHoodiePrefix` as defense-in-depth for callers that bypass the entry points (SQL `ALTER TABLE`, `HoodieCLIUtils`).

**Precedence (low → high):** global DFS props < `spark.hoodie.*` < `hoodie.*` < explicit `.option(...)`.

**Read vs write asymmetry (the key design point):** reads may safely pick up ambient session `hoodie.*` (non-mutating). The write path forwards **only** `spark.hoodie.*` — never bare `hoodie.*`. `df.write` has always been driven solely by explicit options; injecting ambient `hoodie.*` session state would silently change what gets persisted. (An earlier "fully symmetric" revision did exactly that and regressed `TestInsertTable2."Test For read operation's field"` when the test session's `hoodie.logfile.data.block.format` / record-merger confs leaked into a MOR write.) #18649 only needs `spark.hoodie.*`, so scoping the write path to that fixes the bug without the regression.

### Impact

Users setting `spark.hoodie.datasource.write.*` / `*.hive_sync.*` via `--conf` now have them honored on writes (and on the `ALTER TABLE` / CLI paths that go through `parametersWithWriteDefaults`). No change for explicit `.option(...)` callers — explicit always wins. `df.write` does not inherit ambient bare `hoodie.*` session state.

### Risk Level

low. The dominant case (explicit `.option(...)`) is preserved; the only behavior delta is `--conf spark.hoodie.*` now taking effect on writes. Verified by build (`mvn install -pl hudi-spark-datasource/hudi-spark-common -am -DskipTests -Dspark3.5`) and a full green GitHub Actions run.

### Documentation Update

none — aligns actual behavior with the already-documented `spark.hoodie.*` config forwarding.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable