### PR TITLE
refactor(io): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-io/src/main/java/org/apache/hudi/common/metrics/Registry.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/metrics/Registry.java
@@ -98,13 +98,12 @@ public interface Registry extends Serializable {
     Registry registry = REGISTRY_MAP.computeIfAbsent(key, k -> {
       String registryFullName = tableName.isEmpty() ? registryName : tableName + "." + registryName;
       Registry r = (Registry) ReflectionUtils.loadClass(clazz, registryFullName);
-      LOG.info("Created a new registry " + r);
+      LOG.info("Created a new registry {}", r);
       return r;
     });
 
     if (!registry.getClass().getName().equals(clazz)) {
-      LOG.error("Registry with name " + registryName + " already exists with a different class " + registry.getClass().getName()
-          + " than the requested class " + clazz);
+      LOG.error("Registry with name {} already exists with a different class {} than the requested class {}", registryName, registry.getClass().getName(), clazz);
     }
     return registry;
   }

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -136,7 +136,7 @@ public class ReflectionUtils {
     try {
       resources = classLoader.getResources(path);
     } catch (IOException e) {
-      log.error("Unable to fetch Resources in package {}", e.getMessage());
+      log.error("Unable to fetch Resources in package {}", packageName, e);
     }
     List<File> directories = new ArrayList<>();
     while (Objects.requireNonNull(resources).hasMoreElements()) {
@@ -144,7 +144,7 @@ public class ReflectionUtils {
       try {
         directories.add(new File(resource.toURI()));
       } catch (URISyntaxException e) {
-        log.error("Unable to get {}", e.getMessage());
+        log.error("Unable to get URI for {}", resource, e);
       }
     }
     List<String> classes = new ArrayList<>();

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -136,7 +136,7 @@ public class ReflectionUtils {
     try {
       resources = classLoader.getResources(path);
     } catch (IOException e) {
-      log.error("Unable to fetch Resources in package " + e.getMessage());
+      log.error("Unable to fetch Resources in package {}", e.getMessage());
     }
     List<File> directories = new ArrayList<>();
     while (Objects.requireNonNull(resources).hasMoreElements()) {
@@ -144,7 +144,7 @@ public class ReflectionUtils {
       try {
         directories.add(new File(resource.toURI()));
       } catch (URISyntaxException e) {
-        log.error("Unable to get " + e.getMessage());
+        log.error("Unable to get {}", e.getMessage());
       }
     }
     List<String> classes = new ArrayList<>();


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `log`/`LOG` calls in `hudi-io` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157, #19158, #19159, #19160, #19184, #19185, #19186, #19187).

### Summary and Changelog

- Converted string-concatenation `log`/`LOG` calls to `{}` placeholders in `Registry` and `ReflectionUtils`. Mechanical and behavior-preserving.

### Impact

none - purely mechanical, behavior-preserving logging change.

### Risk Level

none

### Documentation Update

none

Note: `Registry` uses a plain `LoggerFactory.getLogger` `LOG` field. Migrating it to the Lombok `@Slf4j` annotation will be done in a separate round of cleanup sweeps; this PR only covers the concatenation-to-templating conversion.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
