### PR TITLE
feat(flink): Add pendingCommitInstantCount metric for write coordinator

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkWriteCoordinatorMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkWriteCoordinatorMetrics.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+
+import java.util.function.IntSupplier;
+
+/**
+ * Metrics for Flink stream write operator coordinator.
+ */
+public class FlinkWriteCoordinatorMetrics extends HoodieFlinkMetrics {
+
+  private static final String PENDING_COMMIT_INSTANT_COUNT = "pendingCommitInstantCount";
+
+  private final IntSupplier pendingCommitInstantCountSupplier;
+
+  public FlinkWriteCoordinatorMetrics(
+      MetricGroup metricGroup,
+      IntSupplier pendingCommitInstantCountSupplier) {
+    super(metricGroup);
+    this.pendingCommitInstantCountSupplier = pendingCommitInstantCountSupplier;
+  }
+
+  @Override
+  public void registerMetrics() {
+    metricGroup.gauge(PENDING_COMMIT_INSTANT_COUNT, pendingCommitInstantCountSupplier::getAsInt);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -35,6 +35,7 @@ import org.apache.hudi.configuration.OptionsResolver;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.hive.HiveSyncTool;
+import org.apache.hudi.metrics.FlinkWriteCoordinatorMetrics;
 import org.apache.hudi.sink.common.AbstractStreamWriteFunction;
 import org.apache.hudi.sink.event.Correspondent;
 import org.apache.hudi.sink.event.WriteMetadataEvent;
@@ -166,6 +167,11 @@ public class StreamWriteOperatorCoordinator
   private transient EventBuffers eventBuffers;
 
   /**
+   * Metrics for the coordinator.
+   */
+  private transient FlinkWriteCoordinatorMetrics metrics;
+
+  /**
    * Task number of the operator.
    */
   private final int parallelism;
@@ -221,6 +227,8 @@ public class StreamWriteOperatorCoordinator
     // reference: https://stackoverflow.com/questions/1771679/difference-between-threads-context-class-loader-and-normal-classloader
     Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
     initEventBufferIfNecessary();
+    this.metrics = new FlinkWriteCoordinatorMetrics(context.metricGroup(), this::getPendingCommitInstantCount);
+    this.metrics.registerMetrics();
     this.tableState = TableState.create(conf);
     this.gateways = new SubtaskGateway[this.parallelism];
     try {
@@ -505,6 +513,11 @@ public class StreamWriteOperatorCoordinator
     }
     // initialize event buffer
     this.eventBuffers = EventBuffers.getInstance(conf, this.parallelism);
+  }
+
+  @VisibleForTesting
+  int getPendingCommitInstantCount() {
+    return this.eventBuffers == null ? 0 : this.eventBuffers.getAllCompletedEvents().size();
   }
 
   private String startInstant() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/EventBuffers.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/utils/EventBuffers.java
@@ -171,7 +171,7 @@ public class EventBuffers implements Serializable {
    */
   public Map<Long, Pair<String, EventBuffer>> getAllCompletedEvents() {
     return this.eventBuffers.entrySet().stream()
-        .filter(entry -> entry.getValue().getRight().allEventsCompleted())
+        .filter(entry -> entry.getValue().getRight().allEventsCompleted() && !entry.getValue().getRight().isEmptyDataWriteBuffer())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkWriteCoordinatorMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/metrics/TestFlinkWriteCoordinatorMetrics.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.hudi.sink.event.WriteMetadataEvent;
+import org.apache.hudi.sink.utils.EventBuffers;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for {@link FlinkWriteCoordinatorMetrics}.
+ */
+class TestFlinkWriteCoordinatorMetrics {
+
+  @Test
+  void testPendingCommitInstantCountGauge() {
+    CapturingMetricGroup metricGroup = new CapturingMetricGroup();
+    EventBuffers eventBuffers = EventBuffers.getInstance(new Configuration(), 2);
+    FlinkWriteCoordinatorMetrics metrics = new FlinkWriteCoordinatorMetrics(
+        metricGroup, () -> eventBuffers.getAllCompletedEvents().size());
+
+    metrics.registerMetrics();
+
+    Gauge<?> gauge = metricGroup.getGauge("pendingCommitInstantCount");
+    assertNotNull(gauge);
+    assertEquals(0, gauge.getValue());
+
+    eventBuffers.initNewEventBuffer(1L, "001");
+    eventBuffers.addEventToBuffer(completedEvent(0));
+    eventBuffers.addEventToBuffer(completedEvent(1));
+    assertEquals(1, gauge.getValue());
+
+    eventBuffers.reset(1L);
+    assertEquals(0, gauge.getValue());
+  }
+
+  private static WriteMetadataEvent completedEvent(int taskId) {
+    return WriteMetadataEvent.builder()
+        .taskID(taskId)
+        .checkpointId(1L)
+        .instantTime("001")
+        .writeStatus(Collections.emptyList())
+        .lastBatch(true)
+        .build();
+  }
+
+  private static class CapturingMetricGroup extends UnregisteredMetricsGroup {
+    private final Map<String, Gauge<?>> gauges = new HashMap<>();
+
+    @Override
+    public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+      gauges.put(name, gauge);
+      return gauge;
+    }
+
+    Gauge<?> getGauge(String name) {
+      return gauges.get(name);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestStreamWriteOperatorCoordinator.java
@@ -106,7 +106,7 @@ public class TestStreamWriteOperatorCoordinator {
 
   @BeforeEach
   public void before() throws Exception {
-    coordinator = createCoordinator(TestConfigurations.getDefaultConf(tempFile.getAbsolutePath()), 2);
+    coordinator = createCoordinator(TestConfigurations.getDefaultConf("file://" + tempFile.getAbsolutePath()), 2);
   }
 
   @AfterEach
@@ -131,6 +131,25 @@ public class TestStreamWriteOperatorCoordinator {
     assertThat("Instant should be complete", lastCompleted, is(instant));
     assertNotEquals("", inflight, "Should start a new instant");
     assertNotEquals(instant, inflight, "Should start a new instant");
+  }
+
+  @Test
+  void testPendingCommitInstantCount() {
+    requestInstantTime(-1);
+    String instant = coordinator.getInstant();
+
+    // no event received, no pending commit instants
+    assertEquals(0, coordinator.getPendingCommitInstantCount());
+
+    OperatorEvent event0 = createOperatorEvent(0, instant, "par1", true, 0.1);
+    OperatorEvent event1 = createOperatorEvent(1, instant, "par2", true, 0.2);
+    coordinator.handleEventFromOperator(0, event0);
+    coordinator.handleEventFromOperator(1, event1);
+
+    assertEquals(1, coordinator.getPendingCommitInstantCount());
+
+    coordinator.notifyCheckpointComplete(1);
+    assertEquals(0, coordinator.getPendingCommitInstantCount());
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Flink stream writes currently do not expose coordinator-side visibility into how many write instants are waiting to be committed. This PR adds a write coordinator metric for pending commit instants and wires it directly to the coordinator's completed event buffers.

Fixes #19116 

### Summary and Changelog
- Added `FlinkWriteCoordinatorMetrics` to register the `pendingCommitInstantCount` gauge.
- Wired `StreamWriteOperatorCoordinator` to register coordinator metrics on start and expose the pending commit instant count for testing.
- Updated `EventBuffers#getAllCompletedEvents` to exclude empty data-write buffers from the completed-events count.
- Added coverage in `TestFlinkWriteCoordinatorMetrics` for gauge registration and dynamic gauge values.
- Added coordinator-level coverage in `TestStreamWriteOperatorCoordinator` to verify pending commit count before and after checkpoint completion.

### Impact
Adds a new Flink write coordinator metric, `pendingCommitInstantCount`, for observing completed instants pending commit.

### Risk Level

low. 

### Documentation Update

Not included in this commit. If Flink write coordinator metrics are documented in a metrics reference, `pendingCommitInstantCount` should be added there.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable