### PR TITLE
fix(spark): reject BLOB columns as record key / ordering / partition path fields

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSchemaUtils.scala
@@ -20,9 +20,10 @@
 package org.apache.hudi
 
 import org.apache.hudi.HoodieSparkSqlWriter.{CANONICALIZE_SCHEMA, SQL_MERGE_INTO_WRITES}
+import org.apache.hudi.avro.HoodieAvroUtils.getRootLevelFieldName
 import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieConfig, TypedProperties}
 import org.apache.hudi.common.model.HoodieRecord
-import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaCompatibility, HoodieSchemaUtils => HoodieCommonSchemaUtils}
+import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaCompatibility, HoodieSchemaType, HoodieSchemaUtils => HoodieCommonSchemaUtils}
 import org.apache.hudi.common.schema.internal.InternalSchema
 import org.apache.hudi.common.schema.internal.convert.InternalSchemaConverter
 import org.apache.hudi.common.schema.internal.utils.AvroSchemaEvolutionUtils
@@ -32,6 +33,7 @@ import org.apache.hudi.common.util.ConfigUtils
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.exception.{HoodieException, SchemaCompatibilityException}
 
+import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
@@ -304,6 +306,36 @@ object HoodieSchemaUtils {
     if (tableSchemaPartitionFields != partitionFields) {
       throw new IllegalArgumentException(s"Partition schema fields order does not match the table schema fields order," +
         s" tableSchemaFields: $tableSchemaPartitionFields, partitionFields: $partitionFields.")
+    }
+  }
+
+  /**
+   * Checks whether a Spark [[StructField]] represents a Hudi BLOB column. BLOB is a logical
+   * type stored as a struct, identified by the [[HoodieSchema.TYPE_METADATA_FIELD]] metadata
+   * attached to the field. Applies to both INLINE and OUT_OF_LINE (EXTERNAL) blobs.
+   */
+  def isBlobField(field: StructField): Boolean = {
+    val md = field.metadata
+    md != null &&
+      md.contains(HoodieSchema.TYPE_METADATA_FIELD) &&
+      md.getString(HoodieSchema.TYPE_METADATA_FIELD).equalsIgnoreCase(HoodieSchemaType.BLOB.name)
+  }
+
+  /**
+   * Returns the distinct top-level field names referenced in `fieldSpec` (a comma-separated list,
+   * possibly empty/null) that resolve to a BLOB column in `schema`. Only the root segment of each
+   * field is considered (consistent with the existing existence checks that use
+   * [[getRootLevelFieldName]]), since a BLOB is always a top-level struct column. Matching honors
+   * the session's case-sensitivity via `resolver`.
+   */
+  def findBlobFields(schema: StructType, fieldSpec: String, resolver: Resolver): Seq[String] = {
+    if (fieldSpec == null || fieldSpec.trim.isEmpty) {
+      Seq.empty
+    } else {
+      fieldSpec.split(",").map(_.trim).filter(_.nonEmpty)
+        .map(getRootLevelFieldName).distinct
+        .filter(name => schema.fields.exists(f => resolver(f.name, name) && isBlobField(f)))
+        .toSeq
     }
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -70,6 +70,7 @@ import org.apache.hadoop.hive.shims.ShimLoader
 import org.apache.spark.{SPARK_VERSION, SparkContext}
 import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.execution.{QueryExecution, SQLExecution}
 import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.types.StructType
@@ -233,6 +234,8 @@ class HoodieSparkSqlWriterInternal {
     // Validate datasource and tableconfig keygen are the same
     validateKeyGeneratorConfig(originKeyGeneratorClassName, tableConfig)
     validateTableConfig(sparkSession, optParams, tableConfig, mode == SaveMode.Overwrite)
+    // Reject BLOB columns used as record key / ordering(preCombine) / partition path fields.
+    validateBlobFieldUsage(sourceDf.schema, optParams, sparkSession.sessionState.conf.resolver)
 
     asyncCompactionTriggerFnDefined = streamingWritesParamsOpt.map(_.asyncCompactionTriggerFn.isDefined).orElse(Some(false)).get
     asyncClusteringTriggerFnDefined = streamingWritesParamsOpt.map(_.asyncClusteringTriggerFn.isDefined).orElse(Some(false)).get
@@ -710,6 +713,8 @@ class HoodieSparkSqlWriterInternal {
     // fetch table config for an already existing table and SaveMode is not Overwrite.
     val tableConfig = getHoodieTableConfig(sparkContext, path, mode, hoodieTableConfigOpt)
     validateTableConfig(sparkSession, optParams, tableConfig, mode == SaveMode.Overwrite)
+    // Reject BLOB columns used as record key / ordering(preCombine) / partition path fields.
+    validateBlobFieldUsage(df.schema, optParams, sparkSession.sessionState.conf.resolver)
 
     val (parameters, hoodieConfig) = mergeParamsAndGetHoodieConfig(optParams, tableConfig, mode, streamingWritesParamsOpt.isDefined)
     val tableName = hoodieConfig.getStringOrThrow(HoodieWriteConfig.TBL_NAME, s"'${HoodieWriteConfig.TBL_NAME.key}' must be set.")
@@ -811,6 +816,31 @@ class HoodieSparkSqlWriterInternal {
       throw new HoodieException(HoodieRecord.HOODIE_IS_DELETED_FIELD + " has to be BOOLEAN type. Passed in dataframe's schema has type "
         + fieldOpt.get().schema().getType)
     }
+  }
+
+  /**
+   * Rejects BLOB-typed columns used as record key, ordering(preCombine), or partition path fields.
+   * BLOB columns hold large binary payloads (INLINE or EXTERNAL); using them as keys balloons the
+   * record key / shuffle / metadata index, or ties record identity to a storage path. Fails fast
+   * with a clear message naming the offending column(s).
+   */
+  private def validateBlobFieldUsage(schema: StructType,
+                                     optParams: Map[String, String],
+                                     resolver: Resolver): Unit = {
+    def check(spec: Option[String], usage: String): Unit = spec.foreach { s =>
+      val blobs = HoodieSchemaUtils.findBlobFields(schema, s, resolver)
+      if (blobs.nonEmpty) {
+        throw new HoodieException(
+          s"BLOB type column(s) ${blobs.mkString("[", ", ", "]")} cannot be used as $usage. " +
+            "BLOB columns hold large binary payloads (INLINE or EXTERNAL) and are not supported as " +
+            "record key, ordering/preCombine, or partition path fields.")
+      }
+    }
+
+    check(optParams.get(DataSourceWriteOptions.RECORDKEY_FIELD.key()), "record key")
+    check(optParams.get(DataSourceWriteOptions.PARTITIONPATH_FIELD.key())
+      .map(p => getPartitionColumns(p).map(_.split(":")(0)).mkString(",")), "partition path field")
+    check(optParams.get(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key()), "ordering field (preCombine)")
   }
 
   def bulkInsertAsRow(writeClient: SparkRDDWriteClient[_],

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.hudi.{DataSourceOptionsHelper, HoodieSchemaConversionUtils}
 import org.apache.hudi.DataSourceWriteOptions.OPERATION
+import org.apache.hudi.HoodieSchemaUtils
 import org.apache.hudi.HoodieWriterUtils._
 import org.apache.hudi.common.config.{DFSPropertiesConfiguration, HoodieConfig, TypedProperties}
 import org.apache.hudi.common.model.HoodieTableType
@@ -281,6 +282,23 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
       mapHoodieConfigsToSqlOptions(tableConfigs))
 
     val resolver = spark.sessionState.conf.resolver
+    // Reject BLOB columns as partition path fields (record key / ordering are validated in validateTable).
+    // Partition fields are not part of sqlOptions, so they are derived here the same way as in initHoodieTable.
+    val partitionFieldSpec =
+      if (SparkConfigUtils.containsConfigProperty(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)) {
+        SparkConfigUtils.getStringWithAltKeys(tableConfigs, KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME)
+          .split(",").map(_.split(":")(0)).mkString(",")
+      } else {
+        table.partitionColumnNames.mkString(",")
+      }
+    val partitionBlobs = HoodieSchemaUtils.findBlobFields(finalSchema, partitionFieldSpec, resolver)
+    if (partitionBlobs.nonEmpty) {
+      throw new HoodieAnalysisException(
+        s"BLOB type column(s) ${partitionBlobs.mkString("[", ", ", "]")} cannot be used as partition path field. " +
+          "BLOB columns hold large binary payloads (INLINE or EXTERNAL) and are not supported as " +
+          "record key, ordering/preCombine, or partition path fields.")
+    }
+
     val dataSchema = finalSchema.filterNot { f =>
       table.partitionColumnNames.exists(resolver(_, f.name))
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hudi
 
 import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.HoodieSchemaUtils
 import org.apache.hudi.avro.HoodieAvroUtils.getRootLevelFieldName
 import org.apache.hudi.common.model.HoodieTableType
 import org.apache.hudi.common.table.HoodieTableConfig
@@ -232,6 +233,11 @@ object HoodieOptionConfig {
         ValidationUtils.checkArgument(schema.exists(f => resolver(f.name, getRootLevelFieldName(primaryKey))),
           s"Can't find primaryKey `$primaryKey` in ${schema.treeString}.")
       }
+      val pkBlobs = HoodieSchemaUtils.findBlobFields(schema, primaryKeys.get.mkString(","), resolver)
+      ValidationUtils.checkArgument(pkBlobs.isEmpty,
+        s"BLOB type column(s) ${pkBlobs.mkString("[", ", ", "]")} cannot be used as primaryKey (record key). " +
+          "BLOB columns hold large binary payloads (INLINE or EXTERNAL) and are not supported as " +
+          "record key, ordering/preCombine, or partition path fields.")
     }
 
     // validate preCombine key
@@ -239,6 +245,11 @@ object HoodieOptionConfig {
     if (orderingFields.isDefined && orderingFields.get.nonEmpty) {
       ValidationUtils.checkArgument(schema.exists(f => resolver(f.name, getRootLevelFieldName(orderingFields.get))),
         s"Can't find ordering fields `${orderingFields.get}` in ${schema.treeString}.")
+      val orderingBlobs = HoodieSchemaUtils.findBlobFields(schema, orderingFields.get, resolver)
+      ValidationUtils.checkArgument(orderingBlobs.isEmpty,
+        s"BLOB type column(s) ${orderingBlobs.mkString("[", ", ", "]")} cannot be used as orderingFields (preCombine field). " +
+          "BLOB columns hold large binary payloads (INLINE or EXTERNAL) and are not supported as " +
+          "record key, ordering/preCombine, or partition path fields.")
     }
 
     // validate table type

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
@@ -18,6 +18,7 @@
 package org.apache.hudi
 
 import org.apache.hudi.DataSourceWriteOptions.{DROP_INSERT_DUP_POLICY, FAIL_INSERT_DUP_POLICY, INSERT_DROP_DUPS, INSERT_DUP_POLICY}
+import org.apache.hudi.blob.BlobTestHelpers.inlineBlobStructCol
 import org.apache.hudi.client.SparkRDDWriteClient
 import org.apache.hudi.common.config.{HoodieConfig, HoodieMetadataConfig, RecordMergeMode}
 import org.apache.hudi.common.model.{DefaultHoodieRecordPayload, HoodieFileFormat, HoodieRecord, HoodieRecordPayload, HoodieReplaceCommitMetadata, HoodieTableType, WriteOperationType}
@@ -37,7 +38,7 @@ import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 import org.apache.commons.io.FileUtils
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
-import org.apache.spark.sql.functions.{expr, lit}
+import org.apache.spark.sql.functions.{col, expr, lit}
 import org.apache.spark.sql.hudi.command.SqlKeyGenerator
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertNull, assertTrue, fail}
 import org.junit.jupiter.api.Test
@@ -191,6 +192,52 @@ class TestHoodieSparkSqlWriter extends HoodieSparkWriterTestBase {
     val deleteCmdException = intercept[HoodieException](HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, deleteTableModifier, dataFrame2))
     assert(tableAlreadyExistException.getMessage.contains("Config conflict"))
     assert(tableAlreadyExistException.getMessage.contains(s"${HoodieWriteConfig.TBL_NAME.key}:\thoodie_bar_tbl\thoodie_foo_tbl"))
+  }
+
+  /**
+   * record key / ordering(preCombine) / partition path cannot be a BLOB column.
+   */
+  @Test
+  def testRejectBlobColumnAsKeyFields(): Unit = {
+    def blobDf: DataFrame = spark.range(0, 3).toDF("id")
+      .withColumn("ts", col("id"))
+      .withColumn("part", lit("a"))
+      .withColumn("data", inlineBlobStructCol("data", expr("cast(cast(id as string) as binary)")))
+
+    def baseModifier: Map[String, String] = Map(
+      "path" -> tempBasePath,
+      HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
+      "hoodie.insert.shuffle.parallelism" -> "4",
+      "hoodie.upsert.shuffle.parallelism" -> "4")
+
+    // record key = blob -> rejected
+    val eRk = intercept[HoodieException](HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite,
+      baseModifier ++ Map("hoodie.datasource.write.recordkey.field" -> "data"), blobDf))
+    assert(eRk.getMessage.contains("BLOB type column"))
+
+    // partition path = blob -> rejected (also covers the col:type form)
+    val ePp = intercept[HoodieException](HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite,
+      baseModifier ++ Map("hoodie.datasource.write.recordkey.field" -> "id",
+        "hoodie.datasource.write.partitionpath.field" -> "data:SIMPLE"), blobDf))
+    assert(ePp.getMessage.contains("BLOB type column"))
+
+    // ordering(preCombine) = blob -> rejected
+    val ePc = intercept[HoodieException](HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite,
+      baseModifier ++ Map("hoodie.datasource.write.recordkey.field" -> "id",
+        "hoodie.datasource.write.precombine.field" -> "data"), blobDf))
+    assert(ePc.getMessage.contains("BLOB type column"))
+
+    // multi-field record key including blob -> rejected
+    val eMulti = intercept[HoodieException](HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite,
+      baseModifier ++ Map("hoodie.datasource.write.recordkey.field" -> "id,data",
+        "hoodie.datasource.write.keygenerator.class" -> "org.apache.hudi.keygen.ComplexKeyGenerator"), blobDf))
+    assert(eMulti.getMessage.contains("BLOB type column"))
+
+    // blob column present but keys point at non-blob columns -> write succeeds
+    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Overwrite,
+      baseModifier ++ Map("hoodie.datasource.write.recordkey.field" -> "id",
+        "hoodie.datasource.write.partitionpath.field" -> "part",
+        "hoodie.datasource.write.precombine.field" -> "ts"), blobDf)
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hudi.common
 
 import org.apache.hudi.common.model.{HoodieRecordMerger, OverwriteWithLatestAvroPayload}
+import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 
@@ -157,6 +158,35 @@ class TestHoodieOptionConfig extends SparkClientFunctionalTestHarness {
       "type" -> "cow"
     )
     HoodieOptionConfig.validateTable(spark, schema, sqlOptions6)
+  }
+
+  @Test
+  def testValidateTableRejectsBlobKeyFields(): Unit = {
+    val blobMetadata = new MetadataBuilder()
+      .putString(HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name())
+      .build()
+    val schema = StructType(
+      Seq(StructField("id", IntegerType, true),
+        StructField("ts", LongType, true),
+        StructField("data", BlobType().asInstanceOf[StructType], true, blobMetadata))
+    )
+
+    // record key = blob -> rejected
+    val ePk = intercept[IllegalArgumentException] {
+      HoodieOptionConfig.validateTable(spark, schema, Map("primaryKey" -> "data", "type" -> "cow"))
+    }
+    assertTrue(ePk.getMessage.contains("BLOB type column"))
+
+    // ordering(preCombine) = blob -> rejected
+    val eOrd = intercept[IllegalArgumentException] {
+      HoodieOptionConfig.validateTable(spark, schema,
+        Map("primaryKey" -> "id", "orderingFields" -> "data", "type" -> "mor"))
+    }
+    assertTrue(eOrd.getMessage.contains("BLOB type column"))
+
+    // blob column present but keys point at non-blob columns -> ok
+    HoodieOptionConfig.validateTable(spark, schema,
+      Map("primaryKey" -> "id", "orderingFields" -> "ts", "type" -> "cow"))
   }
 
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -282,4 +282,72 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
         "Expected at least one .clean instant on the timeline after compaction")
     })
   }
+
+  test("Test BLOB column rejected as primaryKey / preCombine / partition path (DDL)") {
+    withRecordType()(withTempDir { tmp =>
+      def ddl(tableName: String, props: String, partitionedBy: String = ""): String =
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  data blob,
+           |  ts long
+           |) using hudi
+           | location '${new File(tmp, tableName).getCanonicalPath}'
+           | $partitionedBy
+           | tblproperties ( $props )
+       """.stripMargin
+
+      // primaryKey = blob column -> rejected
+      checkExceptionContain(ddl(generateTableName,
+        "primaryKey = 'data', type = 'cow'"))("BLOB type column")
+
+      // multi-field primaryKey including a blob column -> rejected, message names 'data'
+      checkExceptionContain(ddl(generateTableName,
+        "primaryKey = 'id,data', type = 'cow'"))("data")
+
+      // case-insensitive match: 'DATA' resolves to blob column 'data' -> rejected
+      checkExceptionContain(ddl(generateTableName,
+        "primaryKey = 'DATA', type = 'cow'"))("BLOB type column")
+
+      // preCombineField = blob column -> rejected
+      checkExceptionContain(ddl(generateTableName,
+        "primaryKey = 'id', preCombineField = 'data', type = 'mor'"))("BLOB type column")
+
+      // partition path via PARTITIONED BY = blob column -> rejected.
+      // Spark itself rejects a struct-typed partition column before Hudi's check runs, so the
+      // message comes from Spark ("for partition column"); the BLOB is still rejected.
+      checkExceptionContain(ddl(generateTableName,
+        "primaryKey = 'id', type = 'cow'", partitionedBy = "partitioned by (data)"))("for partition column")
+
+      // partition path via tblproperties = blob column -> rejected by Hudi's check
+      checkExceptionContain(ddl(generateTableName,
+        "primaryKey = 'id', type = 'cow', hoodie.datasource.write.partitionpath.field = 'data'"))("BLOB type column")
+    })
+  }
+
+  test("Test BLOB column allowed when keys point at non-BLOB columns (DDL regression)") {
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      // A blob column is present but record key / preCombine / partition all point at non-blob columns.
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  data blob,
+           |  ts long,
+           |  part string
+           |) using hudi
+           | location '${new File(tmp, tableName).getCanonicalPath}'
+           | partitioned by (part)
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  preCombineField = 'ts',
+           |  type = 'cow'
+           | )
+       """.stripMargin)
+      spark.sql(
+        s"insert into $tableName values (1, ${inlineBlobLiteral("01")}, 1000, 'a')")
+      assertResult(1)(spark.sql(s"select id from $tableName").collect().length)
+    })
+  }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18819

A BLOB column (a struct under the hood) silently passed all existing key-field
validation. `CREATE TABLE ... TBLPROPERTIES (primaryKey = '<blob_col>')` and the
equivalent DataSource writes succeeded, producing a JSON-stringified struct as the
`_hoodie_record_key` (e.g. `{"type":"INLINE","data":"hello-0","reference":null}`).

BLOB holds large binary payloads — INLINE bytes or EXTERNAL references. Using it
as a key balloons the record key / shuffle / metadata index (INLINE), or ties
record identity to a storage path rather than content (EXTERNAL). It is not a
valid record key, ordering/preCombine, or partition path field.

### Summary and Changelog

Reject BLOB-typed columns used as record key, ordering(preCombine), or partition
path fields, failing fast with a clear message on both write paths:

- DDL: `HoodieOptionConfig.validateTable` (record key + ordering) and
  `HoodieCatalogTable` (partition path).
- DataSource: `HoodieSparkSqlWriter` `writeInternal` and `bootstrap`.

Adds `HoodieSchemaUtils.isBlobField` / `findBlobFields` helpers (top-level,
case-insensitive, comma-separated multi-field aware). INLINE and EXTERNAL blobs
are treated identically. Note: `PARTITIONED BY (<blob>)` is already rejected
earlier by Spark (struct partition columns are disallowed); this change covers
the `hoodie.datasource.write.partitionpath.field` route.

### Impact

User-facing: a CREATE TABLE / write that previously succeeded with a BLOB key
field now fails fast with a clear error. This is the intended fix; such tables
were already semantically broken.

### Risk Level

low — validation-only, no storage format or read-path change. Covered by new
tests in `TestBlobDataType`, `TestHoodieSparkSqlWriter`, `TestHoodieOptionConfig`.

### Documentation Update

none

### Contributor's checklist

- [x] Read through contributor's guide
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
