### PR TITLE
feat: Support read and write of HFile footer metadata

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
@@ -34,10 +34,14 @@ import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.exception.MetadataNotFoundException;
 import org.apache.hudi.io.compress.CompressionCodec;
 import org.apache.hudi.io.hfile.HFileContext;
+import org.apache.hudi.io.hfile.HFileReader;
 import org.apache.hudi.io.hfile.HFileWriter;
 import org.apache.hudi.io.hfile.HFileWriterImpl;
+import org.apache.hudi.io.hfile.UTF8StringKey;
+import org.apache.hudi.io.storage.HFileReaderFactory;
 import org.apache.hudi.io.storage.HoodieAvroHFileReaderImplBase;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieIOFactory;
@@ -54,6 +58,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +71,7 @@ import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_NUM
 import static org.apache.hudi.common.config.HoodieStorageConfig.BLOOM_FILTER_TYPE;
 import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_COMPRESSION_ALGORITHM_NAME;
 import static org.apache.hudi.common.config.HoodieStorageConfig.HFILE_WITH_BLOOM_FILTER_ENABLED;
+import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
 
 /**
@@ -101,7 +107,25 @@ public class HFileUtils extends FileFormatUtils {
 
   @Override
   public Map<String, String> readFooter(HoodieStorage storage, boolean required, StoragePath filePath, String... footerNames) {
-    throw new UnsupportedOperationException("HFileUtils does not support readFooter");
+    Map<String, String> footerVals = new HashMap<>();
+    try (HFileReader reader = HFileReaderFactory.builder()
+        .withStorage(storage)
+        .withPath(filePath)
+        .build()
+        .createHFileReader()) {
+      for (String footerName : footerNames) {
+        Option<byte[]> footerValue = reader.getMetaInfo(new UTF8StringKey(footerName));
+        if (footerValue.isPresent()) {
+          footerVals.put(footerName, fromUTF8Bytes(footerValue.get()));
+        } else if (required) {
+          throw new MetadataNotFoundException(
+              "Could not find index in HFile footer. Looked for key " + footerName + " in " + filePath);
+        }
+      }
+      return footerVals;
+    } catch (IOException io) {
+      throw new HoodieIOException("Unable to read footer for HFile: " + filePath, io);
+    }
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
@@ -119,7 +119,7 @@ public class HFileUtils extends FileFormatUtils {
           footerVals.put(footerName, fromUTF8Bytes(footerValue.get()));
         } else if (required) {
           throw new MetadataNotFoundException(
-              "Could not find index in HFile footer. Looked for key " + footerName + " in " + filePath);
+              "Could not find metadata key in HFile footer. Key " + footerName + ", file: " + filePath);
         }
       }
       return footerVals;

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroHFileWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroHFileWriter.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hudi.common.util.StringUtils.EMPTY_STRING;
@@ -126,6 +127,11 @@ public class HoodieAvroHFileWriter
   @Override
   public boolean canWrite() {
     return !isWrapperFileSystem || wrapperFs.get().getBytesWritten(file) < maxFileSize;
+  }
+
+  @Override
+  public void addFooterMetadata(Map<String, String> footerMetadata) {
+    footerMetadata.forEach((key, value) -> writer.appendFileInfo(key, getUTF8Bytes(value)));
   }
 
   @Override

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
@@ -31,9 +31,12 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.log.NativeLogFooterMetadata;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.HFileUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.exception.MetadataNotFoundException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.io.hfile.HFileReader;
 import org.apache.hudi.io.hfile.UTF8StringKey;
@@ -199,6 +202,27 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Test
+  public void testReadFooterMetadata() throws Exception {
+    HoodieSchema schema = getSchemaFromResource(TestHoodieOrcReaderWriter.class, "/exampleSchemaWithMetaFields.avsc");
+    HoodieAvroHFileWriter writer = createWriter(schema, false);
+    Map<String, String> footerMetadata = new TreeMap<>();
+    footerMetadata.put(NativeLogFooterMetadata.FOOTER_METADATA_KEY, "{\"SCHEMA\":\"schema\"}");
+    footerMetadata.put("custom", "value");
+    writer.addFooterMetadata(footerMetadata);
+    writer.close();
+
+    HoodieStorage storage = HoodieTestUtils.getStorage(getFilePath());
+    Map<String, String> footer = new HFileUtils().readFooter(
+        storage, false, getFilePath(), NativeLogFooterMetadata.FOOTER_METADATA_KEY, "custom", "missing");
+
+    assertEquals(2, footer.size());
+    assertEquals("{\"SCHEMA\":\"schema\"}", footer.get(NativeLogFooterMetadata.FOOTER_METADATA_KEY));
+    assertEquals("value", footer.get("custom"));
+    assertThrows(MetadataNotFoundException.class,
+        () -> new HFileUtils().readFooter(storage, true, getFilePath(), "missing"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

HFile footer metadata is used by shared file-format utilities, but the HFile path did not support reading footer metadata and the Avro HFile writer did not expose a way to write custom footer entries. This left HFile inconsistent with other storage formats for metadata-driven flows that need to persist and retrieve footer-level information.

This PR adds read/write support for HFile footer metadata and covers both optional and required metadata lookup behavior.

Fixes #19127

### Summary and Changelog

- Implemented `HFileUtils.readFooter` by opening an `HFileReader`, reading requested metadata keys via `getMetaInfo`, decoding UTF-8 values, and throwing `MetadataNotFoundException` when required metadata is missing.
- Added `HoodieAvroHFileWriter.addFooterMetadata` to append footer metadata entries through HFile file info.
- Added `TestHoodieHFileReaderWriter.testReadFooterMetadata` to verify custom footer metadata, native log footer metadata, optional missing keys, and required missing-key failures.

### Impact

- **Functional impact**: HFile now supports writing and reading footer metadata through the existing file-format utility and writer APIs.
- **Maintainability**: HFile footer handling is aligned with the shared `FileFormatUtils.readFooter` contract instead of throwing `UnsupportedOperationException`.
- **Extensibility**: Enables future HFile-backed metadata flows that need footer-level schema or custom metadata entries.

### Risk Level

low. 

### Documentation Update

none.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable