### PR TITLE
feat: switch default log format version to v2

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogFormatWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogFormatWriter.java
@@ -61,7 +61,6 @@ import static org.apache.hudi.common.model.LogExtensions.DELETE_LOG_EXTENSION;
  */
 public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
 
-  private static final int NATIVE_LOG_FORMAT_VERSION = 2;
   private static final String LOG_FORMAT_METADATA_FOOTER_KEY = "hudi.log.format.metadata";
 
   private final HoodieWriteConfig writeConfig;
@@ -222,7 +221,7 @@ public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
 
   private Map<String, String> getFooterMetadata(Map<HeaderMetadataType, String> header) throws IOException {
     Map<String, String> logFormatMetadata = new LinkedHashMap<>();
-    logFormatMetadata.put(HeaderMetadataType.VERSION.name(), String.valueOf(NATIVE_LOG_FORMAT_VERSION));
+    logFormatMetadata.put(HeaderMetadataType.VERSION.name(), String.valueOf(HoodieLogFormat.CURRENT_VERSION));
     header.forEach((key, value) -> {
       if (value != null) {
         logFormatMetadata.put(key.name(), value);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormat.java
@@ -56,7 +56,12 @@ public interface HoodieLogFormat {
    * The current version of the log format. Anytime the log format changes this version needs to be bumped and
    * corresponding changes need to be made to {@link HoodieLogFormatVersion}
    */
-  int CURRENT_VERSION = 1;
+  int CURRENT_VERSION = 2;
+
+  /**
+   * The current version of the inline log format.
+   */
+  int INLINE_LOG_FORMAT_VERSION = 1;
 
   String UNKNOWN_WRITE_TOKEN = "1-0-1";
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestHoodieLogFormatVersion.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestHoodieLogFormatVersion.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common.table.log;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,43 +30,57 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestHoodieLogFormatVersion {
   private static HoodieLogFormatVersion verDefault = 
       new HoodieLogFormatVersion(HoodieLogFormatVersion.DEFAULT_VERSION);
-  private static HoodieLogFormatVersion verCurrent = 
+  private static HoodieLogFormatVersion verInline = 
+      new HoodieLogFormatVersion(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
+  private static HoodieLogFormatVersion verCurrent =
       new HoodieLogFormatVersion(HoodieLogFormat.CURRENT_VERSION);
+
+  @Test
+  public void testCurrentVersionValues() {
+    assertEquals(1, HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
+    assertEquals(2, HoodieLogFormat.CURRENT_VERSION);
+  }
 
   @Test
   public void testHasMagicHeader() {
     assertTrue(verDefault.hasMagicHeader());
+    assertTrue(verInline.hasMagicHeader());
     assertTrue(verCurrent.hasMagicHeader());
   }
 
   @Test
   public void testHasContent() {
     assertTrue(verDefault.hasContent());
+    assertTrue(verInline.hasContent());
     assertTrue(verCurrent.hasContent());
   }
 
   @Test
   public void testHasContentLength() {
     assertTrue(verDefault.hasContentLength());
+    assertTrue(verInline.hasContentLength());
     assertTrue(verCurrent.hasContentLength());
   }
 
   @Test
   public void testHasOrdinal() {
     assertTrue(verDefault.hasOrdinal());
+    assertTrue(verInline.hasOrdinal());
     assertTrue(verCurrent.hasOrdinal());
   }
 
   @Test
   public void testHasHeader() {
     assertFalse(verDefault.hasHeader());
+    assertTrue(verInline.hasHeader());
     assertTrue(verCurrent.hasHeader());
   }
 
   @Test
   public void testHasFooter() {
     assertFalse(verDefault.hasFooter());
-    assertTrue(verCurrent.hasFooter());
+    assertTrue(verInline.hasFooter());
+    assertFalse(verCurrent.hasFooter());
 
     HoodieLogFormatVersion verNew =  
             new HoodieLogFormatVersion(HoodieLogFormat.CURRENT_VERSION + 1);
@@ -75,7 +90,8 @@ public class TestHoodieLogFormatVersion {
   @Test
   public void testHasLogBlockLength() {
     assertFalse(verDefault.hasLogBlockLength());
-    assertTrue(verCurrent.hasLogBlockLength());
+    assertTrue(verInline.hasLogBlockLength());
+    assertFalse(verCurrent.hasLogBlockLength());
 
     HoodieLogFormatVersion verNew =  
             new HoodieLogFormatVersion(HoodieLogFormat.CURRENT_VERSION + 1);

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -127,9 +127,8 @@ public class HoodieLogFormatWriter extends HoodieLogFormat.Writer {
   @Override
   public AppendResult appendBlocks(List<HoodieLogBlock> blocks) throws IOException {
     try {
-      // Find current version
-      HoodieLogFormat.LogFormatVersion currentLogFormatVersion =
-          new HoodieLogFormatVersion(HoodieLogFormat.CURRENT_VERSION);
+      HoodieLogFormat.LogFormatVersion inlineLogFormatVersion =
+          new HoodieLogFormatVersion(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
 
       FSDataOutputStream originalOutputStream = getOutputStream();
       long startPos = originalOutputStream.getPos();
@@ -153,7 +152,7 @@ public class HoodieLogFormatWriter extends HoodieLogFormat.Writer {
         outputStream.writeLong(getLogBlockLength(content.size(), headerBytes.length, footerBytes.length));
 
         // 3. Write the version of this log block
-        outputStream.writeInt(currentLogFormatVersion.getVersion());
+        outputStream.writeInt(inlineLogFormatVersion.getVersion());
         // 4. Write the block type
         outputStream.writeInt(block.getBlockType().ordinal());
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/functional/TestHoodieLogFormat.java
@@ -985,7 +985,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     // Write out a length that does not confirm with the content
     outputStream.writeLong(474);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(400);
     // Write out incomplete content
@@ -1016,7 +1016,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     // Write out a length that does not confirm with the content
     outputStream.writeLong(1000);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(500);
     // Write out some bytes
@@ -1162,7 +1162,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     // Write out a length that does not confirm with the content
     outputStream.writeLong(474);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(400);
     // Write out incomplete content
@@ -1341,7 +1341,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     // Write out a length that does not confirm with the content
     outputStream.writeLong(1000);
 
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
 
     // Write out some header
@@ -2220,7 +2220,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.write(HoodieLogFormat.MAGIC);
     outputStream.writeLong(1000);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(100);
     outputStream.flush();
@@ -2232,7 +2232,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.write(HoodieLogFormat.MAGIC);
     outputStream.writeLong(1000);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(100);
     outputStream.flush();
@@ -2256,7 +2256,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.write(HoodieLogFormat.MAGIC);
     outputStream.writeLong(1000);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(100);
     outputStream.flush();
@@ -2353,7 +2353,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.write(HoodieLogFormat.MAGIC);
     outputStream.writeLong(1000);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(100);
     outputStream.flush();
@@ -2365,7 +2365,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.write(HoodieLogFormat.MAGIC);
     outputStream.writeLong(1000);
     outputStream.writeInt(HoodieLogBlockType.AVRO_DATA_BLOCK.ordinal());
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(100);
     outputStream.flush();
@@ -3007,7 +3007,7 @@ public class TestHoodieLogFormat extends HoodieCommonTestHarness {
     outputStream.write(HoodieLogFormat.MAGIC);
     // Write out a length that does not confirm with the content
     outputStream.writeLong(473);
-    outputStream.writeInt(HoodieLogFormat.CURRENT_VERSION);
+    outputStream.writeInt(HoodieLogFormat.INLINE_LOG_FORMAT_VERSION);
     outputStream.writeInt(10000); // an invalid block type
 
     // Write out a length that does not confirm with the content


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This closes #19086 

Hudi now needs to distinguish the current log format version from the inline log block format version. The native log format should use log format version `2`, while existing inline log files should continue writing inline block envelopes as version `1`.

Without separating these constants, bumping `HoodieLogFormat.CURRENT_VERSION` would also make `HoodieLogFormatWriter` emit inline log blocks as version `2`, even though the inline log block feature flags and compatibility behavior remain tied to version `1`. This PR explicitly calls out that storage-format split.

### Summary and Changelog

This PR switches the current log format version to `2` while preserving inline log writes at format version `1`.

- Bumped `HoodieLogFormat.CURRENT_VERSION` from `1` to `2`.
- Added `HoodieLogFormat.INLINE_LOG_FORMAT_VERSION = 1`.
- Updated `HoodieLogFormatWriter` to write inline log blocks with `INLINE_LOG_FORMAT_VERSION`.
- Updated `HoodieNativeLogFormatWriter` to use `HoodieLogFormat.CURRENT_VERSION` for native log footer metadata instead of a separate hard-coded native version constant.
- Updated `TestHoodieLogFormatVersion` to assert the current and inline version values and feature behavior.
- Updated manual inline block construction in `TestHoodieLogFormat` to use `INLINE_LOG_FORMAT_VERSION`.

### Impact

This changes internal log format versioning behavior for native logs by making version `2` the shared current log format version. Inline logs remain compatible because their block writer continues emitting version `1`.

There is no new user-facing config or public API behavior change. The affected area is core log writing and log-format metadata, especially inline MOR log block serialization and native log footer metadata.

### Risk Level

medium

This touches storage-format version constants and core log writer paths. The risk is mitigated by keeping inline log serialization pinned to version `1`, updating tests that manually serialize inline log blocks, and validating with:

- `mvn -pl hudi-common -DskipITs -Dtest=TestHoodieLogFormatVersion test`
- `mvn -pl hudi-hadoop-common -am -DskipITs -Dtest=TestHoodieLogFormatWriter,TestHoodieLogFormat -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl hudi-client/hudi-client-common -am -DskipTests -DskipITs compile`

### Documentation Update

none

This is an internal log format versioning change with no new user-facing configuration or documented workflow. Inline log compatibility is preserved by continuing to write inline log blocks as version `1`.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
