### PR TITLE
perf(fs-view): skip bootstrap index init for non-bootstrap tables to cut S3 HEAD calls

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.common.table.view;
 
 import org.apache.hudi.common.bootstrap.index.BootstrapIndex;
+import org.apache.hudi.common.bootstrap.index.NoOpBootstrapIndex;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BootstrapBaseFileMapping;
 import org.apache.hudi.common.model.BootstrapFileMapping;
@@ -43,6 +44,7 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SamplingLogger;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
@@ -121,6 +123,11 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   private BootstrapIndex bootstrapIndex;
   private HoodieTableVersion tableVersion;
 
+  @VisibleForTesting
+  BootstrapIndex getBootstrapIndex() {
+    return bootstrapIndex;
+  }
+
   protected AbstractTableFileSystemView(HoodieTableMetadata tableMetadata) {
     this.tableMetadata = tableMetadata;
   }
@@ -134,7 +141,16 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
     this.tableVersion = metaClient.getTableConfig().getTableVersion();
     refreshTimeline(visibleActiveTimeline);
     resetFileGroupsReplaced(visibleCommitsAndCompactionTimeline);
-    this.bootstrapIndex =  BootstrapIndex.getBootstrapIndex(metaClient);
+    // For non-bootstrap tables, skip initializing the real bootstrap index and use a NoOp
+    // implementation instead. HFileBootstrapIndex's constructor issues two storage.exists()
+    // probes (plus a reflective class load) on every view init; on object stores like S3
+    // each probe is a billable HEAD request, so for the common case where no bootstrap
+    // table exists this is a pure waste of latency and money. useIndex() already
+    // short-circuits to false when the bootstrap base path is absent, so swapping in
+    // NoOpBootstrapIndex is behavior-preserving while cutting those S3 API calls.
+    this.bootstrapIndex = metaClient.getTableConfig().getBootstrapBasePath().isPresent()
+        ? BootstrapIndex.getBootstrapIndex(metaClient)
+        : new NoOpBootstrapIndex(metaClient);
     // Load Pending Compaction Operations
     resetPendingCompactionOperations(CompactionUtils.getAllPendingCompactionOperations(metaClient).values().stream()
         .map(e -> Pair.of(e.getKey(), CompactionOperation.convertFromAvroRecordInstance(e.getValue()))));

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -257,7 +257,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     refreshFsView();
 
-    BootstrapIndex index = readBootstrapIndex(fsView);
+    BootstrapIndex index = getBootstrapIndex(fsView);
     assertTrue(index instanceof NoOpBootstrapIndex,
         "Expected NoOpBootstrapIndex for non-bootstrap tables to skip storage.exists() probes, got: "
             + index.getClass().getName());
@@ -281,13 +281,13 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
 
     refreshFsView();
 
-    BootstrapIndex index = readBootstrapIndex(fsView);
+    BootstrapIndex index = getBootstrapIndex(fsView);
     assertTrue(index instanceof HFileBootstrapIndex,
         "Expected HFileBootstrapIndex when bootstrap base path is configured and index is enabled, got: "
             + index.getClass().getName());
   }
 
-  private static BootstrapIndex readBootstrapIndex(SyncableFileSystemView view) {
+  private static BootstrapIndex getBootstrapIndex(SyncableFileSystemView view) {
     return ((AbstractTableFileSystemView) view).getBootstrapIndex();
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -25,7 +25,9 @@ import org.apache.hudi.avro.model.HoodieFSPermission;
 import org.apache.hudi.avro.model.HoodieFileStatus;
 import org.apache.hudi.avro.model.HoodiePath;
 import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.common.bootstrap.index.BootstrapIndex;
 import org.apache.hudi.common.bootstrap.index.BootstrapIndex.IndexWriter;
+import org.apache.hudi.common.bootstrap.index.NoOpBootstrapIndex;
 import org.apache.hudi.common.bootstrap.index.hfile.HFileBootstrapIndex;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
@@ -235,6 +237,58 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
       // completionTimeQueryView will be set to null after close.
       Assertions.assertThrows(NullPointerException.class, () -> ((AbstractTableFileSystemView) fsView).getCompletionTime(""));
     }
+  }
+
+  /**
+   * For non-bootstrap tables, the file system view must avoid instantiating the real
+   * {@link HFileBootstrapIndex} during init: its constructor issues two storage.exists()
+   * probes, which translate to billable HEAD requests on S3-like object stores. The
+   * NoOp substitute keeps {@code useIndex()} returning false without those probes.
+   */
+  @Test
+  public void testBootstrapIndexIsNoOpWhenBootstrapBasePathAbsent() throws Exception {
+    closeFsView();
+    cleanMetaClient();
+    // Re-init the table WITHOUT a bootstrap base path.
+    metaClient = HoodieTestUtils.init(tempDir.toAbsolutePath().toString(), getTableType());
+    basePath = metaClient.getBasePath().toString();
+    assertFalse(metaClient.getTableConfig().getBootstrapBasePath().isPresent(),
+        "Precondition: table must not have a bootstrap base path configured");
+
+    refreshFsView();
+
+    BootstrapIndex index = readBootstrapIndex(fsView);
+    assertTrue(index instanceof NoOpBootstrapIndex,
+        "Expected NoOpBootstrapIndex for non-bootstrap tables to skip storage.exists() probes, got: "
+            + index.getClass().getName());
+    assertFalse(index.useIndex(), "NoOpBootstrapIndex.useIndex() must be false");
+  }
+
+  /**
+   * Counterpart of {@link #testBootstrapIndexIsNoOpWhenBootstrapBasePathAbsent()}:
+   * when a bootstrap base path is configured we must still load the real index
+   * implementation (here {@link HFileBootstrapIndex}).
+   */
+  @Test
+  public void testBootstrapIndexIsLoadedWhenBootstrapBasePathPresent() throws Exception {
+    closeFsView();
+    cleanMetaClient();
+    metaClient = HoodieTestUtils.init(tempDir.toAbsolutePath().toString(), getTableType(),
+        BOOTSTRAP_SOURCE_PATH, /* bootstrapIndexEnable = */ true);
+    basePath = metaClient.getBasePath().toString();
+    assertTrue(metaClient.getTableConfig().getBootstrapBasePath().isPresent(),
+        "Precondition: table must have a bootstrap base path configured");
+
+    refreshFsView();
+
+    BootstrapIndex index = readBootstrapIndex(fsView);
+    assertTrue(index instanceof HFileBootstrapIndex,
+        "Expected HFileBootstrapIndex when bootstrap base path is configured and index is enabled, got: "
+            + index.getClass().getName());
+  }
+
+  private static BootstrapIndex readBootstrapIndex(SyncableFileSystemView view) {
+    return ((AbstractTableFileSystemView) view).getBootstrapIndex();
   }
 
   protected void testViewForFileSlicesWithNoBaseFile(int expNumTotalFileSlices,

--- a/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
+++ b/hudi-timeline-service/src/test/java/org/apache/hudi/timeline/service/functional/TestRemoteHoodieTableFileSystemView.java
@@ -41,6 +41,7 @@ import org.apache.hudi.timeline.service.TimelineServiceTestHarness;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -110,6 +111,24 @@ public class TestRemoteHoodieTableFileSystemView extends TestHoodieTableFileSyst
     getFileSystemView(metaClient.getActiveTimeline(), 3);
     RemoteHoodieTableFileSystemView viewWithRetries = initFsView(metaClient, server.getServerPort(), true);
     viewWithRetries.getLatestBaseFiles();
+  }
+
+  /**
+   * The base class reads {@code AbstractTableFileSystemView.bootstrapIndex} through the
+   * {@code @VisibleForTesting getBootstrapIndex()} accessor to verify non-bootstrap tables get
+   * NoOpBootstrapIndex (avoiding S3 HEAD probes during init). {@link RemoteHoodieTableFileSystemView}
+   * does not extend {@code AbstractTableFileSystemView} — the real view, and hence that accessor,
+   * lives server-side, so the assertion isn't applicable here.
+   */
+  @Test
+  @Disabled("bootstrapIndex lives on the server-side AbstractTableFileSystemView; not reachable through the remote view. Covered by the base test against the local view.")
+  public void testBootstrapIndexIsNoOpWhenBootstrapBasePathAbsent() throws Exception {
+  }
+
+  /** See {@link #testBootstrapIndexIsNoOpWhenBootstrapBasePathAbsent()}. */
+  @Test
+  @Disabled("bootstrapIndex lives on the server-side AbstractTableFileSystemView; not reachable through the remote view. Covered by the base test against the local view.")
+  public void testBootstrapIndexIsLoadedWhenBootstrapBasePathPresent() throws Exception {
   }
 
   @Test


### PR DESCRIPTION


### Describe the issue this Pull Request addresses

 For non-bootstrap tables, skip initializing the real bootstrap index and use a NoOp implementation instead. HFileBootstrapIndex's constructor issues two storage.exists() probes (plus a reflective class load) on every view init; on object stores like S3 each probe is a billable HEAD request, so for the common case where no bootstrap able exists this is a pure waste of latency and money. useIndex() already short-circuits to false when the bootstrap base path is absent, so swapping in NoOpBootstrapIndex is behavior-preserving while cutting those S3 API calls.

### Summary and Changelog

Init `BootstrapIndex` as `NoOpBootstrapIndex` when is not bootstrap table to avoid call s3 api to save money

### Impact

None

### Risk Level

low

### Documentation Update
none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
