### PR TITLE
refactor: Retire leftover Avro Schema usages in AvroSchemaUtils and LSMTimelineWriter

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/LSMTimelineWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v2/LSMTimelineWriter.java
@@ -49,7 +49,6 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
@@ -137,9 +136,8 @@ public class LSMTimelineWriter {
       throw new HoodieIOException("Failed to check archiving file before write: " + filePath, ioe);
     }
     try (HoodieFileWriter writer = openWriter(filePath)) {
-      Schema wrapperSchema = HoodieLSMTimelineInstant.getClassSchema();
-      log.info("Writing schema " + wrapperSchema.toString());
-      HoodieSchema schema = HoodieSchema.fromAvroSchema(wrapperSchema);
+      HoodieSchema schema = HoodieSchema.fromAvroSchema(HoodieLSMTimelineInstant.getClassSchema());
+      log.info("Writing schema {}", schema);
       for (ActiveAction activeAction : activeActions) {
         try {
           preWriteCallback.ifPresent(callback -> callback.accept(activeAction));
@@ -147,7 +145,7 @@ public class LSMTimelineWriter {
           final HoodieLSMTimelineInstant metaEntry = MetadataConversionUtils.createLSMTimelineInstant(activeAction, metaClient);
           writer.write(metaEntry.getInstantTime(), new HoodieAvroIndexedRecord(metaEntry), schema);
         } catch (Exception e) {
-          log.error("Failed to write instant: " + activeAction.getInstantTime(), e);
+          log.error("Failed to write instant: {}", activeAction.getInstantTime(), e);
           exceptionHandler.ifPresent(handler -> handler.accept(e));
         }
       }
@@ -290,7 +288,7 @@ public class LSMTimelineWriter {
       compactFiles(candidateFiles, compactedFileName);
       // 4. update the manifest file
       updateManifest(candidateFiles, compactedFileName);
-      log.info("Finishes compaction of source files: " + candidateFiles);
+      log.info("Finishes compaction of source files: {}", candidateFiles);
       return Option.of(compactedFileName);
     }
     return Option.empty();

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroSchemaUtils.java
@@ -114,10 +114,6 @@ public class AvroSchemaUtils {
     return Schema.createUnion(Schema.create(Schema.Type.NULL), schema);
   }
 
-  public static String createSchemaErrorString(String errorMessage, Schema writerSchema, Schema tableSchema) {
-    return String.format("%s\nwriterSchema: %s\ntableSchema: %s", errorMessage, writerSchema, tableSchema);
-  }
-
   /**
    * Create a new schema by force changing all the fields as nullable.
    *


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Part of #14263 (RFC-99: consolidate Avro `Schema` usage under `HoodieSchema`). Two small, independent cleanups that retire leftover Avro `Schema` surface now that the `HoodieSchema` equivalents are already in place. No functional change.

### Summary and Changelog

Two no-op cleanups:

- **`AvroSchemaUtils.createSchemaErrorString(String, Schema, Schema)` -- removed.** It has no callers in `main` or test; every site uses the `HoodieSchema` twin `HoodieSchemaUtils.createSchemaErrorString(String, HoodieSchema, HoodieSchema)`. The Avro overload is a `public static` method on the (unannotated, internal) `AvroSchemaUtils` and has shipped since 1.0.0, but is now vestigial after the migration -- downstream code calling it directly should move to the `HoodieSchema` twin.
- **`LSMTimelineWriter.write(...)` -- inline the schema wrapper.** Replaces an intermediate Avro `Schema` local with `HoodieSchema schema = HoodieSchema.fromAvroSchema(HoodieLSMTimelineInstant.getClassSchema())`, matching the sibling write paths already in this file, and drops the now-unused `org.apache.avro.Schema` import. Log output is unchanged: `HoodieSchema.toString()` delegates to the wrapped Avro schema.
  - Incidental (editor auto-format): two adjacent concatenated log statements in the same file are normalized to parameterized slf4j form.

### Impact

No user-facing, on-disk, serialization, or behavior change. The only API delta is removing the unused `AvroSchemaUtils.createSchemaErrorString(String, Schema, Schema)` overload (unannotated internal util, no in-repo callers); the `HoodieSchema` twin remains. The `LSMTimelineWriter` change is a behavior-preserving local inline with identical log output.

### Risk Level

low. Both changes are compile-verified across the affected modules (`hudi-common`, `hudi-client-common`). The removed overload has zero callers in the repo and a direct `HoodieSchema` replacement; the `LSMTimelineWriter` change only inlines a local and matches existing sibling code, so the archival write path is unaffected.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (n/a -- dead-code removal plus a behavior-preserving inline; covered by existing compilation and timeline tests)
