### PR TITLE
feat: support configurable parallelism for partition TTL stats collection

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieTTLConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieTTLConfig.java
@@ -84,6 +84,16 @@ public class HoodieTTLConfig extends HoodieConfig {
       .sinceVersion("1.0.0")
       .withDocumentation("max partitions to delete in partition ttl management");
 
+  public static final ConfigProperty<Integer> STATS_MAX_PARALLELISM = ConfigProperty
+      .key(PARTITION_TTL_STRATEGY_PARAM_PREFIX + "stats.max.parallelism")
+      .defaultValue(200)
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("Max parallelism used to collect the last commit time for candidate partitions "
+          + "during partition ttl management. The effective parallelism is the smaller of the candidate "
+          + "partition count and this value. When a table enables partition ttl for the first time, there "
+          + "may be a large number of historical partitions, so a higher value than the default may be desired.");
+
   public static class Builder {
     private final HoodieTTLConfig ttlConfig = new HoodieTTLConfig();
 
@@ -94,6 +104,11 @@ public class HoodieTTLConfig extends HoodieConfig {
 
     public HoodieTTLConfig.Builder withTTLDaysRetain(Integer daysRetain) {
       ttlConfig.setValue(DAYS_RETAIN, daysRetain.toString());
+      return this;
+    }
+
+    public HoodieTTLConfig.Builder withTTLStatsMaxParallelism(Integer statsMaxParallelism) {
+      ttlConfig.setValue(STATS_MAX_PARALLELISM, statsMaxParallelism.toString());
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3058,6 +3058,10 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieTTLConfig.MAX_PARTITION_TO_DELETE);
   }
 
+  public Integer getPartitionTTLStatsMaxParallelism() {
+    return getInt(HoodieTTLConfig.STATS_MAX_PARALLELISM);
+  }
+
   public boolean isSecondaryIndexEnabled() {
     return metadataConfig.isSecondaryIndexEnabled();
   }
@@ -3873,6 +3877,11 @@ public class HoodieWriteConfig extends HoodieConfig {
       checkArgument(lookbackCommits >= 0,
           String.format("%s must be non-negative, but was %d",
               ROLLING_METADATA_TIMELINE_LOOKBACK_COMMITS.key(), lookbackCommits));
+
+      int ttlStatsMaxParallelism = writeConfig.getInt(HoodieTTLConfig.STATS_MAX_PARALLELISM);
+      checkArgument(ttlStatsMaxParallelism > 0,
+          String.format("%s must be positive, but was %d",
+              HoodieTTLConfig.STATS_MAX_PARALLELISM.key(), ttlStatsMaxParallelism));
     }
 
     public HoodieWriteConfig build() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByTimeStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/ttl/strategy/KeepByTimeStrategy.java
@@ -85,7 +85,7 @@ public class KeepByTimeStrategy extends PartitionTTLStrategy {
       log.info("Candidate partition paths list is empty, skip TTL stats collection");
       return Collections.emptyMap();
     }
-    int statsParallelism = Math.min(partitionPaths.size(), 200);
+    int statsParallelism = Math.min(partitionPaths.size(), writeConfig.getPartitionTTLStatsMaxParallelism());
     return hoodieTable.getContext().map(partitionPaths, partitionPath -> {
       Option<String> partitionLastModifiedTime = hoodieTable.getHoodieView()
           .getLatestFileSlicesBeforeOrOn(partitionPath, instantTime, true)

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/config/TestHoodieWriteConfig.java
@@ -50,6 +50,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -122,6 +123,27 @@ public class TestHoodieWriteConfig {
           assertEquals(version, HoodieWriteConfig.newBuilder()
               .withPath("/tmp").withProperties(props).build().getWriteVersion());
         });
+  }
+
+  @Test
+  public void testPartitionTTLStatsMaxParallelismMustBePositive() {
+    // A non-positive value (0 or negative) is a misconfiguration and must fail fast at build time,
+    // rather than being silently coerced when TTL stats collection runs.
+    for (int invalid : new int[] {0, -5}) {
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+          () -> HoodieWriteConfig.newBuilder().withPath("/tmp")
+              .withProps(Collections.singletonMap(
+                  HoodieTTLConfig.STATS_MAX_PARALLELISM.key(), String.valueOf(invalid)))
+              .build());
+      assertTrue(e.getMessage().contains(HoodieTTLConfig.STATS_MAX_PARALLELISM.key()),
+          "Validation error should mention the offending config key");
+    }
+
+    // A positive value builds successfully.
+    assertEquals(8, HoodieWriteConfig.newBuilder().withPath("/tmp")
+        .withProps(java.util.Collections.singletonMap(
+            HoodieTTLConfig.STATS_MAX_PARALLELISM.key(), "8"))
+        .build().getPartitionTTLStatsMaxParallelism());
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/ttl/strategy/TestKeepByTimeStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/ttl/strategy/TestKeepByTimeStrategy.java
@@ -18,15 +18,23 @@
 
 package org.apache.hudi.table.action.ttl.strategy;
 
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.function.SerializableFunction;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTable;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -58,5 +66,61 @@ public class TestKeepByTimeStrategy {
     assertTrue(expired.isEmpty(), "Empty candidate list should yield no expired partitions");
     // Crucial: we must never reach the engine map call with parallelism=0.
     verify(hoodieTable, never()).getContext();
+  }
+
+  /**
+   * When the candidate partition count exceeds the configured max parallelism,
+   * the stats collection must be capped at the configured value.
+   */
+  @Test
+  public void testStatsParallelism_cappedByConfiguredMax() {
+    int configuredMax = 500;
+    List<String> partitions = IntStream.range(0, 1000)
+        .mapToObj(i -> "p" + i)
+        .collect(Collectors.toList());
+
+    int captured = captureStatsParallelism(configuredMax, partitions);
+
+    assertEquals(configuredMax, captured,
+        "Parallelism should be capped at the configured max when partitions exceed it");
+  }
+
+  /**
+   * When the candidate partition count is below the configured max parallelism,
+   * the effective parallelism should be the partition count (avoid over-provisioning).
+   */
+  @Test
+  public void testStatsParallelism_boundedByPartitionCount() {
+    int configuredMax = 500;
+    List<String> partitions = IntStream.range(0, 50)
+        .mapToObj(i -> "p" + i)
+        .collect(Collectors.toList());
+
+    int captured = captureStatsParallelism(configuredMax, partitions);
+
+    assertEquals(partitions.size(), captured,
+        "Parallelism should equal the partition count when it is below the configured max");
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private int captureStatsParallelism(int configuredMax, List<String> partitions) {
+    HoodieTable hoodieTable = mock(HoodieTable.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieEngineContext context = mock(HoodieEngineContext.class);
+    when(hoodieTable.getConfig()).thenReturn(writeConfig);
+    when(writeConfig.getPartitionTTLStrategyDaysRetain()).thenReturn(10);
+    when(writeConfig.getPartitionTTLStatsMaxParallelism()).thenReturn(configuredMax);
+    when(hoodieTable.getContext()).thenReturn(context);
+    // Return an empty result so no expired partitions are produced; we only care
+    // about the parallelism argument handed to the engine.
+    when(context.map(any(List.class), any(SerializableFunction.class), anyInt()))
+        .thenReturn(Collections.emptyList());
+
+    KeepByTimeStrategy strategy = new KeepByTimeStrategy(hoodieTable, "20240101000000000");
+    strategy.getExpiredPartitionsForTimeStrategy(partitions);
+
+    ArgumentCaptor<Integer> parallelismCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(context).map(any(List.class), any(SerializableFunction.class), parallelismCaptor.capture());
+    return parallelismCaptor.getValue();
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

 KeepByTimeStrategy hard-codes the parallelism used to collect the last commit time of candidate partitions to Math.min(partitionPaths.size(), 200). When a Hudi table enables partition TTL for the first time,  there can be a very large number of historical partitions, and the fixed cap of 200 makes the stats-collection phase unnecessarily slow. This PR makes that parallelism cap configurable.

### Summary and Changelog

 Users can now tune the parallelism used during partition TTL stats collection via a new config, instead of being limited to the hard-coded value of 200. The default remains 200, so existing behavior is unchanged.

  Changes:
  - HoodieTTLConfig: added config hoodie.partition.ttl.strategy.stats.max.parallelism (constant STATS_MAX_PARALLELISM, default 200, advanced, since 1.3.0) with documentation, plus builder method withTTLStatsMaxParallelism(...).
  - HoodieWriteConfig: added getter getPartitionTTLStatsMaxParallelism().
  - KeepByTimeStrategy: replaced the hard-coded 200 with Math.max(1, Math.min(partitionPaths.size(), writeConfig.getPartitionTTLStatsMaxParallelism())). The config is an upper bound — the effective parallelism is the smaller of the candidate partition count and the configured value.
  - TestKeepByTimeStrategy: added tests covering both branches — parallelism capped by the configured max when partitions exceed it, and bounded by the partition count when it is smaller.

  No code was copied.

### Impact

none

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
