### PR TITLE
chore(ci): upload integration-test coverage to Codecov

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1404,7 +1404,7 @@ jobs:
           SPARK_PROFILE: ${{ matrix.sparkProfile }}
           SCALA_PROFILE: '-Dscala-2.12 -Dscala.binary.version=2.12'
         run:
-          mvn test $SCALA_PROFILE -D"$SPARK_PROFILE" -Pintegration-tests -DskipUTs=false -DskipITs=true -pl hudi-integ-test $MVN_ARGS
+          mvn test $SCALA_PROFILE -D"$SPARK_PROFILE" -Pintegration-tests -DskipUTs=false -DskipITs=true -pl hudi-integ-test $MVN_ARGS -Djacoco.skip=false
       - name: 'IT'
         if: needs.changes.outputs.relevant == 'true'
         env:
@@ -1419,7 +1419,18 @@ jobs:
           SPARK_ARCHIVE_BASENAME=$(basename $SPARK_ARCHIVE)
           export SPARK_HOME=$GITHUB_WORKSPACE/${SPARK_ARCHIVE_BASENAME%.*}
           rm -f $GITHUB_WORKSPACE/$SPARK_ARCHIVE
-          mvn verify $SCALA_PROFILE -D"$SPARK_PROFILE" -Pintegration-tests -pl !hudi-flink-datasource/hudi-flink $MVN_ARGS
+          mvn verify $SCALA_PROFILE -D"$SPARK_PROFILE" -Pintegration-tests -pl !hudi-flink-datasource/hudi-flink $MVN_ARGS -Djacoco.skip=false
+      - name: Generate merged coverage report
+        if: always() && needs.changes.outputs.relevant == 'true'
+        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
+      - name: Upload coverage to Codecov
+        if: always() && needs.changes.outputs.relevant == 'true'
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          files: ./jacoco-report.xml
+          disable_search: true
+          flags: integration-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build-spark-java17:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -2339,6 +2339,24 @@
               </execution>
             </executions>
           </plugin>
+          <!-- Attach the JaCoCo agent so the integration-test (failsafe) and integ-test unit
+               (surefire) runs emit coverage. The agent argument is appended to the argLine
+               property, which both plugins pick up. destFile matches the jacoco-agent path
+               that scripts/jacoco/generate_merged_coverage_report.sh globs for. -->
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+                <configuration>
+                  <destFile>${project.build.directory}/jacoco-agent/${jacoco.agent.dest.filename}</destFile>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The `integration-tests` GitHub Actions job runs the Hudi CLI and `hudi-integ-test` integration tests, but reported no code coverage to Codecov. The `integration-tests` Maven profile wired no JaCoCo agent (unlike the `unit-tests` / `functional-tests*` profiles), so no `.exec` data was produced, and the job had no coverage upload step. Because `hudi-cli` is excluded from the unit/functional test jobs, its production code was exercised only by these integration tests and its coverage was never reported.

### Summary and Changelog

Report integration-test coverage to Codecov, closing the `hudi-cli` blind spot.

- `pom.xml`: add a JaCoCo `prepare-agent` execution to the `integration-tests` profile, writing exec data under `target/jacoco-agent/` so the existing `scripts/jacoco/generate_merged_coverage_report.sh` picks it up. The agent is appended to the `argLine` property, which both failsafe (IT) and surefire (integ-test UT) already consume.
- `.github/workflows/bot.yml`: enable JaCoCo on the `UT integ-test` and `IT` steps (`-Djacoco.skip=false`), and add the standard "Generate merged coverage report" + "Upload coverage to Codecov" steps (flag `integration-tests`), mirroring the other test jobs.

Scope is limited to the `integration-tests` job; the Flink integration-test jobs are intentionally left out.

### Impact

CI only; no production code or public API change. The `integration-tests` job now uploads coverage under the `integration-tests` flag.

### Risk Level

low

CI-only change. It reuses the same JaCoCo agent plus merge/upload path already proven by the unit/functional test jobs. Failsafe/surefire memory settings are unchanged, since the agent is appended to the existing `argLine` property rather than replacing it.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
