### PR TITLE
test(clean): cover executing pending clean before scheduling a new one

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/common/fs/TestHoodieSerializableFileStatus.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/common/fs/TestHoodieSerializableFileStatus.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.common.fs;
 
-import org.apache.hudi.client.common.HoodieSparkEngineContext;
-import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.hadoop.fs.HoodieSerializableFileStatus;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 
@@ -45,7 +43,6 @@ import java.util.List;
 @TestInstance(Lifecycle.PER_CLASS)
 public class TestHoodieSerializableFileStatus extends HoodieSparkClientTestHarness {
 
-  HoodieEngineContext engineContext;
   List<Path> testPaths;
 
   @BeforeAll
@@ -55,7 +52,6 @@ public class TestHoodieSerializableFileStatus extends HoodieSparkClientTestHarne
     for (int i = 0; i < 5; i++) {
       testPaths.add(new Path("s3://table-bucket/"));
     }
-    engineContext = new HoodieSparkEngineContext(jsc);
   }
 
   @AfterAll
@@ -67,7 +63,7 @@ public class TestHoodieSerializableFileStatus extends HoodieSparkClientTestHarne
   public void testNonSerializableFileStatus() {
     Exception e = Assertions.assertThrows(SparkException.class,
         () -> {
-          List<FileStatus> statuses = engineContext.flatMap(testPaths, path -> {
+          List<FileStatus> statuses = context.flatMap(testPaths, path -> {
             FileSystem fileSystem = new NonSerializableFileSystem();
             return Arrays.stream(fileSystem.listStatus(path));
           }, 5);
@@ -78,7 +74,7 @@ public class TestHoodieSerializableFileStatus extends HoodieSparkClientTestHarne
 
   @Test
   public void testHoodieFileStatusSerialization() {
-    Assertions.assertDoesNotThrow(() -> engineContext.flatMap(testPaths, path -> {
+    Assertions.assertDoesNotThrow(() -> context.flatMap(testPaths, path -> {
       FileSystem fileSystem = new NonSerializableFileSystem();
       return Arrays.stream(HoodieSerializableFileStatus.fromFileStatuses(fileSystem.listStatus(path)));
     }, 5));

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -53,6 +53,7 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.TableServiceType;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -133,6 +134,7 @@ import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_PA
 import static org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy.EAGER;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.INFLIGHT;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
+import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLEAN_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTERING_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
@@ -2150,6 +2152,61 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     String rolledSchema = latestMeta.getMetadata(schemaKey);
     assertFalse(StringUtils.isNullOrEmpty(rolledSchema),
         "Schema should be rolled over into new commit even with lookback=1");
+  }
+
+  @Test
+  public void testExecutingPendingCleanInstantsBeforeSchedulingNewCleanInstant() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("hoodie.clean.automatic", "false");
+    HoodieWriteConfig cfg = getConfigBuilder().withProperties(props).build();
+    SparkRDDWriteClient client = getHoodieWriteClient(cfg);
+
+    // Bulk insert
+    String firstCommit = WriteClientTestUtils.createNewInstantTime();
+    insertFirstBatch(cfg, client, firstCommit, "000", 100, SparkRDDWriteClient::bulkInsert,
+        false, false, 100, INSTANT_GENERATOR);
+
+    // First upsert
+    String secondCommit = WriteClientTestUtils.createNewInstantTime();
+    updateBatch(cfg, client, secondCommit, firstCommit, Option.empty(), "000", 100,
+        SparkRDDWriteClient::upsert, false, true, 100, 100, 2, INSTANT_GENERATOR);
+
+    // Second upsert
+    String thirdCommit = WriteClientTestUtils.createNewInstantTime();
+    updateBatch(cfg, client, thirdCommit, secondCommit, Option.empty(), "000", 100,
+        SparkRDDWriteClient::upsert, false, true, 100, 100, 3, INSTANT_GENERATOR);
+
+    // Schedule clean operation
+    Properties cleanProps = new Properties();
+    cleanProps.setProperty("hoodie.clean.automatic", "true");
+    cleanProps.setProperty("hoodie.clean.commits.retained", "1");
+    cleanProps.setProperty("hoodie.clean.multiple.enabled", "false");
+    HoodieWriteConfig cleanCfgs = getConfigBuilder().withProperties(cleanProps).build();
+    SparkRDDWriteClient cleanClient = new SparkRDDWriteClient(context, cleanCfgs);
+    cleanClient.scheduleTableService(Option.empty(), TableServiceType.CLEAN);
+
+    // Verify whether clean operation is scheduled.
+    Option<HoodieInstant> firsCleanInstant = metaClient.reloadActiveTimeline().lastInstant();
+    assertTrue(firsCleanInstant.isPresent());
+    assertEquals(CLEAN_ACTION, firsCleanInstant.get().getAction());
+
+    // Second upsert
+    String fourthCommit = WriteClientTestUtils.createNewInstantTime();
+    updateBatch(cfg, client, fourthCommit, thirdCommit, Option.empty(), "000", 100,
+        SparkRDDWriteClient::upsert, false, true, 100, 100, 4, INSTANT_GENERATOR);
+
+    // Execute clean operation. This should complete pending clean operation.
+    cleanClient.clean();
+
+    // Verify timeline
+    HoodieTimeline timeline = metaClient.reloadActiveTimeline();
+    assertEquals(5, timeline.countInstants());
+    assertEquals(0, timeline.filterInflights().countInstants());
+    HoodieTimeline cleanTimeline = timeline.filter(instant -> instant.getAction().equals(CLEAN_ACTION));
+    assertEquals(1, cleanTimeline.countInstants());
+    HoodieInstant cleanInstant = cleanTimeline.getInstants().get(0);
+    assertTrue(cleanInstant.isCompleted());
+    assertEquals(firsCleanInstant.get().requestedTime(), cleanInstant.requestedTime());
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestHoodieClientOnCopyOnWriteStorage.java
@@ -2181,16 +2181,16 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     cleanProps.setProperty("hoodie.clean.automatic", "true");
     cleanProps.setProperty("hoodie.clean.commits.retained", "1");
     cleanProps.setProperty("hoodie.clean.multiple.enabled", "false");
-    HoodieWriteConfig cleanCfgs = getConfigBuilder().withProperties(cleanProps).build();
-    SparkRDDWriteClient cleanClient = new SparkRDDWriteClient(context, cleanCfgs);
+    HoodieWriteConfig cleanCfg = getConfigBuilder().withProperties(cleanProps).build();
+    SparkRDDWriteClient cleanClient = new SparkRDDWriteClient(context, cleanCfg);
     cleanClient.scheduleTableService(Option.empty(), TableServiceType.CLEAN);
 
     // Verify whether clean operation is scheduled.
-    Option<HoodieInstant> firsCleanInstant = metaClient.reloadActiveTimeline().lastInstant();
-    assertTrue(firsCleanInstant.isPresent());
-    assertEquals(CLEAN_ACTION, firsCleanInstant.get().getAction());
+    Option<HoodieInstant> firstCleanInstant = metaClient.reloadActiveTimeline().lastInstant();
+    assertTrue(firstCleanInstant.isPresent());
+    assertEquals(CLEAN_ACTION, firstCleanInstant.get().getAction());
 
-    // Second upsert
+    // Third upsert
     String fourthCommit = WriteClientTestUtils.createNewInstantTime();
     updateBatch(cfg, client, fourthCommit, thirdCommit, Option.empty(), "000", 100,
         SparkRDDWriteClient::upsert, false, true, 100, 100, 4, INSTANT_GENERATOR);
@@ -2206,7 +2206,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends HoodieClientTestBase {
     assertEquals(1, cleanTimeline.countInstants());
     HoodieInstant cleanInstant = cleanTimeline.getInstants().get(0);
     assertTrue(cleanInstant.isCompleted());
-    assertEquals(firsCleanInstant.get().requestedTime(), cleanInstant.requestedTime());
+    assertEquals(firstCleanInstant.get().requestedTime(), cleanInstant.requestedTime());
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Adds missing test coverage for clean scheduling: when multiple cleans are disabled (`hoodie.clean.multiple.enabled=false`) and a clean is already pending, `clean()` should execute the pending clean instead of scheduling a new one. Also removes a redundant variable in an existing test.

### Summary and Changelog

- Add `testExecutingPendingCleanInstantsBeforeSchedulingNewCleanInstant` to `TestHoodieClientOnCopyOnWriteStorage`.
- Remove the redundant `engineContext` from `TestHoodieSerializableFileStatus` (use the inherited `context`; drop now-unused imports).

### Impact

None. Test-only change; no production code or public API is affected.

### Risk Level

none — only test code.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
