### PR TITLE
feat: support read native cdc logs

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCEngineRecordAccessor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCEngineRecordAccessor.java
@@ -18,33 +18,16 @@
 
 package org.apache.hudi.common.table.log;
 
-import org.apache.hudi.common.util.collection.ClosableIterator;
-
-import java.util.NoSuchElementException;
-
 /**
- * Record iterator for Hudi CDC log files.
+ * Accessor for CDC operation, record key, and before/after images in an engine-specific row.
  *
  * @param <T> Engine-specific record type used by native CDC log files
  */
-public interface HoodieCDCLogRecordIterator<T> extends ClosableIterator<HoodieCDCLogRecord<T>> {
+public interface HoodieCDCEngineRecordAccessor<T> {
 
-  static <T> HoodieCDCLogRecordIterator<T> empty() {
-    return new HoodieCDCLogRecordIterator<T>() {
-      @Override
-      public boolean hasNext() {
-        return false;
-      }
+  String getOperation(T record);
 
-      @Override
-      public HoodieCDCLogRecord<T> next() {
-        throw new NoSuchElementException("No CDC log records");
-      }
+  String getRecordKey(T record);
 
-      @Override
-      public void close() {
-        // no-op
-      }
-    };
-  }
+  T getImage(T record, int ordinal, int imageArity);
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCInlineLogRecordIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCInlineLogRecordIterator.java
@@ -96,6 +96,7 @@ public class HoodieCDCInlineLogRecordIterator implements HoodieCDCLogRecordItera
     closeItr();
     itr = new CloseableMappingIterator<>(
         dataBlock.getRecordIterator(HoodieRecordType.AVRO),
+        // Cast via Object to avoid an unchecked-cast warning; AVRO record iterators yield HoodieAvroIndexedRecord.
         record -> new InlineCDCLogRecord(((HoodieAvroIndexedRecord) (Object) record).getData()));
     return itr.hasNext();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCInlineLogRecordIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCInlineLogRecordIterator.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.log;
+
+import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.log.block.HoodieDataBlock;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.storage.HoodieStorage;
+
+import org.apache.avro.generic.IndexedRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * CDC log record iterator for inline CDC log blocks.
+ */
+public class HoodieCDCInlineLogRecordIterator implements HoodieCDCLogRecordIterator<IndexedRecord> {
+
+  private final HoodieStorage storage;
+
+  private final HoodieSchema cdcSchema;
+
+  private final Iterator<HoodieLogFile> cdcLogFileIter;
+
+  private HoodieLogFormat.Reader reader;
+
+  private ClosableIterator<HoodieCDCLogRecord<IndexedRecord>> itr;
+
+  private HoodieCDCLogRecord<IndexedRecord> record;
+
+  public HoodieCDCInlineLogRecordIterator(HoodieStorage storage, HoodieLogFile[] cdcLogFiles, HoodieSchema cdcSchema) {
+    this.storage = storage;
+    this.cdcSchema = cdcSchema;
+    this.cdcLogFileIter = Arrays.stream(cdcLogFiles).iterator();
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (record != null) {
+      return true;
+    }
+    if (itr == null || !itr.hasNext()) {
+      if (reader == null || !reader.hasNext()) {
+        if (!loadReader()) {
+          return false;
+        }
+      }
+      if (!loadItr()) {
+        return false;
+      }
+    }
+    record = itr.next();
+    return true;
+  }
+
+  private boolean loadReader() {
+    try {
+      closeReader();
+      if (cdcLogFileIter.hasNext()) {
+        reader = new HoodieLogFileReader(
+            storage, cdcLogFileIter.next(), cdcSchema, HoodieLogFileReader.DEFAULT_BUFFER_SIZE);
+        return reader.hasNext();
+      }
+      return false;
+    } catch (IOException e) {
+      throw new HoodieIOException(e.getMessage(), e);
+    }
+  }
+
+  private boolean loadItr() {
+    HoodieDataBlock dataBlock = (HoodieDataBlock) reader.next();
+    closeItr();
+    itr = new CloseableMappingIterator<>(
+        dataBlock.getRecordIterator(HoodieRecordType.AVRO),
+        record -> new InlineCDCLogRecord(((HoodieAvroIndexedRecord) (Object) record).getData()));
+    return itr.hasNext();
+  }
+
+  @Override
+  public HoodieCDCLogRecord<IndexedRecord> next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException("No more CDC log records");
+    }
+    HoodieCDCLogRecord<IndexedRecord> ret = record;
+    record = null;
+    return ret;
+  }
+
+  @Override
+  public void close() {
+    try {
+      closeItr();
+      closeReader();
+    } catch (IOException e) {
+      throw new HoodieIOException(e.getMessage(), e);
+    }
+  }
+
+  private void closeReader() throws IOException {
+    if (reader != null) {
+      reader.close();
+      reader = null;
+    }
+  }
+
+  private void closeItr() {
+    if (itr != null) {
+      itr.close();
+      itr = null;
+    }
+  }
+
+  private static class InlineCDCLogRecord implements HoodieCDCLogRecord<IndexedRecord> {
+    private final IndexedRecord record;
+
+    private InlineCDCLogRecord(IndexedRecord record) {
+      this.record = record;
+    }
+
+    @Override
+    public String getOperation() {
+      return String.valueOf(record.get(0));
+    }
+
+    @Override
+    public String getRecordKey() {
+      return String.valueOf(record.get(1));
+    }
+
+    @Override
+    public IndexedRecord getAvroImage(int ordinal) {
+      return (IndexedRecord) record.get(ordinal);
+    }
+
+    @Override
+    public IndexedRecord getEngineImage(int ordinal, int imageArity) {
+      throw new UnsupportedOperationException("Inline CDC records do not contain engine row images");
+    }
+
+    @Override
+    public boolean isNative() {
+      return false;
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCLogRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCLogRecord.java
@@ -18,33 +18,23 @@
 
 package org.apache.hudi.common.table.log;
 
-import org.apache.hudi.common.util.collection.ClosableIterator;
-
-import java.util.NoSuchElementException;
+import org.apache.avro.generic.IndexedRecord;
 
 /**
- * Record iterator for Hudi CDC log files.
+ * Normalized CDC log record that can represent inline Avro CDC records or native CDC records
+ * materialized in an engine-specific row type.
  *
  * @param <T> Engine-specific record type used by native CDC log files
  */
-public interface HoodieCDCLogRecordIterator<T> extends ClosableIterator<HoodieCDCLogRecord<T>> {
+public interface HoodieCDCLogRecord<T> {
 
-  static <T> HoodieCDCLogRecordIterator<T> empty() {
-    return new HoodieCDCLogRecordIterator<T>() {
-      @Override
-      public boolean hasNext() {
-        return false;
-      }
+  String getOperation();
 
-      @Override
-      public HoodieCDCLogRecord<T> next() {
-        throw new NoSuchElementException("No CDC log records");
-      }
+  String getRecordKey();
 
-      @Override
-      public void close() {
-        // no-op
-      }
-    };
-  }
+  IndexedRecord getAvroImage(int ordinal);
+
+  T getEngineImage(int ordinal, int imageArity);
+
+  boolean isNative();
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCNativeLogRecordIterator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieCDCNativeLogRecordIterator.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.log;
+
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+
+import org.apache.avro.generic.IndexedRecord;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+/**
+ * CDC log record iterator for native CDC log files read as engine-specific rows.
+ *
+ * @param <T> Engine-specific record type used by native CDC log files
+ */
+public class HoodieCDCNativeLogRecordIterator<T> implements HoodieCDCLogRecordIterator<T> {
+
+  private final Iterator<String> cdcFileIterator;
+  private final Function<String, ClosableIterator<T>> recordIteratorFunc;
+  private final HoodieCDCEngineRecordAccessor<T> recordAccessor;
+  private ClosableIterator<T> recordIterator;
+
+  public HoodieCDCNativeLogRecordIterator(
+      Iterator<String> cdcFileIterator,
+      Function<String, ClosableIterator<T>> recordIteratorFunc,
+      HoodieCDCEngineRecordAccessor<T> recordAccessor) {
+    this.cdcFileIterator = cdcFileIterator;
+    this.recordIteratorFunc = recordIteratorFunc;
+    this.recordAccessor = recordAccessor;
+  }
+
+  @Override
+  public boolean hasNext() {
+    while (recordIterator == null || !recordIterator.hasNext()) {
+      if (recordIterator != null) {
+        recordIterator.close();
+        recordIterator = null;
+      }
+      if (!cdcFileIterator.hasNext()) {
+        return false;
+      }
+      recordIterator = recordIteratorFunc.apply(cdcFileIterator.next());
+      ValidationUtils.checkState(recordIterator != null, "Native CDC record iterator must not be null");
+    }
+    return true;
+  }
+
+  @Override
+  public HoodieCDCLogRecord<T> next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException("No more CDC log records");
+    }
+    return new NativeCDCLogRecord<>(recordIterator.next(), recordAccessor);
+  }
+
+  @Override
+  public void close() {
+    if (recordIterator != null) {
+      recordIterator.close();
+      recordIterator = null;
+    }
+  }
+
+  private static class NativeCDCLogRecord<T> implements HoodieCDCLogRecord<T> {
+    private final T record;
+    private final HoodieCDCEngineRecordAccessor<T> recordAccessor;
+
+    private NativeCDCLogRecord(T record, HoodieCDCEngineRecordAccessor<T> recordAccessor) {
+      this.record = record;
+      this.recordAccessor = recordAccessor;
+    }
+
+    @Override
+    public String getOperation() {
+      return recordAccessor.getOperation(record);
+    }
+
+    @Override
+    public String getRecordKey() {
+      return recordAccessor.getRecordKey(record);
+    }
+
+    @Override
+    public IndexedRecord getAvroImage(int ordinal) {
+      throw new UnsupportedOperationException("Native CDC records do not contain Avro images");
+    }
+
+    @Override
+    public T getEngineImage(int ordinal, int imageArity) {
+      return recordAccessor.getImage(record, ordinal, imageArity);
+    }
+
+    @Override
+    public boolean isNative() {
+      return true;
+    }
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestHoodieCDCNativeLogRecordIterator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestHoodieCDCNativeLogRecordIterator.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.log;
+
+import org.apache.hudi.common.util.collection.ClosableIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestHoodieCDCNativeLogRecordIterator {
+
+  @Test
+  public void testIteratesAcrossFilesAndClosesExhaustedIterators() {
+    Map<String, TrackingClosableIterator<String>> fileIterators = new LinkedHashMap<>();
+    fileIterators.put("file1", new TrackingClosableIterator<>(Collections.singletonList("i:key1:before1:after1")));
+    fileIterators.put("file2", new TrackingClosableIterator<>(Collections.emptyList()));
+    fileIterators.put("file3", new TrackingClosableIterator<>(Arrays.asList("u:key2:before2:after2", "d:key3:before3:null")));
+
+    HoodieCDCNativeLogRecordIterator<String> iterator = new HoodieCDCNativeLogRecordIterator<>(
+        fileIterators.keySet().iterator(),
+        fileIterators::get,
+        accessor());
+
+    assertTrue(iterator.hasNext());
+    HoodieCDCLogRecord<String> insertRecord = iterator.next();
+    assertEquals("i", insertRecord.getOperation());
+    assertEquals("key1", insertRecord.getRecordKey());
+    assertEquals("after1", insertRecord.getEngineImage(3, 2));
+    assertTrue(insertRecord.isNative());
+
+    assertTrue(iterator.hasNext());
+    HoodieCDCLogRecord<String> updateRecord = iterator.next();
+    assertEquals("u", updateRecord.getOperation());
+    assertEquals("key2", updateRecord.getRecordKey());
+    assertEquals("before2", updateRecord.getEngineImage(2, 2));
+
+    assertTrue(iterator.hasNext());
+    HoodieCDCLogRecord<String> deleteRecord = iterator.next();
+    assertEquals("d", deleteRecord.getOperation());
+    assertEquals("key3", deleteRecord.getRecordKey());
+    assertNull(deleteRecord.getEngineImage(3, 2));
+
+    assertFalse(iterator.hasNext());
+    assertTrue(fileIterators.get("file1").isClosed());
+    assertTrue(fileIterators.get("file2").isClosed());
+    assertTrue(fileIterators.get("file3").isClosed());
+  }
+
+  @Test
+  public void testCloseClosesCurrentIterator() {
+    Map<String, TrackingClosableIterator<String>> fileIterators = new LinkedHashMap<>();
+    fileIterators.put("file1", new TrackingClosableIterator<>(Arrays.asList("i:key1:before1:after1", "u:key2:before2:after2")));
+
+    HoodieCDCNativeLogRecordIterator<String> iterator = new HoodieCDCNativeLogRecordIterator<>(
+        fileIterators.keySet().iterator(),
+        fileIterators::get,
+        accessor());
+
+    assertTrue(iterator.hasNext());
+    iterator.close();
+
+    assertTrue(fileIterators.get("file1").isClosed());
+  }
+
+  @Test
+  public void testRejectsNullNativeRecordIterator() {
+    HoodieCDCNativeLogRecordIterator<String> iterator = new HoodieCDCNativeLogRecordIterator<>(
+        Collections.singletonList("file1").iterator(),
+        cdcFile -> null,
+        accessor());
+
+    assertThrows(IllegalStateException.class, iterator::hasNext);
+  }
+
+  @Test
+  public void testEmptyIteratorThrowsOnNext() {
+    HoodieCDCLogRecordIterator<String> iterator = HoodieCDCLogRecordIterator.empty();
+
+    assertFalse(iterator.hasNext());
+    assertThrows(NoSuchElementException.class, iterator::next);
+  }
+
+  private static HoodieCDCEngineRecordAccessor<String> accessor() {
+    return new HoodieCDCEngineRecordAccessor<String>() {
+      @Override
+      public String getOperation(String record) {
+        return split(record)[0];
+      }
+
+      @Override
+      public String getRecordKey(String record) {
+        return split(record)[1];
+      }
+
+      @Override
+      public String getImage(String record, int ordinal, int imageArity) {
+        String image = split(record)[ordinal];
+        return "null".equals(image) ? null : image;
+      }
+    };
+  }
+
+  private static String[] split(String record) {
+    return record.split(":");
+  }
+
+  private static class TrackingClosableIterator<T> implements ClosableIterator<T> {
+    private final Iterator<T> iterator;
+    private boolean closed;
+
+    private TrackingClosableIterator(Iterable<T> records) {
+      this.iterator = records.iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+      return iterator.next();
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+    private boolean isClosed() {
+      return closed;
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
@@ -210,16 +210,16 @@ public class HoodieCdcSplitReaderFunction extends AbstractSplitReaderFunction {
         switch (mode) {
           case DATA_BEFORE_AFTER:
             return new CdcIterators.BeforeAfterImageIterator(
-                getHadoopConf(), tablePath, tableSchema, requiredSchema,
+                conf, getHadoopConf(), tablePath, tableSchema, requiredSchema,
                 tableState.getRequiredRowType(), cdcSchema, fileSplit);
           case DATA_BEFORE:
             return new CdcIterators.BeforeImageIterator(
-                getHadoopConf(), tablePath, tableSchema, requiredSchema,
+                conf, getHadoopConf(), tablePath, tableSchema, requiredSchema,
                 tableState.getRequiredRowType(), tableState.getRequiredPositions(),
                 maxCompactionMemoryInBytes, cdcSchema, fileSplit, imageManager);
           case OP_KEY_ONLY:
             return new CdcIterators.RecordKeyImageIterator(
-                getHadoopConf(), tablePath, tableSchema, requiredSchema,
+                conf, getHadoopConf(), tablePath, tableSchema, requiredSchema,
                 tableState.getRequiredRowType(), tableState.getRequiredPositions(),
                 maxCompactionMemoryInBytes, cdcSchema, fileSplit, imageManager);
           default:

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
@@ -138,14 +138,14 @@ public class CdcInputFormat extends MergeOnReadInputFormat {
         switch (mode) {
           case DATA_BEFORE_AFTER:
             return new CdcIterators.BeforeAfterImageIterator(
-                hadoopConf, tablePath, tblSchema, reqSchema, tableState.getRequiredRowType(), cdcSchema, fileSplit);
+                conf, hadoopConf, tablePath, tblSchema, reqSchema, tableState.getRequiredRowType(), cdcSchema, fileSplit);
           case DATA_BEFORE:
             return new CdcIterators.BeforeImageIterator(
-                hadoopConf, tablePath, tblSchema, reqSchema, tableState.getRequiredRowType(),
+                conf, hadoopConf, tablePath, tblSchema, reqSchema, tableState.getRequiredRowType(),
                 tableState.getRequiredPositions(), maxCompactionMemoryInBytes, cdcSchema, fileSplit, imageManager);
           case OP_KEY_ONLY:
             return new CdcIterators.RecordKeyImageIterator(
-                hadoopConf, tablePath, tblSchema, reqSchema, tableState.getRequiredRowType(),
+                conf, hadoopConf, tablePath, tblSchema, reqSchema, tableState.getRequiredRowType(),
                 tableState.getRequiredPositions(), maxCompactionMemoryInBytes, cdcSchema, fileSplit, imageManager);
           default:
             throw new AssertionError("Unexpected mode: " + mode);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -52,25 +53,25 @@ import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
-import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.io.storage.HoodieIOFactory;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.FlinkReaderContextFactory;
 import org.apache.hudi.table.format.FormatUtils;
+import org.apache.hudi.table.format.HoodieRowDataFileReader;
 import org.apache.hudi.table.format.InternalSchemaManager;
-import org.apache.hudi.table.format.RecordIterators;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
 import org.apache.hudi.util.AvroToRowDataConverters;
+import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.RowDataProjection;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
@@ -78,11 +79,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.apache.hudi.table.format.FormatUtils.buildAvroRecordBySchema;
 
@@ -433,6 +432,9 @@ public final class CdcIterators {
         String tablePath,
         HoodieSchema cdcSchema,
         HoodieCDCFileSplit fileSplit) {
+      if (fileSplit.getCdcFiles() == null || fileSplit.getCdcFiles().isEmpty()) {
+        return HoodieCDCLogRecordIterator.empty();
+      }
       if (isNativeCdcFileSplit(fileSplit)) {
         return new HoodieCDCNativeLogRecordIterator<>(
             fileSplit.getCdcFiles().iterator(),
@@ -461,26 +463,55 @@ public final class CdcIterators {
         String tablePath,
         String cdcFile,
         HoodieSchema cdcSchema) {
+      HoodieRowDataFileReader reader = null;
       try {
-        DataType cdcDataType = HoodieSchemaConverter.convertToDataType(cdcSchema);
-        RowType cdcRowType = (RowType) cdcDataType.getLogicalType();
-        return RecordIterators.getParquetRecordIterator(
-            InternalSchemaManager.DISABLED,
-            conf.get(FlinkOptions.READ_UTC_TIMEZONE),
-            true,
-            HadoopConfigurations.getParquetConf(conf, hadoopConf),
-            cdcRowType.getFieldNames().toArray(new String[0]),
-            cdcDataType.getChildren().toArray(new DataType[0]),
-            new LinkedHashMap<>(),
-            IntStream.range(0, cdcRowType.getFieldCount()).toArray(),
-            2048,
-            new org.apache.flink.core.fs.Path(new StoragePath(tablePath, cdcFile).toString()),
-            0,
-            Long.MAX_VALUE,
-            Collections.emptyList());
+        StoragePath cdcFilePath = new StoragePath(tablePath, cdcFile);
+        HoodieStorage storage = HoodieStorageUtils.getStorage(
+            tablePath, HadoopFSUtils.getStorageConf(hadoopConf));
+        HoodieFileFormat cdcFileFormat = HoodieFileFormat.fromFileExtension(cdcFilePath.getFileExtension());
+        reader = (HoodieRowDataFileReader) HoodieIOFactory.getIOFactory(storage)
+            .getReaderFactory(HoodieRecord.HoodieRecordType.FLINK)
+            .getFileReader(
+                FlinkWriteClients.getHoodieClientConfig(conf), cdcFilePath, cdcFileFormat, Option.empty());
+        return closeReaderWithIterator(
+            reader,
+            reader.getRowDataIterator(cdcSchema, cdcSchema, InternalSchemaManager.DISABLED, Collections.emptyList()));
       } catch (IOException e) {
+        if (reader != null) {
+          reader.close();
+        }
         throw new HoodieIOException("Failed to create native CDC record iterator for file: " + cdcFile, e);
+      } catch (RuntimeException e) {
+        if (reader != null) {
+          reader.close();
+        }
+        throw e;
       }
+    }
+
+    private static ClosableIterator<RowData> closeReaderWithIterator(
+        HoodieRowDataFileReader reader,
+        ClosableIterator<RowData> iterator) {
+      return new ClosableIterator<RowData>() {
+        @Override
+        public boolean hasNext() {
+          return iterator.hasNext();
+        }
+
+        @Override
+        public RowData next() {
+          return iterator.next();
+        }
+
+        @Override
+        public void close() {
+          try {
+            iterator.close();
+          } finally {
+            reader.close();
+          }
+        }
+      };
     }
 
     private static int[] computeRequiredPos(HoodieSchema tableSchema, HoodieSchema requiredSchema) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
@@ -33,7 +33,11 @@ import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.cdc.HoodieCDCFileSplit;
 import org.apache.hudi.common.table.cdc.HoodieCDCUtils;
+import org.apache.hudi.common.table.log.HoodieCDCEngineRecordAccessor;
+import org.apache.hudi.common.table.log.HoodieCDCInlineLogRecordIterator;
+import org.apache.hudi.common.table.log.HoodieCDCLogRecord;
 import org.apache.hudi.common.table.log.HoodieCDCLogRecordIterator;
+import org.apache.hudi.common.table.log.HoodieCDCNativeLogRecordIterator;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.read.BufferedRecordMerger;
 import org.apache.hudi.common.table.read.BufferedRecordMergerFactory;
@@ -48,6 +52,7 @@ import org.apache.hudi.common.util.collection.ExternalSpillableMap;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.storage.HoodieStorage;
@@ -55,6 +60,8 @@ import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.FlinkReaderContextFactory;
 import org.apache.hudi.table.format.FormatUtils;
+import org.apache.hudi.table.format.InternalSchemaManager;
+import org.apache.hudi.table.format.RecordIterators;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
 import org.apache.hudi.util.AvroToRowDataConverters;
 import org.apache.hudi.util.HoodieSchemaConverter;
@@ -63,6 +70,7 @@ import org.apache.hudi.util.RowDataProjection;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
@@ -70,9 +78,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.apache.hudi.table.format.FormatUtils.buildAvroRecordBySchema;
 
@@ -364,21 +374,42 @@ public final class CdcIterators {
 
   /**
    * Base iterator for CDC log files stored with supplemental logging (AS_IS inference case).
-   * Reads a {@link HoodieCDCLogRecordIterator} and resolves before/after images using
-   * subclass-specific logic.
+   * Reads inline or native CDC log files through a normalized CDC record iterator and resolves
+   * before/after images using subclass-specific logic.
    */
   public abstract static class BaseImageIterator implements ClosableIterator<RowData> {
     private final HoodieSchema requiredSchema;
     private final int[] requiredPos;
     private final GenericRecordBuilder recordBuilder;
     private final AvroToRowDataConverters.AvroToRowDataConverter avroToRowDataConverter;
-    private HoodieCDCLogRecordIterator cdcItr;
+    private final RowDataProjection nativeCdcImageProjection;
+    private final int nativeCdcImageArity;
+    private static final HoodieCDCEngineRecordAccessor<RowData> ROW_DATA_CDC_RECORD_ACCESSOR =
+        new HoodieCDCEngineRecordAccessor<RowData>() {
+          @Override
+          public String getOperation(RowData record) {
+            return record.getString(0).toString();
+          }
 
-    private GenericRecord cdcRecord;
+          @Override
+          public String getRecordKey(RowData record) {
+            return record.getString(1).toString();
+          }
+
+          @Override
+          public RowData getImage(RowData record, int ordinal, int imageArity) {
+            return record.isNullAt(ordinal) ? null : record.getRow(ordinal, imageArity);
+          }
+        };
+
+    private HoodieCDCLogRecordIterator<?> cdcItr;
+
+    private HoodieCDCLogRecord<?> cdcRecord;
     private RowData sideImage;
     private RowData currentImage;
 
     protected BaseImageIterator(
+        org.apache.flink.configuration.Configuration conf,
         org.apache.hadoop.conf.Configuration hadoopConf,
         String tablePath,
         HoodieSchema tableSchema,
@@ -390,20 +421,66 @@ public final class CdcIterators {
       this.requiredPos = computeRequiredPos(tableSchema, requiredSchema);
       this.recordBuilder = new GenericRecordBuilder(requiredSchema.getAvroSchema());
       this.avroToRowDataConverter = AvroToRowDataConverters.createRowConverter(requiredSchema, requiredRowType, true);
+      this.nativeCdcImageProjection = RowDataProjection.instance(requiredRowType, requiredPos);
+      this.nativeCdcImageArity = HoodieSchemaUtils.removeMetadataFields(tableSchema).getFields().size();
+      this.cdcItr = createCdcRecordIterator(
+          conf, hadoopConf, tablePath, cdcSchema, fileSplit);
+    }
 
-      StoragePath hadoopTablePath = new StoragePath(tablePath);
-      HoodieStorage storage = HoodieStorageUtils.getStorage(
-          tablePath, HadoopFSUtils.getStorageConf(hadoopConf));
-      HoodieLogFile[] cdcLogFiles = fileSplit.getCdcFiles().stream()
-          .map(cdcFile -> {
-            try {
-              return new HoodieLogFile(storage.getPathInfo(new StoragePath(hadoopTablePath, cdcFile)));
-            } catch (IOException e) {
-              throw new HoodieIOException("Failed to get file status for CDC log: " + cdcFile, e);
-            }
-          })
-          .toArray(HoodieLogFile[]::new);
-      this.cdcItr = new HoodieCDCLogRecordIterator(storage, cdcLogFiles, cdcSchema);
+    private static HoodieCDCLogRecordIterator<?> createCdcRecordIterator(
+        org.apache.flink.configuration.Configuration conf,
+        org.apache.hadoop.conf.Configuration hadoopConf,
+        String tablePath,
+        HoodieSchema cdcSchema,
+        HoodieCDCFileSplit fileSplit) {
+      if (isNativeCdcFileSplit(fileSplit)) {
+        return new HoodieCDCNativeLogRecordIterator<>(
+            fileSplit.getCdcFiles().iterator(),
+            cdcFile -> getNativeCdcFileIterator(conf, hadoopConf, tablePath, cdcFile, cdcSchema),
+            ROW_DATA_CDC_RECORD_ACCESSOR);
+      } else {
+        StoragePath hadoopTablePath = new StoragePath(tablePath);
+        HoodieStorage storage = HoodieStorageUtils.getStorage(
+            tablePath, HadoopFSUtils.getStorageConf(hadoopConf));
+        HoodieLogFile[] cdcLogFiles = fileSplit.getCdcFiles().stream()
+            .map(cdcFile -> {
+              try {
+                return new HoodieLogFile(storage.getPathInfo(new StoragePath(hadoopTablePath, cdcFile)));
+              } catch (IOException e) {
+                throw new HoodieIOException("Failed to get file status for CDC log: " + cdcFile, e);
+              }
+            })
+            .toArray(HoodieLogFile[]::new);
+        return new HoodieCDCInlineLogRecordIterator(storage, cdcLogFiles, cdcSchema);
+      }
+    }
+
+    private static ClosableIterator<RowData> getNativeCdcFileIterator(
+        org.apache.flink.configuration.Configuration conf,
+        org.apache.hadoop.conf.Configuration hadoopConf,
+        String tablePath,
+        String cdcFile,
+        HoodieSchema cdcSchema) {
+      try {
+        DataType cdcDataType = HoodieSchemaConverter.convertToDataType(cdcSchema);
+        RowType cdcRowType = (RowType) cdcDataType.getLogicalType();
+        return RecordIterators.getParquetRecordIterator(
+            InternalSchemaManager.DISABLED,
+            conf.get(FlinkOptions.READ_UTC_TIMEZONE),
+            true,
+            HadoopConfigurations.getParquetConf(conf, hadoopConf),
+            cdcRowType.getFieldNames().toArray(new String[0]),
+            cdcDataType.getChildren().toArray(new DataType[0]),
+            new LinkedHashMap<>(),
+            IntStream.range(0, cdcRowType.getFieldCount()).toArray(),
+            2048,
+            new org.apache.flink.core.fs.Path(new StoragePath(tablePath, cdcFile).toString()),
+            0,
+            Long.MAX_VALUE,
+            Collections.emptyList());
+      } catch (IOException e) {
+        throw new HoodieIOException("Failed to create native CDC record iterator for file: " + cdcFile, e);
+      }
     }
 
     private static int[] computeRequiredPos(HoodieSchema tableSchema, HoodieSchema requiredSchema) {
@@ -417,6 +494,14 @@ public final class CdcIterators {
           .toArray();
     }
 
+    private static boolean isNativeCdcFileSplit(HoodieCDCFileSplit fileSplit) {
+      boolean nativeCdc = FSUtils.matchNativeLogFile(fileSplit.getCdcFiles().get(0)).isPresent();
+      ValidationUtils.checkState(fileSplit.getCdcFiles().stream()
+              .allMatch(path -> FSUtils.matchNativeLogFile(path).isPresent() == nativeCdc),
+          "CDC file split cannot mix inline and native CDC log files");
+      return nativeCdc;
+    }
+
     @Override
     public boolean hasNext() {
       if (sideImage != null) {
@@ -424,17 +509,16 @@ public final class CdcIterators {
         sideImage = null;
         return true;
       } else if (cdcItr.hasNext()) {
-        cdcRecord = (GenericRecord) cdcItr.next();
-        String op = String.valueOf(cdcRecord.get(0));
-        resolveImage(op);
+        cdcRecord = cdcItr.next();
+        resolveImage(cdcRecord.getOperation());
         return true;
       }
       return false;
     }
 
-    protected abstract RowData getAfterImage(RowKind rowKind, GenericRecord cdcRecord);
+    protected abstract RowData getAfterImage(RowKind rowKind, HoodieCDCLogRecord<?> cdcRecord);
 
-    protected abstract RowData getBeforeImage(RowKind rowKind, GenericRecord cdcRecord);
+    protected abstract RowData getBeforeImage(RowKind rowKind, HoodieCDCLogRecord<?> cdcRecord);
 
     @Override
     public RowData next() {
@@ -473,6 +557,18 @@ public final class CdcIterators {
       resolved.setRowKind(rowKind);
       return resolved;
     }
+
+    protected RowData resolveImage(RowKind rowKind, HoodieCDCLogRecord<?> cdcRecord, int ordinal) {
+      if (!cdcRecord.isNative()) {
+        return resolveAvro(rowKind, (GenericRecord) cdcRecord.getAvroImage(ordinal));
+      }
+      RowData image = (RowData) cdcRecord.getEngineImage(ordinal, nativeCdcImageArity);
+      if (image == null) {
+        return null;
+      }
+      image.setRowKind(rowKind);
+      return nativeCdcImageProjection.project(image);
+    }
   }
 
   /**
@@ -481,6 +577,7 @@ public final class CdcIterators {
    */
   public static class BeforeAfterImageIterator extends BaseImageIterator {
     public BeforeAfterImageIterator(
+        org.apache.flink.configuration.Configuration conf,
         org.apache.hadoop.conf.Configuration hadoopConf,
         String tablePath,
         HoodieSchema tableSchema,
@@ -488,17 +585,17 @@ public final class CdcIterators {
         RowType requiredRowType,
         HoodieSchema cdcSchema,
         HoodieCDCFileSplit fileSplit) {
-      super(hadoopConf, tablePath, tableSchema, requiredSchema, requiredRowType, cdcSchema, fileSplit);
+      super(conf, hadoopConf, tablePath, tableSchema, requiredSchema, requiredRowType, cdcSchema, fileSplit);
     }
 
     @Override
-    protected RowData getAfterImage(RowKind rowKind, GenericRecord cdcRecord) {
-      return resolveAvro(rowKind, (GenericRecord) cdcRecord.get(3));
+    protected RowData getAfterImage(RowKind rowKind, HoodieCDCLogRecord<?> cdcRecord) {
+      return resolveImage(rowKind, cdcRecord, 3);
     }
 
     @Override
-    protected RowData getBeforeImage(RowKind rowKind, GenericRecord cdcRecord) {
-      return resolveAvro(rowKind, (GenericRecord) cdcRecord.get(2));
+    protected RowData getBeforeImage(RowKind rowKind, HoodieCDCLogRecord<?> cdcRecord) {
+      return resolveImage(rowKind, cdcRecord, 2);
     }
   }
 
@@ -514,6 +611,7 @@ public final class CdcIterators {
     protected final CdcImageManager imageManager;
 
     public BeforeImageIterator(
+        org.apache.flink.configuration.Configuration conf,
         org.apache.hadoop.conf.Configuration hadoopConf,
         String tablePath,
         HoodieSchema tableSchema,
@@ -524,7 +622,7 @@ public final class CdcIterators {
         HoodieSchema cdcSchema,
         HoodieCDCFileSplit fileSplit,
         CdcImageManager imageManager) throws IOException {
-      super(hadoopConf, tablePath, tableSchema, requiredSchema, requiredRowType, cdcSchema, fileSplit);
+      super(conf, hadoopConf, tablePath, tableSchema, requiredSchema, requiredRowType, cdcSchema, fileSplit);
       this.maxCompactionMemoryInBytes = maxCompactionMemoryInBytes;
       this.projection = RowDataProjection.instance(requiredRowType, requiredPositions);
       this.imageManager = imageManager;
@@ -539,16 +637,16 @@ public final class CdcIterators {
     }
 
     @Override
-    protected RowData getAfterImage(RowKind rowKind, GenericRecord cdcRecord) {
-      String recordKey = cdcRecord.get(1).toString();
+    protected RowData getAfterImage(RowKind rowKind, HoodieCDCLogRecord<?> cdcRecord) {
+      String recordKey = cdcRecord.getRecordKey();
       RowData row = imageManager.getImageRecord(recordKey, afterImages, rowKind);
       row.setRowKind(rowKind);
       return projection.project(row);
     }
 
     @Override
-    protected RowData getBeforeImage(RowKind rowKind, GenericRecord cdcRecord) {
-      return resolveAvro(rowKind, (GenericRecord) cdcRecord.get(2));
+    protected RowData getBeforeImage(RowKind rowKind, HoodieCDCLogRecord<?> cdcRecord) {
+      return resolveImage(rowKind, cdcRecord, 2);
     }
   }
 
@@ -561,6 +659,7 @@ public final class CdcIterators {
     protected ExternalSpillableMap<String, byte[]> beforeImages;
 
     public RecordKeyImageIterator(
+        org.apache.flink.configuration.Configuration conf,
         org.apache.hadoop.conf.Configuration hadoopConf,
         String tablePath,
         HoodieSchema tableSchema,
@@ -571,7 +670,7 @@ public final class CdcIterators {
         HoodieSchema cdcSchema,
         HoodieCDCFileSplit fileSplit,
         CdcImageManager imageManager) throws IOException {
-      super(hadoopConf, tablePath, tableSchema, requiredSchema, requiredRowType,
+      super(conf, hadoopConf, tablePath, tableSchema, requiredSchema, requiredRowType,
           requiredPositions, maxCompactionMemoryInBytes, cdcSchema, fileSplit, imageManager);
     }
 
@@ -585,8 +684,8 @@ public final class CdcIterators {
     }
 
     @Override
-    protected RowData getBeforeImage(RowKind rowKind, GenericRecord cdcRecord) {
-      String recordKey = cdcRecord.get(1).toString();
+    protected RowData getBeforeImage(RowKind rowKind, HoodieCDCLogRecord<?> cdcRecord) {
+      String recordKey = cdcRecord.getRecordKey();
       RowData row = imageManager.getImageRecord(recordKey, beforeImages, rowKind);
       row.setRowKind(rowKind);
       return projection.project(row);

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -39,7 +39,7 @@ import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode._
 import org.apache.hudi.common.table.log.{HoodieCDCEngineRecordAccessor, HoodieCDCInlineLogRecordIterator, HoodieCDCLogRecord, HoodieCDCLogRecordIterator, HoodieCDCNativeLogRecordIterator, HoodieMergedLogRecordReader}
 import org.apache.hudi.common.table.read.{BufferedRecord, BufferedRecordMerger, BufferedRecordMergerFactory, BufferedRecords, FileGroupReaderSchemaHandler, HoodieFileGroupReader, HoodieReadStats, IteratorMode, UpdateProcessor}
 import org.apache.hudi.common.table.read.buffer.KeyBasedFileGroupRecordBuffer
-import org.apache.hudi.common.util.{DefaultSizeEstimator, HoodieRecordUtils, Option}
+import org.apache.hudi.common.util.{DefaultSizeEstimator, HoodieRecordUtils, Option, ValidationUtils}
 import org.apache.hudi.common.util.collection.{ClosableIterator, ExternalSpillableMap}
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.data.CloseableIteratorListener
@@ -228,7 +228,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
   private lazy val cdcDataSparkSchema: StructType = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(
     HoodieSchemaUtils.removeMetadataFields(schema))
 
-  private lazy val nativeCdcTableSchemaOpt = {
+  private lazy val nativeCdcParquetSchemaOpt = {
     val hadoopConf = storage.getConf.unwrapAs(classOf[Configuration])
     val parquetSchema = getAvroSchemaConverter(hadoopConf).convert(cdcHoodieSchema)
     org.apache.hudi.common.util.Option.of(parquetSchema)
@@ -523,7 +523,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
     val pf = sparkPartitionedFileUtils.createPartitionedFile(
       InternalRow.empty, absCDCPath, 0, fileStatus.getLength)
     baseFileReader.read(pf, cdcSparkSchema, new StructType(),
-      org.apache.hudi.common.util.Option.empty(), Seq.empty, conf, nativeCdcTableSchemaOpt)
+      org.apache.hudi.common.util.Option.empty(), Seq.empty, conf, nativeCdcParquetSchemaOpt)
   }
 
   private val nativeCdcRecordAccessor = new HoodieCDCEngineRecordAccessor[InternalRow] {
@@ -535,7 +535,9 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
   }
 
   private def createCdcRecordIterator(fileSplit: HoodieCDCFileSplit): HoodieCDCLogRecordIterator[_] = {
-    if (isNativeCdcFileSplit(fileSplit)) {
+    if (fileSplit.getCdcFiles == null || fileSplit.getCdcFiles.isEmpty) {
+      HoodieCDCLogRecordIterator.empty()
+    } else if (isNativeCdcFileSplit(fileSplit)) {
       new HoodieCDCNativeLogRecordIterator[InternalRow](
         fileSplit.getCdcFiles.iterator(),
         cdcFile => ClosableIterator.wrap(readNativeCdcFile(cdcFile).asJava),
@@ -550,7 +552,8 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
 
   private def isNativeCdcFileSplit(fileSplit: HoodieCDCFileSplit): Boolean = {
     val nativeFlags = fileSplit.getCdcFiles.asScala.map(path => FSUtils.matchNativeLogFile(path).isPresent)
-    assert(nativeFlags.forall(_ == nativeFlags.head), "CDC file split cannot mix inline and native CDC log files")
+    ValidationUtils.checkState(nativeFlags.forall(_ == nativeFlags.head),
+      "CDC file split cannot mix inline and native CDC log files")
     nativeFlags.head
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
@@ -36,11 +36,11 @@ import org.apache.hudi.common.table.cdc.{HoodieCDCFileSplit, HoodieCDCUtils}
 import org.apache.hudi.common.table.cdc.HoodieCDCInferenceCase._
 import org.apache.hudi.common.table.cdc.HoodieCDCOperation._
 import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode._
-import org.apache.hudi.common.table.log.{HoodieCDCLogRecordIterator, HoodieMergedLogRecordReader}
+import org.apache.hudi.common.table.log.{HoodieCDCEngineRecordAccessor, HoodieCDCInlineLogRecordIterator, HoodieCDCLogRecord, HoodieCDCLogRecordIterator, HoodieCDCNativeLogRecordIterator, HoodieMergedLogRecordReader}
 import org.apache.hudi.common.table.read.{BufferedRecord, BufferedRecordMerger, BufferedRecordMergerFactory, BufferedRecords, FileGroupReaderSchemaHandler, HoodieFileGroupReader, HoodieReadStats, IteratorMode, UpdateProcessor}
 import org.apache.hudi.common.table.read.buffer.KeyBasedFileGroupRecordBuffer
 import org.apache.hudi.common.util.{DefaultSizeEstimator, HoodieRecordUtils, Option}
-import org.apache.hudi.common.util.collection.ExternalSpillableMap
+import org.apache.hudi.common.util.collection.{ClosableIterator, ExternalSpillableMap}
 import org.apache.hudi.config.HoodieWriteConfig
 import org.apache.hudi.data.CloseableIteratorListener
 import org.apache.hudi.io.util.FileIOUtils
@@ -52,7 +52,6 @@ import org.apache.parquet.avro.HoodieAvroParquetSchemaConverter.getAvroSchemaCon
 import org.apache.spark.Partition
 import org.apache.spark.sql.HoodieCatalystExpressionUtils.generateUnsafeProjection
 import org.apache.spark.sql.HoodieInternalRowUtils
-import org.apache.spark.sql.avro.HoodieAvroDeserializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Projection
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
@@ -153,13 +152,6 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
     org.apache.hudi.common.util.Option.empty[org.apache.parquet.schema.MessageType]()
   }
 
-  /**
-   * The deserializer used to convert the CDC GenericRecord to Spark InternalRow.
-   */
-  private lazy val cdcRecordDeserializer: HoodieAvroDeserializer = {
-    sparkAdapter.createAvroDeserializer(cdcHoodieSchema, cdcSparkSchema)
-  }
-
   private lazy val projection: Projection = generateUnsafeProjection(cdcSchema, requiredCdcSchema)
 
   // Iterator on cdc file
@@ -189,7 +181,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
   /**
    * Only one case where it will be used is that extract the change data from cdc log files.
    */
-  private var cdcLogRecordIterator: HoodieCDCLogRecordIterator = _
+  private var cdcRecordIterator: HoodieCDCLogRecordIterator[_] = HoodieCDCLogRecordIterator.empty()
 
   /**
    * The next record need to be returned when call next().
@@ -233,10 +225,21 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
   // images. Keyed by the record's schema id so schema evolution is handled correctly.
   private val cdcImageConverterMap: mutable.Map[Integer, (UnaryOperator[InternalRow], InternalRowToJsonStringConverter)] = mutable.Map.empty
 
+  private lazy val cdcDataSparkSchema: StructType = HoodieSchemaConversionUtils.convertHoodieSchemaToStructType(
+    HoodieSchemaUtils.removeMetadataFields(schema))
+
+  private lazy val nativeCdcTableSchemaOpt = {
+    val hadoopConf = storage.getConf.unwrapAs(classOf[Configuration])
+    val parquetSchema = getAvroSchemaConverter(hadoopConf).convert(cdcHoodieSchema)
+    org.apache.hudi.common.util.Option.of(parquetSchema)
+  }
+
+  private lazy val nativeCdcImageConverter = new InternalRowToJsonStringConverter(cdcDataSparkSchema)
+
   private def needLoadNextFile: Boolean = {
     !recordIter.hasNext &&
       !logRecordIter.hasNext &&
-      (cdcLogRecordIterator == null || !cdcLogRecordIterator.hasNext)
+      !cdcRecordIterator.hasNext
   }
 
   @tailrec final def hasNextInternal: Boolean = {
@@ -260,7 +263,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
             hasNextInternal
           }
         case AS_IS =>
-          if (cdcLogRecordIterator.hasNext && loadNext()) {
+          if (cdcRecordIterator.hasNext && loadNext()) {
             true
           } else {
             hasNextInternal
@@ -296,46 +299,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
       case LOG_FILE =>
         loaded = loadNextLogRecord()
       case AS_IS =>
-        val record = cdcLogRecordIterator.next().asInstanceOf[GenericRecord]
-        cdcSupplementalLoggingMode match {
-          case `DATA_BEFORE_AFTER` =>
-            recordToLoad.update(0, convertToUTF8String(String.valueOf(record.get(0))))
-            val before = record.get(2).asInstanceOf[GenericRecord]
-            recordToLoad.update(2, recordToJsonAsUTF8String(before))
-            val after = record.get(3).asInstanceOf[GenericRecord]
-            recordToLoad.update(3, recordToJsonAsUTF8String(after))
-          case `DATA_BEFORE` =>
-            val row = cdcRecordDeserializer.deserialize(record).get.asInstanceOf[InternalRow]
-            val op = row.getString(0)
-            val recordKey = row.getString(1)
-            recordToLoad.update(0, convertToUTF8String(op))
-            val before = record.get(2).asInstanceOf[GenericRecord]
-            recordToLoad.update(2, recordToJsonAsUTF8String(before))
-            parse(op) match {
-              case INSERT =>
-                recordToLoad.update(3, convertBufferedRecordToJsonString(afterImageRecords.get(recordKey)))
-              case UPDATE =>
-                recordToLoad.update(3, convertBufferedRecordToJsonString(afterImageRecords.get(recordKey)))
-              case _ =>
-                recordToLoad.update(3, null)
-            }
-          case _ =>
-            val row = cdcRecordDeserializer.deserialize(record).get.asInstanceOf[InternalRow]
-            val op = row.getString(0)
-            val recordKey = row.getString(1)
-            recordToLoad.update(0, convertToUTF8String(op))
-            parse(op) match {
-              case INSERT =>
-                recordToLoad.update(2, null)
-                recordToLoad.update(3, convertBufferedRecordToJsonString(afterImageRecords.get(recordKey)))
-              case UPDATE =>
-                recordToLoad.update(2, convertBufferedRecordToJsonString(beforeImageRecords(recordKey)))
-                recordToLoad.update(3, convertBufferedRecordToJsonString(afterImageRecords.get(recordKey)))
-              case _ =>
-                recordToLoad.update(2, convertBufferedRecordToJsonString(beforeImageRecords(recordKey)))
-                recordToLoad.update(3, null)
-            }
-        }
+        loadNextCdcRecord()
         loaded = true
       case REPLACE_COMMIT =>
         val originRecord = recordIter.next()
@@ -395,14 +359,12 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
     // reset all the iterator first.
     recordIter = Iterator.empty
     logRecordIter = Iterator.empty
+    cdcRecordIterator.close()
+    cdcRecordIterator = HoodieCDCLogRecordIterator.empty()
     keyBasedFileGroupRecordBuffer.ifPresent(k => k.close())
     keyBasedFileGroupRecordBuffer = Option.empty.asInstanceOf[Option[KeyBasedFileGroupRecordBuffer[InternalRow]]]
     beforeImageRecords.clear()
     afterImageRecords.clear()
-    if (cdcLogRecordIterator != null) {
-      cdcLogRecordIterator.close()
-      cdcLogRecordIterator = null
-    }
 
     if (cdcFileIter.hasNext) {
       val split = cdcFileIter.next()
@@ -444,10 +406,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
             }
           }
 
-          val cdcLogFiles = currentCDCFileSplit.getCdcFiles.asScala.map { cdcFile =>
-            new HoodieLogFile(storage.getPathInfo(new StoragePath(basePath, cdcFile)))
-          }.toArray
-          cdcLogRecordIterator = new HoodieCDCLogRecordIterator(storage, cdcLogFiles, cdcHoodieSchema)
+          cdcRecordIterator = createCdcRecordIterator(currentCDCFileSplit)
         case REPLACE_COMMIT =>
           if (currentCDCFileSplit.getBeforeFileSlice.isPresent) {
             loadBeforeFileSliceIfNeeded(currentCDCFileSplit.getBeforeFileSlice.get)
@@ -558,6 +517,88 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
     CloseableIteratorListener.addListener(keyBasedFileGroupRecordBuffer.get().getLogRecordIterator).asScala
   }
 
+  private def readNativeCdcFile(cdcFile: String): Iterator[InternalRow] = {
+    val absCDCPath = new StoragePath(basePath, cdcFile)
+    val fileStatus = storage.getPathInfo(absCDCPath)
+    val pf = sparkPartitionedFileUtils.createPartitionedFile(
+      InternalRow.empty, absCDCPath, 0, fileStatus.getLength)
+    baseFileReader.read(pf, cdcSparkSchema, new StructType(),
+      org.apache.hudi.common.util.Option.empty(), Seq.empty, conf, nativeCdcTableSchemaOpt)
+  }
+
+  private val nativeCdcRecordAccessor = new HoodieCDCEngineRecordAccessor[InternalRow] {
+    override def getOperation(record: InternalRow): String = record.getString(0)
+    override def getRecordKey(record: InternalRow): String = record.getString(1)
+    override def getImage(record: InternalRow, ordinal: Int, imageArity: Int): InternalRow = {
+      if (record.isNullAt(ordinal)) null else record.getStruct(ordinal, imageArity)
+    }
+  }
+
+  private def createCdcRecordIterator(fileSplit: HoodieCDCFileSplit): HoodieCDCLogRecordIterator[_] = {
+    if (isNativeCdcFileSplit(fileSplit)) {
+      new HoodieCDCNativeLogRecordIterator[InternalRow](
+        fileSplit.getCdcFiles.iterator(),
+        cdcFile => ClosableIterator.wrap(readNativeCdcFile(cdcFile).asJava),
+        nativeCdcRecordAccessor)
+    } else {
+      val cdcLogFiles = fileSplit.getCdcFiles.asScala.map { cdcFile =>
+        new HoodieLogFile(storage.getPathInfo(new StoragePath(basePath, cdcFile)))
+      }.toArray
+      new HoodieCDCInlineLogRecordIterator(storage, cdcLogFiles, cdcHoodieSchema)
+    }
+  }
+
+  private def isNativeCdcFileSplit(fileSplit: HoodieCDCFileSplit): Boolean = {
+    val nativeFlags = fileSplit.getCdcFiles.asScala.map(path => FSUtils.matchNativeLogFile(path).isPresent)
+    assert(nativeFlags.forall(_ == nativeFlags.head), "CDC file split cannot mix inline and native CDC log files")
+    nativeFlags.head
+  }
+
+  private def loadNextCdcRecord(): Unit = {
+    val record = cdcRecordIterator.next()
+    cdcSupplementalLoggingMode match {
+      case `DATA_BEFORE_AFTER` =>
+        recordToLoad.update(0, convertToUTF8String(record.getOperation))
+        recordToLoad.update(2, cdcRecordImageToJson(record, 2))
+        recordToLoad.update(3, cdcRecordImageToJson(record, 3))
+      case `DATA_BEFORE` =>
+        recordToLoad.update(0, convertToUTF8String(record.getOperation))
+        recordToLoad.update(2, cdcRecordImageToJson(record, 2))
+        parse(record.getOperation) match {
+          case INSERT | UPDATE =>
+            recordToLoad.update(3, convertBufferedRecordToJsonString(afterImageRecords.get(record.getRecordKey)))
+          case _ =>
+            recordToLoad.update(3, null)
+        }
+      case _ =>
+        loadNextKeyOnlyCdcRecord(record)
+    }
+  }
+
+  private def loadNextKeyOnlyCdcRecord(record: HoodieCDCLogRecord[_]): Unit = {
+    recordToLoad.update(0, convertToUTF8String(record.getOperation))
+    parse(record.getOperation) match {
+      case INSERT =>
+        recordToLoad.update(2, null)
+        recordToLoad.update(3, convertBufferedRecordToJsonString(afterImageRecords.get(record.getRecordKey)))
+      case UPDATE =>
+        recordToLoad.update(2, convertBufferedRecordToJsonString(beforeImageRecords(record.getRecordKey)))
+        recordToLoad.update(3, convertBufferedRecordToJsonString(afterImageRecords.get(record.getRecordKey)))
+      case _ =>
+        recordToLoad.update(2, convertBufferedRecordToJsonString(beforeImageRecords(record.getRecordKey)))
+        recordToLoad.update(3, null)
+    }
+  }
+
+  private def cdcRecordImageToJson(record: HoodieCDCLogRecord[_], ordinal: Int): UTF8String = {
+    if (record.isNative) {
+      val image = record.getEngineImage(ordinal, cdcDataSparkSchema.length).asInstanceOf[InternalRow]
+      if (image == null) null else nativeCdcImageConverter.convert(image)
+    } else {
+      recordToJsonAsUTF8String(record.getAvroImage(ordinal).asInstanceOf[GenericRecord])
+    }
+  }
+
   /**
    * Convert InternalRow to json string.
    */
@@ -586,7 +627,11 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
   }
 
   private def recordToJsonAsUTF8String(record: GenericRecord): UTF8String = {
-    convertToUTF8String(HoodieCDCUtils.recordToJson(record))
+    if (record == null) {
+      null
+    } else {
+      convertToUTF8String(HoodieCDCUtils.recordToJson(record))
+    }
   }
 
   private def merge(currentRecord: BufferedRecord[InternalRow], newRecord: BufferedRecord[InternalRow]): BufferedRecord[InternalRow] = {
@@ -605,15 +650,14 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
   override def close(): Unit = {
     recordIter = Iterator.empty
     logRecordIter = Iterator.empty
+    cdcRecordIterator.close()
+    cdcRecordIterator = HoodieCDCLogRecordIterator.empty()
     keyBasedFileGroupRecordBuffer.ifPresent(k => k.close())
     keyBasedFileGroupRecordBuffer = Option.empty.asInstanceOf[Option[KeyBasedFileGroupRecordBuffer[InternalRow]]]
     beforeImageRecords.clear()
     afterImageRecords.clear()
-    if (cdcLogRecordIterator != null) {
-      cdcLogRecordIterator.close()
-      cdcLogRecordIterator = null
-    }
   }
+
 }
 
 object CDCFileGroupIterator {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This closes #19088 

Hudi CDC readers had inline CDC log iteration tied to Avro log blocks, while native CDC log files need to be read as engine-specific records. This made Spark and Flink CDC readers handle CDC log formats through separate code paths instead of a shared record abstraction.

This PR adds a normalized CDC log record iterator layer that can represent both inline Avro CDC records and native CDC records, then wires Spark and Flink CDC AS_IS readers through that abstraction.

### Summary and Changelog

CDC readers can now consume native CDC log files while keeping inline CDC log support behind the same iterator contract.

- Added common CDC abstractions: `HoodieCDCLogRecord`, `HoodieCDCLogRecordIterator`, and `HoodieCDCEngineRecordAccessor`.
- Moved existing inline CDC log reading into `HoodieCDCInlineLogRecordIterator`.
- Added `HoodieCDCNativeLogRecordIterator` for native CDC log files backed by engine-specific row iterators.
- Updated Spark `CDCFileGroupIterator` to detect native CDC log files, read them as `InternalRow`, and convert native before/after images to CDC JSON output.
- Updated Flink `CdcIterators` to choose inline or native CDC iterators internally and project native `RowData` images for required schemas.
- Removed the need to pass native CDC iterator functions through Flink CDC reader call sites.
- Added `TestHoodieCDCNativeLogRecordIterator` covering cross-file iteration, empty native files, close behavior, null iterator validation, and empty iterator behavior.

### Impact

This affects CDC read paths for Spark and Flink, specifically AS_IS CDC file splits using supplemental logging modes. Inline CDC log files remain supported through the new inline iterator implementation, while native CDC log files are now readable through the same normalized record interface.

No storage format is changed by this PR. The change introduces common-layer CDC iterator interfaces/classes and updates internal reader behavior, but does not add a new user-facing config or default.

### Risk Level

medium

The change touches shared CDC reader logic across `hudi-common`, Spark CDC reading, and Flink CDC reading. The main risks are incorrect image extraction/projection for native CDC rows or regressions in inline CDC handling.

Validation performed:
- `mvn -pl hudi-common -am -DskipTests -DskipITs compile`
- `mvn -pl hudi-spark-datasource/hudi-spark-common -am -DskipTests -DskipITs -Dscala-2.12 compile`
- `mvn -pl hudi-flink-datasource/hudi-flink -am -DskipTests -DskipITs -Drat.skip=true compile`
- `mvn -pl hudi-common -DskipITs -Dtest=TestHoodieCDCNativeLogRecordIterator test`
- `git diff --check`
- `git diff --cached --check`

### Documentation Update

none

No new user-facing option, default, or storage format is introduced. This extends existing CDC read support to native CDC log files through internal reader abstractions.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable