### PR TITLE
fix(ci): cap UT_FT_10 reactor install to -T 1 to avoid GCLocker-induced compile OOM

### DIFF
--- a/azure-pipelines-20230430.yml
+++ b/azure-pipelines-20230430.yml
@@ -515,17 +515,21 @@ stages:
               containerRegistry: 'apachehudi-docker-hub'
               repository: 'apachehudi/hudi-ci-bundle-validation-base'
               command: 'run'
-              # UT_FT_10 builds the full reactor with `clean install`. Under the
-              # shared MVN_OPTS_INSTALL `-T 3`, concurrent module builds (notably
-              # parallel maven-shade of large bundles) can spike heap past the 8g
-              # ceiling and flakily OOM. Prepend `-T 2` below so Maven (first -T
-              # wins) caps concurrency for THIS job's install only; other jobs
-              # keep the shared -T 3.
+              # UT_FT_10 builds the full reactor with `clean install`. javac runs
+              # in-process in this job's single MAVEN_OPTS='-Xmx8g' JVM, so concurrent
+              # module builds (parallel maven-shade of large bundles + javac reading
+              # huge classpaths via zipfs) do heavy native zip work. That work holds
+              # JNI-critical sections which block the GC (see the "Retried waiting for
+              # GCLocker too often" warnings preceding the OOM): garbage piles up
+              # uncollected and the heap is exhausted even though the live set is small.
+              # A prior `-T 2` cap reduced but did not eliminate this (it recurred while
+              # compiling hudi-cli-bundle). Prepend `-T 1` below so Maven (first -T wins)
+              # serializes THIS job's install only; other jobs keep the shared -T 3.
               arguments: >
                 -v $(Build.SourcesDirectory):/hudi
                 -v /var/run/docker.sock:/var/run/docker.sock
                 -i docker.io/apachehudi/hudi-ci-bundle-validation-base:$(Build.BuildId)
-                /bin/bash -c "MAVEN_OPTS='-Xmx8g' mvn clean install -T 2 $(MVN_OPTS_INSTALL) -Phudi-platform-service -Pthrift-gen-source
+                /bin/bash -c "MAVEN_OPTS='-Xmx8g' mvn clean install -T 1 $(MVN_OPTS_INSTALL) -Phudi-platform-service -Pthrift-gen-source
                 && mvn test  $(MVN_OPTS_TEST) -Punit-tests -Dsurefire.failIfNoSpecifiedTests=false $(JACOCO_AGENT_DESTFILE1_ARG) -pl $(JOB10_UT_MODULES)
                 && mvn test  $(MVN_OPTS_TEST) -Punit-tests $(JACOCO_AGENT_DESTFILE2_ARG) -Dtest="!TestHoodie*" -Dsurefire.failIfNoSpecifiedTests=false -pl hudi-utilities
                 && mvn test  $(MVN_OPTS_TEST) -Pfunctional-tests -Dsurefire.failIfNoSpecifiedTests=false  $(JACOCO_AGENT_DESTFILE3_ARG) -pl $(JOB10_FT_MODULES)"


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Azure CI job "UT FT common & other modules" (UT_FT_10) intermittently fails during its initial `mvn clean install` reactor build with `java.lang.OutOfMemoryError: Java heap space`, surfaced as a generic `[ERROR] An unknown compilation problem occurred` from the maven-compiler-plugin. The OOM happens while compiling a large packaging bundle (the stack trace is in `jdk.nio.zipfs.ZipFileSystem.initCEN`), before any test runs, so it is a spurious infra failure unrelated to the code under test. Recent occurrences: buildId 15037 (on PR #19117, compiling `hudi-cli-bundle`) https://dev.azure.com/apachehudi/a1a51da7-8592-47d4-88dc-fd67bed336bb/_build/results?buildId=15037 and buildId 14704 (on PR #19004, compiling `hudi-kafka-connect-bundle`).

### Summary and Changelog

javac runs in-process in this job's single `MAVEN_OPTS='-Xmx8g'` JVM (`JavaxToolsCompiler.compileInProcess` is in the OOM stack). Under a parallel reactor build, concurrent maven-shade of large bundles plus javac reading huge classpaths via zipfs perform heavy native zip work that holds JNI-critical sections and blocks the GC (the log shows "Retried waiting for GCLocker too often" right before the OOM). Garbage then accumulates uncollected and the 8g heap is exhausted even though the live set is small (a full `clean install` peaks around 2.4 GB locally). A previous `-T 2` cap (#19008) reduced but did not eliminate the issue; it recurred on a different bundle.

- Change the prepended parallelism cap for the UT_FT_10 install from `-T 2` to `-T 1` so Maven (first `-T` wins) serializes this single job's reactor install, removing the concurrent JNI-critical contention that starves the GC.
- Update the explanatory comment to describe the GCLocker mechanism and the `-T 2` recurrence.
- No other jobs are affected; they keep the shared `-T 3` from `MVN_OPTS_INSTALL`.

### Impact

CI-only change. It makes the UT_FT_10 install phase single-threaded, slightly increasing that phase's wall-clock time but well within the job's 120-minute timeout. No production code or test changes.

### Risk Level

low. CI configuration only; no change to Hudi runtime or test code. The fix is exercised by this PR's own Azure run.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
