### PR TITLE
feat: Allow disabling the partition stats index independently of column stats

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -2268,7 +2268,9 @@ public class HoodieWriteConfig extends HoodieConfig {
    * @return {@code true} if the partition stats index is enabled, {@code false} otherwise.
    */
   public boolean isPartitionStatsIndexEnabled() {
-    return isMetadataColumnStatsIndexEnabled();
+    // Delegate to the metadata config (which already requires column stats) so the build and delete
+    // paths stay consistent.
+    return isMetadataTableEnabled() && getMetadataConfig().isPartitionStatsIndexEnabled();
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -236,6 +236,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "For the Spark engine, this config defaults to true (enabled), overriding the base default of false. "
           + "For Flink and Java engines, this remains false by default.");
 
+  public static final ConfigProperty<Boolean> ENABLE_METADATA_INDEX_PARTITION_STATS = ConfigProperty
+      .key(METADATA_PREFIX + ".index.partition.stats.enable")
+      .defaultValue(true)
+      .markAdvanced()
+      .sinceVersion("1.0.0")
+      .withDocumentation("Enable aggregating the column stats index to the partition level in the metadata table, "
+          + "used to prune partitions during index lookups. Partition stats requires the column stats index "
+          + "(" + METADATA_PREFIX + ".index.column.stats.enable) to be enabled and has no effect when column stats "
+          + "is disabled. This is an advanced option that should generally be left enabled; disabling it while "
+          + "keeping column stats enabled is recommended only for tables composed of externally created files "
+          + "(e.g. file formats integrated through Apache XTable), where partition stats are not generated.");
+
   public static final ConfigProperty<Integer> METADATA_INDEX_COLUMN_STATS_FILE_GROUP_COUNT = ConfigProperty
       .key(METADATA_PREFIX + ".index.column.stats.file.group.count")
       .defaultValue(2)
@@ -929,7 +941,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
   }
 
   public boolean isPartitionStatsIndexEnabled() {
-    return getBooleanOrDefault(ENABLE_METADATA_INDEX_COLUMN_STATS);
+    // Partition stats are derived from the column stats index, so they can only be enabled when column
+    // stats is enabled. Within that constraint the partition stats flag is honoured: it defaults to true
+    // (mirroring column stats) but can be explicitly disabled, e.g. for tables of externally created files.
+    return getBooleanOrDefault(ENABLE_METADATA_INDEX_COLUMN_STATS)
+        && getBooleanOrDefault(ENABLE_METADATA_INDEX_PARTITION_STATS);
   }
 
   public int getPartitionStatsIndexFileGroupCount() {
@@ -1095,6 +1111,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withMetadataIndexColumnStats(boolean enable) {
       metadataConfig.setValue(ENABLE_METADATA_INDEX_COLUMN_STATS, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder withMetadataIndexPartitionStats(boolean enable) {
+      metadataConfig.setValue(ENABLE_METADATA_INDEX_PARTITION_STATS, String.valueOf(enable));
       return this;
     }
 
@@ -1453,13 +1474,6 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       }
     }
   }
-
-  /**
-   * The config is now deprecated. Partition stats are configured using the column stats config itself.
-   */
-  @Deprecated
-  public static final String ENABLE_METADATA_INDEX_PARTITION_STATS =
-      METADATA_PREFIX + ".index.partition.stats.enable";
 
   /**
    * @deprecated Use {@link #ENABLE} and its methods.

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -240,7 +240,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".index.partition.stats.enable")
       .defaultValue(true)
       .markAdvanced()
-      .sinceVersion("1.0.0")
+      .sinceVersion("1.3.0")
       .withDocumentation("Enable aggregating the column stats index to the partition level in the metadata table, "
           + "used to prune partitions during index lookups. Partition stats requires the column stats index "
           + "(" + METADATA_PREFIX + ".index.column.stats.enable) to be enabled and has no effect when column stats "

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -149,6 +149,25 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
   }
 
   /**
+   * Test case to validate that on a partitioned table, partition stats can be disabled independently while column
+   * stats remains enabled: the column stats index is still built but the partition stats index is not.
+   */
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  def testColumnStatsEnabledWithPartitionStatsDisabled(tableType: HoodieTableType): Unit = {
+    val hudiOpts = commonOpts ++ Map(
+      DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key -> "false")
+    doWriteAndValidateDataAndPartitionStats(hudiOpts, operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL, saveMode = SaveMode.Overwrite, validate = false)
+    doWriteAndValidateDataAndPartitionStats(hudiOpts, operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL, saveMode = SaveMode.Append, validate = false)
+    // column stats should be built, but partition stats should not be present in the MDT
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    val metadataPartitions = metaClient.getTableConfig.getMetadataPartitions
+    assertTrue(metadataPartitions.contains(MetadataPartitionType.COLUMN_STATS.getPartitionPath))
+    assertFalse(metadataPartitions.contains(MetadataPartitionType.PARTITION_STATS.getPartitionPath))
+  }
+
+  /**
    * Test case to do a write with updates and rollback the last instant and validate the partition stats index.
    */
   @ParameterizedTest


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19112

`hoodie.metadata.index.partition.stats.enable` was deprecated in #14165 so that partition stats are controlled solely by the column stats config, for configuration simplicity. A side effect is that the partition stats index can no longer be disabled independently of column stats. Tables composed of externally created files (e.g. formats integrated through Apache XTable) want the column stats index for file-level data skipping, but partition stats generation rebuilds a `FileSystemView` over the external base files and is not supported for them, so it fails. The only current workaround is to disable column stats entirely, which also loses file-level skipping.

### Summary and Changelog

Reintroduce `ENABLE_METADATA_INDEX_PARTITION_STATS` as an advanced config while preserving #14165's simple default:

- `isPartitionStatsIndexEnabled()` now returns `columnStatsEnabled && partitionStatsEnabled`. Partition stats still require column stats.
- The flag defaults to `true`, so when unset, behavior is unchanged — partition stats mirror column stats exactly as today.
- When explicitly set to `false`, partition stats are skipped while column stats remain enabled.
- Setting it on while column stats is off has no effect.
- Adds the matching `HoodieMetadataConfig.Builder#withMetadataIndexPartitionStats(boolean)` setter.

### Impact

No behavior change for existing tables (the flag defaults to mirroring column stats). Adds an opt-out for users who want column-stats data skipping without partition stats, recommended only for external table formats.

### Risk Level

low. Default-preserving; the only behavioral change occurs when the new flag is explicitly set to `false`. Validated end-to-end against Apache XTable's partitioned conversion path (`ITConversionController#testPartitionedData`) using a locally built snapshot: with column stats enabled for partitioned tables and partition stats explicitly disabled, conversion succeeds (previously it failed in partition stats generation).

### Documentation Update

`hoodie.metadata.index.partition.stats.enable` is reintroduced as an advanced config (was deprecated). Default `true`; effective only when column stats is enabled. The config description is included on the `ConfigProperty`.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
