### PR TITLE
fix: Fix Typo in PartitionTTLStrategyType#getPartitionTTLStrategyClassName

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/PartitionTTLStrategyType.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/PartitionTTLStrategyType.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.table.action.ttl.strategy;
 
 import org.apache.hudi.common.config.HoodieConfig;
-import org.apache.hudi.keygen.constant.KeyGeneratorType;
 
 import lombok.Getter;
 
@@ -67,7 +66,7 @@ public enum PartitionTTLStrategyType {
     if (config.contains(PARTITION_TTL_STRATEGY_CLASS_NAME)) {
       return config.getString(PARTITION_TTL_STRATEGY_CLASS_NAME);
     } else if (config.contains(PARTITION_TTL_STRATEGY_TYPE)) {
-      return KeyGeneratorType.valueOf(config.getString(PARTITION_TTL_STRATEGY_TYPE)).getClassName();
+      return PartitionTTLStrategyType.valueOf(config.getString(PARTITION_TTL_STRATEGY_TYPE)).getClassName();
     }
     return null;
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/ttl/strategy/TestPartitionTTLStrategyType.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/ttl/strategy/TestPartitionTTLStrategyType.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.ttl.strategy;
+
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.config.HoodieTTLConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link PartitionTTLStrategyType}.
+ */
+public class TestPartitionTTLStrategyType {
+
+  @Test
+  public void resolvesKeepByTimeFromType() {
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(HoodieTTLConfig.PARTITION_TTL_STRATEGY_TYPE,
+        PartitionTTLStrategyType.KEEP_BY_TIME.name());
+
+    assertEquals(PartitionTTLStrategyType.KEEP_BY_TIME.getClassName(),
+        PartitionTTLStrategyType.getPartitionTTLStrategyClassName(config));
+  }
+
+  @Test
+  public void resolvesKeepByCreationTimeFromType() {
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(HoodieTTLConfig.PARTITION_TTL_STRATEGY_TYPE,
+        PartitionTTLStrategyType.KEEP_BY_CREATION_TIME.name());
+
+    assertEquals(PartitionTTLStrategyType.KEEP_BY_CREATION_TIME.getClassName(),
+        PartitionTTLStrategyType.getPartitionTTLStrategyClassName(config));
+  }
+
+  @Test
+  public void throwsOnUnknownType() {
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(HoodieTTLConfig.PARTITION_TTL_STRATEGY_TYPE, "NOT_A_REAL_TYPE");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> PartitionTTLStrategyType.getPartitionTTLStrategyClassName(config));
+  }
+}


### PR DESCRIPTION
…TLStrategyClassName

### Describe the issue this Pull Request addresses

`KeyGeneratorType.valueOf` should be a typo
```
  @Nullable
  public static String getPartitionTTLStrategyClassName(HoodieConfig config) {
    if (config.contains(PARTITION_TTL_STRATEGY_CLASS_NAME)) {
      return config.getString(PARTITION_TTL_STRATEGY_CLASS_NAME);
    } else if (config.contains(PARTITION_TTL_STRATEGY_TYPE)) {
      return KeyGeneratorType.valueOf(config.getString(PARTITION_TTL_STRATEGY_TYPE)).getClassName();
    }
    return null;
  }
```

### Summary and Changelog

Fix wrong eunm name in PartitionTTLStrategyType

### Impact

None

### Risk Level

low

### Documentation Update

None

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
