### PR TITLE
refactor(examples): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieWriteClientExample.java
+++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieWriteClientExample.java
@@ -101,7 +101,7 @@ public class HoodieWriteClientExample {
 
         // inserts
         String newCommitTime = client.startCommit();
-        log.info("Starting commit " + newCommitTime);
+        log.info("Starting commit {}", newCommitTime);
 
         List<HoodieRecord<HoodieAvroPayload>> records = dataGen.generateInserts(newCommitTime, 10);
         List<HoodieRecord<HoodieAvroPayload>> recordsSoFar = new ArrayList<>(records);
@@ -110,7 +110,7 @@ public class HoodieWriteClientExample {
 
         // updates
         newCommitTime = client.startCommit();
-        log.info("Starting commit " + newCommitTime);
+        log.info("Starting commit {}", newCommitTime);
         List<HoodieRecord<HoodieAvroPayload>> toBeUpdated = dataGen.generateUpdates(newCommitTime, 2);
         records.addAll(toBeUpdated);
         recordsSoFar.addAll(toBeUpdated);
@@ -119,7 +119,7 @@ public class HoodieWriteClientExample {
 
         // Delete
         newCommitTime = client.startCommit();
-        log.info("Starting commit " + newCommitTime);
+        log.info("Starting commit {}", newCommitTime);
         // just delete half of the records
         int numToDelete = recordsSoFar.size() / 2;
         List<HoodieKey> toBeDeleted = recordsSoFar.stream().map(HoodieRecord::getKey).limit(numToDelete).collect(Collectors.toList());
@@ -128,7 +128,7 @@ public class HoodieWriteClientExample {
 
         // Delete by partition
         newCommitTime = client.startCommit(HoodieTimeline.REPLACE_COMMIT_ACTION);
-        log.info("Starting commit " + newCommitTime);
+        log.info("Starting commit {}", newCommitTime);
         // The partition where the data needs to be deleted
         List<String> partitionList = toBeDeleted.stream().map(s -> s.getPartitionPath()).distinct().collect(Collectors.toList());
         List<String> deleteList = recordsSoFar.stream().filter(f -> !partitionList.contains(f.getPartitionPath()))


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The `log` calls in `HoodieWriteClientExample` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157, #19158, #19159, #19160, #19184, #19185, #19186).

### Summary and Changelog

- Converted the repeated `log.info("Starting commit " + newCommitTime)` statements in `HoodieWriteClientExample` to `{}` placeholders. Mechanical and behavior-preserving.

### Impact

none - example-only, purely mechanical logging change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
