### PR TITLE
chore(ci): modernize Codecov config for the coverage initiative

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,68 +15,121 @@
 
 # For more configuration details:
 # https://docs.codecov.io/docs/codecov-yaml
-
-# Check if this file is valid by running in bash:
+#
+# Validate this file:
 # curl -X POST --data-binary @.codecov.yml https://codecov.io/validate
+
+codecov:
+  # Wait for the parallel test jobs to finish uploading before evaluating status
+  # and posting the PR comment, so a partial upload does not report a false drop.
+  notify:
+    wait_for_ci: true
 
 coverage:
   precision: 2
   round: down
   range: "50...100"
+  status:
+    # Statuses are informational for now: they surface the delta on each PR but do
+    # not fail the build. Flip a component to blocking (drop `informational`, set a
+    # `target`/`threshold`) once its coverage has climbed, so the initiative does
+    # not gate unrelated PRs mid-flight.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
 
-# Ignoring Paths
-# --------------
-# which folders/files to ignore
+# Generated code (Avro/Thrift/Protobuf/ANTLR) is produced at build time, has no
+# source in git, and is therefore already absent from the Codecov report; it needs
+# no entry here. The paths below are non-generated code that should not count.
 ignore:
-  - "hudi-common/src/main/java/org/apache/hudi/avro/model/*"
-  - "hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java"
-  - "hudi-common/src/main/java/org/apache/hudi/common/HoodieJsonPayload"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactionAdminTool.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieSnapshotCopier.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/UpgradePayloadFromUberToApache.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/perf/TimelineServerPerf.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java"
-  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/adhoc/UpgradePayloadFromUberToApache.java"
-  - "hudi-client/src/main/java/org/apache/hudi/metrics/JmxMetricsReporter.java"
-  - "hudi-client/src/main/java/org/apache/hudi/metrics/JmxReporterServer.java"
-  - "hudi-client/src/main/java/org/apache/hudi/metrics/MetricsGraphiteReporter.java"
-  - "hudi-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/HoodieInputFormat.java"
-  - "hudi-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeInputFormat.java"
+  # Generated Avro model classes (kept for safety in case sources are ever committed).
+  - "hudi-common/src/main/java/org/apache/hudi/avro/model/**"
+  # Example and quickstart applications are illustrative, not production.
+  - "hudi-examples/**"
+  # Integration-test harness (test DAGs, fixtures, generators), not production behavior.
+  - "hudi-integ-test/**"
+  # Packaging and bundle shims: assembly config, no testable logic.
+  - "packaging/**"
+  # Vendored copy of Spark's HadoopFSUtils; owned upstream, not Hudi logic.
+  - "hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/HoodieHadoopFSUtils.scala"
+  # Metaserver is an incubating component with no shipped coverage. Remove this line
+  # if it is taken into scope for the coverage initiative.
+  - "hudi-platform-service/**"
 
-comment: false
+# Post a coverage summary on every PR so reviewers can see the per-component and
+# per-patch delta (used to enforce the coverage-quality bar for the initiative).
+comment:
+  layout: "condensed_header, diff, components, flags, files"
+  behavior: default
+  require_changes: false
 
-flags:
-  hudicli:
-    paths:
-      - hudi-cli/src/main/
-  hudiclient:
-    paths:
-      - hudi-client/src/main/
-  hudicommon:
-    paths:
-      - hudi-common/src/main/
-  hudiexamples:
-    paths:
-      - hudi-examples/src/main/
-  hudihadoopmr:
-    paths:
-      - hudi-hadoop-mr/src/main/
-  hudihivesync:
-    paths:
-      - hudi-hive-sync/src/main/
-  hudiintegtest:
-    paths:
-      - hudi-integ-test/src/main/
-  hudispark:
-    paths:
-      - hudi-spark/src/main/
-  huditimelineservice:
-    paths:
-      - hudi-timeline-service/src/main/
-  hudiutilities:
-    paths:
-      - hudi-utilities/src/main/
+# Carry the last known coverage forward for a flag when its CI job is skipped by the
+# path filter on a given PR, so a partial run does not zero out that flag's coverage.
+# Flags uploaded by .github/workflows/bot.yml: spark-client-hadoop-common, utilities,
+# common-and-other-modules, spark-java-tests, spark-scala-tests, hadoop-mr-java-client,
+# integration-tests.
+flag_management:
+  default_rules:
+    carryforward: true
+
+# Per-ownership-area coverage, so each coverage subtask can read its own number on
+# every PR. Paths align with the module layout and the ENG-44401 subtask breakdown.
+component_management:
+  individual_components:
+    - component_id: hudi-common
+      name: hudi-common
+      paths:
+        - "hudi-common/**"
+    - component_id: hudi-client
+      name: hudi-client
+      paths:
+        - "hudi-client/hudi-client-common/**"
+        - "hudi-client/hudi-spark-client/**"
+        - "hudi-client/hudi-java-client/**"
+    - component_id: hudi-flink
+      name: hudi-flink
+      paths:
+        - "hudi-flink-datasource/**"
+        - "hudi-client/hudi-flink-client/**"
+    - component_id: hudi-spark-datasource
+      name: hudi-spark-datasource
+      paths:
+        - "hudi-spark-datasource/**"
+    - component_id: hudi-utilities
+      name: hudi-utilities
+      paths:
+        - "hudi-utilities/**"
+    - component_id: hudi-cli
+      name: hudi-cli
+      paths:
+        - "hudi-cli/**"
+    - component_id: hudi-hadoop
+      name: hudi-hadoop
+      paths:
+        - "hudi-hadoop-common/**"
+        - "hudi-hadoop-mr/**"
+    - component_id: hudi-sync
+      name: hudi-sync
+      paths:
+        - "hudi-sync/**"
+    - component_id: hudi-io
+      name: hudi-io
+      paths:
+        - "hudi-io/**"
+    - component_id: hudi-timeline-service
+      name: hudi-timeline-service
+      paths:
+        - "hudi-timeline-service/**"
+    - component_id: hudi-cloud
+      name: hudi-cloud
+      paths:
+        - "hudi-aws/**"
+        - "hudi-gcp/**"
+        - "hudi-azure/**"
+    - component_id: hudi-kafka-connect
+      name: hudi-kafka-connect
+      paths:
+        - "hudi-kafka-connect/**"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -58,6 +58,17 @@ ignore:
   # Metaserver is an incubating component with no shipped coverage. Remove this line
   # if it is taken into scope for the coverage initiative.
   - "hudi-platform-service/**"
+  # Standalone main()-style tools and legacy JSON/payload helpers carried over from the
+  # previous config; these are exercised by integration tests, not unit tests. Kept
+  # excluded for consistency (entries for since-deleted classes have been dropped).
+  - "hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java"
+  - "hudi-common/src/main/java/org/apache/hudi/common/HoodieJsonPayload.java"
+  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java"
+  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactionAdminTool.java"
+  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactor.java"
+  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java"
+  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/perf/TimelineServerPerf.java"
+  - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java"
 
 # Post a coverage summary on every PR so reviewers can see the per-component and
 # per-patch delta (used to enforce the coverage-quality bar for the initiative).

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -43,7 +43,10 @@ coverage:
 
 # Generated code (Avro/Thrift/Protobuf/ANTLR) is produced at build time, has no
 # source in git, and is therefore already absent from the Codecov report; it needs
-# no entry here. The paths below are non-generated code that should not count.
+# no entry here. Likewise, modules whose CI jobs do not upload a JaCoCo report
+# (e.g. hudi-trino-plugin) never reach Codecov, so they are intentionally absent
+# from both the ignore list and component_management below. The paths below are
+# non-generated code that should not count.
 ignore:
   # Generated Avro model classes (kept for safety in case sources are ever committed).
   - "hudi-common/src/main/java/org/apache/hudi/avro/model/**"
@@ -60,8 +63,8 @@ ignore:
   - "hudi-platform-service/**"
   # Standalone main()-style tools and legacy JSON/payload helpers carried over from the
   # previous config; these are exercised by integration tests, not unit tests. Kept
-  # excluded for consistency (entries for since-deleted classes have been dropped).
-  - "hudi-common/src/main/java/org/apache/hudi/avro/MercifulJsonConverter.java"
+  # excluded for consistency (entries for since-deleted or now-tested classes have been
+  # dropped, e.g. MercifulJsonConverter, which now has TestMercifulJsonConverter).
   - "hudi-common/src/main/java/org/apache/hudi/common/HoodieJsonPayload.java"
   - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCleaner.java"
   - "hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactionAdminTool.java"

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
@@ -29,8 +29,6 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
  */
 public final class Base64CodecUtil {
 
-  // DNM: temporary no-op comment to trigger CI so the updated Codecov config uploads a report. Revert before merge.
-
   /**
    * Decodes data from the input string into using the encoding scheme.
    *

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
@@ -29,6 +29,8 @@ import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
  */
 public final class Base64CodecUtil {
 
+  // DNM: temporary no-op comment to trigger CI so the updated Codecov config uploads a report. Revert before merge.
+
   /**
    * Decodes data from the input string into using the encoding scheme.
    *

--- a/scripts/jacoco/README.md
+++ b/scripts/jacoco/README.md
@@ -125,8 +125,9 @@ This is the canonical per-PR view.
   ownership area (hudi-common, hudi-client, hudi-spark-datasource, hudi-flink, ...); and
   `flag_management` carries a flag's coverage forward when its job is skipped by the path filter,
   so a partial run does not report a false drop.
-- Generated code (Avro, Thrift, Protobuf, ANTLR) has no source committed to git, so it never
-  appears in the Codecov report and needs no exclusion.
+- Generated code (Thrift, Protobuf, ANTLR) has no source committed to git, so it never appears
+  in the Codecov report and needs no exclusion. The one committed generated path, the Avro model
+  classes, is still ignored defensively in `.codecov.yml`.
 - Codecov posts a summary comment on each PR with the project, per-component, and per-patch
   coverage delta. Statuses are informational (they do not fail the build); to gate a component
   against regression later, remove `informational` and set a `target`/`threshold` for it.

--- a/scripts/jacoco/README.md
+++ b/scripts/jacoco/README.md
@@ -136,7 +136,7 @@ To read coverage for a single module locally, run its tests with the JaCoCo agen
 generated `target/site/jacoco*/index.html`, for example:
 
 ```bash
-mvn test -pl hudi-common -Punit-tests -Djacoco.skip=false
+mvn test -pl hudi-common -Punit-tests
 ```
 
 Instruction coverage is the headline metric; branch coverage (also in the report) shows whether

--- a/scripts/jacoco/README.md
+++ b/scripts/jacoco/README.md
@@ -108,3 +108,35 @@ Published Artifacts
 - `merge_jacoco_job_files.sh`: merges multiple JaCoCo execution data files from multiple Azure pipeline jobs.
 - `generate_jacoco_coverage_report.sh`: generates the JaCoCo code coverage report by taking the execution data file,
   source files and class files.
+
+## Per-PR coverage on Codecov
+
+In addition to the aggregated Azure report described above, coverage is uploaded to
+[Codecov](https://app.codecov.io/gh/apache/hudi) on every pull request and every commit to master.
+This is the canonical per-PR view.
+
+- Each test job in `.github/workflows/bot.yml` runs with the JaCoCo agent, builds a merged report
+  via `scripts/jacoco/generate_merged_coverage_report.sh`, and uploads `jacoco-report.xml` to
+  Codecov under a flag (`spark-java-tests`, `spark-scala-tests`, `utilities`,
+  `common-and-other-modules`, `spark-client-hadoop-common`, `hadoop-mr-java-client`,
+  `integration-tests`).
+- `.codecov.yml` configures reporting: `ignore` drops non-production code (examples, packaging,
+  the integration-test harness, an incubating module); `component_management` reports coverage per
+  ownership area (hudi-common, hudi-client, hudi-spark-datasource, hudi-flink, ...); and
+  `flag_management` carries a flag's coverage forward when its job is skipped by the path filter,
+  so a partial run does not report a false drop.
+- Generated code (Avro, Thrift, Protobuf, ANTLR) has no source committed to git, so it never
+  appears in the Codecov report and needs no exclusion.
+- Codecov posts a summary comment on each PR with the project, per-component, and per-patch
+  coverage delta. Statuses are informational (they do not fail the build); to gate a component
+  against regression later, remove `informational` and set a `target`/`threshold` for it.
+
+To read coverage for a single module locally, run its tests with the JaCoCo agent and open the
+generated `target/site/jacoco*/index.html`, for example:
+
+```bash
+mvn test -pl hudi-common -Punit-tests -Djacoco.skip=false
+```
+
+Instruction coverage is the headline metric; branch coverage (also in the report) shows whether
+both sides of each conditional are exercised, which is what catches untested error and config paths.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`.codecov.yml` has drifted since the module layout changed. Its `ignore` list points at pre-2021 paths and files that no longer exist (`hudi-hive-sync/`, `com/uber/hoodie/...`, `hudi-client/src/main/...`), its `flags` block uses names (`hudicli`, `hudispark`, ...) that no longer match what CI uploads, per-PR comments are disabled, and there are no components or carryforward. Meanwhile Codecov already receives coverage on every PR and commit, so the config, not the pipeline, is what needs fixing.

Note on generated code: JaCoCo on the Azure report counts generated Avro/Thrift/Protobuf/ANTLR classes, but those have no source committed to git, so they are already absent from the Codecov report. No JaCoCo/Maven exclusion is needed to keep them out of the Codecov number; only the source-backed, non-production paths below need ignoring.

### Summary and Changelog

Modernize `.codecov.yml` so per-PR coverage is accurate and actionable:

- **ignore**: remove stale/nonexistent entries; ignore non-production code that Codecov still counts today: `hudi-examples`, `packaging`, the `hudi-integ-test` harness, the vendored `HoodieHadoopFSUtils.scala` (owned by Spark upstream), and the incubating `hudi-platform-service` (metaserver, 0% and unshipped; a comment marks it for removal if taken into scope). The per-class legacy-tool ignores (`HoodieJsonPayload`, the standalone `main()` utilities) are kept; `MercifulJsonConverter` is dropped and now counts, since it moved under `common.avro` in the reorg and has a dedicated `TestMercifulJsonConverter`.
- **flag_management**: `carryforward: true` so a flag's coverage is retained when its CI job is skipped by the path filter, instead of dropping to zero on partial runs. Replaces the dead `flags` block.
- **component_management**: per-ownership-area components (hudi-common, hudi-client, hudi-flink, hudi-spark-datasource, hudi-utilities, hudi-cli, hudi-hadoop, hudi-sync, hudi-io, hudi-timeline-service, hudi-cloud, hudi-kafka-connect) so each area has a coverage number on every PR. Modules whose CI jobs do not upload a report (e.g. `hudi-trino-plugin`) are intentionally absent, documented with a comment.
- **comment**: post a per-PR summary (project, components, patch delta); previously `comment: false`.
- **status**: `project` and `patch` are `informational` (report, do not fail the build). They can be flipped to enforcing per component as coverage climbs, without gating unrelated PRs now.
- Documents the Codecov per-PR flow in `scripts/jacoco/README.md`.

Validated with `curl -X POST --data-binary @.codecov.yml https://codecov.io/validate` (Valid).

### Impact

CI reporting only; no production code, no build change. Contributors will start seeing a Codecov comment on PRs and per-component coverage. The headline number rises modestly once the integration-test harness and examples stop counting.

### Risk Level

low

CI-config only. Coverage statuses are informational, so nothing new can fail a build.

### Documentation Update

`scripts/jacoco/README.md` gains a "Per-PR coverage on Codecov" section.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
