### PR TITLE
refactor(client): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncClusteringService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncClusteringService.java
@@ -71,7 +71,7 @@ public abstract class AsyncClusteringService extends HoodieAsyncTableService {
     return Pair.of(CompletableFuture.allOf(IntStream.range(0, maxConcurrentClustering).mapToObj(i -> CompletableFuture.supplyAsync(() -> {
       try {
         // Set Compactor Pool Name for allowing users to prioritize compaction
-        log.info("Setting pool name for clustering to " + CLUSTERING_POOL_NAME);
+        log.info("Setting pool name for clustering to {}", CLUSTERING_POOL_NAME);
         context.setProperty(EngineProperty.CLUSTERING_POOL_NAME, CLUSTERING_POOL_NAME);
         while (!isShutdownRequested()) {
           final String instant = fetchNextAsyncServiceInstant();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/AsyncCompactService.java
@@ -71,16 +71,16 @@ public abstract class AsyncCompactService extends HoodieAsyncTableService {
     return Pair.of(CompletableFuture.allOf(IntStream.range(0, maxConcurrentCompaction).mapToObj(i -> CompletableFuture.supplyAsync(() -> {
       try {
         // Set Compactor Pool Name for allowing users to prioritize compaction
-        log.info("Setting pool name for compaction to " + COMPACT_POOL_NAME);
+        log.info("Setting pool name for compaction to {}", COMPACT_POOL_NAME);
         context.setProperty(EngineProperty.COMPACTION_POOL_NAME, COMPACT_POOL_NAME);
 
         while (!isShutdownRequested()) {
           final String instantTime = fetchNextAsyncServiceInstant();
 
           if (null != instantTime) {
-            log.info("Starting Compaction for instant " + instantTime);
+            log.info("Starting Compaction for instant {}", instantTime);
             compactor.compact(instantTime);
-            log.info("Finished Compaction for instant " + instantTime);
+            log.info("Finished Compaction for instant {}", instantTime);
           }
         }
         log.info("Compactor shutting down properly!!");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncService.java
@@ -186,7 +186,7 @@ public abstract class HoodieAsyncService implements Serializable {
    * @param instantTime {@link String} to enqueue.
    */
   public void enqueuePendingAsyncServiceInstant(String instantTime) {
-    log.info("Enqueuing new pending table service instant: " + instantTime);
+    log.info("Enqueuing new pending table service instant: {}", instantTime);
     pendingInstants.add(instantTime);
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -1431,7 +1431,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       case CLEAN:
         return tableServiceManagerClient.executeClean();
       default:
-        log.info("Not supported delegate to table service manager, tableServiceType : " + tableServiceType.getAction());
+        log.info("Not supported delegate to table service manager, tableServiceType : {}", tableServiceType.getAction());
         return Option.empty();
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/CompactionAdminClient.java
@@ -299,13 +299,12 @@ public class CompactionAdminClient extends BaseHoodieClient {
         context.setJobStatus(this.getClass().getSimpleName(), "Execute unschedule operations: " + config.getTableName());
         return context.map(renameActions, lfPair -> {
           try {
-            log.info("RENAME " + lfPair.getLeft().getPath() + " => " + lfPair.getRight().getPath());
+            log.info("RENAME {} => {}", lfPair.getLeft().getPath(), lfPair.getRight().getPath());
             renameLogFile(metaClient, lfPair.getLeft(), lfPair.getRight());
             return new RenameOpResult(lfPair, true, Option.empty());
           } catch (IOException e) {
             log.error("Error renaming log file", e);
-            log.error("\n\n\n***NOTE Compaction is in inconsistent state. Try running \"compaction repair "
-                + lfPair.getLeft().getDeltaCommitTime() + "\" to recover from failure ***\n\n\n");
+            log.error("\n\n\n***NOTE Compaction is in inconsistent state. Try running \"compaction repair {}\" to recover from failure ***\n\n\n", lfPair.getLeft().getDeltaCommitTime());
             return new RenameOpResult(lfPair, false, Option.of(e));
           }
         }, parallelism);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTableServiceManagerClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/HoodieTableServiceManagerClient.java
@@ -93,7 +93,7 @@ public class HoodieTableServiceManagerClient {
     queryParameters.forEach(builder::addParameter);
 
     String url = builder.toString();
-    log.info("Sending request to table management service : (" + url + ")");
+    log.info("Sending request to table management service : ({})", url);
     int timeoutMs = this.config.getConnectionTimeoutSec() * 1000;
     int requestRetryLimit = config.getConnectionRetryLimit();
     int connectionRetryDelay = config.getConnectionRetryDelay();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/selector/BootstrapRegexModeSelector.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/bootstrap/selector/BootstrapRegexModeSelector.java
@@ -48,7 +48,7 @@ public class BootstrapRegexModeSelector extends BootstrapModeSelector {
     this.bootstrapModeOnMatch = writeConfig.getBootstrapModeForRegexMatch();
     this.defaultMode = BootstrapMode.FULL_RECORD.equals(bootstrapModeOnMatch)
         ? BootstrapMode.METADATA_ONLY : BootstrapMode.FULL_RECORD;
-    log.info("Default Mode :" + defaultMode + ", on Match Mode :" + bootstrapModeOnMatch);
+    log.info("Default Mode :{}, on Match Mode :{}", defaultMode, bootstrapModeOnMatch);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -97,7 +97,7 @@ public class EmbeddedTimelineService {
       synchronized (SERVICE_LOCK) {
         if (RUNNING_SERVICES.containsKey(timelineServiceIdentifier)) {
           RUNNING_SERVICES.get(timelineServiceIdentifier).addBasePath(writeConfig.getBasePath());
-          log.info("Reusing existing embedded timeline server with configuration: " + RUNNING_SERVICES.get(timelineServiceIdentifier).serviceConfig);
+          log.info("Reusing existing embedded timeline server with configuration: {}", RUNNING_SERVICES.get(timelineServiceIdentifier).serviceConfig);
           return RUNNING_SERVICES.get(timelineServiceIdentifier);
         }
         // if no compatible instance is found, create a new one

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
@@ -359,7 +359,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
           log.info("Not archiving as there is no compaction yet on the metadata table");
           instants = Stream.empty();
         } else {
-          log.info("Limiting archiving of instants to latest compaction on metadata table at " + latestCompactionTime.get());
+          log.info("Limiting archiving of instants to latest compaction on metadata table at {}", latestCompactionTime.get());
           instants = instants.filter(instant -> compareTimestamps(instant.requestedTime(), LESSER_THAN,
               latestCompactionTime.get()));
         }
@@ -419,7 +419,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
   }
 
   private boolean deleteArchivedInstants(List<HoodieInstant> archivedInstants, HoodieEngineContext context) throws IOException {
-    log.info("Deleting instants " + archivedInstants);
+    log.info("Deleting instants {}", archivedInstants);
 
     List<HoodieInstant> pendingInstants = new ArrayList<>();
     List<HoodieInstant> completedInstants = new ArrayList<>();
@@ -463,7 +463,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
   public void archive(HoodieEngineContext context, List<HoodieInstant> instants) throws HoodieCommitException {
     try {
       Schema wrapperSchema = HoodieArchivedMetaEntry.getClassSchema();
-      log.info("Wrapper schema " + wrapperSchema.toString());
+      log.info("Wrapper schema {}", wrapperSchema.toString());
       List<IndexedRecord> records = new ArrayList<>();
       for (HoodieInstant hoodieInstant : instants) {
         try {
@@ -474,7 +474,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
           }
         } catch (Exception e) {
           InstantFileNameGenerator fileNameFactory = new InstantFileNameGeneratorV1();
-          log.error("Failed to archive commits, .commit file: " + fileNameFactory.getFileName(hoodieInstant), e);
+          log.error("Failed to archive commits, .commit file: {}", fileNameFactory.getFileName(hoodieInstant), e);
           if (this.config.isFailOnTimelineArchivingEnabled()) {
             throw e;
           }
@@ -489,7 +489,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
   private void deleteAnyLeftOverMarkers(HoodieEngineContext context, HoodieInstant instant) {
     WriteMarkers writeMarkers = WriteMarkersFactory.get(config.getMarkersType(), table, instant.requestedTime());
     if (writeMarkers.deleteMarkerDir(context, config.getMarkersDeleteParallelism())) {
-      log.info("Cleaned up left over marker directory for instant :" + instant);
+      log.info("Cleaned up left over marker directory for instant :{}", instant);
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/timeline/versioning/v1/TimelineArchiverV1.java
@@ -463,7 +463,7 @@ public class TimelineArchiverV1<T extends HoodieAvroPayload, I, K, O> implements
   public void archive(HoodieEngineContext context, List<HoodieInstant> instants) throws HoodieCommitException {
     try {
       Schema wrapperSchema = HoodieArchivedMetaEntry.getClassSchema();
-      log.info("Wrapper schema {}", wrapperSchema.toString());
+      log.info("Wrapper schema {}", wrapperSchema);
       List<IndexedRecord> records = new ArrayList<>();
       for (HoodieInstant hoodieInstant : instants) {
         try {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/BucketIndexConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/BucketIndexConcurrentFileWritesConflictResolutionStrategy.java
@@ -51,8 +51,7 @@ public class BucketIndexConcurrentFileWritesConflictResolutionStrategy
     Set<String> intersection = new HashSet<>(partitionBucketIdSetForFirstInstant);
     intersection.retainAll(partitionBucketIdSetForSecondInstant);
     if (!intersection.isEmpty()) {
-      log.info("Found conflicting writes between first operation = " + thisOperation
-          + ", second operation = " + otherOperation + " , intersecting bucket ids " + intersection);
+      log.info("Found conflicting writes between first operation = {}, second operation = {} , intersecting bucket ids {}", thisOperation, otherOperation, intersection);
       return true;
     }
     return false;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/DirectMarkerTransactionManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/DirectMarkerTransactionManager.java
@@ -48,22 +48,20 @@ public class DirectMarkerTransactionManager extends TransactionManager {
 
   public void beginTransaction(String newTxnOwnerInstantTime, InstantGenerator instantGenerator) {
     if (isLockRequired) {
-      LOG.info("Transaction starting for " + newTxnOwnerInstantTime + " and " + filePath);
+      LOG.info("Transaction starting for {} and {}", newTxnOwnerInstantTime, filePath);
       lockManager.lock();
 
       reset(changeActionInstant, Option.of(getInstant(newTxnOwnerInstantTime, instantGenerator)), Option.empty());
-      LOG.info("Transaction started for " + newTxnOwnerInstantTime + " and " + filePath);
+      LOG.info("Transaction started for {} and {}", newTxnOwnerInstantTime, filePath);
     }
   }
 
   public void endTransaction(String currentTxnOwnerInstantTime, InstantGenerator instantGenerator) {
     if (isLockRequired) {
-      LOG.info("Transaction ending with transaction owner " + currentTxnOwnerInstantTime
-          + " for " + filePath);
+      LOG.info("Transaction ending with transaction owner {} for {}", currentTxnOwnerInstantTime, filePath);
       if (reset(Option.of(getInstant(currentTxnOwnerInstantTime, instantGenerator)), Option.empty(), Option.empty())) {
         lockManager.unlock();
-        LOG.info("Transaction ended with transaction owner " + currentTxnOwnerInstantTime
-            + " for " + filePath);
+        LOG.info("Transaction ended with transaction owner {} for {}", currentTxnOwnerInstantTime, filePath);
       }
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleConcurrentFileWritesConflictResolutionStrategy.java
@@ -142,8 +142,7 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
     Set<Pair<String, String>> intersection = new HashSet<>(partitionAndFileIdsSetForFirstInstant);
     intersection.retainAll(partitionAndFileIdsSetForSecondInstant);
     if (!intersection.isEmpty()) {
-      log.info("Found conflicting writes between first operation = " + thisOperation
-          + ", second operation = " + otherOperation + " , intersecting file ids " + intersection);
+      log.info("Found conflicting writes between first operation = {}, second operation = {} , intersecting file ids {}", thisOperation, otherOperation, intersection);
       return true;
     }
     return false;
@@ -163,8 +162,7 @@ public class SimpleConcurrentFileWritesConflictResolutionStrategy
       String rolledbackCommit = otherOperation.getRolledbackCommit();
       String thisCommitTimestamp = thisOperation.getInstantTimestamp();
       if (rolledbackCommit != null && rolledbackCommit.equals(thisCommitTimestamp)) {
-        log.error("Found rollback conflict: rollback operation " + otherOperation
-            + " is rolling back commit " + thisCommitTimestamp + " created by operation " + thisOperation);
+        log.error("Found rollback conflict: rollback operation {} is rolling back commit {} created by operation {}", otherOperation, thisCommitTimestamp, thisOperation);
         return true;
       }
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -169,7 +169,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
         return true;
       }
     } catch (IOException | HoodieIOException e) {
-      log.error(generateLogStatement(LockState.ALREADY_RELEASED) + " failed to get lockFile's modification time", e);
+      log.error("{} failed to get lockFile's modification time", generateLogStatement(LockState.ALREADY_RELEASED), e);
     }
     return false;
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/LockManager.java
@@ -109,7 +109,7 @@ public class LockManager implements Serializable, AutoCloseable {
   public synchronized LockProvider getLockProvider() {
     // Perform lazy initialization of lock provider only if needed
     if (lockProvider == null) {
-      log.info("LockProvider " + writeConfig.getLockProviderClass());
+      log.info("LockProvider {}", writeConfig.getLockProviderClass());
       
       // Try to load lock provider with HoodieLockMetrics constructor first
       Class<?>[] metricsConstructorTypes = {LockConfiguration.class, StorageConfiguration.class, HoodieLockMetrics.class};

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/TransactionUtils.java
@@ -89,8 +89,7 @@ public class TransactionUtils {
         try {
           ConcurrentOperation otherOperation = new ConcurrentOperation(instant, table.getMetaClient());
           if (resolutionStrategy.hasConflict(thisOperation, otherOperation)) {
-            log.info("Conflict encountered between current instant = " + thisOperation + " and instant = "
-                + otherOperation + ", attempting to resolve it...");
+            log.info("Conflict encountered between current instant = {} and instant = {}, attempting to resolve it...", thisOperation, otherOperation);
             resolutionStrategy.resolveConflict(table, thisOperation, otherOperation);
           }
         } catch (IOException io) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/StreamingOffsetValidator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/validator/StreamingOffsetValidator.java
@@ -210,7 +210,7 @@ public abstract class StreamingOffsetValidator extends BasePreCommitValidator {
           previousCheckpoint, currentCheckpoint);
 
       if (failurePolicy == ValidationFailurePolicy.WARN_LOG) {
-        log.warn(errorMsg + " (failure policy is WARN_LOG, commit will proceed)");
+        log.warn("{} (failure policy is WARN_LOG, commit will proceed)", errorMsg);
       } else {
         throw new HoodieValidationException(errorMsg);
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/execution/FileMetadataWriteStatusConverter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/execution/FileMetadataWriteStatusConverter.java
@@ -61,7 +61,7 @@ public class FileMetadataWriteStatusConverter<T extends HoodieRecordPayload, I, 
    */
   public WriteStatus convert(String parquetFile, String partitionPath,
                              Map<String, Object> executionConfigs) throws IOException {
-    LOG.info("Creating write status for parquet file " + parquetFile);
+    LOG.info("Creating write status for parquet file {}", parquetFile);
     WriteStatus writeStatus = (WriteStatus) ReflectionUtils.loadClass(this.writeConfig.getWriteStatusClassName(),
         this.hoodieTable.shouldTrackSuccessRecords(), this.writeConfig.getWriteStatusFailureFraction(), this.hoodieTable.isMetadataTable());
     StoragePath parquetFilePath = new StoragePath(parquetFile);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/ConsistentBucketIndexUtils.java
@@ -175,7 +175,7 @@ public class ConsistentBucketIndexUtils {
     } catch (FileNotFoundException e) {
       return Option.empty();
     } catch (IOException e) {
-      log.error("Error when loading hashing metadata, partition: " + partition, e);
+      log.error("Error when loading hashing metadata, partition: {}", partition, e);
       throw new HoodieIndexException("Error while loading hashing metadata", e);
     }
   }
@@ -258,7 +258,7 @@ public class ConsistentBucketIndexUtils {
     } catch (FileNotFoundException e) {
       return Option.empty();
     } catch (IOException e) {
-      log.error("Error when loading hashing metadata, for path: " + metaFile.getPath().getName(), e);
+      log.error("Error when loading hashing metadata, for path: {}", metaFile.getPath().getName(), e);
       throw new HoodieIndexException("Error while loading hashing metadata", e);
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieBucketIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bucket/HoodieBucketIndex.java
@@ -58,7 +58,7 @@ public abstract class HoodieBucketIndex extends HoodieIndex<Object, Object> {
 
     this.numBuckets = config.getBucketIndexNumBuckets();
     this.indexKeyFields = KeyGenUtils.getIndexKeyFields(config.getBucketIndexHashField());
-    log.info("Use bucket index, numBuckets = " + numBuckets + ", indexFields: " + indexKeyFields);
+    log.info("Use bucket index, numBuckets = {}, indexFields: {}", numBuckets, indexKeyFields);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/BaseCreateHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/BaseCreateHandle.java
@@ -117,7 +117,7 @@ public abstract class BaseCreateHandle<T, I, K, O> extends HoodieWriteHandle<T, 
       // record successful.
       record.deflate();
     } catch (Throwable t) {
-      log.error("Error writing record " + record, t);
+      log.error("Error writing record {}", record, t);
       if (!config.getIgnoreWriteFailed()) {
         throw new HoodieException(t.getMessage(), t);
       }
@@ -178,7 +178,7 @@ public abstract class BaseCreateHandle<T, I, K, O> extends HoodieWriteHandle<T, 
    */
   @Override
   public List<WriteStatus> close() {
-    log.info("Closing the file " + writeStatus.getFileId() + " as we are done with all the records " + recordsWritten);
+    log.info("Closing the file {} as we are done with all the records {}", writeStatus.getFileId(), recordsWritten);
     try {
       if (isClosed()) {
         // Handle has already been closed

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/ExternalFileClusteringWriteHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/ExternalFileClusteringWriteHandle.java
@@ -63,7 +63,7 @@ public class ExternalFileClusteringWriteHandle<T extends HoodieRecordPayload, I,
 
     // Create inProgress marker file
     createMarkerFile(partitionPath, path.getName());
-    LOG.info("New ExternalFileClusteringWriteHandle for partition :" + partitionPath + " with fileId " + fileId);
+    LOG.info("New ExternalFileClusteringWriteHandle for partition :{} with fileId {}", partitionPath, fileId);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -255,7 +255,7 @@ public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T
           ? getInstantTimeForLogFile(record) : deltaWriteStat.getPrevCommit();
       createLogWriterForAppend(logInstantTime, fileSliceOpt);
     } catch (Exception e) {
-      log.error("Error in update task at commit " + instantTime, e);
+      log.error("Error in update task at commit {}", instantTime, e);
       writeStatus.setGlobalError(e);
       throw new HoodieUpsertException("Failed to initialize HoodieAppendHandle for FileId: " + fileId
           + " on commit " + instantTime + " on storage path " + hoodieTable.getMetaClient().getBasePath() + "/" + partitionPath, e);
@@ -378,7 +378,7 @@ public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T
       hoodieRecord.deflate();
       return true;
     } catch (Exception e) {
-      log.error("Error writing record " + hoodieRecord, e);
+      log.error("Error writing record {}", hoodieRecord, e);
       if (!config.getIgnoreWriteFailed()) {
         throw new HoodieException(e.getMessage(), e);
       }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieBinaryCopyHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieBinaryCopyHandle.java
@@ -70,7 +70,7 @@ public class HoodieBinaryCopyHandle<T, I, K, O> extends HoodieWriteHandle<T, I, 
       try {
         ParquetUtils parquetUtils = new ParquetUtils();
         MessageType fileSchema = parquetUtils.readMessageType(table.getStorage(), inputFiles.get(0));
-        log.info("Binary copy schema evolution disabled. Using schema from input file: " + inputFiles.get(0));
+        log.info("Binary copy schema evolution disabled. Using schema from input file: {}", inputFiles.get(0));
         return fileSchema;
       } catch (Exception e) {
         log.error("Failed to read schema from input file", e);
@@ -109,8 +109,7 @@ public class HoodieBinaryCopyHandle<T, I, K, O> extends HoodieWriteHandle<T, I, 
   }
 
   public void write() {
-    log.info("Start to merge source files " + this.inputFiles + " into target file: " + this.path
-        + ". Please pay attention that we will not rolling files based on max-file-size config during binary copy.");
+    log.info("Start to merge source files {} into target file: {}. Please pay attention that we will not rolling files based on max-file-size config during binary copy.", this.inputFiles, this.path);
     HoodieTimer timer = HoodieTimer.start();
     long records = 0;
     try {
@@ -123,12 +122,12 @@ public class HoodieBinaryCopyHandle<T, I, K, O> extends HoodieWriteHandle<T, I, 
       this.recordsWritten = records;
       this.insertRecordsWritten = records;
     }
-    log.info("Finish rewriting " + this.path + ". Using " + timer.endTimer() + " mills");
+    log.info("Finish rewriting {}. Using {} mills", this.path, timer.endTimer());
   }
 
   @Override
   public List<WriteStatus> close() {
-    log.info("Closing the file " + writeStatus.getFileId() + " as we are done with all the records " + recordsWritten);
+    log.info("Closing the file {} as we are done with all the records {}", writeStatus.getFileId(), recordsWritten);
     try {
       this.writer.close();
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieBinaryCopyHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieBinaryCopyHandle.java
@@ -109,7 +109,8 @@ public class HoodieBinaryCopyHandle<T, I, K, O> extends HoodieWriteHandle<T, I, 
   }
 
   public void write() {
-    log.info("Start to merge source files {} into target file: {}. Please pay attention that we will not rolling files based on max-file-size config during binary copy.", this.inputFiles, this.path);
+    log.info("Start to merge source files {} into target file: {}. Please pay attention that we will not rolling files based on max-file-size config during binary copy.",
+        this.inputFiles, this.path);
     HoodieTimer timer = HoodieTimer.start();
     long records = 0;
     try {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieInlineLogAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieInlineLogAppendHandle.java
@@ -298,7 +298,7 @@ public class HoodieInlineLogAppendHandle<T, I, K, O> extends HoodieAppendHandle<
     if (numberOfRecords >= (maxBlockSize / averageRecordSize)) {
       // Recompute averageRecordSize before writing a new block and update existing value with
       // avg of new and old
-      log.info("Flush log block to disk, the current avgRecordSize => " + averageRecordSize);
+      log.info("Flush log block to disk, the current avgRecordSize => {}", averageRecordSize);
       // Delete blocks will be appended after appending all the data blocks.
       appendDataAndDeleteBlocks(header, appendDeleteBlocks);
       estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/IOUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/IOUtils.java
@@ -122,7 +122,7 @@ public class IOUtils {
 
     // TODO(vc): This needs to be revisited
     if (mergeHandle.getPartitionPath() == null) {
-      log.info("Upsert Handle has partition path as null " + mergeHandle.getOldFilePath() + ", " + mergeHandle.getWriteStatuses());
+      log.info("Upsert Handle has partition path as null {}, {}", mergeHandle.getOldFilePath(), mergeHandle.getWriteStatuses());
     }
 
     return Collections.singletonList(mergeHandle.close()).iterator();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
@@ -237,7 +237,7 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
 
       String rollbackInstantTime = createRollbackTimestamp(instantTime);
       if (metadataMetaClient.getActiveTimeline().containsInstant(deltaCommitInstant)) {
-        LOG.info("Rolling back MDT deltacommit " + commitToRollbackInstantTime);
+        LOG.info("Rolling back MDT deltacommit {}", commitToRollbackInstantTime);
         if (!getWriteClient().rollback(commitToRollbackInstantTime, rollbackInstantTime)) {
           throw new HoodieMetadataException("Failed to rollback deltacommit at " + commitToRollbackInstantTime);
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -757,7 +757,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
             .collect(Collectors.toList()),
         partitionFilePair -> {
           final HoodieStorage storage = metaClient.getStorage();
-          log.info("Deleting invalid data file=" + partitionFilePair);
+          log.info("Deleting invalid data file={}", partitionFilePair);
           // Delete
           try {
             StoragePath pathToDelete = new StoragePath(partitionFilePair.getValue());
@@ -828,7 +828,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
           throw new HoodieDuplicateDataFileDetectedException("Duplicate data files detected " + invalidDataPaths);
         }
 
-        log.info("Removing duplicate files created due to task retries before committing. Paths=" + invalidDataPaths);
+        log.info("Removing duplicate files created due to task retries before committing. Paths={}", invalidDataPaths);
         Map<String, List<Pair<String, String>>> invalidPathsByPartition = invalidDataPaths.stream()
             .map(dp ->
                 Pair.of(new StoragePath(basePath, dp).getParent().toString(),
@@ -1147,7 +1147,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
     Stream.of(MetadataPartitionType.getValidValues()).forEach(partitionType -> {
       if (shouldDeleteMetadataPartition(partitionType)) {
         try {
-          log.info("Deleting metadata partition because it is disabled in writer: " + partitionType.name());
+          log.info("Deleting metadata partition because it is disabled in writer: {}", partitionType.name());
           if (metadataPartitionExists(metaClient.getBasePath(), context, partitionType.getPartitionPath())) {
             deleteMetadataPartition(metaClient.getBasePath(), context, partitionType.getPartitionPath());
           }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/CommitBasedClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/CommitBasedClusteringPlanStrategy.java
@@ -86,7 +86,7 @@ public class CommitBasedClusteringPlanStrategy<T, I, K, O> extends PartitionAwar
       LOG.error("earliest commit to cluster is not specified");
       return Option.empty();
     }
-    LOG.info("Earliest commit to cluster (exclusive): " + earliestCommit);
+    LOG.info("Earliest commit to cluster (exclusive): {}", earliestCommit);
 
     HoodieTimeline commitTimeline = metaClient.getCommitsTimeline().findInstantsAfter(earliestCommit).filterCompletedInstants();
     // For each completed commit, invoke getFileSlicesEligibleForCommitBasedClustering
@@ -247,7 +247,7 @@ public class CommitBasedClusteringPlanStrategy<T, I, K, O> extends PartitionAwar
       try {
         commitMetadata = TimelineUtils.getCommitMetadata(instant, metaClient.getActiveTimeline());
       } catch (IOException e) {
-        LOG.error("Failed to read commit metadata for instant: " + instant, e);
+        LOG.error("Failed to read commit metadata for instant: {}", instant, e);
         throw new HoodieException("Failed to read commit metadata for instant: " + instant, e);
       }
     } else {
@@ -285,7 +285,7 @@ public class CommitBasedClusteringPlanStrategy<T, I, K, O> extends PartitionAwar
         try {
           pathInfo = storage.getPathInfo(path);
         } catch (Exception e) {
-          LOG.error("Could not get PathInfo for file path: " + path, e);
+          LOG.error("Could not get PathInfo for file path: {}", path, e);
           throw new HoodieException("Could not get PathInfo for file path: " + path, e);
         }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/cluster/strategy/PartitionAwareClusteringPlanStrategy.java
@@ -82,15 +82,15 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
       // check if max size is reached and create new group, if needed.
       if (totalSizeSoFar + currentSize > writeConfig.getClusteringMaxBytesInGroup() && !currentGroup.isEmpty()) {
         int numOutputGroups = getNumberOfOutputFileGroups(totalSizeSoFar, writeConfig.getClusteringTargetFileMaxBytes());
-        log.info("Adding one clustering group " + totalSizeSoFar + " max bytes: "
-            + writeConfig.getClusteringMaxBytesInGroup() + " num input slices: " + currentGroup.size() + " output groups: " + numOutputGroups);
+        log.info("Adding one clustering group {} max bytes: {} num input slices: {} output groups: {}",
+            totalSizeSoFar, writeConfig.getClusteringMaxBytesInGroup(), currentGroup.size(), numOutputGroups);
         fileSliceGroups.add(Pair.of(currentGroup, numOutputGroups));
         currentGroup = new ArrayList<>();
         totalSizeSoFar = 0;
 
         // if fileSliceGroups's size reach the max group, stop loop
         if (fileSliceGroups.size() >= writeConfig.getClusteringMaxNumGroups()) {
-          log.info("Having generated the maximum number of groups : " + writeConfig.getClusteringMaxNumGroups());
+          log.info("Having generated the maximum number of groups : {}", writeConfig.getClusteringMaxNumGroups());
           partialScheduled = true;
           break;
         }
@@ -104,8 +104,8 @@ public abstract class PartitionAwareClusteringPlanStrategy<T,I,K,O> extends Clus
 
     if (!currentGroup.isEmpty()) {
       int numOutputGroups = getNumberOfOutputFileGroups(totalSizeSoFar, writeConfig.getClusteringTargetFileMaxBytes());
-      log.info("Adding final clustering group " + totalSizeSoFar + " max bytes: "
-          + writeConfig.getClusteringMaxBytesInGroup() + " num input slices: " + currentGroup.size() + " output groups: " + numOutputGroups);
+      log.info("Adding final clustering group {} max bytes: {} num input slices: {} output groups: {}",
+          totalSizeSoFar, writeConfig.getClusteringMaxBytesInGroup(), currentGroup.size(), numOutputGroups);
       fileSliceGroups.add(Pair.of(currentGroup, numOutputGroups));
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseCommitActionExecutor.java
@@ -188,7 +188,7 @@ public abstract class BaseCommitActionExecutor<T, I, K, O, R>
       initializeLastCompletedTnxAndPendingInstants();
     }
     autoCommit(result);
-    log.info("Completed commit for " + instantTime);
+    log.info("Completed commit for {}", instantTime);
   }
 
   protected void autoCommit(HoodieWriteMetadata<O> result) {
@@ -216,7 +216,7 @@ public abstract class BaseCommitActionExecutor<T, I, K, O, R>
 
   protected void commit(HoodieWriteMetadata<O> result, List<HoodieWriteStat> writeStats) {
     String actionType = getCommitActionType();
-    log.info("Committing " + instantTime + ", action Type " + actionType + ", operation Type " + operationType);
+    log.info("Committing {}, action Type {}, operation Type {}", instantTime, actionType, operationType);
     result.setCommitted(true);
     result.setWriteStats(writeStats);
     // Finalize write
@@ -234,7 +234,7 @@ public abstract class BaseCommitActionExecutor<T, I, K, O, R>
       activeTimeline.saveAsComplete(false,
           table.getMetaClient().createNewInstant(State.INFLIGHT, actionType, instantTime), Option.of(metadata),
           completedInstant -> table.getMetaClient().getTableFormat().commit(metadata, completedInstant, table.getContext(), table.getMetaClient(), table.getViewManager()));
-      log.info("Committed " + instantTime);
+      log.info("Committed {}", instantTime);
       result.setCommitMetadata(Option.of(metadata));
       // update cols to Index as applicable
       HoodieColumnStatsIndexUtils.updateColsToIndex(table, config, metadata, actionType,
@@ -308,7 +308,7 @@ public abstract class BaseCommitActionExecutor<T, I, K, O, R>
 
     writeMetadata.setWriteStatuses(statuses);
 
-    log.debug("Create place holder commit metadata for clustering with instant time " + instantTime);
+    log.debug("Create place holder commit metadata for clustering with instant time {}", instantTime);
     HoodieCommitMetadata commitMetadata = CommitUtils.buildMetadata(Collections.emptyList(), Collections.emptyMap(),
         extraMetadata, operationType, schema.get().toString(), getCommitActionType());
     writeMetadata.setCommitMetadata(Option.of(commitMetadata));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/ScheduleCompactionActionExecutor.java
@@ -124,11 +124,11 @@ public class ScheduleCompactionActionExecutor<T, I, K, O> extends BaseTableServi
 
   @Nullable
   private HoodieCompactionPlan scheduleCompaction() {
-    log.info("Checking if compaction needs to be run on " + config.getBasePath());
+    log.info("Checking if compaction needs to be run on {}", config.getBasePath());
     // judge if we need to compact according to num delta commits and time elapsed
     boolean compactable = needCompact(config.getInlineCompactTriggerStrategy());
     if (compactable) {
-      log.info("Generating compaction plan for merge on read table " + config.getBasePath());
+      log.info("Generating compaction plan for merge on read table {}", config.getBasePath());
       try {
         context.setJobStatus(this.getClass().getSimpleName(), "Compaction: generating compaction plan");
         return planGenerator.generateCompactionPlan(instantTime);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/HoodieCompactionPlanGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/HoodieCompactionPlanGenerator.java
@@ -47,7 +47,7 @@ public class HoodieCompactionPlanGenerator<T extends HoodieRecordPayload, I, K, 
                                        BaseTableServicePlanActionExecutor executor) {
     super(table, engineContext, writeConfig, executor);
     this.compactionStrategy = writeConfig.getCompactionStrategy();
-    log.info("Compaction Strategy used is: " + compactionStrategy.toString());
+    log.info("Compaction Strategy used is: {}", compactionStrategy.toString());
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/HoodieCompactionPlanGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/compact/plan/generators/HoodieCompactionPlanGenerator.java
@@ -47,7 +47,7 @@ public class HoodieCompactionPlanGenerator<T extends HoodieRecordPayload, I, K, 
                                        BaseTableServicePlanActionExecutor executor) {
     super(table, engineContext, writeConfig, executor);
     this.compactionStrategy = writeConfig.getCompactionStrategy();
-    log.info("Compaction Strategy used is: {}", compactionStrategy.toString());
+    log.info("Compaction Strategy used is: {}", compactionStrategy);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/AbstractIndexingCatchupTask.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/index/AbstractIndexingCatchupTask.java
@@ -107,7 +107,7 @@ public abstract class AbstractIndexingCatchupTask implements IndexingCatchupTask
         try {
           // we need take a lock here as inflight writer could also try to update the timeline
           transactionManager.beginStateChange(Option.of(instant), Option.empty());
-          log.info("Updating metadata table for instant: " + instant);
+          log.info("Updating metadata table for instant: {}", instant);
           switch (instant.getAction()) {
             case HoodieTimeline.COMMIT_ACTION:
             case HoodieTimeline.DELTA_COMMIT_ACTION:

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/restore/BaseRestoreActionExecutor.java
@@ -86,7 +86,7 @@ public abstract class BaseRestoreActionExecutor<T, I, K, O> extends BaseActionEx
 
       instantsToRollback.forEach(instant -> {
         instantToMetadata.put(instant.requestedTime(), Collections.singletonList(rollbackInstant(instant)));
-        log.info("Deleted instant " + instant);
+        log.info("Deleted instant {}", instant);
       });
 
       return finishRestore(instantToMetadata,
@@ -143,7 +143,7 @@ public abstract class BaseRestoreActionExecutor<T, I, K, O> extends BaseActionEx
       table.getActiveTimeline().deletePending(instantGenerator.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, entry.requestedTime()));
       table.getActiveTimeline().deletePending(instantGenerator.createNewInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.ROLLBACK_ACTION, entry.requestedTime()));
     });
-    log.info("Commits " + instantsRolledBack + " rollback is complete. Restored table to " + savepointToRestoreTimestamp);
+    log.info("Commits {} rollback is complete. Restored table to {}", instantsRolledBack, savepointToRestoreTimestamp);
     return restoreMetadata;
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/BaseRollbackActionExecutor.java
@@ -210,7 +210,7 @@ public abstract class BaseRollbackActionExecutor<T, I, K, O> extends BaseActionE
     if (!table.getIndex().rollbackCommit(instantToRollback.requestedTime())) {
       throw new HoodieRollbackException("Rollback index changes failed, for time :" + instantToRollback);
     }
-    log.info("Index rolled back for commits " + instantToRollback);
+    log.info("Index rolled back for commits {}", instantToRollback);
   }
 
   public List<HoodieRollbackStat> doRollbackAndGetStats(HoodieRollbackPlan hoodieRollbackPlan) {
@@ -235,7 +235,7 @@ public abstract class BaseRollbackActionExecutor<T, I, K, O> extends BaseActionE
 
     try {
       List<HoodieRollbackStat> stats = executeRollback(hoodieRollbackPlan);
-      log.info("Rolled back inflight instant " + instantTimeToRollback);
+      log.info("Rolled back inflight instant {}", instantTimeToRollback);
       if (!isPendingCompaction) {
         rollBackIndex();
       }
@@ -289,7 +289,7 @@ public abstract class BaseRollbackActionExecutor<T, I, K, O> extends BaseActionE
         // when skipLocking is true, the caller should have already held the lock.
         table.getActiveTimeline().transitionRollbackInflightToComplete(false, inflightInstant, rollbackMetadata,
             completedInstant -> table.getMetaClient().getTableFormat().completedRollback(completedInstant, table.getContext(), table.getMetaClient(), table.getViewManager()));
-        log.info("Rollback of Commits " + rollbackMetadata.getCommitsRollback() + " is complete");
+        log.info("Rollback of Commits {} is complete", rollbackMetadata.getCommitsRollback());
       }
     } finally {
       if (enableLocking) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/CopyOnWriteRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/CopyOnWriteRollbackActionExecutor.java
@@ -66,7 +66,7 @@ public class CopyOnWriteRollbackActionExecutor<T, I, K, O> extends BaseRollbackA
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
 
     if (instantToRollback.isCompleted()) {
-      log.info("Unpublishing instant " + instantToRollback);
+      log.info("Unpublishing instant {}", instantToRollback);
       table.getMetaClient().getTableFormat().rollback(instantToRollback, table.getContext(), table.getMetaClient(), table.getViewManager());
       // Revert the completed instant to inflight in native format.
       resolvedInstant = activeTimeline.revertToInflight(instantToRollback);
@@ -88,13 +88,13 @@ public class CopyOnWriteRollbackActionExecutor<T, I, K, O> extends BaseRollbackA
     // deleting the timeline file
     if (!resolvedInstant.isRequested()) {
       // delete all the data files for this commit
-      log.info("Clean out all base files generated for commit: " + resolvedInstant);
+      log.info("Clean out all base files generated for commit: {}", resolvedInstant);
       stats = executeRollback(resolvedInstant, hoodieRollbackPlan);
     }
 
     dropBootstrapIndexIfNeeded(instantToRollback);
 
-    log.info("Time(in ms) taken to finish rollback " + rollbackTimer.endTimer());
+    log.info("Time(in ms) taken to finish rollback {}", rollbackTimer.endTimer());
     return stats;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/ListingBasedRollbackStrategy.java
@@ -215,7 +215,7 @@ public class ListingBasedRollbackStrategy implements BaseRollbackPlanActionExecu
         return hoodieRollbackRequests.stream();
       }, numPartitions);
     } catch (Exception e) {
-      log.error("Generating rollback requests failed for " + instantToRollback.requestedTime(), e);
+      log.error("Generating rollback requests failed for {}", instantToRollback.requestedTime(), e);
       throw new HoodieRollbackException("Generating rollback requests failed for " + instantToRollback.requestedTime(), e);
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MergeOnReadRollbackActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MergeOnReadRollbackActionExecutor.java
@@ -60,11 +60,11 @@ public class MergeOnReadRollbackActionExecutor<T, I, K, O> extends BaseRollbackA
   protected List<HoodieRollbackStat> executeRollback(HoodieRollbackPlan hoodieRollbackPlan) {
     HoodieTimer rollbackTimer = HoodieTimer.start();
 
-    log.info("Rolling back instant " + instantToRollback);
+    log.info("Rolling back instant {}", instantToRollback);
 
     // Atomically un-publish all non-inflight commits
     if (instantToRollback.isCompleted()) {
-      log.info("Un-publishing instant " + instantToRollback + ", deleteInstants=" + deleteInstants);
+      log.info("Un-publishing instant {}, deleteInstants={}", instantToRollback, deleteInstants);
       resolvedInstant = table.getActiveTimeline().revertToInflight(instantToRollback);
       // reload meta-client to reflect latest timeline status
       table.getMetaClient().reloadActiveTimeline();
@@ -81,13 +81,13 @@ public class MergeOnReadRollbackActionExecutor<T, I, K, O> extends BaseRollbackA
     // For Requested State (like failure during index lookup), there is nothing to do rollback other than
     // deleting the timeline file
     if (!resolvedInstant.isRequested()) {
-      log.info("Unpublished " + resolvedInstant);
+      log.info("Unpublished {}", resolvedInstant);
       allRollbackStats = executeRollback(instantToRollback, hoodieRollbackPlan);
     }
 
     dropBootstrapIndexIfNeeded(resolvedInstant);
 
-    log.info("Time(in ms) taken to finish rollback " + rollbackTimer.endTimer());
+    log.info("Time(in ms) taken to finish rollback {}", rollbackTimer.endTimer());
     return allRollbackStats;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/TimelineServerBasedWriteMarkers.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/TimelineServerBasedWriteMarkers.java
@@ -133,8 +133,7 @@ public class TimelineServerBasedWriteMarkers extends WriteMarkers {
 
     Map<String, String> paramsMap = getConfigMap(partitionPath, markerFileName, false);
     boolean success = executeCreateMarkerRequest(paramsMap, partitionPath, markerFileName);
-    log.info("[timeline-server-based] Created marker file " + partitionPath + "/" + markerFileName
-        + " in " + timer.endTimer() + " ms");
+    log.info("[timeline-server-based] Created marker file {}/{} in {} ms", partitionPath, markerFileName, timer.endTimer());
     if (success) {
       return Option.of(new StoragePath(FSUtils.constructAbsolutePath(markerDirPath, partitionPath), markerFileName));
     } else {
@@ -151,8 +150,7 @@ public class TimelineServerBasedWriteMarkers extends WriteMarkers {
 
     boolean success = executeCreateMarkerRequest(paramsMap, partitionPath, markerFileName);
 
-    log.info("[timeline-server-based] Created marker file with early conflict detection " + partitionPath + "/" + markerFileName
-        + " in " + timer.endTimer() + " ms");
+    log.info("[timeline-server-based] Created marker file with early conflict detection {}/{} in {} ms", partitionPath, markerFileName, timer.endTimer());
 
     if (success) {
       return Option.of(new StoragePath(FSUtils.constructAbsolutePath(markerDirPath, partitionPath), markerFileName));

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FiveToSixUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/FiveToSixUpgradeHandler.java
@@ -64,12 +64,12 @@ public class FiveToSixUpgradeHandler implements UpgradeHandler {
 
     compactionTimeline.getInstantsAsStream().forEach(
         deleteInstant -> {
-          log.info("Deleting instant " + deleteInstant + " in auxiliary meta path " + metaClient.getMetaAuxiliaryPath());
+          log.info("Deleting instant {} in auxiliary meta path {}", deleteInstant, metaClient.getMetaAuxiliaryPath());
           StoragePath metaFile = new StoragePath(metaClient.getMetaAuxiliaryPath(), factory.getFileName(deleteInstant));
           try {
             if (metaClient.getStorage().exists(metaFile)) {
               metaClient.getStorage().deleteFile(metaFile);
-              log.info("Deleted instant file in auxiliary meta path : " + metaFile);
+              log.info("Deleted instant file in auxiliary meta path : {}", metaFile);
             }
           } catch (IOException e) {
             throw new HoodieUpgradeDowngradeException(HoodieTableVersion.FIVE.versionCode(), HoodieTableVersion.SIX.versionCode(), true, e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/UpgradeDowngrade.java
@@ -208,7 +208,7 @@ public class UpgradeDowngrade {
 
 
     // Perform the actual upgrade/downgrade; this has to be idempotent, for now.
-    log.info("Attempting to move table from version " + fromVersion + " to " + toVersion);
+    log.info("Attempting to move table from version {} to {}", fromVersion, toVersion);
     Map<ConfigProperty, String> tablePropsToAdd = new Hashtable<>();
     Set<ConfigProperty> tablePropsToRemove = new HashSet<>();
     if (isUpgrade) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestLegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestLegacyArchivedMetaEntryReader.java
@@ -117,7 +117,7 @@ public class TestLegacyArchivedMetaEntryReader {
   public void archive(HoodieTableMetaClient metaClient, List<HoodieInstant> instants) throws HoodieCommitException {
     try (HoodieLogFormat.Writer writer = openWriter(metaClient)) {
       Schema wrapperSchema = HoodieArchivedMetaEntry.getClassSchema();
-      log.info("Wrapper schema {}", wrapperSchema.toString());
+      log.info("Wrapper schema {}", wrapperSchema);
       List<IndexedRecord> records = new ArrayList<>();
       for (HoodieInstant hoodieInstant : instants) {
         try {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestLegacyArchivedMetaEntryReader.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/utils/TestLegacyArchivedMetaEntryReader.java
@@ -117,13 +117,13 @@ public class TestLegacyArchivedMetaEntryReader {
   public void archive(HoodieTableMetaClient metaClient, List<HoodieInstant> instants) throws HoodieCommitException {
     try (HoodieLogFormat.Writer writer = openWriter(metaClient)) {
       Schema wrapperSchema = HoodieArchivedMetaEntry.getClassSchema();
-      log.info("Wrapper schema " + wrapperSchema.toString());
+      log.info("Wrapper schema {}", wrapperSchema.toString());
       List<IndexedRecord> records = new ArrayList<>();
       for (HoodieInstant hoodieInstant : instants) {
         try {
           records.add(convertToAvroRecord(hoodieInstant, metaClient));
         } catch (Exception e) {
-          log.error("Failed to archive commits, .commit file: " + INSTANT_FILE_NAME_GENERATOR.getFileName(hoodieInstant), e);
+          log.error("Failed to archive commits, .commit file: {}", INSTANT_FILE_NAME_GENERATOR.getFileName(hoodieInstant), e);
           throw e;
         }
       }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -341,7 +341,7 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
       fail("Should not have reached here");
     } catch (HoodieException e) {
       if (!(e.getCause() instanceof HoodieIOException)) {
-        log.error("Expected HoodieIOException to be thrown, but found " + e.getCause() + ", w/ error msg " + e.getCause().getMessage());
+        log.error("Expected HoodieIOException to be thrown, but found {}, w/ error msg {}", e.getCause(), e.getCause().getMessage());
       }
       assertTrue(e.getCause() instanceof HoodieIOException);
       assertTrue(e.getCause().getMessage().contains("Failing to delete file during rollback execution failed : " + expectedFileToFailOnDeletion));

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/HoodieWriteableTestTable.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/HoodieWriteableTestTable.java
@@ -111,7 +111,7 @@ public class HoodieWriteableTestTable extends HoodieMetadataTestTable {
 
     StoragePath baseFilePath = new StoragePath(Paths.get(basePath, partition, fileName).toString());
     if (storage.exists(baseFilePath)) {
-      log.warn("Deleting the existing base file " + baseFilePath);
+      log.warn("Deleting the existing base file {}", baseFilePath);
       storage.deleteFile(baseFilePath);
     }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -99,7 +99,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
               + config.getBasePath() + " at time " + compactionCommitTime, e);
         }
       }
-      log.info("Compacted successfully on commit " + compactionCommitTime);
+      log.info("Compacted successfully on commit {}", compactionCommitTime);
     } finally {
       if (config.getWriteConcurrencyMode().supportsMultiWriter()) {
         this.heartbeatClient.stop(compactionCommitTime);
@@ -159,7 +159,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
             + config.getBasePath() + " at time " + clusteringCommitTime, e);
       }
     }
-    log.info("Clustering successfully on commit " + clusteringCommitTime);
+    log.info("Clustering successfully on commit {}", clusteringCommitTime);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkCreateHandle.java
@@ -90,7 +90,7 @@ public class FlinkCreateHandle<T, I, K, O>
     final StoragePath path = makeNewFilePath(partitionPath, lastDataFileName);
     try {
       if (storage.exists(path)) {
-        log.info("Deleting invalid INSERT file due to task retry: " + lastDataFileName);
+        log.info("Deleting invalid INSERT file due to task retry: {}", lastDataFileName);
         storage.deleteFile(path);
       }
     } catch (IOException e) {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowDataCreateHandle.java
@@ -130,7 +130,7 @@ public class HoodieRowDataCreateHandle implements Serializable {
     } catch (IOException e) {
       throw new HoodieInsertException("Failed to initialize file writer for path " + path, e);
     }
-    log.info("New handle created for partition :" + partitionPath + " with fileId " + fileId);
+    log.info("New handle created for partition :{} with fileId {}", partitionPath, fileId);
   }
 
   /**
@@ -170,7 +170,7 @@ public class HoodieRowDataCreateHandle implements Serializable {
             ? HoodieRecordDelegate.create(recordKey, partitionPath, null, newRecordLocation) : null;
         writeStatus.markSuccess(recordDelegate, recordMetadata);
       } catch (Throwable t) {
-        log.error("Error writing record " + record, t);
+        log.error("Error writing record {}", record, t);
         if (!writeConfig.getIgnoreWriteFailed()) {
           throw new HoodieException(t.getMessage(), t);
         }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkPartitionTTLActionExecutor.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/table/action/commit/FlinkPartitionTTLActionExecutor.java
@@ -58,7 +58,7 @@ public class FlinkPartitionTTLActionExecutor<T> extends BaseFlinkCommitActionExe
       if (expiredPartitions.isEmpty()) {
         return emptyResult;
       }
-      log.info("Partition ttl find the following expired partitions to delete:  " + String.join(",", expiredPartitions));
+      log.info("Partition ttl find the following expired partitions to delete:  {}", String.join(",", expiredPartitions));
       return new FlinkAutoCommitActionExecutor(new FlinkDeletePartitionCommitActionExecutor<>(context, config, table, instantTime, expiredPartitions)).execute();
     } catch (HoodieDeletePartitionPendingTableServiceException deletePartitionPendingTableServiceException) {
       log.info("Partition is under table service, do nothing, call delete partition next time.");

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/BaseJavaCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/BaseJavaCommitActionExecutor.java
@@ -94,7 +94,7 @@ public abstract class BaseJavaCommitActionExecutor<T> extends
 
     WorkloadProfile workloadProfile =
         new WorkloadProfile(buildProfile(inputRecords), table.getIndex().canIndexLogFiles());
-    log.info("Input workload profile :" + workloadProfile);
+    log.info("Input workload profile :{}", workloadProfile);
     final Partitioner partitioner = getPartitioner(workloadProfile);
     try {
       saveWorkloadProfileMetadataToInflight(workloadProfile, instantTime);
@@ -236,7 +236,7 @@ public abstract class BaseJavaCommitActionExecutor<T> extends
       throws IOException {
     // This is needed since sometimes some buckets are never picked in getPartition() and end up with 0 records
     if (!recordItr.hasNext()) {
-      log.info("Empty partition with fileId => " + fileId);
+      log.info("Empty partition with fileId => {}", fileId);
       return Collections.singletonList((List<WriteStatus>) Collections.EMPTY_LIST).iterator();
     }
     // these are updates

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/commit/JavaUpsertPartitioner.java
@@ -93,9 +93,8 @@ public class JavaUpsertPartitioner<T> implements Partitioner  {
     assignUpdates(workloadProfile);
     assignInserts(workloadProfile, context);
 
-    log.info("Total Buckets :" + totalBuckets + ", buckets info => " + bucketInfoMap + ", \n"
-        + "Partition to insert buckets => " + partitionPathToInsertBucketInfos + ", \n"
-        + "UpdateLocations mapped to buckets =>" + updateLocationToBucket);
+    log.info("Total Buckets :{}, buckets info => {}, \nPartition to insert buckets => {}, \nUpdateLocations mapped to buckets =>{}",
+        totalBuckets, bucketInfoMap, partitionPathToInsertBucketInfos, updateLocationToBucket);
   }
 
   private void assignUpdates(WorkloadProfile profile) {
@@ -132,7 +131,7 @@ public class JavaUpsertPartitioner<T> implements Partitioner  {
     long averageRecordSize =
         averageBytesPerRecord(table.getMetaClient().getActiveTimeline().getCommitAndReplaceTimeline().filterCompletedInstants(),
             config);
-    log.info("AvgRecordSize => " + averageRecordSize);
+    log.info("AvgRecordSize => {}", averageRecordSize);
 
     Map<String, List<SmallFile>> partitionSmallFilesMap =
         getSmallFilesForPartitions(new ArrayList<String>(partitionPaths), context);
@@ -145,7 +144,7 @@ public class JavaUpsertPartitioner<T> implements Partitioner  {
         List<SmallFile> smallFiles = partitionSmallFilesMap.getOrDefault(partitionPath, new ArrayList<>());
         this.smallFiles.addAll(smallFiles);
 
-        log.info("For partitionPath : " + partitionPath + " Small Files => " + smallFiles);
+        log.info("For partitionPath : {} Small Files => {}", partitionPath, smallFiles);
 
         long totalUnassignedInserts = pStat.getNumInserts();
         List<Integer> bucketNumbers = new ArrayList<>();
@@ -160,10 +159,10 @@ public class JavaUpsertPartitioner<T> implements Partitioner  {
             int bucket;
             if (updateLocationToBucket.containsKey(smallFile.location.getFileId())) {
               bucket = updateLocationToBucket.get(smallFile.location.getFileId());
-              log.info("Assigning " + recordsToAppend + " inserts to existing update bucket " + bucket);
+              log.info("Assigning {} inserts to existing update bucket {}", recordsToAppend, bucket);
             } else {
               bucket = addUpdateBucket(partitionPath, smallFile.location.getFileId());
-              log.info("Assigning " + recordsToAppend + " inserts to new update bucket " + bucket);
+              log.info("Assigning {} inserts to new update bucket {}", recordsToAppend, bucket);
             }
             if (profile.hasOutputWorkLoadStats()) {
               outputWorkloadStats.addInserts(smallFile.location, recordsToAppend);
@@ -182,8 +181,7 @@ public class JavaUpsertPartitioner<T> implements Partitioner  {
           }
 
           int insertBuckets = (int) Math.ceil((1.0 * totalUnassignedInserts) / insertRecordsPerBucket);
-          log.info("After small file assignment: unassignedInserts => " + totalUnassignedInserts
-              + ", totalInsertBuckets => " + insertBuckets + ", recordsPerBucket => " + insertRecordsPerBucket);
+          log.info("After small file assignment: unassignedInserts => {}, totalInsertBuckets => {}, recordsPerBucket => {}", totalUnassignedInserts, insertBuckets, insertRecordsPerBucket);
           for (int b = 0; b < insertBuckets; b++) {
             bucketNumbers.add(totalBuckets);
             if (b < insertBuckets - 1) {
@@ -210,7 +208,7 @@ public class JavaUpsertPartitioner<T> implements Partitioner  {
           currentCumulativeWeight += bkt.weight;
           insertBuckets.add(new InsertBucketCumulativeWeightPair(bkt, currentCumulativeWeight));
         }
-        log.info("Total insert buckets for partition path " + partitionPath + " => " + insertBuckets);
+        log.info("Total insert buckets for partition path {} => {}", partitionPath, insertBuckets);
         partitionPathToInsertBucketInfos.put(partitionPath, insertBuckets);
       }
       if (profile.hasOutputWorkLoadStats()) {

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/deltacommit/BaseJavaDeltaCommitActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/table/action/deltacommit/BaseJavaDeltaCommitActionExecutor.java
@@ -71,10 +71,10 @@ abstract class BaseJavaDeltaCommitActionExecutor<T> extends BaseJavaCommitAction
 
   @Override
   public Iterator<List<WriteStatus>> handleUpdate(String partitionPath, String fileId, Iterator<HoodieRecord<T>> recordItr) throws IOException {
-    log.info("Merging updates for commit " + instantTime + " for file " + fileId);
+    log.info("Merging updates for commit {} for file {}", instantTime, fileId);
     if (!table.getIndex().canIndexLogFiles() && partitioner != null
         && partitioner.getSmallFileIds().contains(fileId)) {
-      log.info("Small file corrections for updates for commit " + instantTime + " for file " + fileId);
+      log.info("Small file corrections for updates for commit {} for file {}", instantTime, fileId);
       return super.handleUpdate(partitionPath, fileId, recordItr);
     } else {
       if (table.requireSortedRecords()) {

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -1840,7 +1840,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
       // Ensure all commits were synced to the Metadata Table
       HoodieTableMetaClient metadataMetaClient = createMetaClientForMetadataTable();
-      log.warn("total commits in metadata table " + metadataMetaClient.getActiveTimeline().getCommitsTimeline().countInstants());
+      log.warn("total commits in metadata table {}", metadataMetaClient.getActiveTimeline().getCommitsTimeline().countInstants());
 
       // 6 commits and 2 cleaner commits.
       assertEquals(metadataMetaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().countInstants(), 8);
@@ -2832,17 +2832,17 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
 
         if ((fsFileNames.size() != metadataFilenames.size())
             || (!fsFileNames.equals(metadataFilenames))) {
-          log.info("*** File system listing = " + Arrays.toString(fsFileNames.toArray()));
-          log.info("*** Metadata listing = " + Arrays.toString(metadataFilenames.toArray()));
+          log.info("*** File system listing = {}", Arrays.toString(fsFileNames.toArray()));
+          log.info("*** Metadata listing = {}", Arrays.toString(metadataFilenames.toArray()));
 
           for (String fileName : fsFileNames) {
             if (!metadataFilenames.contains(fileName)) {
-              log.error(partition + "FsFilename " + fileName + " not found in Meta data");
+              log.error("{}FsFilename {} not found in Meta data", partition, fileName);
             }
           }
           for (String fileName : metadataFilenames) {
             if (!fsFileNames.contains(fileName)) {
-              log.error(partition + "Metadata file " + fileName + " not found in original FS");
+              log.error("{}Metadata file {} not found in original FS", partition, fileName);
             }
           }
         }
@@ -2922,7 +2922,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       });
 
       // TODO: include validation for record_index partition here.
-      log.info("Validation time=" + timer.endTimer());
+      log.info("Validation time={}", timer.endTimer());
     }
   }
 

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestJavaCopyOnWriteActionExecutor.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/table/action/commit/TestJavaCopyOnWriteActionExecutor.java
@@ -366,7 +366,7 @@ public class TestJavaCopyOnWriteActionExecutor extends HoodieJavaClientTestHarne
     int counts = 0;
     for (File file : Paths.get(basePath, "2016/01/31").toFile().listFiles()) {
       if (file.getName().endsWith(table.getBaseFileExtension()) && FSUtils.getCommitTime(file.getName()).equals(instantTime)) {
-        log.info(file.getName() + "-" + file.length());
+        log.info("{}-{}", file.getName(), file.length());
         counts++;
       }
     }

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/HoodieJavaClientTestHarness.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/testutils/HoodieJavaClientTestHarness.java
@@ -353,7 +353,7 @@ public abstract class HoodieJavaClientTestHarness extends HoodieWriterClientTest
       runFullValidation(writeConfig, metadataTableBasePath, engineContext);
     }
 
-    log.info("Validation time=" + timer.endTimer());
+    log.info("Validation time={}", timer.endTimer());
   }
 
   protected void validateFilesPerPartition(HoodieTestTable testTable,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SparkBinaryCopyClusteringExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SparkBinaryCopyClusteringExecutionStrategy.java
@@ -95,7 +95,7 @@ public class SparkBinaryCopyClusteringExecutionStrategy<T> extends SparkSortAndS
     JavaSparkContext engineContext = HoodieSparkEngineContext.getSparkContext(getEngineContext());
     TaskContextSupplier taskContextSupplier = getEngineContext().getTaskContextSupplier();
     JavaRDD<ClusteringGroupInfo> groupInfoJavaRDD = engineContext.parallelize(clusteringGroupInfos, clusteringGroupInfos.size());
-    log.info("number of partitions for clustering " + groupInfoJavaRDD.getNumPartitions());
+    log.info("number of partitions for clustering {}", groupInfoJavaRDD.getNumPartitions());
     JavaRDD<WriteStatus> writeStatusRDD = groupInfoJavaRDD
         .mapPartitions(clusteringOps -> {
           Iterable<ClusteringGroupInfo> clusteringOpsIterable = () -> clusteringOps;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SparkExternalFileClusteringExecutionStrategy.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/clustering/run/strategy/SparkExternalFileClusteringExecutionStrategy.java
@@ -87,7 +87,7 @@ public abstract class SparkExternalFileClusteringExecutionStrategy<T extends Hoo
       try {
         getHoodieTable().getStorage().deleteFile(writeHandler.getPath());
       } catch (Exception deleteEx) {
-        LOG.warn("Failed to clean up partial output file: " + writeHandler.getPath(), deleteEx);
+        LOG.warn("Failed to clean up partial output file: {}", writeHandler.getPath(), deleteEx);
       }
       throw new HoodieClusteringException("Failed to transform file: " + dataFilePathStr, e);
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SparkPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SparkPreCommitValidator.java
@@ -96,7 +96,7 @@ public abstract class SparkPreCommitValidator<T, I, K, O extends HoodieData<Writ
       throw new RuntimeException(e);
     } finally {
       long duration = timer.endTimer();
-      log.info(getClass() + " validator took " + duration + " ms" + ", metrics on? " + getWriteConfig().isMetricsOn());
+      log.info("{} validator took {} ms, metrics on? {}", getClass(), duration, getWriteConfig().isMetricsOn());
       publishRunStats(instantTime, duration);
     }
   }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryEqualityPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryEqualityPreCommitValidator.java
@@ -57,16 +57,16 @@ public class SqlQueryEqualityPreCommitValidator<T, I, K, O extends HoodieData<Wr
     try {
       prevRows = executeSqlQuery(
           sqlContext, query, prevTableSnapshot, "previous state").cache();
-      log.info("Total rows in prevRows " + prevRows.count());
+      log.info("Total rows in prevRows {}", prevRows.count());
       newRows = executeSqlQuery(
           sqlContext, query, newTableSnapshot, "new state").cache();
-      log.info("Total rows in newRows " + newRows.count());
+      log.info("Total rows in newRows {}", newRows.count());
       printAllRowsIfDebugEnabled(prevRows);
       printAllRowsIfDebugEnabled(newRows);
       boolean areDatasetsEqual = prevRows.intersect(newRows).count() == prevRows.count();
-      log.info("Completed Equality Validation, datasets equal? " + areDatasetsEqual);
+      log.info("Completed Equality Validation, datasets equal? {}", areDatasetsEqual);
       if (!areDatasetsEqual) {
-        log.error("query validation failed. See stdout for sample query results. Query: " + query);
+        log.error("query validation failed. See stdout for sample query results. Query: {}", query);
         System.out.println("Expected result (sample records only):");
         prevRows.show();
         System.out.println("Actual result (sample records only):");

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryInequalityPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQueryInequalityPreCommitValidator.java
@@ -54,16 +54,16 @@ public class SqlQueryInequalityPreCommitValidator<T, I, K, O extends HoodieData<
   protected void validateUsingQuery(String query, String prevTableSnapshot, String newTableSnapshot, SQLContext sqlContext) {
     Dataset<Row> prevRows = executeSqlQuery(
         sqlContext, query, prevTableSnapshot, "previous state").cache();
-    log.info("Total rows in prevRows " + prevRows.count());
+    log.info("Total rows in prevRows {}", prevRows.count());
     Dataset<Row> newRows = executeSqlQuery(
         sqlContext, query, newTableSnapshot, "new state").cache();
-    log.info("Total rows in newRows " + newRows.count());
+    log.info("Total rows in newRows {}", newRows.count());
     printAllRowsIfDebugEnabled(prevRows);
     printAllRowsIfDebugEnabled(newRows);
     boolean areDatasetsEqual = prevRows.intersect(newRows).count() == prevRows.count();
-    log.info("Completed Inequality Validation, datasets equal? " + areDatasetsEqual);
+    log.info("Completed Inequality Validation, datasets equal? {}", areDatasetsEqual);
     if (areDatasetsEqual) {
-      log.error("query validation failed. See stdout for sample query results. Query: " + query);
+      log.error("query validation failed. See stdout for sample query results. Query: {}", query);
       System.out.println("Expected query results to be different, but they are same. Result (sample records only):");
       prevRows.show();
       throw new HoodieValidationException("Query validation failed for '" + query

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQuerySingleResultPreCommitValidator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/validator/SqlQuerySingleResultPreCommitValidator.java
@@ -66,11 +66,11 @@ public class SqlQuerySingleResultPreCommitValidator<T, I, K, O extends HoodieDat
     }
     Object result = newRows.get(0).apply(0);
     if (result == null || !expectedResult.equals(result.toString())) {
-      log.error("Mismatch query result. Expected: " + expectedResult + " got " + result + " on Query: " + query);
+      log.error("Mismatch query result. Expected: {} got {} on Query: {}", expectedResult, result, query);
       throw new HoodieValidationException("Query validation failed for '" + query
           + "'. Expected " + expectedResult + " row(s), Found " + result);
     } else {
-      log.info("Query validation successful. Expected: " + expectedResult + " got " + result);
+      log.info("Query validation successful. Expected: {} got {}", expectedResult, result);
     }
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowCreateHandle.java
@@ -194,7 +194,7 @@ public class HoodieRowCreateHandle implements Serializable {
             ? HoodieRecordDelegate.create(recordKey.toString(), partitionPath.toString(), null, newRecordLocation) : null;
         writeStatus.markSuccess(recordDelegate, Option.empty());
       } catch (Exception t) {
-        log.error("Error writing record " + row, t);
+        log.error("Error writing record {}", row, t);
         if (!writeConfig.getIgnoreWriteFailed()) {
           throw new HoodieException(t.getMessage(), t);
         }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/BaseBootstrapMetadataHandler.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/BaseBootstrapMetadataHandler.java
@@ -65,7 +65,7 @@ public abstract class BaseBootstrapMetadataHandler implements BootstrapMetadataH
           .collect(Collectors.toList());
       HoodieSchema recordKeySchema = HoodieSchemaUtils.generateProjectionSchema(schema, recordKeyColumns);
 
-      LOG.info("Schema to be used for reading record keys: " + recordKeySchema);
+      LOG.info("Schema to be used for reading record keys: {}", recordKeySchema);
 
       executeBootstrap(bootstrapHandle, sourceFilePath, keyGenerator, partitionPath, recordKeySchema);
     } catch (Exception e) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/table/action/bootstrap/SparkBootstrapCommitActionExecutor.java
@@ -204,14 +204,12 @@ public class SparkBootstrapCommitActionExecutor<T>
     HoodieTableMetaClient metaClient = table.getMetaClient();
     try (BootstrapIndex.IndexWriter indexWriter = BootstrapIndex.getBootstrapIndex(metaClient)
         .createWriter(metaClient.getTableConfig().getBootstrapBasePath().get())) {
-      log.info("Starting to write bootstrap index for source " + config.getBootstrapSourceBasePath() + " in table "
-          + config.getBasePath());
+      log.info("Starting to write bootstrap index for source {} in table {}", config.getBootstrapSourceBasePath(), config.getBasePath());
       indexWriter.begin();
       bootstrapSourceAndStats.forEach((key, value) -> indexWriter.appendNextPartition(key,
           value.stream().map(Pair::getKey).collect(Collectors.toList())));
       indexWriter.finish();
-      log.info("Finished writing bootstrap index for source " + config.getBootstrapSourceBasePath() + " in table "
-          + config.getBasePath());
+      log.info("Finished writing bootstrap index for source {} in table {}", config.getBootstrapSourceBasePath(), config.getBasePath());
     }
     commit(result, bootstrapSourceAndStats.values().stream()
         .flatMap(f -> f.stream().map(Pair::getValue)).collect(Collectors.toList()));
@@ -278,7 +276,7 @@ public class SparkBootstrapCommitActionExecutor<T>
     log.info("Fetching Bootstrap Schema !!");
     HoodieBootstrapSchemaProvider sourceSchemaProvider = new HoodieSparkBootstrapSchemaProvider(config);
     bootstrapSchema = sourceSchemaProvider.getBootstrapSchema(context, folders).toString();
-    log.info("Bootstrap Schema :" + bootstrapSchema);
+    log.info("Bootstrap Schema :{}", bootstrapSchema);
 
     BootstrapModeSelector selector =
         (BootstrapModeSelector) ReflectionUtils.loadClass(config.getBootstrapModeSelectorClass(), config);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/common/TestHoodieSparkEngineDynamicRepartition.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/common/TestHoodieSparkEngineDynamicRepartition.java
@@ -210,7 +210,7 @@ public class TestHoodieSparkEngineDynamicRepartition {
     } catch (AssertionError e) {
       logRDDContent("Original RDD", originalRdd);
       logRDDContent("Repartitioned RDD", repartitionedRdd);
-      LOG.error("Validation failed: " + e.getMessage(), e);
+      LOG.error("Validation failed: {}", e.getMessage(), e);
       throw e; // rethrow to fail the test
     }
   }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/io/TestHoodieTimelineArchiver.java
@@ -940,7 +940,7 @@ public class TestHoodieTimelineArchiver extends HoodieSparkClientTestHarness {
       int finalCounter = counter;
       curFuture.exceptionally(ex -> {
         if (!jobFailed.getAndSet(true)) {
-          log.warn("One of the job failed. Cancelling all other futures. " + ex.getCause() + ", " + ex.getMessage());
+          log.warn("One of the job failed. Cancelling all other futures. {}, {}", ex.getCause(), ex.getMessage());
           int secondCounter = 0;
           while (secondCounter < futures.size()) {
             if (secondCounter != finalCounter) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/marker/TestTimelineServerBasedWriteMarkers.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/marker/TestTimelineServerBasedWriteMarkers.java
@@ -74,7 +74,7 @@ public class TestTimelineServerBasedWriteMarkers extends TestWriteMarkersBase {
     this.markerFolderPath = new StoragePath(metaClient.getMarkerFolderPath("000"));
 
     restartServerAndClient(0);
-    log.info("Connecting to Timeline Server :" + timelineService.getServerPort());
+    log.info("Connecting to Timeline Server :{}", timelineService.getServerPort());
   }
 
   @AfterEach
@@ -108,7 +108,7 @@ public class TestTimelineServerBasedWriteMarkers extends TestWriteMarkersBase {
   @EnumSource(value = FileSystemViewStorageType.class)
   public void testCreationWithTimelineServiceRetries(FileSystemViewStorageType storageType) throws Exception {
     restartServerAndClient(0, storageType);
-    log.info("Connecting to Timeline Server :" + timelineService.getServerPort());
+    log.info("Connecting to Timeline Server :{}", timelineService.getServerPort());
     // Validate marker creation/ deletion work without any failures in the timeline service.
     createSomeMarkers(true);
     assertTrue(storage.exists(markerFolderPath));


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Many `hudi-client` log statements build their message with `+` string concatenation instead of SLF4J `{}` placeholders. This is the first batch of a broader logging cleanup.

### Summary and Changelog

Convert `+`-concatenated log messages to SLF4J parameterized `{}` logging across `hudi-client` (`client-common`, `java-client`, `spark-client`, `flink-client`) - 132 call sites in 67 files.

- Each concatenated expression becomes a placeholder argument, in order.
- A trailing throwable is kept as the last argument, so stack traces are still logged.
- Multi-line concatenations collapse to a single `{}` message; 3 long ones were re-wrapped to stay within the 200-char line limit.

No code was copied. Behaviour-preserving - no functional change.

### Impact

None (logging only). Minor perf benefit: the message string is no longer built eagerly when the log level is disabled.

### Risk Level

low - mechanical, behaviour-preserving change. Only provably-safe rewrites were applied (leading-arithmetic and brace-collision cases were skipped and handled by hand). Verified with `mvn test-compile` on client-common + java-client (JDK 17) and `checkstyle:check` across all four submodules.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
