### PR TITLE
feat(config): express small-file threshold as a fraction of max file size

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -23,6 +23,8 @@ import org.apache.hudi.common.config.ConfigGroups;
 import org.apache.hudi.common.config.ConfigProperty;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
 import org.apache.hudi.table.action.compact.plan.generators.HoodieCompactionPlanGenerator;
 import org.apache.hudi.table.action.compact.strategy.CompactionStrategy;
@@ -105,7 +107,34 @@ public class HoodieCompactionConfig extends HoodieConfig {
       .withDocumentation("During upsert operation, we opportunistically expand existing small files on storage, instead of writing"
           + " new files, to keep number of files to an optimum. This config sets the file size limit below which a file on storage "
           + " becomes a candidate to be selected as such a `small file`. By default, treat any file <= 100MB as a small file."
-          + " Also note that if this set <= 0, will not try to get small files and directly write new files");
+          + " Also note that if this set <= 0, will not try to get small files and directly write new files."
+          + " As of the fraction-based small-file config, this byte value is no longer read directly at runtime — it feeds"
+          + " the infer function of `hoodie.parquet.small.file.fraction.max.file.size` so tables that only set this key keep"
+          + " working. If both this and the fraction config are set explicitly, the fraction config takes precedence.");
+
+  public static final ConfigProperty<Double> PARQUET_SMALL_FILE_FRACTION_MAX_FILE_SIZE = ConfigProperty
+      .key("hoodie.parquet.small.file.fraction.max.file.size")
+      .defaultValue(0.0)
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withInferFunction(cfg -> {
+        // Fall back to the built-in defaults of the byte-based configs when the keys are not yet
+        // present in props. This happens when HoodieCompactionConfig.Builder.build() runs
+        // standalone (before HoodieStorageConfig defaults are merged in the outer
+        // HoodieWriteConfig.Builder.setDefaults path). Using *OrDefault ensures the fraction is
+        // still correctly inferred as 100MB/120MB in that path.
+        long maxFileBytes = cfg.getLongOrDefault(HoodieStorageConfig.PARQUET_MAX_FILE_SIZE);
+        if (maxFileBytes <= 0) {
+          return Option.empty();
+        }
+        long smallFileBytes = cfg.getLongOrDefault(PARQUET_SMALL_FILE_LIMIT);
+        return Option.of(((double) smallFileBytes) / ((double) maxFileBytes));
+      })
+      .withDocumentation("Small-file threshold expressed as a fraction of `hoodie.parquet.max.file.size`. When unset, this is"
+          + " inferred from `hoodie.parquet.small.file.limit / hoodie.parquet.max.file.size` so existing tables see identical"
+          + " behavior. When explicitly set, this config takes precedence and the byte-limit config is ignored. A value of 0.0"
+          + " disables small-file bin-packing (equivalent to setting `hoodie.parquet.small.file.limit=0`). The default of 0.0"
+          + " is only observed when max.file.size is misconfigured to <= 0.");
 
   public static final ConfigProperty<String> RECORD_SIZE_ESTIMATION_THRESHOLD = ConfigProperty
       .key("hoodie.record.size.estimation.threshold")
@@ -389,6 +418,11 @@ public class HoodieCompactionConfig extends HoodieConfig {
 
     public Builder compactionSmallFileSize(long smallFileLimitBytes) {
       compactionConfig.setValue(PARQUET_SMALL_FILE_LIMIT, String.valueOf(smallFileLimitBytes));
+      return this;
+    }
+
+    public Builder withParquetSmallFileFractionOfMaxFileSize(double fraction) {
+      compactionConfig.setValue(PARQUET_SMALL_FILE_FRACTION_MAX_FILE_SIZE, String.valueOf(fraction));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1827,8 +1827,12 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieArchivalConfig.TIMELINE_MANIFEST_RETAINED_VERSIONS);
   }
 
-  public int getParquetSmallFileLimit() {
-    return getInt(HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT);
+  public long getParquetSmallFileLimit() {
+    // Effective threshold is fraction * max.file.size. The fraction config is the single source of
+    // truth at runtime; it is either user-set or derived by its infer function from the byte-based
+    // `hoodie.parquet.small.file.limit` at build time. See HoodieCompactionConfig.
+    double fraction = getDouble(HoodieCompactionConfig.PARQUET_SMALL_FILE_FRACTION_MAX_FILE_SIZE);
+    return (long) (fraction * getParquetMaxFileSize());
   }
 
   public double getRecordSizeEstimationThreshold() {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -234,6 +234,77 @@ public class TestHoodieWriteConfig {
     assertEquals(HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS, writeConfig.getCleanerPolicy());
   }
 
+  @Test
+  public void testParquetSmallFileFractionDerivation() {
+    final long defaultSmallFileLimit = 104857600L;  // 100 MB — matches PARQUET_SMALL_FILE_LIMIT default
+    final long defaultMaxFileSize = 125829120L;     // 120 MB — matches PARQUET_MAX_FILE_SIZE default
+
+    // 1. Default behavior — neither config set. Effective threshold must match today's byte-limit
+    //    default so existing tables see no behavior change.
+    HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath("/tmp").build();
+    assertEquals(defaultSmallFileLimit, cfg.getParquetSmallFileLimit(),
+        "back-compat: default fraction (inferred) must reproduce the legacy 100MB threshold");
+
+    // 2. Only the byte-limit is set — infer function must derive fraction from user's byte value.
+    cfg = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .compactionSmallFileSize(50 * 1024 * 1024)  // 50 MB
+            .build())
+        .build();
+    long expectedBytesForByteOnly = (long) ((50.0 * 1024 * 1024) / (double) defaultMaxFileSize * defaultMaxFileSize);
+    assertEquals(expectedBytesForByteOnly, cfg.getParquetSmallFileLimit(),
+        "byte-limit-only path: effective threshold must round-trip to the user's byte value (~50MB)");
+
+    // 3. Only the fraction is set explicitly — must be honored, byte config ignored.
+    cfg = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withParquetSmallFileFractionOfMaxFileSize(0.5)
+            .build())
+        .build();
+    assertEquals(defaultMaxFileSize / 2, cfg.getParquetSmallFileLimit(),
+        "fraction-only path: 0.5 * 120MB max must produce 60MB threshold");
+
+    // 4. Both set — fraction wins (infer is skipped because the fraction key is explicitly present).
+    cfg = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .compactionSmallFileSize(90 * 1024 * 1024)  // 90 MB — should be ignored
+            .withParquetSmallFileFractionOfMaxFileSize(0.25)
+            .build())
+        .build();
+    assertEquals(defaultMaxFileSize / 4, cfg.getParquetSmallFileLimit(),
+        "both-set path: fraction (0.25) wins over the byte limit (90MB); expect 30MB");
+
+    // 5. Disable sentinel — user sets small.file.limit=0 to disable small-file bin-packing today.
+    //    Under the fraction scheme, infer returns 0/max = 0.0, so the accessor returns 0 and every
+    //    `<= 0` disable check at the call site continues to trip.
+    cfg = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .compactionSmallFileSize(0)
+            .build())
+        .build();
+    assertEquals(0L, cfg.getParquetSmallFileLimit(),
+        "disable sentinel: small.file.limit=0 must produce fraction=0.0 and an effective threshold of 0");
+
+    // 6. Custom max — when only the max file size is bumped (e.g. to 1 GB), the byte-limit default
+    //    (100 MB) drives the fraction (100/1024 ≈ 0.0977). The effective threshold ends up back at
+    //    ~100 MB because the byte-limit is unchanged, which is the correct back-compat outcome for
+    //    a user who only tunes the max size.
+    long oneGiB = 1024L * 1024 * 1024;
+    cfg = HoodieWriteConfig.newBuilder()
+        .withPath("/tmp")
+        .withStorageConfig(HoodieStorageConfig.newBuilder()
+            .parquetMaxFileSize(oneGiB)
+            .build())
+        .build();
+    long expectedBytesForCustomMax = (long) ((double) defaultSmallFileLimit / (double) oneGiB * oneGiB);
+    assertEquals(expectedBytesForCustomMax, cfg.getParquetSmallFileLimit(),
+        "custom-max path: with only max.file.size=1GB, effective threshold should stay near 100MB");
+  }
+
   @ParameterizedTest
   @EnumSource(HoodieTableType.class)
   public void testAutoConcurrencyConfigAdjustmentWithTableServices(HoodieTableType tableType) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Today the small-file threshold used by upsert/insert bin-packing is a
static byte value (`hoodie.parquet.small.file.limit`, default 100 MB)
with no relationship to `hoodie.parquet.max.file.size` (default 120 MB).
When operators tune `max.file.size` up or down for a workload, they also
have to remember to re-tune `small.file.limit` or the two settings drift
out of proportion — e.g., a 1 GB `max.file.size` still treats anything
under 100 MB as "small", which is a fraction most operators would not
choose deliberately.

This PR makes the small-file threshold travel with the max file size by
expressing it as a fraction.

### Summary and Changelog

Adds a new config `hoodie.parquet.small.file.fraction.max.file.size`
(`ConfigProperty<Double>`, `HoodieCompactionConfig`) that becomes the
single source of truth for the small-file threshold at runtime. An
`InferFunction` derives the fraction from
`hoodie.parquet.small.file.limit / hoodie.parquet.max.file.size` when
the new key is not explicitly set, so existing tables see identical
behavior without any migration.

Interaction matrix:

| User sets | Effective threshold |
| --- | --- |
| Neither config | `100 MB / 120 MB ≈ 0.833` × max = 100 MB (bit-identical to today) |
| Only `small.file.limit` | inferred `user_bytes / max_size` × max = user_bytes |
| Only `max.file.size` (e.g. 1 GB) | inferred `100 MB / 1 GB ≈ 0.098` × 1 GB ≈ 100 MB (ratio auto-scales) |
| Only new fraction | user fraction × max |
| Both | fraction wins; byte-limit ignored |
| `small.file.limit=0` (disable idiom) | inferred 0.0 → effective threshold 0 → every `<= 0` disable check trips as before |

**Files:**

- `HoodieCompactionConfig.java` — new
  `PARQUET_SMALL_FILE_FRACTION_MAX_FILE_SIZE` config with the infer
  function. Existing `PARQUET_SMALL_FILE_LIMIT` doc updated to note its
  new role as infer input.
- `HoodieWriteConfig.java` — `getParquetSmallFileLimit()` now returns
  `long` and computes `(long) (fraction * getParquetMaxFileSize())`.
  This is the single behavior-change site. All 10 existing call sites
  (Spark/Java `UpsertPartitioner`, `SparkUpsertDeltaCommitPartitioner`,
  Flink `WriteProfile`, `AverageRecordSizeEstimator`) already accept
  `long`, so no source edits at any call site.
- `TestHoodieWriteConfig.java` — new
  `testParquetSmallFileFractionDerivation` covering: default
  back-compat, byte-limit-only, fraction-only, both-set precedence, the
  disable sentinel, and a custom `max.file.size`.

### Impact

- **User-facing configs**: 1 new config
  (`hoodie.parquet.small.file.fraction.max.file.size`, default `0.0`
  with infer). The existing `hoodie.parquet.small.file.limit` is not
  deprecated — it becomes the infer input, so setting it alone still
  works. No user has to change anything to keep today's behavior.
- **Public API**: `HoodieWriteConfig.getParquetSmallFileLimit()` return
  type widens from `int` to `long`. Source-compatible at every known
  call site (all compare against `long` file sizes or multiply into
  `long`). Binary-compat is a re-compile away for external callers.
- **Performance**: none. The accessor does one extra double-to-long
  multiplication per call — negligible vs. the file-listing work at
  every call site.

### Risk Level

low.

Verification: full `hudi-client-common` module test suite green
(1088/1088 tests, 0 failures, 0 errors), including 41/41
`TestHoodieWriteConfig` (of which 6 are the new fraction-derivation
cases). `hudi-client-common`, `hudi-spark-client`, `hudi-java-client`,
`hudi-flink-datasource/hudi-flink` all compile clean with the return-type
widening.

### Documentation Update

- Inline config documentation on `PARQUET_SMALL_FILE_FRACTION_MAX_FILE_SIZE`
  and updated docstring on `PARQUET_SMALL_FILE_LIMIT` — covered in the
  patch itself via `@ConfigProperty` `withDocumentation(...)`.
- No user-facing website change needed; both configs are marked
  `markAdvanced()` and appear in the generated config reference.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
