### PR TITLE
test: fix flaky TestJavaHoodieBackedMetadata.testReattemptOfFailedClusteringCommit

### DIFF
--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -1867,7 +1867,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieJavaWriteClient client = getHoodieWriteClient(config);
 
     // Write 1 (Bulk insert)
-    String newCommitTime = "0000001";
+    String newCommitTime = WriteClientTestUtils.createNewInstantTime();
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
     WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     List<WriteStatus> writeStatuses = client.insert(records, newCommitTime);
@@ -1876,7 +1876,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
     validateMetadata(client);
 
     // Write 2 (inserts)
-    newCommitTime = "0000002";
+    newCommitTime = WriteClientTestUtils.createNewInstantTime();
     WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(records, newCommitTime);
@@ -1909,7 +1909,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
             replacedFileIds.add(new HoodieFileGroupId(partitionFiles.getKey(), file))));
 
     // trigger new write to mimic other writes succeeding before re-attempt.
-    newCommitTime = "0000003";
+    newCommitTime = WriteClientTestUtils.createNewInstantTime();
     WriteClientTestUtils.startCommitWithTime(client, newCommitTime);
     records = dataGen.generateInserts(newCommitTime, 20);
     writeStatuses = client.insert(records, newCommitTime);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`TestJavaHoodieBackedMetadata.testReattemptOfFailedClusteringCommit` fails intermittently in CI.

The post-clustering insert used a hardcoded commit time `"0000003"`, which sorts lexicographically *before* the real wall-clock `clusteringCommitTime` (e.g. `"20241201..."`). Writing this out-of-order commit after clustering corrupts the metadata table's file-listing state, so `validateMetadata` intermittently reports mismatched listings for partitions such as `2015/03/16`.

### Summary and Changelog

Use `WriteClientTestUtils.createNewInstantTime()` instead of the hardcoded commit times so the writes are monotonically increasing and stay ordered after the clustering commit.

- `TestJavaHoodieBackedMetadata.testReattemptOfFailedClusteringCommit`: replace the three hardcoded `"0000001"/"0000002"/"0000003"` commit times with `WriteClientTestUtils.createNewInstantTime()`.

> An earlier revision of this PR also touched `TestMultipleHoodieJavaWriteClient.testOccWithMultipleWriters`; that change was dropped since #19124 already landed the OCC fix in master.

### Impact

None. Test-only change -- no production code, public API, or performance impact.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
