### PR TITLE
refactor(flink): migrate hand-declared LOG to Lombok @Slf4j

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/FlinkCheckpointClient.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/FlinkCheckpointClient.java
@@ -22,8 +22,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.sink.muttley.AthenaIngestionGateway;
 import org.apache.hudi.sink.muttley.AthenaIngestionGateway.CheckpointKafkaOffsetInfo;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Map;
@@ -32,9 +31,8 @@ import java.util.Map;
  * Client for fetching Kafka checkpoint information from Athena Ingestion Gateway using MuttleyClient.
  * This uses the MuttleyClient implementation for RPC communication.
  */
+@Slf4j
 public class FlinkCheckpointClient {
-  
-  private static final Logger LOG = LoggerFactory.getLogger(FlinkCheckpointClient.class);
   
   private final AthenaIngestionGateway athenaGateway;
 
@@ -65,15 +63,15 @@ public class FlinkCheckpointClient {
    * @throws IOException if the HTTP request fails
    */
   public Option<CheckpointKafkaOffsetInfo> getKafkaCheckpointsInfo(CheckpointRequest request) throws IOException {
-    LOG.info("getKafkaCheckpointsInfo called with request: {}", request);
-    LOG.debug("Request details - DC: {}, Env: {}, CheckpointId: {}, JobName: {}, HadoopUser: {}, "
+    log.info("getKafkaCheckpointsInfo called with request: {}", request);
+    log.debug("Request details - DC: {}, Env: {}, CheckpointId: {}, JobName: {}, HadoopUser: {}, "
         + "SourceCluster: {}, TargetCluster: {}, CheckpointLookback: {}, TopicOperatorIds: {}, ServiceTier: {}, ServiceName: {}",
         request.getDc(), request.getEnv(), request.getCheckpointId(), request.getJobName(),
         request.getHadoopUser(), request.getSourceCluster(), request.getTargetCluster(),
         request.getCheckpointLookback(), request.getTopicOperatorIds(), request.getServiceTier(), request.getServiceName());
     
     try {
-      LOG.info("Calling athenaGateway.getKafkaCheckpointsInfo...");
+      log.info("Calling athenaGateway.getKafkaCheckpointsInfo...");
       Option<CheckpointKafkaOffsetInfo> result = athenaGateway.getKafkaCheckpointsInfo(
           request.getDc(),
           request.getEnv(),
@@ -87,13 +85,13 @@ public class FlinkCheckpointClient {
           request.getServiceTier(),
           request.getServiceName()
       );
-      LOG.info("Call to athenaGateway completed. Result present: {}", result.isPresent());
+      log.info("Call to athenaGateway completed. Result present: {}", result.isPresent());
       return result;
     } catch (IOException e) {
-      LOG.error("IOException in getKafkaCheckpointsInfo: {}", e.getMessage(), e);
+      log.error("IOException in getKafkaCheckpointsInfo: {}", e.getMessage(), e);
       throw e;
     } catch (Exception e) {
-      LOG.error("Unexpected exception in getKafkaCheckpointsInfo: {}", e.getMessage(), e);
+      log.error("Unexpected exception in getKafkaCheckpointsInfo: {}", e.getMessage(), e);
       throw new IOException("Unexpected error getting checkpoint info", e);
     }
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithContinuousSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithContinuousSort.java
@@ -27,6 +27,7 @@ import org.apache.hudi.sink.buffer.TotalSizeTracer;
 import org.apache.hudi.sink.bulk.sort.SortOperatorGen;
 import org.apache.hudi.utils.RuntimeContextUtils;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
@@ -38,8 +39,6 @@ import org.apache.flink.table.runtime.generated.RecordComparator;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Collector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -67,9 +66,8 @@ import java.util.TreeMap;
  * @param <T> Type of the input record
  * @see StreamWriteOperatorCoordinator
  */
+@Slf4j
 public class AppendWriteFunctionWithContinuousSort<T> extends AppendWriteFunction<T> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(AppendWriteFunctionWithContinuousSort.class);
 
   private final long maxCapacity;
   private final int drainSize;
@@ -99,7 +97,7 @@ public class AppendWriteFunctionWithContinuousSort<T> extends AppendWriteFunctio
     this.maxCapacity = config.get(FlinkOptions.WRITE_BUFFER_SIZE);
     this.drainSize = config.get(FlinkOptions.WRITE_BUFFER_SORT_CONTINUOUS_DRAIN_SIZE);
 
-    LOG.info("AppendWriteFunctionWithContinuousSort created: maxCapacity={}, drainSize={}",
+    log.info("AppendWriteFunctionWithContinuousSort created: maxCapacity={}, drainSize={}",
         maxCapacity, drainSize);
   }
 
@@ -121,7 +119,7 @@ public class AppendWriteFunctionWithContinuousSort<T> extends AppendWriteFunctio
 
     super.open(parameters);
 
-    LOG.info("Initializing continuous sort with keys: {}", sortKeyList);
+    log.info("Initializing continuous sort with keys: {}", sortKeyList);
 
     // Create sort code generator for normalized key computation and record comparison
     SortOperatorGen sortOperatorGen = new SortOperatorGen(rowType, sortKeyList.toArray(new String[0]));
@@ -169,7 +167,7 @@ public class AppendWriteFunctionWithContinuousSort<T> extends AppendWriteFunctio
     // Initialize memory size tracer for bounding buffer memory footprint
     this.sizeTracer = new TotalSizeTracer(config);
 
-    LOG.info("AppendWriteFunctionWithContinuousSort initialized successfully");
+    log.info("AppendWriteFunctionWithContinuousSort initialized successfully");
   }
 
   @Override
@@ -244,14 +242,14 @@ public class AppendWriteFunctionWithContinuousSort<T> extends AppendWriteFunctio
     try {
       // Drain all remaining records and reset for next checkpoint interval
       if (!sortedRecords.isEmpty()) {
-        LOG.info("Snapshot: draining {} remaining records", sortedRecords.size());
+        log.info("Snapshot: draining {} remaining records", sortedRecords.size());
         drainRecords(sortedRecords.size());
         sortedRecords.clear();
         insertionSequence = 0L;
         sizeTracer.reset();
       }
 
-      LOG.info("Snapshot complete: total drained={}, operations={}",
+      log.info("Snapshot complete: total drained={}, operations={}",
           totalDrainedRecords, totalDrainOperations);
 
     } catch (IOException e) {
@@ -265,7 +263,7 @@ public class AppendWriteFunctionWithContinuousSort<T> extends AppendWriteFunctio
     try {
       // Drain all remaining records and clear buffer
       if (!sortedRecords.isEmpty()) {
-        LOG.info("EndInput: draining {} remaining records", sortedRecords.size());
+        log.info("EndInput: draining {} remaining records", sortedRecords.size());
         drainRecords(sortedRecords.size());
         sortedRecords.clear();
         insertionSequence = 0L;
@@ -281,7 +279,7 @@ public class AppendWriteFunctionWithContinuousSort<T> extends AppendWriteFunctio
   @Override
   public void close() throws Exception {
     try {
-      LOG.info("AppendWriteFunctionWithContinuousSort closed: totalInserted={}, totalDrained={}, operations={}",
+      log.info("AppendWriteFunctionWithContinuousSort closed: totalInserted={}, totalDrained={}, operations={}",
           totalInserted, totalDrainedRecords, totalDrainOperations);
 
     } finally {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringPlanSourceFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/ClusteringPlanSourceFunction.java
@@ -26,9 +26,8 @@ import org.apache.hudi.common.model.ClusteringGroupInfo;
 import org.apache.hudi.common.model.ClusteringOperation;
 import org.apache.hudi.util.StreamerUtil;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Flink hudi clustering source function.
@@ -46,9 +45,8 @@ import org.slf4j.LoggerFactory;
  *   as the instant time.</li>
  * </ul>
  */
+@Slf4j
 public class ClusteringPlanSourceFunction extends AbstractRichFunctionAdapter implements SourceFunctionAdapter<ClusteringPlanEvent> {
-
-  protected static final Logger LOG = LoggerFactory.getLogger(ClusteringPlanSourceFunction.class);
 
   /**
    * The clustering plan.
@@ -78,11 +76,11 @@ public class ClusteringPlanSourceFunction extends AbstractRichFunctionAdapter im
     boolean isPending = StreamerUtil.createMetaClient(conf).getActiveTimeline().isPendingClusteringInstant(clusteringInstantTime);
     if (isPending) {
       for (HoodieClusteringGroup clusteringGroup : clusteringPlan.getInputGroups()) {
-        LOG.info("Execute clustering plan for instant {} as {} file slices", clusteringInstantTime, clusteringGroup.getSlices().size());
+        log.info("Execute clustering plan for instant {} as {} file slices", clusteringInstantTime, clusteringGroup.getSlices().size());
         sourceContext.collect(new ClusteringPlanEvent(this.clusteringInstantTime, ClusteringGroupInfo.create(clusteringGroup), clusteringPlan.getStrategy().getStrategyParams()));
       }
     } else {
-      LOG.warn("{} not found in pending clustering instants.", clusteringInstantTime);
+      log.warn("{} not found in pending clustering instants.", clusteringInstantTime);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/HoodieFlinkClusteringJob.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/clustering/HoodieFlinkClusteringJob.java
@@ -43,6 +43,7 @@ import org.apache.hudi.util.HoodieSchemaConverter;
 import org.apache.hudi.util.StreamerUtil;
 
 import com.beust.jcommander.JCommander;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.client.deployment.application.ApplicationExecutionException;
@@ -51,8 +52,6 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -64,9 +63,8 @@ import static org.apache.hudi.sink.utils.FlinkTransformationUtils.setManagedMemo
 /**
  * Flink hudi clustering program that can be executed manually.
  */
+@Slf4j
 public class HoodieFlinkClusteringJob {
-
-  protected static final Logger LOG = LoggerFactory.getLogger(HoodieFlinkClusteringJob.class);
 
   private static final String NO_EXECUTE_KEYWORD = "no execute";
 
@@ -85,7 +83,7 @@ public class HoodieFlinkClusteringJob {
 
     // Validate configuration
     if (cfg.retryLastFailedJob && cfg.maxProcessingTimeMs <= 0) {
-      LOG.warn("--retry-last-failed-job is enabled but --job-max-processing-time-ms is not set or <= 0. "
+      log.warn("--retry-last-failed-job is enabled but --job-max-processing-time-ms is not set or <= 0. "
           + "The retry-last-failed feature will have no effect. Set --job-max-processing-time-ms to a positive value.");
     }
 
@@ -108,7 +106,7 @@ public class HoodieFlinkClusteringJob {
               new HoodieFlinkClusteringJob(service).start(false);
             } catch (ApplicationExecutionException aee) {
               if (aee.getMessage() != null && aee.getMessage().contains(NO_EXECUTE_KEYWORD)) {
-                LOG.info("Clustering is not performed - no work to do");
+                log.info("Clustering is not performed - no work to do");
                 // Not a failure, no need to retry
               } else {
                 throw new RuntimeException(aee);
@@ -134,24 +132,24 @@ public class HoodieFlinkClusteringJob {
       } catch (Exception e) {
         throw new HoodieException(e.getMessage(), e);
       } finally {
-        LOG.info("Shut down hoodie flink clustering");
+        log.info("Shut down hoodie flink clustering");
       }
     } else {
-      LOG.info("Hoodie Flink Clustering running only single round");
+      log.info("Hoodie Flink Clustering running only single round");
       try {
         clusteringScheduleService.cluster();
       } catch (ApplicationExecutionException aee) {
         if (aee.getMessage() != null && aee.getMessage().contains(NO_EXECUTE_KEYWORD)) {
-          LOG.info("Clustering is not performed");
+          log.info("Clustering is not performed");
         } else {
-          LOG.error("Got error trying to perform clustering. Shutting down", aee);
+          log.error("Got error trying to perform clustering. Shutting down", aee);
           throw aee;
         }
       } catch (Exception e) {
-        LOG.error("Got error running delta sync once. Shutting down", e);
+        log.error("Got error running delta sync once. Shutting down", e);
         throw e;
       } finally {
-        LOG.info("Shut down hoodie flink clustering");
+        log.info("Shut down hoodie flink clustering");
       }
     }
   }
@@ -250,12 +248,12 @@ public class HoodieFlinkClusteringJob {
               Thread.sleep(cfg.minClusteringIntervalSeconds * 1000);
             } catch (ApplicationExecutionException aee) {
               if (aee.getMessage() != null && aee.getMessage().contains(NO_EXECUTE_KEYWORD)) {
-                LOG.info("Clustering is not performed.");
+                log.info("Clustering is not performed.");
               } else {
                 throw new HoodieException(aee.getMessage(), aee);
               }
             } catch (Exception e) {
-              LOG.error("Shutting down clustering service due to exception", e);
+              log.error("Shutting down clustering service due to exception", e);
               error = true;
               throw new HoodieException(e.getMessage(), e);
             }
@@ -285,11 +283,11 @@ public class HoodieFlinkClusteringJob {
         // create a clustering plan on the timeline
         ClusteringUtil.validateClusteringScheduling(conf);
 
-        LOG.info("Creating a clustering plan");
+        log.info("Creating a clustering plan");
         Option<String> clusteringInstantTime = writeClient.scheduleClustering(Option.empty());
         if (!clusteringInstantTime.isPresent()) {
           // do nothing.
-          LOG.info("No clustering plan for this job");
+          log.info("No clustering plan for this job");
           return;
         }
         table.getMetaClient().reloadActiveTimeline();
@@ -304,7 +302,7 @@ public class HoodieFlinkClusteringJob {
         staleInflightInstant = TableServiceUtils.findStaleInflightInstant(
             table.getMetaClient(), HoodieTimeline.CLUSTERING_ACTION, cfg.maxProcessingTimeMs);
         if (staleInflightInstant.isPresent()) {
-          LOG.info("Found stale inflight clustering instant [{}] exceeding max processing time {}ms. Will rollback and retry.",
+          log.info("Found stale inflight clustering instant [{}] exceeding max processing time {}ms. Will rollback and retry.",
               staleInflightInstant.get(), cfg.maxProcessingTimeMs);
         }
       }
@@ -317,7 +315,7 @@ public class HoodieFlinkClusteringJob {
 
       if (instants.isEmpty()) {
         // do nothing.
-        LOG.info("No clustering plan scheduled, turns on the clustering plan schedule with --schedule option");
+        log.info("No clustering plan scheduled, turns on the clustering plan schedule with --schedule option");
         return;
       }
 
@@ -339,7 +337,7 @@ public class HoodieFlinkClusteringJob {
       Option<HoodieInstant> inflightInstantOpt = ClusteringUtils.getInflightClusteringInstant(clusteringInstant.requestedTime(),
           table.getActiveTimeline(), table.getInstantGenerator());
       if (inflightInstantOpt.isPresent()) {
-        LOG.info("Rollback inflight clustering instant: [{}]", clusteringInstant);
+        log.info("Rollback inflight clustering instant: [{}]", clusteringInstant);
         table.rollbackInflightClustering(inflightInstantOpt.get(),
             commitToRollback -> writeClient.getTableServiceClient().getPendingRollbackInfo(table.getMetaClient(), commitToRollback, false),
             writeClient.getTransactionManager());
@@ -353,7 +351,7 @@ public class HoodieFlinkClusteringJob {
 
       if (!clusteringPlanOption.isPresent()) {
         // do nothing.
-        LOG.info("No clustering plan scheduled, turns on the clustering plan schedule with --schedule option");
+        log.info("No clustering plan scheduled, turns on the clustering plan schedule with --schedule option");
         return;
       }
 
@@ -362,7 +360,7 @@ public class HoodieFlinkClusteringJob {
       if (clusteringPlan == null || (clusteringPlan.getInputGroups() == null)
           || (clusteringPlan.getInputGroups().isEmpty())) {
         // no clustering plan, do nothing and return.
-        LOG.info("No clustering plan for instant {}", clusteringInstant.requestedTime());
+        log.info("No clustering plan for instant {}", clusteringInstant.requestedTime());
         return;
       }
 
@@ -418,7 +416,7 @@ public class HoodieFlinkClusteringJob {
      * Shutdown async services like compaction/clustering as DeltaSync is shutdown.
      */
     public void shutdownAsyncService(boolean error) {
-      LOG.info("Gracefully shutting down clustering job. Error: {}", error);
+      log.info("Gracefully shutting down clustering job. Error: {}", error);
       executor.shutdown();
       writeClient.close();
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanSourceFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/CompactionPlanSourceFunction.java
@@ -26,9 +26,8 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.util.StreamerUtil;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,9 +48,8 @@ import java.util.stream.Collectors;
  *   as the instant time.</li>
  * </ul>
  */
+@Slf4j
 public class CompactionPlanSourceFunction extends AbstractRichFunctionAdapter implements SourceFunctionAdapter<CompactionPlanEvent> {
-
-  protected static final Logger LOG = LoggerFactory.getLogger(CompactionPlanSourceFunction.class);
 
   /**
    * compaction plan instant -> compaction plan
@@ -74,13 +72,13 @@ public class CompactionPlanSourceFunction extends AbstractRichFunctionAdapter im
     HoodieTimeline pendingCompactionTimeline = StreamerUtil.createMetaClient(conf).getActiveTimeline().filterPendingCompactionTimeline();
     for (Pair<String, HoodieCompactionPlan> pair : compactionPlans) {
       if (!pendingCompactionTimeline.containsInstant(pair.getLeft())) {
-        LOG.warn("{} not found in pending compaction instants.", pair.getLeft());
+        log.warn("{} not found in pending compaction instants.", pair.getLeft());
         continue;
       }
       HoodieCompactionPlan compactionPlan = pair.getRight();
       List<CompactionOperation> operations = compactionPlan.getOperations().stream()
           .map(CompactionOperation::convertFromAvroRecordInstance).collect(Collectors.toList());
-      LOG.info("CompactionPlanFunction compacting {} files", operations);
+      log.info("CompactionPlanFunction compacting {} files", operations);
       for (CompactionOperation operation : operations) {
         sourceContext.collect(new CompactionPlanEvent(pair.getLeft(), operation));
       }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
@@ -40,13 +40,12 @@ import org.apache.hudi.util.FlinkWriteClients;
 import org.apache.hudi.util.StreamerUtil;
 
 import com.beust.jcommander.JCommander;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.client.deployment.application.ApplicationExecutionException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -57,9 +56,8 @@ import java.util.stream.Collectors;
 /**
  * Flink hudi compaction program that can be executed manually.
  */
+@Slf4j
 public class HoodieFlinkCompactor {
-
-  protected static final Logger LOG = LoggerFactory.getLogger(HoodieFlinkCompactor.class);
 
   private static final String NO_EXECUTE_KEYWORD = "no execute";
 
@@ -78,7 +76,7 @@ public class HoodieFlinkCompactor {
 
     // Validate configuration
     if (cfg.retryLastFailedJob && cfg.maxProcessingTimeMs <= 0) {
-      LOG.warn("--retry-last-failed-job is enabled but --job-max-processing-time-ms is not set or <= 0. "
+      log.warn("--retry-last-failed-job is enabled but --job-max-processing-time-ms is not set or <= 0. "
           + "The retry-last-failed feature will have no effect.");
     }
 
@@ -101,7 +99,7 @@ public class HoodieFlinkCompactor {
               new HoodieFlinkCompactor(service).start(false);
             } catch (ApplicationExecutionException aee) {
               if (aee.getMessage() != null && aee.getMessage().contains(NO_EXECUTE_KEYWORD)) {
-                LOG.info("Compaction is not performed - no work to do");
+                log.info("Compaction is not performed - no work to do");
                 // Not a failure, no need to retry
               } else {
                 throw new RuntimeException(aee);
@@ -127,23 +125,23 @@ public class HoodieFlinkCompactor {
       } catch (Exception e) {
         throw new HoodieException(e.getMessage(), e);
       } finally {
-        LOG.info("Shut down hoodie flink compactor");
+        log.info("Shut down hoodie flink compactor");
       }
     } else {
-      LOG.info("Hoodie Flink Compactor running only single round");
+      log.info("Hoodie Flink Compactor running only single round");
       try {
         compactionScheduleService.compact();
       } catch (ApplicationExecutionException aee) {
         if (aee.getMessage() != null && aee.getMessage().contains(NO_EXECUTE_KEYWORD)) {
-          LOG.info("Compaction is not performed");
+          log.info("Compaction is not performed");
         } else {
           throw aee;
         }
       } catch (Exception e) {
-        LOG.error("Got error running delta sync once. Shutting down", e);
+        log.error("Got error running delta sync once. Shutting down", e);
         throw e;
       } finally {
-        LOG.info("Shut down hoodie flink compactor");
+        log.info("Shut down hoodie flink compactor");
       }
     }
   }
@@ -244,12 +242,12 @@ public class HoodieFlinkCompactor {
               Thread.sleep(cfg.minCompactionIntervalSeconds * 1000);
             } catch (ApplicationExecutionException aee) {
               if (aee.getMessage() != null && aee.getMessage().contains(NO_EXECUTE_KEYWORD)) {
-                LOG.info("Compaction is not performed.");
+                log.info("Compaction is not performed.");
               } else {
                 throw new HoodieException(aee.getMessage(), aee);
               }
             } catch (Exception e) {
-              LOG.error("Shutting down compaction service due to exception", e);
+              log.error("Shutting down compaction service due to exception", e);
               error = true;
               throw new HoodieException(e.getMessage(), e);
             }
@@ -269,7 +267,7 @@ public class HoodieFlinkCompactor {
         boolean scheduled = writeClient.scheduleCompaction(Option.empty()).isPresent();
         if (!scheduled) {
           // do nothing.
-          LOG.info("No compaction plan for this job ");
+          log.info("No compaction plan for this job ");
           return;
         }
         table.getMetaClient().reloadActiveTimeline();
@@ -284,7 +282,7 @@ public class HoodieFlinkCompactor {
         Option<HoodieInstant> staleInflightInstant = TableServiceUtils.findStaleInflightInstant(
             table.getMetaClient(), HoodieTimeline.COMPACTION_ACTION, cfg.maxProcessingTimeMs);
         if (staleInflightInstant.isPresent()) {
-          LOG.info("Found stale inflight compaction instant [{}] exceeding max processing time {}ms. Will rollback and retry.",
+          log.info("Found stale inflight compaction instant [{}] exceeding max processing time {}ms. Will rollback and retry.",
               staleInflightInstant.get(), cfg.maxProcessingTimeMs);
           requested = java.util.Collections.singletonList(staleInflightInstant.get());
         }
@@ -292,7 +290,7 @@ public class HoodieFlinkCompactor {
 
       if (requested.isEmpty()) {
         // do nothing.
-        LOG.info("No compaction plan scheduled, turns on the compaction plan schedule with --schedule option");
+        log.info("No compaction plan scheduled, turns on the compaction plan schedule with --schedule option");
         return;
       }
 
@@ -300,7 +298,7 @@ public class HoodieFlinkCompactor {
       compactionInstantTimes.forEach(timestamp -> {
         HoodieInstant inflightInstant = table.getInstantGenerator().getCompactionInflightInstant(timestamp);
         if (pendingCompactionTimeline.containsInstant(inflightInstant)) {
-          LOG.info("Rollback inflight compaction instant: [{}]", timestamp);
+          log.info("Rollback inflight compaction instant: [{}]", timestamp);
           table.rollbackInflightCompaction(inflightInstant, writeClient.getTransactionManager());
           table.getMetaClient().reloadActiveTimeline();
         }
@@ -322,7 +320,7 @@ public class HoodieFlinkCompactor {
 
       if (compactionPlans.isEmpty()) {
         // No compaction plan, do nothing and return.
-        LOG.info("No compaction plan for instant {}", String.join(",", compactionInstantTimes));
+        log.info("No compaction plan for instant {}", String.join(",", compactionInstantTimes));
         return;
       }
 
@@ -336,7 +334,7 @@ public class HoodieFlinkCompactor {
           ? totalOperations
           : Math.min(conf.get(FlinkOptions.COMPACTION_TASKS), totalOperations);
 
-      LOG.info("Start to compaction for instant {}", compactionInstantTimes);
+      log.info("Start to compaction for instant {}", compactionInstantTimes);
 
       // Mark instant as compaction inflight
       for (HoodieInstant instant : instants) {
@@ -367,7 +365,7 @@ public class HoodieFlinkCompactor {
      * Shutdown async services like compaction/clustering as DeltaSync is shutdown.
      */
     public void shutdownAsyncService(boolean error) {
-      LOG.info("Gracefully shutting down compactor. Error: {}", error);
+      log.info("Gracefully shutting down compactor. Error: {}", error);
       executor.shutdown();
       writeClient.close();
     }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/AthenaIngestionGateway.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/AthenaIngestionGateway.java
@@ -23,8 +23,7 @@ import org.apache.hudi.common.util.ValidationUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.http.HttpResponse;
@@ -35,9 +34,9 @@ import java.util.Map;
 /**
  * Client for interacting with Athena Ingestion Gateway using MuttleyClient.
  */
+@Slf4j
 public class AthenaIngestionGateway extends FlinkHudiMuttleyClient {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AthenaIngestionGateway.class);
   protected static final String PATH_URL = "";
   protected static final String ATHENA_INGESTION_BASE =
       "uber.data.athena.manager.protos.CheckpointService::";
@@ -100,14 +99,14 @@ public class AthenaIngestionGateway extends FlinkHudiMuttleyClient {
       final String requestJson = OBJECT_MAPPER.writeValueAsString(getKafkaOffsetsRequest);
       HttpResponse<String> response = post(PATH_URL, requestJson, GET_KAFKA_OFFSETS_PROCEDURE);
       String resultAsJson = response.body();
-      LOG.info("Get Kafka Offsets response: {} \nfor request: {}", resultAsJson, requestJson);
+      log.info("Get Kafka Offsets response: {} \nfor request: {}", resultAsJson, requestJson);
 
       final CheckpointKafkaOffsetInfoResponse checkpointKafkaResponse = OBJECT_MAPPER
           .readValue(resultAsJson, CheckpointKafkaOffsetInfoResponse.class);
       if (checkpointKafkaResponse != null && checkpointKafkaResponse.isValid()) {
         return Option.of(checkpointKafkaResponse.kafkaOffsetsInfo);
       } else {
-        LOG.warn(
+        log.warn(
             "Empty kafka checkpoints info received for topic: {}, job: {}, "
                 + "env: {}, request: {}, \nresponse: {}",
             topicOperatorIds, jobName, env, requestJson, checkpointKafkaResponse);

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/FlinkHudiMuttleyClient.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/muttley/FlinkHudiMuttleyClient.java
@@ -21,8 +21,7 @@ package org.apache.hudi.sink.muttley;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.URI;
@@ -34,9 +33,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 public abstract class FlinkHudiMuttleyClient {
-
-  private static final Logger LOG = LoggerFactory.getLogger(FlinkHudiMuttleyClient.class);
 
   public static final String URL = "http://localhost:%d/%s";
   public static final int DEFAULT_PORT = 5436;
@@ -117,9 +115,9 @@ public abstract class FlinkHudiMuttleyClient {
                            final Option<String> rpcProcedure)
       throws IOException, FlinkHudiMuttleyException {
     final String url = getUrl(path);
-    LOG.info("MuttleyClient request - Method: {}, URL: {}, Path: {}, RPC Procedure: {}",
+    log.info("MuttleyClient request - Method: {}, URL: {}, Path: {}, RPC Procedure: {}",
         method, url, path, rpcProcedure.orElse("none"));
-    LOG.debug("Request payload: {}", jsonPayload);
+    log.debug("Request payload: {}", jsonPayload);
 
     // Build request body
     HttpRequest.BodyPublisher bodyPublisher = jsonPayload == null
@@ -151,14 +149,14 @@ public abstract class FlinkHudiMuttleyClient {
     }
 
     final HttpRequest request = requestBuilder.build();
-    LOG.info("Executing HTTP request with headers: {}", request.headers());
+    log.info("Executing HTTP request with headers: {}", request.headers());
 
     // Execute with retry logic
     HttpResponse<String> response = executeWithRetry(request);
 
     int statusCode = response.statusCode();
     if (statusCode >= 200 && statusCode < 300) {
-      LOG.debug("Request successful, returning response");
+      log.debug("Request successful, returning response");
       return response;
     }
 
@@ -167,13 +165,13 @@ public abstract class FlinkHudiMuttleyClient {
         this.getService(), statusCode, error);
 
     if (statusCode >= 400 && statusCode < 500) {
-      LOG.error("path : {}, rpcProcedure : {}, statusCode : {}",
+      log.error("path : {}, rpcProcedure : {}, statusCode : {}",
           path, rpcProcedure.orElse("No RPC Procedure"), statusCode);
       throw new FlinkHudiMuttleyClientException(message, statusCode);
     }
 
     if (statusCode >= 500) {
-      LOG.error("path : {}, rpcProcedure : {}, statusCode : {}",
+      log.error("path : {}, rpcProcedure : {}, statusCode : {}",
           path, rpcProcedure.orElse("No RPC Procedure"), statusCode);
       throw new FlinkHudiMuttleyServerException(message, statusCode);
     }
@@ -190,15 +188,15 @@ public abstract class FlinkHudiMuttleyClient {
       try {
         response = client.send(request, HttpResponse.BodyHandlers.ofString());
         if (response.statusCode() >= 200 && response.statusCode() < 300) {
-          LOG.info("HTTP response received - Status code: {}, Successful: true", response.statusCode());
+          log.info("HTTP response received - Status code: {}, Successful: true", response.statusCode());
           return response;
         }
-        LOG.info("HTTP response received - Status code: {}, Successful: false", response.statusCode());
+        log.info("HTTP response received - Status code: {}, Successful: false", response.statusCode());
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new IOException("HTTP request interrupted", e);
       } catch (IOException e) {
-        LOG.error("IOException during HTTP request execution (attempt {}/{}): {}",
+        log.error("IOException during HTTP request execution (attempt {}/{}): {}",
             tryCount + 1, maxTries, e.getMessage(), e);
         if (tryCount + 1 >= maxTries) {
           throw e;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/HoodieSource.java
@@ -43,6 +43,7 @@ import org.apache.hudi.source.split.assign.HoodieSplitAssigner;
 import org.apache.hudi.source.split.assign.HoodieSplitAssigners;
 import org.apache.hudi.util.FileIndexReader;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
@@ -53,8 +54,6 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -71,9 +70,8 @@ import java.util.stream.Collectors;
  *
  * @param <T> the record type to emit
  */
+@Slf4j
 public class HoodieSource<T> extends FileIndexReader implements Source<T, HoodieSourceSplit, HoodieSplitEnumeratorState> {
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieSource.class);
-
   private final HoodieScanContext scanContext;
   private final SplitReaderFunction<T> readerFunction;
   private final SerializableComparator<HoodieSourceSplit> splitComparator;
@@ -142,7 +140,7 @@ public class HoodieSource<T> extends FileIndexReader implements Source<T, Hoodie
     if (enumeratorState == null) {
       splitProvider = new DefaultHoodieSplitProvider(splitAssigner);
     } else {
-      LOG.info(
+      log.info(
           "Hoodie source restored {} splits from state for table {}",
           enumeratorState.getPendingSplitStates().size(), tableName);
       List<HoodieSourceSplit> pendingSplits =
@@ -179,7 +177,7 @@ public class HoodieSource<T> extends FileIndexReader implements Source<T, Hoodie
             List<HoodieSourceSplit> splits = buildHoodieSplits(metaClient, flinkConf);
             if (splits.isEmpty()) {
               // When there is no input splits, just return an empty source.
-              LOG.info("No input splits generate for MERGE_ON_READ input format. Returning empty collection");
+              log.info("No input splits generate for MERGE_ON_READ input format. Returning empty collection");
             }
             return splits;
           case COPY_ON_WRITE:

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/HoodieContinuousSplitEnumerator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/enumerator/HoodieContinuousSplitEnumerator.java
@@ -26,18 +26,16 @@ import org.apache.hudi.source.split.HoodieContinuousSplitDiscover;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 import org.apache.hudi.source.split.HoodieSplitProvider;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Continuous Hoodie enumerator that discovers Hoodie splits from new Hoodie commits of upstream Hoodie table.
  */
+@Slf4j
 public class HoodieContinuousSplitEnumerator extends AbstractHoodieSplitEnumerator {
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieContinuousSplitEnumerator.class);
-
   private final SplitEnumeratorContext<HoodieSourceSplit> enumeratorContext;
   private final HoodieSplitProvider splitProvider;
   private final HoodieContinuousSplitDiscover splitDiscover;
@@ -95,7 +93,7 @@ public class HoodieContinuousSplitEnumerator extends AbstractHoodieSplitEnumerat
   private HoodieContinuousSplitBatch discoverSplits() {
     int pendingSplitNumber = splitProvider.pendingSplitCount();
     if (pendingSplitNumber > scanContext.getMaxPendingSplits()) {
-      LOG.info(
+      log.info(
           "Pause split discovery as the assigner already has too many pending splits: {}",
           pendingSplitNumber);
       return HoodieContinuousSplitBatch.EMPTY;
@@ -113,13 +111,13 @@ public class HoodieContinuousSplitEnumerator extends AbstractHoodieSplitEnumerat
       if (enumeratorMetrics != null) {
         position.get().getIssuedInstant().ifPresent(enumeratorMetrics::setIssuedInstant);
       }
-      LOG.debug(
+      log.debug(
           "Added {} splits discovered between ({}, {}] to the assigner",
           result.getSplits().size(),
           position.get().getIssuedOffset(),
           result.getOffset());
     } else {
-      LOG.debug(
+      log.debug(
           "No new splits discovered between ({}, {}]",
           position.get().getIssuedOffset(),
           result.getOffset());
@@ -130,7 +128,7 @@ public class HoodieContinuousSplitEnumerator extends AbstractHoodieSplitEnumerat
     // resumes from the correct point, which is required for READ_COMMITS_LIMIT to work correctly.
     if (!StringUtils.isNullOrEmpty(result.getOffset())) {
       position.set(HoodieEnumeratorPosition.of(result.getEndInstant(), result.getOffset()));
-      LOG.info("Update enumerator position to {}", position.get());
+      log.info("Update enumerator position to {}", position.get());
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieSourceSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieSourceSplitReader.java
@@ -24,14 +24,13 @@ import org.apache.hudi.source.reader.function.SplitReaderFunction;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 import org.apache.hudi.source.split.SerializableComparator;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.RecordsBySplits;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -53,9 +52,8 @@ import java.util.Set;
  *
  * @param <T> record type
  */
+@Slf4j
 public class HoodieSourceSplitReader<T> implements SplitReader<HoodieRecordWithPosition<T>, HoodieSourceSplit> {
-  private static final Logger LOG = LoggerFactory.getLogger(HoodieSourceSplitReader.class);
-
   private final SerializableComparator<HoodieSourceSplit> splitComparator;
   private final Queue<HoodieSourceSplit> splits;
   private final FlinkStreamReadMetrics readerMetrics;
@@ -112,10 +110,10 @@ public class HoodieSourceSplitReader<T> implements SplitReader<HoodieRecordWithP
     if (splitComparator != null) {
       List<HoodieSourceSplit> newSplits = new ArrayList<>(splitsChange.splits());
       newSplits.sort(splitComparator);
-      LOG.info("Add {} splits to reader: {}", newSplits.size(), newSplits);
+      log.info("Add {} splits to reader: {}", newSplits.size(), newSplits);
       splits.addAll(newSplits);
     } else {
-      LOG.info("Add {} splits to reader", splitsChange.splits().size());
+      log.info("Add {} splits to reader", splitsChange.splits().size());
       splits.addAll(splitsChange.splits());
     }
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/DefaultHoodieSplitDiscover.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/split/DefaultHoodieSplitDiscover.java
@@ -24,19 +24,17 @@ import org.apache.hudi.source.HoodieScanContext;
 import org.apache.hudi.source.IncrementalInputSplits;
 import org.apache.hudi.util.StreamerUtil;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.core.fs.Path;
 import org.apache.hadoop.conf.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 /**
  * Default implementation of HoodieContinuousSplitDiscover.
  */
+@Slf4j
 public class DefaultHoodieSplitDiscover implements HoodieContinuousSplitDiscover {
-  private static final Logger LOG = LoggerFactory.getLogger(DefaultHoodieSplitDiscover.class);
-
   private final HoodieScanContext scanContext;
   private final IncrementalInputSplits incrementalInputSplits;
   private final Configuration hadoopConf;

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestFlinkCheckpointClient.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestFlinkCheckpointClient.java
@@ -23,11 +23,10 @@ import org.apache.hudi.sink.FlinkCheckpointClient.CheckpointRequest;
 import org.apache.hudi.sink.muttley.AthenaIngestionGateway;
 import org.apache.hudi.sink.muttley.AthenaIngestionGateway.CheckpointKafkaOffsetInfo;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -45,14 +44,13 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 
+@Slf4j
 public class TestFlinkCheckpointClient {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestFlinkCheckpointClient.class);
 
   @Test
   @Disabled("Requires real connection to Athena service")
   public void testGetKafkaCheckpointsInfo() throws IOException {
-    LOG.info("Test starts");
+    log.info("Test starts");
     // Create client with MuttleyClient implementation
     // TODO: Update with actual Athena service endpoint when available
     FlinkCheckpointClient client = new FlinkCheckpointClient(
@@ -83,21 +81,21 @@ public class TestFlinkCheckpointClient {
       
       // Assert the result
       assertNotNull(result);
-      LOG.info("Result is not null");
+      log.info("Result is not null");
       if (result.isPresent()) {
         CheckpointKafkaOffsetInfo info = result.get();
-        LOG.info("Checkpoint info retrieved successfully:");
-        LOG.info("  Checkpoint ID: {}", info.getCheckpointId());
-        LOG.info("  Checkpoint Timestamp: {}", info.getCheckpointTimestamp());
-        LOG.info("  Hudi Commit Time: {}", info.getHudiCommitInstantTime());
-        LOG.info("  Kafka Offsets Info: {}", info.getKafkaOffsetsInfo());
+        log.info("Checkpoint info retrieved successfully:");
+        log.info("  Checkpoint ID: {}", info.getCheckpointId());
+        log.info("  Checkpoint Timestamp: {}", info.getCheckpointTimestamp());
+        log.info("  Hudi Commit Time: {}", info.getHudiCommitInstantTime());
+        log.info("  Kafka Offsets Info: {}", info.getKafkaOffsetsInfo());
       } else {
-        LOG.warn("No checkpoint info found");
+        log.warn("No checkpoint info found");
       }
     } catch (IOException e) {
-      LOG.error("Failed to connect to Athena service", e);
+      log.error("Failed to connect to Athena service", e);
       // This is expected when not connected to a real Athena service
-      LOG.info("Test skipped - requires actual Athena service connection");
+      log.info("Test skipped - requires actual Athena service connection");
     }
   }
   

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
@@ -54,6 +54,7 @@ import org.apache.hudi.utils.TestTableEnvs;
 import org.apache.hudi.utils.TestUtils;
 import org.apache.hudi.utils.factory.CollectSinkTableFactory;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.execution.JobClient;
@@ -79,8 +80,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -127,9 +126,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * IT cases for Hoodie table source and sink.
  */
 @ExtendWith(FlinkMiniCluster.class)
+@Slf4j
 public class ITTestHoodieDataSource {
-  private static final Logger LOG = LoggerFactory.getLogger(ITTestHoodieDataSource.class);
-
   // A streaming read collected via CollectTableSink is terminated by a forced SuccessException once it
   // reaches its expected row count. A benign teardown race (see isAcceptableTerminalFailure) can instead
   // close the source stream mid-read and terminate the job before all rows are emitted, leaving an
@@ -1259,7 +1257,7 @@ public class ITTestHoodieDataSource {
       if (result.size() >= expectedNum) {
         break;
       }
-      LOG.warn("testLookupJoin collected {} of {} rows on attempt {}/{}; a teardown race produced an "
+      log.warn("testLookupJoin collected {} of {} rows on attempt {}/{}; a teardown race produced an "
           + "empty lookup join. Retrying.", result.size(), expectedNum, attempt, MAX_STREAM_READ_ATTEMPTS);
     }
 
@@ -3981,7 +3979,7 @@ public class ITTestHoodieDataSource {
       if (expectedNum <= 0 || rows.size() >= expectedNum) {
         return rows;
       }
-      LOG.warn("Streaming read collected {} of {} expected rows on attempt {}/{}; a tolerated teardown "
+      log.warn("Streaming read collected {} of {} expected rows on attempt {}/{}; a tolerated teardown "
               + "race ended the job before the read completed. Retrying. select=[{}]",
           rows.size(), expectedNum, attempt, MAX_STREAM_READ_ATTEMPTS, select);
     }
@@ -4046,7 +4044,7 @@ public class ITTestHoodieDataSource {
       // before - ending the read with a short result. Log the tolerated cause so an incomplete read is
       // diagnosable; submitAndFetchWithRetry re-reads when the collected count is below the expectation.
       if (!isSuccessException(e)) {
-        LOG.warn("Streaming read terminated by a tolerated teardown race ({}); collected {} rows so far.",
+        log.warn("Streaming read terminated by a tolerated teardown race ({}); collected {} rows so far.",
             describeTerminalCause(e),
             CollectSinkTableFactory.RESULT.values().stream().mapToInt(List::size).sum());
       }

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table.format.cow.vector.reader;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.ParquetDictionary;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
@@ -37,8 +38,6 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,10 +53,9 @@ import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
  * <p>Note: Reference Flink release 1.11.2 {@link org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader}
  * because some of the package scope methods.
  */
+@Slf4j(topic = "org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader")
 public abstract class AbstractColumnReader<V extends WritableColumnVector>
     implements ColumnReader<V> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader.class);
 
   private final PageReader pageReader;
 
@@ -277,7 +275,7 @@ public abstract class AbstractColumnReader<V extends WritableColumnVector>
         throw new UnsupportedOperationException("Unsupported encoding: " + dataEncoding);
       }
       this.dictionaryIdsDecoder = null;
-      LOG.debug("init from page at offset {} for length {}", in.position(), in.available());
+      log.debug("init from page at offset {} for length {}", in.position(), in.available());
       this.dataInputStream = in.remainingStream();
       this.isCurrentPageDictionaryEncoded = false;
     }

--- a/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.18.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
@@ -22,6 +22,7 @@ import org.apache.hudi.table.format.cow.utils.IntArrayList;
 import org.apache.hudi.table.format.cow.vector.ParquetDecimalVector;
 import org.apache.hudi.table.format.cow.vector.position.LevelDelegation;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.heap.HeapBooleanVector;
@@ -50,8 +51,6 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -73,9 +72,8 @@ import static org.apache.parquet.column.ValuesType.VALUES;
  * reader creation boundary in {@code ParquetSplitReaderUtil}, not inside this class — keeping it
  * a faithful copy of upstream.
  */
+@Slf4j
 public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnVector> {
-  private static final Logger LOG = LoggerFactory.getLogger(NestedPrimitiveColumnReader.class);
-
   private final IntArrayList repetitionLevelList = new IntArrayList(0);
   private final IntArrayList definitionLevelList = new IntArrayList(0);
 
@@ -545,13 +543,13 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn = new ValuesReaderIntIterator(dlReader);
     try {
       BytesInput bytes = page.getBytes();
-      LOG.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
+      log.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
       ByteBufferInputStream in = bytes.toInputStream();
-      LOG.debug("Reading repetition levels at {}.", in.position());
+      log.debug("Reading repetition levels at {}.", in.position());
       rlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading definition levels at {}.", in.position());
+      log.debug("Reading definition levels at {}.", in.position());
       dlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading data at {}.", in.position());
+      log.debug("Reading data at {}.", in.position());
       initDataReader(page.getValueEncoding(), in, page.getValueCount());
     } catch (IOException e) {
       throw new ParquetDecodingException(
@@ -566,7 +564,7 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn =
         newRLEIterator(descriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
     try {
-      LOG.debug(
+      log.debug(
           "Page data size {} bytes and {} records.", page.getData().size(), pageValueCount);
       initDataReader(
           page.getDataEncoding(), page.getData().toInputStream(), page.getValueCount());

--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table.format.cow.vector.reader;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.ParquetDictionary;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
@@ -37,8 +38,6 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,10 +53,9 @@ import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
  * <p>Note: Reference Flink release 1.11.2 {@link org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader}
  * because some of the package scope methods.
  */
+@Slf4j(topic = "org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader")
 public abstract class AbstractColumnReader<V extends WritableColumnVector>
     implements ColumnReader<V> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader.class);
 
   private final PageReader pageReader;
 
@@ -277,7 +275,7 @@ public abstract class AbstractColumnReader<V extends WritableColumnVector>
         throw new UnsupportedOperationException("Unsupported encoding: " + dataEncoding);
       }
       this.dictionaryIdsDecoder = null;
-      LOG.debug("init from page at offset {} for length {}", in.position(), in.available());
+      log.debug("init from page at offset {} for length {}", in.position(), in.available());
       this.dataInputStream = in.remainingStream();
       this.isCurrentPageDictionaryEncoded = false;
     }

--- a/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.19.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
@@ -22,6 +22,7 @@ import org.apache.hudi.table.format.cow.utils.IntArrayList;
 import org.apache.hudi.table.format.cow.vector.ParquetDecimalVector;
 import org.apache.hudi.table.format.cow.vector.position.LevelDelegation;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.heap.HeapBooleanVector;
@@ -50,8 +51,6 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -73,9 +72,8 @@ import static org.apache.parquet.column.ValuesType.VALUES;
  * reader creation boundary in {@code ParquetSplitReaderUtil}, not inside this class — keeping it
  * a faithful copy of upstream.
  */
+@Slf4j
 public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnVector> {
-  private static final Logger LOG = LoggerFactory.getLogger(NestedPrimitiveColumnReader.class);
-
   private final IntArrayList repetitionLevelList = new IntArrayList(0);
   private final IntArrayList definitionLevelList = new IntArrayList(0);
 
@@ -545,13 +543,13 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn = new ValuesReaderIntIterator(dlReader);
     try {
       BytesInput bytes = page.getBytes();
-      LOG.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
+      log.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
       ByteBufferInputStream in = bytes.toInputStream();
-      LOG.debug("Reading repetition levels at {}.", in.position());
+      log.debug("Reading repetition levels at {}.", in.position());
       rlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading definition levels at {}.", in.position());
+      log.debug("Reading definition levels at {}.", in.position());
       dlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading data at {}.", in.position());
+      log.debug("Reading data at {}.", in.position());
       initDataReader(page.getValueEncoding(), in, page.getValueCount());
     } catch (IOException e) {
       throw new ParquetDecodingException(
@@ -566,7 +564,7 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn =
         newRLEIterator(descriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
     try {
-      LOG.debug(
+      log.debug(
           "Page data size {} bytes and {} records.", page.getData().size(), pageValueCount);
       initDataReader(
           page.getDataEncoding(), page.getData().toInputStream(), page.getValueCount());

--- a/hudi-flink-datasource/hudi-flink1.20.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.20.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table.format.cow.vector.reader;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.ParquetDictionary;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
@@ -37,8 +38,6 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,10 +53,9 @@ import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
  * <p>Note: Reference Flink release 1.11.2 {@link org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader}
  * because some of the package scope methods.
  */
+@Slf4j(topic = "org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader")
 public abstract class AbstractColumnReader<V extends WritableColumnVector>
     implements ColumnReader<V> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader.class);
 
   private final PageReader pageReader;
 
@@ -277,7 +275,7 @@ public abstract class AbstractColumnReader<V extends WritableColumnVector>
         throw new UnsupportedOperationException("Unsupported encoding: " + dataEncoding);
       }
       this.dictionaryIdsDecoder = null;
-      LOG.debug("init from page at offset {} for length {}", in.position(), in.available());
+      log.debug("init from page at offset {} for length {}", in.position(), in.available());
       this.dataInputStream = in.remainingStream();
       this.isCurrentPageDictionaryEncoded = false;
     }

--- a/hudi-flink-datasource/hudi-flink1.20.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink1.20.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
@@ -22,6 +22,7 @@ import org.apache.hudi.table.format.cow.utils.IntArrayList;
 import org.apache.hudi.table.format.cow.vector.ParquetDecimalVector;
 import org.apache.hudi.table.format.cow.vector.position.LevelDelegation;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.heap.HeapBooleanVector;
@@ -50,8 +51,6 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -73,9 +72,8 @@ import static org.apache.parquet.column.ValuesType.VALUES;
  * reader creation boundary in {@code ParquetSplitReaderUtil}, not inside this class — keeping it
  * a faithful copy of upstream.
  */
+@Slf4j
 public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnVector> {
-  private static final Logger LOG = LoggerFactory.getLogger(NestedPrimitiveColumnReader.class);
-
   private final IntArrayList repetitionLevelList = new IntArrayList(0);
   private final IntArrayList definitionLevelList = new IntArrayList(0);
 
@@ -545,13 +543,13 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn = new ValuesReaderIntIterator(dlReader);
     try {
       BytesInput bytes = page.getBytes();
-      LOG.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
+      log.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
       ByteBufferInputStream in = bytes.toInputStream();
-      LOG.debug("Reading repetition levels at {}.", in.position());
+      log.debug("Reading repetition levels at {}.", in.position());
       rlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading definition levels at {}.", in.position());
+      log.debug("Reading definition levels at {}.", in.position());
       dlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading data at {}.", in.position());
+      log.debug("Reading data at {}.", in.position());
       initDataReader(page.getValueEncoding(), in, page.getValueCount());
     } catch (IOException e) {
       throw new ParquetDecodingException(
@@ -566,7 +564,7 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn =
         newRLEIterator(descriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
     try {
-      LOG.debug(
+      log.debug(
           "Page data size {} bytes and {} records.", page.getData().size(), pageValueCount);
       initDataReader(
           page.getDataEncoding(), page.getData().toInputStream(), page.getValueCount());

--- a/hudi-flink-datasource/hudi-flink2.0.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink2.0.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table.format.cow.vector.reader;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.ParquetDictionary;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
@@ -37,8 +38,6 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,10 +53,9 @@ import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
  * <p>Note: Reference Flink release 1.11.2 {@link org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader}
  * because some of the package scope methods.
  */
+@Slf4j(topic = "org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader")
 public abstract class AbstractColumnReader<V extends WritableColumnVector>
     implements ColumnReader<V> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader.class);
 
   private final PageReader pageReader;
 
@@ -277,7 +275,7 @@ public abstract class AbstractColumnReader<V extends WritableColumnVector>
         throw new UnsupportedOperationException("Unsupported encoding: " + dataEncoding);
       }
       this.dictionaryIdsDecoder = null;
-      LOG.debug("init from page at offset {} for length {}", in.position(), in.available());
+      log.debug("init from page at offset {} for length {}", in.position(), in.available());
       this.dataInputStream = in.remainingStream();
       this.isCurrentPageDictionaryEncoded = false;
     }

--- a/hudi-flink-datasource/hudi-flink2.0.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink2.0.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
@@ -22,6 +22,7 @@ import org.apache.hudi.table.format.cow.utils.IntArrayList;
 import org.apache.hudi.table.format.cow.vector.ParquetDecimalVector;
 import org.apache.hudi.table.format.cow.vector.position.LevelDelegation;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.heap.HeapBooleanVector;
@@ -50,8 +51,6 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -73,9 +72,8 @@ import static org.apache.parquet.column.ValuesType.VALUES;
  * reader creation boundary in {@code ParquetSplitReaderUtil}, not inside this class — keeping it
  * a faithful copy of upstream.
  */
+@Slf4j
 public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnVector> {
-  private static final Logger LOG = LoggerFactory.getLogger(NestedPrimitiveColumnReader.class);
-
   private final IntArrayList repetitionLevelList = new IntArrayList(0);
   private final IntArrayList definitionLevelList = new IntArrayList(0);
 
@@ -545,13 +543,13 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn = new ValuesReaderIntIterator(dlReader);
     try {
       BytesInput bytes = page.getBytes();
-      LOG.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
+      log.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
       ByteBufferInputStream in = bytes.toInputStream();
-      LOG.debug("Reading repetition levels at {}.", in.position());
+      log.debug("Reading repetition levels at {}.", in.position());
       rlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading definition levels at {}.", in.position());
+      log.debug("Reading definition levels at {}.", in.position());
       dlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading data at {}.", in.position());
+      log.debug("Reading data at {}.", in.position());
       initDataReader(page.getValueEncoding(), in, page.getValueCount());
     } catch (IOException e) {
       throw new ParquetDecodingException(
@@ -566,7 +564,7 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn =
         newRLEIterator(descriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
     try {
-      LOG.debug(
+      log.debug(
           "Page data size {} bytes and {} records.", page.getData().size(), pageValueCount);
       initDataReader(
           page.getDataEncoding(), page.getData().toInputStream(), page.getValueCount());

--- a/hudi-flink-datasource/hudi-flink2.1.x/pom.xml
+++ b/hudi-flink-datasource/hudi-flink2.1.x/pom.xml
@@ -33,6 +33,12 @@
     </properties>
 
     <dependencies>
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/hudi-flink-datasource/hudi-flink2.1.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink2.1.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/AbstractColumnReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table.format.cow.vector.reader;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.ParquetDictionary;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
@@ -37,8 +38,6 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,10 +53,9 @@ import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
  * <p>Note: Reference Flink release 1.11.2 {@link org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader}
  * because some of the package scope methods.
  */
+@Slf4j(topic = "org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader")
 public abstract class AbstractColumnReader<V extends WritableColumnVector>
     implements ColumnReader<V> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader.class);
 
   private final PageReader pageReader;
 
@@ -277,7 +275,7 @@ public abstract class AbstractColumnReader<V extends WritableColumnVector>
         throw new UnsupportedOperationException("Unsupported encoding: " + dataEncoding);
       }
       this.dictionaryIdsDecoder = null;
-      LOG.debug("init from page at offset {} for length {}", in.position(), in.available());
+      log.debug("init from page at offset {} for length {}", in.position(), in.available());
       this.dataInputStream = in.remainingStream();
       this.isCurrentPageDictionaryEncoded = false;
     }

--- a/hudi-flink-datasource/hudi-flink2.1.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/BaseVectorizedColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink2.1.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/BaseVectorizedColumnReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.table.format.cow.vector.reader;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -35,8 +36,6 @@ import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -48,9 +47,8 @@ import static org.apache.parquet.column.ValuesType.VALUES;
 /**
  * Abstract {@link ColumnReader}. part of the code is referred from Apache Hive and Apache Parquet.
  */
+@Slf4j
 public abstract class BaseVectorizedColumnReader implements ColumnReader<WritableColumnVector> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(BaseVectorizedColumnReader.class);
 
   protected boolean isUtcTimestamp;
 
@@ -207,13 +205,13 @@ public abstract class BaseVectorizedColumnReader implements ColumnReader<Writabl
     this.definitionLevelColumn = new ValuesReaderIntIterator(dlReader);
     try {
       BytesInput bytes = page.getBytes();
-      LOG.debug("page size {} bytes and {} records", bytes.size(), pageValueCount);
+      log.debug("page size {} bytes and {} records", bytes.size(), pageValueCount);
       ByteBufferInputStream in = bytes.toInputStream();
-      LOG.debug("reading repetition levels at {}", in.position());
+      log.debug("reading repetition levels at {}", in.position());
       rlReader.initFromPage(pageValueCount, in);
-      LOG.debug("reading definition levels at {}", in.position());
+      log.debug("reading definition levels at {}", in.position());
       dlReader.initFromPage(pageValueCount, in);
-      LOG.debug("reading data at {}", in.position());
+      log.debug("reading data at {}", in.position());
       initDataReader(page.getValueEncoding(), in, page.getValueCount());
     } catch (IOException e) {
       throw new ParquetDecodingException(
@@ -228,7 +226,7 @@ public abstract class BaseVectorizedColumnReader implements ColumnReader<Writabl
     this.definitionLevelColumn =
         newRLEIterator(descriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
     try {
-      LOG.debug("page data size {} bytes and {} records", page.getData().size(), pageValueCount);
+      log.debug("page data size {} bytes and {} records", page.getData().size(), pageValueCount);
       initDataReader(
           page.getDataEncoding(), page.getData().toInputStream(), page.getValueCount());
     } catch (IOException e) {

--- a/hudi-flink-datasource/hudi-flink2.1.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
+++ b/hudi-flink-datasource/hudi-flink2.1.x/src/main/java/org/apache/hudi/table/format/cow/vector/reader/NestedPrimitiveColumnReader.java
@@ -22,6 +22,7 @@ import org.apache.hudi.table.format.cow.utils.IntArrayList;
 import org.apache.hudi.table.format.cow.vector.ParquetDecimalVector;
 import org.apache.hudi.table.format.cow.vector.position.LevelDelegation;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.formats.parquet.vector.reader.ColumnReader;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.heap.HeapBooleanVector;
@@ -50,8 +51,6 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -73,9 +72,8 @@ import static org.apache.parquet.column.ValuesType.VALUES;
  * reader creation boundary in {@code ParquetSplitReaderUtil}, not inside this class — keeping it
  * a faithful copy of upstream.
  */
+@Slf4j
 public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnVector> {
-  private static final Logger LOG = LoggerFactory.getLogger(NestedPrimitiveColumnReader.class);
-
   private final IntArrayList repetitionLevelList = new IntArrayList(0);
   private final IntArrayList definitionLevelList = new IntArrayList(0);
 
@@ -545,13 +543,13 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn = new ValuesReaderIntIterator(dlReader);
     try {
       BytesInput bytes = page.getBytes();
-      LOG.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
+      log.debug("Page size {}  bytes and {} records.", bytes.size(), pageValueCount);
       ByteBufferInputStream in = bytes.toInputStream();
-      LOG.debug("Reading repetition levels at {}.", in.position());
+      log.debug("Reading repetition levels at {}.", in.position());
       rlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading definition levels at {}.", in.position());
+      log.debug("Reading definition levels at {}.", in.position());
       dlReader.initFromPage(pageValueCount, in);
-      LOG.debug("Reading data at {}.", in.position());
+      log.debug("Reading data at {}.", in.position());
       initDataReader(page.getValueEncoding(), in, page.getValueCount());
     } catch (IOException e) {
       throw new ParquetDecodingException(
@@ -566,7 +564,7 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     this.definitionLevelColumn =
         newRLEIterator(descriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
     try {
-      LOG.debug(
+      log.debug(
           "Page data size {} bytes and {} records.", page.getData().size(), pageValueCount);
       initDataReader(
           page.getDataEncoding(), page.getData().toInputStream(), page.getValueCount());


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Many classes in `hudi-flink-datasource` still declare their logger by hand (`private/protected static final Logger LOG = LoggerFactory.getLogger(...)`) instead of the Lombok `@Slf4j` annotation the codebase has standardized on. This PR migrates them. Part of the ongoing logging cleanup (follows the SLF4J parameterized-logging PRs #19155-#19160 and #19184-#19189).

### Summary and Changelog

- Migrated 25 files in `hudi-flink-datasource` (12 main + 11 Flink-version-module + 2 test) from a hand-declared `LOG` field to the Lombok `@Slf4j` annotation.
- Per file: add `@Slf4j`, delete the `LOG` field and the `org.slf4j.Logger` / `org.slf4j.LoggerFactory` imports, add `import lombok.extern.slf4j.Slf4j;`, and rename `LOG` -> `log` (Lombok generates a lowercase `log`).
- The 5 `AbstractColumnReader` classes deliberately log under the Flink parent class name, so they use `@Slf4j(topic = "org.apache.flink.formats.parquet.vector.reader.AbstractColumnReader")` to keep the **logger category identical**.

### Impact

none - mechanical. The Lombok-generated logger is equivalent to the hand-declared one (same category), so log output is unchanged.

### Risk Level

low - touches many files across all Flink version modules. Verified with checkstyle (0 violations under all 5 Flink profiles: flink1.18/1.19/1.20/2.0/2.1) and compilation of the main module plus flink2.1.x (Lombok generates `log`, all references resolve, including the `@Slf4j(topic=...)` form).

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
