### PR TITLE
refactor(common): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -220,7 +220,7 @@ public class HoodieCommitMetadata implements Serializable {
 
   public String toJsonString() throws IOException {
     if (partitionToWriteStats.containsKey(null)) {
-      log.info("partition path is null for " + partitionToWriteStats.get(null));
+      log.info("partition path is null for {}", partitionToWriteStats.get(null));
       partitionToWriteStats.remove(null);
     }
     return JsonUtils.getObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(this);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/TimelineUtils.java
@@ -263,7 +263,7 @@ public class TimelineUtils {
 
   private static Option<String> getMetadataValue(HoodieTableMetaClient metaClient, String extraMetadataKey, HoodieInstant instant) {
     try {
-      log.info("reading checkpoint info for:" + instant + " key: " + extraMetadataKey);
+      log.info("reading checkpoint info for:{} key: {}", instant, extraMetadataKey);
       byte[] contents = metaClient.getCommitsTimeline().getInstantDetails(instant).get();
       if (instant.isCompleted()) {
         if (contents == null || contents.length == 0) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
@@ -207,8 +207,7 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
 
   @Override
   void resetFileGroupsInPendingClustering(Map<HoodieFileGroupId, HoodieInstant> fgIdToInstantMap) {
-    log.info("Resetting file groups in pending clustering to ROCKSDB based file-system view at "
-        + config.getRocksdbBasePath() + ", Total file-groups=" + fgIdToInstantMap.size());
+    log.info("Resetting file groups in pending clustering to ROCKSDB based file-system view at {}, Total file-groups={}", config.getRocksdbBasePath(), fgIdToInstantMap.size());
 
     // Delete all replaced file groups
     rocksDB.prefixDelete(schemaHelper.getColFamilyForFileGroupsInPendingClustering(), "part=");
@@ -517,8 +516,7 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
 
   @Override
   protected void resetReplacedFileGroups(final Map<HoodieFileGroupId, HoodieInstant> replacedFileGroups) {
-    log.info("Resetting replacedFileGroups to ROCKSDB based file-system view at "
-        + config.getRocksdbBasePath() + ", Total file-groups=" + replacedFileGroups.size());
+    log.info("Resetting replacedFileGroups to ROCKSDB based file-system view at {}, Total file-groups={}", config.getRocksdbBasePath(), replacedFileGroups.size());
 
     // Delete all replaced file groups
     rocksDB.prefixDelete(schemaHelper.getColFamilyForReplacedFileGroups(), "part=");
@@ -543,8 +541,8 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
           })
       );
 
-      log.info("Finished adding replaced file groups to  partition (" + partitionPath + ") to ROCKSDB based view at "
-          + config.getRocksdbBasePath() + ", Total file-groups=" + partitionToReplacedFileGroupsEntry.getValue().size());
+      log.info("Finished adding replaced file groups to  partition ({}) to ROCKSDB based view at {}, Total file-groups={}",
+          partitionPath, config.getRocksdbBasePath(), partitionToReplacedFileGroupsEntry.getValue().size());
     });
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -682,7 +682,7 @@ public class ConfigUtils {
           return props;
         } catch (IOException e) {
           if (HoodieExceptionUtil.isPermissionDeniedException(e)) {
-            log.error("Permission denied for " + path.toString() + " file.", e);
+            log.error("Permission denied for {} file.", path, e);
             throw new HoodieIOException("Permission denied for " + path + " file path. User does not have read access on the dataset.", e);
           } else {
             log.warn("Could not read properties from {}: {}", path, e);

--- a/hudi-common/src/main/java/org/apache/hudi/metrics/JmxMetricsReporter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/JmxMetricsReporter.java
@@ -60,7 +60,7 @@ public class JmxMetricsReporter extends MetricsReporter {
             "Could not start JMX server on any configured port. Ports: " + portsConfig
                 + ". Maybe require port range for multiple hoodie tables");
       }
-      log.info("Configured JMXReporter with {port:" + portsConfig + "}");
+      log.info("Configured JMXReporter with {port: {}}", portsConfig);
     } catch (Exception e) {
       String msg = "Jmx initialize failed: ";
       log.error(msg, e);
@@ -76,13 +76,13 @@ public class JmxMetricsReporter extends MetricsReporter {
     for (int port : ports) {
       try {
         jmxReporterServer = createJmxReport(host, port);
-        log.info("Started JMX server on port " + port + ".");
+        log.info("Started JMX server on port {}.", port);
         break;
       } catch (Exception e) {
         if (e.getCause() instanceof ExportException) {
-          log.info("Skip for initializing jmx port " + port + " because of already in use");
+          log.info("Skip for initializing jmx port {} because of already in use", port);
         } else {
-          log.info("Failed to initialize jmx port " + port + ". " + e.getMessage());
+          log.info("Failed to initialize jmx port {}. {}", port, e.getMessage());
         }
       }
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
@@ -94,7 +94,7 @@ public class MetricsReporterFactory {
         reporter = new Slf4jMetricsReporter(registry);
         break;
       default:
-        log.error("Reporter type[" + type + "] is not supported.");
+        log.error("Reporter type[{}] is not supported.", type);
         break;
     }
     return Option.ofNullable(reporter);

--- a/hudi-common/src/test/java/org/apache/hudi/TestReportJvmConfiguration.java
+++ b/hudi-common/src/test/java/org/apache/hudi/TestReportJvmConfiguration.java
@@ -42,14 +42,14 @@ public class TestReportJvmConfiguration {
     MemoryUsage nonHeapMemoryUsage = memoryBean.getNonHeapMemoryUsage();
 
     LOG.warn("Heap Memory Usage (MemoryMXBean):");
-    LOG.warn("  Used: " + heapMemoryUsage.getUsed() + " bytes");
-    LOG.warn("  Committed: " + heapMemoryUsage.getCommitted() + " bytes");
-    LOG.warn("  Max: " + heapMemoryUsage.getMax() + " bytes");
+    LOG.warn("  Used: {} bytes", heapMemoryUsage.getUsed());
+    LOG.warn("  Committed: {} bytes", heapMemoryUsage.getCommitted());
+    LOG.warn("  Max: {} bytes", heapMemoryUsage.getMax());
 
     LOG.warn("Non-Heap Memory Usage (MemoryMXBean):");
-    LOG.warn("  Used: " + nonHeapMemoryUsage.getUsed() + " bytes");
-    LOG.warn("  Committed: " + nonHeapMemoryUsage.getCommitted() + " bytes");
-    LOG.warn("  Max: " + nonHeapMemoryUsage.getMax() + " bytes");
+    LOG.warn("  Used: {} bytes", nonHeapMemoryUsage.getUsed());
+    LOG.warn("  Committed: {} bytes", nonHeapMemoryUsage.getCommitted());
+    LOG.warn("  Max: {} bytes", nonHeapMemoryUsage.getMax());
   }
 
   private void reportMemoryUsageWithRuntime() {
@@ -60,8 +60,8 @@ public class TestReportJvmConfiguration {
     long usedMemory = totalMemory - freeMemory;
 
     LOG.warn("Memory Usage (Runtime):");
-    LOG.warn("  Total Memory: " + totalMemory + " bytes");
-    LOG.warn("  Free Memory: " + freeMemory + " bytes");
-    LOG.warn("  Used Memory: " + usedMemory + " bytes");
+    LOG.warn("  Total Memory: {} bytes", totalMemory);
+    LOG.warn("  Free Memory: {} bytes", freeMemory);
+    LOG.warn("  Used Memory: {} bytes", usedMemory);
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/minicluster/ZookeeperTestService.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/minicluster/ZookeeperTestService.java
@@ -101,7 +101,7 @@ public class ZookeeperTestService {
 
     // NOTE: Changed from the original, where InetSocketAddress was
     // originally created to bind to the wildcard IP, we now configure it.
-    log.info("Zookeeper force binding to: " + this.bindIP);
+    log.info("Zookeeper force binding to: {}", this.bindIP);
     standaloneServerFactory.configure(new InetSocketAddress(bindIP, clientPort), 1000);
 
     // Start up this ZK server
@@ -118,7 +118,7 @@ public class ZookeeperTestService {
     }
 
     started = true;
-    log.info("Zookeeper Minicluster service started on client port: " + clientPort);
+    log.info("Zookeeper Minicluster service started on client port: {}", clientPort);
     return zooKeeperServer;
   }
 
@@ -217,7 +217,7 @@ public class ZookeeperTestService {
         }
       } catch (IOException e) {
         // ignore as this is expected
-        log.info("server " + hostname + ":" + port + " not up " + e);
+        log.info("server {}:{} not up {}", hostname, port, e.toString());
       }
 
       if (System.currentTimeMillis() > start + timeout) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `log`/`LOG` calls in `hudi-common` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157).

### Summary and Changelog

- Converted string-concatenation `log`/`LOG` calls to `{}` placeholders across `hudi-common` (main + tests). Mechanical and behavior-preserving.
- Manual handling worth calling out:
  - `ZookeeperTestService`: the caught `IOException` is passed as `e.toString()`, not a bare `e`. Passed as a trailing `e`, SLF4J would peel it as the stacktrace throwable, leave the placeholder literal, and dump a stack on an intentionally-ignored path (`// ignore as this is expected`). `toString()` keeps it an inline message value, preserving the original output.
  - `ConfigUtils`: dropped a redundant `path.toString()`; the trailing `e` stays the throwable arg, so the stacktrace is logged as before.
  - `JmxMetricsReporter`: one message wraps the value in literal braces; written as `{port: {}}` so SLF4J fills the inner `{}` and prints the outer braces literally.
  - `RocksDbBasedFileSystemView`: one long line wrapped across two lines to stay within the 200-char limit.

### Impact

none - purely mechanical, behavior-preserving logging change.

### Risk Level

none

### Documentation Update

none

Note: a couple of files still use plain `LoggerFactory.getLogger` `LOG` fields. Migrating those to the Lombok `@Slf4j` annotation will be done in a separate round of cleanup sweeps; this PR only covers the concatenation-to-templating conversion.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
