### PR TITLE
[HUDI-19096] Add Spark DDL and option scaffolding for vector indexes

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.ReaderContextFactory;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.index.vector.VectorIndexOptions;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -101,6 +102,8 @@ import static org.apache.hudi.index.expression.HoodieExpressionIndex.IDENTITY_TR
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX_PREFIX;
 import static org.apache.hudi.table.action.commit.HoodieDeleteHelper.createDeleteRecord;
 
 /**
@@ -673,8 +676,36 @@ public class HoodieIndexUtils {
         .build();
   }
 
+  static HoodieIndexDefinition getVectorIndexDefinition(HoodieTableMetaClient metaClient,
+                                                        String userIndexName,
+                                                        Map<String, Map<String, String>> columns,
+                                                        Map<String, String> options) throws Exception {
+    String fullIndexName = userIndexName.startsWith(PARTITION_NAME_VECTOR_INDEX_PREFIX)
+        ? userIndexName
+        : PARTITION_NAME_VECTOR_INDEX_PREFIX + userIndexName;
+    HoodieTableVersion tableVersion = metaClient.getTableConfig().getTableVersion();
+    HoodieIndexVersion indexVersion = HoodieIndexVersion.getCurrentVersion(tableVersion, MetadataPartitionType.VECTOR_INDEX);
+    if (indexExists(metaClient, fullIndexName)) {
+      throw new HoodieMetadataIndexException("Index already exists: " + userIndexName);
+    }
+
+    checkArgument(columns.size() == 1, "Only one vector column can be indexed at a time.");
+    VectorIndexOptions.validate(options);
+    validateEligibilityForVectorIndex(metaClient, options, columns, userIndexName);
+
+    return HoodieIndexDefinition.newBuilder()
+        .withIndexName(fullIndexName)
+        .withIndexType(PARTITION_NAME_VECTOR_INDEX)
+        .withIndexFunction(VectorIndexOptions.getAlgorithm(options))
+        .withSourceFields(new ArrayList<>(columns.keySet()))
+        .withIndexOptions(options)
+        .withVersion(indexVersion)
+        .build();
+  }
+
   static boolean indexExists(HoodieTableMetaClient metaClient, String indexName) {
-    return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(indexName));
+    return metaClient.getTableConfig().getMetadataPartitions().stream().anyMatch(partition -> partition.equals(indexName))
+        || metaClient.getIndexForMetadataPartition(indexName).isPresent();
   }
 
   static void validateEligibilityForSecondaryOrExpressionIndex(HoodieTableMetaClient metaClient,
@@ -731,6 +762,34 @@ public class HoodieIndexUtils {
                 + "Please choose a column with a primitive data type.",
             userIndexName, columnName, fieldSchema.getType()));
       }
+    }
+  }
+
+  static void validateEligibilityForVectorIndex(HoodieTableMetaClient metaClient,
+                                                Map<String, String> options,
+                                                Map<String, Map<String, String>> columns,
+                                                String userIndexName) throws Exception {
+    HoodieSchema tableSchema = new TableSchemaResolver(metaClient).getTableSchema();
+    List<String> sourceFields = new ArrayList<>(columns.keySet());
+    String columnName = sourceFields.get(0);
+    Pair<String, HoodieSchemaField> fieldSchema = HoodieSchemaUtils.getNestedField(tableSchema, columnName)
+        .orElseThrow(() -> new HoodieMetadataIndexException(String.format(
+            "Cannot create vector index '%s': Column '%s' does not exist in the table schema.",
+            userIndexName, columnName)));
+
+    HoodieSchema fieldType = fieldSchema.getRight().schema().getNonNullType();
+    if (fieldType.getType() != HoodieSchemaType.VECTOR) {
+      throw new HoodieMetadataIndexException(String.format(
+          "Cannot create vector index '%s': Column '%s' has type '%s'. Vector indexes require a VECTOR column.",
+          userIndexName, columnName, fieldType.getType()));
+    }
+
+    HoodieSchema.Vector vectorType = (HoodieSchema.Vector) fieldType;
+    int configuredDimension = VectorIndexOptions.getDimension(options);
+    if (vectorType.getDimension() != configuredDimension) {
+      throw new HoodieMetadataIndexException(String.format(
+          "Cannot create vector index '%s': Column '%s' has VECTOR(%s) but OPTIONS specifies dimension %s.",
+          userIndexName, columnName, vectorType.getDimension(), configuredDimension));
     }
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/HoodieSparkIndexClient.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/HoodieSparkIndexClient.java
@@ -65,6 +65,7 @@ import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BL
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault;
 
 @Slf4j
@@ -95,6 +96,8 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
     if (indexType.equals(PARTITION_NAME_SECONDARY_INDEX) || indexType.equals(PARTITION_NAME_BLOOM_FILTERS)
         || indexType.equals(PARTITION_NAME_COLUMN_STATS)) {
       createExpressionOrSecondaryIndex(metaClient, userIndexName, indexType, columns, options, tableProperties);
+    } else if (indexType.equals(PARTITION_NAME_VECTOR_INDEX)) {
+      createVectorIndex(metaClient, userIndexName, columns, options);
     } else {
       createRecordIndex(metaClient, userIndexName, indexType, options);
     }
@@ -182,8 +185,24 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
     }
   }
 
+  private void createVectorIndex(HoodieTableMetaClient metaClient,
+                                 String userIndexName,
+                                 Map<String, Map<String, String>> columns,
+                                 Map<String, String> options) throws Exception {
+    HoodieIndexDefinition indexDefinition = HoodieIndexUtils.getVectorIndexDefinition(metaClient, userIndexName, columns, options);
+    if (!metaClient.getIndexForMetadataPartition(indexDefinition.getIndexName()).isPresent()) {
+      log.info("Registering vector index definition: {}", indexDefinition.getIndexName());
+      register(metaClient, indexDefinition);
+    }
+  }
+
   private void drop(HoodieTableMetaClient metaClient, String indexName, Option<HoodieIndexDefinition> indexDefinitionOpt) {
     log.info("Dropping index {}", indexName);
+    if (metaClient.getIndexForMetadataPartition(indexName).isPresent()
+        && !metaClient.getTableConfig().getMetadataPartitions().contains(indexName)) {
+      metaClient.deleteIndexDefinition(indexName);
+      return;
+    }
     try (SparkRDDWriteClient writeClient = getWriteClient(metaClient, indexDefinitionOpt, Option.empty(), Collections.emptyMap())) {
       writeClient.dropIndex(Collections.singletonList(indexName));
     }
@@ -195,6 +214,10 @@ public class HoodieSparkIndexClient extends BaseHoodieIndexClient {
     Option<HoodieIndexDefinition> indexDefinitionOpt = metaClient.getIndexMetadata()
         .map(HoodieIndexMetadata::getIndexDefinitions)
         .map(definition -> definition.get(indexName));
+    if (indexDefinitionOpt.isPresent() && !metaClient.getTableConfig().getMetadataPartitions().contains(indexName)) {
+      metaClient.deleteIndexDefinition(indexName);
+      return;
+    }
     try (SparkRDDWriteClient writeClient = getWriteClient(metaClient, indexDefinitionOpt, Option.empty(), Collections.emptyMap())) {
       writeClient.dropIndex(Collections.singletonList(indexName));
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorIndexOptions.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorIndexOptions.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Option keys accepted in the {@code OPTIONS} clause of
+ * {@code CREATE INDEX ... USING VECTOR}.
+ */
+public final class VectorIndexOptions {
+
+  private static final Set<String> SUPPORTED_METRICS = Set.of("cosine", "l2", "dot_product");
+  private static final Set<String> SUPPORTED_ALGORITHMS = Set.of("ivfflat", "ivfpq_hnsw", "ivf_rabitq_mdt");
+  private static final Set<String> SUPPORTED_QUANTIZERS = Set.of("IVF_RABITQ", "IVF_PQ");
+
+  private VectorIndexOptions() {
+  }
+
+  public static final String DIMENSION = "vector.dimension";
+  public static final String METRIC = "vector.metric";
+  public static final String ALGORITHM = "vector.algorithm";
+  public static final String QUANTIZER = "vector.quantizer";
+  public static final String NUM_CLUSTERS = "vector.num_clusters";
+  public static final String NUM_PROBES = "vector.num_probes";
+  public static final String REFINE_FACTOR = "vector.refine_factor";
+  public static final String MAX_ITER = "vector.max_iter";
+  public static final String RABITQ_RANDOM_SEED = "vector.rabitq.random_seed";
+  public static final String RABITQ_TOTAL_BITS = "vector.rabitq.total_bits";
+  public static final String RABITQ_BITS = "vector.rabitq.bits";
+  public static final String RABITQ_ASSUME_NORMALIZED = "vector.rabitq.assume_normalized";
+
+  public static final String DEFAULT_METRIC = "cosine";
+  public static final String DEFAULT_ALGORITHM = "ivfflat";
+  public static final String DEFAULT_QUANTIZER = "IVF_RABITQ";
+  public static final int DEFAULT_NUM_CLUSTERS = 256;
+  public static final int DEFAULT_NUM_PROBES = 8;
+  public static final int DEFAULT_REFINE_FACTOR = 10;
+  public static final int DEFAULT_MAX_ITER = 20;
+  public static final long DEFAULT_RABITQ_RANDOM_SEED = 42L;
+  public static final int DEFAULT_RABITQ_TOTAL_BITS = 1;
+
+  public static void validate(Map<String, String> options) {
+    getDimension(options);
+    getMetric(options);
+    getAlgorithm(options);
+    getQuantizer(options);
+    getNumClusters(options);
+    getNumProbes(options);
+    getRefineFactor(options);
+    getMaxIter(options);
+    getRaBitQRandomSeed(options);
+    getRaBitQTotalBits(options);
+    getRaBitQAssumeNormalized(options);
+
+    if (getNumProbes(options) > getNumClusters(options)) {
+      throw new IllegalArgumentException(String.format(
+          "Vector index option '%s' (%s) cannot exceed '%s' (%s)",
+          NUM_PROBES, getNumProbes(options), NUM_CLUSTERS, getNumClusters(options)));
+    }
+  }
+
+  public static int getDimension(Map<String, String> options) {
+    String value = options.get(DIMENSION);
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException("Vector index requires '" + DIMENSION + "' in OPTIONS");
+    }
+    return parsePositiveInt(DIMENSION, value);
+  }
+
+  public static String getMetric(Map<String, String> options) {
+    return requireOneOf(METRIC, options.getOrDefault(METRIC, DEFAULT_METRIC), SUPPORTED_METRICS);
+  }
+
+  public static String getAlgorithm(Map<String, String> options) {
+    return requireOneOf(ALGORITHM, options.getOrDefault(ALGORITHM, DEFAULT_ALGORITHM), SUPPORTED_ALGORITHMS);
+  }
+
+  public static String getQuantizer(Map<String, String> options) {
+    String value = options.getOrDefault(QUANTIZER, DEFAULT_QUANTIZER).toUpperCase(Locale.ROOT);
+    if (!SUPPORTED_QUANTIZERS.contains(value)) {
+      throw new IllegalArgumentException(String.format(
+          "Vector index option '%s' must be one of %s, got: %s", QUANTIZER, SUPPORTED_QUANTIZERS, value));
+    }
+    return value;
+  }
+
+  public static int getNumClusters(Map<String, String> options) {
+    return parsePositiveInt(NUM_CLUSTERS,
+        options.getOrDefault(NUM_CLUSTERS, String.valueOf(DEFAULT_NUM_CLUSTERS)));
+  }
+
+  public static int getNumProbes(Map<String, String> options) {
+    return parsePositiveInt(NUM_PROBES,
+        options.getOrDefault(NUM_PROBES, String.valueOf(DEFAULT_NUM_PROBES)));
+  }
+
+  public static int getRefineFactor(Map<String, String> options) {
+    return parsePositiveInt(REFINE_FACTOR,
+        options.getOrDefault(REFINE_FACTOR, String.valueOf(DEFAULT_REFINE_FACTOR)));
+  }
+
+  public static int getMaxIter(Map<String, String> options) {
+    return parsePositiveInt(MAX_ITER,
+        options.getOrDefault(MAX_ITER, String.valueOf(DEFAULT_MAX_ITER)));
+  }
+
+  public static long getRaBitQRandomSeed(Map<String, String> options) {
+    return parseLong(RABITQ_RANDOM_SEED,
+        options.getOrDefault(RABITQ_RANDOM_SEED, String.valueOf(DEFAULT_RABITQ_RANDOM_SEED)));
+  }
+
+  public static int getRaBitQTotalBits(Map<String, String> options) {
+    String rawValue = options.containsKey(RABITQ_TOTAL_BITS)
+        ? options.get(RABITQ_TOTAL_BITS)
+        : options.getOrDefault(RABITQ_BITS, String.valueOf(DEFAULT_RABITQ_TOTAL_BITS));
+    int bits = parsePositiveInt(RABITQ_TOTAL_BITS, rawValue);
+    if (bits > 8) {
+      throw new IllegalArgumentException("RaBitQ total bits must be in [1, 8], got: " + bits);
+    }
+    return bits;
+  }
+
+  public static boolean getRaBitQAssumeNormalized(Map<String, String> options) {
+    String value = options.getOrDefault(RABITQ_ASSUME_NORMALIZED, "false");
+    if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+      throw new IllegalArgumentException(String.format(
+          "Vector index option '%s' must be either 'true' or 'false', got: %s",
+          RABITQ_ASSUME_NORMALIZED, value));
+    }
+    return Boolean.parseBoolean(value);
+  }
+
+  private static int parsePositiveInt(String key, String value) {
+    try {
+      int parsed = Integer.parseInt(value);
+      if (parsed <= 0) {
+        throw new IllegalArgumentException(
+            String.format("Vector index option '%s' must be > 0, got: %s", key, value));
+      }
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format("Vector index option '%s' must be an integer, got: %s", key, value), e);
+    }
+  }
+
+  private static long parseLong(String key, String value) {
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format("Vector index option '%s' must be a long, got: %s", key, value), e);
+    }
+  }
+
+  private static String requireOneOf(String key, String value, Set<String> allowedValues) {
+    String normalized = value.toLowerCase(Locale.ROOT);
+    if (!allowedValues.contains(normalized)) {
+      throw new IllegalArgumentException(String.format(
+          "Vector index option '%s' must be one of %s, got: %s", key, allowedValues, value));
+    }
+    return normalized;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieIndexVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieIndexVersion.java
@@ -107,6 +107,9 @@ public enum HoodieIndexVersion {
         }
         return V1;
 
+      case VECTOR_INDEX:
+        return V1;
+
       case FILES:
         return V1;
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -211,6 +211,8 @@ public class HoodieTableMetadataUtil {
   public static final String PARTITION_NAME_EXPRESSION_INDEX_PREFIX = "expr_index_";
   public static final String PARTITION_NAME_SECONDARY_INDEX = "secondary_index";
   public static final String PARTITION_NAME_SECONDARY_INDEX_PREFIX = "secondary_index_";
+  public static final String PARTITION_NAME_VECTOR_INDEX = "vector_index";
+  public static final String PARTITION_NAME_VECTOR_INDEX_PREFIX = "vector_index_";
 
   public static final Set<String> SUPPORTED_META_FIELDS_PARTITION_STATS = new HashSet<>(Arrays.asList(
       HoodieRecord.HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName(),

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -82,6 +82,7 @@ import static org.apache.hudi.metadata.HoodieMetadataPayload.SECONDARY_INDEX_FIE
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.combineFileSystemMetadata;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.mergeColumnStatsRecords;
 
@@ -242,6 +243,28 @@ public enum MetadataPartitionType {
     @Override
     public SerializableBiFunction<String, Integer, Integer> getFileGroupMappingFunction(HoodieIndexVersion indexVersion) {
       return HoodieTableMetadataUtil.getSecondaryKeyToFileGroupMappingFunction(indexVersion.greaterThanOrEquals(HoodieIndexVersion.V2));
+    }
+  },
+  VECTOR_INDEX(PARTITION_NAME_VECTOR_INDEX_PREFIX, "vector-index-", 8) {
+    @Override
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
+      return false;
+    }
+
+    @Override
+    public boolean isMetadataPartitionAvailable(HoodieTableMetaClient metaClient) {
+      if (metaClient.getIndexMetadata().isPresent()) {
+        return metaClient.getIndexMetadata().get().getIndexDefinitions().values().stream()
+            .anyMatch(indexDef -> indexDef.getIndexName().startsWith(PARTITION_NAME_VECTOR_INDEX_PREFIX));
+      }
+      return false;
+    }
+
+    @Override
+    public String getPartitionPath(HoodieTableMetaClient metaClient, String indexName) {
+      return metaClient.getIndexForMetadataPartition(indexName)
+          .map(HoodieIndexDefinition::getIndexName)
+          .orElseThrow(() -> new IllegalArgumentException("Index definition is not present for index: " + indexName));
     }
   },
   PARTITION_STATS(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, "partition-stats-", 6) {

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieIndexVersion.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestHoodieIndexVersion.java
@@ -58,6 +58,7 @@ public class TestHoodieIndexVersion {
         Arguments.of("BLOOM_FILTERS", HoodieTableVersion.NINE, "secondary_index_idx1", HoodieIndexVersion.V2),
         Arguments.of("FILES", HoodieTableVersion.EIGHT, "files", HoodieIndexVersion.V1),
         Arguments.of("FILES", HoodieTableVersion.NINE, "files", HoodieIndexVersion.V1),
+        Arguments.of("VECTOR_INDEX", HoodieTableVersion.NINE, "vector_index_idx1", HoodieIndexVersion.V1),
         Arguments.of("EXPRESSION INDEX", HoodieTableVersion.EIGHT, "files", HoodieIndexVersion.V1),
         Arguments.of("EXPRESSION INDEX", HoodieTableVersion.NINE, "files", HoodieIndexVersion.V1),
         Arguments.of("PARTITION_STATS", HoodieTableVersion.EIGHT, "partition_stats", HoodieIndexVersion.V1),
@@ -79,6 +80,7 @@ public class TestHoodieIndexVersion {
         Arguments.of("COLUMN_STATS", HoodieTableVersion.EIGHT, MetadataPartitionType.COLUMN_STATS, HoodieIndexVersion.V1),
         Arguments.of("BLOOM_FILTERS", HoodieTableVersion.EIGHT, MetadataPartitionType.BLOOM_FILTERS, HoodieIndexVersion.V1),
         Arguments.of("EXPRESSION_INDEX", HoodieTableVersion.EIGHT, MetadataPartitionType.EXPRESSION_INDEX, HoodieIndexVersion.V1),
+        Arguments.of("VECTOR_INDEX", HoodieTableVersion.NINE, MetadataPartitionType.VECTOR_INDEX, HoodieIndexVersion.V1),
         Arguments.of("FILES", HoodieTableVersion.EIGHT, MetadataPartitionType.FILES, HoodieIndexVersion.V1),
         Arguments.of("PARTITION_STATS", HoodieTableVersion.EIGHT, MetadataPartitionType.PARTITION_STATS, HoodieIndexVersion.V1),
         Arguments.of("ALL_PARTITIONS", HoodieTableVersion.EIGHT, MetadataPartitionType.ALL_PARTITIONS, HoodieIndexVersion.V1)
@@ -145,6 +147,11 @@ public class TestHoodieIndexVersion {
         Arguments.of("Table version 9 with non-SI v1",
             HoodieTableVersion.NINE,
             createIndexDefinition("column_stats", HoodieIndexVersion.V1),
+            true),
+
+        Arguments.of("Table version 9 with vector index v1",
+            HoodieTableVersion.NINE,
+            createIndexDefinition("vector_index_idx_test", HoodieIndexVersion.V1),
             true),
 
         // Table version 9, non-SI with no version is not allowed

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -61,6 +61,10 @@ public class TestMetadataPartitionType {
             // PARTITION_STATS can only be enabled if the table is partitioned
             return Stream.of(Arguments.of(type, true));
           }
+          if (type == MetadataPartitionType.VECTOR_INDEX) {
+            // VECTOR_INDEX is registered explicitly through CREATE INDEX, not metadata config flags.
+            return Stream.empty();
+          }
           return Stream.of(Arguments.of(type, true), Arguments.of(type, false));
         });
   }
@@ -191,6 +195,7 @@ public class TestMetadataPartitionType {
     assertEquals(MetadataPartitionType.COLUMN_STATS, MetadataPartitionType.fromPartitionPath("column_stats"));
     assertEquals(MetadataPartitionType.BLOOM_FILTERS, MetadataPartitionType.fromPartitionPath("bloom_filters"));
     assertEquals(MetadataPartitionType.RECORD_INDEX, MetadataPartitionType.fromPartitionPath("record_index"));
+    assertEquals(MetadataPartitionType.VECTOR_INDEX, MetadataPartitionType.fromPartitionPath("vector_index_idx_embedding"));
     assertEquals(MetadataPartitionType.PARTITION_STATS, MetadataPartitionType.fromPartitionPath("partition_stats"));
     assertThrows(IllegalArgumentException.class, () -> MetadataPartitionType.fromPartitionPath("unknown"));
   }
@@ -204,6 +209,7 @@ public class TestMetadataPartitionType {
     assertEquals(5, MetadataPartitionType.RECORD_INDEX.getRecordType());
     assertEquals(6, MetadataPartitionType.PARTITION_STATS.getRecordType());
     assertEquals(7, MetadataPartitionType.SECONDARY_INDEX.getRecordType());
+    assertEquals(8, MetadataPartitionType.VECTOR_INDEX.getRecordType());
   }
 
   @ParameterizedTest
@@ -212,7 +218,8 @@ public class TestMetadataPartitionType {
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     String expressionIndexName = "expr_index_dummyExpressionIndex";
     String secondaryIndexName = "secondary_index_dummySecondaryIndex";
-    HoodieIndexMetadata indexMetadata = getIndexMetadata(expressionIndexName, secondaryIndexName);
+    String vectorIndexName = "vector_index_dummyVectorIndex";
+    HoodieIndexMetadata indexMetadata = getIndexMetadata(expressionIndexName, secondaryIndexName, vectorIndexName);
     when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
     
     // Mock getIndexForMetadataPartition for both index names
@@ -220,17 +227,21 @@ public class TestMetadataPartitionType {
         .thenReturn(Option.of(indexMetadata.getIndexDefinitions().get(expressionIndexName)));
     when(metaClient.getIndexForMetadataPartition(secondaryIndexName))
         .thenReturn(Option.of(indexMetadata.getIndexDefinitions().get(secondaryIndexName)));
+    when(metaClient.getIndexForMetadataPartition(vectorIndexName))
+        .thenReturn(Option.of(indexMetadata.getIndexDefinitions().get(vectorIndexName)));
     
     if (partitionType == MetadataPartitionType.EXPRESSION_INDEX) {
       assertEquals(expressionIndexName, partitionType.getPartitionPath(metaClient, expressionIndexName));
     } else if (partitionType == MetadataPartitionType.SECONDARY_INDEX) {
       assertEquals(secondaryIndexName, partitionType.getPartitionPath(metaClient, secondaryIndexName));
+    } else if (partitionType == MetadataPartitionType.VECTOR_INDEX) {
+      assertEquals(vectorIndexName, partitionType.getPartitionPath(metaClient, vectorIndexName));
     } else {
       assertEquals(partitionType.getPartitionPath(), partitionType.getPartitionPath(metaClient, null));
     }
   }
 
-  private static HoodieIndexMetadata getIndexMetadata(String expressionIndexName, String secondaryIndexName) {
+  private static HoodieIndexMetadata getIndexMetadata(String expressionIndexName, String secondaryIndexName, String vectorIndexName) {
     Map<String, HoodieIndexDefinition> indexDefinitions = new HashMap<>();
     HoodieIndexDefinition expressionIndexDefinition = HoodieIndexDefinition.newBuilder()
         .withIndexName(expressionIndexName)
@@ -248,6 +259,14 @@ public class TestMetadataPartitionType {
         .withSourceFields(Collections.singletonList("name"))
         .build();
     indexDefinitions.put(secondaryIndexName, secondaryIndexDefinition);
+    HoodieIndexDefinition vectorIndexDefinition = HoodieIndexDefinition.newBuilder()
+        .withIndexName(vectorIndexName)
+        .withIndexType("vector_index")
+        .withVersion(HoodieIndexVersion.getCurrentVersion(HoodieTableVersion.current(), vectorIndexName))
+        .withIndexFunction("ivfflat")
+        .withSourceFields(Collections.singletonList("embedding"))
+        .build();
+    indexDefinitions.put(vectorIndexName, vectorIndexDefinition);
     return new HoodieIndexMetadata(indexDefinitions);
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/IndexCommands.scala
@@ -63,6 +63,14 @@ case class CreateIndexCommand(table: CatalogTable,
           "Please refer https://hudi.apache.org/docs/metadata for more info")
       }
       new HoodieSparkIndexClient(sparkSession).create(metaClient, indexName, indexType, columnsMap, options.asJava, table.properties.asJava)
+    } else if (indexType.equalsIgnoreCase("vector") || indexType.equals(HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX)) {
+      new HoodieSparkIndexClient(sparkSession).create(
+        metaClient,
+        indexName,
+        HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX,
+        columnsMap,
+        options.asJava,
+        table.properties.asJava)
     } else if (indexName.equals(HoodieTableMetadataUtil.PARTITION_NAME_RECORD_INDEX)) {
       ValidationUtils.checkArgument(CreateIndexCommand.matchesRecordKeys(columnsMap.keySet().asScala.toSet, metaClient.getTableConfig),
         "Input columns should match configured record key columns: " + metaClient.getTableConfig.getRecordKeyFieldProp)
@@ -159,20 +167,23 @@ case class ShowIndexesCommand(table: CatalogTable,
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val metaClient = createHoodieTableMetaClient(table.identifier, sparkSession)
-    // need to ensure that the index name is for a valid partition type
-    metaClient.getTableConfig.getMetadataPartitions.asScala.map(
-      partition => {
-        if (MetadataPartitionType.isExpressionOrSecondaryIndex(partition)) {
-          val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.get(partition)
-          Row(partition, indexDefinition.getIndexType.toLowerCase, indexDefinition.getSourceFields.asScala.mkString(","))
-        } else if (!partition.equals(MetadataPartitionType.FILES.getPartitionPath)) {
-          Row(partition, partition, "")
-        } else {
-          Row.empty
-        }
+    val partitionNames = new util.LinkedHashSet[String]()
+    metaClient.getTableConfig.getMetadataPartitions.asScala.foreach(partition => partitionNames.add(partition))
+    if (metaClient.getIndexMetadata.isPresent) {
+      metaClient.getIndexMetadata.get().getIndexDefinitions.keySet().asScala.foreach(partition => partitionNames.add(partition))
+    }
+
+    partitionNames.asScala.map(partition => {
+      if (MetadataPartitionType.isExpressionOrSecondaryIndex(partition)
+        || partition.startsWith(HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX_PREFIX)) {
+        val indexDefinition = metaClient.getIndexMetadata.get().getIndexDefinitions.get(partition)
+        Row(partition, indexDefinition.getIndexType.toLowerCase, indexDefinition.getSourceFields.asScala.mkString(","))
+      } else if (!partition.equals(MetadataPartitionType.FILES.getPartitionPath)) {
+        Row(partition, partition, "")
+      } else {
+        Row.empty
       }
-    ).filter(row => row.length != 0)
-     .toSeq
+    }).filter(row => row.length != 0).toSeq
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestIndexSyntax.scala
@@ -188,6 +188,97 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
     }
   }
 
+  test("Test Vector Index Syntax and Validation") {
+    withTempDir { tmp =>
+      val databaseName = "default"
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  name string,
+           |  embedding VECTOR(3),
+           |  ts long
+           |) using hudi
+           | location '$basePath'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'mor',
+           |  preCombineField = 'ts'
+           | )
+       """.stripMargin)
+      spark.sql(
+        s"insert into $tableName values " +
+          "(1, 'a1', array(cast(0.1 as float), cast(0.2 as float), cast(0.3 as float)), 1000)")
+
+      val createVectorIndexSql =
+        s"create index idx_embedding on $tableName using vector(embedding) options(" +
+          "'vector.dimension'='3'," +
+          "'vector.metric'='cosine'," +
+          "'vector.algorithm'='ivfflat'," +
+          "'vector.quantizer'='IVF_RABITQ'," +
+          "'vector.num_clusters'='32'," +
+          "'vector.num_probes'='4'," +
+          "'vector.refine_factor'='8'," +
+          "'vector.max_iter'='12'," +
+          "'vector.rabitq.total_bits'='2'," +
+          "'vector.rabitq.random_seed'='99'," +
+          "'vector.rabitq.assume_normalized'='false')"
+
+      val sqlParser: ParserInterface = spark.sessionState.sqlParser
+      val analyzer: Analyzer = spark.sessionState.analyzer
+      val logicalPlan = sqlParser.parsePlan(createVectorIndexSql)
+      val resolvedLogicalPlan = analyzer.execute(logicalPlan)
+      assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
+      assertResult("idx_embedding")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+      assertResult("vector")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+      assertResult(Map(
+        "vector.dimension" -> "3",
+        "vector.metric" -> "cosine",
+        "vector.algorithm" -> "ivfflat",
+        "vector.quantizer" -> "IVF_RABITQ",
+        "vector.num_clusters" -> "32",
+        "vector.num_probes" -> "4",
+        "vector.refine_factor" -> "8",
+        "vector.max_iter" -> "12",
+        "vector.rabitq.total_bits" -> "2",
+        "vector.rabitq.random_seed" -> "99",
+        "vector.rabitq.assume_normalized" -> "false"))(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].options)
+
+      spark.sql(createVectorIndexSql)
+
+      var metaClient = HoodieTableMetaClient.builder()
+        .setBasePath(basePath)
+        .setConf(HoodieTestUtils.getDefaultStorageConf)
+        .build()
+      assertTrue(metaClient.getIndexForMetadataPartition("vector_index_idx_embedding").isPresent)
+
+      val showIndexesRows = spark.sql(s"show indexes from $tableName").collect()
+      assertTrue(showIndexesRows.exists(row =>
+        row.getString(0) == "vector_index_idx_embedding"
+          && row.getString(1) == "vector_index"
+          && row.getString(2) == "embedding"))
+
+      spark.sql(s"drop index idx_embedding on $tableName")
+      metaClient = HoodieTableMetaClient.reload(metaClient)
+      assertFalse(metaClient.getIndexForMetadataPartition("vector_index_idx_embedding").isPresent)
+
+      checkExceptionContain(
+        s"create index idx_missing_dim on $tableName using vector(embedding) options('vector.algorithm'='ivfflat')")(
+        "Vector index requires 'vector.dimension' in OPTIONS")
+      checkExceptionContain(
+        s"create index idx_bad_alg on $tableName using vector(embedding) options('vector.dimension'='3', 'vector.algorithm'='nope')")(
+        "Vector index option 'vector.algorithm' must be one of")
+      checkExceptionContain(
+        s"create index idx_bad_dim on $tableName using vector(embedding) options('vector.dimension'='4')")(
+        "Column 'embedding' has VECTOR(3) but OPTIONS specifies dimension 4")
+      checkExceptionContain(
+        s"create index idx_bad_col on $tableName using vector(name) options('vector.dimension'='1')")(
+        "Vector indexes require a VECTOR column")
+    }
+  }
+
   test("Test matchesRecordKeys API") {
     val tableConfig = new HoodieTableConfig()
 


### PR DESCRIPTION
## Summary

Add the initial Spark DDL and option scaffolding for vector indexes.

This PR is intentionally thin and focuses on the `#19096` scope only:

- `CREATE INDEX ... USING VECTOR`
- vector option surface and validation
- `SHOW INDEXES` / `DROP INDEX` scaffolding for vector index definitions
- minimal metadata partition naming/version plumbing for vector index definitions
- Spark SQL and metadata/versioning test coverage for the new scaffolding

## What this PR includes

- Adds a minimal `VectorIndexOptions` contract for vector DDL options, including:
  - `vector.dimension`
  - `vector.metric`
  - `vector.algorithm`
  - `vector.quantizer`
  - probe / cluster / refine / iteration settings
  - `vector.rabitq.total_bits`
- Adds vector index definition construction and early validation:
  - exactly one indexed column
  - indexed column must exist
  - indexed column must be `VECTOR`
  - configured dimension must match the schema dimension
- Wires `USING VECTOR` through Spark SQL command handling
- Registers vector index definitions through the Spark index client
- Makes `SHOW INDEXES` include vector index definitions even before full metadata partition materialization
- Adds minimal metadata naming/version support for `vector_index_*`

## What this PR does not include

To keep review scope small, this PR does **not** include:

- MDT payload/schema changes for vector postings
- bootstrap / clustering / posting generation logic
- vector query planning or read path execution
- approximate candidate generation or exact rerank
- rebuild / cleanup semantics beyond thin DDL definition handling

Those pieces are intended for follow-up PRs in the RFC-104 sequence.

## Validation

### Completed

- added SQL parser/analyzer + execution coverage in `TestIndexSyntax`
- added metadata partition coverage in `TestMetadataPartitionType`
- added versioning coverage in `TestHoodieIndexVersion`
- verified the intended Maven/JDK 17 command setup for this PR scope

### Additional validation

Comprehensive end-to-end Maven validation remains subject to broader build and dependency constraints outside this PR scope.

CI and follow-up verification will provide full reactor coverage.

## Related

- Parent: #19094
- Child scope: #19096
- RFC umbrella: #18676
