### PR TITLE
fix: Handle map/array-nested leaf columns in column stats collection during MOR log-append

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/avro/AvroRecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/avro/AvroRecordContext.java
@@ -79,6 +79,14 @@ public class AvroRecordContext extends RecordContext<IndexedRecord> {
     String[] path = fieldName.split("\\.");
     for (int i = 0; i < path.length; i++) {
       currentSchema = currentSchema.getNonNullType();
+      // Value navigation here can only descend through RECORD fields. Column-stats field paths
+      // that traverse a MAP (".key_value.key" / ".key_value.value") or ARRAY (".list.element")
+      // synthetic accessor, or that hit a null intermediate value, cannot be resolved to a single
+      // value and yield null instead of throwing. This mirrors HoodieAvroUtils.getNestedFieldVal;
+      // statistics for such nested leaves are still collected from the base-file (Parquet) path.
+      if (currentRecord == null || !currentSchema.hasFields()) {
+        return null;
+      }
       Option<HoodieSchemaField> fieldOpt = currentSchema.getField(path[i]);
       if (fieldOpt.isEmpty()) {
         return null;
@@ -89,7 +97,7 @@ public class AvroRecordContext extends RecordContext<IndexedRecord> {
         return value;
       }
       currentSchema = field.schema();
-      currentRecord = (IndexedRecord) value;
+      currentRecord = value instanceof IndexedRecord ? (IndexedRecord) value : null;
     }
     return null;
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/avro/TestAvroRecordContext.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/avro/TestAvroRecordContext.java
@@ -105,7 +105,7 @@ class TestAvroRecordContext {
     assertThrows(IllegalArgumentException.class, () -> getFieldValueFromIndexedRecord(record, ""));
   }
 
-  private static final Schema COMPLEX_SCHEMA = new Schema.Parser().parse(
+  private static final Schema MAP_AND_ARRAY_SCHEMA = new Schema.Parser().parse(
       "{\"type\":\"record\",\"name\":\"complex\",\"fields\":["
           + "{\"name\":\"id\",\"type\":\"int\"},"
           + "{\"name\":\"str_map\",\"type\":[\"null\",{\"type\":\"map\",\"values\":\"string\"}],\"default\":null},"
@@ -115,7 +115,7 @@ class TestAvroRecordContext {
 
   @Test
   void testGetFieldValueMapAndArrayLeavesReturnNull() {
-    GenericRecord record = new GenericData.Record(COMPLEX_SCHEMA);
+    GenericRecord record = new GenericData.Record(MAP_AND_ARRAY_SCHEMA);
     record.put("id", 7);
     Map<Utf8, Utf8> strMap = new HashMap<>();
     strMap.put(new Utf8("a"), new Utf8("v1"));
@@ -138,7 +138,7 @@ class TestAvroRecordContext {
     assertNull(getFieldValueFromIndexedRecord(record, "rec_map.key_value.value.x"));
 
     // and null when the complex field itself is absent/null
-    GenericRecord empty = new GenericData.Record(COMPLEX_SCHEMA);
+    GenericRecord empty = new GenericData.Record(MAP_AND_ARRAY_SCHEMA);
     empty.put("id", 0);
     assertNull(getFieldValueFromIndexedRecord(empty, "str_map.key_value.value"));
     assertNull(getFieldValueFromIndexedRecord(empty, "int_array.list.element"));

--- a/hudi-common/src/test/java/org/apache/hudi/common/avro/TestAvroRecordContext.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/avro/TestAvroRecordContext.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.avro.AvroRecordContext.getFieldValueFromIndexedRecord;
@@ -94,9 +97,51 @@ class TestAvroRecordContext {
   @Test
   void testGetFieldValueErrorCases() {
     GenericRecord record = buildRecord();
-    // a union that is not [null, T] does not support field lookups
-    assertThrows(IllegalStateException.class, () -> getFieldValueFromIndexedRecord(record, "multi.sub"));
+    // a union that is not [null, T] cannot be navigated into; instead of throwing, the value
+    // navigator returns null so callers (e.g. column-stats collection) degrade gracefully,
+    // matching HoodieAvroUtils.getNestedFieldVal
+    assertNull(getFieldValueFromIndexedRecord(record, "multi.sub"));
+    // an empty field name is still rejected up front
     assertThrows(IllegalArgumentException.class, () -> getFieldValueFromIndexedRecord(record, ""));
+  }
+
+  private static final Schema COMPLEX_SCHEMA = new Schema.Parser().parse(
+      "{\"type\":\"record\",\"name\":\"complex\",\"fields\":["
+          + "{\"name\":\"id\",\"type\":\"int\"},"
+          + "{\"name\":\"str_map\",\"type\":[\"null\",{\"type\":\"map\",\"values\":\"string\"}],\"default\":null},"
+          + "{\"name\":\"int_array\",\"type\":[\"null\",{\"type\":\"array\",\"items\":\"int\"}],\"default\":null},"
+          + "{\"name\":\"rec_map\",\"type\":[\"null\",{\"type\":\"map\",\"values\":{\"type\":\"record\","
+          + "\"name\":\"inner\",\"fields\":[{\"name\":\"x\",\"type\":\"int\"}]}}],\"default\":null}]}");
+
+  @Test
+  void testGetFieldValueMapAndArrayLeavesReturnNull() {
+    GenericRecord record = new GenericData.Record(COMPLEX_SCHEMA);
+    record.put("id", 7);
+    Map<Utf8, Utf8> strMap = new HashMap<>();
+    strMap.put(new Utf8("a"), new Utf8("v1"));
+    record.put("str_map", strMap);
+    record.put("int_array", Arrays.asList(3, 1, 2));
+    // rec_map left null
+
+    // top-level scalar still resolves normally
+    assertEquals(7, getFieldValueFromIndexedRecord(record, "id"));
+
+    // Parquet-style synthetic accessors that traverse a MAP (".key_value.key/value") or an
+    // ARRAY (".list.element") cannot be resolved to a single value and must return null instead
+    // of throwing. Regression: these previously threw
+    // IllegalStateException "Cannot get field from schema type: MAP" during MOR log-append
+    // column-stats collection. Such nested leaves still get statistics from the base-file path.
+    assertNull(getFieldValueFromIndexedRecord(record, "str_map.key_value.key"));
+    assertNull(getFieldValueFromIndexedRecord(record, "str_map.key_value.value"));
+    assertNull(getFieldValueFromIndexedRecord(record, "int_array.list.element"));
+    // a deep path descending through a MAP into a record field also degrades to null
+    assertNull(getFieldValueFromIndexedRecord(record, "rec_map.key_value.value.x"));
+
+    // and null when the complex field itself is absent/null
+    GenericRecord empty = new GenericData.Record(COMPLEX_SCHEMA);
+    empty.put("id", 0);
+    assertNull(getFieldValueFromIndexedRecord(empty, "str_map.key_value.value"));
+    assertNull(getFieldValueFromIndexedRecord(empty, "int_array.list.element"));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/avro/TestAvroRecordContext.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/avro/TestAvroRecordContext.java
@@ -40,6 +40,23 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestAvroRecordContext {
 
+  private static final Schema RECORD_SCHEMA = new Schema.Parser().parse(
+      "{\"type\":\"record\",\"name\":\"top\",\"fields\":["
+          + "{\"name\":\"id\",\"type\":\"int\"},"
+          + "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+          + "{\"name\":\"address\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"address\",\"fields\":["
+          + "{\"name\":\"city\",\"type\":\"string\"},"
+          + "{\"name\":\"zip\",\"type\":[\"null\",\"int\"],\"default\":null}]}],\"default\":null},"
+          + "{\"name\":\"multi\",\"type\":[\"null\",\"string\",\"int\"],\"default\":null}]}");
+
+  private static final Schema MAP_AND_ARRAY_SCHEMA = new Schema.Parser().parse(
+      "{\"type\":\"record\",\"name\":\"complex\",\"fields\":["
+          + "{\"name\":\"id\",\"type\":\"int\"},"
+          + "{\"name\":\"str_map\",\"type\":[\"null\",{\"type\":\"map\",\"values\":\"string\"}],\"default\":null},"
+          + "{\"name\":\"int_array\",\"type\":[\"null\",{\"type\":\"array\",\"items\":\"int\"}],\"default\":null},"
+          + "{\"name\":\"rec_map\",\"type\":[\"null\",{\"type\":\"map\",\"values\":{\"type\":\"record\","
+          + "\"name\":\"inner\",\"fields\":[{\"name\":\"x\",\"type\":\"int\"}]}}],\"default\":null}]}");
+
   private static Stream<Arguments> testConvertValueToEngineType() {
     return Stream.of(
         Arguments.of(1L, 1L),
@@ -54,15 +71,6 @@ class TestAvroRecordContext {
     Comparable actual = AvroRecordContext.getFieldAccessorInstance().convertValueToEngineType(input);
     assertEquals(expected, actual);
   }
-
-  private static final Schema RECORD_SCHEMA = new Schema.Parser().parse(
-      "{\"type\":\"record\",\"name\":\"top\",\"fields\":["
-          + "{\"name\":\"id\",\"type\":\"int\"},"
-          + "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
-          + "{\"name\":\"address\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"address\",\"fields\":["
-          + "{\"name\":\"city\",\"type\":\"string\"},"
-          + "{\"name\":\"zip\",\"type\":[\"null\",\"int\"],\"default\":null}]}],\"default\":null},"
-          + "{\"name\":\"multi\",\"type\":[\"null\",\"string\",\"int\"],\"default\":null}]}");
 
   private static GenericRecord buildRecord() {
     GenericRecord address = new GenericData.Record(RECORD_SCHEMA.getField("address").schema().getTypes().get(1));
@@ -104,14 +112,6 @@ class TestAvroRecordContext {
     // an empty field name is still rejected up front
     assertThrows(IllegalArgumentException.class, () -> getFieldValueFromIndexedRecord(record, ""));
   }
-
-  private static final Schema MAP_AND_ARRAY_SCHEMA = new Schema.Parser().parse(
-      "{\"type\":\"record\",\"name\":\"complex\",\"fields\":["
-          + "{\"name\":\"id\",\"type\":\"int\"},"
-          + "{\"name\":\"str_map\",\"type\":[\"null\",{\"type\":\"map\",\"values\":\"string\"}],\"default\":null},"
-          + "{\"name\":\"int_array\",\"type\":[\"null\",{\"type\":\"array\",\"items\":\"int\"}],\"default\":null},"
-          + "{\"name\":\"rec_map\",\"type\":[\"null\",{\"type\":\"map\",\"values\":{\"type\":\"record\","
-          + "\"name\":\"inner\",\"fields\":[{\"name\":\"x\",\"type\":\"int\"}]}}],\"default\":null}]}");
 
   @Test
   void testGetFieldValueMapAndArrayLeavesReturnNull() {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19125

Building the column-stats index on a table version 9 (timeline layout V2) Merge-on-Read table crashes during the inline log-append upsert when the col-stats column list contains a leaf nested inside a `MAP` or `ARRAY` (e.g. `my_map.key_value.value`, `my_array.list.element`):

```
Caused by: java.lang.IllegalStateException: Cannot get field from schema type: MAP
	at org.apache.hudi.common.schema.HoodieSchema.getField(HoodieSchema.java:1172)
	at org.apache.hudi.avro.AvroRecordContext.getFieldValueFromIndexedRecord(AvroRecordContext.java:90)
	at org.apache.hudi.common.model.HoodieAvroIndexedRecord.getColumnValueAsJava(HoodieAvroIndexedRecord.java:193)
	at org.apache.hudi.metadata.HoodieTableMetadataUtil.collectColumnRangeFieldValueV2(HoodieTableMetadataUtil.java:354)
	at org.apache.hudi.io.HoodieInlineLogAppendHandle.collectColumnStats(HoodieInlineLogAppendHandle.java:182)
```

### Summary and Changelog

#17694 added column stats for primitives nested inside `MAP`/`ARRAY` by teaching the schema-side navigator (`HoodieSchema.getNestedField`) and the base-file (Parquet) path to resolve the synthetic accessors `.key_value.key`, `.key_value.value` and `.list.element`. Such leaves therefore pass `isColumnTypeSupported` (the resolved leaf is a scalar).

The column-stats V2 record path used by MOR inline log-append (`HoodieTableMetadataUtil.collectColumnRangeFieldValueV2` -> `HoodieRecord.getColumnValueAsJava` -> `AvroRecordContext.getFieldValueFromIndexedRecord`) was never taught the same navigation. It splits the field path on `.` and assumes every segment is a `RECORD` field, so when it reaches the `MAP`/`ARRAY` schema it calls `HoodieSchema.getField(...)` on it, which throws `IllegalStateException: Cannot get field from schema type: MAP`.

The V1 path (table version 6) does not hit this: `HoodieAvroUtils.getNestedFieldVal` returns `null` when a path segment is not a record. Only the V2 record navigator was left asymmetric.

This PR makes `AvroRecordContext.getFieldValueFromIndexedRecord` return `null` when a path segment cannot be resolved as a plain `RECORD` field, instead of throwing:

- Return `null` when the current schema does not support fields (a `MAP`/`ARRAY`/other non-record intermediate) or when the intermediate value is `null`, mirroring `HoodieAvroUtils.getNestedFieldVal`.
- Guard the intermediate downcast so a non-record value (java `Map`/`List`) degrades to `null` rather than throwing `ClassCastException`.

A map/array leaf is multi-valued per record and has no single value to fold into a min/max, so returning `null` (no stats from the record path) is correct and safe; statistics for such leaves are still collected from the base-file (Parquet) footer path added in #17694.

### Impact

MOR tables at table version 9 with column stats configured on map/array-nested leaves can be upserted (no longer crash on log-append). No change for scalar or record-nested columns. Behavior now matches table version 6.

### Risk Level

low. The change is scoped to path segments that cannot be resolved as record fields, which previously threw. Covered by new unit tests in `TestAvroRecordContext` and validated end-to-end via Apache XTable's `ITHudiConversionSource` (MOR source at table version 9 with column stats on map/array leaves): the upsert that previously crashed with `Cannot get field from schema type: MAP` now succeeds.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
