### PR TITLE
test: handle expected OCC conflict in concurrent Java writer test

### DIFF
--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/common/TestMultipleHoodieJavaWriteClient.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/common/TestMultipleHoodieJavaWriteClient.java
@@ -35,6 +35,7 @@ import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieWriteConflictException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
 import org.apache.hudi.storage.StorageConfiguration;
@@ -207,13 +208,24 @@ public class TestMultipleHoodieJavaWriteClient {
               String startCommitTime = writer.startCommit();
               List<WriteStatus> s = writer.upsert(Collections.singletonList(record), startCommitTime);
 
-              writer.commit(startCommitTime, s);
-              LOGGER.info("Completed commit");
-              synchronized (writerQueue) {
-                try {
-                  writerQueue.put(writer);
-                } catch (InterruptedException e) {
-                  throw new RuntimeException(e);
+              try {
+                writer.commit(startCommitTime, s);
+                LOGGER.info("Completed commit");
+              } catch (HoodieWriteConflictException e) {
+                // Under OPTIMISTIC_CONCURRENCY_CONTROL, two writers updating overlapping file
+                // groups conflict and one of them is aborted by design. This test validates that
+                // concurrent writers do not deadlock, so an aborted commit is an expected outcome
+                // and must not fail the test.
+                LOGGER.info("Commit {} was aborted by an expected OCC conflict", startCommitTime);
+              } finally {
+                // Always return the writer to the pool, even when its commit was aborted, so the
+                // remaining records are not starved of writers.
+                synchronized (writerQueue) {
+                  try {
+                    writerQueue.put(writer);
+                  } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                  }
                 }
               }
             }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`TestMultipleHoodieJavaWriteClient.testOccWithMultipleWriters` is flaky. It runs three concurrent Java write clients under `OPTIMISTIC_CONCURRENCY_CONTROL` and deliberately creates contention (20 records over keys repeated twice). When two concurrent commits touch overlapping file groups, OCC correctly aborts one of them by throwing `HoodieWriteConflictException` (from `SimpleConcurrentFileWritesConflictResolutionStrategy`). The test never handles that exception, so it propagates out of the parallel commit loop and fails the test whenever the race lands. The conflict is correct behavior, not a bug, so the flakiness lives in the test itself.

### Summary and Changelog

This test was added under HUDI-5583 to validate that concurrent Java writers do not deadlock, not that every commit succeeds. This change makes it tolerate the conflict OCC is designed to throw:

- Catch `HoodieWriteConflictException` around `writer.commit(...)`. An aborted commit is an acceptable outcome under OCC contention, so it is logged and skipped rather than failing the test.
- Move the writer return into a `finally` block so the writer pool is never starved when a commit is aborted (previously a thrown commit also leaked the writer).

The conflict-resolution path already releases the transaction lock in a `finally` block, so the writer is safe to reuse after an aborted commit.

### Impact

Test-only change. No production code or public API is affected.

### Risk Level

low

Verified locally on the Java client. Forcing maximum contention (collapsing all records onto a single file group) reproduces the failure on every run with the exact `HoodieWriteConflictException` (wrapping `ConcurrentModificationException`, "overlapping file groups") observed in CI. With this change the same workload completes: conflicts are caught and tolerated. The unmodified test (both COPY_ON_WRITE and MERGE_ON_READ) passes with no checkstyle violations.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
