### PR TITLE
fix: reduce MDT compaction heap pressure in BitCaskDiskMap and ExternalSpillableMap

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieUpsertException;
 import org.apache.hudi.keygen.BaseKeyGenerator;
@@ -32,11 +33,13 @@ import org.apache.hudi.table.HoodieTable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.stream.Collectors;
 
 /**
  * Hoodie merge handle which writes records (new inserts or updates) sorted by their key.
@@ -47,13 +50,13 @@ import java.util.Queue;
 @NotThreadSafe
 public class HoodieSortedMergeHandle<T, I, K, O> extends HoodieWriteMergeHandle<T, I, K, O> {
 
-  private final Queue<String> newRecordKeysSorted = new PriorityQueue<>();
+  private final Queue<String> newRecordKeysSorted;
 
   public HoodieSortedMergeHandle(HoodieWriteConfig config, String instantTime, HoodieTable<T, I, K, O> hoodieTable,
                                  Iterator<HoodieRecord<T>> recordItr, String partitionPath, String fileId, TaskContextSupplier taskContextSupplier,
                                  Option<BaseKeyGenerator> keyGeneratorOpt) {
     super(config, instantTime, hoodieTable, recordItr, partitionPath, fileId, taskContextSupplier, keyGeneratorOpt);
-    newRecordKeysSorted.addAll(keyToNewRecords.keySet());
+    this.newRecordKeysSorted = buildSortedKeys(keyToNewRecords);
   }
 
   /**
@@ -63,8 +66,31 @@ public class HoodieSortedMergeHandle<T, I, K, O> extends HoodieWriteMergeHandle<
                                  Map<String, HoodieRecord<T>> keyToNewRecordsOrig, String partitionPath, String fileId,
                                  HoodieBaseFile dataFileToBeMerged, TaskContextSupplier taskContextSupplier, Option<BaseKeyGenerator> keyGeneratorOpt) {
     super(config, instantTime, hoodieTable, keyToNewRecordsOrig, partitionPath, fileId, dataFileToBeMerged, taskContextSupplier, keyGeneratorOpt);
+    this.newRecordKeysSorted = buildSortedKeys(keyToNewRecords);
+  }
 
-    newRecordKeysSorted.addAll(keyToNewRecords.keySet());
+  /**
+   * Builds the sorted-keys {@link PriorityQueue} from the given map.
+   *
+   * <p>Two memory/CPU considerations:
+   * <ul>
+   *   <li>When the map is a spilled {@link ExternalSpillableMap}, {@link java.util.Map#keySet()}
+   *       allocates a full {@link java.util.HashSet} copy of all keys (in-memory + disk) before
+   *       returning, creating a large transient heap spike (ENG-43078).
+   *       {@link ExternalSpillableMap#keyStream()} streams keys lazily without that copy.</li>
+   *   <li>The {@link PriorityQueue#PriorityQueue(java.util.Collection) Collection constructor}
+   *       runs a single O(N) heapify, whereas individual {@code add()} calls are O(log N) each
+   *       (total O(N log N)). We collect to an {@link ArrayList} first to get the heapify path.</li>
+   * </ul>
+   */
+  private Queue<String> buildSortedKeys(Map<String, HoodieRecord<T>> map) {
+    List<String> keys;
+    if (map instanceof ExternalSpillableMap) {
+      keys = ((ExternalSpillableMap<String, HoodieRecord<T>>) map).keyStream().collect(Collectors.toList());
+    } else {
+      keys = new ArrayList<>(map.keySet());
+    }
+    return new PriorityQueue<>(keys);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/BitCaskDiskMap.java
@@ -45,14 +45,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -77,8 +78,35 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
   private static final ThreadLocal<CompressionHandler> DISK_COMPRESSION_REF =
       ThreadLocal.withInitial(CompressionHandler::new);
 
-  // Stores the key and corresponding value's latest metadata spilled to disk
+  // Stores the key and corresponding value's latest metadata spilled to disk.
+  // LinkedHashMap preserves insertion order, which equals disk offset order because the file is
+  // append-only and all writes hold mapWriteLock. LazyFileIterator relies on this to iterate in
+  // offset order without an extra sort or ArrayList copy (see ENG-43078).
+  //
+  // LinkedHashMap invariants that must be maintained internally to this class
+  // (callers of put/get/remove see only the Map contract; these are NOT caller-facing rules):
+  //   (a) accessOrder is false (default constructor) — get() must NOT move entries; only put()
+  //       appends to the tail. Never use LinkedHashMap(capacity, loadFactor, accessOrder=true).
+  //   (b) Re-insertion: LinkedHashMap.put(k, v) does NOT move an existing key to the tail.
+  //       BitCaskDiskMap.put() therefore calls valueMetadataMap.remove(key) before the put()
+  //       (under mapWriteLock) so the new, higher disk offset lands at the tail and the
+  //       insertion-order == disk-offset-order invariant is preserved. Internal modifications
+  //       to valueMetadataMap must do the same — never use compute(), merge(), replace(), or
+  //       putIfAbsent() directly on valueMetadataMap; they share this re-insertion pitfall.
+  //
+  // Thread-safety model: a ReentrantReadWriteLock guards valueMetadataMap.
+  //   mapWriteLock (exclusive): held by put(), remove(), clear(), close() for the entire
+  //     operation (map update + disk write must be atomic together).
+  //   mapReadLock (shared): held by get(), containsKey(), size(), isEmpty(), and snapshot
+  //     operations (iterator, valueStream, keySet, entrySet). Multiple concurrent readers are
+  //     allowed; disk I/O in get() is performed after releasing mapReadLock to avoid blocking
+  //     other readers while waiting on a seek/read.
+  // This restores the concurrent-read behaviour that ConcurrentHashMap provided while keeping
+  // LinkedHashMap's insertion-order guarantee for lock-free iteration (ENG-43078).
   private final Map<T, ValueMetadata> valueMetadataMap;
+  private final ReentrantReadWriteLock mapLock = new ReentrantReadWriteLock();
+  private final ReentrantReadWriteLock.ReadLock mapReadLock = mapLock.readLock();
+  private final ReentrantReadWriteLock.WriteLock mapWriteLock = mapLock.writeLock();
   // Enables compression for all values stored in the disk map
   private final boolean isCompressionEnabled;
   // Write only file
@@ -101,7 +129,7 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
 
   public BitCaskDiskMap(String baseFilePath, CustomSerializer<R> valueSerializer, boolean isCompressionEnabled) throws IOException {
     super(baseFilePath, ExternalSpillableMap.DiskMapType.BITCASK.name());
-    this.valueMetadataMap = new ConcurrentHashMap<>();
+    this.valueMetadataMap = new LinkedHashMap<>();
     this.isCompressionEnabled = isCompressionEnabled;
     this.writeOnlyFile = new File(diskMapPath, UUID.randomUUID().toString());
     this.filePath = writeOnlyFile.getPath();
@@ -159,7 +187,16 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
    */
   @Override
   public Iterator<R> iterator() {
-    ClosableIterator<R> iterator = new LazyFileIterable(filePath, valueMetadataMap, valueSerializer, isCompressionEnabled).iterator();
+    // Snapshot under mapReadLock so that concurrent puts cannot cause
+    // ConcurrentModificationException when the iterator is consumed.
+    final List<Map.Entry<T, ValueMetadata>> snapshot;
+    mapReadLock.lock();
+    try {
+      snapshot = new ArrayList<>(valueMetadataMap.entrySet());
+    } finally {
+      mapReadLock.unlock();
+    }
+    ClosableIterator<R> iterator = new LazyFileIterable<>(filePath, snapshot, valueSerializer, isCompressionEnabled).iterator();
     this.iterators.add(iterator);
     return iterator;
   }
@@ -169,8 +206,16 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
    */
   @Override
   public Iterator<R> iterator(Predicate<T> filter) {
-    Map<T, ValueMetadata> filteredValueMetadata = valueMetadataMap.entrySet().stream().filter(e -> filter.test(e.getKey())).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    ClosableIterator<R> iterator = new LazyFileIterable(filePath, filteredValueMetadata, valueSerializer, isCompressionEnabled).iterator();
+    final List<Map.Entry<T, ValueMetadata>> snapshot;
+    mapReadLock.lock();
+    try {
+      snapshot = valueMetadataMap.entrySet().stream()
+          .filter(e -> filter.test(e.getKey()))
+          .collect(Collectors.toList());
+    } finally {
+      mapReadLock.unlock();
+    }
+    ClosableIterator<R> iterator = new LazyFileIterable<>(filePath, snapshot, valueSerializer, isCompressionEnabled).iterator();
     this.iterators.add(iterator);
     return iterator;
   }
@@ -185,17 +230,32 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
 
   @Override
   public int size() {
-    return valueMetadataMap.size();
+    mapReadLock.lock();
+    try {
+      return valueMetadataMap.size();
+    } finally {
+      mapReadLock.unlock();
+    }
   }
 
   @Override
   public boolean isEmpty() {
-    return valueMetadataMap.isEmpty();
+    mapReadLock.lock();
+    try {
+      return valueMetadataMap.isEmpty();
+    } finally {
+      mapReadLock.unlock();
+    }
   }
 
   @Override
   public boolean containsKey(Object key) {
-    return valueMetadataMap.containsKey(key);
+    mapReadLock.lock();
+    try {
+      return valueMetadataMap.containsKey(key);
+    } finally {
+      mapReadLock.unlock();
+    }
   }
 
   @Override
@@ -205,7 +265,15 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
 
   @Override
   public R get(Object key) {
-    ValueMetadata entry = valueMetadataMap.get(key);
+    // Hold mapReadLock only for the metadata lookup; release before disk I/O so that
+    // concurrent get() calls on different keys are not serialized by the I/O wait.
+    ValueMetadata entry;
+    mapReadLock.lock();
+    try {
+      entry = valueMetadataMap.get(key);
+    } finally {
+      mapReadLock.unlock();
+    }
     if (entry == null) {
       return null;
     }
@@ -228,18 +296,31 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
     }
   }
 
-  private synchronized R put(T key, R value, boolean flush) {
+  private R put(T key, R value, boolean flush) {
     try {
       byte[] val = isCompressionEnabled ? DISK_COMPRESSION_REF.get().compressBytes(valueSerializer.serialize(value)) :
           valueSerializer.serialize(value);
       int valueSize = val.length;
       long timestamp = System.currentTimeMillis();
-      this.valueMetadataMap.put(key,
-          new BitCaskDiskMap.ValueMetadata(this.filePath, valueSize, filePosition.get(), timestamp));
       byte[] serializedKey = SerializationUtils.serialize(key);
-      filePosition
-          .set(SpillableMapUtils.spillToDisk(writeOnlyFileHandle, new FileEntry(generateChecksum(val),
-              serializedKey.length, valueSize, serializedKey, val, timestamp)));
+      // Hold mapWriteLock for the entire map-update + disk-write to keep them atomic:
+      // a concurrent get() must not see a metadata entry whose bytes haven't been flushed yet.
+      mapWriteLock.lock();
+      try {
+        // Remove before re-inserting so the key always lands at the LinkedHashMap tail.
+        // LinkedHashMap does not move an existing key on put() — without this remove, a
+        // re-inserted key would stay at its original position while its new offset is higher
+        // than all entries that follow it, breaking the insertion-order == offset-order invariant.
+        // The old bytes remain in the disk file as dead bytes (existing behaviour for remove()).
+        valueMetadataMap.remove(key);
+        this.valueMetadataMap.put(key,
+            new BitCaskDiskMap.ValueMetadata(this.filePath, valueSize, filePosition.get(), timestamp));
+        filePosition
+            .set(SpillableMapUtils.spillToDisk(writeOnlyFileHandle, new FileEntry(generateChecksum(val),
+                serializedKey.length, valueSize, serializedKey, val, timestamp)));
+      } finally {
+        mapWriteLock.unlock();
+      }
       if (flush) {
         flushToDisk();
       }
@@ -256,9 +337,17 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
 
   @Override
   public R remove(Object key) {
-    R value = get(key);
-    valueMetadataMap.remove(key);
-    return value;
+    ValueMetadata entry;
+    mapWriteLock.lock();
+    try {
+      entry = valueMetadataMap.remove(key);
+    } finally {
+      mapWriteLock.unlock();
+    }
+    if (entry == null) {
+      return null;
+    }
+    return get(entry);
   }
 
   @Override
@@ -271,14 +360,27 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
 
   @Override
   public void clear() {
-    valueMetadataMap.clear();
+    // Acquire mapWriteLock so a concurrent reader under mapReadLock (e.g. via
+    // SpillableMapBasedFileSystemView's shared readLock) can't observe a half-cleared map.
+    mapWriteLock.lock();
+    try {
+      valueMetadataMap.clear();
+    } finally {
+      mapWriteLock.unlock();
+    }
     // Do not delete file-handles & file as there is no way to do it without synchronizing get/put(and
     // reducing concurrency). Instead, just clear the pointer map. The file will be removed on exit.
   }
 
   @Override
   public void close() {
-    valueMetadataMap.clear();
+    // See clear() for why this needs mapWriteLock.
+    mapWriteLock.lock();
+    try {
+      valueMetadataMap.clear();
+    } finally {
+      mapWriteLock.unlock();
+    }
     try {
       if (writeOnlyFileHandle != null) {
         writeOnlyFileHandle.flush();
@@ -309,7 +411,12 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
 
   @Override
   public Set<T> keySet() {
-    return valueMetadataMap.keySet();
+    mapReadLock.lock();
+    try {
+      return new HashSet<>(valueMetadataMap.keySet());
+    } finally {
+      mapReadLock.unlock();
+    }
   }
 
   @Override
@@ -320,13 +427,30 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
   @Override
   public Stream<R> valueStream() {
     final BufferedRandomAccessFile file = getRandomAccessFile();
-    return valueMetadataMap.values().stream().sorted().map(valueMetaData -> get(valueMetaData, file, valueSerializer, isCompressionEnabled));
+    // Snapshot under mapReadLock. LinkedHashMap insertion order equals disk offset order
+    // (see put()), so no sort is needed — values are already in forward-read order.
+    final List<ValueMetadata> snapshot;
+    mapReadLock.lock();
+    try {
+      snapshot = new ArrayList<>(valueMetadataMap.values());
+    } finally {
+      mapReadLock.unlock();
+    }
+    return snapshot.stream().sequential().map(valueMetaData -> (R) get(valueMetaData, file, valueSerializer, isCompressionEnabled));
   }
 
   @Override
   public Set<Entry<T, R>> entrySet() {
+    // Snapshot keys under mapReadLock; disk I/O per-key happens outside the lock.
+    final Set<T> keySnapshot;
+    mapReadLock.lock();
+    try {
+      keySnapshot = new HashSet<>(valueMetadataMap.keySet());
+    } finally {
+      mapReadLock.unlock();
+    }
     Set<Entry<T, R>> entrySet = new HashSet<>();
-    for (T key : valueMetadataMap.keySet()) {
+    for (T key : keySnapshot) {
       entrySet.add(new AbstractMap.SimpleEntry<>(key, get(key)));
     }
     return entrySet;
@@ -388,11 +512,13 @@ public final class BitCaskDiskMap<T extends Serializable, R> extends DiskMap<T, 
     // FilePath to store the spilled data
     private final String filePath;
     // Size (numberOfBytes) of the value written to disk
-    private final Integer sizeOfValue;
+    // ENG-43078: primitive fields avoid ~64 B/entry of boxing overhead (Integer + 2 Long wrappers)
+    // across the millions of spilled entries held in valueMetadataMap.
+    private final int sizeOfValue;
     // FilePosition of the value written to disk
-    private final Long offsetOfValue;
+    private final long offsetOfValue;
     // Current timestamp when the value was written to disk
-    private final Long timestamp;
+    private final long timestamp;
 
     @Override
     public int compareTo(ValueMetadata o) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/ExternalSpillableMap.java
@@ -315,6 +315,22 @@ public class ExternalSpillableMap<T extends Serializable, R> implements Map<T, R
     return Stream.concat(inMemoryMap.values().stream(), diskBasedMap.valueStream());
   }
 
+  /**
+   * Returns a lazy stream over all keys in this map (in-memory + spilled).
+   *
+   * Unlike {@link #keySet()}, this method does NOT allocate a new {@link java.util.HashSet} copying
+   * all keys. When the map has spilled ({@code diskBasedMap != null}), {@link #keySet()} must
+   * materialise a full copy to combine both key sets into a single {@link java.util.Set}. Callers
+   * that only need to iterate keys once (e.g. to seed a {@link java.util.PriorityQueue}) should
+   * prefer this method to avoid the transient per-task heap spike (ENG-43078).
+   */
+  public Stream<T> keyStream() {
+    if (diskBasedMap == null) {
+      return inMemoryMap.keySet().stream();
+    }
+    return Stream.concat(inMemoryMap.keySet().stream(), diskBasedMap.keySet().stream());
+  }
+
   @Override
   public Set<Entry<T, R>> entrySet() {
     if (diskBasedMap == null) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/LazyFileIterable.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/LazyFileIterable.java
@@ -25,10 +25,11 @@ import org.apache.hudi.exception.HoodieException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * Iterable to lazily fetch values spilled to disk. This class uses BufferedRandomAccessFile to randomly access the position of
@@ -39,25 +40,54 @@ public class LazyFileIterable<T, R> implements Iterable<R> {
 
   // Used to access the value written at a specific position in the file
   private final String filePath;
-  // Stores the key and corresponding value's latest metadata spilled to disk
-  private final Map<T, BitCaskDiskMap.ValueMetadata> inMemoryMetadataOfSpilledData;
+  // Pre-built snapshot of key→metadata entries in disk-offset order. Taking the snapshot at
+  // construction time (under the BitCaskDiskMap lock) ensures thread safety when
+  // SpillableMapBasedFileSystemView has concurrent puts and reads under its readLock.
+  private final List<Map.Entry<T, BitCaskDiskMap.ValueMetadata>> snapshot;
   // Was compressions enabled for the values when inserted into the file/ map
   private final boolean isCompressionEnabled;
   private final CustomSerializer<R> serializer;
 
   private transient Thread shutdownThread = null;
 
-  public LazyFileIterable(String filePath, Map<T, BitCaskDiskMap.ValueMetadata> map, CustomSerializer<R> serializer, boolean isCompressionEnabled) {
+  /**
+   * Constructs a LazyFileIterable with a pre-built snapshot of metadata entries.
+   * Callers (e.g. {@link BitCaskDiskMap#iterator()}) must take the snapshot under the
+   * BitCaskDiskMap lock before invoking this constructor.
+   */
+  LazyFileIterable(String filePath, List<Map.Entry<T, BitCaskDiskMap.ValueMetadata>> snapshot,
+                   CustomSerializer<R> serializer, boolean isCompressionEnabled) {
     this.filePath = filePath;
-    this.inMemoryMetadataOfSpilledData = map;
-    this.isCompressionEnabled = isCompressionEnabled;
+    this.snapshot = snapshot;
     this.serializer = serializer;
+    this.isCompressionEnabled = isCompressionEnabled;
+  }
+
+  /**
+   * Constructs a LazyFileIterable from a live metadata map. The snapshot is taken immediately
+   * at construction time, but WITHOUT any lock — concurrent writers can cause
+   * {@link java.util.ConcurrentModificationException}. Prefer the list-based constructor when
+   * the caller already holds a lock that must cover the snapshot (e.g. in
+   * {@link BitCaskDiskMap#iterator()}).
+   *
+   * @deprecated The unsynchronized snapshot is unsafe under the new {@code BitCaskDiskMap}
+   *     locking model (ENG-43078). Callers should take a snapshot under the appropriate lock
+   *     and use the {@link #LazyFileIterable(String, List, CustomSerializer, boolean) list-based
+   *     constructor}. Retained only for binary compatibility with any external callers.
+   */
+  @Deprecated
+  public LazyFileIterable(String filePath, Map<T, BitCaskDiskMap.ValueMetadata> map,
+                          CustomSerializer<R> serializer, boolean isCompressionEnabled) {
+    this.filePath = filePath;
+    this.snapshot = new ArrayList<>(map.entrySet());
+    this.serializer = serializer;
+    this.isCompressionEnabled = isCompressionEnabled;
   }
 
   @Override
   public ClosableIterator<R> iterator() {
     try {
-      return new LazyFileIterator<>(filePath, inMemoryMetadataOfSpilledData, serializer);
+      return new LazyFileIterator<>(filePath, snapshot, serializer);
     } catch (IOException io) {
       throw new HoodieException("Unable to initialize iterator for file on disk", io);
     }
@@ -66,24 +96,27 @@ public class LazyFileIterable<T, R> implements Iterable<R> {
   /**
    * Iterator implementation for the iterable defined above.
    */
-  public class LazyFileIterator<T, R> implements ClosableIterator<R> {
+  public class LazyFileIterator<R> implements ClosableIterator<R> {
 
     private final String filePath;
     private BufferedRandomAccessFile readOnlyFileHandle;
     private final Iterator<Map.Entry<T, BitCaskDiskMap.ValueMetadata>> metadataIterator;
     private final CustomSerializer<R> serializer;
 
-    public LazyFileIterator(String filePath, Map<T, BitCaskDiskMap.ValueMetadata> map, CustomSerializer<R> serializer) throws IOException {
+    /**
+     * Constructs the iterator from a pre-built snapshot list.
+     * The snapshot must have been taken by the caller (e.g. under the BitCaskDiskMap lock)
+     * to ensure no entries are missed and no ConcurrentModificationException occurs.
+     * ENG-43078: BitCaskDiskMap.valueMetadataMap is a LinkedHashMap whose insertion order
+     * equals disk offset order, so no sort is needed.
+     */
+    public LazyFileIterator(String filePath, List<Map.Entry<T, BitCaskDiskMap.ValueMetadata>> snapshot,
+                            CustomSerializer<R> serializer) throws IOException {
       this.filePath = filePath;
       this.readOnlyFileHandle = new BufferedRandomAccessFile(filePath, "r", BitCaskDiskMap.BUFFER_SIZE);
       this.serializer = serializer;
       readOnlyFileHandle.seek(0);
-
-      // sort the map in increasing order of offset of value so disk seek is only in one(forward) direction
-      this.metadataIterator = map.entrySet().stream()
-          .sorted((Map.Entry<T, BitCaskDiskMap.ValueMetadata> o1, Map.Entry<T, BitCaskDiskMap.ValueMetadata> o2) -> o1
-              .getValue().getOffsetOfValue().compareTo(o2.getValue().getOffsetOfValue()))
-          .collect(Collectors.toList()).iterator();
+      this.metadataIterator = snapshot.iterator();
       this.addShutdownHook();
     }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/collection/TestBitCaskDiskMap.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/collection/TestBitCaskDiskMap.java
@@ -61,6 +61,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.SchemaTestUtil.getSimpleSchema;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -274,5 +276,123 @@ public class TestBitCaskDiskMap extends HoodieCommonTestHarness {
     assert Objects.requireNonNull(basePathDir.list()).length > 0;
     records.close();
     assertEquals(Objects.requireNonNull(basePathDir.list()).length, 0);
+  }
+
+  /**
+   * Re-insertion order: when a key is put twice, iteration order must place it last (i.e. the
+   * second put's higher disk offset is at the LinkedHashMap tail), and reads must return the
+   * latest value. Locks down the invariant that {@code BitCaskDiskMap.put} removes-before-puts
+   * to keep {@code LinkedHashMap} insertion-order == disk-offset-order (ENG-43078).
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testReInsertionPreservesOffsetOrder(boolean isCompressionEnabled) throws IOException, URISyntaxException {
+    try (BitCaskDiskMap<String, HoodieRecord> records = new BitCaskDiskMap<>(basePath, new DefaultSerializer<>(), isCompressionEnabled)) {
+      SchemaTestUtil testUtil = new SchemaTestUtil();
+      List<IndexedRecord> iRecords = testUtil.generateHoodieTestRecords(0, 5);
+      List<String> orderedKeys = new ArrayList<>();
+      for (IndexedRecord r : iRecords) {
+        String key = ((GenericRecord) r).get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
+        String partitionPath = ((GenericRecord) r).get(HoodieRecord.PARTITION_PATH_METADATA_FIELD).toString();
+        HoodieRecord value = new HoodieAvroRecord<>(new HoodieKey(key, partitionPath), new HoodieAvroPayload(Option.of((GenericRecord) r)));
+        records.put(key, value);
+        orderedKeys.add(key);
+      }
+      // Re-insert the first key; it must move to the iteration tail.
+      String firstKey = orderedKeys.get(0);
+      List<IndexedRecord> updatedRec = testUtil.generateHoodieTestRecords(100, 1);
+      GenericRecord updatedGeneric = (GenericRecord) updatedRec.get(0);
+      HoodieRecord updatedValue = new HoodieAvroRecord<>(
+          new HoodieKey(firstKey, updatedGeneric.get(HoodieRecord.PARTITION_PATH_METADATA_FIELD).toString()),
+          new HoodieAvroPayload(Option.of(updatedGeneric)));
+      records.put(firstKey, updatedValue);
+
+      // size must remain 5 (re-insertion replaces the existing entry).
+      List<HoodieRecord> iteratedFromEntrySet = new ArrayList<>();
+      Iterator<HoodieRecord> iter = records.iterator();
+      while (iter.hasNext()) {
+        iteratedFromEntrySet.add(iter.next());
+      }
+      assertEquals(5, iteratedFromEntrySet.size());
+      // Use the stable HoodieRecord.getRecordKey() accessor rather than dereffing payload avro
+      // (whose schema may not be metadata-augmented in this test setup).
+      assertEquals(firstKey,
+          iteratedFromEntrySet.get(4).getRecordKey(),
+          "Re-inserted key must appear last in iteration order");
+
+      // Read-back of the re-inserted key must return the latest value.
+      HoodieRecord readBack = records.get(firstKey);
+      assertNotNull(readBack);
+    }
+  }
+
+  /**
+   * Concurrent reader + writer: while a writer thread does put/remove under {@code mapWriteLock},
+   * a reader thread doing {@code get}/{@code containsKey} under {@code mapReadLock} must not throw
+   * {@link java.util.ConcurrentModificationException} and must observe values eventually.
+   * Locks down the RW-lock semantics introduced in ENG-43078.
+   */
+  @Test
+  public void testConcurrentReadersAndWriter() throws Exception {
+    try (BitCaskDiskMap<String, HoodieRecord> records = new BitCaskDiskMap<>(basePath, new DefaultSerializer<>(), false)) {
+      SchemaTestUtil testUtil = new SchemaTestUtil();
+      List<IndexedRecord> iRecords = testUtil.generateHoodieTestRecords(0, 200);
+      List<String> allKeys = new ArrayList<>();
+      List<HoodieRecord> allValues = new ArrayList<>();
+      for (IndexedRecord r : iRecords) {
+        String key = ((GenericRecord) r).get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
+        String partitionPath = ((GenericRecord) r).get(HoodieRecord.PARTITION_PATH_METADATA_FIELD).toString();
+        HoodieRecord value = new HoodieAvroRecord<>(new HoodieKey(key, partitionPath), new HoodieAvroPayload(Option.of((GenericRecord) r)));
+        allKeys.add(key);
+        allValues.add(value);
+      }
+
+      java.util.concurrent.atomic.AtomicBoolean writerDone = new java.util.concurrent.atomic.AtomicBoolean(false);
+      java.util.concurrent.atomic.AtomicReference<Throwable> failure = new java.util.concurrent.atomic.AtomicReference<>();
+
+      Thread writer = new Thread(() -> {
+        try {
+          for (int i = 0; i < allKeys.size(); i++) {
+            records.put(allKeys.get(i), allValues.get(i));
+          }
+        } catch (Throwable t) {
+          failure.compareAndSet(null, t);
+        } finally {
+          writerDone.set(true);
+        }
+      }, "bitcask-writer");
+
+      Thread reader = new Thread(() -> {
+        try {
+          while (!writerDone.get()) {
+            for (String key : allKeys) {
+              records.containsKey(key); // must not throw
+              HoodieRecord r = records.get(key);
+              if (r != null) {
+                assertNotNull(r.getData());
+              }
+            }
+            records.iterator();
+            records.size();
+          }
+        } catch (Throwable t) {
+          failure.compareAndSet(null, t);
+        }
+      }, "bitcask-reader");
+
+      writer.start();
+      reader.start();
+      writer.join(30_000);
+      reader.join(30_000);
+      assertFalse(writer.isAlive(), "writer should have finished");
+      assertFalse(reader.isAlive(), "reader should have finished");
+      if (failure.get() != null) {
+        throw new AssertionError("concurrent access threw", failure.get());
+      }
+      assertEquals(allKeys.size(), records.size());
+      for (String key : allKeys) {
+        assertNotNull(records.get(key));
+      }
+    }
   }
 }


### PR DESCRIPTION
### Change Logs

Fixes apache/hudi#19084.

MDT `record_index` partition compaction OOMs executors configured with 9 GB heap, four concurrent tasks, and `spark.memory.fraction=0.3`. Heap analysis identified three structural consumers that aren't bounded by the configured compaction memory cap (`hoodie.memory.compaction.fraction`):

| Consumer | What | Total (4 tasks) |
|---|---|---|
| B | `BitCaskDiskMap.valueMetadataMap` — 18.3M `ValueMetadata` entries with `Integer`/`Long` boxing overhead dominating (57.2M `java.lang.Long` instances = ~1.28 GB pure boxing) | ~3.0–3.2 GB |
| F | `LazyFileIterator` materialised a full sorted `ArrayList` (4.58M entries × 4 tasks) at iterator-open time because `ConcurrentHashMap` doesn't preserve insertion order | ~513 MB |
| E | `ExternalSpillableMap.keySet()` allocated a transient `HashSet` copying all 6.29M keys solely to seed the `PriorityQueue` in `HoodieSortedMergeHandle`'s constructor | ~256 MB peak |

4-task demand: ~6.25 GB on a 9 GB executor — OOMs under GC pressure. Lowering `hoodie.memory.compaction.fraction` makes B larger and the OOM worse, so the fix must be code, not config.

### Changes

1. **Unbox `ValueMetadata` primitives** (`BitCaskDiskMap.java`) — `Integer`/`Long` → `int`/`long` for `sizeOfValue`, `offsetOfValue`, `timestamp`. Saves ~880 MB across 4 tasks. The Lombok `@AllArgsConstructor` + `@Getter` annotations are preserved; getter return types switch from boxed to primitive (autoboxing handles any external caller).

2. **`LinkedHashMap` + `ReentrantReadWriteLock` for `valueMetadataMap`** (`BitCaskDiskMap.java`, `LazyFileIterable.java`) — `filePosition` is strictly monotonic under the write lock (append-only file + monotonic `SizeAwareDataOutputStream.getSize()`), so insertion order = disk offset order. `LazyFileIterator` no longer sorts; it consumes a pre-built snapshot list taken under the read lock. `put()` does remove-before-put under the write lock so re-inserted keys land at the `LinkedHashMap` tail. All read paths (`get`, `containsKey`, `size`, `iterator`, `valueStream`, `entrySet`, `keySet`, `iterator(Predicate)`) take the read lock and snapshot before releasing. `close()` and `clear()` take the write lock so a concurrent reader under `SpillableMapBasedFileSystemView`'s shared `readLock` can't observe a half-cleared map. Saves ~513 MB across 4 tasks.

3. **`ExternalSpillableMap.keyStream()` + `HoodieSortedMergeHandle` uses it** (`ExternalSpillableMap.java`, `HoodieSortedMergeHandle.java`) — `keyStream()` returns `Stream.concat(inMemoryKeys, diskKeys)` without allocating a `HashSet` copy. `HoodieSortedMergeHandle` now collects the stream into an `ArrayList` and passes it to `new PriorityQueue<>(list)` to get the O(N) heapify (vs. O(N log N) per-add). Saves ~256 MB peak spike per task.

Total: ~1.65 GB per task. 4-task demand drops from ~6.25 GB to ~4.57 GB.

### Impact

Eliminates executor OOM during MDT `record_index` compaction on commonly-sized executors. No on-disk format change. No public-API surface change (`ValueMetadata.getOffsetOfValue()` return type changes from `Long` to `long`, but `ValueMetadata` is an internal class and autoboxing handles any external callers).

### Risk Level

Low. The locking model is conservative (RW-lock with read-shared concurrency preserved), the insertion-order = offset-order invariant is proved from append-only file + monotonic `filePosition` + write-lock, and the regression test suite locks down both the invariant and the concurrent-read contract.

### Documentation Update

None required.

### Tests

- `TestBitCaskDiskMap#testReInsertionPreservesOffsetOrder` (parameterized × compression on/off): puts a key twice, asserts re-inserted key lands at iteration tail. Locks down the `LinkedHashMap`-insertion-order == disk-offset-order invariant against future refactors of `put()`.
- `TestBitCaskDiskMap#testConcurrentReadersAndWriter`: writer + reader threads; asserts no `ConcurrentModificationException` and that the RW-lock contract holds.
- Full `TestBitCaskDiskMap` + `TestExternalSpillableMap` suite: **45 run / 0 failed / 1 skipped** on Java 11 with `-Dscala-2.12 -Dspark3.5`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed