### PR TITLE
fix(streamer): write non-partitioned sample-writes table for record-size estimation

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
@@ -25,6 +25,7 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -44,6 +45,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.SAMPLE_WRITES_FOLDER_PATH;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
@@ -108,7 +110,14 @@ public class SparkSampleWritesUtils {
     try (SparkRDDWriteClient sampleWriteClient = new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), sampleWriteConfig, Option.empty())) {
       int size = writeConfig.getIntOrDefault(SAMPLE_WRITES_SIZE);
       return recordsOpt.map(records -> {
-        List<HoodieRecord> samples = records.coalesce(1).take(size);
+        // Rewrite each record with an empty partition path so the sample-writes table is
+        // effectively non-partitioned. The bulk-insert writer routes records to files by
+        // HoodieRecord.getPartitionPath(); without this, an input that spans many source
+        // partitions fans out into many tiny files even though parallelism is 1, slowing
+        // the sample write and inflating per-file metadata in the size estimate.
+        List<HoodieRecord> samples = records.coalesce(1).take(size).stream()
+            .map(r -> r.newInstance(new HoodieKey(r.getRecordKey(), "")))
+            .collect(Collectors.toList());
         if (samples.isEmpty()) {
           return emptyRes;
         }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/SparkSampleWritesUtils.java
@@ -110,11 +110,8 @@ public class SparkSampleWritesUtils {
     try (SparkRDDWriteClient sampleWriteClient = new SparkRDDWriteClient(new HoodieSparkEngineContext(jsc), sampleWriteConfig, Option.empty())) {
       int size = writeConfig.getIntOrDefault(SAMPLE_WRITES_SIZE);
       return recordsOpt.map(records -> {
-        // Rewrite each record with an empty partition path so the sample-writes table is
-        // effectively non-partitioned. The bulk-insert writer routes records to files by
-        // HoodieRecord.getPartitionPath(); without this, an input that spans many source
-        // partitions fans out into many tiny files even though parallelism is 1, slowing
-        // the sample write and inflating per-file metadata in the size estimate.
+        // Empty partition path so all sampled records write to a single non-partitioned file,
+        // instead of fanning out into one tiny file per source partition and skewing the estimate.
         List<HoodieRecord> samples = records.coalesce(1).take(size).stream()
             .map(r -> r.newInstance(new HoodieKey(r.getRecordKey(), "")))
             .collect(Collectors.toList());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
@@ -32,12 +32,19 @@ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 import org.apache.hudi.utilities.config.HoodieStreamerConfig;
 import org.apache.hudi.utilities.streamer.SparkSampleWritesUtils;
 
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -86,7 +93,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
   }
 
   @Test
-  public void overwriteRecordSizeEstimateForEmptyTable() {
+  public void overwriteRecordSizeEstimateForEmptyTable() throws IOException {
     int originalRecordSize = 100;
     TypedProperties props = new TypedProperties();
     props.put(HoodieStreamerConfig.SAMPLE_WRITES_ENABLED.key(), "true");
@@ -99,9 +106,70 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
         .build();
 
     String commitTime = HoodieTestDataGenerator.getCommitTimeAtUTC(1);
+    // dataGen round-robins across the three DEFAULT_PARTITION_PATHS, so the input spans
+    // multiple source partitions. The sample-writes table must still write non-partitioned.
     JavaRDD<HoodieRecord> records = jsc().parallelize(dataGen.generateInserts(commitTime, 2000), 2);
     Option<HoodieWriteConfig> writeConfigOpt = SparkSampleWritesUtils.getWriteConfigWithRecordSizeEstimate(jsc(), Option.of(records), originalWriteConfig);
     assertTrue(writeConfigOpt.isPresent());
-    assertEquals(779.0, writeConfigOpt.get().getCopyOnWriteRecordSizeEstimate(), 10.0);
+    // The 2000 records now land in a single non-partitioned file instead of being diluted
+    // across the three source partitions, so the per-record estimate is lower and more
+    // accurate (one parquet footer/dictionary amortized over all records) than the previous
+    // multi-file value of ~779.
+    assertEquals(337.0, writeConfigOpt.get().getCopyOnWriteRecordSizeEstimate(), 10.0);
+    assertSampleWritesNonPartitioned();
+  }
+
+  @Test
+  public void sampleWritesAreNonPartitionedEvenForManyPartitionInput() throws IOException {
+    int recordsPerPartition = 50;
+    String[] partitionPaths = IntStream.range(0, 20)
+        .mapToObj(i -> String.format("year=2024/month=01/day=%02d", i + 1))
+        .toArray(String[]::new);
+    HoodieTestDataGenerator manyPartitionGen = new HoodieTestDataGenerator(partitionPaths);
+
+    TypedProperties props = new TypedProperties();
+    props.put(HoodieStreamerConfig.SAMPLE_WRITES_ENABLED.key(), "true");
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withProperties(props)
+        .forTable("foo")
+        .withPath(basePath())
+        .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+        .build();
+
+    String commitTime = HoodieTestDataGenerator.getCommitTimeAtUTC(1);
+    List<HoodieRecord> allRecords = new ArrayList<>();
+    for (String partition : partitionPaths) {
+      allRecords.addAll(manyPartitionGen.generateInsertsForPartition(commitTime, recordsPerPartition, partition));
+    }
+    JavaRDD<HoodieRecord> records = jsc().parallelize(allRecords, 4);
+
+    Option<HoodieWriteConfig> writeConfigOpt = SparkSampleWritesUtils.getWriteConfigWithRecordSizeEstimate(jsc(), Option.of(records), writeConfig);
+    assertTrue(writeConfigOpt.isPresent(), "Sample write should produce a record-size estimate.");
+    assertSampleWritesNonPartitioned();
+  }
+
+  /**
+   * Walks the sample-writes folder and fails if any data files were placed under a
+   * source-partition subdirectory. A non-partitioned sample-writes table places its data
+   * files directly under each run directory; a partitioned write would fan them out across
+   * subdirectories named after the source partition paths.
+   */
+  private void assertSampleWritesNonPartitioned() throws IOException {
+    Path sampleWritesPath = new Path(basePath(), ".hoodie/.aux/.sample_writes");
+    FileSystem fs = sampleWritesPath.getFileSystem(jsc().hadoopConfiguration());
+    assertTrue(fs.exists(sampleWritesPath), "Sample-writes folder should exist after a sample write.");
+    FileStatus[] runs = fs.listStatus(sampleWritesPath);
+    assertTrue(runs.length > 0, "Sample-writes folder should contain at least one run.");
+    for (FileStatus run : runs) {
+      List<String> partitionDirs = new ArrayList<>();
+      for (FileStatus entry : fs.listStatus(run.getPath())) {
+        if (entry.isDirectory() && !entry.getPath().getName().equals(".hoodie")) {
+          partitionDirs.add(entry.getPath().getName());
+        }
+      }
+      assertTrue(partitionDirs.isEmpty(),
+          "Sample-writes run at " + run.getPath() + " should have no source partition subdirectories, but found: "
+              + Arrays.toString(partitionDirs.toArray()));
+    }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
@@ -93,7 +93,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
   }
 
   @Test
-  public void overwriteRecordSizeEstimateForEmptyTable() throws IOException {
+  void overwriteRecordSizeEstimateForEmptyTable() throws IOException {
     int originalRecordSize = 100;
     TypedProperties props = new TypedProperties();
     props.put(HoodieStreamerConfig.SAMPLE_WRITES_ENABLED.key(), "true");
@@ -115,7 +115,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
   }
 
   @Test
-  public void sampleWritesAreNonPartitionedEvenForManyPartitionInput() throws IOException {
+  void sampleWritesAreNonPartitionedEvenForManyPartitionInput() throws IOException {
     int recordsPerPartition = 50;
     String[] partitionPaths = IntStream.range(0, 20)
         .mapToObj(i -> String.format("year=2024/month=01/day=%02d", i + 1))

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
@@ -106,15 +106,10 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
         .build();
 
     String commitTime = HoodieTestDataGenerator.getCommitTimeAtUTC(1);
-    // dataGen round-robins across the three DEFAULT_PARTITION_PATHS, so the input spans
-    // multiple source partitions. The sample-writes table must still write non-partitioned.
+    // Input spans multiple source partitions; the sample-writes table must still be non-partitioned.
     JavaRDD<HoodieRecord> records = jsc().parallelize(dataGen.generateInserts(commitTime, 2000), 2);
     Option<HoodieWriteConfig> writeConfigOpt = SparkSampleWritesUtils.getWriteConfigWithRecordSizeEstimate(jsc(), Option.of(records), originalWriteConfig);
     assertTrue(writeConfigOpt.isPresent());
-    // The 2000 records now land in a single non-partitioned file instead of being diluted
-    // across the three source partitions, so the per-record estimate is lower and more
-    // accurate (one parquet footer/dictionary amortized over all records) than the previous
-    // multi-file value of ~779.
     assertEquals(337.0, writeConfigOpt.get().getCopyOnWriteRecordSizeEstimate(), 10.0);
     assertSampleWritesNonPartitioned();
   }
@@ -149,10 +144,8 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
   }
 
   /**
-   * Walks the sample-writes folder and fails if any data files were placed under a
-   * source-partition subdirectory. A non-partitioned sample-writes table places its data
-   * files directly under each run directory; a partitioned write would fan them out across
-   * subdirectories named after the source partition paths.
+   * Fails if the sample-writes folder contains any source-partition subdirectory, i.e. the
+   * sample write was not flattened into a single non-partitioned file.
    */
   private void assertSampleWritesNonPartitioned() throws IOException {
     Path sampleWritesPath = new Path(basePath(), ".hoodie/.aux/.sample_writes");

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestSparkSampleWritesUtils.java
@@ -42,10 +42,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.apache.hudi.common.table.HoodieTableMetaClient.SAMPLE_WRITES_FOLDER_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -148,7 +148,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
    * sample write was not flattened into a single non-partitioned file.
    */
   private void assertSampleWritesNonPartitioned() throws IOException {
-    Path sampleWritesPath = new Path(basePath(), ".hoodie/.aux/.sample_writes");
+    Path sampleWritesPath = new Path(basePath(), SAMPLE_WRITES_FOLDER_PATH);
     FileSystem fs = sampleWritesPath.getFileSystem(jsc().hadoopConfiguration());
     assertTrue(fs.exists(sampleWritesPath), "Sample-writes folder should exist after a sample write.");
     FileStatus[] runs = fs.listStatus(sampleWritesPath);
@@ -162,7 +162,7 @@ public class TestSparkSampleWritesUtils extends SparkClientFunctionalTestHarness
       }
       assertTrue(partitionDirs.isEmpty(),
           "Sample-writes run at " + run.getPath() + " should have no source partition subdirectories, but found: "
-              + Arrays.toString(partitionDirs.toArray()));
+              + partitionDirs);
     }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When `hoodie.streamer.sample.writes.enabled` is on, the first batch's sample write estimates the average record size by writing a sample to the auxiliary `.hoodie/.aux/.sample_writes` table. The sample bulk insert runs with parallelism 1, but it routes each record to a file by the record's partition path. When the incoming batch spans many source partitions, the write fans out into one tiny file per partition, which slows the sample write and inflates the per-record size estimate through per-file metadata overhead.

### Summary and Changelog

Rewrite each sampled record with an empty partition path before the sample bulk insert, so the auxiliary sample-writes table is effectively non-partitioned and all sampled records land in a single file. The sample write is faster and the record-size estimate is more accurate (one parquet footer/dictionary amortized over all records instead of one per source partition).

- `SparkSampleWritesUtils.doSampleWrites`: map each record to `newInstance(new HoodieKey(recordKey, ""))` before the bulk insert.
- `TestSparkSampleWritesUtils`: assert the sample-writes folder has no source-partition subdirectories, and add a test with 20 source partitions. The empty-table estimate adjusts from ~779 to ~337 to reflect the single-file layout.

### Impact

No public API or config change. Faster and more accurate first-batch record-size estimation for partitioned sources that use Hudi Streamer sample writes.

### Risk Level

low

The change only affects the throwaway sample-writes table used for size estimation. The estimate is derived from write-stat byte and record counts (partition-agnostic), so flattening the layout does not change correctness. Covered by unit tests including a 20-partition case.

### Documentation Update

none

### Contributor's checklist

- [x] Read through contributor's guide
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
