### PR TITLE
feat(partition-ttl): Introduce KeepByEventTimeStrategy to expire partitions by event time

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieTTLConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieTTLConfig.java
@@ -94,6 +94,32 @@ public class HoodieTTLConfig extends HoodieConfig {
           + "partition count and this value. When a table enables partition ttl for the first time, there "
           + "may be a large number of historical partitions, so a higher value than the default may be desired.");
 
+  public static final ConfigProperty<String> EVENT_TIME_FORMAT = ConfigProperty
+      .key(PARTITION_TTL_STRATEGY_PARAM_PREFIX + "event.time.format")
+      .defaultValue("yyyy-MM-dd")
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Used by KEEP_BY_EVENT_TIME. Date-time pattern for the event time encoded in the partition path. "
+          + "A '/' in the pattern means the time spans multiple path segments. Examples: 'yyyy-MM-dd' (default), "
+          + "'yyyyMMdd', 'yyyy-MM-dd/HH', 'yyyyMMdd/HH'.");
+
+  public static final ConfigProperty<Integer> EVENT_TIME_SEGMENT_START_INDEX = ConfigProperty
+      .key(PARTITION_TTL_STRATEGY_PARAM_PREFIX + "event.time.segment.start.index")
+      .defaultValue(0)
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Used by KEEP_BY_EVENT_TIME. 0-based index of the first path segment that carries the event time. "
+          + "Defaults to 0 for pure time partitions like 'dt=2026-04-24'. Set to a higher value when non-time prefix segments exist, "
+          + "e.g. 1 for 'region=us/20260424/05'.");
+
+  public static final ConfigProperty<Boolean> EVENT_TIME_DELETE_HIVE_DEFAULT_PARTITION = ConfigProperty
+      .key(PARTITION_TTL_STRATEGY_PARAM_PREFIX + "event.time.delete.hive.default.partition")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("When true, KEEP_BY_EVENT_TIME treats partitions containing __HIVE_DEFAULT_PARTITION__ as expired and removes them. "
+          + "Defaults to false so such partitions are skipped (with a WARN log) and the user keeps explicit control over their lifecycle.");
+
   public static class Builder {
     private final HoodieTTLConfig ttlConfig = new HoodieTTLConfig();
 
@@ -124,6 +150,21 @@ public class HoodieTTLConfig extends HoodieConfig {
 
     public HoodieTTLConfig.Builder withTTLStrategyType(PartitionTTLStrategyType ttlStrategyType) {
       ttlConfig.setValue(PARTITION_TTL_STRATEGY_TYPE, ttlStrategyType.name());
+      return this;
+    }
+
+    public HoodieTTLConfig.Builder withEventTimeFormat(String format) {
+      ttlConfig.setValue(EVENT_TIME_FORMAT, format);
+      return this;
+    }
+
+    public HoodieTTLConfig.Builder withEventTimeSegmentStartIndex(int timeSegStartIndex) {
+      ttlConfig.setValue(EVENT_TIME_SEGMENT_START_INDEX, Integer.toString(timeSegStartIndex));
+      return this;
+    }
+
+    public HoodieTTLConfig.Builder withEventTimeDeleteHiveDefaultPartition(boolean deleteHiveDefaultPartition) {
+      ttlConfig.setValue(EVENT_TIME_DELETE_HIVE_DEFAULT_PARTITION, Boolean.toString(deleteHiveDefaultPartition));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3062,6 +3062,18 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieTTLConfig.STATS_MAX_PARALLELISM);
   }
 
+  public String getPartitionTTLEventTimeFormat() {
+    return getStringOrDefault(HoodieTTLConfig.EVENT_TIME_FORMAT);
+  }
+
+  public int getPartitionTTLEventTimeSegmentStartIndex() {
+    return getIntOrDefault(HoodieTTLConfig.EVENT_TIME_SEGMENT_START_INDEX);
+  }
+
+  public boolean shouldPartitionTTLEventTimeDeleteHiveDefaultPartition() {
+    return getBooleanOrDefault(HoodieTTLConfig.EVENT_TIME_DELETE_HIVE_DEFAULT_PARTITION);
+  }
+
   public boolean isSecondaryIndexEnabled() {
     return metadataConfig.isSecondaryIndexEnabled();
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3106,6 +3106,18 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieTTLConfig.STATS_MAX_PARALLELISM);
   }
 
+  public String getPartitionTTLEventTimeFormat() {
+    return getStringOrDefault(HoodieTTLConfig.EVENT_TIME_FORMAT);
+  }
+
+  public int getPartitionTTLEventTimeSegmentStartIndex() {
+    return getIntOrDefault(HoodieTTLConfig.EVENT_TIME_SEGMENT_START_INDEX);
+  }
+
+  public boolean shouldPartitionTTLEventTimeDeleteHiveDefaultPartition() {
+    return getBooleanOrDefault(HoodieTTLConfig.EVENT_TIME_DELETE_HIVE_DEFAULT_PARTITION);
+  }
+
   public boolean isSecondaryIndexEnabled() {
     return metadataConfig.isSecondaryIndexEnabled();
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/HoodiePartitionTTLStrategyFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/HoodiePartitionTTLStrategyFactory.java
@@ -79,6 +79,8 @@ public class HoodiePartitionTTLStrategyFactory {
         return KeepByTimeStrategy.class.getName();
       case KEEP_BY_CREATION_TIME:
         return KeepByCreationTimeStrategy.class.getName();
+      case KEEP_BY_EVENT_TIME:
+        return KeepByEventTimeStrategy.class.getName();
       default:
         throw new HoodieException("Unsupported PartitionTTLStrategy Type " + type);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByEventTimeStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByEventTimeStrategy.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.ttl.strategy;
+
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
+import org.apache.hudi.common.util.PartitionPathEncodeUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieTTLConfig;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.table.HoodieTable;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.text.ParseException;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Event-time based partition TTL strategy: lifetime is read from the partition path, not from
+ * commit metadata. Late-arriving writes into an old partition do not extend its lifetime, and
+ * backfilled historic partitions are still considered old. Compare with {@link KeepByTimeStrategy}
+ * (last commit time) and {@link KeepByCreationTimeStrategy} (creation commit time).
+ *
+ * <h3>Supported path shapes</h3>
+ * The first-class, tested shapes are day and hour granularity. Each example shows the partition
+ * path on the left and the required {@code timeSegStartIndex} on the right (see
+ * <i>Locating the time block</i> below); non-time segments may appear before and/or after the
+ * time block.
+ * <ul>
+ *   <li>Day, {@code format=yyyy-MM-dd}
+ *     <ul>
+ *       <li>time only: {@code 2026-06-27}, {@code dt=2026-06-27} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time: {@code region=us/2026-06-27}, {@code region=us/dt=2026-06-27} — timeSegStartIndex {@code 1}</li>
+ *       <li>time + suffix: {@code 2026-06-27/source=app}, {@code dt=2026-06-27/source=app} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time + suffix: {@code region=us/dt=2026-06-27/source=app} — timeSegStartIndex {@code 1}</li>
+ *     </ul>
+ *   </li>
+ *   <li>Day, {@code format=yyyyMMdd}
+ *     <ul>
+ *       <li>time only: {@code 20260627}, {@code dt=20260627} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time: {@code region=us/20260627}, {@code region=us/dt=20260627} — timeSegStartIndex {@code 1}</li>
+ *       <li>time + suffix: {@code 20260627/source=app}, {@code dt=20260627/source=app} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time + suffix: {@code region=us/dt=20260627/source=app} — timeSegStartIndex {@code 1}</li>
+ *     </ul>
+ *   </li>
+ *   <li>Hour, {@code format=yyyy-MM-dd/HH}
+ *     <ul>
+ *       <li>time only: {@code 2026-06-27/12}, {@code dt=2026-06-27/hh=12} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time: {@code region=us/2026-06-27/12}, {@code region=us/dt=2026-06-27/hh=12} — timeSegStartIndex {@code 1}</li>
+ *       <li>time + suffix: {@code 2026-06-27/12/source=app}, {@code dt=2026-06-27/hh=12/source=app} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time + suffix: {@code region=us/dt=2026-06-27/hh=12/source=app} — timeSegStartIndex {@code 1}</li>
+ *     </ul>
+ *   </li>
+ *   <li>Hour, {@code format=yyyyMMdd/HH}
+ *     <ul>
+ *       <li>time only: {@code 20260627/12}, {@code dt=20260627/hh=12} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time: {@code region=us/20260627/12}, {@code region=us/dt=20260627/hh=12} — timeSegStartIndex {@code 1}</li>
+ *       <li>time + suffix: {@code 20260627/12/source=app}, {@code dt=20260627/hh=12/source=app} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time + suffix: {@code region=us/dt=20260627/hh=12/source=app} — timeSegStartIndex {@code 1}</li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ * Hive-style key names are not constrained: {@code dt=}, {@code day=}, {@code event_date=},
+ * {@code hh=}, {@code hour=} all work; only the value after {@code =} is parsed.
+ * <p>
+ * Any {@link java.time.format.DateTimeFormatter} pattern works as long as the resulting
+ * {@link java.time.temporal.TemporalAccessor} can be resolved to either an {@link java.time.Instant}
+ * or a {@link java.time.LocalDate} (day-only patterns are anchored at UTC start-of-day). A
+ * {@code /} in the pattern means the time value spans that many consecutive path segments.
+ * Patterns missing day-of-month, e.g. month-only {@code yyyy-MM}, cannot be resolved and will
+ * raise the standard parse-failure error at runtime.
+ *
+ * <h3>Locating the time block</h3>
+ * The time block must occupy a <i>contiguous</i> segment range of the partition path. Only the
+ * segments before it count toward {@code timeSegStartIndex}; segments after are ignored. Interleaved
+ * layouts such as {@code dt=20260627/source=app/hh=12} are not supported -- the time block must
+ * be in one piece.
+ *
+ * <h3>Time zone</h3>
+ * Both the partition's event time and the cutoff derived from {@code instantTime} are interpreted
+ * in UTC. Set {@code hoodie.table.timeline.timezone=UTC} so the timeline writes instants under the
+ * same convention; otherwise the cutoff drifts by the JVM's UTC offset -- a boundary effect at
+ * day granularity, a full-offset shift at hour granularity.
+ *
+ * <h3>Configuration</h3>
+ * All three knobs come with defaults, so a table whose partition path is purely a date in
+ * {@code yyyy-MM-dd} form works out of the box.
+ * <ul>
+ *   <li>{@link org.apache.hudi.config.HoodieTTLConfig#EVENT_TIME_FORMAT} — date-time pattern of
+ *       the time block in the partition path. Default {@code yyyy-MM-dd}. A {@code /} in the
+ *       pattern means the time block spans that many consecutive segments.</li>
+ *   <li>{@link org.apache.hudi.config.HoodieTTLConfig#EVENT_TIME_SEGMENT_START_INDEX} —
+ *       0-based index of the first segment that carries the time block. Default {@code 0}.
+ *       Raise it when non-time segments come before the time block (see examples above).</li>
+ *   <li>{@link org.apache.hudi.config.HoodieTTLConfig#EVENT_TIME_DELETE_HIVE_DEFAULT_PARTITION} —
+ *       whether to treat partitions whose time block contains {@code __HIVE_DEFAULT_PARTITION__}
+ *       in <i>any</i> segment as expired. Such a partition has an undefined event time (one of
+ *       its event-time columns was {@code NULL}, so the row cannot be placed on the configured
+ *       time axis) and falls outside the normal cutoff comparison. Default {@code false}, i.e.
+ *       such partitions are skipped with a WARN and the user keeps explicit control over them.
+ *       Applies to both single-segment formats (e.g. {@code dt=__HIVE_DEFAULT_PARTITION__}) and
+ *       multi-segment ones (e.g. {@code dt=2026-06-28/hh=__HIVE_DEFAULT_PARTITION__}).</li>
+ * </ul>
+ */
+@Slf4j
+public class KeepByEventTimeStrategy extends KeepByTimeStrategy {
+
+  private final String eventTimeFormat;
+  private final int timeSegStartIndex;
+  private final boolean shouldDeleteHiveDefaultPartition;
+  private final boolean hiveStylePartitioning;
+
+  public KeepByEventTimeStrategy(HoodieTable hoodieTable, String instantTime) {
+    super(hoodieTable, instantTime);
+    // Defaults: format='yyyy-MM-dd', timeSegStartIndex=0, deleteHiveDefaultPartition=false. The
+    // two guards below catch users who set the values explicitly to obviously-broken inputs.
+    this.eventTimeFormat = writeConfig.getPartitionTTLEventTimeFormat();
+    if (eventTimeFormat == null || eventTimeFormat.isEmpty()) {
+      throw new IllegalArgumentException(
+          HoodieTTLConfig.EVENT_TIME_FORMAT.key() + " must not be empty.");
+    }
+    this.timeSegStartIndex = writeConfig.getPartitionTTLEventTimeSegmentStartIndex();
+    if (timeSegStartIndex < 0) {
+      throw new IllegalArgumentException(
+          HoodieTTLConfig.EVENT_TIME_SEGMENT_START_INDEX.key() + " must be >= 0, got " + timeSegStartIndex);
+    }
+    this.shouldDeleteHiveDefaultPartition = writeConfig.shouldPartitionTTLEventTimeDeleteHiveDefaultPartition();
+    // Hive-style partitioning is a table-level property recorded at table creation; trust it
+    // rather than guessing per-segment from a stray '=' character in a value.
+    this.hiveStylePartitioning = Boolean.parseBoolean(
+        hoodieTable.getMetaClient().getTableConfig().getHiveStylePartitioningEnable());
+  }
+
+  @Override
+  protected List<String> getExpiredPartitionsForTimeStrategy(List<String> partitionPathsForTTL) {
+    long cutoffMillis = resolveCutoffMillis(instantTime, ttlInMilis);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(eventTimeFormat).withZone(ZoneOffset.UTC);
+    int segCount = segmentCount(eventTimeFormat);
+
+    // Step 1: filter by event time. Pure computation over immutable inputs (no shared state, no
+    // I/O), so a raw parallel stream on the common ForkJoinPool is safe. In a healthy table the
+    // vast majority of partitions survive this filter, so most of the work stays here and never
+    // reaches the more expensive step 2.
+    List<String> eventTimeExpired = partitionPathsForTTL.stream().parallel()
+        .filter(path -> isPartitionExpiredByEventTime(
+            path, formatter, timeSegStartIndex, segCount, cutoffMillis,
+            shouldDeleteHiveDefaultPartition, hiveStylePartitioning))
+        .collect(Collectors.toList());
+    if (eventTimeExpired.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    // Step 2: drop partitions that an earlier TTL replace already emptied. Their event time is
+    // derived from the (unchanged) path, so without this filter they would be re-selected on
+    // every batch -- issuing an empty replace commit each time and never converging. Keep only
+    // partitions that still have a live file slice, mirroring KeepByTimeStrategy which keys off
+    // the surviving slices' last commit time and thus naturally skips deleted ones.
+    //
+    // hasLiveFileSlice touches hoodieTable.getHoodieView(), which for non-default view types
+    // (SPILLABLE_DISK, EMBEDDED_KV_STORE) mutates a backing store during first-time partition
+    // load under a shared read lock -- unsafe under unbounded concurrent access on the common
+    // ForkJoinPool. Route the lookup through the engine context with bounded parallelism, the
+    // same pattern KeepByTimeStrategy#getLastCommitTimeForPartitions uses, so that blocking file
+    // listings don't run on the common pool and respect getPartitionTTLStatsMaxParallelism.
+    int statsParallelism = Math.min(eventTimeExpired.size(), writeConfig.getPartitionTTLStatsMaxParallelism());
+    return hoodieTable.getContext().map(eventTimeExpired,
+        partitionPath -> Pair.of(partitionPath, hasLiveFileSlice(partitionPath)),
+        statsParallelism).stream()
+        .filter(Pair::getRight)
+        .map(Pair::getLeft)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Whether the partition still has at least one live file slice as of {@code instantTime}.
+   * File groups replaced by an earlier TTL delete are excluded by the file system view, so an
+   * already-deleted partition returns {@code false} here even while its directory lingers on
+   * storage awaiting the cleaner.
+   */
+  private boolean hasLiveFileSlice(String partitionPath) {
+    return hoodieTable.getHoodieView()
+        .getLatestFileSlicesBeforeOrOn(partitionPath, instantTime, true)
+        .findAny()
+        .isPresent();
+  }
+
+  /**
+   * Number of '/'-separated path segments the configured format occupies.
+   * Example: {@code yyyy-MM-dd/HH} -> 2.
+   */
+  static int segmentCount(String format) {
+    return format.split("/").length;
+  }
+
+  /**
+   * Resolve the "now" reference timestamp from {@code instantTime}, in UTC.
+   * <p>
+   * Anchoring on {@code instantTime} keeps the strategy idempotent across retries of the same
+   * replace commit. We parse it in UTC so the cutoff and the partition's event time (also parsed
+   * in UTC above) sit on the same axis -- otherwise expiry drifts by the JVM's UTC offset, which
+   * is negligible at day granularity but a full-offset shift at hour granularity.
+   */
+  static long resolveCutoffMillis(String instantTime, long ttlInMillis) {
+    try {
+      return HoodieInstantTimeGenerator.parseDateFromInstantTime(instantTime, ZoneOffset.UTC).getTime() - ttlInMillis;
+    } catch (ParseException e) {
+      throw new IllegalStateException("Failed to parse instant time " + instantTime, e);
+    }
+  }
+
+  /**
+   * Decide whether a partition path is expired.
+   * <p>
+   * The strategy treats any partition that cannot be parsed under the configured format /
+   * start-index / hive-style as a hard error. Reasoning: this class derives lifetime from the
+   * path itself, so a partition we cannot parse has no defined lifetime, and silently skipping
+   * it would leave it in the table forever while the rest of TTL appears to succeed. Switch to
+   * {@code KEEP_BY_TIME} or {@code KEEP_BY_CREATION_TIME} (which key off commit metadata, not
+   * the path) if the table contains partitions that don't conform to a single event-time shape.
+   * <p>
+   * Package-private so unit tests can exercise it directly without spinning up a HoodieTable.
+   * <p>
+   * Note the two trailing {@code boolean} flags are easy to transpose at call sites; keep them in
+   * this order: {@code deleteHiveDefaultPartition} first, {@code hiveStylePartitioning} last.
+   *
+   * @param partitionPath              the partition path to evaluate
+   * @param formatter                  formatter built from the configured event-time format
+   * @param timeSegStartIndex          0-based index of the first segment carrying the time block
+   * @param segCount                   number of segments the time block spans
+   * @param cutoffMillis               partitions with event time strictly before this are expired
+   * @param deleteHiveDefaultPartition treat a time block containing the Hive default marker as expired
+   * @param hiveStylePartitioning      whether segments carry a {@code field=value} prefix to strip
+   */
+  static boolean isPartitionExpiredByEventTime(String partitionPath,
+                                               DateTimeFormatter formatter,
+                                               int timeSegStartIndex,
+                                               int segCount,
+                                               long cutoffMillis,
+                                               boolean deleteHiveDefaultPartition,
+                                               boolean hiveStylePartitioning) {
+    String[] segments = partitionPath.split("/");
+    if (segments.length < timeSegStartIndex + segCount) {
+      throw new IllegalArgumentException(String.format(
+          "Partition '%s' has %d segment(s) but the configured event time spans %d segment(s) starting at index %d. "
+              + "Check %s and %s, "
+              + "or switch to KEEP_BY_TIME / KEEP_BY_CREATION_TIME if not all partitions of this table follow an event-time shape.",
+          partitionPath, segments.length, segCount, timeSegStartIndex,
+          HoodieTTLConfig.EVENT_TIME_FORMAT.key(), HoodieTTLConfig.EVENT_TIME_SEGMENT_START_INDEX.key()));
+    }
+
+    String[] timeSegs = new String[segCount];
+    boolean hasDefaultSegment = false;
+    for (int i = 0; i < segCount; i++) {
+      String seg = segments[timeSegStartIndex + i];
+      if (hiveStylePartitioning) {
+        int eq = seg.indexOf('=');
+        if (eq < 0) {
+          throw new IllegalArgumentException(String.format(
+              "Partition '%s' segment '%s' has no hive-style 'field=value' prefix but "
+                  + "%s=true on the table. "
+                  + "Switch to KEEP_BY_TIME / KEEP_BY_CREATION_TIME if such legacy partitions must coexist.",
+              partitionPath, seg, KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE.key()));
+        }
+        timeSegs[i] = seg.substring(eq + 1);
+      } else {
+        timeSegs[i] = seg;
+      }
+      if (PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH.equals(timeSegs[i])) {
+        hasDefaultSegment = true;
+      }
+    }
+
+    // Any default-marker segment means the event time itself is undefined: a date-recorded /
+    // hour-NULL row cannot be placed on the hour axis any more than a date-NULL row can. We
+    // therefore treat the whole time block as "the default partition" and let the explicit
+    // user switch decide. Without this branch a multi-segment shape like
+    // dt=2026-06-28/hh=__HIVE_DEFAULT_PARTITION__ would either silently expire (old code) or
+    // stall TTL forever on a hard error.
+    if (hasDefaultSegment) {
+      if (deleteHiveDefaultPartition) {
+        log.info("Partition '{}' time block contains {} (event time undefined) and delete switch "
+            + "is on; marking expired", partitionPath, PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH);
+        return true;
+      }
+      log.warn("Skipping partition '{}': time block contains {} (event time undefined; set "
+              + "{}=true to delete)",
+          partitionPath, PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH,
+          HoodieTTLConfig.EVENT_TIME_DELETE_HIVE_DEFAULT_PARTITION.key());
+      return false;
+    }
+
+    String timeStr = String.join("/", timeSegs);
+    Long eventMillis = parseEventMillis(timeStr, formatter);
+    if (eventMillis == null) {
+      throw new IllegalArgumentException(String.format(
+          "Partition '%s': cannot parse '%s' with pattern '%s'. "
+              + "Fix %s, or switch to "
+              + "KEEP_BY_TIME / KEEP_BY_CREATION_TIME if such partitions must remain in the table.",
+          partitionPath, timeStr, formatter, HoodieTTLConfig.EVENT_TIME_FORMAT.key()));
+    }
+    return eventMillis < cutoffMillis;
+  }
+
+  /**
+   * Parse {@code timeStr} into epoch millis. Tries full date-time first; falls back to a
+   * date-only parse anchored at UTC start-of-day so day-level patterns (e.g. {@code yyyy-MM-dd})
+   * also work.
+   */
+  static Long parseEventMillis(String timeStr, DateTimeFormatter formatter) {
+    TemporalAccessor parsed;
+    try {
+      parsed = formatter.parse(timeStr);
+    } catch (DateTimeParseException e) {
+      return null;
+    }
+    try {
+      return Instant.from(parsed).toEpochMilli();
+    } catch (DateTimeException ignore) {
+      // Day-level pattern with no time-of-day: anchor at UTC start of day.
+      try {
+        return LocalDate.from(parsed).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+      } catch (DateTimeException e) {
+        return null;
+      }
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByEventTimeStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByEventTimeStrategy.java
@@ -161,7 +161,27 @@ public class KeepByEventTimeStrategy extends KeepByTimeStrategy {
     return partitionPathsForTTL.stream().parallel()
         .filter(path -> isPartitionExpiredByEventTime(
             path, formatter, timeSegStartIndex, segCount, cutoffMillis, shouldDeleteHiveDefaultPartition, hiveStylePartitioning))
+        // A partition emptied by a previous TTL replace commit keeps showing up in
+        // getAllPartitionPaths() until the cleaner physically removes it, and its event time is
+        // derived from the (unchanged) path, so it would be re-selected on every batch -- issuing
+        // an empty replace commit each time and never converging. Keep only partitions that still
+        // have a live file slice so the strategy is idempotent, mirroring KeepByTimeStrategy which
+        // keys off the surviving slices' last commit time and thus naturally skips deleted ones.
+        .filter(this::hasLiveFileSlice)
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Whether the partition still has at least one live file slice as of {@code instantTime}.
+   * File groups replaced by an earlier TTL delete are excluded by the file system view, so an
+   * already-deleted partition returns {@code false} here even while its directory lingers on
+   * storage awaiting the cleaner.
+   */
+  private boolean hasLiveFileSlice(String partitionPath) {
+    return hoodieTable.getHoodieView()
+        .getLatestFileSlicesBeforeOrOn(partitionPath, instantTime, true)
+        .findAny()
+        .isPresent();
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByEventTimeStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByEventTimeStrategy.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.ttl.strategy;
+
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
+import org.apache.hudi.common.util.PartitionPathEncodeUtils;
+import org.apache.hudi.config.HoodieTTLConfig;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.table.HoodieTable;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.text.ParseException;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Event-time based partition TTL strategy: lifetime is read from the partition path, not from
+ * commit metadata. Late-arriving writes into an old partition do not extend its lifetime, and
+ * backfilled historic partitions are still considered old. Compare with {@link KeepByTimeStrategy}
+ * (last commit time) and {@link KeepByCreationTimeStrategy} (creation commit time).
+ *
+ * <h3>Supported path shapes</h3>
+ * The first-class, tested shapes are day and hour granularity. Each example shows the partition
+ * path on the left and the required {@code timeSegStartIndex} on the right (see
+ * <i>Locating the time block</i> below); non-time segments may appear before and/or after the
+ * time block.
+ * <ul>
+ *   <li>Day, {@code format=yyyy-MM-dd}
+ *     <ul>
+ *       <li>time only: {@code 2026-06-27}, {@code dt=2026-06-27} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time: {@code region=us/2026-06-27}, {@code region=us/dt=2026-06-27} — timeSegStartIndex {@code 1}</li>
+ *       <li>time + suffix: {@code 2026-06-27/source=app}, {@code dt=2026-06-27/source=app} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time + suffix: {@code region=us/dt=2026-06-27/source=app} — timeSegStartIndex {@code 1}</li>
+ *     </ul>
+ *   </li>
+ *   <li>Day, {@code format=yyyyMMdd}
+ *     <ul>
+ *       <li>time only: {@code 20260627}, {@code dt=20260627} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time: {@code region=us/20260627}, {@code region=us/dt=20260627} — timeSegStartIndex {@code 1}</li>
+ *       <li>time + suffix: {@code 20260627/source=app}, {@code dt=20260627/source=app} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time + suffix: {@code region=us/dt=20260627/source=app} — timeSegStartIndex {@code 1}</li>
+ *     </ul>
+ *   </li>
+ *   <li>Hour, {@code format=yyyy-MM-dd/HH}
+ *     <ul>
+ *       <li>time only: {@code 2026-06-27/12}, {@code dt=2026-06-27/hh=12} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time: {@code region=us/2026-06-27/12}, {@code region=us/dt=2026-06-27/hh=12} — timeSegStartIndex {@code 1}</li>
+ *       <li>time + suffix: {@code 2026-06-27/12/source=app}, {@code dt=2026-06-27/hh=12/source=app} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time + suffix: {@code region=us/dt=2026-06-27/hh=12/source=app} — timeSegStartIndex {@code 1}</li>
+ *     </ul>
+ *   </li>
+ *   <li>Hour, {@code format=yyyyMMdd/HH}
+ *     <ul>
+ *       <li>time only: {@code 20260627/12}, {@code dt=20260627/hh=12} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time: {@code region=us/20260627/12}, {@code region=us/dt=20260627/hh=12} — timeSegStartIndex {@code 1}</li>
+ *       <li>time + suffix: {@code 20260627/12/source=app}, {@code dt=20260627/hh=12/source=app} — timeSegStartIndex {@code 0}</li>
+ *       <li>prefix + time + suffix: {@code region=us/dt=20260627/hh=12/source=app} — timeSegStartIndex {@code 1}</li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ * Hive-style key names are not constrained: {@code dt=}, {@code day=}, {@code event_date=},
+ * {@code hh=}, {@code hour=} all work; only the value after {@code =} is parsed.
+ * <p>
+ * Any {@link java.time.format.DateTimeFormatter} pattern works as long as the resulting
+ * {@link java.time.temporal.TemporalAccessor} can be resolved to either an {@link java.time.Instant}
+ * or a {@link java.time.LocalDate} (day-only patterns are anchored at UTC start-of-day). A
+ * {@code /} in the pattern means the time value spans that many consecutive path segments.
+ * Patterns missing day-of-month, e.g. month-only {@code yyyy-MM}, cannot be resolved and will
+ * raise the standard parse-failure error at runtime.
+ *
+ * <h3>Locating the time block</h3>
+ * The time block must occupy a <i>contiguous</i> segment range of the partition path. Only the
+ * segments before it count toward {@code timeSegStartIndex}; segments after are ignored. Interleaved
+ * layouts such as {@code dt=20260627/source=app/hh=12} are not supported -- the time block must
+ * be in one piece.
+ *
+ * <h3>Time zone</h3>
+ * Both the partition's event time and the cutoff derived from {@code instantTime} are interpreted
+ * in UTC. Set {@code hoodie.table.timeline.timezone=UTC} so the timeline writes instants under the
+ * same convention; otherwise the cutoff drifts by the JVM's UTC offset -- a boundary effect at
+ * day granularity, a full-offset shift at hour granularity.
+ *
+ * <h3>Configuration</h3>
+ * All three knobs come with defaults, so a table whose partition path is purely a date in
+ * {@code yyyy-MM-dd} form works out of the box.
+ * <ul>
+ *   <li>{@link org.apache.hudi.config.HoodieTTLConfig#EVENT_TIME_FORMAT} — date-time pattern of
+ *       the time block in the partition path. Default {@code yyyy-MM-dd}. A {@code /} in the
+ *       pattern means the time block spans that many consecutive segments.</li>
+ *   <li>{@link org.apache.hudi.config.HoodieTTLConfig#EVENT_TIME_SEGMENT_START_INDEX} —
+ *       0-based index of the first segment that carries the time block. Default {@code 0}.
+ *       Raise it when non-time segments come before the time block (see examples above).</li>
+ *   <li>{@link org.apache.hudi.config.HoodieTTLConfig#EVENT_TIME_DELETE_HIVE_DEFAULT_PARTITION} —
+ *       whether to treat partitions whose time block contains {@code __HIVE_DEFAULT_PARTITION__}
+ *       in <i>any</i> segment as expired. Such a partition has an undefined event time (one of
+ *       its event-time columns was {@code NULL}, so the row cannot be placed on the configured
+ *       time axis) and falls outside the normal cutoff comparison. Default {@code false}, i.e.
+ *       such partitions are skipped with a WARN and the user keeps explicit control over them.
+ *       Applies to both single-segment formats (e.g. {@code dt=__HIVE_DEFAULT_PARTITION__}) and
+ *       multi-segment ones (e.g. {@code dt=2026-06-28/hh=__HIVE_DEFAULT_PARTITION__}).</li>
+ * </ul>
+ */
+@Slf4j
+public class KeepByEventTimeStrategy extends KeepByTimeStrategy {
+
+  private final String eventTimeFormat;
+  private final int timeSegStartIndex;
+  private final boolean shouldDeleteHiveDefaultPartition;
+  private final boolean hiveStylePartitioning;
+
+  public KeepByEventTimeStrategy(HoodieTable hoodieTable, String instantTime) {
+    super(hoodieTable, instantTime);
+    // Defaults: format='yyyy-MM-dd', timeSegStartIndex=0, deleteHiveDefaultPartition=false. The
+    // two guards below catch users who set the values explicitly to obviously-broken inputs.
+    this.eventTimeFormat = writeConfig.getPartitionTTLEventTimeFormat();
+    if (eventTimeFormat == null || eventTimeFormat.isEmpty()) {
+      throw new IllegalArgumentException(
+          HoodieTTLConfig.EVENT_TIME_FORMAT.key() + " must not be empty.");
+    }
+    this.timeSegStartIndex = writeConfig.getPartitionTTLEventTimeSegmentStartIndex();
+    if (timeSegStartIndex < 0) {
+      throw new IllegalArgumentException(
+          HoodieTTLConfig.EVENT_TIME_SEGMENT_START_INDEX.key() + " must be >= 0, got " + timeSegStartIndex);
+    }
+    this.shouldDeleteHiveDefaultPartition = writeConfig.shouldPartitionTTLEventTimeDeleteHiveDefaultPartition();
+    // Hive-style partitioning is a table-level property recorded at table creation; trust it
+    // rather than guessing per-segment from a stray '=' character in a value.
+    this.hiveStylePartitioning = Boolean.parseBoolean(
+        hoodieTable.getMetaClient().getTableConfig().getHiveStylePartitioningEnable());
+  }
+
+  @Override
+  protected List<String> getExpiredPartitionsForTimeStrategy(List<String> partitionPathsForTTL) {
+    long cutoffMillis = resolveCutoffMillis(instantTime, ttlInMilis);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(eventTimeFormat).withZone(ZoneOffset.UTC);
+    int segCount = segmentCount(eventTimeFormat);
+    return partitionPathsForTTL.stream().parallel()
+        .filter(path -> isPartitionExpiredByEventTime(
+            path, formatter, timeSegStartIndex, segCount, cutoffMillis, shouldDeleteHiveDefaultPartition, hiveStylePartitioning))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Number of '/'-separated path segments the configured format occupies.
+   * Example: {@code yyyy-MM-dd/HH} -> 2.
+   */
+  static int segmentCount(String format) {
+    return format.split("/").length;
+  }
+
+  /**
+   * Resolve the "now" reference timestamp from {@code instantTime}, in UTC.
+   * <p>
+   * Anchoring on {@code instantTime} keeps the strategy idempotent across retries of the same
+   * replace commit. We parse it in UTC so the cutoff and the partition's event time (also parsed
+   * in UTC above) sit on the same axis -- otherwise expiry drifts by the JVM's UTC offset, which
+   * is negligible at day granularity but a full-offset shift at hour granularity.
+   */
+  static long resolveCutoffMillis(String instantTime, long ttlInMillis) {
+    try {
+      return HoodieInstantTimeGenerator.parseDateFromInstantTime(instantTime, ZoneOffset.UTC).getTime() - ttlInMillis;
+    } catch (ParseException e) {
+      throw new IllegalStateException("Failed to parse instant time " + instantTime, e);
+    }
+  }
+
+  /**
+   * Decide whether a partition path is expired.
+   * <p>
+   * The strategy treats any partition that cannot be parsed under the configured format /
+   * start-index / hive-style as a hard error. Reasoning: this class derives lifetime from the
+   * path itself, so a partition we cannot parse has no defined lifetime, and silently skipping
+   * it would leave it in the table forever while the rest of TTL appears to succeed. Switch to
+   * {@code KEEP_BY_TIME} or {@code KEEP_BY_CREATION_TIME} (which key off commit metadata, not
+   * the path) if the table contains partitions that don't conform to a single event-time shape.
+   * <p>
+   * Package-private so unit tests can exercise it directly without spinning up a HoodieTable.
+   * <p>
+   * Note the two trailing {@code boolean} flags are easy to transpose at call sites; keep them in
+   * this order: {@code deleteHiveDefaultPartition} first, {@code hiveStylePartitioning} last.
+   *
+   * @param partitionPath              the partition path to evaluate
+   * @param formatter                  formatter built from the configured event-time format
+   * @param timeSegStartIndex          0-based index of the first segment carrying the time block
+   * @param segCount                   number of segments the time block spans
+   * @param cutoffMillis               partitions with event time strictly before this are expired
+   * @param deleteHiveDefaultPartition treat a time block containing the Hive default marker as expired
+   * @param hiveStylePartitioning      whether segments carry a {@code field=value} prefix to strip
+   */
+  static boolean isPartitionExpiredByEventTime(String partitionPath,
+                                               DateTimeFormatter formatter,
+                                               int timeSegStartIndex,
+                                               int segCount,
+                                               long cutoffMillis,
+                                               boolean deleteHiveDefaultPartition,
+                                               boolean hiveStylePartitioning) {
+    String[] segments = partitionPath.split("/");
+    if (segments.length < timeSegStartIndex + segCount) {
+      throw new IllegalArgumentException(String.format(
+          "Partition '%s' has %d segment(s) but the configured event time spans %d segment(s) starting at index %d. "
+              + "Check %s and %s, "
+              + "or switch to KEEP_BY_TIME / KEEP_BY_CREATION_TIME if not all partitions of this table follow an event-time shape.",
+          partitionPath, segments.length, segCount, timeSegStartIndex,
+          HoodieTTLConfig.EVENT_TIME_FORMAT.key(), HoodieTTLConfig.EVENT_TIME_SEGMENT_START_INDEX.key()));
+    }
+
+    String[] timeSegs = new String[segCount];
+    boolean hasDefaultSegment = false;
+    for (int i = 0; i < segCount; i++) {
+      String seg = segments[timeSegStartIndex + i];
+      if (hiveStylePartitioning) {
+        int eq = seg.indexOf('=');
+        if (eq < 0) {
+          throw new IllegalArgumentException(String.format(
+              "Partition '%s' segment '%s' has no hive-style 'field=value' prefix but "
+                  + "%s=true on the table. "
+                  + "Switch to KEEP_BY_TIME / KEEP_BY_CREATION_TIME if such legacy partitions must coexist.",
+              partitionPath, seg, KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE.key()));
+        }
+        timeSegs[i] = seg.substring(eq + 1);
+      } else {
+        timeSegs[i] = seg;
+      }
+      if (PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH.equals(timeSegs[i])) {
+        hasDefaultSegment = true;
+      }
+    }
+
+    // Any default-marker segment means the event time itself is undefined: a date-recorded /
+    // hour-NULL row cannot be placed on the hour axis any more than a date-NULL row can. We
+    // therefore treat the whole time block as "the default partition" and let the explicit
+    // user switch decide. Without this branch a multi-segment shape like
+    // dt=2026-06-28/hh=__HIVE_DEFAULT_PARTITION__ would either silently expire (old code) or
+    // stall TTL forever on a hard error.
+    if (hasDefaultSegment) {
+      if (deleteHiveDefaultPartition) {
+        log.info("Partition '{}' time block contains {} (event time undefined) and delete switch "
+            + "is on; marking expired", partitionPath, PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH);
+        return true;
+      }
+      log.warn("Skipping partition '{}': time block contains {} (event time undefined; set "
+              + "{}=true to delete)",
+          partitionPath, PartitionPathEncodeUtils.DEFAULT_PARTITION_PATH,
+          HoodieTTLConfig.EVENT_TIME_DELETE_HIVE_DEFAULT_PARTITION.key());
+      return false;
+    }
+
+    String timeStr = String.join("/", timeSegs);
+    Long eventMillis = parseEventMillis(timeStr, formatter);
+    if (eventMillis == null) {
+      throw new IllegalArgumentException(String.format(
+          "Partition '%s': cannot parse '%s' with pattern '%s'. "
+              + "Fix %s, or switch to "
+              + "KEEP_BY_TIME / KEEP_BY_CREATION_TIME if such partitions must remain in the table.",
+          partitionPath, timeStr, formatter, HoodieTTLConfig.EVENT_TIME_FORMAT.key()));
+    }
+    return eventMillis < cutoffMillis;
+  }
+
+  /**
+   * Parse {@code timeStr} into epoch millis. Tries full date-time first; falls back to a
+   * date-only parse anchored at UTC start-of-day so day-level patterns (e.g. {@code yyyy-MM-dd})
+   * also work.
+   */
+  static Long parseEventMillis(String timeStr, DateTimeFormatter formatter) {
+    TemporalAccessor parsed;
+    try {
+      parsed = formatter.parse(timeStr);
+    } catch (DateTimeParseException e) {
+      return null;
+    }
+    try {
+      return Instant.from(parsed).toEpochMilli();
+    } catch (DateTimeException ignore) {
+      // Day-level pattern with no time-of-day: anchor at UTC start of day.
+      try {
+        return LocalDate.from(parsed).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+      } catch (DateTimeException e) {
+        return null;
+      }
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/PartitionTTLStrategyType.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/PartitionTTLStrategyType.java
@@ -36,7 +36,8 @@ import static org.apache.hudi.config.HoodieTTLConfig.PARTITION_TTL_STRATEGY_TYPE
  */
 public enum PartitionTTLStrategyType {
   KEEP_BY_TIME("org.apache.hudi.table.action.ttl.strategy.KeepByTimeStrategy"),
-  KEEP_BY_CREATION_TIME("org.apache.hudi.table.action.ttl.strategy.KeepByCreationTimeStrategy");
+  KEEP_BY_CREATION_TIME("org.apache.hudi.table.action.ttl.strategy.KeepByCreationTimeStrategy"),
+  KEEP_BY_EVENT_TIME("org.apache.hudi.table.action.ttl.strategy.KeepByEventTimeStrategy");
 
   @Getter
   private final String className;

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/ttl/strategy/TestKeepByEventTimeStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/ttl/strategy/TestKeepByEventTimeStrategy.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.table.action.ttl.strategy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link KeepByEventTimeStrategy}'s pure parsing logic. Exercises the static helpers
+ * directly so we don't need to spin up a HoodieTable / write client.
+ */
+public class TestKeepByEventTimeStrategy {
+
+  @Test
+  public void segmentCountCountsSlashes() {
+    assertEquals(1, KeepByEventTimeStrategy.segmentCount("yyyy-MM-dd"));
+    assertEquals(1, KeepByEventTimeStrategy.segmentCount("yyyyMMdd"));
+    assertEquals(2, KeepByEventTimeStrategy.segmentCount("yyyy-MM-dd/HH"));
+    assertEquals(2, KeepByEventTimeStrategy.segmentCount("yyyyMMdd/HH"));
+  }
+
+  // path, format, startIdx, hiveStyle, expectedExpired
+  //
+  // Full matrix mirroring the class-level JavaDoc: 4 formats x 4 position shapes
+  // (time only / prefix+time / time+suffix / prefix+time+suffix) x hive vs non-hive.
+  // Cutoff is "2026-04-30 00:00 UTC" so any 2026-04-22 path expires; the two
+  // "not expired" rows pin down the strict-less-than boundary.
+  @ParameterizedTest
+  @CsvSource({
+      // -------- Day, format=yyyy-MM-dd --------
+      // time only
+      "'dt=2026-04-22',                                'yyyy-MM-dd',     0, true,  true",
+      "'dt=2026-04-30',                                'yyyy-MM-dd',     0, true,  false",
+      "'2026-04-22',                                   'yyyy-MM-dd',     0, false, true",
+      "'2026-04-30',                                   'yyyy-MM-dd',     0, false, false",
+      // prefix + time
+      "'region=us/dt=2026-04-22',                      'yyyy-MM-dd',     1, true,  true",
+      "'eventType=login/dt=2026-04-30',                'yyyy-MM-dd',     1, true,  false",
+      "'region=us/2026-04-22',                         'yyyy-MM-dd',     1, false, true",
+      // time + suffix
+      "'dt=2026-04-22/source=app',                     'yyyy-MM-dd',     0, true,  true",
+      "'2026-04-22/source=app',                        'yyyy-MM-dd',     0, false, true",
+      // prefix + time + suffix
+      "'region=us/dt=2026-04-22/source=app',           'yyyy-MM-dd',     1, true,  true",
+      "'region=us/2026-04-22/source=app',              'yyyy-MM-dd',     1, false, true",
+
+      // -------- Day, format=yyyyMMdd --------
+      // time only
+      "'dt=20260422',                                  'yyyyMMdd',       0, true,  true",
+      "'dt=20260430',                                  'yyyyMMdd',       0, true,  false",
+      "'20260422',                                     'yyyyMMdd',       0, false, true",
+      // prefix + time
+      "'region=us/dt=20260422',                        'yyyyMMdd',       1, true,  true",
+      "'region=us/20260422',                           'yyyyMMdd',       1, false, true",
+      // time + suffix
+      "'dt=20260422/source=app',                       'yyyyMMdd',       0, true,  true",
+      "'20260422/source=app',                          'yyyyMMdd',       0, false, true",
+      // prefix + time + suffix
+      "'region=us/dt=20260422/source=app',             'yyyyMMdd',       1, true,  true",
+      "'region=us/20260422/source=app',                'yyyyMMdd',       1, false, true",
+
+      // -------- Hour, format=yyyy-MM-dd/HH --------
+      // time only
+      "'dt=2026-04-22/hh=06',                          'yyyy-MM-dd/HH',  0, true,  true",
+      "'2026-04-22/06',                                'yyyy-MM-dd/HH',  0, false, true",
+      // prefix + time
+      "'region=us/dt=2026-04-22/hh=06',                'yyyy-MM-dd/HH',  1, true,  true",
+      "'region=us/2026-04-22/06',                      'yyyy-MM-dd/HH',  1, false, true",
+      // time + suffix
+      "'dt=2026-04-22/hh=06/source=app',               'yyyy-MM-dd/HH',  0, true,  true",
+      "'2026-04-22/06/source=app',                     'yyyy-MM-dd/HH',  0, false, true",
+      // prefix + time + suffix
+      "'region=us/dt=2026-04-22/hh=06/source=app',     'yyyy-MM-dd/HH',  1, true,  true",
+      "'region=us/2026-04-22/06/source=app',           'yyyy-MM-dd/HH',  1, false, true",
+
+      // -------- Hour, format=yyyyMMdd/HH --------
+      // time only
+      "'dt=20260422/hh=06',                            'yyyyMMdd/HH',    0, true,  true",
+      "'20260422/06',                                  'yyyyMMdd/HH',    0, false, true",
+      // prefix + time
+      "'eventType=login/dt=20260422/hh=06',            'yyyyMMdd/HH',    1, true,  true",
+      "'login/20260422/06',                            'yyyyMMdd/HH',    1, false, true",
+      // time + suffix
+      "'dt=20260422/hh=06/eventType=login',            'yyyyMMdd/HH',    0, true,  true",
+      "'20260422/06/source=app',                       'yyyyMMdd/HH',    0, false, true",
+      // prefix + time + suffix
+      "'region=us/dt=20260422/hh=06/source=app',       'yyyyMMdd/HH',    1, true,  true",
+      "'region=us/20260422/06/source=app',             'yyyyMMdd/HH',    1, false, true",
+  })
+  public void parsesPartitionAndCompares(String path,
+                                         String format,
+                                         int startIdx,
+                                         boolean hiveStyle,
+                                         boolean expectedExpired) {
+    // Cutoff is "2026-04-30 00:00 UTC" so 2026-04-22 is expired (strictly before) while 2026-04-30 is not.
+    long cutoff = LocalDate.of(2026, 4, 30).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneOffset.UTC);
+    int segCount = KeepByEventTimeStrategy.segmentCount(format);
+
+    boolean expired = KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+        path, formatter, startIdx, segCount, cutoff, false, hiveStyle);
+
+    assertEquals(expectedExpired, expired, "path=" + path + " format=" + format);
+  }
+
+  @Test
+  public void parseFailureThrows() {
+    // A partition whose time segment can't be parsed has no defined lifetime under event-time
+    // semantics, so the strategy fails fast and asks the user to switch to commit-time TTL.
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+    assertThrows(IllegalArgumentException.class, () ->
+        KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+            "dt=not-a-date", f, 0, 1, Long.MAX_VALUE, false, true));
+  }
+
+  @Test
+  public void shorterPathThanFormatThrows() {
+    // Partition layout is fixed per table — a mismatch is a configuration error, not a per-row skip.
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd/HH").withZone(ZoneOffset.UTC);
+    assertThrows(IllegalArgumentException.class, () ->
+        KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+            "dt=2026-04-22", f, 0, 2, Long.MAX_VALUE, false, true));
+  }
+
+  @Test
+  public void startIndexOutOfRangeThrows() {
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+    assertThrows(IllegalArgumentException.class, () ->
+        KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+            "dt=2026-04-22", f, 5, 1, Long.MAX_VALUE, false, true));
+  }
+
+  @Test
+  public void hiveStyleSegmentWithoutEqualsThrows() {
+    // Table is hive-style but the segment lacks 'field=' prefix -> misconfiguration, fail fast.
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+    assertThrows(IllegalArgumentException.class, () ->
+        KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+            "2026-04-22", f, 0, 1, Long.MAX_VALUE, false, /*hiveStyle*/ true));
+  }
+
+  @Test
+  public void nonHiveStyleSegmentWithEqualsThrows() {
+    // hiveStyle=false: segment is taken verbatim, so '=' becomes part of the time string and
+    // fails parsing -> hard error, same as any other unparseable partition.
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+    assertThrows(IllegalArgumentException.class, () ->
+        KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+            "dt=2026-04-22", f, 0, 1, Long.MAX_VALUE, false, /*hiveStyle*/ false));
+  }
+
+  @Test
+  public void hiveDefaultPartitionSkippedWhenSwitchOff() {
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+    boolean expired = KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+        "dt=__HIVE_DEFAULT_PARTITION__", f, 0, 1, Long.MAX_VALUE, false, true);
+    assertFalse(expired);
+  }
+
+  @Test
+  public void hiveDefaultPartitionDeletedWhenSwitchOn() {
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+    boolean expired = KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+        "dt=__HIVE_DEFAULT_PARTITION__", f, 0, 1, /*cutoff*/ 0, /*deleteHiveDefault*/ true, /*hiveStyle*/ true);
+    assertTrue(expired);
+  }
+
+  @Test
+  public void wholeTimeBlockDefaultPartitionDeletedWhenSwitchOn() {
+    // Multi-segment format where the entire time block is the default marker -> treated as
+    // "the default partition" and respects the delete switch (just like the single-segment case).
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd/HH").withZone(ZoneOffset.UTC);
+    boolean expired = KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+        "dt=__HIVE_DEFAULT_PARTITION__/hh=__HIVE_DEFAULT_PARTITION__",
+        f, 0, 2, /*cutoff*/ 0, /*deleteHiveDefault*/ true, /*hiveStyle*/ true);
+    assertTrue(expired);
+  }
+
+  @Test
+  public void partialDefaultPartitionTimeBlockFollowsSwitch() {
+    // dt=2026-06-28/hh=__HIVE_DEFAULT_PARTITION__: the date column was recorded but the hour
+    // column was NULL, so the event time has no place on the hour axis. We treat this exactly
+    // like a fully-null time block — the explicit delete switch decides. The cutoff is a recent
+    // date precisely to nail down that this is NOT a "the date is fresh, keep it" path.
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd/HH").withZone(ZoneOffset.UTC);
+    long cutoff = LocalDate.of(2026, 4, 30).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+
+    // switch on -> expire (even though dt looks fresh, event time is undefined)
+    assertTrue(KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+        "dt=2026-06-28/hh=__HIVE_DEFAULT_PARTITION__",
+        f, 0, 2, cutoff, /*deleteHiveDefault*/ true, /*hiveStyle*/ true));
+    // switch off -> skip with WARN (user retains explicit control)
+    assertFalse(KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+        "dt=2026-06-28/hh=__HIVE_DEFAULT_PARTITION__",
+        f, 0, 2, cutoff, /*deleteHiveDefault*/ false, /*hiveStyle*/ true));
+  }
+
+  @Test
+  public void resolveCutoffMillisInterpretsInstantInUtc() {
+    // The instant string '20260430120000000' must be read as 2026-04-30T12:00:00Z regardless of the
+    // JVM default zone. With ttl=0 the cutoff equals that exact instant; this pins down the contract
+    // that resolveCutoffMillis and the partition formatter both speak UTC.
+    long expected = LocalDateTime.of(2026, 4, 30, 12, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+    assertEquals(expected, KeepByEventTimeStrategy.resolveCutoffMillis("20260430120000000", 0));
+
+    // ttl=1d shifts back exactly 24h, again with no dependence on the JVM zone.
+    long oneDay = TimeUnit.DAYS.toMillis(1);
+    assertEquals(expected - oneDay,
+        KeepByEventTimeStrategy.resolveCutoffMillis("20260430120000000", oneDay));
+  }
+
+  @Test
+  public void hourBoundaryRespected() {
+    // Cutoff is 2026-04-22 12:00 UTC. 11:00 expired, 12:00 not expired.
+    long cutoff = LocalDateTime.of(2026, 4, 22, 12, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+    DateTimeFormatter f = DateTimeFormatter.ofPattern("yyyy-MM-dd/HH").withZone(ZoneOffset.UTC);
+
+    assertTrue(KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+        "2026-04-22/11", f, 0, 2, cutoff, false, /*hiveStyle*/ false));
+    assertFalse(KeepByEventTimeStrategy.isPartitionExpiredByEventTime(
+        "2026-04-22/12", f, 0, 2, cutoff, false, /*hiveStyle*/ false));
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/ttl/strategy/TestPartitionTTLStrategyType.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/ttl/strategy/TestPartitionTTLStrategyType.java
@@ -52,6 +52,16 @@ public class TestPartitionTTLStrategyType {
   }
 
   @Test
+  public void resolvesKeepByEventTimeFromType() {
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(HoodieTTLConfig.PARTITION_TTL_STRATEGY_TYPE,
+        PartitionTTLStrategyType.KEEP_BY_EVENT_TIME.name());
+
+    assertEquals(PartitionTTLStrategyType.KEEP_BY_EVENT_TIME.getClassName(),
+        PartitionTTLStrategyType.getPartitionTTLStrategyClassName(config));
+  }
+
+  @Test
   public void throwsOnUnknownType() {
     HoodieConfig config = new HoodieConfig();
     config.setValue(HoodieTTLConfig.PARTITION_TTL_STRATEGY_TYPE, "NOT_A_REAL_TYPE");

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionTTLActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/commit/SparkPartitionTTLActionExecutor.java
@@ -40,7 +40,7 @@ import java.util.List;
 public class SparkPartitionTTLActionExecutor<T>
     extends BaseSparkCommitActionExecutor<T> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ConsistentBucketBulkInsertDataInternalWriterHelper.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SparkPartitionTTLActionExecutor.class);
 
   public SparkPartitionTTLActionExecutor(HoodieEngineContext context, HoodieWriteConfig config, HoodieTable table,
                                          String instantTime) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -144,6 +145,46 @@ public class TestPartitionTTLManagement extends HoodieClientTestBase {
 
       // remain 10 rows
       Assertions.assertEquals(10, readRecords(new String[] {partitionPath0, partitionPath1, partitionPath2}).size());
+    }
+  }
+
+  @Test
+  public void testKeepByEventTime() {
+    final HoodieWriteConfig cfg = getConfigBuilder()
+        .withPath(metaClient.getBasePath())
+        .withTTLConfig(HoodieTTLConfig
+            .newBuilder()
+            .withTTLDaysRetain(10)
+            .withTTLStrategyType(PartitionTTLStrategyType.KEEP_BY_EVENT_TIME)
+            .withEventTimeFormat("yyyy/MM/dd")
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().build())
+        .build();
+    // Use default partition paths (yyyy/MM/dd) plus one in the far future so we exercise both branches.
+    String futurePartition = "2099/01/01";
+    String[] partitions = {
+        HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH,   // 2016/03/15 -> expired
+        HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH,  // 2015/03/16 -> expired
+        futurePartition                                         // 2099/01/01 -> not expired
+    };
+    HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEED, partitions, new HashMap<>());
+    try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
+      String instant0 = getCommitTimeAtUTC(0);
+      writeRecordsForPartition(client, dataGen, partitions[0], instant0);
+
+      String instant1 = getCommitTimeAtUTC(1000);
+      writeRecordsForPartition(client, dataGen, partitions[1], instant1);
+
+      String currentInstant = WriteClientTestUtils.createNewInstantTime();
+      writeRecordsForPartition(client, dataGen, partitions[2], currentInstant);
+
+      String instantTime = client.startDeletePartitionCommit(metaClient);
+      HoodieWriteResult result = client.managePartitionTTL(instantTime);
+
+      // Both historic partitions are expired by event time; the future one is preserved.
+      Assertions.assertEquals(Sets.newHashSet(partitions[0], partitions[1]),
+          result.getPartitionToReplaceFileIds().keySet());
+      Assertions.assertEquals(10, readRecords(partitions).size());
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
@@ -185,6 +185,15 @@ public class TestPartitionTTLManagement extends HoodieClientTestBase {
       Assertions.assertEquals(Sets.newHashSet(partitions[0], partitions[1]),
           result.getPartitionToReplaceFileIds().keySet());
       Assertions.assertEquals(10, readRecords(partitions).size());
+
+      // Idempotency: the partitions we just replaced still linger in getAllPartitionPaths() until
+      // the cleaner runs, and their event time is derived from the (unchanged) path. Without the
+      // live-file-slice guard they would be re-selected here, producing an endless stream of empty
+      // replace commits. A second run must find nothing to delete.
+      String instantTime2 = client.startDeletePartitionCommit(metaClient);
+      HoodieWriteResult result2 = client.managePartitionTTL(instantTime2);
+      Assertions.assertTrue(result2.getPartitionToReplaceFileIds().isEmpty(),
+          "Already-deleted partitions must not be re-selected on the next TTL batch");
     }
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/TestPartitionTTLManagement.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -144,6 +145,55 @@ public class TestPartitionTTLManagement extends HoodieClientTestBase {
 
       // remain 10 rows
       Assertions.assertEquals(10, readRecords(new String[] {partitionPath0, partitionPath1, partitionPath2}).size());
+    }
+  }
+
+  @Test
+  public void testKeepByEventTime() {
+    final HoodieWriteConfig cfg = getConfigBuilder()
+        .withPath(metaClient.getBasePath())
+        .withTTLConfig(HoodieTTLConfig
+            .newBuilder()
+            .withTTLDaysRetain(10)
+            .withTTLStrategyType(PartitionTTLStrategyType.KEEP_BY_EVENT_TIME)
+            .withEventTimeFormat("yyyy/MM/dd")
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder().build())
+        .build();
+    // Use default partition paths (yyyy/MM/dd) plus one in the far future so we exercise both branches.
+    String futurePartition = "2099/01/01";
+    String[] partitions = {
+        HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH,   // 2016/03/15 -> expired
+        HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH,  // 2015/03/16 -> expired
+        futurePartition                                         // 2099/01/01 -> not expired
+    };
+    HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEED, partitions, new HashMap<>());
+    try (SparkRDDWriteClient client = getHoodieWriteClient(cfg)) {
+      String instant0 = getCommitTimeAtUTC(0);
+      writeRecordsForPartition(client, dataGen, partitions[0], instant0);
+
+      String instant1 = getCommitTimeAtUTC(1000);
+      writeRecordsForPartition(client, dataGen, partitions[1], instant1);
+
+      String currentInstant = WriteClientTestUtils.createNewInstantTime();
+      writeRecordsForPartition(client, dataGen, partitions[2], currentInstant);
+
+      String instantTime = client.startDeletePartitionCommit(metaClient);
+      HoodieWriteResult result = client.managePartitionTTL(instantTime);
+
+      // Both historic partitions are expired by event time; the future one is preserved.
+      Assertions.assertEquals(Sets.newHashSet(partitions[0], partitions[1]),
+          result.getPartitionToReplaceFileIds().keySet());
+      Assertions.assertEquals(10, readRecords(partitions).size());
+
+      // Idempotency: the partitions we just replaced still linger in getAllPartitionPaths() until
+      // the cleaner runs, and their event time is derived from the (unchanged) path. Without the
+      // live-file-slice guard they would be re-selected here, producing an endless stream of empty
+      // replace commits. A second run must find nothing to delete.
+      String instantTime2 = client.startDeletePartitionCommit(metaClient);
+      HoodieWriteResult result2 = client.managePartitionTTL(instantTime2);
+      Assertions.assertTrue(result2.getPartitionToReplaceFileIds().isEmpty(),
+          "Already-deleted partitions must not be re-selected on the next TTL batch");
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstantTimeGenerator.java
@@ -84,10 +84,22 @@ public class HoodieInstantTimeGenerator {
   }
 
   public static Date parseDateFromInstantTime(String timestamp) throws ParseException {
+    return parseDateFromInstantTime(timestamp, ZoneId.systemDefault());
+  }
+
+  /**
+   * Parse an instant time string into a {@link Date}, interpreting the digits in {@code zoneId}.
+   * <p>
+   * Instant times are bare {@code yyyyMMddHHmmssSSS} digits with no zone information, so the
+   * caller decides which zone produced them -- typically the table's
+   * {@code hoodie.table.timeline.timezone}. The no-arg overload preserves the legacy behaviour
+   * of {@link ZoneId#systemDefault()}.
+   */
+  public static Date parseDateFromInstantTime(String timestamp, ZoneId zoneId) throws ParseException {
     try {
       String timestampInMillis = fixInstantTimeCompatibility(timestamp);
       LocalDateTime dt = LocalDateTime.parse(timestampInMillis, MILLIS_INSTANT_TIME_FORMATTER);
-      return Date.from(dt.atZone(ZoneId.systemDefault()).toInstant());
+      return Date.from(dt.atZone(zoneId).toInstant());
     } catch (DateTimeParseException e) {
       throw new ParseException(e.getMessage(), e.getErrorIndex());
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

 Today Hudi ships two partition TTL strategies, both keyed off processing time:

   - KeepByCreationTimeStrategy uses the partition creation commit time recorded in .hoodie_partition_metadata. Backfilled historical partitions look "newly created" and never expire.
  - KeepByTimeStrategy uses the last commit time that touched the partition. Any late-arriving write extends the partition's lifetime, silently disabling TTL.

  In practice, what most users actually want is event-time semantics: the date encoded in the partition path (e.g. dt=2026-04-24) is the business event date, and anything older than N days should be dropped —
  regardless of when/how writes land.

  This PR introduces a new strategy KeepByEventTimeStrategy that derives the partition's reference time from the partition path itself, decoupling TTL from write behavior.


### Summary and Changelog

 For users: a new KEEP_BY_EVENT_TIME partition TTL strategy that expires partitions based on the date encoded in the partition path. TTL is no longer affected by backfill, late-arriving data, or commit timing.

  Supported partition path shapes (v1 scope):

Day, format=yyyy-MM-dd
time only: 2026-06-27, dt=2026-06-27 — startIndex 0
prefix + time: region=us/2026-06-27, region=us/dt=2026-06-27 — startIndex 1
time + suffix: 2026-06-27/source=app, dt=2026-06-27/source=app — startIndex 0
prefix + time + suffix: region=us/dt=2026-06-27/source=app — startIndex 1

Day, format=yyyyMMdd
time only: 20260627, dt=20260627 — startIndex 0
prefix + time: region=us/20260627, region=us/dt=20260627 — startIndex 1
time + suffix: 20260627/source=app, dt=20260627/source=app — startIndex 0
prefix + time + suffix: region=us/dt=20260627/source=app — startIndex 1

Hour, format=yyyy-MM-dd/HH
time only: 2026-06-27/12, dt=2026-04-05/hh=12 — startIndex 0
prefix + time: region=us/2026-06-27/12, region=us/dt=2026-04-05/hh=12 — startIndex 1
time + suffix: 2026-06-27/12/source=app, dt=2026-04-05/hh=12/source=app — startIndex 0
prefix + time + suffix: region=us/dt=2026-04-05/hh=12/source=app — startIndex 1

Hour, format=yyyyMMdd/HH
time only: 20260627/12, dt=20260405/hh=12 — startIndex 0
prefix + time: region=us/20260627/12, region=us/dt=20260405/hh=12 — startIndex 1
time + suffix: 20260627/12/source=app, dt=20260405/hh=12/source=app — startIndex 0
prefix + time + suffix: region=us/dt=20260405/hh=12/source=app — startIndex 1

Hive-style key names are not constrained: dt=, day=, event_date=, hh=, hour= all work; only the value after = is parsed.

  Hive-style is honored from the table's hoodie.datasource.write.hive_style_partitioning flag (authoritative table-level setting, not guessed per-segment).


### Impact

  - Public API: none broken. New enum value, three new configs (all with defaults), one new class — strictly additive.
  - User-facing: a new opt-in TTL strategy. Existing strategies and configs are untouched. Users adopt it by setting hoodie.partition.ttl.management.strategy.type=KEEP_BY_EVENT_TIME.
  - Performance: negligible — partition path parsing is in-memory string ops, runs only inside the existing TTL replace commit, no extra metadata reads.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
