### PR TITLE
chore(glue-sync): Ignore EntityNotFoundException when dropping Glue partitions

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -71,6 +71,7 @@ import software.amazon.awssdk.services.glue.model.GetPartitionsRequest;
 import software.amazon.awssdk.services.glue.model.GetPartitionsResponse;
 import software.amazon.awssdk.services.glue.model.GetTableRequest;
 import software.amazon.awssdk.services.glue.model.KeySchemaElement;
+import software.amazon.awssdk.services.glue.model.PartitionError;
 import software.amazon.awssdk.services.glue.model.PartitionIndex;
 import software.amazon.awssdk.services.glue.model.PartitionIndexDescriptor;
 import software.amazon.awssdk.services.glue.model.PartitionInput;
@@ -437,8 +438,22 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
 
       BatchDeletePartitionResponse response = future.get();
       if (CollectionUtils.nonEmpty(response.errors())) {
-        throw new HoodieGlueSyncException("Fail to drop partitions to " + tableId(databaseName, tableName)
-            + " with error(s): " + response.errors());
+        // Dropping a partition that no longer exists is a no-op for an idempotent cleanup, so
+        // ignore EntityNotFoundException errors and only fail on other (e.g. permission/throttling) errors.
+        Map<Boolean, List<PartitionError>> errorsByIgnorable = response.errors().stream()
+            .collect(Collectors.partitioningBy(
+                error -> EntityNotFoundException.class.getSimpleName().equals(error.errorDetail().errorCode())));
+        List<PartitionError> ignoredErrors = errorsByIgnorable.get(true);
+        if (!ignoredErrors.isEmpty()) {
+          log.info("Ignored dropping {} non-existent partition(s) from table {}: {}", ignoredErrors.size(),
+              tableId(databaseName, tableName),
+              ignoredErrors.stream().map(PartitionError::partitionValues).collect(Collectors.toList()));
+        }
+        List<PartitionError> realErrors = errorsByIgnorable.get(false);
+        if (!realErrors.isEmpty()) {
+          throw new HoodieGlueSyncException("Fail to drop partitions to " + tableId(databaseName, tableName)
+              + " with error(s): " + realErrors);
+        }
       }
     } catch (Exception e) {
       throw new HoodieGlueSyncException("Fail to drop partitions to " + tableId(databaseName, tableName), e);

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -138,6 +138,8 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   private static final int MAX_PARTITIONS_PER_CHANGE_REQUEST = 100;
   private static final int MAX_PARTITIONS_PER_READ_REQUEST = 1000;
   private static final int MAX_DELETE_PARTITIONS_PER_REQUEST = 25;
+  // Glue reports a missing partition using the EntityNotFoundException class name as the error code.
+  private static final String ENTITY_NOT_FOUND_ERROR_CODE = EntityNotFoundException.class.getSimpleName();
   protected final GlueAsyncClient awsGlue;
   private static final String GLUE_PARTITION_INDEX_ENABLE = "partition_filtering.enabled";
   private static final int PARTITION_INDEX_MAX_NUMBER = 3;
@@ -442,12 +444,12 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
         // ignore EntityNotFoundException errors and only fail on other (e.g. permission/throttling) errors.
         Map<Boolean, List<PartitionError>> errorsByIgnorable = response.errors().stream()
             .collect(Collectors.partitioningBy(
-                error -> EntityNotFoundException.class.getSimpleName().equals(error.errorDetail().errorCode())));
-        List<PartitionError> ignoredErrors = errorsByIgnorable.get(true);
-        if (!ignoredErrors.isEmpty()) {
-          log.info("Ignored dropping {} non-existent partition(s) from table {}: {}", ignoredErrors.size(),
+                error -> ENTITY_NOT_FOUND_ERROR_CODE.equals(error.errorDetail().errorCode())));
+        List<PartitionError> ignorableErrors = errorsByIgnorable.get(true);
+        if (!ignorableErrors.isEmpty()) {
+          log.info("Ignored dropping {} non-existent partition(s) from table {}: {}", ignorableErrors.size(),
               tableId(databaseName, tableName),
-              ignoredErrors.stream().map(PartitionError::partitionValues).collect(Collectors.toList()));
+              ignorableErrors.stream().map(PartitionError::partitionValues).collect(Collectors.toList()));
         }
         List<PartitionError> realErrors = errorsByIgnorable.get(false);
         if (!realErrors.isEmpty()) {

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -138,8 +138,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   private static final int MAX_PARTITIONS_PER_CHANGE_REQUEST = 100;
   private static final int MAX_PARTITIONS_PER_READ_REQUEST = 1000;
   private static final int MAX_DELETE_PARTITIONS_PER_REQUEST = 25;
-  // Glue reports a missing partition using the EntityNotFoundException class name as the error code.
-  private static final String ENTITY_NOT_FOUND_ERROR_CODE = EntityNotFoundException.class.getSimpleName();
+  private static final String ENTITY_NOT_FOUND_ERROR_CODE = "EntityNotFoundException";
   protected final GlueAsyncClient awsGlue;
   private static final String GLUE_PARTITION_INDEX_ENABLE = "partition_filtering.enabled";
   private static final int PARTITION_INDEX_MAX_NUMBER = 3;

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/sync/TestAWSGlueSyncClient.java
@@ -647,6 +647,62 @@ class TestAWSGlueSyncClient {
     assertTrue(ex.getCause().getCause().getMessage().contains("Fail to drop partitions"));
   }
 
+  @Test
+  void testDropPartitions_IgnoresEntityNotFound() {
+    String tableName = "tbl";
+    List<String> toDrop = List.of("2025/05/19");
+
+    // Glue reports EntityNotFoundException for a partition that no longer exists; it should be ignored.
+    ErrorDetail detail = ErrorDetail.builder().errorCode(EntityNotFoundException.class.getSimpleName()).build();
+    PartitionError pe = PartitionError.builder().partitionValues(Arrays.asList("2025", "05", "19")).errorDetail(detail).build();
+    BatchDeletePartitionResponse resp = BatchDeletePartitionResponse.builder()
+        .errors(Collections.singletonList(pe))
+        .build();
+    when(mockAwsGlue.batchDeletePartition(any(BatchDeletePartitionRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(resp));
+
+    // should swallow the EntityNotFound error and not throw
+    awsGlueSyncClient.dropPartitions(tableName, toDrop);
+
+    verify(mockAwsGlue).batchDeletePartition(any(BatchDeletePartitionRequest.class));
+  }
+
+  @Test
+  void testDropPartitions_MixedErrorsStillThrow() {
+    String tableName = "tbl";
+    List<String> toDrop = Arrays.asList("2025/05/19", "2025/05/18");
+
+    // One ignorable EntityNotFound error and one real error -> should still throw for the real one.
+    PartitionError ignorable = PartitionError.builder()
+        .partitionValues(Arrays.asList("2025", "05", "19"))
+        .errorDetail(ErrorDetail.builder().errorCode(EntityNotFoundException.class.getSimpleName()).build())
+        .build();
+    PartitionError real = PartitionError.builder()
+        .partitionValues(Arrays.asList("2025", "05", "18"))
+        .errorDetail(ErrorDetail.builder().errorCode("InternalServiceException").build())
+        .build();
+    BatchDeletePartitionResponse resp = BatchDeletePartitionResponse.builder()
+        .errors(Arrays.asList(ignorable, real))
+        .build();
+    when(mockAwsGlue.batchDeletePartition(any(BatchDeletePartitionRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(resp));
+
+    HoodieGlueSyncException ex = assertThrows(
+        HoodieGlueSyncException.class,
+        () -> awsGlueSyncClient.dropPartitions(tableName, toDrop)
+    );
+    // Walk the full cause chain: the error list is nested a few wrappers deep.
+    StringBuilder chain = new StringBuilder();
+    for (Throwable t = ex; t != null; t = t.getCause()) {
+      chain.append(t.getMessage()).append('\n');
+    }
+    String messages = chain.toString();
+    assertTrue(messages.contains("Fail to drop partitions"));
+    // Only the real error should be surfaced, not the ignored EntityNotFound one.
+    assertTrue(messages.contains("InternalServiceException"));
+    assertFalse(messages.contains(EntityNotFoundException.class.getSimpleName()));
+  }
+
   @Disabled("Integration test – requires real AWS environment")
   @Test
   void testIntegrationTableExists_RealGlueEnvironment() {


### PR DESCRIPTION


### Describe the issue this Pull Request addresses

AWSGlueCatalogSyncClient#dropPartitionsInternal previously failed the whole sync whenever BatchDeletePartition returned any error, including EntityNotFoundException for partitions that no longer exist. Dropping a non-existent partition is a no-op for this idempotent cleanup and is easily triggered by sync retries, concurrent writers, or externally-removed partitions.

### Summary and Changelog
  `AWSGlueCatalogSyncClient#dropPartitionsInternal` previously failed the entire sync whenever `BatchDeletePartition` returned any error in the response, including `EntityNotFoundException` for partitions that no longer exist.

  Dropping a non-existent partition is a no-op for this idempotent cleanup and is easily triggered in practice by sync retries, concurrent writers dropping the same partitions, or partitions removed externally.

  Changes:
  - Filter out `EntityNotFoundException` errors returned by `BatchDeletePartition`;
  - other errors (e.g. permission / throttling) still raise `HoodieGlueSyncException`.
  - Log the ignored (non-existent) partition values at INFO level so the skip is observable.
  - Added unit tests `testDropPartitions_IgnoresEntityNotFound` and `testDropPartitions_MixedErrorsStillThrow`.

### Impact

none
### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
