### PR TITLE
fix(spark): correct self-recursive equals in ProcedureParameterImpl

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ProcedureParameterImpl.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/ProcedureParameterImpl.scala
@@ -25,15 +25,14 @@ case class ProcedureParameterImpl(index: Int, name: String, dataType: DataType, 
   extends ProcedureParameter {
 
   override def equals(other: Any): Boolean = {
-    val that = other.asInstanceOf[ProcedureParameterImpl]
-    val rtn = if (this == other) {
+    if (this eq other.asInstanceOf[AnyRef]) {
       true
     } else if (other == null || (getClass ne other.getClass)) {
       false
     } else {
+      val that = other.asInstanceOf[ProcedureParameterImpl]
       index == that.index && required == that.required && default == that.default && Objects.equals(name, that.name) && Objects.equals(dataType, that.dataType)
     }
-    rtn
   }
 
   override def hashCode: Int = Seq(index, name, dataType, required, default).hashCode()


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`ProcedureParameterImpl.equals` is broken in two ways:

1. It begins with `if (this == other)`. In Scala `==` dispatches to `equals`, so this self-recurses and any call to `equals` on a `ProcedureParameterImpl` throws `StackOverflowError`.
2. It casts `other` to `ProcedureParameterImpl` before the null/type guard, so comparing against a value of another type throws `ClassCastException`.

The method was effectively never exercised (nothing compares these objects), which hid the defect.

### Summary and Changelog

- Use reference equality (`eq`) for the identity short-circuit instead of `==`.
- Move the cast after the null/type guard.

### Impact

Corrects `ProcedureParameterImpl` equality. No behavior change for existing call sites (equality was previously unusable); enables correct comparison and hash-set/map usage.

### Risk Level

low. Single-method change; equality semantics are the standard identity/null/type/field-compare form.

### Documentation Update

none

Part of the hudi-spark-datasource test-coverage effort (ENG-44401).

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable

