### PR TITLE
feat: support write native format log files

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/AppendHandleFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/AppendHandleFactory.java
@@ -19,17 +19,37 @@
 package org.apache.hudi.io;
 
 import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
+
+import java.util.Iterator;
 
 public class AppendHandleFactory<T, I, K, O> extends WriteHandleFactory<T, I, K, O> {
 
   @Override
   public HoodieAppendHandle<T, I, K, O> create(final HoodieWriteConfig hoodieConfig, final String commitTime,
-                                     final HoodieTable<T, I, K, O> hoodieTable, final String partitionPath,
-                                     final String fileIdPrefix, final TaskContextSupplier sparkTaskContextSupplier) {
+                                               final HoodieTable<T, I, K, O> hoodieTable, final String partitionPath,
+                                               final String fileIdPrefix, final TaskContextSupplier sparkTaskContextSupplier) {
 
-    return new HoodieAppendHandle(hoodieConfig, commitTime, hoodieTable, partitionPath,
-        getNextFileId(fileIdPrefix), sparkTaskContextSupplier);
+    String fileId = getNextFileId(fileIdPrefix);
+    if (hoodieTable.getMetaClient().getTableConfig().isLSMTreeStorageLayout()) {
+      return new HoodieNativeLogAppendHandle<>(hoodieConfig, commitTime, hoodieTable, partitionPath,
+          fileId, sparkTaskContextSupplier);
+    }
+    return new HoodieInlineLogAppendHandle<>(hoodieConfig, commitTime, hoodieTable, partitionPath,
+        fileId, sparkTaskContextSupplier);
+  }
+
+  public HoodieAppendHandle<T, I, K, O> create(final HoodieWriteConfig hoodieConfig, final String commitTime,
+                                               final HoodieTable<T, I, K, O> hoodieTable, final String partitionPath,
+                                               final String fileId, final Iterator<HoodieRecord<T>> recordItr,
+                                               final TaskContextSupplier sparkTaskContextSupplier) {
+    if (hoodieTable.getMetaClient().getTableConfig().isLSMTreeStorageLayout()) {
+      return new HoodieNativeLogAppendHandle<>(hoodieConfig, commitTime, hoodieTable, partitionPath,
+          fileId, recordItr, sparkTaskContextSupplier);
+    }
+    return new HoodieInlineLogAppendHandle<>(hoodieConfig, commitTime, hoodieTable, partitionPath,
+        fileId, recordItr, sparkTaskContextSupplier);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedInlineLogAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedInlineLogAppendHandle.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.config.HoodieMemoryConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.CompactionOperation;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.read.HoodieFileGroupReader;
+import org.apache.hudi.common.table.read.HoodieReadStats;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.exception.HoodieUpsertException;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.utils.SerDeHelper;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieTable;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.config.HoodieReaderConfig.MERGE_USE_RECORD_POSITIONS;
+
+/**
+ * A base append handle implementation based on the {@link HoodieFileGroupReader}.
+ * <p>
+ * This append-handle is used for log-compaction, which passes a file slice from the
+ * compaction operation of a single file group to a file group reader, get an iterator of
+ * the records, and writes the records to a new log file.
+ */
+@NotThreadSafe
+public class FileGroupReaderBasedInlineLogAppendHandle<T, I, K, O> extends HoodieInlineLogAppendHandle<T, I, K, O> {
+  private final HoodieReaderContext<T> readerContext;
+  private final CompactionOperation operation;
+  private HoodieReadStats readStats;
+
+  public FileGroupReaderBasedInlineLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                                          CompactionOperation operation, TaskContextSupplier taskContextSupplier, HoodieReaderContext<T> readerContext) {
+    super(config, instantTime, hoodieTable, operation.getPartitionPath(), operation.getFileId(), taskContextSupplier);
+    this.operation = operation;
+    this.readerContext = readerContext;
+  }
+
+  @Override
+  public void doAppend() {
+    boolean usePosition = config.getBooleanOrDefault(MERGE_USE_RECORD_POSITIONS);
+    Option<InternalSchema> internalSchemaOption = SerDeHelper.fromJson(config.getInternalSchema());
+    TypedProperties props = TypedProperties.copy(config.getProps());
+    long maxMemoryPerCompaction = IOUtils.getMaxMemoryPerCompaction(taskContextSupplier, config);
+    props.put(HoodieMemoryConfig.MAX_MEMORY_FOR_MERGE.key(), String.valueOf(maxMemoryPerCompaction));
+    Stream<HoodieLogFile> logFiles = operation.getDeltaFileNames().stream().map(logFileName ->
+        new HoodieLogFile(new StoragePath(FSUtils.constructAbsolutePath(
+            config.getBasePath(), operation.getPartitionPath()), logFileName)));
+    // Initializes the record iterator, log compaction requires writing the deletes into the delete block of the resulting log file.
+    try (HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>builder()
+        .withReaderContext(readerContext)
+        .withHoodieTableMetaClient(hoodieTable.getMetaClient())
+        .withLatestCommitTime(instantTime)
+        .withPartitionPath(partitionPath)
+        .withLogFiles(logFiles)
+        .withBaseFileOption(Option.empty())
+        .withDataSchema(writeSchemaWithMetaFields)
+        .withRequestedSchema(writeSchemaWithMetaFields)
+        .withInternalSchemaOpt(internalSchemaOption)
+        .withProps(props)
+        .withEmitDelete(true)
+        .withShouldUseRecordPosition(usePosition)
+        .withSortOutput(hoodieTable.requireSortedRecords())
+        // instead of using config.enableOptimizedLogBlocksScan(), we set to true as log compaction blocks only supported in scanV2
+        .build()) {
+      recordItr = new CloseableMappingIterator<>(fileGroupReader.getLogRecordsOnly(), record -> {
+        HoodieRecord<T> hoodieRecord = readerContext.getRecordContext().constructHoodieRecord(record);
+        hoodieRecord.setCurrentLocation(newRecordLocation);
+        return hoodieRecord;
+      });
+      header.put(HoodieLogBlock.HeaderMetadataType.COMPACTED_BLOCK_TIMES,
+          StringUtils.join(fileGroupReader.getValidBlockInstants(), ","));
+      super.doAppend();
+      this.readStats = fileGroupReader.getReadStats();
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to initialize file group reader for " + fileId, e);
+    }
+  }
+
+  @Override
+  public List<WriteStatus> close() {
+    try {
+      super.close();
+      writeStatus.getStat().setPartitionPath(operation.getPartitionPath());
+      writeStatus.getStat().setTotalLogReadTimeMs(readStats.getTotalLogReadTimeMs());
+      writeStatus.getStat().setTotalUpdatedRecordsCompacted(readStats.getTotalUpdatedRecordsCompacted());
+      writeStatus.getStat().setTotalLogFilesCompacted(readStats.getTotalLogFilesCompacted());
+      writeStatus.getStat().setTotalLogRecords(readStats.getTotalLogRecords());
+      writeStatus.getStat().setTotalLogBlocks(readStats.getTotalLogBlocks());
+      writeStatus.getStat().setTotalCorruptLogBlock(readStats.getTotalCorruptLogBlock());
+      writeStatus.getStat().setTotalRollbackBlocks(readStats.getTotalRollbackBlocks());
+      writeStatus.getStat().setTotalLogSizeCompacted(readStats.getTotalLogSizeCompacted());
+
+      if (writeStatus.getStat().getRuntimeStats() != null) {
+        writeStatus.getStat().getRuntimeStats().setTotalScanTime(readStats.getTotalLogReadTimeMs());
+      }
+      writeStatus.getStat().setPrevCommit(operation.getBaseInstantTime());
+      return Collections.singletonList(writeStatus);
+    } catch (Exception e) {
+      throw new HoodieUpsertException("Failed to close " + this.getClass().getSimpleName(), e);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedNativeLogAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedNativeLogAppendHandle.java
@@ -52,20 +52,17 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.config.HoodieReaderConfig.MERGE_USE_RECORD_POSITIONS;
 
 /**
- * A base append handle implementation based on the {@link HoodieFileGroupReader}.
- * <p>
- * This append-handle is used for log-compaction, which passes a file slice from the
- * compaction operation of a single file group to a file group reader, get an iterator of
- * the records, and writes the records to a new log file.
+ * File-group-reader based log-compaction append handle for native MOR log files.
  */
 @NotThreadSafe
-public class FileGroupReaderBasedAppendHandle<T, I, K, O> extends HoodieAppendHandle<T, I, K, O> {
+public class FileGroupReaderBasedNativeLogAppendHandle<T, I, K, O> extends HoodieNativeLogAppendHandle<T, I, K, O> {
   private final HoodieReaderContext<T> readerContext;
   private final CompactionOperation operation;
   private HoodieReadStats readStats;
 
-  public FileGroupReaderBasedAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
-                                          CompactionOperation operation, TaskContextSupplier taskContextSupplier, HoodieReaderContext<T> readerContext) {
+  public FileGroupReaderBasedNativeLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                                                   CompactionOperation operation, TaskContextSupplier taskContextSupplier,
+                                                   HoodieReaderContext<T> readerContext) {
     super(config, instantTime, hoodieTable, operation.getPartitionPath(), operation.getFileId(), taskContextSupplier);
     this.operation = operation;
     this.readerContext = readerContext;
@@ -81,7 +78,6 @@ public class FileGroupReaderBasedAppendHandle<T, I, K, O> extends HoodieAppendHa
     Stream<HoodieLogFile> logFiles = operation.getDeltaFileNames().stream().map(logFileName ->
         new HoodieLogFile(new StoragePath(FSUtils.constructAbsolutePath(
             config.getBasePath(), operation.getPartitionPath()), logFileName)));
-    // Initializes the record iterator, log compaction requires writing the deletes into the delete block of the resulting log file.
     try (HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>builder()
         .withReaderContext(readerContext)
         .withHoodieTableMetaClient(hoodieTable.getMetaClient())

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
-import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
@@ -35,171 +34,242 @@ import org.apache.hudi.common.model.HoodieWriteStat.RuntimeStats;
 import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.model.MetadataValues;
 import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.schema.HoodieSchemaField;
-import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.log.AppendResult;
-import org.apache.hudi.common.table.log.HoodieLogFormat;
-import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
-import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
-import org.apache.hudi.common.table.log.block.HoodieHFileDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
-import org.apache.hudi.common.table.log.block.HoodieParquetDataBlock;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.table.view.TableFileSystemView;
-import org.apache.hudi.common.util.ConfigUtils;
-import org.apache.hudi.common.util.DefaultSizeEstimator;
 import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
-import org.apache.hudi.common.util.SizeEstimator;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.exception.HoodieAppendException;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieUpsertException;
-import org.apache.hudi.metadata.HoodieIndexVersion;
-import org.apache.hudi.metadata.HoodieTableMetadataUtil;
-import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
-import org.apache.hudi.util.CommonClientUtils;
-import org.apache.hudi.util.Lazy;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_DYNAMIC_MAX_ENTRIES;
-import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_FPP_VALUE;
-import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_NUM_ENTRIES_VALUE;
-import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_TYPE;
-import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_COMPRESSION_ALGORITHM_NAME;
-import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_WITH_BLOOM_FILTER_ENABLED;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.collectColumnRangeMetadata;
-
 /**
- * IO Operation to append data onto an existing file.
+ * Shared base for append handles writing merge-on-read log files.
+ *
+ * <p>This class owns the common append lifecycle:
+ * <ol>
+ *   <li>Initialize write status and log writer state for the target file group.</li>
+ *   <li>Iterate incoming {@link HoodieRecord}s and route each record as an insert/update or delete.</li>
+ *   <li>Track write counters, record locations, write-status success/failure state, and runtime stats.</li>
+ *   <li>Flush pending records to one or more physical log files and update {@link HoodieDeltaWriteStat}s.</li>
+ *   <li>Close the record iterator and log writer, then publish secondary-index streaming stats when enabled.</li>
+ * </ol>
+ *
+ * <p>Concrete subclasses provide only the physical log representation. Inline-log handles buffer records
+ * into Hudi log blocks, while native-log handles stream records into engine-native file writers. Both variants
+ * share the same accounting and status update logic through this class.
  */
 @Slf4j
-public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O> {
-  // This acts as the sequenceID for records written
+public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O> {
+
   private static final AtomicLong RECORD_COUNTER = new AtomicLong(1);
-  private static final int NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE = 100;
 
-  // Buffer for holding records in memory before they are flushed to disk
-  protected final List<HoodieRecord> recordList = new ArrayList<>();
-  // Buffer for holding records (to be deleted), along with their position in log block, in memory before they are flushed to disk
-  protected final List<Pair<DeleteRecord, Long>> recordsToDeleteWithPositions = new ArrayList<>();
-  // Base file instant time of the record positions
-  protected final Option<String> baseFileInstantTimeOfPositions;
-  // Incoming records to be written to logs.
   protected Iterator<HoodieRecord<T>> recordItr;
-  // Writer to log into the file group's latest slice.
-  protected HoodieLogFormat.Writer writer;
-
-  protected final List<WriteStatus> statuses;
-  // Total number of records written during appending
-  protected long recordsWritten = 0;
-  // Total number of records deleted during appending
-  protected long recordsDeleted = 0;
-  // Total number of records updated during appending
-  protected long updatedRecordsWritten = 0;
-  // Total number of new records inserted into the delta file
-  protected long insertRecordsWritten = 0;
-
-  // Average record size for a HoodieRecord. This size is updated at the end of every log block flushed to disk
-  private long averageRecordSize = 0;
-  // Flag used to initialize some metadata
-  private boolean doInit = true;
-  // Total number of bytes written during this append phase (an estimation)
-  protected long estimatedNumberOfBytesWritten;
-  // Number of records that must be written to meet the max block size for a log block
-  private long numberOfRecords = 0;
-  // Max block size to limit to for a log block
-  private final long maxBlockSize = config.getLogFileDataBlockMaxSize();
-  // Header metadata for a log block
+  protected final List<WriteStatus> statuses = new ArrayList<>();
   protected final Map<HeaderMetadataType, String> header = new HashMap<>();
-  private final SizeEstimator<HoodieRecord> sizeEstimator;
-  // This is used to distinguish between normal append and logcompaction's append operation.
-  private boolean isLogCompaction = false;
-  // use writer schema for log compaction.
-  private boolean useWriterSchema = false;
+  protected final Properties recordProperties = new Properties();
+  protected final Option<String> baseFileInstantTimeOfPositions;
+  protected boolean isLogCompaction = false;
+  protected boolean useWriterSchema = false;
+  protected boolean doInit = true;
+  protected long recordsWritten = 0;
+  protected long recordsDeleted = 0;
+  protected long updatedRecordsWritten = 0;
+  protected long insertRecordsWritten = 0;
+  protected Option<HoodieLogBlock> appendDataBlock = Option.empty();
 
-  private final Properties recordProperties = new Properties();
-  private final String[] orderingFields;
-
-  /**
-   * This is used by log compaction only.
-   */
-  public HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
-                            String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr,
-                            TaskContextSupplier taskContextSupplier, Map<HeaderMetadataType, String> header) {
-    this(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, true);
-    this.useWriterSchema = true;
-    this.isLogCompaction = true;
-    this.header.putAll(header);
-  }
-
-  public HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
-                            String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr, TaskContextSupplier taskContextSupplier) {
+  protected HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                               String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr,
+                               TaskContextSupplier taskContextSupplier) {
     this(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, false);
   }
 
-  private HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
-                             String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr, TaskContextSupplier taskContextSupplier, boolean preserveMetadata) {
+  protected HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                               String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr,
+                               TaskContextSupplier taskContextSupplier, Map<HeaderMetadataType, String> header) {
+    this(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, true);
+    this.header.putAll(header);
+  }
+
+  protected HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                               String partitionPath, String fileId, TaskContextSupplier taskContextSupplier) {
+    this(config, instantTime, hoodieTable, partitionPath, fileId, null, taskContextSupplier);
+  }
+
+  protected HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                               String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr,
+                               TaskContextSupplier taskContextSupplier, boolean preserveMetadata) {
     super(config, instantTime, partitionPath, fileId, hoodieTable,
         config.shouldWritePartialUpdates()
-            // When enabling writing partial updates to the data blocks in log files,
-            // i.e., partial update schema is set, the writer schema is the partial
-            // schema containing the updated fields only
             ? Option.of(HoodieSchema.parse(config.getPartialUpdateSchema()))
             : Option.empty(),
         taskContextSupplier,
         preserveMetadata);
     this.recordItr = recordItr;
-    this.sizeEstimator = getSizeEstimator();
-    this.statuses = new ArrayList<>();
+    this.isLogCompaction = preserveMetadata;
+    this.useWriterSchema = preserveMetadata;
     this.recordProperties.putAll(config.getProps());
-    this.orderingFields = ConfigUtils.getOrderingFields(recordProperties);
-    boolean shouldWriteRecordPositions = config.shouldWriteRecordPositions()
-        // record positions supported only from table version 8
-        && config.getWriteVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT);
-    this.baseFileInstantTimeOfPositions = shouldWriteRecordPositions
+    this.baseFileInstantTimeOfPositions = config.shouldWriteRecordPositions()
+        && config.getWriteVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
         ? getBaseFileInstantTimeOfPositions()
         : Option.empty();
   }
 
-  public HoodieAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
-                            String partitionPath, String fileId, TaskContextSupplier sparkTaskContextSupplier) {
-    this(config, instantTime, hoodieTable, partitionPath, fileId, null, sparkTaskContextSupplier);
+  protected HoodieAppendHandle(HoodieWriteConfig config, String instantTime, String partitionPath, String fileId,
+                               HoodieTable<T, I, K, O> hoodieTable, Option<HoodieSchema> writerSchema,
+                               TaskContextSupplier taskContextSupplier, boolean preserveMetadata) {
+    super(config, instantTime, partitionPath, fileId, hoodieTable, writerSchema, taskContextSupplier, preserveMetadata);
+    this.baseFileInstantTimeOfPositions = config.shouldWriteRecordPositions()
+        && config.getWriteVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
+        ? getBaseFileInstantTimeOfPositions()
+        : Option.empty();
   }
 
-  protected SizeEstimator<HoodieRecord> getSizeEstimator() {
-    return new DefaultSizeEstimator<>();
+  /**
+   * Writes all records from the incoming iterator and flushes remaining pending data.
+   */
+  public void doAppend() {
+    while (recordItr.hasNext()) {
+      HoodieRecord<T> record = recordItr.next();
+      writeRecord(record);
+    }
+    flushAppend();
   }
 
-  protected Option<String> getBaseFileInstantTimeOfPositions() {
-    return hoodieTable.getHoodieView().getLatestBaseFile(partitionPath, fileId)
-        .map(HoodieBaseFile::getCommitTime);
+  /**
+   * Writes one record for APIs that call the handle directly instead of using {@link #doAppend()}.
+   */
+  @Override
+  protected void doWrite(HoodieRecord record, HoodieSchema schema, TypedProperties props) {
+    writeRecord(record);
   }
 
-  private Option<FileSlice> populateWriteStatAndFetchFileSlice(HoodieRecord record, HoodieDeltaWriteStat deltaWriteStat) {
+  /**
+   * Writes a keyed record map, primarily used by log compaction paths.
+   */
+  @Override
+  public void write(Map<String, HoodieRecord<T>> recordMap) {
+    try {
+      for (Map.Entry<String, HoodieRecord<T>> entry : recordMap.entrySet()) {
+        HoodieRecord<T> record = entry.getValue();
+        writeRecord(record);
+      }
+      flushAppend();
+    } catch (Exception e) {
+      throw new HoodieUpsertException("Failed to compact blocks for fileId " + fileId, e);
+    }
+  }
+
+  /**
+   * Flushes pending data, closes resources, finalizes log file sizes, and publishes secondary-index stats.
+   */
+  @Override
+  public List<WriteStatus> close() {
+    try {
+      if (isClosed()) {
+        return statuses.isEmpty() ? java.util.Collections.singletonList(writeStatus) : statuses;
+      }
+
+      markClosed();
+      flushAppend();
+      if (recordItr instanceof Closeable) {
+        ((Closeable) recordItr).close();
+      }
+      recordItr = null;
+      closeLogWriter();
+
+      for (WriteStatus status : statuses) {
+        HoodieDeltaWriteStat stat = (HoodieDeltaWriteStat) status.getStat();
+        long appendedBytes = stat.getFileSizeInBytes();
+        stat.setFileSizeInBytes(stat.getLogOffset() + appendedBytes);
+      }
+
+      if (isSecondaryIndexStatsStreamingWritesEnabled && !statuses.isEmpty()) {
+        SecondaryIndexStreamingTracker.trackSecondaryIndexStats(partitionPath, fileId, getReadFileSlice(),
+            statuses.stream().map(status -> status.getStat().getPath()).collect(Collectors.toList()),
+            statuses.get(statuses.size() - 1), hoodieTable, secondaryIndexDefns, config, instantTime, writeSchemaWithMetaFields);
+      }
+
+      return statuses;
+    } catch (IOException e) {
+      throw new HoodieUpsertException("Failed to close " + getClass().getSimpleName(), e);
+    }
+  }
+
+  @Override
+  public IOType getIOType() {
+    return IOType.APPEND;
+  }
+
+  public List<WriteStatus> getWriteStatuses() {
+    return statuses;
+  }
+
+  /**
+   * Lazily initializes the append handle on the first record.
+   *
+   * <p>Initialization is delayed until the first record so that append paths which receive an externally supplied
+   * iterator can still derive file-slice and instant-time details from the actual record being written. The
+   * concrete subclass is responsible for creating the physical writer in {@link #createLogWriterForAppend}.
+   */
+  protected void init(HoodieRecord record) {
+    if (!doInit) {
+      return;
+    }
+
+    HoodieDeltaWriteStat deltaWriteStat = new HoodieDeltaWriteStat();
+    writeStatus.setStat(deltaWriteStat);
+    writeStatus.setFileId(fileId);
+    writeStatus.setPartitionPath(partitionPath);
+    deltaWriteStat.setPartitionPath(partitionPath);
+    deltaWriteStat.setFileId(fileId);
+    Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
+    try {
+      HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
+          new StoragePath(config.getBasePath()),
+          FSUtils.constructAbsolutePath(config.getBasePath(), partitionPath),
+          hoodieTable.getPartitionMetafileFormat());
+      partitionMetadata.trySave();
+
+      String logInstantTime = config.getWriteVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
+          ? getInstantTimeForLogFile(record) : deltaWriteStat.getPrevCommit();
+      createLogWriterForAppend(logInstantTime, fileSliceOpt);
+    } catch (Exception e) {
+      log.error("Error in update task at commit " + instantTime, e);
+      writeStatus.setGlobalError(e);
+      throw new HoodieUpsertException("Failed to initialize HoodieAppendHandle for FileId: " + fileId
+          + " on commit " + instantTime + " on storage path " + hoodieTable.getMetaClient().getBasePath() + "/" + partitionPath, e);
+    }
+    doInit = false;
+  }
+
+  /**
+   * Initializes the first {@link HoodieDeltaWriteStat} for this append handle and fetches the latest file slice.
+   *
+   * <p>The stat needs the previous commit, base file name, and existing log file names before any new log append
+   * happens. Newer table versions use the current instant as the write instant, while older versions still rely
+   * on the latest file slice to determine the previous commit.
+   */
+  protected Option<FileSlice> populateWriteStatAndFetchFileSlice(HoodieRecord record, HoodieDeltaWriteStat deltaWriteStat) {
     HoodieTableVersion tableVersion = hoodieTable.version();
     String prevCommit;
     String baseFile = "";
@@ -207,10 +277,8 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     Option<FileSlice> fileSlice = Option.empty();
 
     if (tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
-      // table versions 8 and greater.
       prevCommit = instantTime;
       if (hoodieTable.getMetaClient().getTableConfig().isCDCEnabled()) {
-        // the cdc reader needs the base file metadata to have deterministic update sequence.
         fileSlice = hoodieTable.getSliceView().getLatestFileSlice(partitionPath, fileId);
         if (fileSlice.isPresent()) {
           prevCommit = fileSlice.get().getBaseInstantTime();
@@ -219,18 +287,13 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
         }
       }
     } else {
-      // older table versions.
       fileSlice = hoodieTable.getSliceView().getLatestFileSlice(partitionPath, fileId);
       if (fileSlice.isPresent()) {
         prevCommit = fileSlice.get().getBaseInstantTime();
         baseFile = fileSlice.get().getBaseFile().map(BaseFile::getFileName).orElse("");
         logFiles = fileSlice.get().getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
       } else {
-        // Set the base commit time as the current instantTime for new inserts into log files
-        // Handle log file only case. This is necessary for the concurrent clustering and writer case (e.g., consistent hashing bucket index).
-        // NOTE: flink engine use instantTime to mark operation type, check BaseFlinkCommitActionExecutor::execute
         prevCommit = getInstantTimeForLogFile(record);
-        // This means there is no base data file, start appending to a new log file
         log.info("New file group from append handle for partition {}", partitionPath);
       }
     }
@@ -241,50 +304,16 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     return fileSlice;
   }
 
-  private void init(HoodieRecord record) {
-    if (!doInit) {
-      return;
-    }
-    // Prepare the first write status
-    HoodieDeltaWriteStat deltaWriteStat = new HoodieDeltaWriteStat();
-    writeStatus.setStat(deltaWriteStat);
-    writeStatus.setFileId(fileId);
-    writeStatus.setPartitionPath(partitionPath);
-    deltaWriteStat.setPartitionPath(partitionPath);
-    deltaWriteStat.setFileId(fileId);
-    Option<FileSlice> fileSliceOpt = populateWriteStatAndFetchFileSlice(record, deltaWriteStat);
-    averageRecordSize = sizeEstimator.sizeEstimate(record);
-    try {
-      // Save hoodie partition meta in the partition path
-      HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(storage, instantTime,
-          new StoragePath(config.getBasePath()),
-          FSUtils.constructAbsolutePath(config.getBasePath(), partitionPath),
-          hoodieTable.getPartitionMetafileFormat());
-      partitionMetadata.trySave();
-
-      String instantTime = config.getWriteVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
-          ? getInstantTimeForLogFile(record) : deltaWriteStat.getPrevCommit();
-      this.writer = createLogWriter(instantTime, fileSliceOpt);
-    } catch (Exception e) {
-      log.error("Error in update task at commit " + instantTime, e);
-      writeStatus.setGlobalError(e);
-      throw new HoodieUpsertException("Failed to initialize HoodieAppendHandle for FileId: " + fileId + " on commit "
-          + instantTime + " on storage path " + hoodieTable.getMetaClient().getBasePath() + "/" + partitionPath, e);
-    }
-    doInit = false;
-  }
-
   /**
-   * Returns the instant time to use in the log file name.
+   * Returns the instant time to use in the new log file name.
+   *
+   * <p>For consistent hashing, records may be tagged with a pending clustering instant. In that case the log file
+   * must use the tagged instant so the dual-write file is shadowed correctly in the reader view.
    */
-  private String getInstantTimeForLogFile(HoodieRecord<?> record) {
+  protected String getInstantTimeForLogFile(HoodieRecord<?> record) {
     if (config.isConsistentHashingEnabled()) {
-      // Handle log file only case. This is necessary for the concurrent clustering and writer case (e.g., consistent hashing bucket index).
-      // NOTE: flink engine use instantTime to mark operation type, check BaseFlinkCommitActionExecutor::execute
       String taggedInstant = HoodieRecordUtils.getCurrentLocationInstant(record);
       if (HoodieInstantTimeGenerator.isValidInstantTime(taggedInstant) && !instantTime.equals(taggedInstant)) {
-        // the tagged instant is the pending clustering instant, use this instant in the file name so that
-        // the dual-write file is shadowed to the reader view.
         return taggedInstant;
       }
     }
@@ -292,52 +321,102 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
   }
 
   /**
-   * Returns whether the hoodie record is an UPDATE.
+   * Returns the base-file instant used to encode record positions in log blocks.
+   *
+   * <p>Record positions are only written for table versions that support them. Subclasses may override this
+   * when an engine-specific writer cannot produce compatible position metadata yet.
    */
-  protected boolean isUpdateRecord(HoodieRecord<T> hoodieRecord) {
-    // If currentLocation is present, then this is an update
-    return hoodieRecord.getCurrentLocation() != null;
+  protected Option<String> getBaseFileInstantTimeOfPositions() {
+    return hoodieTable.getHoodieView().getLatestBaseFile(partitionPath, fileId)
+        .map(HoodieBaseFile::getCommitTime);
   }
 
-  private void bufferRecord(HoodieRecord<T> hoodieRecord) {
+  /**
+   * Returns the file slice visible to readers after this append, used for secondary-index streaming stats.
+   */
+  protected Option<FileSlice> getReadFileSlice() {
+    TableFileSystemView.SliceView rtView = hoodieTable.getSliceView();
+    return rtView.getLatestMergedFileSliceBeforeOrOn(partitionPath, instantTime, fileId);
+  }
+
+  /**
+   * Writes one record through the shared append flow.
+   *
+   * <p>This method performs partition validation, new-location assignment, update/delete routing, payload update
+   * flags, write-status success/failure marking, and record deflation. Subclasses should generally override
+   * {@link #writeInsertAndUpdate} and {@link #writeDelete} instead of this method, unless they need to add
+   * behavior around the whole record-write operation.
+   */
+  protected boolean writeRecord(HoodieRecord<T> hoodieRecord) {
     HoodieSchema schema = useWriterSchema ? writeSchemaWithMetaFields : writeSchema;
     Option<Map<String, String>> recordMetadata = getRecordMetadata(hoodieRecord, schema, recordProperties);
     try {
-      // Pass the isUpdateRecord to the props for HoodieRecordPayload to judge
-      // Whether it is an update or insert record.
+      init(hoodieRecord);
+      if (!partitionPath.equals(hoodieRecord.getPartitionPath())) {
+        HoodieUpsertException failureEx = new HoodieUpsertException("mismatched partition path, record partition: "
+            + hoodieRecord.getPartitionPath() + " but trying to insert into partition: " + partitionPath);
+        writeStatus.markFailure(hoodieRecord, failureEx, recordMetadata);
+        return false;
+      }
+
+      if (needsUpdateLocation()) {
+        hoodieRecord.unseal();
+        hoodieRecord.setNewLocation(newRecordLocation);
+        hoodieRecord.seal();
+      }
+
       boolean isUpdateRecord = isUpdateRecord(hoodieRecord);
       recordProperties.put(HoodiePayloadProps.PAYLOAD_IS_UPDATE_RECORD_FOR_MOR, String.valueOf(isUpdateRecord));
-
-      // Check for delete
       if (config.allowOperationMetadataField() || !hoodieRecord.isDelete(deleteContext, recordProperties)) {
-        bufferInsertAndUpdate(schema, hoodieRecord, isUpdateRecord);
+        writeInsertAndUpdate(schema, hoodieRecord, isUpdateRecord);
       } else {
-        bufferDelete(hoodieRecord);
+        writeDelete(schema, hoodieRecord);
       }
 
       writeStatus.markSuccess(hoodieRecord, recordMetadata);
-      // deflate record payload after recording success. This will help users access payload as a
-      // part of marking
-      // record successful.
       hoodieRecord.deflate();
+      return true;
     } catch (Exception e) {
-      log.error("Error writing record {}", hoodieRecord, e);
+      log.error("Error writing record " + hoodieRecord, e);
       if (!config.getIgnoreWriteFailed()) {
         throw new HoodieException(e.getMessage(), e);
       }
       writeStatus.markFailure(hoodieRecord, e, recordMetadata);
+      return false;
     }
   }
 
-  private MetadataValues populateMetadataFields(HoodieRecord<T> hoodieRecord) {
+  /**
+   * Returns whether a record should be accounted as an update.
+   *
+   * <p>The default implementation follows the record location. Engines with bucket-level append semantics can
+   * override this when update/insert intent is carried by the bucket instead of the individual record.
+   */
+  protected boolean isUpdateRecord(HoodieRecord<T> hoodieRecord) {
+    return hoodieRecord.getCurrentLocation() != null;
+  }
+
+  /**
+   * Returns whether the append flow should assign a new record location before writing.
+   */
+  protected boolean needsUpdateLocation() {
+    return true;
+  }
+
+  /**
+   * Builds metadata values that should be prepended to a record before it is written.
+   *
+   * <p>Log compaction preserves commit metadata from input records, while normal append writes generate new
+   * commit time and sequence number values for the current instant.
+   */
+  protected MetadataValues populateMetadataFields(HoodieRecord<T> hoodieRecord) {
     MetadataValues metadataValues = new MetadataValues();
     if (config.populateMetaFields()) {
-      String seqId =
-          HoodieRecord.generateSequenceId(instantTime, getPartitionId(), RECORD_COUNTER.getAndIncrement());
+      String seqId = HoodieRecord.generateSequenceId(instantTime, getPartitionId(), RECORD_COUNTER.getAndIncrement());
       metadataValues.setFileName(fileId);
       metadataValues.setPartitionPath(partitionPath);
       metadataValues.setRecordKey(hoodieRecord.getRecordKey());
-      if (!this.isLogCompaction) {
+      if (!isLogCompaction) {
         metadataValues.setCommitTime(instantTime);
         metadataValues.setCommitSeqno(seqId);
       }
@@ -345,15 +424,73 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     if (config.allowOperationMetadataField()) {
       metadataValues.setOperation(hoodieRecord.getOperation().getName());
     }
-
     return metadataValues;
   }
 
-  private void initNewStatus() {
-    HoodieDeltaWriteStat prevStat = (HoodieDeltaWriteStat) this.writeStatus.getStat();
-    // Make a new write status and copy basic fields over.
-    HoodieDeltaWriteStat stat = prevStat.copy();
+  protected Map<HeaderMetadataType, String> getUpdatedHeader(Map<HeaderMetadataType, String> header) {
+    Map<HeaderMetadataType, String> updatedHeader = new HashMap<>(header);
+    if (config.shouldWritePartialUpdates()) {
+      updatedHeader.put(HeaderMetadataType.IS_PARTIAL, Boolean.toString(true));
+    }
+    if (baseFileInstantTimeOfPositions.isPresent()) {
+      updatedHeader.put(HeaderMetadataType.BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS, baseFileInstantTimeOfPositions.get());
+    }
+    return updatedHeader;
+  }
 
+  /**
+   * Finalizes accounting for one flushed append.
+   *
+   * <p>Subclasses call this after they flush buffered inline blocks or native writer state. The method updates
+   * write stats, records log-file membership, collects optional column stats, resets per-flush counters, and
+   * restarts the runtime timer for the next append.
+   */
+  protected void processAppendResult(AppendResult result) {
+    HoodieDeltaWriteStat stat = (HoodieDeltaWriteStat) this.writeStatus.getStat();
+    updateWriteStatus(result, stat);
+    stat = (HoodieDeltaWriteStat) this.writeStatus.getStat();
+    updateLogFiles(stat);
+    collectColumnStats(stat);
+    resetWriteCounts();
+    assert stat.getRuntimeStats() != null;
+    log.info("AppendHandle for partitionPath {} filePath {}, took {} ms.", partitionPath,
+        stat.getPath(), stat.getRuntimeStats().getTotalUpsertTime());
+    timer.startTimer();
+  }
+
+  /**
+   * Applies the result of one physical append to the current write status.
+   *
+   * <p>A single handle can write multiple physical log files because of rollover. Appends to the same log file
+   * accumulate into the current stat; appends to a new log file create a new write status.
+   */
+  protected void updateWriteStatus(AppendResult result, HoodieDeltaWriteStat stat) {
+    if (stat.getPath() == null) {
+      updateWriteStat(stat, result);
+      updateWriteCounts(stat, result);
+      updateRuntimeStats(stat);
+      statuses.add(this.writeStatus);
+    } else if (stat.getPath().endsWith(result.logFile().getFileName())) {
+      stat.setLogOffset(Math.min(stat.getLogOffset(), result.offset()));
+      stat.setFileSizeInBytes(stat.getFileSizeInBytes() + result.size());
+      accumulateWriteCounts(stat, result);
+      accumulateRuntimeStats(stat);
+    } else {
+      initNewStatus();
+      stat = (HoodieDeltaWriteStat) this.writeStatus.getStat();
+      updateWriteStat(stat, result);
+      updateWriteCounts(stat, result);
+      updateRuntimeStats(stat);
+      statuses.add(this.writeStatus);
+    }
+  }
+
+  /**
+   * Starts a new write status when a flush rolls over to another physical log file.
+   */
+  protected void initNewStatus() {
+    HoodieDeltaWriteStat prevStat = (HoodieDeltaWriteStat) this.writeStatus.getStat();
+    HoodieDeltaWriteStat stat = prevStat.copy();
     this.writeStatus = (WriteStatus) ReflectionUtils.loadClass(config.getWriteStatusClassName(),
         hoodieTable.shouldTrackSuccessRecords(), config.getWriteStatusFailureFraction(), hoodieTable.isMetadataTable());
     this.writeStatus.setFileId(fileId);
@@ -361,17 +498,39 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     this.writeStatus.setStat(stat);
   }
 
-  private String makeFilePath(HoodieLogFile logFile) {
-    return partitionPath.isEmpty()
-        ? new StoragePath(logFile.getFileName()).toString()
-        : new StoragePath(partitionPath, logFile.getFileName()).toString();
-  }
-
   protected void resetWriteCounts() {
     recordsWritten = 0;
     updatedRecordsWritten = 0;
     insertRecordsWritten = 0;
     recordsDeleted = 0;
+  }
+
+  /**
+   * Allows subclasses to add extra log file names to the current stat after a flush.
+   *
+   * <p>Inline log appends usually have a single {@link AppendResult}. Native log appends can flush both data and
+   * delete files together, so they use this hook to record every physical file written by the flush.
+   */
+  protected void updateLogFiles(HoodieDeltaWriteStat stat) {
+  }
+
+  /**
+   * Allows subclasses to collect column stats after a flush.
+   *
+   * <p>Inline log handles may compute stats from buffered records or inline block metadata. Native log handles
+   * can collect stats from the native file footer and should skip delete-only files.
+   */
+  protected void collectColumnStats(HoodieDeltaWriteStat stat) {
+  }
+
+  private void updateWriteStat(HoodieDeltaWriteStat stat, AppendResult result) {
+    stat.setPath(makeFilePath(result.logFile()));
+    stat.setLogOffset(result.offset());
+    stat.setLogVersion(result.logFile().getLogVersion());
+    if (!stat.getLogFiles().contains(result.logFile().getFileName())) {
+      stat.addLogFiles(result.logFile().getFileName());
+    }
+    stat.setFileSizeInBytes(result.size());
   }
 
   private void updateWriteCounts(HoodieDeltaWriteStat stat, AppendResult result) {
@@ -390,16 +549,6 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     stat.setTotalWriteBytes(stat.getTotalWriteBytes() + result.size());
   }
 
-  private void updateWriteStat(HoodieDeltaWriteStat stat, AppendResult result) {
-    stat.setPath(makeFilePath(result.logFile()));
-    stat.setLogOffset(result.offset());
-    stat.setLogVersion(result.logFile().getLogVersion());
-    if (!stat.getLogFiles().contains(result.logFile().getFileName())) {
-      stat.addLogFiles(result.logFile().getFileName());
-    }
-    stat.setFileSizeInBytes(result.size());
-  }
-
   private void updateRuntimeStats(HoodieDeltaWriteStat stat) {
     RuntimeStats runtimeStats = new RuntimeStats();
     runtimeStats.setTotalUpsertTime(timer.endTimer());
@@ -412,355 +561,34 @@ public class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T, I, K, O
     runtimeStats.setTotalUpsertTime(runtimeStats.getTotalUpsertTime() + timer.endTimer());
   }
 
-  protected void updateWriteStatus(AppendResult result, HoodieDeltaWriteStat stat) {
-    if (stat.getPath() == null) {
-      // first time writing to this log block.
-      updateWriteStat(stat, result);
-      updateWriteCounts(stat, result);
-      updateRuntimeStats(stat);
-      statuses.add(this.writeStatus);
-    } else if (stat.getPath().endsWith(result.logFile().getFileName())) {
-      // append/continued writing to the same log file
-      stat.setLogOffset(Math.min(stat.getLogOffset(), result.offset()));
-      stat.setFileSizeInBytes(stat.getFileSizeInBytes() + result.size());
-      accumulateWriteCounts(stat, result);
-      accumulateRuntimeStats(stat);
-    } else {
-      // written to a newer log file, due to rollover/otherwise.
-      initNewStatus();
-      stat = (HoodieDeltaWriteStat) this.writeStatus.getStat();
-
-      updateWriteStat(stat, result);
-      updateWriteCounts(stat, result);
-      updateRuntimeStats(stat);
-      statuses.add(this.writeStatus);
-    }
-  }
-
-  protected void processAppendResult(AppendResult result, Option<HoodieLogBlock> dataBlock) {
-    HoodieDeltaWriteStat stat = (HoodieDeltaWriteStat) this.writeStatus.getStat();
-    updateWriteStatus(result, stat);
-
-    if (config.isMetadataColumnStatsIndexEnabled()) {
-      HoodieIndexVersion indexVersion = HoodieTableMetadataUtil.existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, hoodieTable.getMetaClient());
-      Set<String> columnsToIndexSet = new HashSet<>(HoodieTableMetadataUtil
-          .getColumnsToIndex(hoodieTable.getMetaClient().getTableConfig(),
-              config.getMetadataConfig(), Lazy.eagerly(Option.of(writeSchemaWithMetaFields)),
-              Option.of(this.recordMerger.getRecordType()), indexVersion).keySet());
-      final List<Pair<String, HoodieSchemaField>> fieldsToIndex = columnsToIndexSet.stream()
-          .map(fieldName -> HoodieSchemaUtils.getNestedField(writeSchemaWithMetaFields, fieldName))
-          .filter(Option::isPresent)
-          .map(Option::get)
-          .collect(Collectors.toList());
-      try {
-        Map<String, HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataMap =
-            collectColumnRangeMetadata(recordList.iterator(), fieldsToIndex, stat.getPath(), writeSchemaWithMetaFields, storage.getConf(),
-                indexVersion);
-        stat.putRecordsStats(columnRangeMetadataMap);
-      } catch (HoodieException e) {
-        throw new HoodieAppendException("Failed to extract append result", e);
-      }
-    }
-
-    resetWriteCounts();
-    assert stat.getRuntimeStats() != null;
-    log.info("AppendHandle for partitionPath {} filePath {}, took {} ms.", partitionPath,
-        stat.getPath(), stat.getRuntimeStats().getTotalUpsertTime());
-    timer.startTimer();
-  }
-
-  public void doAppend() {
-    while (recordItr.hasNext()) {
-      HoodieRecord record = recordItr.next();
-      init(record);
-      flushToDiskIfRequired(record, false);
-      writeToBuffer(record);
-    }
-    appendDataAndDeleteBlocks(header, true);
-    estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
+  private String makeFilePath(HoodieLogFile logFile) {
+    return partitionPath.isEmpty()
+        ? new StoragePath(logFile.getFileName()).toString()
+        : new StoragePath(partitionPath, logFile.getFileName()).toString();
   }
 
   /**
-   * Appends data and delete blocks. When appendDeleteBlocks value is false, only data blocks are appended.
-   * This is done so that all the data blocks are created first and then a single delete block is added.
-   * Otherwise what can end up happening is creation of multiple small delete blocks get added after each data block.
+   * Creates the concrete log writer for this append handle.
    */
-  protected void appendDataAndDeleteBlocks(Map<HeaderMetadataType, String> header, boolean appendDeleteBlocks) {
-    try {
-      header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, instantTime);
-      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
-      List<HoodieLogBlock> blocks = new ArrayList<>(2);
-      HoodieLogBlock dataBlock = null;
-      if (!recordList.isEmpty()) {
-        String keyField = config.populateMetaFields()
-            ? HoodieRecord.RECORD_KEY_METADATA_FIELD
-            : hoodieTable.getMetaClient().getTableConfig().getRecordKeyFieldProp();
-
-        dataBlock = getDataBlock(config, getLogBlockType(), recordList,
-            getUpdatedHeader(header, config, baseFileInstantTimeOfPositions), keyField);
-        blocks.add(dataBlock);
-      }
-
-      if (appendDeleteBlocks && !recordsToDeleteWithPositions.isEmpty()) {
-        blocks.add(new HoodieDeleteBlock(
-            recordsToDeleteWithPositions,
-            getUpdatedHeader(
-                header, config, baseFileInstantTimeOfPositions)));
-      }
-
-      if (!blocks.isEmpty()) {
-        AppendResult appendResult = writer.appendBlocks(blocks);
-        processAppendResult(appendResult, Option.ofNullable(dataBlock));
-        recordList.clear();
-        if (appendDeleteBlocks) {
-          recordsToDeleteWithPositions.clear();
-        }
-      }
-    } catch (Exception e) {
-      throw new HoodieAppendException("Failed while appending records to " + writer.getLogFile().getPath(), e);
-    }
-  }
-
-  @Override
-  public boolean canWrite(HoodieRecord record) {
-    return config.getParquetMaxFileSize() >= estimatedNumberOfBytesWritten
-        * config.getLogFileToParquetCompressionRatio();
-  }
-
-  @Override
-  protected void doWrite(HoodieRecord record, HoodieSchema schema, TypedProperties props) {
-    Option<Map<String, String>> recordMetadata = record.getMetadata();
-    try {
-      init(record);
-      flushToDiskIfRequired(record, false);
-      writeToBuffer(record);
-    } catch (Throwable t) {
-      log.error("Error writing record " + record, t);
-      if (!config.getIgnoreWriteFailed()) {
-        throw new HoodieException(t.getMessage(), t);
-      }
-      writeStatus.markFailure(record, t, recordMetadata);
-    }
-  }
-
-  @Override
-  public List<WriteStatus> close() {
-    try {
-      if (isClosed()) {
-        // Handle has already been closed
-        return Collections.singletonList(writeStatus);
-      }
-
-      markClosed();
-      // flush any remaining records to disk
-      appendDataAndDeleteBlocks(header, true);
-      if (recordItr instanceof Closeable) {
-        ((Closeable) recordItr).close();
-      }
-      recordItr = null;
-
-      if (writer != null) {
-        writer.close();
-        writer = null;
-      }
-
-      // Set the final on-disk size of each log file. Appends within an append handle are contiguous,
-      // so a log file's length equals its start offset plus the total bytes appended to it. That is
-      // exactly what fs.getFileStatus().getLength() returns, and both values are already captured by
-      // the AppendResult stats (logOffset and the accumulated fileSizeInBytes). Deriving the size this
-      // way avoids a getPathInfo/HEAD per log file, which is a remote round trip per file group on
-      // object stores.
-      for (WriteStatus status : statuses) {
-        HoodieDeltaWriteStat stat = (HoodieDeltaWriteStat) status.getStat();
-        long appendedBytes = stat.getFileSizeInBytes();
-        stat.setFileSizeInBytes(stat.getLogOffset() + appendedBytes);
-      }
-
-      // generate Secondary index stats if streaming writes is enabled.
-      if (isSecondaryIndexStatsStreamingWritesEnabled) {
-        // Adds secondary index only for the last log file write status. We do not need to add secondary index stats
-        // for every log file written as part of the append handle write. The last write status would update the
-        // secondary index considering all the log files.
-        SecondaryIndexStreamingTracker.trackSecondaryIndexStats(partitionPath, fileId, getReadFileSlice(),
-            statuses.stream().map(status -> status.getStat().getPath()).collect(Collectors.toList()),
-            statuses.get(statuses.size() - 1), hoodieTable, secondaryIndexDefns, config, instantTime, writeSchemaWithMetaFields);
-      }
-
-      return statuses;
-    } catch (IOException e) {
-      throw new HoodieUpsertException("Failed to close UpdateHandle", e);
-    }
-  }
-
-  public void write(Map<String, HoodieRecord<T>> recordMap) {
-    try {
-      for (Map.Entry<String, HoodieRecord<T>> entry: recordMap.entrySet()) {
-        HoodieRecord<T> record = entry.getValue();
-        init(record);
-        flushToDiskIfRequired(record, false);
-        writeToBuffer(record);
-      }
-      appendDataAndDeleteBlocks(header, true);
-      estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
-    } catch (Exception e) {
-      throw new HoodieUpsertException("Failed to compact blocks for fileId " + fileId, e);
-    }
-  }
-
-  @Override
-  public IOType getIOType() {
-    return IOType.APPEND;
-  }
-
-  public List<WriteStatus> getWriteStatuses() {
-    return statuses;
-  }
+  protected abstract void createLogWriterForAppend(String instantTime, Option<FileSlice> fileSliceOpt) throws IOException;
 
   /**
-   * Whether there is need to update the record location.
+   * Writes an insert or update record to the concrete log representation.
    */
-  protected boolean needsUpdateLocation() {
-    return true;
-  }
-
-  private void writeToBuffer(HoodieRecord<T> record) {
-    if (!partitionPath.equals(record.getPartitionPath())) {
-      HoodieUpsertException failureEx = new HoodieUpsertException("mismatched partition path, record partition: "
-          + record.getPartitionPath() + " but trying to insert into partition: " + partitionPath);
-      writeStatus.markFailure(record, failureEx, record.getMetadata());
-      return;
-    }
-
-    // update the new location of the record, so we know where to find it next
-    if (needsUpdateLocation()) {
-      record.unseal();
-      record.setNewLocation(newRecordLocation);
-      record.seal();
-    }
-    // fetch the ordering val first in case the record was deflated.
-    bufferRecord(record);
-    numberOfRecords++;
-  }
-
-  private void bufferInsertAndUpdate(HoodieSchema schema, HoodieRecord<T> hoodieRecord, boolean isUpdateRecord) throws IOException {
-    // Check if the record should be ignored (special case for [[ExpressionPayload]])
-    if (hoodieRecord.shouldIgnore(schema, recordProperties)) {
-      return;
-    }
-
-    // Prepend meta-fields into the record
-    MetadataValues metadataValues = populateMetadataFields(hoodieRecord);
-    HoodieRecord populatedRecord =
-        hoodieRecord.prependMetaFields(schema, writeSchemaWithMetaFields, metadataValues, recordProperties);
-
-    // NOTE: Record have to be cloned here to make sure if it holds low-level engine-specific
-    //       payload pointing into a shared, mutable (underlying) buffer we get a clean copy of
-    //       it since these records will be put into the recordList(List).
-    recordList.add(populatedRecord.copy());
-    if (isUpdateRecord || isLogCompaction) {
-      updatedRecordsWritten++;
-    } else {
-      insertRecordsWritten++;
-    }
-    recordsWritten++;
-  }
-
-  private void bufferDelete(HoodieRecord<T> hoodieRecord) {
-    // Clear the new location as the record was deleted
-    hoodieRecord.unseal();
-    hoodieRecord.clearNewLocation();
-    hoodieRecord.seal();
-    recordsDeleted++;
-
-    // store ordering value with Java type.
-    final Comparable<?> orderingVal = hoodieRecord.getOrderingValueAsJava(writeSchema, recordProperties, orderingFields);
-    long position = baseFileInstantTimeOfPositions.isPresent() ? hoodieRecord.getCurrentPosition() : -1L;
-    recordsToDeleteWithPositions.add(Pair.of(DeleteRecord.create(hoodieRecord.getKey(), orderingVal), position));
-  }
+  protected abstract void writeInsertAndUpdate(HoodieSchema schema, HoodieRecord<T> hoodieRecord, boolean isUpdateRecord) throws IOException;
 
   /**
-   * Checks if the number of records have reached the set threshold and then flushes the records to disk.
+   * Writes a delete record to the concrete log representation.
    */
-  protected void flushToDiskIfRequired(HoodieRecord record, boolean appendDeleteBlocks) {
-    if (numberOfRecords >= (int) (maxBlockSize / averageRecordSize)
-        || numberOfRecords % NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE == 0) {
-      averageRecordSize = (long) (averageRecordSize * 0.8 + sizeEstimator.sizeEstimate(record) * 0.2);
-    }
-
-    // Append if max number of records reached to achieve block size
-    if (numberOfRecords >= (maxBlockSize / averageRecordSize)) {
-      // Recompute averageRecordSize before writing a new block and update existing value with
-      // avg of new and old
-      log.info("Flush log block to disk, the current avgRecordSize => " + averageRecordSize);
-      // Delete blocks will be appended after appending all the data blocks.
-      appendDataAndDeleteBlocks(header, appendDeleteBlocks);
-      estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
-      numberOfRecords = 0;
-    }
-  }
-
-  protected HoodieLogBlock.HoodieLogBlockType getLogBlockType() {
-    return CommonClientUtils.getLogBlockType(config, hoodieTable.getMetaClient().getTableConfig());
-  }
-
-  private static Map<HeaderMetadataType, String> getUpdatedHeader(Map<HeaderMetadataType, String> header,
-                                                                  HoodieWriteConfig config,
-                                                                  Option<String> baseInstantTimeForPositions) {
-    Map<HeaderMetadataType, String> updatedHeader = new HashMap<>(header);
-    if (config.shouldWritePartialUpdates()) {
-      // When enabling writing partial updates to the data blocks, the "IS_PARTIAL" flag is also
-      // written to the block header so that the reader can differentiate partial updates, i.e.,
-      // the "SCHEMA" header contains the partial schema.
-      updatedHeader.put(
-          HeaderMetadataType.IS_PARTIAL, Boolean.toString(true));
-    }
-    if (baseInstantTimeForPositions.isPresent()) {
-      updatedHeader.put(
-          HeaderMetadataType.BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS,
-          baseInstantTimeForPositions.get());
-    }
-    return updatedHeader;
-  }
-
-  protected HoodieLogBlock getDataBlock(HoodieWriteConfig writeConfig,
-                                        HoodieLogBlock.HoodieLogBlockType logDataBlockFormat,
-                                        List<HoodieRecord> records,
-                                        Map<HeaderMetadataType, String> header,
-                                        String keyField) {
-    switch (logDataBlockFormat) {
-      case AVRO_DATA_BLOCK:
-        return new HoodieAvroDataBlock(records, header, keyField);
-      case HFILE_DATA_BLOCK:
-        // Not supporting positions in HFile data blocks
-        header.remove(HeaderMetadataType.BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS);
-        records.sort(Comparator.comparing(HoodieRecord::getRecordKey));
-        Map<String, String> hfileParams = new HashMap<>();
-        hfileParams.put(HFILE_COMPRESSION_ALGORITHM_NAME.key(), writeConfig.getHFileCompressionAlgorithm());
-        hfileParams.put(HFILE_WITH_BLOOM_FILTER_ENABLED.key(), Boolean.toString(writeConfig.hfileBloomFilterEnabled()));
-        hfileParams.put(BLOOM_FILTER_NUM_ENTRIES_VALUE.key(), Integer.toString(writeConfig.getBloomFilterNumEntries()));
-        hfileParams.put(BLOOM_FILTER_FPP_VALUE.key(), Double.toString(writeConfig.getBloomFilterFPP()));
-        hfileParams.put(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES.key(), Integer.toString(writeConfig.getDynamicBloomFilterMaxNumEntries()));
-        hfileParams.put(BLOOM_FILTER_TYPE.key(), writeConfig.getBloomFilterType());
-        return new HoodieHFileDataBlock(
-            records, header, writeConfig.getHFileCompressionAlgorithm(), hfileParams, new StoragePath(writeConfig.getBasePath()));
-      case PARQUET_DATA_BLOCK:
-        return new HoodieParquetDataBlock(
-            records,
-            header,
-            keyField,
-            writeConfig.getParquetCompressionCodec(),
-            writeConfig.getParquetCompressionRatio(),
-            writeConfig.parquetDictionaryEnabled());
-      default:
-        throw new HoodieException("Data block format " + logDataBlockFormat + " not implemented");
-    }
-  }
+  protected abstract void writeDelete(HoodieSchema schema, HoodieRecord<T> hoodieRecord) throws IOException;
 
   /**
-   * Returns the file slice for reader view.
+   * Flushes any pending data/delete records and calls {@link #processAppendResult(AppendResult)} for each append result.
    */
-  private Option<FileSlice> getReadFileSlice() {
-    TableFileSystemView.SliceView rtView = hoodieTable.getSliceView();
-    return rtView.getLatestMergedFileSliceBeforeOrOn(partitionPath, instantTime, fileId);
-  }
+  protected abstract void flushAppend();
+
+  /**
+   * Closes the concrete log writer.
+   */
+  protected abstract void closeLogWriter() throws IOException;
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -54,6 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -186,7 +187,7 @@ public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T
   public List<WriteStatus> close() {
     try {
       if (isClosed()) {
-        return statuses.isEmpty() ? java.util.Collections.singletonList(writeStatus) : statuses;
+        return statuses.isEmpty() ? Collections.singletonList(writeStatus) : statuses;
       }
 
       markClosed();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieInlineLogAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieInlineLogAppendHandle.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.DeleteRecord;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieDeltaWriteStat;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.MetadataValues;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.table.log.AppendResult;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
+import org.apache.hudi.common.table.log.block.HoodieHFileDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
+import org.apache.hudi.common.table.log.block.HoodieParquetDataBlock;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.DefaultSizeEstimator;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.SizeEstimator;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieAppendException;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.util.CommonClientUtils;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_DYNAMIC_MAX_ENTRIES;
+import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_FPP_VALUE;
+import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_NUM_ENTRIES_VALUE;
+import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_TYPE;
+import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_COMPRESSION_ALGORITHM_NAME;
+import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_WITH_BLOOM_FILTER_ENABLED;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.collectColumnRangeMetadata;
+
+/**
+ * IO Operation to append data onto an existing file.
+ */
+@Slf4j
+public class HoodieInlineLogAppendHandle<T, I, K, O> extends HoodieAppendHandle<T, I, K, O> {
+  private static final int NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE = 100;
+
+  // Buffer for holding records in memory before they are flushed to disk
+  protected final List<HoodieRecord> recordList = new ArrayList<>();
+  // Buffer for holding records (to be deleted), along with their position in log block, in memory before they are flushed to disk
+  protected final List<Pair<DeleteRecord, Long>> recordsToDeleteWithPositions = new ArrayList<>();
+  // Writer to log into the file group's latest slice.
+  protected HoodieLogFormat.Writer writer;
+
+  // Average record size for a HoodieRecord. This size is updated at the end of every log block flushed to disk
+  private long averageRecordSize = 0;
+  // Total number of bytes written during this append phase (an estimation)
+  protected long estimatedNumberOfBytesWritten;
+  // Number of records that must be written to meet the max block size for a log block
+  private long numberOfRecords = 0;
+  // Max block size to limit to for a log block
+  private final long maxBlockSize = config.getLogFileDataBlockMaxSize();
+  private final SizeEstimator<HoodieRecord> sizeEstimator;
+
+  private final String[] orderingFields;
+
+  /**
+   * This is used by log compaction only.
+   */
+  public HoodieInlineLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                            String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr,
+                            TaskContextSupplier taskContextSupplier, Map<HeaderMetadataType, String> header) {
+    this(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, true);
+    this.useWriterSchema = true;
+    this.isLogCompaction = true;
+    this.header.putAll(header);
+  }
+
+  public HoodieInlineLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                            String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr, TaskContextSupplier taskContextSupplier) {
+    this(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, false);
+  }
+
+  private HoodieInlineLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                             String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr, TaskContextSupplier taskContextSupplier, boolean preserveMetadata) {
+    super(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, preserveMetadata);
+    this.sizeEstimator = getSizeEstimator();
+    this.orderingFields = ConfigUtils.getOrderingFields(recordProperties);
+  }
+
+  public HoodieInlineLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                            String partitionPath, String fileId, TaskContextSupplier sparkTaskContextSupplier) {
+    this(config, instantTime, hoodieTable, partitionPath, fileId, null, sparkTaskContextSupplier);
+  }
+
+  protected SizeEstimator<HoodieRecord> getSizeEstimator() {
+    return new DefaultSizeEstimator<>();
+  }
+
+  @Override
+  protected void createLogWriterForAppend(String instantTime, Option<FileSlice> fileSliceOpt) {
+    this.writer = createLogWriter(instantTime, fileSliceOpt);
+  }
+
+  @Override
+  protected void init(HoodieRecord record) {
+    boolean shouldInit = doInit;
+    super.init(record);
+    if (shouldInit) {
+      averageRecordSize = sizeEstimator.sizeEstimate(record);
+    }
+  }
+
+  @Override
+  protected boolean writeRecord(HoodieRecord<T> hoodieRecord) {
+    init(hoodieRecord);
+    flushToDiskIfRequired(hoodieRecord, false);
+    boolean result = super.writeRecord(hoodieRecord);
+    if (result) {
+      numberOfRecords++;
+    }
+    return result;
+  }
+
+  @Override
+  protected void flushAppend() {
+    appendDataAndDeleteBlocks(header, true);
+    estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
+    numberOfRecords = 0;
+  }
+
+  @Override
+  protected void collectColumnStats(HoodieDeltaWriteStat stat) {
+    if (config.isMetadataColumnStatsIndexEnabled()) {
+      HoodieIndexVersion indexVersion = HoodieTableMetadataUtil.existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, hoodieTable.getMetaClient());
+      Set<String> columnsToIndexSet = new HashSet<>(HoodieTableMetadataUtil
+          .getColumnsToIndex(hoodieTable.getMetaClient().getTableConfig(),
+              config.getMetadataConfig(), Lazy.eagerly(Option.of(writeSchemaWithMetaFields)),
+              Option.of(this.recordMerger.getRecordType()), indexVersion).keySet());
+      final List<Pair<String, HoodieSchemaField>> fieldsToIndex = columnsToIndexSet.stream()
+          .map(fieldName -> HoodieSchemaUtils.getNestedField(writeSchemaWithMetaFields, fieldName))
+          .filter(Option::isPresent)
+          .map(Option::get)
+          .collect(Collectors.toList());
+      try {
+        Map<String, HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataMap =
+            collectColumnRangeMetadata(recordList.iterator(), fieldsToIndex, stat.getPath(), writeSchemaWithMetaFields, storage.getConf(),
+                indexVersion);
+        stat.putRecordsStats(columnRangeMetadataMap);
+      } catch (HoodieException e) {
+        throw new HoodieAppendException("Failed to extract append result", e);
+      }
+    }
+  }
+
+  /**
+   * Appends data and delete blocks. When appendDeleteBlocks value is false, only data blocks are appended.
+   * This is done so that all the data blocks are created first and then a single delete block is added.
+   * Otherwise, what can end up happening is creation of multiple small delete blocks get added after each data block.
+   */
+  protected void appendDataAndDeleteBlocks(Map<HeaderMetadataType, String> header, boolean appendDeleteBlocks) {
+    try {
+      header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, instantTime);
+      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
+      List<HoodieLogBlock> blocks = new ArrayList<>(2);
+      HoodieLogBlock dataBlock = null;
+      if (!recordList.isEmpty()) {
+        String keyField = config.populateMetaFields()
+            ? HoodieRecord.RECORD_KEY_METADATA_FIELD
+            : hoodieTable.getMetaClient().getTableConfig().getRecordKeyFieldProp();
+
+        dataBlock = getDataBlock(config, getLogBlockType(), recordList,
+            getUpdatedHeader(header), keyField);
+        blocks.add(dataBlock);
+      }
+
+      if (appendDeleteBlocks && !recordsToDeleteWithPositions.isEmpty()) {
+        blocks.add(new HoodieDeleteBlock(
+            recordsToDeleteWithPositions,
+            getUpdatedHeader(header)));
+      }
+
+      if (!blocks.isEmpty()) {
+        AppendResult appendResult = writer.appendBlocks(blocks);
+        appendDataBlock = dataBlock == null ? Option.empty() : Option.of(dataBlock);
+        try {
+          processAppendResult(appendResult);
+        } finally {
+          appendDataBlock = Option.empty();
+        }
+        recordList.clear();
+        if (appendDeleteBlocks) {
+          recordsToDeleteWithPositions.clear();
+        }
+      }
+    } catch (Exception e) {
+      throw new HoodieAppendException("Failed while appending records to " + writer.getLogFile().getPath(), e);
+    }
+  }
+
+  @Override
+  public boolean canWrite(HoodieRecord record) {
+    return config.getParquetMaxFileSize() >= estimatedNumberOfBytesWritten
+        * config.getLogFileToParquetCompressionRatio();
+  }
+
+  @Override
+  protected void closeLogWriter() throws IOException {
+    if (writer != null) {
+      writer.close();
+      writer = null;
+    }
+  }
+
+  @Override
+  protected void writeInsertAndUpdate(HoodieSchema schema, HoodieRecord<T> hoodieRecord, boolean isUpdateRecord) throws IOException {
+    // Check if the record should be ignored (special case for [[ExpressionPayload]])
+    if (hoodieRecord.shouldIgnore(schema, recordProperties)) {
+      return;
+    }
+
+    // Prepend meta-fields into the record
+    MetadataValues metadataValues = populateMetadataFields(hoodieRecord);
+    HoodieRecord populatedRecord =
+        hoodieRecord.prependMetaFields(schema, writeSchemaWithMetaFields, metadataValues, recordProperties);
+
+    // NOTE: Record have to be cloned here to make sure if it holds low-level engine-specific
+    //       payload pointing into a shared, mutable (underlying) buffer we get a clean copy of
+    //       it since these records will be put into the recordList(List).
+    recordList.add(populatedRecord.copy());
+    if (isUpdateRecord || isLogCompaction) {
+      updatedRecordsWritten++;
+    } else {
+      insertRecordsWritten++;
+    }
+    recordsWritten++;
+  }
+
+  @Override
+  protected void writeDelete(HoodieSchema schema, HoodieRecord<T> hoodieRecord) {
+    // Clear the new location as the record was deleted
+    hoodieRecord.unseal();
+    hoodieRecord.clearNewLocation();
+    hoodieRecord.seal();
+    recordsDeleted++;
+
+    // store ordering value with Java type.
+    final Comparable<?> orderingVal = hoodieRecord.getOrderingValueAsJava(writeSchema, recordProperties, orderingFields);
+    long position = baseFileInstantTimeOfPositions.isPresent() ? hoodieRecord.getCurrentPosition() : -1L;
+    recordsToDeleteWithPositions.add(Pair.of(DeleteRecord.create(hoodieRecord.getKey(), orderingVal), position));
+  }
+
+  /**
+   * Checks if the number of records have reached the set threshold and then flushes the records to disk.
+   */
+  protected void flushToDiskIfRequired(HoodieRecord record, boolean appendDeleteBlocks) {
+    if (numberOfRecords >= (int) (maxBlockSize / averageRecordSize)
+        || numberOfRecords % NUMBER_OF_RECORDS_TO_ESTIMATE_RECORD_SIZE == 0) {
+      averageRecordSize = (long) (averageRecordSize * 0.8 + sizeEstimator.sizeEstimate(record) * 0.2);
+    }
+
+    // Append if max number of records reached to achieve block size
+    if (numberOfRecords >= (maxBlockSize / averageRecordSize)) {
+      // Recompute averageRecordSize before writing a new block and update existing value with
+      // avg of new and old
+      log.info("Flush log block to disk, the current avgRecordSize => " + averageRecordSize);
+      // Delete blocks will be appended after appending all the data blocks.
+      appendDataAndDeleteBlocks(header, appendDeleteBlocks);
+      estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
+      numberOfRecords = 0;
+    }
+  }
+
+  protected HoodieLogBlock.HoodieLogBlockType getLogBlockType() {
+    return CommonClientUtils.getLogBlockType(config, hoodieTable.getMetaClient().getTableConfig());
+  }
+
+  protected HoodieLogBlock getDataBlock(HoodieWriteConfig writeConfig,
+                                        HoodieLogBlock.HoodieLogBlockType logDataBlockFormat,
+                                        List<HoodieRecord> records,
+                                        Map<HeaderMetadataType, String> header,
+                                        String keyField) {
+    switch (logDataBlockFormat) {
+      case AVRO_DATA_BLOCK:
+        return new HoodieAvroDataBlock(records, header, keyField);
+      case HFILE_DATA_BLOCK:
+        // Not supporting positions in HFile data blocks
+        header.remove(HeaderMetadataType.BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS);
+        records.sort(Comparator.comparing(HoodieRecord::getRecordKey));
+        Map<String, String> hfileParams = new HashMap<>();
+        hfileParams.put(HFILE_COMPRESSION_ALGORITHM_NAME.key(), writeConfig.getHFileCompressionAlgorithm());
+        hfileParams.put(HFILE_WITH_BLOOM_FILTER_ENABLED.key(), Boolean.toString(writeConfig.hfileBloomFilterEnabled()));
+        hfileParams.put(BLOOM_FILTER_NUM_ENTRIES_VALUE.key(), Integer.toString(writeConfig.getBloomFilterNumEntries()));
+        hfileParams.put(BLOOM_FILTER_FPP_VALUE.key(), Double.toString(writeConfig.getBloomFilterFPP()));
+        hfileParams.put(BLOOM_FILTER_DYNAMIC_MAX_ENTRIES.key(), Integer.toString(writeConfig.getDynamicBloomFilterMaxNumEntries()));
+        hfileParams.put(BLOOM_FILTER_TYPE.key(), writeConfig.getBloomFilterType());
+        return new HoodieHFileDataBlock(
+            records, header, writeConfig.getHFileCompressionAlgorithm(), hfileParams, new StoragePath(writeConfig.getBasePath()));
+      case PARQUET_DATA_BLOCK:
+        return new HoodieParquetDataBlock(
+            records,
+            header,
+            keyField,
+            writeConfig.getParquetCompressionCodec(),
+            writeConfig.getParquetCompressionRatio(),
+            writeConfig.parquetDictionaryEnabled());
+      default:
+        throw new HoodieException("Data block format " + logDataBlockFormat + " not implemented");
+    }
+  }
+
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogAppendHandle.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieDeltaWriteStat;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.log.AppendResult;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ParquetUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieAppendException;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.util.Lazy;
+
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
+
+/**
+ * Append handle for native log files. Unlike {@link HoodieInlineLogAppendHandle}, this handle streams
+ * records directly into native format writers and does not buffer records or build inline log blocks.
+ */
+public class HoodieNativeLogAppendHandle<T, I, K, O> extends HoodieAppendHandle<T, I, K, O> {
+
+  private HoodieNativeLogFormatWriter writer;
+
+  public HoodieNativeLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                                     String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr,
+                                     TaskContextSupplier taskContextSupplier) {
+    this(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, false, Collections.emptyMap());
+  }
+
+  public HoodieNativeLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                                     String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr,
+                                     TaskContextSupplier taskContextSupplier, Map<HeaderMetadataType, String> header) {
+    this(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, true, header);
+  }
+
+  public HoodieNativeLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                                     String partitionPath, String fileId, TaskContextSupplier taskContextSupplier) {
+    this(config, instantTime, hoodieTable, partitionPath, fileId, null, taskContextSupplier);
+  }
+
+  private HoodieNativeLogAppendHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
+                                      String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr,
+                                      TaskContextSupplier taskContextSupplier, boolean preserveMetadata,
+                                      Map<HeaderMetadataType, String> header) {
+    super(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, preserveMetadata);
+    this.header.putAll(header);
+  }
+
+  @Override
+  protected void createLogWriterForAppend(String instantTime, Option<FileSlice> fileSliceOpt) {
+    try {
+      this.writer = new HoodieNativeLogFormatWriter(
+          storage.getDefaultBufferSize(),
+          storage,
+          FSUtils.constructAbsolutePath(hoodieTable.getMetaClient().getBasePath(), partitionPath),
+          fileId,
+          instantTime,
+          null,
+          writeToken,
+          config.getLogFileMaxSize(),
+          getLogCreationCallback(),
+          config.getWriteVersion(),
+          config,
+          writeSchemaWithMetaFields,
+          taskContextSupplier,
+          hoodieTable.getReaderContextFactoryForWrite().getContext().getRecordContext(),
+          Arrays.stream(ConfigUtils.getOrderingFields(recordProperties)).collect(Collectors.toList()));
+    } catch (IOException e) {
+      throw new HoodieException("Creating native log writer with fileId: " + fileId + ", "
+          + "delta commit time: " + instantTime + " error", e);
+    }
+  }
+
+  @Override
+  protected void writeInsertAndUpdate(HoodieSchema schema, HoodieRecord<T> hoodieRecord, boolean isUpdateRecord) throws IOException {
+    if (hoodieRecord.shouldIgnore(schema, recordProperties)) {
+      return;
+    }
+    HoodieRecord populatedRecord = hoodieRecord.prependMetaFields(
+        schema, writeSchemaWithMetaFields, populateMetadataFields(hoodieRecord), recordProperties);
+    String keyField = config.populateMetaFields()
+        ? HoodieRecord.RECORD_KEY_METADATA_FIELD
+        : hoodieTable.getMetaClient().getTableConfig().getRecordKeyFieldProp();
+    if (!writer.canWriteDataFile()) {
+      flushDataAppend();
+    }
+    writer.appendRecord(populatedRecord, writeSchemaWithMetaFields, keyField);
+    if (isUpdateRecord || isLogCompaction) {
+      updatedRecordsWritten++;
+    } else {
+      insertRecordsWritten++;
+    }
+    recordsWritten++;
+  }
+
+  @Override
+  protected void writeDelete(HoodieSchema schema, HoodieRecord<T> hoodieRecord) throws IOException {
+    hoodieRecord.unseal();
+    hoodieRecord.clearNewLocation();
+    hoodieRecord.seal();
+    String keyField = schema.getField(HoodieRecord.RECORD_KEY_METADATA_FIELD).isPresent()
+        ? HoodieRecord.RECORD_KEY_METADATA_FIELD
+        : hoodieTable.getMetaClient().getTableConfig().getRecordKeyFieldProp();
+    writer.appendDeleteRecord(hoodieRecord, schema, keyField);
+    recordsDeleted++;
+  }
+
+  @Override
+  protected void flushAppend() {
+    try {
+      header.put(HeaderMetadataType.INSTANT_TIME, instantTime);
+      // header.put(HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
+      if (writer != null && writer.hasPendingWrites()) {
+        processAppendResult(writer.flushAppend(getUpdatedHeader(header)));
+      }
+    } catch (IOException e) {
+      throw new HoodieAppendException("Failed while flushing records to native log for fileId " + fileId, e);
+    }
+  }
+
+  private void flushDataAppend() {
+    try {
+      header.put(HeaderMetadataType.INSTANT_TIME, instantTime);
+      header.put(HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
+      if (writer != null && writer.hasPendingWrites()) {
+        processAppendResult(writer.flushDataAppend(getUpdatedHeader(header)));
+      }
+    } catch (IOException e) {
+      throw new HoodieAppendException("Failed while flushing records to native data log for fileId " + fileId, e);
+    }
+  }
+
+  @Override
+  protected void closeLogWriter() {
+    if (writer != null) {
+      writer.close();
+      writer = null;
+    }
+  }
+
+  protected StoragePath getLogFilePath() {
+    return writer.getLogFile().getPath();
+  }
+
+  @Override
+  public boolean canWrite(HoodieRecord record) {
+    return true;
+  }
+
+  @Override
+  protected void updateLogFiles(HoodieDeltaWriteStat stat) {
+    for (AppendResult appendResult : writer.getLastAppendResults()) {
+      if (!stat.getLogFiles().contains(appendResult.logFile().getFileName())) {
+        stat.addLogFiles(appendResult.logFile().getFileName());
+      }
+    }
+  }
+
+  @Override
+  protected void collectColumnStats(HoodieDeltaWriteStat stat) {
+    Option<Object> dataFileFormatMetadata = writer.getLastDataFileFormatMetadata();
+    if (config.isMetadataColumnStatsIndexEnabled() && dataFileFormatMetadata.isPresent()) {
+      HoodieIndexVersion indexVersion = HoodieTableMetadataUtil.existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, hoodieTable.getMetaClient());
+      Set<String> columnsToIndexSet = new HashSet<>(HoodieTableMetadataUtil
+          .getColumnsToIndex(hoodieTable.getMetaClient().getTableConfig(),
+              config.getMetadataConfig(), Lazy.eagerly(Option.of(writeSchemaWithMetaFields)),
+              Option.of(recordMerger.getRecordType()), indexVersion).keySet());
+      stat.putRecordsStats(collectNativeLogColumnRangeMetadata(
+          stat.getPath(), dataFileFormatMetadata.get(), columnsToIndexSet, indexVersion));
+    }
+  }
+
+  private Map<String, HoodieColumnRangeMetadata<Comparable>> collectNativeLogColumnRangeMetadata(
+      String filePath,
+      Object metadata,
+      Set<String> columnsToIndexSet,
+      HoodieIndexVersion indexVersion) {
+    if (metadata instanceof ParquetMetadata) {
+      return new ParquetUtils()
+          .readColumnStatsFromMetadata((ParquetMetadata) metadata, filePath, Option.of(new ArrayList<>(columnsToIndexSet)), indexVersion)
+          .stream()
+          .filter(columnStats -> columnsToIndexSet.contains(columnStats.getColumnName()))
+          .collect(Collectors.toMap(HoodieColumnRangeMetadata::getColumnName, columnStats -> columnStats));
+    }
+    throw new HoodieAppendException("Unsupported native log file metadata type: " + metadata.getClass().getName());
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogAppendHandle.java
@@ -122,7 +122,7 @@ public class HoodieNativeLogAppendHandle<T, I, K, O> extends HoodieAppendHandle<
         ? HoodieRecord.RECORD_KEY_METADATA_FIELD
         : hoodieTable.getMetaClient().getTableConfig().getRecordKeyFieldProp();
     if (!writer.canWriteDataFile()) {
-      flushDataAppend();
+      flushAppend();
     }
     writer.appendRecord(populatedRecord, writeSchemaWithMetaFields, keyField);
     if (isUpdateRecord || isLogCompaction) {
@@ -141,6 +141,9 @@ public class HoodieNativeLogAppendHandle<T, I, K, O> extends HoodieAppendHandle<
     String keyField = schema.getField(HoodieRecord.RECORD_KEY_METADATA_FIELD).isPresent()
         ? HoodieRecord.RECORD_KEY_METADATA_FIELD
         : hoodieTable.getMetaClient().getTableConfig().getRecordKeyFieldProp();
+    if (!writer.canWriteDeleteFile()) {
+      flushAppend();
+    }
     writer.appendDeleteRecord(hoodieRecord, schema, keyField);
     recordsDeleted++;
   }
@@ -149,24 +152,12 @@ public class HoodieNativeLogAppendHandle<T, I, K, O> extends HoodieAppendHandle<
   protected void flushAppend() {
     try {
       header.put(HeaderMetadataType.INSTANT_TIME, instantTime);
-      // header.put(HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
+      header.put(HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
       if (writer != null && writer.hasPendingWrites()) {
         processAppendResult(writer.flushAppend(getUpdatedHeader(header)));
       }
     } catch (IOException e) {
       throw new HoodieAppendException("Failed while flushing records to native log for fileId " + fileId, e);
-    }
-  }
-
-  private void flushDataAppend() {
-    try {
-      header.put(HeaderMetadataType.INSTANT_TIME, instantTime);
-      header.put(HeaderMetadataType.SCHEMA, writeSchemaWithMetaFields.toString());
-      if (writer != null && writer.hasPendingWrites()) {
-        processAppendResult(writer.flushDataAppend(getUpdatedHeader(header)));
-      }
-    } catch (IOException e) {
-      throw new HoodieAppendException("Failed while flushing records to native data log for fileId " + fileId, e);
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogFormatWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogFormatWriter.java
@@ -39,6 +39,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.ArrayComparable;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.storage.HoodieFileWriter;
 import org.apache.hudi.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.storage.HoodieStorage;
@@ -138,7 +139,7 @@ public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
     try {
       closeFileWriters();
     } catch (IOException e) {
-      throw new RuntimeException("Failed to close native log file writers", e);
+      throw new HoodieIOException("Failed to close native log file writers", e);
     }
   }
 
@@ -148,6 +149,10 @@ public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
 
   public boolean canWriteDataFile() {
     return dataFileWriter == null || dataFileWriter.canWrite();
+  }
+
+  public boolean canWriteDeleteFile() {
+    return deleteFileWriter == null || deleteFileWriter.canWrite();
   }
 
   public void appendRecord(HoodieRecord record, HoodieSchema recordSchema, String keyFieldName) throws IOException {
@@ -188,28 +193,6 @@ public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
     return fieldValues;
   }
 
-  public AppendResult flushAppend() throws IOException {
-    return flushAppend(Collections.emptyMap());
-  }
-
-  public AppendResult flushDataAppend(Map<HeaderMetadataType, String> header) throws IOException {
-    int appendVersion = currentAppendVersion;
-    lastAppendResults = new ArrayList<>();
-    lastDataFileFormatMetadata = Option.empty();
-    addFooterMetadataToDataFile(header);
-    if (dataFileWriter != null) {
-      dataFileWriter.close();
-      lastDataFileFormatMetadata = Option.ofNullable(dataFileWriter.getFileFormatMetadata());
-      dataFileWriter = null;
-    }
-    if (dataLogFile != null) {
-      lastAppendResults.add(toAppendResult(dataLogFile));
-    }
-    dataLogFile = null;
-    currentAppendVersion = -1;
-    return completeAppend(appendVersion);
-  }
-
   public AppendResult flushAppend(Map<HeaderMetadataType, String> header) throws IOException {
     int appendVersion = currentAppendVersion;
     lastAppendResults = new ArrayList<>();
@@ -229,16 +212,6 @@ public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
   }
 
   private void addFooterMetadata(Map<HeaderMetadataType, String> header) throws IOException {
-    Map<String, String> footerMetadata = getFooterMetadata(header);
-    if (dataFileWriter != null) {
-      dataFileWriter.addFooterMetadata(footerMetadata);
-    }
-    if (deleteFileWriter != null) {
-      deleteFileWriter.addFooterMetadata(footerMetadata);
-    }
-  }
-
-  private void addFooterMetadataToDataFile(Map<HeaderMetadataType, String> header) throws IOException {
     if (dataFileWriter != null) {
       dataFileWriter.addFooterMetadata(getFooterMetadata(header));
     }
@@ -248,8 +221,7 @@ public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
     Map<String, String> logFormatMetadata = new LinkedHashMap<>();
     logFormatMetadata.put(HeaderMetadataType.VERSION.name(), String.valueOf(NATIVE_LOG_FORMAT_VERSION));
     header.forEach((key, value) -> {
-      if (value != null && key != HeaderMetadataType.SCHEMA) {
-        // filter out the redundant schema since the footer already carries it.
+      if (value != null) {
         logFormatMetadata.put(key.name(), value);
       }
     });

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogFormatWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogFormatWriter.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.common.engine.RecordContext;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemas;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.log.AppendResult;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.LogFileCreationCallback;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
+import org.apache.hudi.common.table.read.BufferedRecord;
+import org.apache.hudi.common.table.read.BufferedRecords;
+import org.apache.hudi.common.util.JsonUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
+import org.apache.hudi.common.util.collection.ArrayComparable;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.io.storage.HoodieFileWriter;
+import org.apache.hudi.io.storage.HoodieFileWriterFactory;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.hudi.common.model.LogExtensions.DATA_LOG_EXTENSION;
+import static org.apache.hudi.common.model.LogExtensions.DELETE_LOG_EXTENSION;
+
+/**
+ * Writes MOR log blocks as native files, for example {@code .log.parquet} and {@code .deletes.parquet}.
+ */
+public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
+
+  private static final int NATIVE_LOG_FORMAT_VERSION = 2;
+  private static final String LOG_FORMAT_METADATA_FOOTER_KEY = "hudi.log.format.metadata";
+
+  private final HoodieWriteConfig writeConfig;
+  private final HoodieSchema tableSchema;
+  private final TaskContextSupplier taskContextSupplier;
+  private final RecordContext recordContext;
+  private final List<String> orderingFieldNames;
+  private final Properties recordProperties;
+  private HoodieFileWriter dataFileWriter;
+  private HoodieFileWriter deleteFileWriter;
+  private HoodieLogFile dataLogFile;
+  private HoodieLogFile deleteLogFile;
+  private HoodieSchema deleteLogSchema;
+  private int currentAppendVersion = -1;
+  private List<AppendResult> lastAppendResults = new ArrayList<>();
+  private Option<Object> lastDataFileFormatMetadata = Option.empty();
+
+  public HoodieNativeLogFormatWriter(Integer bufferSize,
+                                     HoodieStorage storage,
+                                     StoragePath parentPath,
+                                     String logFileId,
+                                     String instantTime,
+                                     Integer logVersion,
+                                     String logWriteToken,
+                                     Long sizeThreshold,
+                                     LogFileCreationCallback fileCreationCallback,
+                                     HoodieTableVersion tableVersion,
+                                     HoodieWriteConfig writeConfig,
+                                     HoodieSchema tableSchema,
+                                     TaskContextSupplier taskContextSupplier,
+                                     RecordContext recordContext,
+                                     List<String> orderingFieldNames) throws IOException {
+    super(bufferSize, storage, parentPath, logFileId, DATA_LOG_EXTENSION, instantTime, logVersion, logWriteToken,
+        null, 0L, sizeThreshold, fileCreationCallback, tableVersion);
+    this.writeConfig = writeConfig;
+    this.tableSchema = tableSchema;
+    this.taskContextSupplier = taskContextSupplier;
+    this.recordContext = recordContext;
+    this.orderingFieldNames = orderingFieldNames;
+    this.recordProperties = new Properties();
+    this.recordProperties.putAll(writeConfig.getProps());
+    this.logFile = new HoodieLogFile(makeNativeLogPath(this.logVersion, DATA_LOG_EXTENSION), this.fileSize);
+  }
+
+  public List<AppendResult> getLastAppendResults() {
+    return lastAppendResults;
+  }
+
+  public Option<Object> getLastDataFileFormatMetadata() {
+    return lastDataFileFormatMetadata;
+  }
+
+  @Override
+  public AppendResult appendBlock(HoodieLogBlock block) {
+    throw new UnsupportedOperationException("HoodieNativeLogFormatWriter writes native records directly.");
+  }
+
+  @Override
+  public AppendResult appendBlocks(List<HoodieLogBlock> blocks) {
+    throw new UnsupportedOperationException("HoodieNativeLogFormatWriter writes native records directly.");
+  }
+
+  @Override
+  public long getCurrentSize() {
+    return lastAppendResults.stream().mapToLong(AppendResult::size).sum();
+  }
+
+  @Override
+  public void sync() {
+    // Native log files are write-once; closing the file writer publishes the file.
+  }
+
+  @Override
+  public void close() {
+    try {
+      closeFileWriters();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to close native log file writers", e);
+    }
+  }
+
+  public boolean hasPendingWrites() {
+    return dataFileWriter != null || deleteFileWriter != null;
+  }
+
+  public boolean canWriteDataFile() {
+    return dataFileWriter == null || dataFileWriter.canWrite();
+  }
+
+  public void appendRecord(HoodieRecord record, HoodieSchema recordSchema, String keyFieldName) throws IOException {
+    ensureDataFileWriter(recordSchema);
+    dataFileWriter.write(record.getRecordKey(recordSchema, keyFieldName),
+        record, recordSchema, recordProperties);
+  }
+
+  public void appendDeleteRecord(HoodieRecord record, HoodieSchema recordSchema, String keyFieldName) throws IOException {
+    ensureDeleteFileWriter();
+    String recordKey = record.getRecordKey(recordSchema, keyFieldName);
+    Comparable orderingValue = record.getOrderingValue(
+        recordSchema, recordProperties, orderingFieldNames.toArray(new String[0]));
+    Object deleteEngineRecord = recordContext.constructEngineRecord(
+        deleteLogSchema, createDeleteLogFieldValues(recordKey, orderingValue));
+    // Keep isDelete=false here so RecordContext constructs a data-bearing HoodieRecord
+    // with the native delete-log row. The delete semantics come from the delete log file
+    // itself; setting isDelete=true would create a HoodieEmptyRecord and lose the row.
+    BufferedRecord deleteRecord = BufferedRecords.fromEngineRecord(
+        deleteEngineRecord, deleteLogSchema, recordContext, orderingValue, recordKey, false);
+    deleteFileWriter.write(recordKey, recordContext.constructHoodieRecord(deleteRecord, record.getPartitionPath()),
+        deleteLogSchema, recordProperties);
+  }
+
+  private Object[] createDeleteLogFieldValues(String recordKey, Comparable orderingValue) {
+    Object[] fieldValues = new Object[deleteLogSchema.getFields().size()];
+    fieldValues[0] = recordContext.convertValueToEngineType(recordKey);
+    if (!OrderingValues.isCommitTimeOrderingValue(orderingValue)) {
+      if (orderingFieldNames.size() == 1) {
+        fieldValues[1] = orderingValue;
+      } else {
+        List<Comparable> orderingValues = OrderingValues.getValues((ArrayComparable) orderingValue);
+        for (int i = 0; i < orderingValues.size(); i++) {
+          fieldValues[i + 1] = orderingValues.get(i);
+        }
+      }
+    }
+    return fieldValues;
+  }
+
+  public AppendResult flushAppend() throws IOException {
+    return flushAppend(Collections.emptyMap());
+  }
+
+  public AppendResult flushDataAppend(Map<HeaderMetadataType, String> header) throws IOException {
+    int appendVersion = currentAppendVersion;
+    lastAppendResults = new ArrayList<>();
+    lastDataFileFormatMetadata = Option.empty();
+    addFooterMetadataToDataFile(header);
+    if (dataFileWriter != null) {
+      dataFileWriter.close();
+      lastDataFileFormatMetadata = Option.ofNullable(dataFileWriter.getFileFormatMetadata());
+      dataFileWriter = null;
+    }
+    if (dataLogFile != null) {
+      lastAppendResults.add(toAppendResult(dataLogFile));
+    }
+    dataLogFile = null;
+    currentAppendVersion = -1;
+    return completeAppend(appendVersion);
+  }
+
+  public AppendResult flushAppend(Map<HeaderMetadataType, String> header) throws IOException {
+    int appendVersion = currentAppendVersion;
+    lastAppendResults = new ArrayList<>();
+    lastDataFileFormatMetadata = Option.empty();
+    addFooterMetadata(header);
+    closeFileWriters();
+    if (dataLogFile != null) {
+      lastAppendResults.add(toAppendResult(dataLogFile));
+    }
+    if (deleteLogFile != null) {
+      lastAppendResults.add(toAppendResult(deleteLogFile));
+    }
+    dataLogFile = null;
+    deleteLogFile = null;
+    currentAppendVersion = -1;
+    return completeAppend(appendVersion);
+  }
+
+  private void addFooterMetadata(Map<HeaderMetadataType, String> header) throws IOException {
+    Map<String, String> footerMetadata = getFooterMetadata(header);
+    if (dataFileWriter != null) {
+      dataFileWriter.addFooterMetadata(footerMetadata);
+    }
+    if (deleteFileWriter != null) {
+      deleteFileWriter.addFooterMetadata(footerMetadata);
+    }
+  }
+
+  private void addFooterMetadataToDataFile(Map<HeaderMetadataType, String> header) throws IOException {
+    if (dataFileWriter != null) {
+      dataFileWriter.addFooterMetadata(getFooterMetadata(header));
+    }
+  }
+
+  private Map<String, String> getFooterMetadata(Map<HeaderMetadataType, String> header) throws IOException {
+    Map<String, String> logFormatMetadata = new LinkedHashMap<>();
+    logFormatMetadata.put(HeaderMetadataType.VERSION.name(), String.valueOf(NATIVE_LOG_FORMAT_VERSION));
+    header.forEach((key, value) -> {
+      if (value != null && key != HeaderMetadataType.SCHEMA) {
+        // filter out the redundant schema since the footer already carries it.
+        logFormatMetadata.put(key.name(), value);
+      }
+    });
+    return Collections.singletonMap(
+        LOG_FORMAT_METADATA_FOOTER_KEY, JsonUtils.getObjectMapper().writeValueAsString(logFormatMetadata));
+  }
+
+  private void ensureDataFileWriter(HoodieSchema recordSchema) throws IOException {
+    ensureAppendVersion();
+    if (dataFileWriter == null) {
+      dataLogFile = createNativeLogFile(currentAppendVersion, DATA_LOG_EXTENSION);
+      dataFileWriter = HoodieFileWriterFactory.getFileWriter(
+          instantTime, dataLogFile.getPath(), storage, writeConfig, recordSchema, taskContextSupplier,
+          writeConfig.getRecordMerger().getRecordType());
+    }
+  }
+
+  private void ensureDeleteFileWriter() throws IOException {
+    ensureAppendVersion();
+    if (deleteFileWriter == null) {
+      deleteLogFile = createNativeLogFile(currentAppendVersion, DELETE_LOG_EXTENSION);
+      deleteLogSchema = HoodieSchemas.createDeleteLogSchema(tableSchema, orderingFieldNames);
+      deleteFileWriter = HoodieFileWriterFactory.getFileWriter(
+          instantTime, deleteLogFile.getPath(), storage, writeConfig, deleteLogSchema, taskContextSupplier,
+          writeConfig.getRecordMerger().getRecordType());
+    }
+  }
+
+  private void ensureAppendVersion() throws IOException {
+    if (currentAppendVersion < 0) {
+      currentAppendVersion = nextAvailableVersion();
+    }
+  }
+
+  private void closeFileWriters() throws IOException {
+    if (dataFileWriter != null) {
+      dataFileWriter.close();
+      lastDataFileFormatMetadata = Option.ofNullable(dataFileWriter.getFileFormatMetadata());
+      dataFileWriter = null;
+    }
+    if (deleteFileWriter != null) {
+      deleteFileWriter.close();
+      deleteFileWriter = null;
+    }
+  }
+
+  private HoodieLogFile createNativeLogFile(int version, String logExtension) throws IOException {
+    HoodieLogFile nativeLogFile = new HoodieLogFile(makeNativeLogPath(version, logExtension), 0);
+    getFileCreationCallback().preFileCreation(nativeLogFile);
+    return nativeLogFile;
+  }
+
+  private AppendResult toAppendResult(HoodieLogFile nativeLogFile) throws IOException {
+    long fileSize = storage.getPathInfo(nativeLogFile.getPath()).getLength();
+    nativeLogFile.setFileSize(fileSize);
+    return new AppendResult(nativeLogFile, 0, fileSize);
+  }
+
+  private AppendResult completeAppend(int appendVersion) {
+    this.logVersion = appendVersion + 1;
+    if (lastAppendResults.isEmpty()) {
+      return new AppendResult(logFile, 0, 0);
+    }
+
+    long totalSize = lastAppendResults.stream().mapToLong(AppendResult::size).sum();
+    AppendResult firstResult = lastAppendResults.get(0);
+    this.logFile = firstResult.logFile();
+    return new AppendResult(firstResult.logFile(), 0, totalSize);
+  }
+
+  private int nextAvailableVersion() throws IOException {
+    int candidateVersion = logVersion;
+    while (nativeLogExists(candidateVersion, DATA_LOG_EXTENSION)
+        || nativeLogExists(candidateVersion, DELETE_LOG_EXTENSION)) {
+      candidateVersion++;
+    }
+    return candidateVersion;
+  }
+
+  private boolean nativeLogExists(int version, String logExtension) throws IOException {
+    return storage.exists(makeNativeLogPath(version, logExtension));
+  }
+
+  private StoragePath makeNativeLogPath(int version, String logExtension) {
+    return new StoragePath(parentPath, FSUtils.makeNativeLogFileName(
+        logFileId, logWriteToken, instantTime, version, logExtension, HoodieFileFormat.PARQUET));
+  }
+
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieWriteHandle.java
@@ -242,6 +242,10 @@ public abstract class HoodieWriteHandle<T, I, K, O> extends HoodieIOHandle<T, I,
     doWrite(record, schema, props);
   }
 
+  public void write(Map<String, HoodieRecord<T>> recordMap) {
+    recordMap.values().forEach(record -> write(record, writeSchema, config.getProps()));
+  }
+
   protected void markClosed() {
     this.closed = true;
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/HoodieCompactor.java
@@ -41,7 +41,9 @@ import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.io.FileGroupReaderBasedAppendHandle;
+import org.apache.hudi.io.FileGroupReaderBasedInlineLogAppendHandle;
+import org.apache.hudi.io.FileGroupReaderBasedNativeLogAppendHandle;
+import org.apache.hudi.io.HoodieAppendHandle;
 import org.apache.hudi.io.HoodieMergeHandle;
 import org.apache.hudi.io.HoodieMergeHandleFactory;
 import org.apache.hudi.table.HoodieTable;
@@ -171,7 +173,9 @@ public abstract class HoodieCompactor<T, I, K, O> implements Serializable {
                                       TaskContextSupplier taskContextSupplier) throws IOException {
     HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(
         table.getStorageConf(), table.getMetaClient().getTableConfig(), instantRange, Option.empty(), writeConfig.getProps());
-    FileGroupReaderBasedAppendHandle<IndexedRecord, ?, ?, ?> appendHandle = new FileGroupReaderBasedAppendHandle<>(writeConfig, instantTime, table, operation,  taskContextSupplier, readerContext);
+    HoodieAppendHandle<IndexedRecord, ?, ?, ?> appendHandle = table.getMetaClient().getTableConfig().isLSMTreeStorageLayout()
+        ? new FileGroupReaderBasedNativeLogAppendHandle<>(writeConfig, instantTime, table, operation, taskContextSupplier, readerContext)
+        : new FileGroupReaderBasedInlineLogAppendHandle<>(writeConfig, instantTime, table, operation, taskContextSupplier, readerContext);
     appendHandle.doAppend();
     return appendHandle.close();
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkInlineLogAppendHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkInlineLogAppendHandle.java
@@ -44,14 +44,14 @@ import java.util.List;
  * or the file size hits the configured threshold).
  */
 @Slf4j
-public class FlinkAppendHandle<T, I, K, O>
-    extends HoodieAppendHandle<T, I, K, O> implements MiniBatchHandle {
+public class FlinkInlineLogAppendHandle<T, I, K, O>
+    extends HoodieInlineLogAppendHandle<T, I, K, O> implements MiniBatchHandle {
 
   private boolean isClosed = false;
   private final WriteMarkers writeMarkers;
   private final BucketType bucketType;
 
-  public FlinkAppendHandle(
+  public FlinkInlineLogAppendHandle(
       HoodieWriteConfig config,
       String instantTime,
       HoodieTable<T, I, K, O> hoodieTable,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkNativeLogAppendHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkNativeLogAppendHandle.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.commit.BucketType;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Flink mini-batch append handle for native MOR log files.
+ */
+@Slf4j
+public class FlinkNativeLogAppendHandle<T, I, K, O>
+    extends HoodieNativeLogAppendHandle<T, I, K, O> implements MiniBatchHandle {
+
+  private boolean isClosed = false;
+  private final BucketType bucketType;
+
+  public FlinkNativeLogAppendHandle(
+      HoodieWriteConfig config,
+      String instantTime,
+      HoodieTable<T, I, K, O> hoodieTable,
+      String partitionPath,
+      String fileId,
+      BucketType bucketType,
+      Iterator<HoodieRecord<T>> recordItr,
+      TaskContextSupplier taskContextSupplier) {
+    super(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier);
+    this.bucketType = bucketType;
+  }
+
+  @Override
+  public boolean canWrite(HoodieRecord record) {
+    return true;
+  }
+
+  @Override
+  protected boolean needsUpdateLocation() {
+    return false;
+  }
+
+  @Override
+  protected boolean isUpdateRecord(HoodieRecord<T> hoodieRecord) {
+    return bucketType == BucketType.UPDATE;
+  }
+
+  @Override
+  public List<WriteStatus> close() {
+    try {
+      return super.close();
+    } finally {
+      this.isClosed = true;
+    }
+  }
+
+  @Override
+  public void closeGracefully() {
+    if (isClosed) {
+      return;
+    }
+    try {
+      close();
+    } catch (Throwable throwable) {
+      log.warn("Failed to close the APPEND handle", throwable);
+    }
+  }
+
+  @Override
+  public StoragePath getWritePath() {
+    return getLogFilePath();
+  }
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkWriteHandleFactory.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkWriteHandleFactory.java
@@ -23,7 +23,8 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.io.v2.RowDataLogWriteHandle;
+import org.apache.hudi.io.v2.RowDataInlineLogWriteHandle;
+import org.apache.hudi.io.v2.RowDataNativeLogWriteHandle;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
@@ -308,7 +309,12 @@ public class FlinkWriteHandleFactory {
       final String fileID = bucketInfo.getFileIdPrefix();
       final String partitionPath = bucketInfo.getPartitionPath();
       final TaskContextSupplier contextSupplier = table.getTaskContextSupplier();
-      return new FlinkAppendHandle<>(config, instantTime, table, partitionPath, fileID, bucketInfo.getBucketType(), recordItr, contextSupplier);
+      if (table.getMetaClient().getTableConfig().isLSMTreeStorageLayout()) {
+        return new FlinkNativeLogAppendHandle<>(config, instantTime, table, partitionPath, fileID,
+            bucketInfo.getBucketType(), recordItr, contextSupplier);
+      }
+      return new FlinkInlineLogAppendHandle<>(config, instantTime, table, partitionPath, fileID,
+          bucketInfo.getBucketType(), recordItr, contextSupplier);
     }
   }
 
@@ -331,7 +337,18 @@ public class FlinkWriteHandleFactory {
         String instantTime,
         HoodieTable<T, I, K, O> table,
         Iterator<HoodieRecord<T>> recordIterator) {
-      return new RowDataLogWriteHandle<>(
+      if (table.getMetaClient().getTableConfig().isLSMTreeStorageLayout()) {
+        return new RowDataNativeLogWriteHandle<>(
+            config,
+            instantTime,
+            table,
+            recordIterator,
+            bucketInfo.getFileIdPrefix(),
+            bucketInfo.getPartitionPath(),
+            bucketInfo.getBucketType(),
+            table.getTaskContextSupplier());
+      }
+      return new RowDataInlineLogWriteHandle<>(
           config,
           instantTime,
           table,

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataParquetWriteSupport.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataParquetWriteSupport.java
@@ -36,6 +36,7 @@ import java.util.Map;
  */
 public class HoodieRowDataParquetWriteSupport extends RowDataParquetWriteSupport {
 
+  private final Map<String, String> footerMetadata = new HashMap<>();
   private final Option<HoodieBloomFilterWriteSupport<String>> bloomFilterWriteSupportOpt;
 
   public HoodieRowDataParquetWriteSupport(Configuration conf, HoodieSchema schema, BloomFilter bloomFilter) {
@@ -58,8 +59,16 @@ public class HoodieRowDataParquetWriteSupport extends RowDataParquetWriteSupport
       extraMetadata = new HashMap<>(extraMetadata);
       extraMetadata.put(HoodieSchema.VECTOR_COLUMNS_METADATA_KEY, vectorColumnsMetadata);
     }
+    if (!footerMetadata.isEmpty()) {
+      extraMetadata = new HashMap<>(extraMetadata);
+      extraMetadata.putAll(footerMetadata);
+    }
 
     return new WriteSupport.FinalizedWriteContext(extraMetadata);
+  }
+
+  public void addFooterMetadata(Map<String, String> footerMetadata) {
+    this.footerMetadata.putAll(footerMetadata);
   }
 
   public void add(String recordKey) {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataParquetWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataParquetWriter.java
@@ -29,6 +29,7 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.flink.table.data.RowData;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -67,6 +68,11 @@ public class HoodieRowDataParquetWriter extends HoodieBaseParquetWriter<RowData>
   public void writeRow(String key, RowData row) throws IOException {
     super.write(row);
     writeSupport.add(key);
+  }
+
+  @Override
+  public void addFooterMetadata(Map<String, String> footerMetadata) {
+    writeSupport.addFooterMetadata(footerMetadata);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/v2/RowDataInlineLogWriteHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/v2/RowDataInlineLogWriteHandle.java
@@ -21,7 +21,6 @@ package org.apache.hudi.io.v2;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.table.log.AppendResult;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType;
@@ -30,7 +29,7 @@ import org.apache.hudi.common.util.SizeEstimator;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.io.FlinkAppendHandle;
+import org.apache.hudi.io.FlinkInlineLogAppendHandle;
 import org.apache.hudi.io.MiniBatchHandle;
 import org.apache.hudi.io.log.block.HoodieFlinkAvroDataBlock;
 import org.apache.hudi.io.log.block.HoodieFlinkParquetDataBlock;
@@ -59,19 +58,19 @@ import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_CO
 
 /**
  * A write handle that supports creating a log file and writing records based on record Iterator.
- * The differences from {@code FlinkAppendHandle} are:
+ * The differences from {@code FlinkInlineLogAppendHandle} are:
  *
- * <p> 1. {@code RowDataLogHandle} does not convert RowData into Avro record before writing.
- * <p> 2. {@code RowDataLogHandle} writes Parquet data block by default.
+ * <p> 1. {@code RowDataInlineLogWriteHandle} does not convert RowData into Avro record before writing.
+ * <p> 2. {@code RowDataInlineLogWriteHandle} writes Parquet data block by default.
  *
  * <p>The back-up writer may roll over to a new log file if there already exists a log file for the
  * given file group and instant.
  */
 @Slf4j
-public class RowDataLogWriteHandle<T, I, K, O>
-    extends FlinkAppendHandle<T, I, K, O> implements MiniBatchHandle {
+public class RowDataInlineLogWriteHandle<T, I, K, O>
+    extends FlinkInlineLogAppendHandle<T, I, K, O> implements MiniBatchHandle {
 
-  public RowDataLogWriteHandle(
+  public RowDataInlineLogWriteHandle(
       HoodieWriteConfig config,
       String instantTime,
       HoodieTable<T, I, K, O> hoodieTable,
@@ -97,13 +96,11 @@ public class RowDataLogWriteHandle<T, I, K, O>
   }
 
   @Override
-  protected void processAppendResult(AppendResult result, Option<HoodieLogBlock> dataBlock) {
+  protected void collectColumnStats(HoodieDeltaWriteStat stat) {
     if (getLogBlockType() == HoodieLogBlockType.AVRO_DATA_BLOCK) {
-      super.processAppendResult(result, dataBlock);
+      super.collectColumnStats(stat);
       return;
     }
-    HoodieDeltaWriteStat stat = (HoodieDeltaWriteStat) this.writeStatus.getStat();
-    updateWriteStatus(result, stat);
 
     // for parquet data block, we can get column stats from parquet footer directly.
     if (config.isMetadataColumnStatsIndexEnabled()) {
@@ -114,25 +111,20 @@ public class RowDataLogWriteHandle<T, I, K, O>
               Option.of(HoodieRecord.HoodieRecordType.FLINK), indexVersion).keySet());
 
       Map<String, HoodieColumnRangeMetadata<Comparable>> columnRangeMetadata;
-      if (dataBlock.isEmpty()) {
+      if (appendDataBlock.isEmpty()) {
         // only delete block exists
         columnRangeMetadata = new HashMap<>();
         columnsToIndexSet.forEach(col -> columnRangeMetadata.put(col, HoodieColumnRangeMetadata.createEmpty(stat.getPath(), col, indexVersion)));
       } else {
-        ValidationUtils.checkArgument(dataBlock.get() instanceof ColumnRangeMetadataProvider,
+        ValidationUtils.checkArgument(appendDataBlock.get() instanceof ColumnRangeMetadataProvider,
             "Log block for Flink ingestion should always be an instance of ColumnRangeMetadataProvider for collecting column stats efficiently.");
         columnRangeMetadata =
-            ((ColumnRangeMetadataProvider) dataBlock.get()).getColumnRangeMeta(stat.getPath(), indexVersion).entrySet().stream()
+            ((ColumnRangeMetadataProvider) appendDataBlock.get()).getColumnRangeMeta(stat.getPath(), indexVersion).entrySet().stream()
                 .filter(e -> columnsToIndexSet.contains(e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
       }
       stat.putRecordsStats(columnRangeMetadata);
     }
-    resetWriteCounts();
-    assert stat.getRuntimeStats() != null;
-    log.info("WriteHandle for partitionPath {} filePath {}, took {} ms.",
-        partitionPath, stat.getPath(), stat.getRuntimeStats().getTotalUpsertTime());
-    timer.startTimer();
   }
 
   /**

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/v2/RowDataNativeLogWriteHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/v2/RowDataNativeLogWriteHandle.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.v2;
+
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.io.FlinkNativeLogAppendHandle;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.commit.BucketType;
+
+import java.util.Iterator;
+
+/**
+ * RowData write handle for native MOR log files.
+ */
+public class RowDataNativeLogWriteHandle<T, I, K, O> extends FlinkNativeLogAppendHandle<T, I, K, O> {
+
+  public RowDataNativeLogWriteHandle(
+      HoodieWriteConfig config,
+      String instantTime,
+      HoodieTable<T, I, K, O> hoodieTable,
+      Iterator<HoodieRecord<T>> recordItr,
+      String fileId,
+      String partitionPath,
+      BucketType bucketType,
+      TaskContextSupplier taskContextSupplier) {
+    super(config, instantTime, hoodieTable, partitionPath, fileId, bucketType, recordItr, taskContextSupplier);
+  }
+
+  /**
+   * Flink writer does not support record-position for update/delete currently, will be supported later, see HUDI-9192.
+   */
+  @Override
+  protected Option<String> getBaseFileInstantTimeOfPositions() {
+    return Option.empty();
+  }
+}

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkMergeOnReadTable.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/HoodieFlinkMergeOnReadTable.java
@@ -31,8 +31,9 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.io.FlinkAppendHandle;
 import org.apache.hudi.io.HoodieAppendHandle;
+import org.apache.hudi.io.HoodieInlineLogAppendHandle;
+import org.apache.hudi.io.HoodieNativeLogAppendHandle;
 import org.apache.hudi.io.HoodieWriteHandle;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.table.action.commit.BucketInfo;
@@ -69,8 +70,8 @@ public class HoodieFlinkMergeOnReadTable<T>
       BucketInfo bucketInfo,
       String instantTime,
       Iterator<HoodieRecord<T>> records) {
-    ValidationUtils.checkArgument(writeHandle instanceof FlinkAppendHandle,
-        "MOR RowData handle should always be a FlinkAppendHandle");
+    ValidationUtils.checkArgument(writeHandle instanceof HoodieAppendHandle,
+        "MOR RowData handle should always be a HoodieAppendHandle");
     return new FlinkUpsertDeltaCommitActionExecutor<>(context, writeHandle, bucketInfo, config, this, instantTime, records).execute();
   }
 
@@ -81,9 +82,9 @@ public class HoodieFlinkMergeOnReadTable<T>
       BucketInfo bucketInfo,
       String instantTime,
       List<HoodieRecord<T>> preppedRecords) {
-    ValidationUtils.checkArgument(writeHandle instanceof FlinkAppendHandle,
-        "MOR write handle should always be a FlinkAppendHandle");
-    FlinkAppendHandle<?, ?, ?, ?> appendHandle = (FlinkAppendHandle<?, ?, ?, ?>) writeHandle;
+    ValidationUtils.checkArgument(writeHandle instanceof HoodieAppendHandle,
+        "MOR write handle should always be a HoodieAppendHandle");
+    HoodieAppendHandle<?, ?, ?, ?> appendHandle = (HoodieAppendHandle<?, ?, ?, ?>) writeHandle;
     return new FlinkUpsertPreppedDeltaCommitActionExecutor<>(context, appendHandle, bucketInfo, config, this, instantTime, preppedRecords).execute();
   }
 
@@ -94,8 +95,8 @@ public class HoodieFlinkMergeOnReadTable<T>
       BucketInfo bucketInfo,
       String instantTime,
       Iterator<HoodieRecord<T>> hoodieRecords) {
-    if (writeHandle instanceof FlinkAppendHandle) {
-      FlinkAppendHandle<?, ?, ?, ?> appendHandle = (FlinkAppendHandle<?, ?, ?, ?>) writeHandle;
+    if (writeHandle instanceof HoodieAppendHandle) {
+      HoodieAppendHandle<?, ?, ?, ?> appendHandle = (HoodieAppendHandle<?, ?, ?, ?>) writeHandle;
       return new FlinkUpsertDeltaCommitActionExecutor<>(context, appendHandle, bucketInfo, config, this, instantTime, hoodieRecords).execute();
     } else {
       return super.insert(context, writeHandle, bucketInfo, instantTime, hoodieRecords);
@@ -140,8 +141,11 @@ public class HoodieFlinkMergeOnReadTable<T>
   public Iterator<List<WriteStatus>> handleInsertsForLogCompaction(String instantTime, String partitionPath, String fileId,
                                                                    Map<String, HoodieRecord<?>> recordMap,
                                                                    Map<HoodieLogBlock.HeaderMetadataType, String> header) {
-    HoodieAppendHandle appendHandle = new HoodieAppendHandle(config, instantTime, this,
-        partitionPath, fileId, recordMap.values().iterator(), taskContextSupplier, header);
+    HoodieWriteHandle appendHandle = getMetaClient().getTableConfig().isLSMTreeStorageLayout()
+        ? new HoodieNativeLogAppendHandle(config, instantTime, this,
+            partitionPath, fileId, recordMap.values().iterator(), taskContextSupplier, header)
+        : new HoodieInlineLogAppendHandle(config, instantTime, this,
+            partitionPath, fileId, recordMap.values().iterator(), taskContextSupplier, header);
     appendHandle.write(recordMap);
     List<WriteStatus> writeStatuses = appendHandle.close();
     return Collections.singletonList(writeStatuses).iterator();
@@ -161,4 +165,3 @@ public class HoodieFlinkMergeOnReadTable<T>
         skipLocking).execute();
   }
 }
-

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/BaseFlinkDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/BaseFlinkDeltaCommitActionExecutor.java
@@ -25,7 +25,7 @@ import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.execution.FlinkLazyInsertIterable;
 import org.apache.hudi.io.ExplicitWriteHandleFactory;
-import org.apache.hudi.io.FlinkAppendHandle;
+import org.apache.hudi.io.HoodieAppendHandle;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.commit.BaseFlinkCommitActionExecutor;
 import org.apache.hudi.table.action.commit.BucketInfo;
@@ -41,7 +41,7 @@ public abstract class BaseFlinkDeltaCommitActionExecutor<T>
     extends BaseFlinkCommitActionExecutor<T> {
 
   public BaseFlinkDeltaCommitActionExecutor(HoodieEngineContext context,
-                                            FlinkAppendHandle<?, ?, ?, ?> writeHandle,
+                                            HoodieAppendHandle<?, ?, ?, ?> writeHandle,
                                             BucketInfo bucketInfo,
                                             HoodieWriteConfig config,
                                             HoodieTable table,
@@ -52,7 +52,7 @@ public abstract class BaseFlinkDeltaCommitActionExecutor<T>
 
   @Override
   public Iterator<List<WriteStatus>> handleUpdate(String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr) {
-    FlinkAppendHandle appendHandle = (FlinkAppendHandle) writeHandle;
+    HoodieAppendHandle appendHandle = (HoodieAppendHandle) writeHandle;
     appendHandle.doAppend();
     List<WriteStatus> writeStatuses = appendHandle.close();
     return Collections.singletonList(writeStatuses).iterator();

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/FlinkUpsertDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/FlinkUpsertDeltaCommitActionExecutor.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.io.FlinkAppendHandle;
+import org.apache.hudi.io.HoodieAppendHandle;
 import org.apache.hudi.io.HoodieWriteHandle;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
@@ -67,7 +67,7 @@ public class FlinkUpsertDeltaCommitActionExecutor<T> extends BaseFlinkCommitActi
    * When using RowData writing mode for MOR upsert path, same write logic is used for UPSERT and INSERT operation.
    */
   private Iterator<List<WriteStatus>> handleWrite() {
-    FlinkAppendHandle logWriteHandle = (FlinkAppendHandle) writeHandle;
+    HoodieAppendHandle logWriteHandle = (HoodieAppendHandle) writeHandle;
     logWriteHandle.doAppend();
     List<WriteStatus> writeStatuses = logWriteHandle.close();
     return Collections.singletonList(writeStatuses).iterator();

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/FlinkUpsertPreppedDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/delta/FlinkUpsertPreppedDeltaCommitActionExecutor.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.hudi.io.FlinkAppendHandle;
+import org.apache.hudi.io.HoodieAppendHandle;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.table.action.commit.BucketInfo;
@@ -39,7 +39,7 @@ public class FlinkUpsertPreppedDeltaCommitActionExecutor<T>
   private final List<HoodieRecord<T>> preppedRecords;
 
   public FlinkUpsertPreppedDeltaCommitActionExecutor(HoodieEngineContext context,
-                                                     FlinkAppendHandle<?, ?, ?, ?> writeHandle,
+                                                     HoodieAppendHandle<?, ?, ?, ?> writeHandle,
                                                      BucketInfo bucketInfo,
                                                      HoodieWriteConfig config,
                                                      HoodieTable table,

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/deltacommit/BaseJavaDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/deltacommit/BaseJavaDeltaCommitActionExecutor.java
@@ -75,8 +75,8 @@ abstract class BaseJavaDeltaCommitActionExecutor<T> extends BaseJavaCommitAction
       log.info("Small file corrections for updates for commit " + instantTime + " for file " + fileId);
       return super.handleUpdate(partitionPath, fileId, recordItr);
     } else {
-      HoodieAppendHandle<?, ?, ?, ?> appendHandle = new HoodieAppendHandle<>(config, instantTime, table,
-          partitionPath, fileId, recordItr, taskContextSupplier);
+      HoodieAppendHandle<?, ?, ?, ?> appendHandle = new AppendHandleFactory()
+          .create(config, instantTime, table, partitionPath, fileId, recordItr, taskContextSupplier);
       appendHandle.doAppend();
       return Collections.singletonList(appendHandle.close()).iterator();
     }

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/deltacommit/JavaUpsertPreppedDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/deltacommit/JavaUpsertPreppedDeltaCommitActionExecutor.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieUpsertException;
+import org.apache.hudi.io.AppendHandleFactory;
 import org.apache.hudi.io.HoodieAppendHandle;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
@@ -75,8 +76,8 @@ public class JavaUpsertPreppedDeltaCommitActionExecutor<T> extends BaseJavaDelta
     List<WriteStatus> allWriteStatuses = new ArrayList<>();
     try {
       recordsByFileId.forEach((k, v) -> {
-        HoodieAppendHandle<?, ?, ?, ?> appendHandle = new HoodieAppendHandle(config, instantTime, table,
-            k.getRight(), k.getLeft(), v.iterator(), taskContextSupplier);
+        HoodieAppendHandle<?, ?, ?, ?> appendHandle = new AppendHandleFactory()
+            .create(config, instantTime, table, k.getRight(), k.getLeft(), v.iterator(), taskContextSupplier);
         appendHandle.doAppend();
         allWriteStatuses.addAll(appendHandle.close());
       });

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkParquetWriter.java
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.COMMIT_SEQNO_METADATA_FIELD;
@@ -84,6 +85,11 @@ public class HoodieSparkParquetWriter extends HoodieBaseParquetWriter<InternalRo
     if (populateMetaFields) {
       writeSupport.add(UTF8String.fromString(recordKey));
     }
+  }
+
+  @Override
+  public void addFooterMetadata(Map<String, String> footerMetadata) {
+    writeSupport.addFooterMetadata(footerMetadata);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -127,6 +127,7 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
 
   @Getter
   private final Configuration hadoopConf;
+  private final Map<String, String> footerMetadata = new HashMap<>();
   private final Option<HoodieBloomFilterWriteSupport<UTF8String>> bloomFilterWriteSupportOpt;
   private final byte[] decimalBuffer = new byte[Decimal.minBytesForPrecision()[DecimalType.MAX_PRECISION()]];
   private final Enumeration.Value datetimeRebaseMode = (Enumeration.Value) SparkAdapterSupport$.MODULE$.sparkAdapter().getDateTimeRebaseMode();
@@ -432,8 +433,16 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     Map<String, String> extraMetadata =
         bloomFilterWriteSupportOpt.map(HoodieBloomFilterWriteSupport::finalizeMetadata)
             .orElse(Collections.emptyMap());
+    if (!footerMetadata.isEmpty()) {
+      extraMetadata = new HashMap<>(extraMetadata);
+      extraMetadata.putAll(footerMetadata);
+    }
 
     return new WriteSupport.FinalizedWriteContext(extraMetadata);
+  }
+
+  public void addFooterMetadata(Map<String, String> footerMetadata) {
+    this.footerMetadata.putAll(footerMetadata);
   }
 
   public void add(UTF8String recordKey) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadTable.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/HoodieSparkMergeOnReadTable.java
@@ -39,7 +39,9 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieMetadataException;
-import org.apache.hudi.io.HoodieAppendHandle;
+import org.apache.hudi.io.HoodieInlineLogAppendHandle;
+import org.apache.hudi.io.HoodieNativeLogAppendHandle;
+import org.apache.hudi.io.HoodieWriteHandle;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.table.action.bootstrap.HoodieBootstrapWriteMetadata;
 import org.apache.hudi.table.action.bootstrap.SparkBootstrapDeltaCommitActionExecutor;
@@ -200,8 +202,11 @@ public class HoodieSparkMergeOnReadTable<T> extends HoodieSparkCopyOnWriteTable<
   public Iterator<List<WriteStatus>> handleInsertsForLogCompaction(String instantTime, String partitionPath, String fileId,
                                                           Map<String, HoodieRecord<?>> recordMap,
                                                           Map<HoodieLogBlock.HeaderMetadataType, String> header) {
-    HoodieAppendHandle appendHandle = new HoodieAppendHandle(config, instantTime, this,
-        partitionPath, fileId, recordMap.values().iterator(), taskContextSupplier, header);
+    HoodieWriteHandle appendHandle = getMetaClient().getTableConfig().isLSMTreeStorageLayout()
+        ? new HoodieNativeLogAppendHandle(config, instantTime, this,
+            partitionPath, fileId, recordMap.values().iterator(), taskContextSupplier, header)
+        : new HoodieInlineLogAppendHandle(config, instantTime, this,
+            partitionPath, fileId, recordMap.values().iterator(), taskContextSupplier, header);
     appendHandle.write(recordMap);
     List<WriteStatus> writeStatuses = appendHandle.close();
     return Collections.singletonList(writeStatuses).iterator();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/deltacommit/BaseSparkDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/deltacommit/BaseSparkDeltaCommitActionExecutor.java
@@ -77,8 +77,8 @@ public abstract class BaseSparkDeltaCommitActionExecutor<T>
       log.info("Small file corrections for updates for commit {} for file {}", instantTime, fileId);
       return super.handleUpdate(partitionPath, fileId, recordItr);
     } else {
-      HoodieAppendHandle<?, ?, ?, ?> appendHandle = new HoodieAppendHandle<>(config, instantTime, table,
-          partitionPath, fileId, recordItr, taskContextSupplier);
+      HoodieAppendHandle<?, ?, ?, ?> appendHandle = new AppendHandleFactory()
+          .create(config, instantTime, table, partitionPath, fileId, recordItr, taskContextSupplier);
       appendHandle.doAppend();
       return Collections.singletonList(appendHandle.close()).iterator();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -475,6 +475,15 @@ public class FSUtils {
     return HoodieLogFile.LOG_FILE_PREFIX + suffix;
   }
 
+  public static String makeNativeLogFileName(String fileId, String writeToken, String deltaCommitTime, int version,
+                                             String logFileExtension, HoodieFileFormat nativeFileFormat) {
+    String extension = logFileExtension.startsWith(".") ? logFileExtension.substring(1) : logFileExtension;
+    String formatSuffix = nativeFileFormat.getFileExtension().startsWith(".")
+        ? nativeFileFormat.getFileExtension().substring(1)
+        : nativeFileFormat.getFileExtension();
+    return String.format("%s_%s_%s_%d.%s.%s", fileId, writeToken, deltaCommitTime, version, extension, formatSuffix);
+  }
+
   public static boolean isBaseFile(StoragePath path) {
     if (matchNativeLogFile(path.getName()).isPresent()) {
       return false;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieLogFile.java
@@ -59,10 +59,10 @@ public class HoodieLogFile implements Serializable {
 
   static {
     Map<String, Integer> extensionPrecedence = new HashMap<>();
-    extensionPrecedence.put("log", 0);
-    extensionPrecedence.put("deletes", 1); // the deletes come after logs to ensure commit time sequence.
-    extensionPrecedence.put("cdc", 2);
-    extensionPrecedence.put("archive", 3);
+    extensionPrecedence.put(LogExtensions.DATA_LOG_EXTENSION, 0);
+    extensionPrecedence.put(LogExtensions.DELETE_LOG_EXTENSION, 1); // the deletes come after logs to ensure commit time sequence.
+    extensionPrecedence.put(LogExtensions.CDC_LOG_EXTENSION, 2);
+    extensionPrecedence.put(LogExtensions.ARCHIVE_LOG_EXTENSION, 3);
     EXTENSION_PRECEDENCE = Collections.unmodifiableMap(extensionPrecedence);
   }
 
@@ -206,6 +206,11 @@ public class HoodieLogFile implements Serializable {
     String fileId = getFileId();
     String deltaCommitTime = getDeltaCommitTime();
     StoragePath path = getPath();
+    if (FSUtils.matchNativeLogFile(path.getName()).isPresent()) {
+      return new HoodieLogFile(new StoragePath(path.getParent(),
+          FSUtils.makeNativeLogFileName(fileId, logWriteToken, deltaCommitTime, logVersion + 1,
+              fileExtension, HoodieFileFormat.fromFileExtension("." + getSuffix()))));
+    }
     String extension = "." + fileExtension;
     return new HoodieLogFile(new StoragePath(path.getParent(),
         FSUtils.makeLogFileName(fileId, extension, deltaCommitTime, logVersion + 1, logWriteToken)));

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/LogExtensions.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/LogExtensions.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+/**
+ * Logical extensions used in Hudi log file names.
+ */
+public final class LogExtensions {
+
+  public static final String DATA_LOG_EXTENSION = "log";
+  public static final String DELETE_LOG_EXTENSION = "deletes";
+  public static final String CDC_LOG_EXTENSION = "cdc";
+  public static final String ARCHIVE_LOG_EXTENSION = "archive";
+
+  private LogExtensions() {
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemas.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchemas.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.common.schema;
 
+import org.apache.hudi.common.model.HoodieRecord;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,12 +31,11 @@ import static org.apache.hudi.common.schema.HoodieSchemaUtils.createNewSchemaFie
  * Factory class for {@link HoodieSchema}.
  */
 public class HoodieSchemas {
-  public static final String DELETE_LOG_RECORD_KEY_FIELD = "record_key";
 
   public static HoodieSchema createDeleteLogSchema(HoodieSchema tableSchema, List<String> orderingFieldNames) {
     List<HoodieSchemaField> fields = Stream.concat(
         Stream.of(createNewSchemaField(
-            DELETE_LOG_RECORD_KEY_FIELD, HoodieSchema.create(HoodieSchemaType.STRING), null, null)),
+            HoodieRecord.RECORD_KEY_METADATA_FIELD, HoodieSchema.create(HoodieSchemaType.STRING), null, null)),
         orderingFieldNames.stream().map(orderingFieldName -> tableSchema.getField(orderingFieldName)
             .map(HoodieSchemaUtils::createNewSchemaField)
             .orElseThrow(() ->

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -240,6 +240,12 @@ public class HoodieTableConfig extends HoodieConfig {
       .withAlternatives("hoodie.table.rt.file.format")
       .withDocumentation("Log format used for the delta logs.");
 
+  public static final ConfigProperty<String> TABLE_STORAGE_LAYOUT = ConfigProperty
+      .key("hoodie.table.storage.layout")
+      .defaultValue(TableStorageLayout.DEFAULT.configValue)
+      .sinceVersion("1.3.0")
+      .withDocumentation("Physical table storage layout. Valid values are default and lsm_tree.");
+
   public static final ConfigProperty<String> TIMELINE_LAYOUT_VERSION = ConfigProperty
       .key("hoodie.timeline.layout.version")
       .noDefaultValue()
@@ -1168,6 +1174,36 @@ public class HoodieTableConfig extends HoodieConfig {
    */
   public HoodieFileFormat getLogFileFormat() {
     return HoodieFileFormat.valueOf(getStringOrDefault(LOG_FILE_FORMAT));
+  }
+
+  public TableStorageLayout getTableStorageLayout() {
+    return TableStorageLayout.fromConfigValue(getStringOrDefault(TABLE_STORAGE_LAYOUT));
+  }
+
+  public boolean isLSMTreeStorageLayout() {
+    return getTableStorageLayout() == TableStorageLayout.LSM_TREE;
+  }
+
+  public enum TableStorageLayout {
+    DEFAULT("default"),
+    LSM_TREE("lsm_tree");
+
+    private final String configValue;
+
+    TableStorageLayout(String configValue) {
+      this.configValue = configValue;
+    }
+
+    public String configValue() {
+      return configValue;
+    }
+
+    public static TableStorageLayout fromConfigValue(String configValue) {
+      return Arrays.stream(values())
+          .filter(layout -> layout.configValue.equalsIgnoreCase(configValue))
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("Unknown table storage layout: " + configValue));
+    }
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableVersion.java
@@ -57,7 +57,9 @@ public enum HoodieTableVersion {
   // 1.0
   EIGHT(8, CollectionUtils.createImmutableList("1.0.0"), TimelineLayoutVersion.LAYOUT_VERSION_2),
   // 1.1
-  NINE(9, CollectionUtils.createImmutableList("1.1.0"), TimelineLayoutVersion.LAYOUT_VERSION_2);
+  NINE(9, CollectionUtils.createImmutableList("1.1.0"), TimelineLayoutVersion.LAYOUT_VERSION_2),
+  // 1.3
+  TEN(10, CollectionUtils.createImmutableList("1.3.0"), TimelineLayoutVersion.LAYOUT_VERSION_2);
 
   @Accessors(fluent = true) // Required so that #versionCode() is generated instead of #getVersionCode() by Lombok
   private final int versionCode;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -212,7 +212,8 @@ public abstract class HoodieLogBlock {
     RECORD_POSITIONS(HoodieTableVersion.SIX),
     BLOCK_IDENTIFIER(HoodieTableVersion.SIX),
     IS_PARTIAL(HoodieTableVersion.EIGHT),
-    BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS(HoodieTableVersion.EIGHT);
+    BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS(HoodieTableVersion.EIGHT),
+    VERSION(HoodieTableVersion.NINE);
 
     @SuppressWarnings("unused")
     private final HoodieTableVersion earliestTableVersion;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/lsm/LsmFileGroupRecordIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/lsm/LsmFileGroupRecordIterator.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemas;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -325,7 +326,7 @@ public class LsmFileGroupRecordIterator<T> implements ClosableIterator<BufferedR
                                                         HoodieSchema deleteLogSchema,
                                                         List<String> orderingFieldNames) {
     Object recordKey = readerContext.getRecordContext()
-        .getValue(record, deleteLogSchema, HoodieSchemas.DELETE_LOG_RECORD_KEY_FIELD);
+        .getValue(record, deleteLogSchema, HoodieRecord.RECORD_KEY_METADATA_FIELD);
     // Preserve the delete log's ordering value so event-time/custom merge modes can compare
     // deletes against data records instead of treating every native delete as commit-time ordered.
     Comparable orderingValue =

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriter.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.CollectionUtils;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
 
 public interface HoodieFileWriter extends AutoCloseable {
@@ -34,6 +35,10 @@ public interface HoodieFileWriter extends AutoCloseable {
   void write(String recordKey, HoodieRecord record, HoodieSchema schema, Properties props) throws IOException;
 
   void close() throws IOException;
+
+  default void addFooterMetadata(Map<String, String> footerMetadata) {
+    // No-op for file writers that do not support key/value footer metadata.
+  }
 
   default void writeWithMetadata(HoodieKey key, HoodieRecord record, HoodieSchema schema) throws IOException {
     writeWithMetadata(key, record, schema, CollectionUtils.emptyProps());

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
@@ -230,13 +230,12 @@ public class TestHoodieLogFile {
         nativeLogPath(LogExtensions.DELETE_LOG_EXTENSION, 8)));
     HoodieLogFile cdcFile = new HoodieLogFile(new StoragePath(
         nativeLogPath(LogExtensions.CDC_LOG_EXTENSION, 8)));
-    HoodieLogFile archiveFile = new HoodieLogFile(new StoragePath(
-        nativeLogPath(LogExtensions.ARCHIVE_LOG_EXTENSION, 8)));
 
-    List<HoodieLogFile> logFiles = Arrays.asList(archiveFile, cdcFile, deleteFile, logFile);
+    List<HoodieLogFile> logFiles = Arrays.asList(cdcFile, deleteFile, logFile);
     logFiles.sort(HoodieLogFile.getLogFileComparator());
 
-    assertEquals(Arrays.asList(logFile, deleteFile, cdcFile, archiveFile), logFiles);
+    assertEquals(Arrays.asList(logFile, deleteFile, cdcFile), logFiles);
+    assertFalse(FSUtils.matchNativeLogFile(nativeLogPath(LogExtensions.ARCHIVE_LOG_EXTENSION, 8)).isPresent());
   }
 
   private String nativeLogPath(String extension, int version) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestHoodieLogFile.java
@@ -211,15 +211,37 @@ public class TestHoodieLogFile {
   @Test
   void logFileComparatorOrdersNativeDeletesAfterLogsForSameVersion() {
     HoodieLogFile logFile = new HoodieLogFile(new StoragePath(
-        "/tmp/136281f3-c24e-423b-a65a-95dbfbddce1d_1-0-1_20250409161256974_8.log.parquet"));
+        nativeLogPath(LogExtensions.DATA_LOG_EXTENSION, 8)));
     HoodieLogFile deleteFile = new HoodieLogFile(new StoragePath(
-        "/tmp/136281f3-c24e-423b-a65a-95dbfbddce1d_1-0-1_20250409161256974_8.deletes.parquet"));
+        nativeLogPath(LogExtensions.DELETE_LOG_EXTENSION, 8)));
 
     List<HoodieLogFile> logFiles = Arrays.asList(deleteFile, logFile);
     logFiles.sort(HoodieLogFile.getLogFileComparator());
 
     assertEquals(logFile, logFiles.get(0));
     assertEquals(deleteFile, logFiles.get(1));
+  }
+
+  @Test
+  void logFileComparatorOrdersNativeLogExtensionsByPrecedenceForSameVersion() {
+    HoodieLogFile logFile = new HoodieLogFile(new StoragePath(
+        nativeLogPath(LogExtensions.DATA_LOG_EXTENSION, 8)));
+    HoodieLogFile deleteFile = new HoodieLogFile(new StoragePath(
+        nativeLogPath(LogExtensions.DELETE_LOG_EXTENSION, 8)));
+    HoodieLogFile cdcFile = new HoodieLogFile(new StoragePath(
+        nativeLogPath(LogExtensions.CDC_LOG_EXTENSION, 8)));
+    HoodieLogFile archiveFile = new HoodieLogFile(new StoragePath(
+        nativeLogPath(LogExtensions.ARCHIVE_LOG_EXTENSION, 8)));
+
+    List<HoodieLogFile> logFiles = Arrays.asList(archiveFile, cdcFile, deleteFile, logFile);
+    logFiles.sort(HoodieLogFile.getLogFileComparator());
+
+    assertEquals(Arrays.asList(logFile, deleteFile, cdcFile, archiveFile), logFiles);
+  }
+
+  private String nativeLogPath(String extension, int version) {
+    return String.format("/tmp/%s_%s_%s_%d.%s.parquet",
+        fileId, writeToken, "20250409161256974", version, extension);
   }
 
   private void assertFileGetters(StoragePathInfo pathInfo, HoodieLogFile hoodieLogFile,

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/lsm/TestLsmFileGroupRecordIterator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/lsm/TestLsmFileGroupRecordIterator.java
@@ -22,6 +22,7 @@ package org.apache.hudi.common.table.read.lsm;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
@@ -54,10 +55,10 @@ class TestLsmFileGroupRecordIterator {
   void testDeleteLogSchemaUsesRecordKeyAndOrderingFields() {
     HoodieSchema deleteLogSchema = HoodieSchemas.createDeleteLogSchema(tableSchema(), Arrays.asList("ts"));
 
-    assertEquals(Arrays.asList("record_key", "ts"), deleteLogSchema.getFields().stream()
+    assertEquals(Arrays.asList(HoodieRecord.RECORD_KEY_METADATA_FIELD, "ts"), deleteLogSchema.getFields().stream()
         .map(HoodieSchemaField::name)
         .collect(Collectors.toList()));
-    assertEquals(HoodieSchemaType.STRING, deleteLogSchema.getField("record_key").get().schema().getType());
+    assertEquals(HoodieSchemaType.STRING, deleteLogSchema.getField(HoodieRecord.RECORD_KEY_METADATA_FIELD).get().schema().getType());
     assertEquals(HoodieSchemaType.LONG, deleteLogSchema.getField("ts").get().schema().getType());
   }
 
@@ -88,7 +89,7 @@ class TestLsmFileGroupRecordIterator {
     HoodieSchema deleteLogSchema = HoodieSchemas.createDeleteLogSchema(tableSchema(), orderingFields);
 
     when(readerContext.getRecordContext()).thenReturn(recordContext);
-    when(recordContext.getValue(record, deleteLogSchema, "record_key")).thenReturn("key1");
+    when(recordContext.getValue(record, deleteLogSchema, HoodieRecord.RECORD_KEY_METADATA_FIELD)).thenReturn("key1");
     when(recordContext.getOrderingValue(eq(record), eq(deleteLogSchema), eq(orderingFields))).thenReturn(42L);
 
     BufferedRecord<Map<String, Object>> deleteRecord =

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/hadoop/HoodieBaseParquetWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/hadoop/HoodieBaseParquetWriter.java
@@ -167,4 +167,8 @@ public abstract class HoodieBaseParquetWriter<R> implements Closeable {
   public void close() throws IOException {
     this.parquetWriter.close();
   }
+
+  public Object getFileFormatMetadata() {
+    return this.parquetWriter.getFooter();
+  }
 }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroParquetWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroParquetWriter.java
@@ -32,6 +32,7 @@ import org.apache.avro.generic.IndexedRecord;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * HoodieParquetWriter extends the ParquetWriter to help limit the size of underlying file. Provides a way to check if
@@ -82,6 +83,11 @@ public class HoodieAvroParquetWriter
     if (populateMetaFields) {
       writeSupport.add(key);
     }
+  }
+
+  @Override
+  public void addFooterMetadata(Map<String, String> footerMetadata) {
+    footerMetadata.forEach(writeSupport::addFooterMetadata);
   }
 
   @Override

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -357,6 +357,8 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
     assertTrue(HoodieTableConfig.validateConfigVersion(HoodieTableConfig.INITIAL_VERSION, HoodieTableVersion.EIGHT));
     assertTrue(HoodieTableConfig.validateConfigVersion(ConfigProperty.key("").noDefaultValue().withDocumentation(""),
         HoodieTableVersion.SIX));
+    assertFalse(HoodieTableConfig.validateConfigVersion(HoodieTableConfig.TABLE_STORAGE_LAYOUT, HoodieTableVersion.NINE));
+    assertTrue(HoodieTableConfig.validateConfigVersion(HoodieTableConfig.TABLE_STORAGE_LAYOUT, HoodieTableVersion.TEN));
     assertFalse(HoodieTableConfig.validateConfigVersion(HoodieTableConfig.INITIAL_VERSION, HoodieTableVersion.SIX));
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -384,7 +384,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   @Test
   void testDefinedTableConfigs() {
     List<ConfigProperty<?>> configProperties = HoodieTableConfig.definedTableConfigs();
-    assertEquals(44, configProperties.size());
+    assertEquals(45, configProperties.size());
     configProperties.forEach(c -> {
       assertNotNull(c);
       assertFalse(c.doc().isEmpty());
@@ -796,4 +796,3 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
     assertEquals("Unsupported flow for table versions less than 9", ioException.getMessage().toString());
   }
 }
-

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestAppendHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestAppendHandle.java
@@ -95,7 +95,7 @@ public class TestAppendHandle extends BaseTestHandle {
     assertTrue(numDeletes > 0);
     metaClient = HoodieTableMetaClient.reload(metaClient);
     table = HoodieSparkTable.create(config, context, metaClient);
-    HoodieAppendHandle handle = new HoodieAppendHandle(config, instantTime, table, partitionPath, fileId, records.iterator(), new LocalTaskContextSupplier());
+    HoodieInlineLogAppendHandle handle = new HoodieInlineLogAppendHandle(config, instantTime, table, partitionPath, fileId, records.iterator(), new LocalTaskContextSupplier());
     Map<String, HoodieRecord> recordMap = new HashMap<>();
     for (int i = 0; i < records.size(); i++) {
       recordMap.put(String.valueOf(i), records.get(i));

--- a/rfc/rfc-103/rfc-103.md
+++ b/rfc/rfc-103/rfc-103.md
@@ -223,15 +223,13 @@ Footer
   - key-value metadata <-- Hudi log format metadata goes in here
 ```
 
-Hudi log format metadata can be stored as a single entry in the Parquet footer with key = `hudi.log.format.metadata` and value being a serialized map of the metadata entries:
+Hudi log format metadata can be stored as a single entry in the Parquet footer with key = `hudi.log.format.metadata` and value being a serialized JSON of the metadata entries:
 
 | Hudi log format metadata                     |
 |:---------------------------------------------|
-| log format version                           |
-| block type                                   |
+| `VERSION`                                    |
 | `INSTANT_TIME`                               |
 | `TARGET_INSTANT_TIME`                        |
-| `SCHEMA`                                     |
 | `COMMAND_BLOCK_TYPE`                         |
 | `COMPACTED_BLOCK_TIMES`                      |
 | `RECORD_POSITIONS`                           |
@@ -267,13 +265,13 @@ Delete block Parquet schema:
 
 ```text
 message hudi_delete_block {
-  required binary record_key (STRING);
-  optional binary ordering_val;
+  required binary _hoodie_record_key (STRING);
+  optional binary ordering_val (Ordering Field Type);
 }
 ```
 
 - `record_key`: the record key of the record to delete.
-- `ordering_val`: the ordering value used for ordering records, stored as raw bytes in its native representation. The logical type is determined by the table's ordering field schema. This field is null when no ordering value is present.
+- `ordering_val`: the ordering value used for ordering records, stored as table's ordering field schema in its native representation. This field is null when no ordering value is present.
 
 Note: Iceberg and Delta Lake use position-based deletion vectors. These are fundamentally different from Hudi's key-based delete blocks which identify records by key and carry ordering values for merge semantics.
 However, since Hudi already tracks record positions via Roaring64NavigableMap bitmaps in log block metadata (`RECORD_POSITIONS`),


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This closes #19058 .

RFC-103 introduces an LSM-tree table storage layout that needs MOR append writes to produce native-format log files instead of inline Hudi log blocks. The existing append path was centered on `HoodieAppendHandle` buffering records into inline log blocks, which made it hard to support engine-native record types, native file writers, native delete logs, footer metadata, and per-rolled-file column stats.

This PR adds the opt-in table config `hoodie.table.storage.layout=lsm_tree` while keeping the default layout unchanged. When the layout is `lsm_tree`, MOR append/update/log-compaction paths route to native log append handles that write native data and delete log files, including native log footer metadata with format version `2`.

### Summary and Changelog

This PR refactors append handling into a shared append base plus inline/native implementations, then wires Spark, Java, and Flink MOR write paths to choose inline or native log handles based on the table storage layout.

#### Working tree: RFC-103 native log append support
- Added `hoodie.table.storage.layout` in `HoodieTableConfig` with values `default` and `lsm_tree`; `default` preserves the current layout.
- Split `HoodieAppendHandle` into an abstract common append lifecycle and `HoodieInlineLogAppendHandle`, preserving the existing inline log behavior behind the inline implementation.
- Added `HoodieNativeLogAppendHandle` and `HoodieNativeLogFormatWriter` to stream records through engine-native file writers instead of collecting records into inline data/delete blocks.
- Added native data and delete log handling, including `.log.parquet` and `.deletes.parquet` files, native delete-log row construction, native footer metadata under `hudi.log.format.metadata`, and native log format `VERSION=2`.
- Routed `AppendHandleFactory`, Spark/Java MOR delta executors, Flink write handle factories, and log compaction to select native append handles when `isLSMTreeStorageLayout()` is enabled.
- Added native variants for file-group-reader compaction and Flink/RowData append paths: `FileGroupReaderBasedNativeLogAppendHandle`, `FlinkNativeLogAppendHandle`, and `RowDataNativeLogWriteHandle`.
- Renamed existing append classes to make inline/native behavior explicit: `FileGroupReaderBasedInlineLogAppendHandle`, `FlinkInlineLogAppendHandle`, and `RowDataInlineLogWriteHandle`.
- Added file-writer footer metadata plumbing so native log column stats can be collected from native file footers rather than iterating buffered records.
- Updated RFC-103 documentation and existing tests touched by the append-handle split.

#### Working tree: log extension constants and comparator coverage
- Added `LogExtensions` with shared `DATA_LOG_EXTENSION`, `DELETE_LOG_EXTENSION`, `CDC_LOG_EXTENSION`, and `ARCHIVE_LOG_EXTENSION` constants.
- Updated `HoodieLogFile` extension precedence and `HoodieNativeLogFormatWriter` to use `LogExtensions` instead of duplicated string literals.
- Added `TestHoodieLogFile.logFileComparatorOrdersNativeLogExtensionsByPrecedenceForSameVersion` to pin native log ordering as `log < deletes < cdc < archive`.

### Impact

This is an opt-in storage-layout change. Existing tables continue to use the default inline log layout unless `hoodie.table.storage.layout=lsm_tree` is configured.

The PR affects core MOR append/update/log-compaction paths across Spark, Java, and Flink, plus log file naming/comparison and metadata-column-stats collection for native logs. Native logs introduce a new physical log representation and footer metadata contract, but the default layout remains backward compatible.

### Risk Level

medium

The risk is medium because the change touches core MOR write paths, append-handle lifecycle accounting, log file naming/comparison, Flink RowData write handles, log compaction, native file-writer metadata, and column-stats collection. The main compatibility mitigation is that the new behavior is gated behind `hoodie.table.storage.layout=lsm_tree`, with `default` retaining the current inline log layout.

Validation evidence:
- `git diff --check` passed for the latest touched files.
- Attempted `mvn -pl hudi-client/hudi-client-common -DskipTests compile`, but it is currently blocked by an existing compile error in `HoodieNativeLogFormatWriter.java` resolving `org.apache.hudi.common.schema.HoodieSchemas`.
- Attempted `mvn -pl hudi-common -DskipTests compile` and `mvn -pl hudi-common -DskipITs -DfailIfNoTests=false -Dtest=TestHoodieLogFile test`, but both are currently blocked by an existing compile error in `HoodieSchema.java` resolving `StringUtils.splitTopLevelCommas(...)`.

### Documentation Update

RFC-103 is updated in this PR. Additional user-facing docs may be needed for the new `hoodie.table.storage.layout=lsm_tree` config before enabling or advertising the layout outside the RFC context.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable