### PR TITLE
refactor(spark): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/TestHoodieClientMultiWriter.java
@@ -1030,7 +1030,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
         writer1Succeeded.set(true);
       } catch (Exception e) {
         // Expected - one writer may fail due to concurrent execution
-        LOG.info("Writer 1 failed with exception: " + e.getMessage());
+        LOG.info("Writer 1 failed with exception: {}", e.getMessage());
         writer1Succeeded.set(false);
       }
     });
@@ -1045,7 +1045,7 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
         writer2Succeeded.set(true);
       } catch (Exception e) {
         // Expected - one writer may fail due to concurrent execution
-        LOG.info("Writer 2 failed with exception: " + e.getMessage());
+        LOG.info("Writer 2 failed with exception: {}", e.getMessage());
         writer2Succeeded.set(false);
       }
     });
@@ -1528,9 +1528,9 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
           try {
             ingestBatch(writeFn, client1, newCommitTime1, writeRecords1, runCountDownLatch);
           } catch (IOException e) {
-            LOG.error("IOException thrown " + e.getMessage());
+            LOG.error("IOException thrown {}", e.getMessage());
           } catch (InterruptedException e) {
-            LOG.error("Interrupted Exception thrown " + e.getMessage());
+            LOG.error("Interrupted Exception thrown {}", e.getMessage());
           } catch (Exception e) {
             client1Succeeded.set(false);
           }
@@ -1541,9 +1541,9 @@ public class TestHoodieClientMultiWriter extends HoodieClientTestBase {
           try {
             ingestBatch(writeFn, client2, newCommitTime2, writeRecords2, runCountDownLatch);
           } catch (IOException e) {
-            LOG.error("IOException thrown " + e.getMessage());
+            LOG.error("IOException thrown {}", e.getMessage());
           } catch (InterruptedException e) {
-            LOG.error("Interrupted Exception thrown " + e.getMessage());
+            LOG.error("Interrupted Exception thrown {}", e.getMessage());
           } catch (Exception e) {
             client2Succeeded.set(false);
           }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestDataValidationCheckForLogCompactionActions.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestDataValidationCheckForLogCompactionActions.java
@@ -122,12 +122,12 @@ public class TestDataValidationCheckForLogCompactionActions extends HoodieClient
     // Total ingestion writes.
     int totalWrites = 15;
 
-    LOG.warn("Starting trial with seed " + seed);
+    LOG.warn("Starting trial with seed {}", seed);
 
     // Current ingestion commit.
     int curr = 1;
     while (curr < totalWrites) {
-      LOG.warn("Starting write No. " + curr);
+      LOG.warn("Starting write No. {}", curr);
 
       // Pick an action. It can be insert/update/delete and write data to main table.
       boolean status = writeOnMainTable(mainTable, curr);
@@ -145,7 +145,7 @@ public class TestDataValidationCheckForLogCompactionActions extends HoodieClient
 
         // Verify the records in both the tables.
         verifyRecords(mainTable, experimentTable);
-        LOG.warn("For write No." + curr + ", verification passed. Last ingestion commit timestamp is " + mainTable.commitTimeOnMainTable);
+        LOG.warn("For write No.{}, verification passed. Last ingestion commit timestamp is {}", curr, mainTable.commitTimeOnMainTable);
       }
       curr++;
     }
@@ -195,7 +195,7 @@ public class TestDataValidationCheckForLogCompactionActions extends HoodieClient
           result = deleteDataIntoMainTable(mainTable, commitTime);
         }
       } catch (IllegalArgumentException e) {
-        LOG.warn(e.getMessage() + " ignoring current command.");
+        LOG.warn("{} ignoring current command.", e.getMessage());
         return false;
       }
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `LOG` calls in the `hudi-spark` test classes build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157, #19158, #19159, #19160).

### Summary and Changelog

- Converted string-concatenation `LOG` calls to `{}` placeholders in two `hudi-spark` test classes (`TestHoodieClientMultiWriter`, `TestDataValidationCheckForLogCompactionActions`). Mechanical and behavior-preserving.

### Impact

none - test-only, purely mechanical logging change.

### Risk Level

none

### Documentation Update

none

Note: these classes use plain `LoggerFactory.getLogger` `LOG` fields. Migrating them to the Lombok `@Slf4j` annotation will be done in a separate round of cleanup sweeps; this PR only covers the concatenation-to-templating conversion.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
