### PR TITLE
perf: Add dedicated batch size config for LSM timeline migration on u…

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
@@ -89,7 +89,7 @@ public class HoodieArchivalConfig extends HoodieConfig {
           + " archive log. This config controls such archival batch size.");
 
   public static final ConfigProperty<Integer> MIGRATION_COMMITS_ARCHIVAL_BATCH_SIZE = ConfigProperty
-      .key("hoodie.migration.commits.archival.batch")
+      .key("hoodie.timeline.migration.commits.archival.batch")
       .defaultValue(500)
       .markAdvanced()
       .withDocumentation("Batch size used when migrating the legacy archived timeline to the LSM timeline during a"

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieArchivalConfig.java
@@ -88,6 +88,15 @@ public class HoodieArchivalConfig extends HoodieConfig {
       .withDocumentation("Archiving of instants is batched in best-effort manner, to pack more instants into a single"
           + " archive log. This config controls such archival batch size.");
 
+  public static final ConfigProperty<Integer> MIGRATION_COMMITS_ARCHIVAL_BATCH_SIZE = ConfigProperty
+      .key("hoodie.migration.commits.archival.batch")
+      .defaultValue(500)
+      .markAdvanced()
+      .withDocumentation("Batch size used when migrating the legacy archived timeline to the LSM timeline during a"
+          + " table version upgrade. A larger batch size minimizes the number of parquet files (and the associated"
+          + " remote storage operations like exists check, parquet write and manifest update) created during the"
+          + " one-time migration, which significantly reduces the total migration time.");
+
   public static final ConfigProperty<Integer> TIMELINE_COMPACTION_BATCH_SIZE = ConfigProperty
       .key("hoodie.timeline.compaction.batch.size")
       .defaultValue(10)
@@ -208,6 +217,11 @@ public class HoodieArchivalConfig extends HoodieConfig {
 
     public HoodieArchivalConfig.Builder withCommitsArchivalBatchSize(int batchSize) {
       archivalConfig.setValue(COMMITS_ARCHIVAL_BATCH_SIZE, String.valueOf(batchSize));
+      return this;
+    }
+
+    public HoodieArchivalConfig.Builder withMigrationCommitsArchivalBatchSize(int batchSize) {
+      archivalConfig.setValue(MIGRATION_COMMITS_ARCHIVAL_BATCH_SIZE, String.valueOf(batchSize));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2020,6 +2020,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE);
   }
 
+  public int getMigrationCommitArchivalBatchSize() {
+    return getInt(HoodieArchivalConfig.MIGRATION_COMMITS_ARCHIVAL_BATCH_SIZE);
+  }
+
   public boolean shouldBlockArchivalOnCleanECTR() {
     return getBoolean(HoodieArchivalConfig.BLOCK_ARCHIVAL_ON_LATEST_CLEAN_ECTR);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -257,7 +257,11 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
       LegacyArchivedMetaEntryReader reader = new LegacyArchivedMetaEntryReader(table.getMetaClient());
       StoragePath archivePath = new StoragePath(table.getMetaClient().getMetaPath(), "timeline/history");
       LSMTimelineWriter lsmTimelineWriter = LSMTimelineWriter.getInstance(config, table, Option.of(archivePath));
-      int batchSize = config.getCommitArchivalBatchSize();
+      // Use a dedicated, larger batch size for the one-time migration to minimize the number of parquet
+      // files created on remote storage. Each write() call involves multiple remote storage operations
+      // (exists check, parquet write, manifest update); using the regular archival batch size (default 10)
+      // with hundreds of actions creates excessive I/O that significantly increases the migration time.
+      int batchSize = config.getMigrationCommitArchivalBatchSize();
       List<ActiveAction> activeActionsBatch = new ArrayList<>(batchSize);
       try (ClosableIterator<ActiveAction> iterator = reader.getActiveActionsIterator()) {
         while (iterator.hasNext()) {
@@ -265,7 +269,6 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
           // If the batch is full, write it to the LSM timeline
           if (activeActionsBatch.size() == batchSize) {
             lsmTimelineWriter.write(new ArrayList<>(activeActionsBatch), Option.empty(), Option.empty());
-            lsmTimelineWriter.compactAndClean(engineContext);
             activeActionsBatch.clear();
           }
         }
@@ -273,7 +276,6 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
         // Write any remaining actions in the final batch
         if (!activeActionsBatch.isEmpty()) {
           lsmTimelineWriter.write(new ArrayList<>(activeActionsBatch), Option.empty(), Option.empty());
-          lsmTimelineWriter.compactAndClean(engineContext);
         }
       }
     } catch (Exception e) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
@@ -137,7 +137,7 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
       }, instants.size());
     }
 
-    upgradeToLSMTimeline(table, context, config);
+    upgradeToLSMTimeline(table, config);
 
     return new UpgradeDowngrade.TableConfigChangeSet(tablePropsToAdd, Collections.emptySet());
   }
@@ -249,7 +249,7 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
     }
   }
 
-  static void upgradeToLSMTimeline(HoodieTable table, HoodieEngineContext engineContext, HoodieWriteConfig config) {
+  static void upgradeToLSMTimeline(HoodieTable table, HoodieWriteConfig config) {
     table.getMetaClient().getTableConfig().getTimelineLayoutVersion().ifPresent(
         timelineLayoutVersion -> ValidationUtils.checkState(TimelineLayoutVersion.LAYOUT_VERSION_1.equals(timelineLayoutVersion),
             "Upgrade to LSM timeline is only supported for layout version 1. Given version: " + timelineLayoutVersion));
@@ -259,8 +259,9 @@ public class SevenToEightUpgradeHandler implements UpgradeHandler {
       LSMTimelineWriter lsmTimelineWriter = LSMTimelineWriter.getInstance(config, table, Option.of(archivePath));
       // Use a dedicated, larger batch size for the one-time migration to minimize the number of parquet
       // files created on remote storage. Each write() call involves multiple remote storage operations
-      // (exists check, parquet write, manifest update); using the regular archival batch size (default 10)
-      // with hundreds of actions creates excessive I/O that significantly increases the migration time.
+      // (exists check, parquet write, manifest update); the regular archival batch size is much smaller
+      // than what migration needs, so with hundreds of actions it creates excessive I/O that
+      // significantly increases the migration time.
       int batchSize = config.getMigrationCommitArchivalBatchSize();
       List<ActiveAction> activeActionsBatch = new ArrayList<>(batchSize);
       try (ClosableIterator<ActiveAction> iterator = reader.getActiveActionsIterator()) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
@@ -24,7 +24,6 @@ import org.apache.hudi.client.utils.LegacyArchivedMetaEntryReader;
 import org.apache.hudi.common.bootstrap.index.hfile.HFileBootstrapIndex;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.RecordMergeMode;
-import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -174,21 +173,38 @@ class TestSevenToEightUpgradeHandler {
   }
 
   @Test
-  void testUpgradeToLSMTimelineUsesMigrationBatchSize() throws Exception {
+  void testUpgradeToLSMTimelineSingleBatch() throws Exception {
     // A single batch large enough to hold all actions should result in exactly one write() call,
     // proving the migration batch size config (not the regular archival batch size) drives batching.
-    int totalActions = 4;
+    LSMTimelineWriter writer = runMigration(500, 4);
+    verify(writer, times(1)).write(any(), any(), any());
+    verify(writer, never()).compactAndClean(any());
+  }
 
+  @Test
+  void testUpgradeToLSMTimelineBatchesByMigrationBatchSize() throws Exception {
+    // With more actions than the migration batch size, the in-loop batching branch must fire:
+    // 4 actions with a batch size of 2 -> [2, 2] -> 2 write() calls. This pins that the configured
+    // migration batch size (not just "all actions in one batch") actually governs batching.
+    LSMTimelineWriter writer = runMigration(2, 4);
+    verify(writer, times(2)).write(any(), any(), any());
+    verify(writer, never()).compactAndClean(any());
+  }
+
+  /**
+   * Runs {@link SevenToEightUpgradeHandler#upgradeToLSMTimeline} with the given migration batch size
+   * over the given number of archived actions, and returns the (mocked) LSM timeline writer for verification.
+   */
+  private LSMTimelineWriter runMigration(int migrationBatchSize, int totalActions) {
     HoodieTable table = mock(HoodieTable.class);
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
-    HoodieEngineContext context = mock(HoodieEngineContext.class);
 
     when(table.getMetaClient()).thenReturn(metaClient);
     when(metaClient.getTableConfig()).thenReturn(tableConfig);
     when(tableConfig.getTimelineLayoutVersion()).thenReturn(Option.of(TimelineLayoutVersion.LAYOUT_VERSION_1));
     when(metaClient.getMetaPath()).thenReturn(new StoragePath("/tmp/.hoodie"));
-    when(config.getMigrationCommitArchivalBatchSize()).thenReturn(500);
+    when(config.getMigrationCommitArchivalBatchSize()).thenReturn(migrationBatchSize);
     // The regular archival batch size must not be consulted during migration.
     lenient().when(config.getCommitArchivalBatchSize()).thenReturn(1);
 
@@ -206,11 +222,9 @@ class TestSevenToEightUpgradeHandler {
       mockedWriterStatic.when(() -> LSMTimelineWriter.getInstance(
           any(HoodieWriteConfig.class), any(HoodieTable.class), any(Option.class))).thenReturn(writer);
 
-      SevenToEightUpgradeHandler.upgradeToLSMTimeline(table, context, config);
-
-      verify(writer, times(1)).write(any(), any(), any());
-      verify(writer, never()).compactAndClean(any());
+      SevenToEightUpgradeHandler.upgradeToLSMTimeline(table, config);
     }
+    return writer;
   }
 
   private static Map<ConfigProperty, String> createMap(Object... keyValues) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
@@ -19,14 +19,23 @@
 
 package org.apache.hudi.table.upgrade;
 
+import org.apache.hudi.client.timeline.versioning.v2.LSMTimelineWriter;
+import org.apache.hudi.client.utils.LegacyArchivedMetaEntryReader;
 import org.apache.hudi.common.bootstrap.index.hfile.HFileBootstrapIndex;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.ActiveAction;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieTable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,10 +43,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.hudi.common.table.HoodieTableConfig.BOOTSTRAP_INDEX_CLASS_NAME;
@@ -52,8 +65,15 @@ import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_MODE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -150,6 +170,46 @@ class TestSevenToEightUpgradeHandler {
       assertEquals(expectedPayloadClass, tablePropsToAdd.get(HoodieTableConfig.PAYLOAD_CLASS_NAME));
     } else {
       assertTrue(!tablePropsToAdd.containsKey(HoodieTableConfig.PAYLOAD_CLASS_NAME));
+    }
+  }
+
+  @Test
+  void testUpgradeToLSMTimelineUsesMigrationBatchSize() throws Exception {
+    // A single batch large enough to hold all actions should result in exactly one write() call,
+    // proving the migration batch size config (not the regular archival batch size) drives batching.
+    int totalActions = 4;
+
+    HoodieTable table = mock(HoodieTable.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieEngineContext context = mock(HoodieEngineContext.class);
+
+    when(table.getMetaClient()).thenReturn(metaClient);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getTimelineLayoutVersion()).thenReturn(Option.of(TimelineLayoutVersion.LAYOUT_VERSION_1));
+    when(metaClient.getMetaPath()).thenReturn(new StoragePath("/tmp/.hoodie"));
+    when(config.getMigrationCommitArchivalBatchSize()).thenReturn(500);
+    // The regular archival batch size must not be consulted during migration.
+    lenient().when(config.getCommitArchivalBatchSize()).thenReturn(1);
+
+    List<ActiveAction> actions = new ArrayList<>();
+    for (int i = 0; i < totalActions; i++) {
+      actions.add(mock(ActiveAction.class));
+    }
+
+    LSMTimelineWriter writer = mock(LSMTimelineWriter.class);
+    try (MockedStatic<LSMTimelineWriter> mockedWriterStatic = mockStatic(LSMTimelineWriter.class);
+         MockedConstruction<LegacyArchivedMetaEntryReader> mockedReader = Mockito.mockConstruction(
+             LegacyArchivedMetaEntryReader.class,
+             (readerMock, ctx) -> when(readerMock.getActiveActionsIterator())
+                 .thenReturn(ClosableIterator.wrap(actions.iterator())))) {
+      mockedWriterStatic.when(() -> LSMTimelineWriter.getInstance(
+          any(HoodieWriteConfig.class), any(HoodieTable.class), any(Option.class))).thenReturn(writer);
+
+      SevenToEightUpgradeHandler.upgradeToLSMTimeline(table, context, config);
+
+      verify(writer, times(1)).write(any(), any(), any());
+      verify(writer, never()).compactAndClean(any());
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
@@ -130,7 +130,8 @@ public class TestFlinkWriteClients {
     HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
     assertEquals(123, writeConfig.getMigrationCommitArchivalBatchSize());
     // The regular archival batch size must stay independent at its own default.
-    assertEquals(10, writeConfig.getCommitArchivalBatchSize());
+    assertEquals(Integer.parseInt(HoodieArchivalConfig.COMMITS_ARCHIVAL_BATCH_SIZE.defaultValue()),
+        writeConfig.getCommitArchivalBatchSize());
   }
 
   @Test

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestFlinkWriteClients.java
@@ -38,6 +38,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.index.HoodieIndex;
@@ -119,6 +120,17 @@ public class TestFlinkWriteClients {
     conf.setString(HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_MIN_FILE_GROUP_COUNT_PROP.key(), "12");
     HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
     assertEquals(12, writeConfig.getGlobalRecordLevelIndexMinFileGroupCount());
+  }
+
+  @Test
+  void testUserConfiguredMigrationCommitArchivalBatchSizeIsPropagated() {
+    // A raw hoodie.* property set on the Flink configuration must be propagated to the write config
+    // (and therefore reach the upgrade handler that reads it during the v7 -> v8 LSM timeline migration).
+    conf.setString(HoodieArchivalConfig.MIGRATION_COMMITS_ARCHIVAL_BATCH_SIZE.key(), "123");
+    HoodieWriteConfig writeConfig = FlinkWriteClients.getHoodieClientConfig(conf, false, false);
+    assertEquals(123, writeConfig.getMigrationCommitArchivalBatchSize());
+    // The regular archival batch size must stay independent at its own default.
+    assertEquals(10, writeConfig.getCommitArchivalBatchSize());
   }
 
   @Test


### PR DESCRIPTION
…pgrade

### Describe the issue this Pull Request addresses

This pr ports and finalizes https://github.com/apache/hudi/pull/18411.

When a Hudi table is upgraded from table version 7 to 8, the legacy archived timeline is migrated into the LSM timeline in `SevenToEightUpgradeHandler.upgradeToLSMTimeline()`. Previously this migration reused the regular archival batch size (`hoodie.commits.archival.batch`, default 10) and ran `compactAndClean()` after every batch. Each `write()` involves several remote-storage operations (exists check, parquet write, manifest update), so for tables with hundreds of archived actions this produced excessive I/O and significantly inflated the one-time migration time.

This PR makes the migration batch size independently configurable with a larger default and removes the per-batch compaction during migration, addressing [HUDI-18410](https://github.com/apache/hudi/issues/18410).

### Summary and Changelog

- Introduce config `hoodie.migration.commits.archival.batch` in `HoodieArchivalConfig` (default `500`, advanced), with a `withMigrationCommitsArchivalBatchSize(int)` builder method and a `getMigrationCommitArchivalBatchSize()` accessor on `HoodieWriteConfig`.
- `SevenToEightUpgradeHandler.upgradeToLSMTimeline()` now reads the new migration batch size instead of `getCommitArchivalBatchSize()`, so migration batching is decoupled from regular archival batching.
- Drop the `lsmTimelineWriter.compactAndClean(engineContext)` calls (both per-batch and final-batch) from the migration loop.
- `TestSevenToEightUpgradeHandler`: add tests for the config default/override and for migration behavior — batching follows the migration batch size and `compactAndClean` is never invoked (via `mockStatic`/`mockConstruction`).
- `TestFlinkWriteClients`: add a test asserting a raw `hoodie.migration.commits.archival.batch` set on the Flink `Configuration` propagates through `FlinkWriteClients.getHoodieClientConfig()` to `HoodieWriteConfig`, independent of the regular archival batch size.

### Impact

- **Functional impact**: Faster v7→v8 LSM timeline migration for tables with large archived timelines, due to fewer/larger batches and no per-batch compaction. Default migration batch size changes from 10 (shared) to 500 (dedicated). No change to normal read/write paths or to regular archival behavior.
- **Maintainability**: Migration batching is now explicit and separated from the general archival config, removing the previously overloaded reuse of `getCommitArchivalBatchSize()`.
- **Extensibility**: The dedicated config lets operators tune migration throughput per environment without affecting steady-state archival.

### Risk Level

low — Changes are confined to the one-time v7→v8 upgrade path and a new, defaulted config; no public API changes. Verified with new unit tests in `TestSevenToEightUpgradeHandler` (batching count and absence of `compactAndClean`) and `TestFlinkWriteClients` (Flink config propagation); both classes pass (16 and 21 tests respectively).

### Documentation Update

New advanced config `hoodie.migration.commits.archival.batch` (default 500) is self-documented via `withDocumentation` and will surface in the generated configuration reference. No separate docs page change required.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable