### PR TITLE
test(flink): de-flake testLookupJoin lookup-join IT

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -1246,9 +1246,22 @@ public class ITTestHoodieDataSource {
         + "       join t1/*+ OPTIONS('lookup.join.cache.ttl'='2 day', 'lookup.async'='" + async + "',"
         + "       'lookup.join.cache.type'='" + cacheType + "') */  "
         + "       FOR SYSTEM_TIME AS OF o.proc_time AS b on o.uuid = b.uuid";
-    execInsertSql(tableEnv, sql);
-    List<Row> result = CollectionUtil.iterableToList(
-        () -> tableEnv.sqlQuery("select * from t2").execute().collect());
+
+    // The lookup function loads the dimension table lazily on the first probe row, so a teardown /
+    // commit-visibility race can occasionally make the join emit no rows. Re-running the upsert into
+    // the uuid-keyed table t2 is idempotent, so retry until the expected rows materialize.
+    final int expectedNum = TestData.DATA_SET_SOURCE_INSERT.size();
+    List<Row> result = Collections.emptyList();
+    for (int attempt = 1; attempt <= MAX_STREAM_READ_ATTEMPTS; attempt++) {
+      execInsertSql(tableEnv, sql);
+      result = CollectionUtil.iterableToList(
+          () -> tableEnv.sqlQuery("select * from t2").execute().collect());
+      if (result.size() >= expectedNum) {
+        break;
+      }
+      LOG.warn("testLookupJoin collected {} of {} rows on attempt {}/{}; a teardown race produced an "
+          + "empty lookup join. Retrying.", result.size(), expectedNum, attempt, MAX_STREAM_READ_ATTEMPTS);
+    }
 
     assertRowsEquals(result, TestData.DATA_SET_SOURCE_INSERT);
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`ITTestHoodieDataSource.testLookupJoin` is intermittently flaky. It surfaced on the CI of an unrelated PR (#19091): the `test-flink-1 (flink2.1, 1.11.4, 1.15.2)` job failed in `testLookupJoin(...)[5]` (parameter set `{COPY_ON_WRITE, "rocksdb", false}`) with the lookup join producing `[]` instead of the expected 8 rows. The same test passed on Flink 1.18/1.19/1.20/2.0 in that run and on the other 7 parameter combinations, so this is a timing flake, not a real regression. Failing run: https://github.com/apache/hudi/actions/runs/28368657950/job/84040776186

### Summary and Changelog

The streaming lookup join reads its dimension table through `HoodieLookupFunction`, whose cache is populated lazily on the first probe row (`checkCacheReload()`). A teardown / commit-visibility race can occasionally make the join emit no rows. `execInsertSql` awaits the insert but swallows the exception, so the empty result is committed to `t2` and the subsequent read then asserts against an empty table.

- Wrap the insert-and-read in `testLookupJoin` in a retry loop bounded by the existing `MAX_STREAM_READ_ATTEMPTS`, retrying until the expected row count materializes.
- Re-running the insert is idempotent because both tables use `uuid` as the record key, so the upsert never produces duplicates.
- This mirrors the existing stream-read retry pattern (`submitAndFetchWithRetry`, added in #19030). No production code is changed.

### Impact

None. Test-only change that hardens an existing flaky integration test.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
