### PR TITLE
[DO NOT MERGE] CI triage: isolate TestHoodieClientMultiWriter to debug ZK BindException flake

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1,16 +1,11 @@
 name: Java CI
 
+# Disabled for ci-triage-multiwriter-zk branch: only run on manual dispatch so
+# the heavy GA matrix does not consume runners while we triage the Azure
+# TestHoodieClientMultiWriter ZK/BindException flake. Restore on master before
+# merging anything from this branch.
 on:
-  push:
-    branches:
-      - master
-      - 'release-*'
-      - branch-0.x
-  pull_request:
-    branches:
-      - master
-      - 'release-*'
-      - branch-0.x
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}

--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NOTE:
-# This config file defines how Azure CI runs tests with Spark 3.5 and Flink 2.1 profiles.
-# PRs will need to keep in sync with master's version to trigger the CI runs.
-# See scripts/jacoco/README.md for how aggregated code coverage report works
-# across multiple modules.
+# STRIPPED for ci-triage-multiwriter-zk branch:
+# Only runs TestHoodieClientMultiWriter so we can repro the BindException +
+# Failed-to-connect-to-ZooKeeper flake on Azure runners without burning the
+# full UT_FT_1..10 matrix. Restore the original pipeline before merging
+# anything from this branch (see master).
 
 trigger:
   branches:
@@ -27,164 +27,34 @@ trigger:
 pool:
   vmImage: 'ubuntu-22.04'
 
-parameters:
-  - name: job3456UTModules
-    type: object
-    default:
-      - 'hudi-spark-datasource'
-      - 'hudi-spark-datasource/hudi-spark'
-      - 'hudi-spark-datasource/hudi-spark3.5.x'
-      - 'hudi-spark-datasource/hudi-spark3-common'
-      - 'hudi-spark-datasource/hudi-spark-common'
-  - name: job10UTModules
-    type: object
-    default:
-      - '!hudi-hadoop-common'
-      - '!hudi-hadoop-mr'
-      - '!hudi-client/hudi-java-client'
-      - '!hudi-client/hudi-spark-client'
-      - '!hudi-cli'
-      - '!hudi-examples'
-      - '!hudi-examples/hudi-examples-common'
-      - '!hudi-examples/hudi-examples-flink'
-      - '!hudi-examples/hudi-examples-java'
-      - '!hudi-examples/hudi-examples-spark'
-      - '!hudi-spark-datasource'
-      - '!hudi-spark-datasource/hudi-spark'
-      - '!hudi-spark-datasource/hudi-spark3.5.x'
-      - '!hudi-spark-datasource/hudi-spark3-common'
-      - '!hudi-spark-datasource/hudi-spark-common'
-      - '!hudi-utilities'
-  - name: job10FTModules
-    type: object
-    default:
-      - '!hudi-client/hudi-spark-client'
-      - '!hudi-cli'
-      - '!hudi-examples'
-      - '!hudi-examples/hudi-examples-common'
-      - '!hudi-examples/hudi-examples-flink'
-      - '!hudi-examples/hudi-examples-java'
-      - '!hudi-examples/hudi-examples-spark'
-      - '!hudi-spark-datasource/hudi-spark'
-      - '!hudi-utilities'
-  - name: job6HudiSparkDdlOthersWildcardSuites
-    type: object
-    default:
-      - 'org.apache.hudi'
-      - 'org.apache.spark.hudi'
-      - 'org.apache.spark.sql.avro'
-      - 'org.apache.spark.sql.execution'
-      - 'org.apache.spark.sql.hudi.analysis'
-      - 'org.apache.spark.sql.hudi.blob'
-      - 'org.apache.spark.sql.hudi.catalog'
-      - 'org.apache.spark.sql.hudi.command'
-      - 'org.apache.spark.sql.hudi.common'
-      - 'org.apache.spark.sql.hudi.ddl'
-      - 'org.apache.spark.sql.hudi.procedure'
-  - name: jacocoModules
-    type: object
-    default:
-      - '!hudi-examples/hudi-examples-k8s'
-      - '!packaging/hudi-aws-bundle'
-      - '!packaging/hudi-cli-bundle'
-      - '!packaging/hudi-datahub-sync-bundle'
-      - '!packaging/hudi-flink-bundle'
-      - '!packaging/hudi-gcp-bundle'
-      - '!packaging/hudi-hadoop-mr-bundle'
-      - '!packaging/hudi-hive-sync-bundle'
-      - '!packaging/hudi-kafka-connect-bundle'
-      - '!packaging/hudi-metaserver-server-bundle'
-      - '!packaging/hudi-presto-bundle'
-      - '!packaging/hudi-spark-bundle'
-      - '!packaging/hudi-timeline-server-bundle'
-      - '!packaging/hudi-trino-bundle'
-      - '!packaging/hudi-utilities-slim-bundle'
-
 variables:
   BUILD_PROFILES: '-Dscala-2.12 -Dspark3.5 -Dflink2.1'
   PLUGIN_OPTS: '-Dcheckstyle.skip=true -Drat.skip=true -ntp -B -V -Pwarn-log -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=warn -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.dependency=warn'
   MVN_OPTS_INSTALL: '-T 3 -Phudi-platform-service -DskipTests $(BUILD_PROFILES) $(PLUGIN_OPTS) -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=5 -Dorg.eclipse.jetty.LEVEL=WARN'
   MVN_OPTS_TEST: '-fae -Pwarn-log $(BUILD_PROFILES) $(PLUGIN_OPTS)'
-  JAVA_MVN_TEST_FILTER: '-DwildcardSuites=skipScalaTests -Dsurefire.failIfNoSpecifiedTests=false'
-  SCALA_MVN_TEST_FILTER: '-Dtest=skipJavaTests -Dsurefire.failIfNoSpecifiedTests=false'
-  JOB3456_MODULES: ${{ join(',',parameters.job3456UTModules) }}
-  JAVA_FUNCTIONAL_PACKAGE_TEST_FILTER: '**/org/apache/hudi/functional/**/*'
-  MVN_ARG_FUNCTIONAL_PACKAGE_TEST: "-Dtest=\"$(JAVA_FUNCTIONAL_PACKAGE_TEST_FILTER)\""
-  MVN_ARG_NON_FUNCTIONAL_PACKAGE_TEST: "-Dtest=\"!$(JAVA_FUNCTIONAL_PACKAGE_TEST_FILTER)\""
-  JOB6_SPARK_DDL_OTHERS_WILDCARD_SUITES: ${{ join(',',parameters.job6HudiSparkDdlOthersWildcardSuites) }}
-  JOB10_UT_MODULES: ${{ join(',',parameters.job10UTModules) }}
-  JOB10_FT_MODULES: ${{ join(',',parameters.job10FTModules) }}
-  JACOCO_AGENT_DESTFILE1_ARG: '-Djacoco.agent.dest.filename=jacoco1.exec'
-  JACOCO_AGENT_DESTFILE2_ARG: '-Djacoco.agent.dest.filename=jacoco2.exec'
-  JACOCO_AGENT_DESTFILE3_ARG: '-Djacoco.agent.dest.filename=jacoco3.exec'
-  JACOCO_MODULES: ${{ join(',',parameters.jacocoModules) }}
 
 stages:
   - stage: test
-    variables:
-      - name: DOCKER_BUILDKIT
-        value: 1
     jobs:
-      - job: UT_FT_1
-        displayName: UT hudi-hadoop-common & UT FT client/spark-client
-        timeoutInMinutes: '120'
+      - job: TRIAGE_MULTIWRITER
+        displayName: 'Triage TestHoodieClientMultiWriter ZK BindException'
+        timeoutInMinutes: '90'
         steps:
-          - task: Maven@4
-            displayName: maven install
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'clean install'
-              options: $(MVN_OPTS_INSTALL) -pl hudi-client/hudi-spark-client -am
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-          - task: Maven@4
-            displayName: UT hudi-hadoop-common
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests $(JACOCO_AGENT_DESTFILE1_ARG) -pl hudi-hadoop-common
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - task: Maven@4
-            displayName: UT client/spark-client
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests $(JACOCO_AGENT_DESTFILE2_ARG) -pl hudi-client/hudi-spark-client
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - task: Maven@4
-            displayName: FT client/spark-client
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              # TODO(HUDI-9143): Investigate why Jacoco execution data file is corrupt
-              options: $(MVN_OPTS_TEST) -Pfunctional-tests -Djacoco.agent.dest.filename=jacoco2.corrupt -pl hudi-client/hudi-spark-client
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
+          # Print runner-side networking info up front so we can correlate any
+          # BindException with the ephemeral-port range / things already listening.
           - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-1'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_2
-        displayName: FTA hudi-spark
-        timeoutInMinutes: '120'
-        steps:
+              echo "=== runner network triage ==="
+              uname -a || true
+              echo "--- ephemeral port range ---"
+              cat /proc/sys/net/ipv4/ip_local_port_range || true
+              echo "--- pre-test ss -tlnp ---"
+              ss -tlnp || true
+              echo "--- ulimit -a ---"
+              ulimit -a || true
+              echo "=== end runner network triage ==="
+            displayName: 'Runner network triage (pre-test)'
           - task: Maven@4
-            displayName: maven install
+            displayName: maven install (skipTests) for hudi-spark
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'clean install'
@@ -192,415 +62,24 @@ stages:
               publishJUnitResults: false
               jdkVersionOption: '11'
           - task: Maven@4
-            displayName: FTA hudi-spark-datasource/hudi-spark
+            displayName: FT TestHoodieClientMultiWriter only
             inputs:
               mavenPomFile: 'pom.xml'
               goals: 'test'
-              options: $(MVN_OPTS_TEST) -Pfunctional-tests $(JACOCO_AGENT_DESTFILE1_ARG) -pl hudi-spark-datasource/hudi-spark
+              options: $(MVN_OPTS_TEST) -Pfunctional-tests -Dtest=TestHoodieClientMultiWriter -Dsurefire.failIfNoSpecifiedTests=false -pl hudi-spark-datasource/hudi-spark
               publishJUnitResults: true
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               jdkVersionOption: '11'
               mavenOptions: '-Xmx4g'
           - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-2'
-              publishLocation: 'Container'
+              echo "=== runner network triage (post-test) ==="
+              ss -tlnp || true
+              echo "=== end ==="
+            displayName: 'Runner network triage (post-test)'
+            condition: always()
           - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_3
-        displayName: UT spark-datasource Java Test 1
-        timeoutInMinutes: '120'
-        steps:
-          - task: Maven@4
-            displayName: maven install
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'clean install'
-              options: $(MVN_OPTS_INSTALL) -pl $(JOB3456_MODULES) -am
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-          - task: Maven@4
-            displayName: Java UT spark-datasource functional package
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests $(JAVA_MVN_TEST_FILTER) $(MVN_ARG_FUNCTIONAL_PACKAGE_TEST) $(JACOCO_AGENT_DESTFILE2_ARG) -pl $(JOB3456_MODULES)
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-3'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_4
-        displayName: UT spark-datasource Java Test 2
-        timeoutInMinutes: '120'
-        steps:
-          - task: Maven@4
-            displayName: maven install
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'clean install'
-              options: $(MVN_OPTS_INSTALL) -pl $(JOB3456_MODULES) -am
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-          - task: Maven@4
-            displayName: Java UT spark-datasource non-functional package
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests $(JAVA_MVN_TEST_FILTER) $(MVN_ARG_NON_FUNCTIONAL_PACKAGE_TEST) $(JACOCO_AGENT_DESTFILE1_ARG) -pl $(JOB3456_MODULES)
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-4'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_5
-        displayName: UT spark-datasource DML
-        timeoutInMinutes: '120'
-        steps:
-          - task: Maven@4
-            displayName: maven install
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'clean install'
-              options: $(MVN_OPTS_INSTALL) -pl $(JOB3456_MODULES) -am
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-          - task: Maven@4
-            displayName: Scala UT spark-datasource DML 1
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests $(SCALA_MVN_TEST_FILTER) -DwildcardSuites="org.apache.spark.sql.hudi.dml.others" $(JACOCO_AGENT_DESTFILE1_ARG) -pl $(JOB3456_MODULES)
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-5'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_6
-        displayName: UT spark-datasource DDL & Others
-        timeoutInMinutes: '120'
-        steps:
-          - task: Maven@4
-            displayName: maven install
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'clean install'
-              options: $(MVN_OPTS_INSTALL) -pl $(JOB3456_MODULES) -am
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-          - task: Maven@4
-            displayName: Scala UT spark-datasource DDL & Others
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests $(SCALA_MVN_TEST_FILTER) -DwildcardSuites="$(JOB6_SPARK_DDL_OTHERS_WILDCARD_SUITES)" $(JACOCO_AGENT_DESTFILE1_ARG) -pl $(JOB3456_MODULES)
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-6'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_7
-        displayName: UT Hudi Streamer & FT utilities
-        timeoutInMinutes: '120'
-        steps:
-          - task: Docker@2
-            displayName: "login to docker hub"
-            inputs:
-              command: "login"
-              containerRegistry: "apachehudi-docker-hub"
-          - task: Docker@2
-            displayName: "load repo into image"
-            inputs:
-              containerRegistry: 'apachehudi-docker-hub'
-              repository: 'apachehudi/hudi-ci-bundle-validation-base'
-              command: 'build'
-              Dockerfile: '**/Dockerfile'
-              ImageName: $(Build.BuildId)
-          - task: Docker@2
-            displayName: "UT Hudi Streamer & FT utilities"
-            inputs:
-              containerRegistry: 'apachehudi-docker-hub'
-              repository: 'apachehudi/hudi-ci-bundle-validation-base'
-              command: 'run'
-              arguments: >
-                -v $(Build.SourcesDirectory):/hudi
-                -v /var/run/docker.sock:/var/run/docker.sock
-                -i docker.io/apachehudi/hudi-ci-bundle-validation-base:$(Build.BuildId)
-                /bin/bash -c "mvn clean install $(MVN_OPTS_INSTALL) -Phudi-platform-service -Pthrift-gen-source -pl hudi-utilities -am
-                && mvn test  $(MVN_OPTS_TEST) -Punit-tests $(JACOCO_AGENT_DESTFILE1_ARG) -Dtest="TestHoodie*" -Dsurefire.failIfNoSpecifiedTests=false -pl hudi-utilities
-                && mvn test  $(MVN_OPTS_TEST) -Pfunctional-tests $(JACOCO_AGENT_DESTFILE2_ARG) -Dsurefire.failIfNoSpecifiedTests=false -pl hudi-utilities"
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            inputs:
-              testResultsFormat: 'JUnit'
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              searchFolder: '$(Build.SourcesDirectory)'
-              failTaskOnFailedTests: true
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-7'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_8
-        displayName: UT FT Spark and SQL (additional)
-        timeoutInMinutes: '120'
-        steps:
-          - task: Maven@4
-            displayName: maven install
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'clean install'
-              options: $(MVN_OPTS_INSTALL) -pl $(JOB3456_MODULES) -am
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-          - task: Maven@4
-            displayName: Scala UT spark-datasource Hudi SQL features
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests $(SCALA_MVN_TEST_FILTER) -DwildcardSuites="org.apache.spark.sql.hudi.feature" $(JACOCO_AGENT_DESTFILE1_ARG) -pl $(JOB3456_MODULES)
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - task: Maven@4
-            displayName: Scala UT spark-datasource DML 2
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Punit-tests $(SCALA_MVN_TEST_FILTER) -DwildcardSuites="org.apache.spark.sql.hudi.dml.insert" $(JACOCO_AGENT_DESTFILE2_ARG) -pl $(JOB3456_MODULES)
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - task: Maven@4
-            displayName: FTC hudi-spark-datasource/hudi-spark
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Pfunctional-tests-c $(JACOCO_AGENT_DESTFILE3_ARG) -pl hudi-spark-datasource/hudi-spark
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-8'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_9
-        displayName: FT spark 2
-        timeoutInMinutes: '120'
-        steps:
-          - task: Maven@4
-            displayName: maven install
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'clean install'
-              options: $(MVN_OPTS_INSTALL) -pl hudi-client/hudi-spark-client,hudi-spark-datasource/hudi-spark -am
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-          - task: Maven@4
-            displayName: FTB hudi-spark-datasource/hudi-spark
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'test'
-              options: $(MVN_OPTS_TEST) -Pfunctional-tests-b $(JACOCO_AGENT_DESTFILE1_ARG) -pl hudi-spark-datasource/hudi-spark
-              publishJUnitResults: true
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              jdkVersionOption: '11'
-              mavenOptions: '-Xmx4g'
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-9'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: UT_FT_10
-        displayName: UT FT common & other modules
-        timeoutInMinutes: '120'
-        steps:
-          - task: Docker@2
-            displayName: "login to docker hub"
-            inputs:
-              command: "login"
-              containerRegistry: "apachehudi-docker-hub"
-          - task: Docker@2
-            displayName: "load repo into image"
-            inputs:
-              containerRegistry: 'apachehudi-docker-hub'
-              repository: 'apachehudi/hudi-ci-bundle-validation-base'
-              command: 'build'
-              Dockerfile: '**/Dockerfile'
-              ImageName: $(Build.BuildId)
-          - task: Docker@2
-            displayName: "UT FT common & other modules"
-            inputs:
-              containerRegistry: 'apachehudi-docker-hub'
-              repository: 'apachehudi/hudi-ci-bundle-validation-base'
-              command: 'run'
-              # UT_FT_10 builds the full reactor with `clean install`. Under the
-              # shared MVN_OPTS_INSTALL `-T 3`, concurrent module builds (notably
-              # parallel maven-shade of large bundles) can spike heap past the 8g
-              # ceiling and flakily OOM. Prepend `-T 2` below so Maven (first -T
-              # wins) caps concurrency for THIS job's install only; other jobs
-              # keep the shared -T 3.
-              arguments: >
-                -v $(Build.SourcesDirectory):/hudi
-                -v /var/run/docker.sock:/var/run/docker.sock
-                -i docker.io/apachehudi/hudi-ci-bundle-validation-base:$(Build.BuildId)
-                /bin/bash -c "MAVEN_OPTS='-Xmx8g' mvn clean install -T 2 $(MVN_OPTS_INSTALL) -Phudi-platform-service -Pthrift-gen-source
-                && mvn test  $(MVN_OPTS_TEST) -Punit-tests -Dsurefire.failIfNoSpecifiedTests=false $(JACOCO_AGENT_DESTFILE1_ARG) -pl $(JOB10_UT_MODULES)
-                && mvn test  $(MVN_OPTS_TEST) -Punit-tests $(JACOCO_AGENT_DESTFILE2_ARG) -Dtest="!TestHoodie*" -Dsurefire.failIfNoSpecifiedTests=false -pl hudi-utilities
-                && mvn test  $(MVN_OPTS_TEST) -Pfunctional-tests -Dsurefire.failIfNoSpecifiedTests=false  $(JACOCO_AGENT_DESTFILE3_ARG) -pl $(JOB10_FT_MODULES)"
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            inputs:
-              testResultsFormat: 'JUnit'
-              testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              searchFolder: '$(Build.SourcesDirectory)'
-              failTaskOnFailedTests: true
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_exec_files.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/merged-jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-10'
-              publishLocation: 'Container'
-          - script: |
-              grep "testcase" */target/surefire-reports/*.xml */*/target/surefire-reports/*.xml | awk -F'"' ' { print $6,$4,$2 } ' | sort -nr | head -n 100
-            displayName: Top 100 long-running testcases
-      - job: MergeAndPublishCoverage
-        displayName: 'Merge and Publish JaCoCo Code Coverage'
-        dependsOn:
-          - UT_FT_1
-          - UT_FT_2
-          - UT_FT_3
-          - UT_FT_4
-          - UT_FT_5
-          - UT_FT_6
-          - UT_FT_7
-          - UT_FT_8
-          - UT_FT_9
-          - UT_FT_10
-        steps:
-          - task: DownloadBuildArtifacts@0
-            displayName: 'Download JaCoCo Execution Data Files'
-            inputs:
-              buildType: 'current'
-              downloadType: 'specific'
-              downloadPath: '$(System.ArtifactsDirectory)'
-              itemPattern: |
-                **/merged-jacoco-$(Build.BuildId)-*/*.exec
-          - task: JavaToolInstaller@0
-            inputs:
-              versionSpec: '8'
-              jdkArchitectureOption: 'x64'
-              jdkSourceOption: 'PreInstalled'
-          - script: |
-              ./scripts/jacoco/download_jacoco.sh
-              ./scripts/jacoco/merge_jacoco_job_files.sh jacoco-lib/lib/jacococli.jar $(System.ArtifactsDirectory) $(Build.SourcesDirectory)
-            displayName: 'Merge JaCoCo Execution Data Files'
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Merged JaCoCo Execution Data File'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/jacoco.exec'
-              ArtifactName: 'merged-jacoco-$(Build.BuildId)-final'
-              publishLocation: 'Container'
-          - task: Maven@4
-            displayName: 'Aggregate Source and Class Files for JaCoCo'
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'clean package'
-              options: $(MVN_OPTS_INSTALL) -Pcopy-files-for-jacoco -pl $(JACOCO_MODULES)
-              publishJUnitResults: false
-              jdkVersionOption: '11'
-          - script: |
-              ./scripts/jacoco/generate_jacoco_coverage_report.sh jacoco-lib/lib/jacococli.jar $(Build.SourcesDirectory)
-            displayName: 'Generate JaCoCo Code Coverage Report'
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish JaCoCo Code Coverage'
-            inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: '$(Build.SourcesDirectory)/jacoco-report.xml'
-              reportDirectory: '$(Build.SourcesDirectory)/jacoco-html-report'
-              failIfCoverageEmpty: true
+              echo "=== surefire-reports summary ==="
+              find . -path '*/surefire-reports/TEST-*.xml' -print -exec head -5 {} \; -exec echo --- \;
+              echo "=== /surefire-reports summary ==="
+            displayName: 'Surefire report listing'
+            condition: always()

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -178,6 +178,54 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     cleanupResources();
   }
 
+  /**
+   * Triage helper added on the ci-triage-multiwriter-zk branch.
+   *
+   * <p>Wraps {@code new TestingServer()} so we can attribute Azure CI flakes that
+   * look like {@code BindException: Address already in use} or
+   * {@code HoodieLockException: Failed to connect to ZooKeeper within 10000 ms}
+   * to the underlying socket-bind step rather than to any patch under test.
+   *
+   * <p>Logs the chosen ZK port, the time-to-bind, and the JVM PID + hostname.
+   * On {@code BindException} (or any nested {@code BindException} cause) it
+   * retries up to 5 times with a short backoff. Other failures rethrow.
+   */
+  private TestingServer startTestingServerWithDiagnostics() throws Exception {
+    final int maxAttempts = 5;
+    Exception lastFailure = null;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      long startNanos = System.nanoTime();
+      try {
+        TestingServer server = new TestingServer();
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+        String pid = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+        String host = java.net.InetAddress.getLocalHost().getHostName();
+        LOG.info("[ZK-triage] TestingServer started: port={} connectString={} tempDir={} bindMillis={} attempt={} jvm={} host={}",
+            server.getPort(), server.getConnectString(), server.getTempDirectory().getAbsolutePath(),
+            elapsedMs, attempt, pid, host);
+        return server;
+      } catch (Exception e) {
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+        boolean isBindException = false;
+        for (Throwable t = e; t != null; t = t.getCause()) {
+          if (t instanceof java.net.BindException) {
+            isBindException = true;
+            break;
+          }
+        }
+        LOG.warn("[ZK-triage] TestingServer start failed attempt={} bindException={} bindMillis={} message={}",
+            attempt, isBindException, elapsedMs, e.toString(), e);
+        lastFailure = e;
+        if (!isBindException) {
+          throw e;
+        }
+        Thread.sleep(500L * attempt);
+      }
+    }
+    LOG.error("[ZK-triage] TestingServer failed to start after {} attempts", maxAttempts, lastFailure);
+    throw lastFailure;
+  }
+
   private static final List<Class> LOCK_PROVIDER_CLASSES = Arrays.asList(
       // [HUDI-8887] Based on OS/docker container used, the underlying file system API might not support
       // atomic operations which impairs the functionality of lock provider. Disable the test dimension to
@@ -465,7 +513,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     TestingServer server = null;
     if (earlyConflictDetectionStrategy.equalsIgnoreCase(SimpleTransactionDirectMarkerBasedDetectionStrategy.class.getName())) {
       // need to setup zk related env there. Bcz SimpleTransactionDirectMarkerBasedDetectionStrategy is only support zk lock for now.
-      server = new TestingServer();
+      server = startTestingServerWithDiagnostics();
       Properties properties = new Properties();
       properties.setProperty(ZK_BASE_PATH_PROP_KEY, basePath);
       properties.setProperty(ZK_CONNECT_URL_PROP_KEY, server.getConnectString());


### PR DESCRIPTION
**DO NOT MERGE — temporary triage branch.**

Recent Azure CI runs on #18147 and #18650 fail on the same Spark 4.0 java-tests-part2 job with:

```
Caused by: java.net.BindException: Address already in use
Caused by: org.apache.hudi.exception.HoodieLockException: Failed to connect to ZooKeeper within 10000 ms
  at org.apache.hudi.client.transaction.lock.BaseZookeeperBasedLockProvider.<init>(BaseZookeeperBasedLockProvider.java:86)
```

Neither PR touches lock providers, ZK, or the test harness — strongly suggests a runner-resource / port-bind flake in the Curator `TestingServer` used inside `TestHoodieClientMultiWriter.testHoodieClientBasicMultiWriterWithEarlyConflictDetectionDirect`.

This branch is opened against `apache/hudi:master` purely so the Apache Azure CI pipeline runs on it. Contents:

- `.github/workflows/bot.yml` — disabled (workflow_dispatch only) so the GA matrix does not consume runners during triage.
- `azure-pipelines-20230430.yml` — stripped from 10 jobs to a single job that builds `hudi-spark-datasource/hudi-spark -am -DskipTests` then runs `mvn test -Dtest=TestHoodieClientMultiWriter` only. Pre- and post-test diagnostic steps print `ip_local_port_range`, `ss -tlnp`, `ulimit -a` so port-bind contention is visible in the Azure log.
- `TestHoodieClientMultiWriter.java` — wraps the single `new TestingServer()` call in `startTestingServerWithDiagnostics()` which logs bound port, bind latency, JVM PID, hostname, and retries up to 5× on nested `BindException`.

Will close once we have the diagnostic data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)