### PR TITLE
chore(ci): add commit co-author validation as a required PR check

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -50,6 +50,7 @@ github:
           - validate-source
           - validate-pr
           - validate-pr-title
+          - validate-commit-coauthor
           - test-hudi-trino-plugin
           - test-spark-client-and-hadoop-common (scala-2.12, spark3.5, flink2.1)
           - test-utilities (scala-2.12, spark3.5, flink2.1)

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -1,0 +1,38 @@
+name: Commit Co-author Validation
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - master
+      - branch-0.x
+
+concurrency:
+  group: commit-coauthor-validation-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master') && !contains(github.ref, 'branch-0.x') }}
+
+jobs:
+  validate-commit-coauthor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commits for Claude co-author trailers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
+          flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:.*(\\bclaude\\b|anthropic\\.com)"; "i")) | .sha')
+
+          if [[ -n "$flagged" ]]; then
+            echo "❌ The following commits contain a Claude co-author trailer:"
+            echo "$flagged"
+            echo ""
+            echo "Commits must not credit Claude as a co-author."
+            echo "Remove the 'Co-authored-by: Claude ...' trailer from the commit message(s),"
+            echo "e.g., by amending the commit or rebasing, and force-push the branch."
+            exit 1
+          fi
+
+          echo "✅ No Claude co-author trailers found."

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
           flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:\\s*(claude\\s*<|[^\\n]*<noreply@anthropic\\.com>)"; "i")) | .sha')
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:[^\\n]*<noreply@anthropic\\.com>"; "i")) | .sha')
 
           if [[ -n "$flagged" ]]; then
             echo "❌ The following commits contain a Claude co-author trailer:"

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
           flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:.*(\\bclaude\\b|anthropic\\.com)"; "i")) | .sha')
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:\\s*(claude\\s*<|[^\\n]*<noreply@anthropic\\.com>)"; "i")) | .sha')
 
           if [[ -n "$flagged" ]]; then
             echo "❌ The following commits contain a Claude co-author trailer:"

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
           flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:[^\\n]*<noreply@anthropic\\.com>"; "i")) | .sha')
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:\\s*(claude\\s+(opus|sonnet|haiku|fable|mythos|instant|code|[0-9])|[^\\n]*<noreply@anthropic\\.com>)"; "i")) | .sha')
 
           if [[ -n "$flagged" ]]; then
             echo "❌ The following commits contain a Claude co-author trailer:"


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Commits should not credit AI assistants as co-authors. This PR adds an automated guard so that PR commits carrying a `Co-authored-by: Claude ...` trailer are caught in CI instead of relying on reviewers to spot them.

### Summary and Changelog

- Adds a new GitHub Actions workflow `commit_coauthor_validation.yml` with a `validate-commit-coauthor` job that runs on `pull_request` events targeting `master` and `branch-0.x`. It lists all commits of the PR via the GitHub API and fails if any commit message contains a `Co-authored-by:` trailer that either uses the `noreply@anthropic.com` email or names a Claude model (e.g., "Claude Opus 4.5", "Claude Sonnet", "Claude Code"), printing the offending commit SHAs and how to fix them (amend/rebase to drop the trailer). A bare human name like "Claude Perrin" with a personal email is not flagged.
- Registers `validate-commit-coauthor` under `required_status_checks` in `.asf.yaml` so the check is required on `master`.

### Impact

CI/process only; no code or user-facing changes. PRs with a Claude co-author trailer in any commit will fail the new required check until the trailer is removed.

### Risk Level

low. The check is read-only (GitHub API listing of PR commits) and the regex was verified against positive cases (`Co-authored-by: Claude <noreply@anthropic.com>` and model-name variants such as "Claude Opus 4.5", "claude sonnet", "Claude 3.7", "Claude Code" regardless of email) and negative cases (human co-authors, including ones named Claude, and mentions of Claude models or `noreply@anthropic.com` in the commit body outside a trailer).

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
