### PR TITLE
test(spark): de-flake TestHoodieClientMultiWriter early-conflict detection

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -137,8 +137,21 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag("functional")
 public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
 
+  // Pin the tolerable heartbeat misses used by the early-conflict-detection test so its
+  // heartbeat-expiry wait does not depend on the global default
+  // (hoodie.client.heartbeat.tolerable.misses), which changed from 2 to 10 in #18904.
+  private static final int EARLY_CONFLICT_HEARTBEAT_TOLERABLE_MISSES = 2;
+
+  static {
+    // ZooKeeper's embedded admin server binds the fixed default port 8080 (Curator only
+    // randomizes the client port), so a concurrent or leaked TestingServer in a reused
+    // fork collides with "Address already in use". The admin server is unused here.
+    System.setProperty("zookeeper.admin.enableServer", "false");
+  }
+
   private Properties lockProperties = null;
 
+  private TestingServer zkTestingServer = null;
 
   /**
    * super is not thread safe!!
@@ -175,6 +188,10 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
 
   @AfterEach
   public void clean() throws IOException {
+    if (zkTestingServer != null) {
+      zkTestingServer.close();
+      zkTestingServer = null;
+    }
     cleanupResources();
   }
 
@@ -462,14 +479,14 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     int heartBeatIntervalForCommit4 = 3 * 1000;
 
     HoodieWriteConfig writeConfig;
-    TestingServer server = null;
     if (earlyConflictDetectionStrategy.equalsIgnoreCase(SimpleTransactionDirectMarkerBasedDetectionStrategy.class.getName())) {
       // need to setup zk related env there. Bcz SimpleTransactionDirectMarkerBasedDetectionStrategy is only support zk lock for now.
-      server = new TestingServer();
+      // zkTestingServer is closed in @AfterEach so a failing assertion cannot leak it (and its port-8080 admin server).
+      zkTestingServer = new TestingServer();
       Properties properties = new Properties();
       properties.setProperty(ZK_BASE_PATH_PROP_KEY, basePath);
-      properties.setProperty(ZK_CONNECT_URL_PROP_KEY, server.getConnectString());
-      properties.setProperty(ZK_BASE_PATH_PROP_KEY, server.getTempDirectory().getAbsolutePath());
+      properties.setProperty(ZK_CONNECT_URL_PROP_KEY, zkTestingServer.getConnectString());
+      properties.setProperty(ZK_BASE_PATH_PROP_KEY, zkTestingServer.getTempDirectory().getAbsolutePath());
       properties.setProperty(ZK_SESSION_TIMEOUT_MS_PROP_KEY, "10000");
       properties.setProperty(ZK_CONNECTION_TIMEOUT_MS_PROP_KEY, "10000");
       properties.setProperty(ZK_LOCK_KEY_PROP_KEY, "key");
@@ -521,8 +538,11 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     storage.create(heartbeatFilePath, true);
 
     // Wait for heart beat expired for failed commitTime3 "003"
-    // Otherwise commit4 still can see conflict between failed write 003.
-    Thread.sleep(heartBeatIntervalForCommit4 * 2);
+    // Otherwise commit4 still can see conflict between failed write 003. The early-conflict
+    // check treats 003 as alive until its heartbeat is older than
+    // (tolerable misses * heartbeat interval); tolerable misses is pinned in
+    // buildWriteConfigForEarlyConflictDetect, so wait one interval past that window.
+    Thread.sleep(heartBeatIntervalForCommit4 * (EARLY_CONFLICT_HEARTBEAT_TOLERABLE_MISSES + 1));
 
     final String nextCommitTime4 = "004";
     assertDoesNotThrow(() -> {
@@ -541,9 +561,6 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     assertTrue(completedInstant.contains(nextCommitTime4));
 
     FileIOUtils.deleteDirectory(new File(basePath));
-    if (server != null) {
-      server.close();
-    }
     client1.close();
     client2.close();
     client3.close();
@@ -1771,6 +1788,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
     if (markerType.equalsIgnoreCase(MarkerType.DIRECT.name())) {
       return getConfigBuilder()
           .withHeartbeatIntervalInMs(60 * 1000)
+          .withHeartbeatTolerableMisses(EARLY_CONFLICT_HEARTBEAT_TOLERABLE_MISSES)
           .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
               .withStorageType(FileSystemViewStorageType.MEMORY)
               .withSecondaryStorageType(FileSystemViewStorageType.MEMORY).build())
@@ -1791,6 +1809,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
       return getConfigBuilder()
           .withStorageConfig(HoodieStorageConfig.newBuilder().parquetMaxFileSize(20 * 1024).build())
           .withHeartbeatIntervalInMs(60 * 1000)
+          .withHeartbeatTolerableMisses(EARLY_CONFLICT_HEARTBEAT_TOLERABLE_MISSES)
           .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
               .withStorageType(FileSystemViewStorageType.MEMORY)
               .withSecondaryStorageType(FileSystemViewStorageType.MEMORY).build())


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19068

`TestHoodieClientMultiWriter.testHoodieClientBasicMultiWriterWithEarlyConflictDetectionDirect` became flaky in CI at the start of this week. It surfaces in the surefire summary as `Unable to instantiate class org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider`, but that is a downstream symptom.

Root cause: #18904 raised the default `hoodie.client.heartbeat.tolerable.misses` from 2 to 10. The heartbeat expiry window is `interval * tolerableMisses`. The early-conflict test runs commit `004` with a 3000ms heartbeat interval and waits `heartBeatIntervalForCommit4 * 2` (6s) for the failed commit `003`'s heartbeat to expire, assuming the old default of 2 (window = 2 * 3000 = 6000ms). With the new default the window grew to 30000ms, so commit `004` saw `003` as still alive, hit a false early conflict, and failed `assertDoesNotThrow` (line 528).

That failure threw before the `TestingServer` was closed (cleanup was not in a `finally`). With surefire `reuseForks=true`, the leaked embedded ZooKeeper kept holding its admin server's fixed port 8080, so every subsequent rerun failed with `BindException: Address already in use`, re-surfacing as the ZK lock-provider error above.

### Summary and Changelog

Test-only change that de-flakes the early-conflict-detection multi-writer test and hardens its ZooKeeper test fixture. No production code is touched, and no code was copied.

- Pin the heartbeat tolerable misses via a new constant `EARLY_CONFLICT_HEARTBEAT_TOLERABLE_MISSES = 2` and apply it with `withHeartbeatTolerableMisses(...)` in both branches (DIRECT and timeline-server marker) of `buildWriteConfigForEarlyConflictDetect`, so the heartbeat-expiry window no longer depends on the global `hoodie.client.heartbeat.tolerable.misses` default.
- Derive the expiry wait from the same constant: `interval * (misses + 1)` = 9s, giving a clear margin over the 6s window so commit `003` reliably expires before commit `004`'s conflict check.
- Disable ZooKeeper's unused embedded admin server via `System.setProperty("zookeeper.admin.enableServer", "false")` in a static initializer, removing the fixed-port-8080 collision.
- Move the `TestingServer` into an instance field (`zkTestingServer`) closed in `@AfterEach`, so a failing assertion can no longer leak it (and its admin server) across the reused fork.

### Impact

None. Test-only change; no public API, configuration, or user-facing behavior change. The affected test's wait increases from 6s to 9s.

### Risk Level

low

The change is confined to a single test class (`TestHoodieClientMultiWriter`). The heartbeat pin restores the test's pre-#18904 assumption (tolerable misses = 2) and is consistent with why the test passed before (the commit-004 liveness check uses the 3000ms interval). The admin-server disable and `@AfterEach` close only affect test fixtures.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
