### PR TITLE
fix(reader): Remove redundant partition value conversion in RecordCon…

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRecordContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRecordContext.java
@@ -189,17 +189,6 @@ public abstract class BaseSparkInternalRecordContext extends RecordContext<Inter
   }
 
   @Override
-  public Comparable convertPartitionValueToEngineType(Comparable value) {
-    if (value instanceof String) {
-      // Spark reads String field values as UTF8String.
-      // To foster value comparison, if the value is of String type, e.g., from
-      // the delete record, we convert it to UTF8String type.
-      return UTF8String.fromString((String) value);
-    }
-    return value;
-  }
-
-  @Override
   public InternalRow getDeleteRow(String recordKey) {
     UTF8String[] metaFields = new UTF8String[]{
         null,

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
@@ -227,10 +227,6 @@ public abstract class RecordContext<T> implements Serializable {
     return value;
   }
 
-  public Comparable convertPartitionValueToEngineType(Comparable value) {
-    return convertValueToEngineType(value);
-  }
-
   /**
    * Converts the ordering value to the specific engine type, guaranteeing the returned
    * value supports comparison, e.g., by wrapping engine types that do not implement

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/HoodieFileGroupReader.java
@@ -288,7 +288,7 @@ public final class HoodieFileGroupReader<T> implements HoodieRecordReader<T> {
         for (int i = 0; i < partitionFields.length; i++) {
           String field = partitionFields[i];
           if (dataSchema.getField(field).isPresent()) {
-            filterFieldsAndValues.add(Pair.of(field, readerContext.getRecordContext().convertPartitionValueToEngineType((Comparable) partitionValues[i])));
+            filterFieldsAndValues.add(Pair.of(field, readerContext.getRecordContext().convertValueToEngineType((Comparable) partitionValues[i])));
           }
         }
         return filterFieldsAndValues;

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/execution/datasources/parquet/TestSparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/execution/datasources/parquet/TestSparkFileFormatInternalRowReaderContext.scala
@@ -19,23 +19,18 @@
 
 package org.apache.spark.execution.datasources.parquet
 
-import org.apache.hudi.SparkFileFormatInternalRowReaderContext
+import org.apache.hudi.{SparkFileFormatInternalRecordContext, SparkFileFormatInternalRowReaderContext}
 import org.apache.hudi.SparkFileFormatInternalRowReaderContext.{filterIsSafeForBootstrap, filterIsSafeForPrimaryKey}
 import org.apache.hudi.common.model.HoodieRecord
-import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
-import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 
-import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
 import org.apache.spark.sql.sources.{And, IsNotNull, Or}
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
-import org.mockito.Mockito.when
 
-class TestSparkFileFormatInternalRowReaderContext extends SparkClientFunctionalTestHarness {
+class TestSparkFileFormatInternalRowReaderContext {
 
   @Test
   def testBootstrapFilters(): Unit = {
@@ -104,19 +99,16 @@ class TestSparkFileFormatInternalRowReaderContext extends SparkClientFunctionalT
 
   @Test
   def testConvertValueToEngineType(): Unit = {
-    val reader = Mockito.mock(classOf[SparkColumnarFileReader])
     val stringValue = "string_value"
-    val tableConfig = Mockito.mock(classOf[HoodieTableConfig])
-    when(tableConfig.populateMetaFields()).thenReturn(true)
-    val sparkReaderContext = new SparkFileFormatInternalRowReaderContext(reader, Seq.empty, Seq.empty, storageConf(), tableConfig)
-    assertEquals(1, sparkReaderContext.getRecordContext().convertValueToEngineType(1))
-    assertEquals(1L, sparkReaderContext.getRecordContext().convertValueToEngineType(1L))
-    assertEquals(1.1f, sparkReaderContext.getRecordContext().convertValueToEngineType(1.1f))
-    assertEquals(1.1d, sparkReaderContext.getRecordContext().convertValueToEngineType(1.1d))
+    val recordContext = SparkFileFormatInternalRecordContext.apply()
+    assertEquals(1, recordContext.convertValueToEngineType(1))
+    assertEquals(1L, recordContext.convertValueToEngineType(1L))
+    assertEquals(1.1f, recordContext.convertValueToEngineType(1.1f))
+    assertEquals(1.1d, recordContext.convertValueToEngineType(1.1d))
     assertEquals(UTF8String.fromString(stringValue),
-      sparkReaderContext.getRecordContext().convertPartitionValueToEngineType(stringValue))
+      recordContext.convertValueToEngineType(stringValue))
     val utf8StringValue = UTF8String.fromString(stringValue)
     assertEquals(utf8StringValue,
-      sparkReaderContext.getRecordContext().convertPartitionValueToEngineType(utf8StringValue))
+      recordContext.convertValueToEngineType(utf8StringValue))
   }
 }


### PR DESCRIPTION
…text

### Describe the issue this Pull Request addresses

This PR removes the redundant `RecordContext#convertPartitionValueToEngineType` API. The method only forwarded to `convertValueToEngineType`, and the Spark-specific override duplicated the same String-to-`UTF8String` conversion behavior already provided by Spark's regular value conversion path.

This keeps partition filter value conversion in `HoodieFileGroupReader` aligned with the general engine-native value conversion contract.

Fixes #19183

### Summary and Changelog
- Removed `RecordContext#convertPartitionValueToEngineType`.
- Removed the redundant Spark override from `BaseSparkInternalRecordContext`.
- Updated `HoodieFileGroupReader` to call `convertValueToEngineType` directly when building bootstrap partition filter values.
- Updated `TestSparkFileFormatInternalRowReaderContext` to validate Spark value conversion through `SparkFileFormatInternalRecordContext#convertValueToEngineType`.

### Impact

- **Functional impact**: No intended behavior change. Partition values continue to use the same engine-native conversion behavior as before.
- **Maintainability**: Removes a redundant API surface and duplicated Spark conversion logic.
- **Extensibility**: Keeps engine-native value conversion centralized in `convertValueToEngineType`, while ordering/comparability concerns remain separate.

### Risk Level

Low. 

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable