### PR TITLE
refactor(utilities): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDataTableValidator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieDataTableValidator.java
@@ -252,7 +252,7 @@ public class HoodieDataTableValidator implements Serializable {
     try {
       validator.run();
     } catch (Throwable throwable) {
-      log.error("Fail to do hoodie Data table validation for " + validator.cfg, throwable);
+      log.error("Fail to do hoodie Data table validation for {}", validator.cfg, throwable);
     } finally {
       jsc.stop();
     }
@@ -320,7 +320,7 @@ public class HoodieDataTableValidator implements Serializable {
 
         if (!danglingFilePaths.isEmpty() && danglingFilePaths.size() > 0) {
           log.error("Data table validation failed due to dangling files count {}, found before active timeline", danglingFilePaths.size());
-          danglingFilePaths.forEach(entry -> log.error("Dangling file: " + entry.toString()));
+          danglingFilePaths.forEach(entry -> log.error("Dangling file: {}", entry));
           finalResult = false;
           if (!cfg.ignoreFailed) {
             throw new HoodieValidationException(

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DFSPathSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/DFSPathSelector.java
@@ -91,7 +91,7 @@ public class DFSPathSelector implements Serializable {
           new Class<?>[] {TypedProperties.class, Configuration.class},
           props, conf);
 
-      log.info("Using path selector " + selector.getClass().getName());
+      log.info("Using path selector {}", selector.getClass().getName());
       return selector;
     } catch (Exception e) {
       throw new HoodieException("Could not load source selector class " + sourceSelectorClass, e);
@@ -125,8 +125,7 @@ public class DFSPathSelector implements Serializable {
                                                                                  long sourceLimit) {
     try {
       // obtain all eligible files under root folder.
-      log.info("Root path => " + getStringWithAltKeys(props, DFSPathSelectorConfig.ROOT_INPUT_PATH)
-          + " source limit => " + sourceLimit);
+      log.info("Root path => {} source limit => {}", getStringWithAltKeys(props, DFSPathSelectorConfig.ROOT_INPUT_PATH), sourceLimit);
       long lastCheckpointTime = lastCheckpointStr.map(e -> Long.parseLong(e.getCheckpointKey())).orElse(Long.MIN_VALUE);
       List<FileStatus> eligibleFiles = listEligibleFiles(
           fs, new Path(getStringWithAltKeys(props, DFSPathSelectorConfig.ROOT_INPUT_PATH)), lastCheckpointTime);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/S3EventsMetaSelector.java
@@ -73,7 +73,7 @@ public class S3EventsMetaSelector extends CloudObjectsSelector {
               ReflectionUtils.loadClass(
                   sourceSelectorClass, new Class<?>[] {TypedProperties.class}, props);
 
-      log.info("Using path selector " + selector.getClass().getName());
+      log.info("Using path selector {}", selector.getClass().getName());
       return selector;
     } catch (Exception e) {
       throw new HoodieException("Could not load source selector class " + sourceSelectorClass, e);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestHoodieSnapshotExporter.java
@@ -112,7 +112,7 @@ public class TestHoodieSnapshotExporter extends SparkClientFunctionalTestHarness
     }
     List<StoragePathInfo> pathInfoList = storage.listFiles(new StoragePath(sourcePath));
     for (StoragePathInfo pathInfo : pathInfoList) {
-      LOG.info(">>> Prepared test file: " + pathInfo.getPath());
+      LOG.info(">>> Prepared test file: {}", pathInfo.getPath());
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/HoodieOfflineJobTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/offlinejob/HoodieOfflineJobTestBase.java
@@ -110,7 +110,7 @@ public class HoodieOfflineJobTestBase extends UtilitiesTestBase {
     static void assertNCompletedCommits(int expected, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage, tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getWriteTimeline().filterCompletedInstants();
-      LOG.info("Timeline Instants=" + meta.getActiveTimeline().getInstants());
+      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numCommits = timeline.countInstants();
       assertEquals(expected, numCommits, "Got=" + numCommits + ", exp =" + expected);
     }
@@ -118,7 +118,7 @@ public class HoodieOfflineJobTestBase extends UtilitiesTestBase {
     static void assertNCleanCommits(int expected, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage, tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getCleanerTimeline().filterCompletedInstants();
-      LOG.info("Timeline Instants=" + meta.getActiveTimeline().getInstants());
+      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numCleanCommits = timeline.countInstants();
       assertEquals(expected, numCleanCommits, "Got=" + numCleanCommits + ", exp =" + expected);
     }
@@ -126,7 +126,7 @@ public class HoodieOfflineJobTestBase extends UtilitiesTestBase {
     static void assertNClusteringCommits(int expected, String tablePath) {
       HoodieTableMetaClient meta = createMetaClient(storage, tablePath);
       HoodieTimeline timeline = meta.getActiveTimeline().getCompletedReplaceTimeline();
-      LOG.info("Timeline Instants=" + meta.getActiveTimeline().getInstants());
+      LOG.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numCommits = timeline.countInstants();
       assertEquals(expected, numCommits, "Got=" + numCommits + ", exp =" + expected);
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `log`/`LOG` calls in `hudi-utilities` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157, #19158, #19159, #19160, #19184).

### Summary and Changelog

- Converted string-concatenation `log`/`LOG` calls to `{}` placeholders across `hudi-utilities` (main + tests). Mechanical and behavior-preserving.
- `HoodieDataTableValidator`: the trailing `throwable` stays the last arg so its stacktrace is logged as before; also dropped a redundant `entry.toString()`.

### Impact

none - purely mechanical, behavior-preserving logging change.

### Risk Level

none

### Documentation Update

none

Note: a couple of files still use plain `LoggerFactory.getLogger` `LOG` fields. Migrating those to the Lombok `@Slf4j` annotation will be done in a separate round of cleanup sweeps; this PR only covers the concatenation-to-templating conversion.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
