### PR TITLE
refactor(aws): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/sync/AWSGlueCatalogSyncClient.java
@@ -252,7 +252,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
   @Override
   public List<Partition> getPartitionsFromList(String tableName, List<String> partitionList) {
     if (partitionList.isEmpty()) {
-      log.info("No partitions to read for " + tableId(this.databaseName, tableName));
+      log.info("No partitions to read for {}", tableId(this.databaseName, tableName));
       return Collections.emptyList();
     }
     HoodieTimer timer = HoodieTimer.start();
@@ -310,7 +310,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     HoodieTimer timer = HoodieTimer.start();
     try {
       if (partitionsToAdd.isEmpty()) {
-        log.info("No partitions to add for " + tableId(this.databaseName, tableName));
+        log.info("No partitions to add for {}", tableId(this.databaseName, tableName));
         return;
       }
       Table table = getTable(awsGlue, databaseName, tableName);
@@ -373,7 +373,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     HoodieTimer timer = HoodieTimer.start();
     try {
       if (changedPartitions.isEmpty()) {
-        log.info("No partitions to update for " + tableId(this.databaseName, tableName));
+        log.info("No partitions to update for {}", tableId(this.databaseName, tableName));
         return;
       }
       Table table = getTable(awsGlue, databaseName, tableName);
@@ -413,7 +413,7 @@ public class AWSGlueCatalogSyncClient extends HoodieSyncClient {
     HoodieTimer timer = HoodieTimer.start();
     try {
       if (partitionsToDrop.isEmpty()) {
-        log.info("No partitions to drop for " + tableId(this.databaseName, tableName));
+        log.info("No partitions to drop for {}", tableId(this.databaseName, tableName));
         return;
       }
       parallelizeChange(partitionsToDrop, this.changeParallelism, partitions -> this.dropPartitionsInternal(tableName, partitions), MAX_DELETE_PARTITIONS_PER_REQUEST);

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/utils/DynamoTableUtils.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/utils/DynamoTableUtils.java
@@ -222,7 +222,7 @@ public class DynamoTableUtils {
       return true;
     } catch (final ResourceInUseException e) {
       if (log.isTraceEnabled()) {
-        log.trace("Table " + createTableRequest.tableName() + " already exists", e);
+        log.trace("Table {} already exists", createTableRequest.tableName(), e);
       }
     }
     return false;
@@ -240,7 +240,7 @@ public class DynamoTableUtils {
       return true;
     } catch (final ResourceNotFoundException e) {
       if (log.isTraceEnabled()) {
-        log.trace("Table " + deleteTableRequest.tableName() + " does not exist", e);
+        log.trace("Table {} does not exist", deleteTableRequest.tableName(), e);
       }
     }
     return false;


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `log` calls in `hudi-aws` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157, #19158, #19159, #19160, #19184, #19185).

### Summary and Changelog

- Converted string-concatenation `log` calls to `{}` placeholders across `hudi-aws` (`AWSGlueCatalogSyncClient`, `DynamoTableUtils`). Mechanical and behavior-preserving.
- `DynamoTableUtils`: the trailing exception stays the last arg so its stacktrace is logged as before; kept the existing `isTraceEnabled()` guards.

### Impact

none - purely mechanical, behavior-preserving logging change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
