### PR TITLE
fix: support reading tables partitioned on a nested column

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -210,7 +210,9 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       }
       originalVectorTypes.map {
         o: Seq[String] => o.zipWithIndex.map(a => {
-          if (a._2 >= requiredSchema.length && mandatoryFields.contains(partitionSchema.fields(a._2 - requiredSchema.length).name)) {
+          if (a._2 >= requiredSchema.length
+            && mandatoryFields.contains(partitionSchema.fields(a._2 - requiredSchema.length).name)
+            && !isNestedPartitionField(partitionSchema.fields(a._2 - requiredSchema.length).name)) {
             regularVectorType
           } else {
             a._1
@@ -253,7 +255,11 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     val augmentedStorageConf = new HadoopStorageConfiguration(hadoopConf).getInline
     setSchemaEvolutionConfigs(augmentedStorageConf)
     augmentedStorageConf.set(ENABLE_LOGICAL_TIMESTAMP_REPAIR, hasTimestampMillisFieldInTableSchema.toString)
-    val (remainingPartitionSchemaArr, fixedPartitionIndexesArr) = partitionSchema.fields.toSeq.zipWithIndex.filter(p => !mandatoryFields.contains(p._1.name)).unzip
+    // Nested partition columns (e.g. "nested_record.level") are never read from the data file: the
+    // flattened dotted name is not a valid top-level field and the value is materialized from the
+    // partition path. Always keep them in the appended ("remaining") partition fields so they are
+    // not converted into a top-level Avro field below, which would fail Avro name validation.
+    val (remainingPartitionSchemaArr, fixedPartitionIndexesArr) = partitionSchema.fields.toSeq.zipWithIndex.filter(p => !mandatoryFields.contains(p._1.name) || isNestedPartitionField(p._1.name)).unzip
 
     // The schema of the partition cols we want to append the value instead of reading from the file
     val remainingPartitionSchema = StructType(remainingPartitionSchemaArr)
@@ -265,9 +271,9 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     val exclusionFields = new java.util.HashSet[String]()
     exclusionFields.add("op")
     partitionSchema.fields.foreach(f => exclusionFields.add(f.name))
-    val requestedStructType = StructType(requiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
+    val requestedStructType = StructType(requiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name) && !isNestedPartitionField(f.name)))
     val requestedSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(requestedStructType, sanitizedTableName), exclusionFields)
-    val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
+    val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name) && !isNestedPartitionField(f.name)))
     val dataSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(dataStructTypeWithMandatoryPartitionFields, sanitizedTableName), exclusionFields)
 
     spark.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", supportVectorizedRead.toString)
@@ -547,6 +553,14 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       case cb: ColumnarBatch => batchProjection(cb)
     }.asInstanceOf[Iterator[InternalRow]]
   }
+
+  /**
+   * A partition column whose name is a nested field path (e.g. "nested_record.level") cannot be
+   * read from the data file as a flat top-level column, nor converted into a top-level Avro field
+   * (Avro rejects '.' in names). Its value is always materialized from the partition path, so such
+   * fields are treated as appended partition fields rather than read from the file.
+   */
+  private def isNestedPartitionField(name: String): Boolean = name.contains(".")
 
   private def getFixedPartitionValues(allPartitionValues: InternalRow, partitionSchema: StructType, fixedPartitionIndexes: Set[Int]): InternalRow = {
     InternalRow.fromSeq(allPartitionValues.toSeq(partitionSchema).zipWithIndex.filter(p => fixedPartitionIndexes.contains(p._2)).map(p => p._1))

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -210,9 +210,12 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       }
       originalVectorTypes.map {
         o: Seq[String] => o.zipWithIndex.map(a => {
-          if (a._2 >= requiredSchema.length
-            && mandatoryFields.contains(partitionSchema.fields(a._2 - requiredSchema.length).name)
-            && !isNestedPartitionField(partitionSchema.fields(a._2 - requiredSchema.length).name)) {
+          val isPartitionField = a._2 >= requiredSchema.length
+          if (isPartitionField
+            && {
+              val fieldName = partitionSchema.fields(a._2 - requiredSchema.length).name
+              mandatoryFields.contains(fieldName) && !isNestedPartitionField(fieldName)
+            }) {
             regularVectorType
           } else {
             a._1

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -212,9 +212,12 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       }
       originalVectorTypes.map {
         o: Seq[String] => o.zipWithIndex.map(a => {
-          if (a._2 >= requiredSchema.length
-            && mandatoryFields.contains(partitionSchema.fields(a._2 - requiredSchema.length).name)
-            && !isNestedPartitionField(partitionSchema.fields(a._2 - requiredSchema.length).name)) {
+          val isPartitionField = a._2 >= requiredSchema.length
+          if (isPartitionField
+            && {
+              val fieldName = partitionSchema.fields(a._2 - requiredSchema.length).name
+              mandatoryFields.contains(fieldName) && !isNestedPartitionField(fieldName)
+            }) {
             regularVectorType
           } else {
             a._1

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -212,7 +212,9 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       }
       originalVectorTypes.map {
         o: Seq[String] => o.zipWithIndex.map(a => {
-          if (a._2 >= requiredSchema.length && mandatoryFields.contains(partitionSchema.fields(a._2 - requiredSchema.length).name)) {
+          if (a._2 >= requiredSchema.length
+            && mandatoryFields.contains(partitionSchema.fields(a._2 - requiredSchema.length).name)
+            && !isNestedPartitionField(partitionSchema.fields(a._2 - requiredSchema.length).name)) {
             regularVectorType
           } else {
             a._1
@@ -255,7 +257,11 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     val augmentedStorageConf = new HadoopStorageConfiguration(hadoopConf).getInline
     setSchemaEvolutionConfigs(augmentedStorageConf)
     augmentedStorageConf.set(ENABLE_LOGICAL_TIMESTAMP_REPAIR, hasTimestampMillisFieldInTableSchema.toString)
-    val (remainingPartitionSchemaArr, fixedPartitionIndexesArr) = partitionSchema.fields.toSeq.zipWithIndex.filter(p => !mandatoryFields.contains(p._1.name)).unzip
+    // Nested partition columns (e.g. "nested_record.level") are never read from the data file: the
+    // flattened dotted name is not a valid top-level field and the value is materialized from the
+    // partition path. Always keep them in the appended ("remaining") partition fields so they are
+    // not converted into a top-level Avro field below, which would fail Avro name validation.
+    val (remainingPartitionSchemaArr, fixedPartitionIndexesArr) = partitionSchema.fields.toSeq.zipWithIndex.filter(p => !mandatoryFields.contains(p._1.name) || isNestedPartitionField(p._1.name)).unzip
 
     // The schema of the partition cols we want to append the value instead of reading from the file
     val remainingPartitionSchema = StructType(remainingPartitionSchemaArr)
@@ -267,9 +273,9 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
     val exclusionFields = new java.util.HashSet[String]()
     exclusionFields.add("op")
     partitionSchema.fields.foreach(f => exclusionFields.add(f.name))
-    val requestedStructType = StructType(requiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
+    val requestedStructType = StructType(requiredSchema.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name) && !isNestedPartitionField(f.name)))
     val requestedSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(requestedStructType, sanitizedTableName), exclusionFields)
-    val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name)))
+    val dataStructTypeWithMandatoryPartitionFields = StructType(dataStructType.fields ++ partitionSchema.fields.filter(f => mandatoryFields.contains(f.name) && !isNestedPartitionField(f.name)))
     val dataSchema = HoodieSchemaUtils.pruneDataSchema(schema, HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(dataStructTypeWithMandatoryPartitionFields, sanitizedTableName), exclusionFields)
 
     spark.sessionState.conf.setConfString("spark.sql.parquet.enableVectorizedReader", supportVectorizedRead.toString)
@@ -572,6 +578,14 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
       case cb: ColumnarBatch => batchProjection(cb)
     }.asInstanceOf[Iterator[InternalRow]]
   }
+
+  /**
+   * A partition column whose name is a nested field path (e.g. "nested_record.level") cannot be
+   * read from the data file as a flat top-level column, nor converted into a top-level Avro field
+   * (Avro rejects '.' in names). Its value is always materialized from the partition path, so such
+   * fields are treated as appended partition fields rather than read from the file.
+   */
+  private def isNestedPartitionField(name: String): Boolean = name.contains(".")
 
   private def getFixedPartitionValues(allPartitionValues: InternalRow, partitionSchema: StructType, fixedPartitionIndexes: Set[Int]): InternalRow = {
     InternalRow.fromSeq(allPartitionValues.toSeq(partitionSchema).zipWithIndex.filter(p => fixedPartitionIndexes.contains(p._2)).map(p => p._1))

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestFileGroupReaderPartitionColumn.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestFileGroupReaderPartitionColumn.scala
@@ -22,7 +22,7 @@ package org.apache.hudi.functional
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 
 import org.apache.spark.sql.{Row, SaveMode}
-import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DoubleType, IntegerType, LongType, StringType, StructField, StructType}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull}
 import org.junit.jupiter.api.Test
 
@@ -154,5 +154,133 @@ class TestFileGroupReaderPartitionColumn extends SparkClientFunctionalTestHarnes
       "id=14 (untouched, country=IN slice with base+log) must not be null")
     assertEquals("IN", rows(12L), "id=12 partition column must be IN")
     assertEquals("IN", rows(14L), "id=14 partition column must be IN")
+  }
+
+  /**
+   * Regression test for reading a table partitioned on a nested column when that nested column is
+   * also a mandatory field (here, the precombine/ordering field). Being mandatory, the file group
+   * reader requests the partition column as a top-level field; for a nested path
+   * ("nested_record.level") this previously failed in `buildReaderWithPartitionValues` with
+   * `HoodieSchemaException: Illegal character in: nested_record.level` when converting the
+   * StructType into an Avro-backed HoodieSchema.
+   *
+   * The nested partition value is never a flat top-level column in the data file — it must be
+   * materialized from the partition path — so the fix keeps it out of the file-read schema and
+   * appends it from the path. The existing `TestCOWDataSource#testNestedFieldPartition` covers the
+   * common (non-mandatory) path where the field is already appended from the path and does not hit
+   * this case.
+   */
+  @Test
+  def testReadTablePartitionedOnNestedColumnThatIsAlsoPrecombine(): Unit = {
+    val nestedSchema = StructType(Array(
+      StructField("nested_int", IntegerType, nullable = false),
+      StructField("level", StringType, nullable = false)
+    ))
+    val schema = StructType(Array(
+      StructField("id", LongType, nullable = false),
+      StructField("name", StringType, nullable = true),
+      StructField("nested_record", nestedSchema, nullable = true)
+    ))
+
+    val opts = Map(
+      "hoodie.table.name" -> "test_nested_partition_precombine",
+      "hoodie.datasource.write.table.type" -> "COPY_ON_WRITE",
+      "hoodie.datasource.write.recordkey.field" -> "id",
+      // partition column is ALSO the precombine field -> it becomes mandatory (read from file),
+      // which is what drives the nested-name conversion the fix guards against.
+      "hoodie.datasource.write.partitionpath.field" -> "nested_record.level",
+      "hoodie.datasource.write.precombine.field" -> "nested_record.level",
+      "hoodie.insert.shuffle.parallelism" -> "2",
+      "hoodie.upsert.shuffle.parallelism" -> "2"
+    )
+
+    val rows = Seq(
+      Row(1L, "a", Row(10, "INFO")),
+      Row(2L, "b", Row(20, "ERROR")),
+      Row(3L, "c", Row(30, "INFO")),
+      Row(4L, "d", Row(40, "DEBUG"))
+    )
+    spark.createDataFrame(spark.sparkContext.parallelize(rows, 1), schema)
+      .write.format("hudi")
+      .options(opts)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    // Full read: the nested partition column must materialize (from the partition path) for every
+    // row rather than crashing the scan.
+    val all = spark.read.format("hudi").load(basePath)
+      .select("id", "nested_record")
+      .collect()
+      .map(r => r.getLong(0) -> r.getStruct(1).getString(1))
+      .toMap
+    assertEquals(4, all.size, "all rows must read back")
+    assertEquals("INFO", all(1L))
+    assertEquals("ERROR", all(2L))
+    assertEquals("INFO", all(3L))
+    assertEquals("DEBUG", all(4L))
+
+    // Filtered read on the nested partition column (partition pruning path).
+    val infoIds = spark.read.format("hudi").load(basePath)
+      .filter("nested_record.level = 'INFO'")
+      .select("id")
+      .collect()
+      .map(_.getLong(0))
+      .toSet
+    assertEquals(Set(1L, 3L), infoIds, "filter on nested partition column must return INFO rows")
+  }
+
+  /**
+   * Mixed case: one top-level partition column read from the file and one nested partition column
+   * appended from the path, both mandatory (here via multiple ordering fields). Exercises the
+   * `readBaseFile` branch where `remainingPartitionSchema` (the appended nested field) differs from
+   * the full `partitionSchema`, confirming the nested value is materialized from the path while the
+   * top-level value is still read from the file.
+   */
+  @Test
+  def testReadTablePartitionedOnNestedAndTopLevelColumns(): Unit = {
+    val nestedSchema = StructType(Array(
+      StructField("nested_int", IntegerType, nullable = false),
+      StructField("level", StringType, nullable = false)
+    ))
+    val schema = StructType(Array(
+      StructField("id", LongType, nullable = false),
+      StructField("country", StringType, nullable = false),
+      StructField("nested_record", nestedSchema, nullable = true)
+    ))
+
+    val opts = Map(
+      "hoodie.table.name" -> "test_nested_and_toplevel_partition",
+      "hoodie.datasource.write.table.type" -> "COPY_ON_WRITE",
+      "hoodie.datasource.write.recordkey.field" -> "id",
+      "hoodie.datasource.write.partitionpath.field" -> "country,nested_record.level",
+      "hoodie.datasource.write.keygenerator.class" -> "org.apache.hudi.keygen.ComplexKeyGenerator",
+      // both partition columns are ordering fields -> both mandatory; country is read from the file,
+      // the nested column is appended from the path.
+      "hoodie.table.ordering.fields" -> "country,nested_record.level",
+      "hoodie.datasource.write.hive_style_partitioning" -> "true",
+      "hoodie.insert.shuffle.parallelism" -> "2",
+      "hoodie.upsert.shuffle.parallelism" -> "2"
+    )
+
+    val rows = Seq(
+      Row(1L, "US", Row(10, "INFO")),
+      Row(2L, "IN", Row(20, "ERROR")),
+      Row(3L, "US", Row(30, "DEBUG"))
+    )
+    spark.createDataFrame(spark.sparkContext.parallelize(rows, 1), schema)
+      .write.format("hudi")
+      .options(opts)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val all = spark.read.format("hudi").load(basePath)
+      .select("id", "country", "nested_record")
+      .collect()
+      .map(r => r.getLong(0) -> (r.getString(1), r.getStruct(2).getString(1)))
+      .toMap
+    assertEquals(3, all.size, "all rows must read back")
+    assertEquals(("US", "INFO"), all(1L))
+    assertEquals(("IN", "ERROR"), all(2L))
+    assertEquals(("US", "DEBUG"), all(3L))
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19122

Reading a Hudi table partitioned on a nested column (a partition field whose name is a dotted path, e.g. `nested_record.level`) fails on the only batch read path with `HoodieSchemaException: Illegal character in: nested_record.level`, so the table cannot be read at all.

### Summary and Changelog

When a partition field is mandatory, `HoodieFileGroupReaderBasedFileFormat#buildReaderWithPartitionValues` adds it to the `StructType` it converts into a `HoodieSchema` (a top-level Avro field) so it can be read from the file. For a nested partition column the field name is a dotted path, which is not a valid Avro name, so `convertStructTypeToHoodieSchema` throws before the read starts.

A nested partition column is never a flat top-level column in the data file: its value is materialized from the partition path, and its root field (`nested_record`) is already read via the data schema. This PR treats nested partition fields (names containing `.`) as appended partition fields rather than fields read from the file, so they are not converted into a top-level Avro field:

- Add an `isNestedPartitionField(name)` helper (`name.contains(".")`).
- Keep nested partition fields in the appended ("remaining") partition fields when splitting `remainingPartitionSchema` / `fixedPartitionIndexes`, so their values are appended from the partition path.
- Exclude nested partition fields from the two `StructType -> HoodieSchema` conversions (`requestedStructType`, `dataStructTypeWithMandatoryPartitionFields`) so the dotted name is never converted to an Avro field.
- Apply the same exclusion in `vectorTypes`.

This mirrors the existing root-level handling for nested mandatory columns in `HoodieBaseRelation#appendMandatoryColumns` (`HoodieAvroUtils.getRootLevelFieldName`).

### Impact

Tables partitioned on a nested column become readable. No change for tables partitioned on top-level columns (the new predicate only matches dotted names).

### Risk Level

low. The behavioral change is scoped to partition fields whose name contains `.`, which previously could not be read at all. Validated end-to-end via Apache XTable's `ITConversionController#testPartitionedData` (HUDI partitioned on `nested_record.level` -> ICEBERG) against a locally built snapshot: the conversion now succeeds and the `nested_record.level = 'INFO'` filter round-trips, confirming the partition value is materialized correctly (not just that the crash is avoided).

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
