### PR TITLE
chore(integ-test): bump trino-jdbc 390 to 481

### DIFF
--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -296,6 +296,16 @@
                     <exclude>**/*.proto</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <!-- trino-jdbc bundles aircompressor v3 compiled to Java 25 (class major
+                       version 69), which the shade plugin's ASM cannot read. These classes are
+                       unreferenced by the JDBC client (the spooling DecompressionUtils binds the
+                       legacy Java 8 lz4/zstd codecs), so drop the whole subtree from the bundle. -->
+                  <artifact>io.trino:trino-jdbc</artifact>
+                  <excludes>
+                    <exclude>io/trino/jdbc/$internal/airlift/compress/v3/**</exclude>
+                  </excludes>
+                </filter>
               </filters>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <hive.parquet.version>1.10.1</hive.parquet.version>
     <hive.avro.version>1.11.4</hive.avro.version>
     <presto.version>0.273</presto.version>
-    <trino.version>390</trino.version>
+    <trino.version>481</trino.version>
     <hive.exec.classifier>core</hive.exec.classifier>
     <metrics.version>4.1.1</metrics.version>
     <orc.spark.version>1.6.0</orc.spark.version>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes: #19059

`hudi-integ-test`'s `TrinoQueryNode` JDBC client was pinned to a stale `trino.version=390`, well behind current Trino releases. This bumps the `io.trino:trino-jdbc` client to the current release.

### Summary and Changelog

Bumped `trino.version` `390` -> `481` in the root `pom.xml`. This property drives `io.trino:trino-jdbc`, which is consumed by `hudi-integ-test` (`TrinoQueryNode`) and shaded into `hudi-integ-test-bundle`.

- No code changes. `TrinoQueryNode` touches the driver only via `java.sql` + `Class.forName("io.trino.jdbc.TrinoDriver")`, so there is no compile-time coupling to the Trino API.
- `presto.version` is intentionally left untouched in this PR.
- `hudi-trino-plugin` (the connector) is a standalone build on its own `trino-root` parent and is unchanged; the "converge `trino.version` with the connector" note in the issue does not apply here (there is no `trino.connector.version` property).

### Impact

No user-facing or public API impact. Test-only change that refreshes the Trino JDBC client used by the integration-test suite's query node.

### Risk Level

low

The `trino-jdbc:481` driver core is Java 11 bytecode, matching the project's `java.version=11` floor. The jar shades in some Java 25 `aircompressor v3` classes, but they are unreferenced on the client decompression path (`DecompressionUtils` binds the legacy Java 8 codecs), so they are never loaded under JDK 11/17. Validated that the driver class resolves and that no stale version pins remain.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
