### PR TITLE
refactor(hadoop-common): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/config/DFSPropertiesConfiguration.java
@@ -194,7 +194,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
       visitedFilePaths.add(filePath.toString());
       addPropsFromStream(reader, filePath);
     } catch (IOException ioe) {
-      log.error("Error reading in properties from dfs from file " + filePath);
+      log.error("Error reading in properties from dfs from file {}", filePath);
       throw new HoodieIOException("Cannot read properties from dfs from file " + filePath, ioe);
     }
   }
@@ -279,7 +279,7 @@ public class DFSPropertiesConfiguration extends PropertiesConfig {
   private static Option<StoragePath> getConfPathFromEnv() {
     String confDir = System.getenv(CONF_FILE_DIR_ENV_NAME);
     if (confDir == null) {
-      log.debug("Environment variable " + CONF_FILE_DIR_ENV_NAME + ", not set. If desired, set it to the folder containing: " + DEFAULT_PROPERTIES_FILE);
+      log.debug("Environment variable {}, not set. If desired, set it to the folder containing: {}", CONF_FILE_DIR_ENV_NAME, DEFAULT_PROPERTIES_FILE);
       return Option.empty();
     }
     if (StringUtils.isNullOrEmpty(URI.create(confDir).getScheme())) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroHFileWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/storage/hadoop/HoodieAvroHFileWriter.java
@@ -139,7 +139,7 @@ public class HoodieAvroHFileWriter
     if (!this.hfileConfig.isAllowDuplicatesOnHfileWrites()) {
       // When allowDuplicatesOnHfileWrites is true, allow duplicates to be written to hFile.
       if (prevRecordKey.equals(recordKey)) {
-        LOG.info("Duplicate recordKey " + recordKey + " found while writing to HFile. Record payload " + record);
+        LOG.info("Duplicate recordKey {} found while writing to HFile. Record payload {}", recordKey, record);
         throw new HoodieDuplicateKeyException("Duplicate recordKey " + recordKey + " found while writing to HFile.");
       }
     }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/parquet/io/HoodieParquetFileBinaryCopier.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/parquet/io/HoodieParquetFileBinaryCopier.java
@@ -315,7 +315,7 @@ public class HoodieParquetFileBinaryCopier extends HoodieParquetBinaryCopyBase i
         }
         return new PrefetchResult(targetBuffer, requiredSize);
       } catch (IOException e) {
-        log.error("Failed to prefetch file: " + fileToPrefetch, e);
+        log.error("Failed to prefetch file: {}", fileToPrefetch, e);
         throw new RuntimeException(e);
       }
     }, prefetchExecutor);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -1198,7 +1198,7 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarness {
     roView.getAllBaseFiles(partitionPath);
 
     fileSliceList = rtView.getLatestFileSlices(partitionPath).collect(Collectors.toList());
-    log.info("FILESLICE LIST=" + fileSliceList);
+    log.info("FILESLICE LIST={}", fileSliceList);
     dataFiles = fileSliceList.stream().map(FileSlice::getBaseFile).filter(Option::isPresent).map(Option::get)
         .collect(Collectors.toList());
     assertEquals(1, dataFiles.size(), "Expect only one data-files in latest view as there is only one file-group");

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestIncrementalFSViewSync.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/view/TestIncrementalFSViewSync.java
@@ -527,7 +527,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     final int netFilesAddedPerInstant = numFilesAddedPerInstant - numFilesReplacedPerInstant;
     assertEquals(newCleanerInstants.size(), cleanedInstants.size());
     long exp = PARTITIONS.stream().mapToLong(p1 -> view.getAllFileSlices(p1).count()).findAny().getAsLong();
-    log.info("Initial File Slices :" + exp);
+    log.info("Initial File Slices :{}", exp);
     for (int idx = 0; idx < newCleanerInstants.size(); idx++) {
       String instant = cleanedInstants.get(idx);
       try {
@@ -544,8 +544,8 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
         assertEquals(State.COMPLETED, view.getLastInstant().get().getState());
         assertEquals(HoodieTimeline.CLEAN_ACTION, view.getLastInstant().get().getAction());
         PARTITIONS.forEach(p -> {
-          log.info("PARTITION : " + p);
-          log.info("\tFileSlices :" + view.getAllFileSlices(p).collect(Collectors.toList()));
+          log.info("PARTITION : {}", p);
+          log.info("\tFileSlices :{}", view.getAllFileSlices(p).collect(Collectors.toList()));
         });
 
         final int instantIdx = newCleanerInstants.size() - idx;
@@ -593,7 +593,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
             isDeltaCommit ? initialFileSlices : initialFileSlices - ((idx + 1) * (FILE_IDS_PER_PARTITION.size() - totalReplacedFileSlicesPerPartition));
         view.sync();
         assertTrue(view.getLastInstant().isPresent());
-        log.info("Last Instant is :" + view.getLastInstant().get());
+        log.info("Last Instant is :{}", view.getLastInstant().get());
         if (isRestore) {
           assertEquals(newRestoreInstants.get(idx), view.getLastInstant().get().requestedTime());
           assertEquals(HoodieTimeline.RESTORE_ACTION, view.getLastInstant().get().getAction());
@@ -881,7 +881,7 @@ public class TestIncrementalFSViewSync extends HoodieCommonTestHarness {
     int multiple = begin;
     for (int idx = 0; idx < instants.size(); idx++) {
       String instant = instants.get(idx);
-      log.info("Adding instant=" + instant);
+      log.info("Adding instant={}", instant);
       HoodieInstant lastInstant = lastInstants.get(idx);
       // Add a non-empty ingestion to COW table
       List<String> filePaths = addInstant(metaClient, instant, deltaCommit);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/minicluster/HdfsTestService.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/testutils/minicluster/HdfsTestService.java
@@ -63,7 +63,7 @@ public class HdfsTestService {
 
     // If clean, then remove the work dir so we can start fresh.
     if (format) {
-      log.info("Cleaning HDFS cluster data at: " + dfsBaseDirPath + " and starting fresh.");
+      log.info("Cleaning HDFS cluster data at: {} and starting fresh.", dfsBaseDirPath);
       Files.deleteIfExists(dfsBaseDirPath);
     }
 
@@ -114,7 +114,7 @@ public class HdfsTestService {
   private static Configuration configureDFSCluster(Configuration config, String dfsBaseDir, String bindIP,
       int namenodeRpcPort, int datanodePort, int datanodeIpcPort, int datanodeHttpPort) {
 
-    log.info("HDFS force binding to ip: " + bindIP);
+    log.info("HDFS force binding to ip: {}", bindIP);
     config.set(DFSConfigKeys.FS_DEFAULT_NAME_KEY, "hdfs://" + bindIP + ":" + namenodeRpcPort);
     config.set(DFSConfigKeys.DFS_DATANODE_ADDRESS_KEY, bindIP + ":" + datanodePort);
     config.set(DFSConfigKeys.DFS_DATANODE_IPC_ADDRESS_KEY, bindIP + ":" + datanodeIpcPort);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `log`/`LOG` calls in `hudi-hadoop-common` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157, #19158, #19159).

### Summary and Changelog

- Converted string-concatenation `log`/`LOG` calls to `{}` placeholders across `hudi-hadoop-common` (main + tests). Mechanical and behavior-preserving.
- `HoodieParquetFileBinaryCopier`: the trailing `e` stays the throwable arg, so its stacktrace is logged as before.

### Impact

none - purely mechanical, behavior-preserving logging change.

### Risk Level

none

### Documentation Update

none

Note: a couple of files still use plain `LoggerFactory.getLogger` `LOG` fields. Migrating those to the Lombok `@Slf4j` annotation will be done in a separate round of cleanup sweeps; this PR only covers the concatenation-to-templating conversion.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
