### PR TITLE
refactor(cli): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
@@ -432,7 +432,7 @@ public class CompactionCommand {
     ObjectInputStream in = new ObjectInputStream(inputStream);
     try {
       T result = (T) in.readObject();
-      log.info("Result : " + result);
+      log.info("Result : {}", result);
       return result;
     } finally {
       in.close();

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ExportCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/ExportCommand.java
@@ -172,7 +172,7 @@ public class ExportCommand {
 
               final String instantTime = archiveEntryRecord.get("commitTime").toString();
               if (metadata == null) {
-                log.error("Could not load metadata for action " + action + " at instant time " + instantTime);
+                log.error("Could not load metadata for action {} at instant time {}", action, instantTime);
                 continue;
               }
               final String outPath = localFolder + StoragePath.SEPARATOR + instantTime + "." + action;

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/LockAuditingCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/LockAuditingCommand.java
@@ -503,7 +503,7 @@ public class LockAuditingCommand {
             deletedCount++;
           } catch (Exception e) {
             failedCount++;
-            log.warn("Failed to delete audit file: " + pathInfo.getPath(), e);
+            log.warn("Failed to delete audit file: {}", pathInfo.getPath(), e);
           }
         }
         
@@ -543,7 +543,7 @@ public class LockAuditingCommand {
             AuditRecord entry = OBJECT_MAPPER.readValue(line, AuditRecord.class);
             entries.add(entry);
           } catch (Exception e) {
-            log.warn("Failed to parse JSON line in file " + filename + ": " + line, e);
+            log.warn("Failed to parse JSON line in file {}: {}", filename, line, e);
           }
         }
       }
@@ -592,7 +592,7 @@ public class LockAuditingCommand {
           filename
       ));
     } catch (Exception e) {
-      log.warn("Failed to parse audit file: " + filename, e);
+      log.warn("Failed to parse audit file: {}", filename, e);
       return Option.empty();
     }
   }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/MetadataCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/MetadataCommand.java
@@ -307,8 +307,8 @@ public class MetadataCommand {
 
     if (!fsPartitions.equals(metadataPartitions)) {
       log.error("FS partition listing is not matching with metadata partition listing!");
-      log.error("All FS partitions: " + Arrays.toString(fsPartitions.toArray()));
-      log.error("All Metadata partitions: " + Arrays.toString(metadataPartitions.toArray()));
+      log.error("All FS partitions: {}", Arrays.toString(fsPartitions.toArray()));
+      log.error("All Metadata partitions: {}", Arrays.toString(metadataPartitions.toArray()));
     }
 
     final List<Comparable[]> rows = new ArrayList<>();
@@ -351,34 +351,33 @@ public class MetadataCommand {
       }
 
       if (metadataPathInfoList.size() != pathInfoList.size()) {
-        log.error(" FS and metadata files count not matching for " + partition
-            + ". FS files count " + pathInfoList.size()
-            + ", metadata base files count " + metadataPathInfoList.size());
+        log.error(" FS and metadata files count not matching for {}. FS files count {}, metadata base files count {}", partition, pathInfoList.size(), metadataPathInfoList.size());
       }
 
       for (Map.Entry<String, StoragePathInfo> entry : pathInfoMap.entrySet()) {
         if (!metadataPathInfoMap.containsKey(entry.getKey())) {
-          log.error("FS file not found in metadata " + entry.getKey());
+          log.error("FS file not found in metadata {}", entry.getKey());
         } else {
           if (entry.getValue().getLength()
               != metadataPathInfoMap.get(entry.getKey()).getLength()) {
-            log.error(" FS file size mismatch " + entry.getKey() + ", size equality "
-                + (entry.getValue().getLength()
-                == metadataPathInfoMap.get(entry.getKey()).getLength())
-                + ". FS size " + entry.getValue().getLength()
-                + ", metadata size " + metadataPathInfoMap.get(entry.getKey()).getLength());
+            log.error(" FS file size mismatch {}, size equality {}. FS size {}, metadata size {}",
+                entry.getKey(),
+                entry.getValue().getLength() == metadataPathInfoMap.get(entry.getKey()).getLength(),
+                entry.getValue().getLength(),
+                metadataPathInfoMap.get(entry.getKey()).getLength());
           }
         }
       }
       for (Map.Entry<String, StoragePathInfo> entry : metadataPathInfoMap.entrySet()) {
         if (!pathInfoMap.containsKey(entry.getKey())) {
-          log.error("Metadata file not found in FS " + entry.getKey());
+          log.error("Metadata file not found in FS {}", entry.getKey());
         } else {
           if (entry.getValue().getLength() != pathInfoMap.get(entry.getKey()).getLength()) {
-            log.error(" Metadata file size mismatch " + entry.getKey() + ", size equality "
-                + (entry.getValue().getLength() == pathInfoMap.get(entry.getKey()).getLength())
-                + ". Metadata size " + entry.getValue().getLength() + ", FS size "
-                + metadataPathInfoMap.get(entry.getKey()).getLength());
+            log.error(" Metadata file size mismatch {}, size equality {}. Metadata size {}, FS size {}",
+                entry.getKey(),
+                entry.getValue().getLength() == pathInfoMap.get(entry.getKey()).getLength(),
+                entry.getValue().getLength(),
+                metadataPathInfoMap.get(entry.getKey()).getLength());
           }
         }
       }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
@@ -197,12 +197,12 @@ public class RepairsCommand {
       try {
         CleanerUtils.getCleanerPlan(client, instant);
       } catch (AvroRuntimeException e) {
-        log.warn("Corruption found. Trying to remove corrupted clean instant file: " + instant);
+        log.warn("Corruption found. Trying to remove corrupted clean instant file: {}", instant);
         TimelineUtils.deleteInstantFile(client.getStorage(), client.getTimelinePath(),
             instant, client.getInstantFileNameGenerator());
       } catch (IOException ioe) {
         if (ioe.getMessage().contains("Not an Avro data file")) {
-          log.warn("Corruption found. Trying to remove corrupted clean instant file: " + instant);
+          log.warn("Corruption found. Trying to remove corrupted clean instant file: {}", instant);
           TimelineUtils.deleteInstantFile(client.getStorage(), client.getTimelinePath(),
               instant, client.getInstantFileNameGenerator());
         } else {
@@ -216,7 +216,7 @@ public class RepairsCommand {
   public void showFailedCommits() {
     HoodieTableMetaClient metaClient = HoodieCLI.getTableMetaClient();
     HoodieActiveTimeline activeTimeline =  metaClient.getActiveTimeline();
-    activeTimeline.filterCompletedInstants().getInstantsAsStream().filter(activeTimeline::isEmpty).forEach(hoodieInstant -> log.warn("Empty Commit: " + hoodieInstant.toString()));
+    activeTimeline.filterCompletedInstants().getInstantsAsStream().filter(activeTimeline::isEmpty).forEach(hoodieInstant -> log.warn("Empty Commit: {}", hoodieInstant));
   }
 
   @ShellMethod(key = "repair migrate-partition-meta", value = "Migrate all partition meta file currently stored in text format "

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
@@ -206,8 +206,9 @@ public class TableCommand {
     TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(client);
     HoodieSchema schema = tableSchemaResolver.getTableSchema();
     if (outputFilePath != null) {
-      log.info("Latest table schema : {}", schema.toString(true));
-      writeToFile(outputFilePath, schema.toString(true));
+      String schemaStr = schema.toString(true);
+      log.info("Latest table schema : {}", schemaStr);
+      writeToFile(outputFilePath, schemaStr);
       return String.format("Latest table schema written to %s", outputFilePath);
     } else {
       return String.format("Latest table schema %s", schema.toString(true));

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TableCommand.java
@@ -206,7 +206,7 @@ public class TableCommand {
     TableSchemaResolver tableSchemaResolver = new TableSchemaResolver(client);
     HoodieSchema schema = tableSchemaResolver.getTableSchema();
     if (outputFilePath != null) {
-      log.info("Latest table schema : " + schema.toString(true));
+      log.info("Latest table schema : {}", schema.toString(true));
       writeToFile(outputFilePath, schema.toString(true));
       return String.format("Latest table schema written to %s", outputFilePath);
     } else {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `log` calls in `hudi-cli` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157, #19158).

### Summary and Changelog

- Converted string-concatenation `log` calls to `{}` placeholders across `hudi-cli` command classes. Mechanical and behavior-preserving.
- Manual handling worth calling out:
  - `MetadataCommand`: two long multi-line concatenations (FS / metadata file-size mismatch) rewritten as wrapped parameterized calls; the inline `==` equality becomes a boolean `{}` arg.
  - `RepairsCommand`: dropped a redundant `hoodieInstant.toString()` in the parameterized arg.
  - `TableCommand`: kept `schema.toString(true)` as-is - it is a formatted print, not a redundant no-arg `toString()`.
  - `LockAuditingCommand`: the trailing `e` stays the throwable arg, so the stacktrace is logged as before.

### Impact

none - purely mechanical, behavior-preserving logging change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
