### PR TITLE
refactor(hadoop-mr): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/BootstrapColumnStichingRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/BootstrapColumnStichingRecordReader.java
@@ -60,7 +60,7 @@ public class BootstrapColumnStichingRecordReader implements RecordReader<NullWri
           .toArray(new String[0]);
       values = new ArrayWritable(vals);
     }
-    LOG.info("Total ArrayWritable Length :" + values.get().length);
+    LOG.info("Total ArrayWritable Length :{}", values.get().length);
   }
 
   @Override

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieCopyOnWriteTableInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieCopyOnWriteTableInputFormat.java
@@ -212,7 +212,7 @@ public class HoodieCopyOnWriteTableInputFormat extends HoodieTableInputFormat {
 
   private BootstrapBaseFileSplit makeExternalFileSplit(PathWithBootstrapFileStatus file, FileSplit split) {
     try {
-      LOG.info("Making external data split for " + file);
+      LOG.info("Making external data split for {}", file);
       FileStatus externalFileStatus = file.getBootstrapFileStatus();
       FileSplit externalFileSplit = makeSplit(externalFileStatus.getPath(), 0, externalFileStatus.getLen(),
           new String[0], new String[0]);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
@@ -208,7 +208,7 @@ public class HoodieParquetInputFormat extends HoodieParquetInputFormatBase {
     List<Pair<String, String>> colNamesWithTypesForExternal = colNameWithTypes.stream()
         .filter(p -> !HoodieRecord.HOODIE_META_COLUMNS.contains(p.getKey())).collect(Collectors.toList());
 
-    LOG.info("colNameWithTypes =" + colNameWithTypes + ", Num Entries =" + colNameWithTypes.size());
+    LOG.info("colNameWithTypes ={}, Num Entries ={}", colNameWithTypes, colNameWithTypes.size());
 
     if (hoodieColsProjected.isEmpty()) {
       return getRecordReaderInternal(eSplit.getBootstrapFileSplit(), job, reporter);
@@ -225,7 +225,7 @@ public class HoodieParquetInputFormat extends HoodieParquetInputFormatBase {
       jobConfCopy.unset(TableScanDesc.FILTER_EXPR_CONF_STR);
       jobConfCopy.unset(ConvertAstToSearchArg.SARG_PUSHDOWN);
 
-      LOG.info("Generating column stitching reader for " + eSplit.getPath() + " and " + rightSplit.getPath());
+      LOG.info("Generating column stitching reader for {} and {}", eSplit.getPath(), rightSplit.getPath());
       return new BootstrapColumnStichingRecordReader(getRecordReaderInternal(eSplit, jobConfCopy, reporter),
           HoodieRecord.HOODIE_META_COLUMNS.size(),
           getRecordReaderInternal(rightSplit, jobConfCopy, reporter),

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/InputPathHandler.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/InputPathHandler.java
@@ -114,7 +114,7 @@ public class InputPathHandler {
           tagAsIncrementalOrSnapshot(inputPath, metaClient, incrementalTables);
         } catch (TableNotFoundException | InvalidTableException e) {
           // This is a non Hoodie inputPath
-          LOG.info("Handling a non-hoodie path " + inputPath);
+          LOG.info("Handling a non-hoodie path {}", inputPath);
           nonHoodieInputPaths.add(inputPath);
         }
       }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
@@ -174,7 +174,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
       Class<?> inputFormatClass = part.getInputFileFormatClass();
       String inputFormatClassName = inputFormatClass.getName();
       InputFormat inputFormat = getInputFormatFromCache(inputFormatClass, job);
-      LOG.info("Input Format => " + inputFormatClass.getName());
+      LOG.info("Input Format => {}", inputFormatClass.getName());
       // **MOD** Set the hoodie filter in the combine
       if (inputFormatClass.getName().equals(getParquetInputFormatClassName())) {
         combine.setHoodieFilter(true);
@@ -186,7 +186,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
           List<String> partitions = new ArrayList<>(part.getPartSpec().keySet());
           if (!partitions.isEmpty()) {
             String partitionStr = String.join("/", partitions);
-            LOG.info("Setting Partitions in jobConf - Partition Keys for Path : " + path + " is :" + partitionStr);
+            LOG.info("Setting Partitions in jobConf - Partition Keys for Path : {} is :{}", path, partitionStr);
             job.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, partitionStr);
           } else {
             job.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "");
@@ -224,11 +224,11 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
         f = poolMap.get(combinePathInputFormat);
         if (f == null) {
           f = new CombineFilter(filterPath);
-          LOG.info("CombineHiveInputSplit creating pool for " + path + "; using filter path " + filterPath);
+          LOG.info("CombineHiveInputSplit creating pool for {}; using filter path {}", path, filterPath);
           combine.createPool(job, f);
           poolMap.put(combinePathInputFormat, f);
         } else {
-          LOG.info("CombineHiveInputSplit: pool is already created for " + path + "; using filter path " + filterPath);
+          LOG.info("CombineHiveInputSplit: pool is already created for {}; using filter path {}", path, filterPath);
           f.addPath(filterPath);
         }
       } else {
@@ -286,7 +286,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
       result.add(csplit);
     }
 
-    LOG.info("number of splits " + result.size());
+    LOG.info("number of splits {}", result.size());
     return result.toArray(new CombineHiveInputSplit[result.size()]);
   }
 
@@ -295,8 +295,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
    */
   public Set<Integer> getNonCombinablePathIndices(JobConf job, Path[] paths, int numThreads)
       throws ExecutionException, InterruptedException {
-    LOG.info("Total number of paths: " + paths.length + ", launching " + numThreads
-        + " threads to check non-combinable ones.");
+    LOG.info("Total number of paths: {}, launching {} threads to check non-combinable ones.", paths.length, numThreads);
     int numPathPerThread = (int) Math.ceil((double) paths.length / numThreads);
 
     ExecutorService executor = Executors.newFixedThreadPool(numThreads);
@@ -559,7 +558,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
         retLists.add(split);
         long splitgLength = split.getLength();
         if (size + splitgLength >= targetSize) {
-          LOG.info("Sample alias " + entry.getValue() + " using " + (i + 1) + "splits");
+          LOG.info("Sample alias {} using {}splits", entry.getValue(), (i + 1));
           if (size + splitgLength > targetSize) {
             ((InputSplitShim) split).shrinkSplit(targetSize - size);
           }
@@ -963,8 +962,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
       if (job.getLong(org.apache.hadoop.mapreduce.lib.input.FileInputFormat.SPLIT_MAXSIZE, 0L) == 0L) {
         super.setMaxSplitSize(minSize);
       }
-      LOG.info("mapreduce.input.fileinputformat.split.minsize=" + minSize
-          + ", mapreduce.input.fileinputformat.split.maxsize=" + maxSize);
+      LOG.info("mapreduce.input.fileinputformat.split.minsize={}, mapreduce.input.fileinputformat.split.maxsize={}", minSize, maxSize);
 
       if (isRealTime) {
         job.set("hudi.hive.realtime", "true");

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -94,9 +94,9 @@ public abstract class AbstractRealtimeRecordReader {
   public AbstractRealtimeRecordReader(RealtimeSplit split, JobConf job) {
     this.split = split;
     this.jobConf = job;
-    LOG.info("cfg ==> " + job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR));
-    LOG.info("columnIds ==> " + job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
-    LOG.info("partitioningColumns ==> " + job.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, ""));
+    LOG.info("cfg ==> {}", job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR));
+    LOG.info("columnIds ==> {}", job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
+    LOG.info("partitioningColumns ==> {}", job.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, ""));
     this.supportPayload = Boolean.parseBoolean(job.get("hoodie.support.payload", "true"));
     try {
       metaClient = HoodieTableMetaClient.builder()
@@ -106,7 +106,7 @@ public abstract class AbstractRealtimeRecordReader {
         this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getOrderingFieldsStr().orElse(null));
       }
       this.usesCustomPayload = usesCustomPayload(metaClient);
-      LOG.info("usesCustomPayload ==> " + this.usesCustomPayload);
+      LOG.info("usesCustomPayload ==> {}", this.usesCustomPayload);
 
       // get timestamp columns
       supportTimestamp = HoodieColumnProjectionUtils.supportTimestamp(jobConf);
@@ -190,7 +190,7 @@ public abstract class AbstractRealtimeRecordReader {
 
   public HoodieSchema constructHiveOrderedSchema(HoodieSchema writerSchema, Map<String, HoodieSchemaField> schemaFieldsMap, String hiveColumnString) {
     String[] hiveColumns = hiveColumnString.isEmpty() ? new String[0] : hiveColumnString.split(",");
-    LOG.info("Hive Columns : " + hiveColumnString);
+    LOG.info("Hive Columns : {}", hiveColumnString);
     List<HoodieSchemaField> hiveSchemaFields = new ArrayList<>();
 
     for (String columnName : hiveColumns) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieHFileRealtimeInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieHFileRealtimeInputFormat.java
@@ -62,9 +62,7 @@ public class HoodieHFileRealtimeInputFormat extends HoodieMergeOnReadTableInputF
     // actual heavy lifting of reading the parquet files happen.
     if (jobConf.get(HoodieInputFormatUtils.HOODIE_READ_COLUMNS_PROP) == null) {
       synchronized (jobConf) {
-        LOG.info(
-            "Before adding Hoodie columns, Projections :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR)
-                + ", Ids :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
+        LOG.info("Before adding Hoodie columns, Projections :{}, Ids :{}", jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR), jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
         if (jobConf.get(HoodieInputFormatUtils.HOODIE_READ_COLUMNS_PROP) == null) {
           // Hive (across all versions) fails for queries like select count(`_hoodie_commit_time`) from table;
           // In this case, the projection fields gets removed. Looking at HiveInputFormat implementation, in some cases
@@ -82,8 +80,7 @@ public class HoodieHFileRealtimeInputFormat extends HoodieMergeOnReadTableInputF
     }
     HoodieRealtimeInputFormatUtils.cleanProjectionColumnIds(jobConf);
 
-    LOG.info("Creating record reader with readCols :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR)
-        + ", Ids :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
+    LOG.info("Creating record reader with readCols :{}, Ids :{}", jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR), jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
     // sanity check
     ValidationUtils.checkArgument(split instanceof HoodieRealtimeFileSplit,
         "HoodieRealtimeRecordReader can only work on HoodieRealtimeFileSplit and not with " + split);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
@@ -80,8 +80,7 @@ public class HoodieParquetRealtimeInputFormat extends HoodieParquetInputFormat {
     HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(getStorageConf(jobConf)).setBasePath(realtimeSplit.getBasePath()).build();
     HoodieTableConfig tableConfig = metaClient.getTableConfig();
     addProjectionToJobConf(realtimeSplit, jobConf, tableConfig);
-    LOG.info("Creating record reader with readCols :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR)
-        + ", Ids :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
+    LOG.info("Creating record reader with readCols :{}, Ids :{}", jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR), jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
 
     // for log only split, set the parquet reader as empty.
     if (isLogFile(realtimeSplit.getPath())) {
@@ -100,9 +99,7 @@ public class HoodieParquetRealtimeInputFormat extends HoodieParquetInputFormat {
     // actual heavy lifting of reading the parquet files happen.
     if (HoodieRealtimeInputFormatUtils.canAddProjectionToJobConf(realtimeSplit, jobConf)) {
       synchronized (jobConf) {
-        LOG.info(
-            "Before adding Hoodie columns, Projections :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR)
-                + ", Ids :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
+        LOG.info("Before adding Hoodie columns, Projections :{}, Ids :{}", jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR), jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
         if (HoodieRealtimeInputFormatUtils.canAddProjectionToJobConf(realtimeSplit, jobConf)) {
           // Hive (across all versions) fails for queries like select count(`_hoodie_commit_time`) from table;
           // In this case, the projection fields gets removed. Looking at HiveInputFormat implementation, in some cases

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieRealtimeRecordReader.java
@@ -66,7 +66,7 @@ public class HoodieRealtimeRecordReader implements RecordReader<NullWritable, Ar
         LOG.info("Enabling un-merged reading of realtime records");
         return new RealtimeUnmergedRecordReader(split, jobConf, realReader);
       }
-      LOG.info("Enabling merged reading of realtime records for split " + split);
+      LOG.info("Enabling merged reading of realtime records for split {}", split);
       return new RealtimeCompactedRecordReader(split, jobConf, realReader);
     } catch (Exception e) {
       LOG.error("Got exception when constructing record reader", e);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java
@@ -187,8 +187,8 @@ public class RealtimeCompactedRecordReader extends AbstractRealtimeRecordReader
       arrayWritable.set(originalValue);
     } catch (RuntimeException re) {
       LOG.error("Got exception when doing array copy", re);
-      LOG.error("Base record :" + HoodieRealtimeRecordReaderUtils.arrayWritableToString(arrayWritable));
-      LOG.error("Log record :" + HoodieRealtimeRecordReaderUtils.arrayWritableToString(aWritable));
+      LOG.error("Base record :{}", HoodieRealtimeRecordReaderUtils.arrayWritableToString(arrayWritable));
+      LOG.error("Log record :{}", HoodieRealtimeRecordReaderUtils.arrayWritableToString(aWritable));
       String errMsg = "Base-record :" + HoodieRealtimeRecordReaderUtils.arrayWritableToString(arrayWritable)
           + " ,Log-record :" + HoodieRealtimeRecordReaderUtils.arrayWritableToString(aWritable) + " ,Error :" + re.getMessage();
       throw new RuntimeException(errMsg, re);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieHiveUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieHiveUtils.java
@@ -94,7 +94,7 @@ public class HoodieHiveUtils {
   public static boolean stopAtCompaction(JobContext job, String tableName) {
     String compactionPropName = String.format(HOODIE_STOP_AT_COMPACTION_PATTERN, tableName);
     boolean stopAtCompaction = job.getConfiguration().getBoolean(compactionPropName, true);
-    LOG.info("Read stop at compaction - " + stopAtCompaction);
+    LOG.info("Read stop at compaction - {}", stopAtCompaction);
     return stopAtCompaction;
   }
 
@@ -104,13 +104,13 @@ public class HoodieHiveUtils {
     if (maxCommits == MAX_COMMIT_ALL) {
       maxCommits = Integer.MAX_VALUE;
     }
-    LOG.info("Read max commits - " + maxCommits);
+    LOG.info("Read max commits - {}", maxCommits);
     return maxCommits;
   }
 
   public static String readStartCommitTime(JobContext job, String tableName) {
     String startCommitTimestampName = String.format(HOODIE_START_COMMIT_PATTERN, tableName);
-    LOG.info("Read start commit time - " + job.getConfiguration().get(startCommitTimestampName));
+    LOG.info("Read start commit time - {}", job.getConfiguration().get(startCommitTimestampName));
     return job.getConfiguration().get(startCommitTimestampName);
   }
 

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeInputFormatUtils.java
@@ -137,9 +137,7 @@ public class HoodieRealtimeInputFormatUtils extends HoodieInputFormatUtils {
     String columnIds = conf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR);
     if (!columnIds.isEmpty() && columnIds.charAt(0) == ',') {
       conf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, columnIds.substring(1));
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("The projection Ids: {" + columnIds + "} start with ','. First comma is removed");
-      }
+      LOG.debug("The projection Ids: {{}} start with ','. First comma is removed", columnIds);
     }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `LOG.info`/`LOG.error` calls in `hudi-hadoop-mr` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156).

### Summary and Changelog

- Converted 29 `LOG` call sites across 12 files in `hudi-hadoop-mr` from `+` concatenation to `{}` placeholders.
- Multi-line concatenations collapsed into a single parameterized call. Message text is preserved verbatim, including pre-existing quirks (e.g. the missing space in `"using {}splits"`).
- `HoodieRealtimeInputFormatUtils`: the one `LOG.debug` that wraps the value in literal braces is written as `{{}}` so SLF4J fills the inner `{}` and keeps the outer braces literal. Also dropped its now-redundant `isDebugEnabled()` guard, which only existed to avoid the eager string build that parameterization removes.

Note: these classes use plain `LoggerFactory.getLogger` `LOG` fields. Migrating them to the Lombok `@Slf4j` annotation will be done in a separate round of cleanup sweeps; this PR only touches the concatenation-to-templating conversion.

### Impact

none - purely mechanical, behavior-preserving logging change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
