### PR TITLE
refactor(sync): use SLF4J parameterized logging instead of string concatenation

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -555,7 +555,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
 
     List<String> touchPartitions = config.getBoolean(META_SYNC_TOUCH_PARTITIONS_ENABLED) ? filterPartitions(partitionEventList, PartitionEventType.TOUCH) : Collections.emptyList();
     if (!touchPartitions.isEmpty()) {
-      log.info("Touch Partitions " + touchPartitions);
+      log.info("Touch Partitions {}", touchPartitions);
       syncClient.touchPartitionsToTable(tableName, touchPartitions);
     }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/QueryBasedDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/QueryBasedDDLExecutor.java
@@ -205,10 +205,10 @@ public abstract class QueryBasedDDLExecutor implements DDLExecutor {
   @Override
   public void touchPartitionsToTable(String tableName, List<String> touchPartitions) {
     if (touchPartitions.isEmpty()) {
-      log.info("No partitions to touch for " + tableName);
+      log.info("No partitions to touch for {}", tableName);
       return;
     }
-    log.info("Touching partitions " + touchPartitions.size() + " on " + tableName);
+    log.info("Touching partitions {} on {}", touchPartitions.size(), tableName);
     List<String> sqls = constructPartitionAlterStatements(tableName, touchPartitions, PartitionAlterType.TOUCH);
     for (String sql : sqls) {
       runSQL(sql);


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

A number of `log` calls in `hudi-sync` build their message with `+` string concatenation. This eagerly builds the string even when the level is disabled and reads worse than a parameterized statement. This PR converts them to SLF4J `{}` templating. Part of the ongoing logging cleanup (follows #19155, #19156, #19157, #19158, #19159, #19160, #19184, #19185, #19186, #19187, #19188).

### Summary and Changelog

- Converted string-concatenation `log` calls to `{}` placeholders in `HiveSyncTool` and `QueryBasedDDLExecutor` (hudi-hive-sync). Mechanical and behavior-preserving.

### Impact

none - purely mechanical, behavior-preserving logging change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
