### PR TITLE
fix(spark): correct data-skipping translation for LIKE 'prefix%' (StartsWith)

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
@@ -318,16 +318,18 @@ object DataSkippingUtils extends Logging {
         })
 
       // Filter "colA like 'xxx%'"
-      // Translates to "colA_minValue <= xxx AND xxx <= colA_maxValue" for index lookup
+      // Translates to "colA_maxValue >= xxx AND (colA_minValue < xxx OR colA_minValue like 'xxx%')" for index lookup
       //
-      // NOTE: Since a) this operator matches strings by prefix and b) given that this column is going to be ordered
-      //       lexicographically, we essentially need to check that provided literal falls w/in min/max bounds of the
-      //       given column
+      // NOTE: Since a) this operator matches strings by prefix and b) given that this column is ordered
+      //       lexicographically, a file can contain a value carrying the prefix iff its [minValue, maxValue] range
+      //       overlaps the range of all strings with that prefix. Merely checking that the prefix falls within
+      //       [minValue, maxValue] is incorrect: a file whose values all start with the prefix has minValue > prefix
+      //       and would be wrongly pruned.
       case StartsWith(sourceExpr @ AllowedTransformationExpression(attrRef), v @ Literal(_: UTF8String, _)) =>
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            genColumnValuesEqualToExpression(colName, v, targetExprBuilder)
+            genColumnStartsWithExpression(colName, v, targetExprBuilder)
           }.orElse({
           Option.empty
         })
@@ -486,6 +488,21 @@ object ColumnStatsExpressionUtils {
     val maxValueExpr = targetExprBuilder.apply(genColMaxValueExpr(colName))
     // Only case when column C contains value V is when min(C) <= V <= max(c)
     And(LessThanOrEqual(minValueExpr, value), GreaterThanOrEqual(maxValueExpr, value))
+  }
+
+  @inline def genColumnStartsWithExpression(colName: String,
+                                            value: Expression,
+                                            targetExprBuilder: Function[Expression, Expression] = Predef.identity): Expression = {
+    val minValueExpr = targetExprBuilder.apply(genColMinValueExpr(colName))
+    val maxValueExpr = targetExprBuilder.apply(genColMaxValueExpr(colName))
+    // A file may contain a value starting with `prefix` iff its [min, max] range overlaps the range of all
+    // strings carrying that prefix, i.e. [prefix, upperBound(prefix)). That overlap holds iff
+    // max >= prefix AND min < upperBound(prefix). We express `min < upperBound(prefix)` without materializing
+    // the successor string as `min < prefix OR min startsWith prefix` (any string strictly between prefix and
+    // its successor starts with prefix). Checking only that the prefix falls within [min, max] (min <= prefix)
+    // is wrong: a file whose values all start with the prefix has min > prefix and would be pruned incorrectly.
+    And(GreaterThanOrEqual(maxValueExpr, value),
+      Or(LessThan(minValueExpr, value), StartsWith(minValueExpr, value)))
   }
 
   def genColumnOnlyValuesEqualToExpression(colName: String,

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
@@ -176,9 +176,10 @@ object TestDataSkippingUtils {
         Seq(
           IndexRow("file_1", valueCount = 1, B_minValue = "aba", B_maxValue = "adf", B_nullCount = 1), // may contain strings starting w/ "abc"
           IndexRow("file_2", valueCount = 1, B_minValue = "adf", B_maxValue = "azy", B_nullCount = 0),
-          IndexRow("file_3", valueCount = 1, B_minValue = "aaa", B_maxValue = "aba", B_nullCount = 0)
+          IndexRow("file_3", valueCount = 1, B_minValue = "aaa", B_maxValue = "aba", B_nullCount = 0),
+          IndexRow("file_4", valueCount = 1, B_minValue = "abc123", B_maxValue = "abc345", B_nullCount = 0) // all strings start w/ "abc"; minValue > "abc"
         ),
-        Seq("file_1")),
+        Seq("file_1", "file_4")),
       arguments(
         Not(sparkAdapter.getExpressionFromColumn(col("B").startsWith("abc"))),
         Seq(


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #18791.

With data-skipping (column-stats index) enabled, a `LIKE 'prefix%'` predicate (Spark Catalyst `StartsWith`) silently drops rows in 1.x/master when a file's minimum value is lexicographically greater than the literal prefix, e.g. a file whose values all start with `abc` has `minValue = "abc123" > "abc"`. This is a regression from 0.15.x and produces empty/short results with no error.

### Summary and Changelog

The `StartsWith` translation reused `genColumnValuesEqualToExpression`, producing `colMin <= prefix AND colMax >= prefix`. That checks whether the prefix falls inside `[min, max]`, which wrongly prunes files whose values all start with the prefix (their `min > prefix`).

- Add `genColumnStartsWithExpression` in `ColumnStatsExpressionUtils`, producing `colMax >= prefix AND (colMin < prefix OR colMin startsWith prefix)`. This keeps a file iff its `[min, max]` range overlaps the range of all strings carrying the prefix (`[prefix, upperBound(prefix))`), expressed without materializing the successor string.
- Point the `StartsWith` case in `DataSkippingUtils` at the new helper and correct the misleading comment.
- Add a regression case to `TestDataSkippingUtils` (`file_4`, `minValue="abc123"`, `maxValue="abc345"`, query `B.startsWith("abc")`) that the old predicate pruned and the new one keeps.

### Impact

Correct results for `LIKE 'prefix%'` queries when data-skipping is enabled. No API or config change. The `NOT(StartsWith)` path is unchanged.

### Risk Level

low - localized predicate-translation change covered by a red/green unit test in `TestDataSkippingUtils`.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
