### PR TITLE
fix(test): close TestingServer + write clients on all exit paths in TestHoodieClientMultiWriter

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -85,6 +85,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -500,71 +501,83 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
       writeConfig = buildWriteConfigForEarlyConflictDetect(markerType, properties, InProcessLockProvider.class, earlyConflictDetectionStrategy);
     }
 
-    final SparkRDDWriteClient client1 = getHoodieWriteClient(writeConfig);
+    SparkRDDWriteClient client1 = null;
+    SparkRDDWriteClient client2 = null;
+    SparkRDDWriteClient client3 = null;
+    SparkRDDWriteClient client4 = null;
+    try {
+      client1 = getHoodieWriteClient(writeConfig);
 
-    // Create the first commit
-    final String nextCommitTime1 = "001";
-    createCommitWithInserts(writeConfig, client1, "000", nextCommitTime1, 200);
+      // Create the first commit
+      final String nextCommitTime1 = "001";
+      createCommitWithInserts(writeConfig, client1, "000", nextCommitTime1, 200);
 
-    final SparkRDDWriteClient client2 = getHoodieWriteClient(writeConfig);
-    final SparkRDDWriteClient client3 = getHoodieWriteClient(writeConfig);
+      client2 = getHoodieWriteClient(writeConfig);
+      client3 = getHoodieWriteClient(writeConfig);
 
-    final String nextCommitTime2 = "002";
+      final String nextCommitTime2 = "002";
 
-    // start to write commit 002
-    final JavaRDD<WriteStatus> writeStatusList2 = startCommitForUpdate(writeConfig, client2, nextCommitTime2, 100);
+      // start to write commit 002
+      final SparkRDDWriteClient finalClient2 = client2;
+      final JavaRDD<WriteStatus> writeStatusList2 = startCommitForUpdate(writeConfig, client2, nextCommitTime2, 100);
 
-    // start to write commit 003
-    // this commit 003 will fail quickly because early conflict detection before create marker.
-    final String nextCommitTime3 = "003";
-    assertThrows(SparkException.class, () -> {
-      final JavaRDD<WriteStatus> writeStatusList3 =
-          startCommitForUpdate(writeConfig, client3, nextCommitTime3, 100);
-      client3.commit(nextCommitTime3, writeStatusList3);
-    }, "Early conflict detected but cannot resolve conflicts for overlapping writes");
+      // start to write commit 003
+      // this commit 003 will fail quickly because early conflict detection before create marker.
+      final String nextCommitTime3 = "003";
+      final SparkRDDWriteClient finalClient3 = client3;
+      assertThrows(SparkException.class, () -> {
+        final JavaRDD<WriteStatus> writeStatusList3 =
+            startCommitForUpdate(writeConfig, finalClient3, nextCommitTime3, 100);
+        finalClient3.commit(nextCommitTime3, writeStatusList3);
+      }, "Early conflict detected but cannot resolve conflicts for overlapping writes");
 
-    // start to commit 002 and success
-    assertDoesNotThrow(() -> {
-      client2.commit(nextCommitTime2, writeStatusList2);
-    });
+      // start to commit 002 and success
+      assertDoesNotThrow(() -> {
+        finalClient2.commit(nextCommitTime2, writeStatusList2);
+      });
 
-    HoodieWriteConfig config4 =
-        HoodieWriteConfig.newBuilder().withProperties(writeConfig.getProps())
-            .withHeartbeatIntervalInMs(heartBeatIntervalForCommit4).build();
-    final SparkRDDWriteClient client4 = getHoodieWriteClient(config4);
+      HoodieWriteConfig config4 =
+          HoodieWriteConfig.newBuilder().withProperties(writeConfig.getProps())
+              .withHeartbeatIntervalInMs(heartBeatIntervalForCommit4).build();
+      client4 = getHoodieWriteClient(config4);
 
-    StoragePath heartbeatFilePath = new StoragePath(
-        HoodieTableMetaClient.getHeartbeatFolderPath(basePath) + StoragePath.SEPARATOR + nextCommitTime3);
-    storage.create(heartbeatFilePath, true);
+      StoragePath heartbeatFilePath = new StoragePath(
+          HoodieTableMetaClient.getHeartbeatFolderPath(basePath) + StoragePath.SEPARATOR + nextCommitTime3);
+      storage.create(heartbeatFilePath, true);
 
-    // Wait for heart beat expired for failed commitTime3 "003"
-    // Otherwise commit4 still can see conflict between failed write 003. The early-conflict
-    // check treats 003 as alive until its heartbeat is older than
-    // (tolerable misses * heartbeat interval); tolerable misses is pinned in
-    // buildWriteConfigForEarlyConflictDetect, so wait one interval past that window.
-    Thread.sleep(heartBeatIntervalForCommit4 * (EARLY_CONFLICT_HEARTBEAT_TOLERABLE_MISSES + 1));
+      // Wait for heart beat expired for failed commitTime3 "003"
+      // Otherwise commit4 still can see conflict between failed write 003. The early-conflict
+      // check treats 003 as alive until its heartbeat is older than
+      // (tolerable misses * heartbeat interval); tolerable misses is pinned in
+      // buildWriteConfigForEarlyConflictDetect, so wait one interval past that window.
+      Thread.sleep(heartBeatIntervalForCommit4 * (EARLY_CONFLICT_HEARTBEAT_TOLERABLE_MISSES + 1));
 
-    final String nextCommitTime4 = "004";
-    assertDoesNotThrow(() -> {
-      final JavaRDD<WriteStatus> writeStatusList4 =
-          startCommitForUpdate(writeConfig, client4, nextCommitTime4, 100);
-      client4.commit(nextCommitTime4, writeStatusList4);
-    });
+      final String nextCommitTime4 = "004";
+      final SparkRDDWriteClient finalClient4 = client4;
+      assertDoesNotThrow(() -> {
+        final JavaRDD<WriteStatus> writeStatusList4 =
+            startCommitForUpdate(writeConfig, finalClient4, nextCommitTime4, 100);
+        finalClient4.commit(nextCommitTime4, writeStatusList4);
+      });
 
-    List<String> completedInstant = metaClient.reloadActiveTimeline().getCommitsTimeline()
-        .filterCompletedInstants().getInstants().stream()
-        .map(HoodieInstant::requestedTime).collect(Collectors.toList());
+      List<String> completedInstant = metaClient.reloadActiveTimeline().getCommitsTimeline()
+          .filterCompletedInstants().getInstants().stream()
+          .map(HoodieInstant::requestedTime).collect(Collectors.toList());
 
-    assertEquals(3, completedInstant.size());
-    assertTrue(completedInstant.contains(nextCommitTime1));
-    assertTrue(completedInstant.contains(nextCommitTime2));
-    assertTrue(completedInstant.contains(nextCommitTime4));
+      assertEquals(3, completedInstant.size());
+      assertTrue(completedInstant.contains(nextCommitTime1));
+      assertTrue(completedInstant.contains(nextCommitTime2));
+      assertTrue(completedInstant.contains(nextCommitTime4));
 
-    FileIOUtils.deleteDirectory(new File(basePath));
-    client1.close();
-    client2.close();
-    client3.close();
-    client4.close();
+      FileIOUtils.deleteDirectory(new File(basePath));
+    } finally {
+      // Close the write clients on every exit path, including failed assertions.
+      // The TestingServer itself is closed by @AfterEach (see zkTestingServer above).
+      FileIOUtils.closeQuietly(client1 == null ? null : (Closeable) client1::close);
+      FileIOUtils.closeQuietly(client2 == null ? null : (Closeable) client2::close);
+      FileIOUtils.closeQuietly(client3 == null ? null : (Closeable) client3::close);
+      FileIOUtils.closeQuietly(client4 == null ? null : (Closeable) client4::close);
+    }
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Rebased on master after #19069 landed. That PR fixed the root cause of the early-conflict-detection flake (`hoodie.client.heartbeat.tolerable.misses` default raised in #18904 to 10, plus the ZK admin server's fixed port 8080 colliding under `reuseForks=true`) and moved the `TestingServer` cleanup into a `@AfterEach`.

This PR is now reduced to the small remaining cleanup that #19069 did not cover: the four `SparkRDDWriteClient`s in `testHoodieClientBasicMultiWriterWithEarlyConflictDetection` are still constructed in the test body and closed at the tail, outside any `try/finally`. A failed assertion short of the tail leaks all four for the lifetime of the surefire JVM.

### Summary and Changelog

- Wrap the body of `testHoodieClientBasicMultiWriterWithEarlyConflictDetection` in `try/finally` so the four `SparkRDDWriteClient`s are closed on every exit path, including failed assertions.
- Route the four `close()` calls through `FileIOUtils.closeQuietly(...)` so the `finally` block does not mask the original failure with a secondary `close()` exception.

The `TestingServer` field + `@AfterEach` cleanup that #19069 already added is left untouched.

### Impact

Test-only change. No production code or public API is touched.

### Risk Level

none — only test code.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable