### PR TITLE
fix(storage-format): return all records when scanning multi-block native HFiles

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileDataBlock.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileDataBlock.java
@@ -53,7 +53,9 @@ public class HFileDataBlock extends HFileBlock {
   // so the latest timestamp is used.
   private static final long LATEST_TIMESTAMP = Long.MAX_VALUE;
 
-  // End offset of content in the block, relative to the start of the start of the block
+  // End offset of content in the block, relative to the start of the block. The key-values
+  // occupy exactly uncompressedSizeWithoutHeader bytes after the header; the checksum trails
+  // the content and is not part of it, so it must not be subtracted here.
   protected final int uncompressedContentEndRelativeOffset;
   private final List<KeyValueEntry> entriesToWrite = new ArrayList<>();
 
@@ -64,7 +66,7 @@ public class HFileDataBlock extends HFileBlock {
     super(context, HFileBlockType.DATA, byteBuff, startOffsetInBuff);
 
     this.uncompressedContentEndRelativeOffset =
-        this.uncompressedEndOffset - this.sizeCheckSum - this.startOffsetInBuff;
+        this.uncompressedEndOffset - this.startOffsetInBuff;
   }
 
   // For write purpose.

--- a/hudi-io/src/test/java/org/apache/hudi/io/hfile/TestHFileMultiBlockScan.java
+++ b/hudi-io/src/test/java/org/apache/hudi/io/hfile/TestHFileMultiBlockScan.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.hfile;
+
+import org.apache.hudi.io.ByteArraySeekableDataInputStream;
+import org.apache.hudi.io.ByteBufferBackedInputStream;
+import org.apache.hudi.io.compress.CompressionCodec;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Locale;
+
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces a full-scan record drop on native-writer HFiles that span many data blocks. A large
+ * block size packs many records per block; the trailer entry count is correct, but a
+ * {@code seekTo()} then {@code next()} forward scan stops short of a block's content end because
+ * the content-end bound subtracts the trailing checksum size. The drop only surfaces once the
+ * checksum region exceeds the last record's size, which is why small-block tests never caught it.
+ */
+public class TestHFileMultiBlockScan {
+
+  @ParameterizedTest
+  @CsvSource({
+      "NONE, 64, 5000", "GZIP, 64, 5000",
+      "NONE, 1048576, 200000", "GZIP, 1048576, 200000",
+      "NONE, 65536, 200000", "GZIP, 65536, 200000"
+  })
+  public void fullScanReturnsAllRecords(String codec, int blockSize, int numRecords) throws Exception {
+    HFileContext context = new HFileContext.Builder()
+        .blockSize(blockSize)
+        .compressionCodec(CompressionCodec.valueOf(codec))
+        .build();
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (HFileWriter writer = new HFileWriterImpl(context, baos)) {
+      for (int i = 0; i < numRecords; i++) {
+        writer.append(key(i), getUTF8Bytes(value(i)));
+      }
+    }
+    byte[] fileBytes = baos.toByteArray();
+
+    try (HFileReader reader = new HFileReaderImpl(
+        new ByteArraySeekableDataInputStream(new ByteBufferBackedInputStream(fileBytes)),
+        fileBytes.length)) {
+      reader.initializeMetadata();
+      assertEquals(numRecords, reader.getNumKeyValueEntries(),
+          "trailer entry count for codec=" + codec + " blockSize=" + blockSize);
+
+      String scenario = "codec=" + codec + " blockSize=" + blockSize + " numRecords=" + numRecords;
+      int scanned = 0;
+      int firstSkipAt = -1;
+      boolean hasNext = reader.seekTo();
+      while (hasNext) {
+        KeyValue kv = reader.getKeyValue().get();
+        if (firstSkipAt < 0 && !key(scanned).equals(kv.getKey().getContentInString())) {
+          firstSkipAt = scanned;
+        }
+        scanned++;
+        hasNext = reader.next();
+      }
+      assertEquals(numRecords, scanned,
+          "forward scan returned fewer records than written; " + scenario
+              + " firstSkipAtPosition=" + firstSkipAt);
+    }
+  }
+
+  private static String key(int i) {
+    return String.format(Locale.ROOT, "%010d", i);
+  }
+
+  private static String value(int i) {
+    return String.format(Locale.ROOT, "value-%010d", i);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A forward scan (`seekTo()` then `next()`) over a native-writer HFile that spans multiple data blocks can silently return fewer records than were written. The trailer entry count is correct; the scan stops short of each data block's content end.

`HFileDataBlock` computed the block's content-end bound as:

```
uncompressedContentEndRelativeOffset = uncompressedEndOffset - sizeCheckSum - startOffsetInBuff
```

The key-values occupy exactly `uncompressedSizeWithoutHeader` bytes after the header, and the checksum trails that content rather than being part of it. `uncompressedEndOffset` already points at the true end of the content (`startOffsetInBuff + HFILEBLOCK_HEADER_SIZE + uncompressedSizeWithoutHeader`), so subtracting `sizeCheckSum` moves the bound too early by the checksum-region size. `seekTo`/`next` then stop before the block's trailing key-values and skip to the next block, dropping those records; a point lookup for such a key in the block also misses.

The drop only surfaces once a block's checksum region is larger than its last record, so it scales with block size and is invisible at the record counts and block sizes used by existing tests. With 16 KB `bytesPerChecksum`, an uncompressed 1 MB data block has 256 checksum bytes, enough to cut several ~50-byte records from the tail of every block. Compressed blocks size the checksum from the (smaller) on-disk size, so they usually stay under one record and do not visibly drop, which is why GZIP masks the bug.

### Summary and Changelog

- `HFileDataBlock`: compute `uncompressedContentEndRelativeOffset` as `uncompressedEndOffset - startOffsetInBuff`, without subtracting `sizeCheckSum`. The checksum trails the content and is not traversed by the read cursor.
- `TestHFileMultiBlockScan`: writes native HFiles across `{NONE, GZIP}` and block sizes/record counts that force many records per block, asserts the trailer count and, critically, that a full `seekTo()`+`next()` scan returns every record in key order.

### Impact

Full scans of multi-block native HFiles return all records. No format or API change; the fix only extends the read cursor to the block's true content end. Behavior for single-block files and compressed files that did not hit the boundary is unchanged.

The new test fails on the pre-fix code with `codec=NONE blockSize=1048576 numRecords=200000`, returning 199955 of 200000 records (first skip at scan position 22305), and passes with the fix. The existing `hudi-io` HFile suites (`TestHFileReader`, `TestHFileWriter`, `TestHFileReadCompatibility`, `TestHFileCompatibility`) and the `hudi-hadoop-common` reader/writer tests pass.

### Risk Level

low

The change removes an incorrect term from a single read-side offset computation, widening the readable window to the block's true content end. It is covered by the new multi-block scan test and the existing golden and cross-reader (HBase) HFile tests.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
