### PR TITLE
feat(flink): Support reading and materializing OOL BLOB columns

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/blob/BlobRangeReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/blob/BlobRangeReader.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.blob;
+
+import org.apache.hudi.io.SeekableDataInputStream;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Engine-agnostic utility for batched byte-range reads of out-of-line (OOL) BLOB references.
+ *
+ * <h3>Algorithm</h3>
+ * <ol>
+ *   <li>Separate whole-file requests from range requests.
+ *   <li>Group range requests by {@code filePath}, sort each group by {@code offset}, and merge
+ *       adjacent or nearby ranges whose gap is ≤ {@code maxGapBytes} into a single
+ *       {@link MergedRange}.
+ *   <li>For each {@link MergedRange}: seek to {@code startOffset} and {@code readFully} the
+ *       entire merged span in one I/O call; slice the buffer to extract each individual request's
+ *       bytes.
+ *   <li>For whole-file requests: open the file and read all bytes.
+ * </ol>
+ *
+ * <p>The caller provides opaque {@code tag} values on each {@link BlobReadRequest}; those tags are
+ * used as keys in the returned map so results can be correlated back to the caller's domain
+ * (e.g. row index + field position in Flink). Spark's {@code BatchedBlobReader} solves the same
+ * problem by carrying a {@code RowInfo} through {@code MergedRange} instead of a separate tag.
+ *
+ * <h3>Overlap detection</h3>
+ * If two requests for the same file have overlapping byte ranges an
+ * {@link IllegalArgumentException} is thrown (same check exists in Spark's
+ * {@code BatchedBlobReader.mergeRanges}). Hudi's OOL blob writer assigns disjoint
+ * {@code (offset, length)} spans when appending to an external file, so well-formed table data
+ * should never produce overlaps; this guard catches corruption, manual edits, or buggy callers.
+ * Adjacent or gapped ranges within {@code maxGapBytes} are merged; truly overlapping ranges are not.
+ */
+public final class BlobRangeReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BlobRangeReader.class);
+
+  /**
+   * Read chunk size for whole-file streaming. Spark's {@code BatchedBlobReader.readWholeFile}
+   * uses {@code InputStream.readAllBytes()} (Java 9+); hudi-common targets Java 8, so we stream
+   * into a {@link ByteArrayOutputStream} with a standard 8 KiB buffer instead.
+   */
+  private static final int WHOLE_FILE_READ_BUFFER_SIZE = 8192;
+
+  private BlobRangeReader() {
+  }
+
+  // -------------------------------------------------------------------------
+  //  Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Issues batched DFS reads for all {@code requests} and returns a map from each request's
+   * {@code tag} to the bytes that were read.
+   *
+   * @param requests    OOL blob read requests (may contain a mix of range and whole-file refs)
+   * @param storage     HoodieStorage instance for file I/O
+   * @param maxGapBytes maximum byte gap between two range requests in the same file that are
+   *                    still coalesced into a single read (0 = only truly adjacent ranges are
+   *                    merged)
+   * @param <T>         caller-supplied correlation tag type
+   * @return map from {@link BlobReadRequest#tag} to the bytes read for that request
+   */
+  public static <T> Map<T, byte[]> readBatched(
+      List<BlobReadRequest<T>> requests,
+      HoodieStorage storage,
+      int maxGapBytes) {
+    if (requests == null || requests.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    List<BlobReadRequest<T>> wholeFileReqs = new ArrayList<>();
+    List<BlobReadRequest<T>> rangeReqs = new ArrayList<>();
+    for (BlobReadRequest<T> req : requests) {
+      (req.isWholeFile() ? wholeFileReqs : rangeReqs).add(req);
+    }
+
+    return Stream.concat(
+            readWholeFiles(wholeFileReqs, storage).entrySet().stream(),
+            readRanges(rangeReqs, storage, maxGapBytes).entrySet().stream())
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  // -------------------------------------------------------------------------
+  //  Package-private: visible for testing
+  // -------------------------------------------------------------------------
+
+  /**
+   * Groups {@code requests} by file path, sorts each group by offset, and merges nearby ranges.
+   *
+   * <p>Cross-file processing order does not affect read correctness — each file is opened and
+   * read independently. Only within-file offset order matters for range merging. We use a
+   * {@link LinkedHashMap} so iteration follows first-seen file path in the request list, giving
+   * stable I/O ordering for tests and debug logs. Sorting file paths (e.g. via {@code TreeMap})
+   * would also be stable but is unnecessary for correctness.
+   */
+  static <T> List<MergedRange<T>> groupSortMerge(
+      List<BlobReadRequest<T>> requests,
+      int maxGapBytes) {
+    Map<String, List<BlobReadRequest<T>>> byFile = new LinkedHashMap<>();
+    for (BlobReadRequest<T> req : requests) {
+      byFile.computeIfAbsent(req.filePath, k -> new ArrayList<>()).add(req);
+    }
+
+    List<MergedRange<T>> merged = new ArrayList<>();
+    for (Map.Entry<String, List<BlobReadRequest<T>>> entry : byFile.entrySet()) {
+      List<BlobReadRequest<T>> fileReqs = entry.getValue();
+      fileReqs.sort((a, b) -> Long.compare(a.offset, b.offset));
+      merged.addAll(mergeWithinFile(fileReqs, maxGapBytes));
+    }
+    return merged;
+  }
+
+  // -------------------------------------------------------------------------
+  //  Private helpers
+  // -------------------------------------------------------------------------
+
+  private static <T> Map<T, byte[]> readWholeFiles(
+      List<BlobReadRequest<T>> reqs,
+      HoodieStorage storage) {
+    Map<T, byte[]> result = new HashMap<>();
+    for (BlobReadRequest<T> req : reqs) {
+      try (InputStream in = storage.open(new StoragePath(req.filePath))) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buf = new byte[WHOLE_FILE_READ_BUFFER_SIZE];
+        int n;
+        while ((n = in.read(buf)) != -1) {
+          baos.write(buf, 0, n);
+        }
+        result.put(req.tag, baos.toByteArray());
+        LOG.debug("Read whole file {} for tag {}", req.filePath, req.tag);
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to read whole-file blob: " + req.filePath, e);
+      }
+    }
+    return result;
+  }
+
+  private static <T> Map<T, byte[]> readRanges(
+      List<BlobReadRequest<T>> rangeReqs,
+      HoodieStorage storage,
+      int maxGapBytes) {
+    if (rangeReqs.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<T, byte[]> result = new HashMap<>();
+    for (MergedRange<T> range : groupSortMerge(rangeReqs, maxGapBytes)) {
+      try (SeekableDataInputStream in =
+          storage.openSeekable(new StoragePath(range.filePath), false)) {
+        in.seek(range.startOffset);
+        int totalLength = (int) (range.endOffset - range.startOffset);
+        byte[] buffer = new byte[totalLength];
+        in.readFully(buffer, 0, totalLength);
+        LOG.debug("Read {} bytes from {} at offset {} for {} request(s)",
+            totalLength, range.filePath, range.startOffset, range.requests.size());
+        for (BlobReadRequest<T> req : range.requests) {
+          int relOff = (int) (req.offset - range.startOffset);
+          result.put(req.tag, Arrays.copyOfRange(buffer, relOff, relOff + (int) req.length));
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(
+            "Failed to read batched blob ranges from: " + range.filePath, e);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Merges a sorted (by offset) list of range requests from the same file into
+   * {@link MergedRange}s. Requests whose gap is ≤ {@code maxGapBytes} are combined into a single
+   * range. Truly overlapping ranges (gap &lt; 0) are rejected.
+   *
+   * @throws IllegalArgumentException if two requests have overlapping byte ranges
+   */
+  private static <T> List<MergedRange<T>> mergeWithinFile(
+      List<BlobReadRequest<T>> sortedReqs,
+      int maxGapBytes) {
+    List<MergedRange<T>> merged = new ArrayList<>();
+    MergedRange<T> current = null;
+    for (BlobReadRequest<T> req : sortedReqs) {
+      if (current == null) {
+        current = new MergedRange<>(req.filePath, req.offset, req.offset + req.length);
+        current.requests.add(req);
+      } else {
+        long gap = req.offset - current.endOffset;
+        if (gap < 0) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Overlapping OOL blob ranges in %s: existing [%d, %d), new [%d, %d)",
+                  req.filePath, current.startOffset, current.endOffset,
+                  req.offset, req.offset + req.length));
+        }
+        if (gap <= maxGapBytes) {
+          current.endOffset = Math.max(current.endOffset, req.offset + req.length);
+          current.requests.add(req);
+        } else {
+          merged.add(current);
+          current = new MergedRange<>(req.filePath, req.offset, req.offset + req.length);
+          current.requests.add(req);
+        }
+      }
+    }
+    if (current != null) {
+      merged.add(current);
+    }
+    return merged;
+  }
+
+  /**
+   * A merged byte range combining one or more {@link BlobReadRequest}s from the same file
+   * that were close enough to be issued as a single seek+readFully operation.
+   *
+   * @param <T> caller-supplied correlation tag type
+   */
+  static final class MergedRange<T> {
+
+    final String filePath;
+    final long startOffset;
+    long endOffset;
+    final List<BlobReadRequest<T>> requests = new ArrayList<>();
+
+    MergedRange(String filePath, long startOffset, long endOffset) {
+      this.filePath = filePath;
+      this.startOffset = startOffset;
+      this.endOffset = endOffset;
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/blob/BlobReadRequest.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/blob/BlobReadRequest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.blob;
+
+/**
+ * Describes a single byte-range read for one out-of-line (OOL) BLOB field.
+ *
+ * <p>{@code tag} is an opaque correlation key supplied by the caller. {@link BlobRangeReader}
+ * groups, sorts, and merges requests before issuing I/O, so result order no longer matches
+ * submission order and a caller-side list index cannot be used to match bytes back to rows.
+ * The tag travels with each request through merge/read and is returned as the key in the
+ * result map from {@link BlobRangeReader#readBatched}.
+ *
+ * <p>Spark solves the same problem differently: {@code BatchedBlobReader} attaches a
+ * {@code RowInfo} (original row + file path + offset + length + index) to every read request,
+ * and that object is carried inside {@code MergedRange} through merge/read. Our {@code tag}
+ * is the engine-agnostic equivalent for callers that do not use Spark rows (e.g. Flink
+ * {@code RowFieldKey = (rowIndex, blobFieldPosition)}).
+ *
+ * <p>Use {@link #range(String, long, long, Object)} for normal offset+length refs and
+ * {@link #wholeFile(String, Object)} when no offset/length is available (the entire file
+ * will be read).
+ *
+ * @param <T> caller-supplied correlation tag type
+ */
+public final class BlobReadRequest<T> {
+
+  /** Path to the external file. */
+  public final String filePath;
+
+  /**
+   * Byte offset within the file (0 for whole-file reads).
+   */
+  public final long offset;
+
+  /**
+   * Number of bytes to read. {@code -1} signals a whole-file read
+   * (no specific offset/length was stored in the reference).
+   */
+  public final long length;
+
+  /** Opaque caller tag for correlating this request with its result. */
+  public final T tag;
+
+  private BlobReadRequest(String filePath, long offset, long length, T tag) {
+    this.filePath = filePath;
+    this.offset = offset;
+    this.length = length;
+    this.tag = tag;
+  }
+
+  /**
+   * Creates a request to read a specific byte range from {@code filePath}.
+   *
+   * @param filePath absolute path to the external file
+   * @param offset   byte offset of the range start (≥ 0)
+   * @param length   number of bytes to read (≥ 0)
+   * @param tag      caller correlation key
+   */
+  public static <T> BlobReadRequest<T> range(String filePath, long offset, long length, T tag) {
+    if (offset < 0) {
+      throw new IllegalArgumentException("offset must be non-negative, got: " + offset);
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException("length must be non-negative, got: " + length);
+    }
+    return new BlobReadRequest<>(filePath, offset, length, tag);
+  }
+
+  /**
+   * Creates a request to read the entire contents of {@code filePath}.
+   *
+   * @param filePath absolute path to the external file
+   * @param tag      caller correlation key
+   */
+  public static <T> BlobReadRequest<T> wholeFile(String filePath, T tag) {
+    return new BlobReadRequest<>(filePath, 0L, -1L, tag);
+  }
+
+  /** Returns {@code true} if this request should read the whole file. */
+  public boolean isWholeFile() {
+    return length < 0;
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/blob/TestBlobRangeReader.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/blob/TestBlobRangeReader.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.blob;
+
+import org.apache.hudi.io.SeekableDataInputStream;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link BlobRangeReader} and {@link BlobReadRequest}.
+ *
+ * <p>I/O is driven through a mock {@link HoodieStorage} backed by in-memory byte arrays.
+ */
+public class TestBlobRangeReader {
+
+  // -------------------------------------------------------------------------
+  //  groupSortMerge tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testGroupSortMergeEmptyList() {
+    List<BlobRangeReader.MergedRange<Integer>> result = BlobRangeReader.groupSortMerge(
+        Collections.emptyList(), 0);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testGroupSortMergeAdjacentRangesMergedWhenGapIsZero() {
+    // [0, 10) and [10, 20) — zero gap → merged into [0, 20)
+    List<BlobReadRequest<Integer>> reqs = Arrays.asList(
+        BlobReadRequest.range("f.bin", 0, 10, 1),
+        BlobReadRequest.range("f.bin", 10, 10, 2)
+    );
+    List<BlobRangeReader.MergedRange<Integer>> merged = BlobRangeReader.groupSortMerge(reqs, 0);
+    assertEquals(1, merged.size());
+    assertEquals(0L, merged.get(0).startOffset);
+    assertEquals(20L, merged.get(0).endOffset);
+    assertEquals(2, merged.get(0).requests.size());
+  }
+
+  @Test
+  public void testGroupSortMergeRangesWithinMaxGapAreMerged() {
+    // [0, 10) and [15, 25) — gap = 5 ≤ maxGapBytes = 10 → merged into [0, 25)
+    List<BlobReadRequest<Integer>> reqs = Arrays.asList(
+        BlobReadRequest.range("f.bin", 0, 10, 1),
+        BlobReadRequest.range("f.bin", 15, 10, 2)
+    );
+    List<BlobRangeReader.MergedRange<Integer>> merged = BlobRangeReader.groupSortMerge(reqs, 10);
+    assertEquals(1, merged.size());
+    assertEquals(0L, merged.get(0).startOffset);
+    assertEquals(25L, merged.get(0).endOffset);
+  }
+
+  @Test
+  public void testGroupSortMergeRangesExceedingMaxGapAreNotMerged() {
+    // [0, 10) and [50, 60) — gap = 40 > maxGapBytes = 10 → two separate ranges
+    List<BlobReadRequest<Integer>> reqs = Arrays.asList(
+        BlobReadRequest.range("f.bin", 0, 10, 1),
+        BlobReadRequest.range("f.bin", 50, 10, 2)
+    );
+    List<BlobRangeReader.MergedRange<Integer>> merged = BlobRangeReader.groupSortMerge(reqs, 10);
+    assertEquals(2, merged.size());
+    assertEquals(0L, merged.get(0).startOffset);
+    assertEquals(50L, merged.get(1).startOffset);
+  }
+
+  @Test
+  public void testGroupSortMergeUnsortedInputIsSortedByOffset() {
+    // Requests intentionally out of order; they should be sorted before merging.
+    List<BlobReadRequest<Integer>> reqs = Arrays.asList(
+        BlobReadRequest.range("f.bin", 20, 10, 2),
+        BlobReadRequest.range("f.bin", 0, 10, 1)
+    );
+    List<BlobRangeReader.MergedRange<Integer>> merged = BlobRangeReader.groupSortMerge(reqs, 5);
+    assertEquals(2, merged.size());
+    assertEquals(0L, merged.get(0).startOffset);
+    assertEquals(20L, merged.get(1).startOffset);
+  }
+
+  @Test
+  public void testGroupSortMergeSeparateFilesProduceSeparateRanges() {
+    List<BlobReadRequest<Integer>> reqs = Arrays.asList(
+        BlobReadRequest.range("a.bin", 0, 10, 1),
+        BlobReadRequest.range("b.bin", 0, 10, 2)
+    );
+    List<BlobRangeReader.MergedRange<Integer>> merged = BlobRangeReader.groupSortMerge(reqs, 1000);
+    // Even with a huge maxGap, different files must not be merged.
+    assertEquals(2, merged.size());
+  }
+
+  @Test
+  public void testGroupSortMergeOverlappingRangesThrow() {
+    // [0, 20) and [10, 30) overlap → should throw
+    List<BlobReadRequest<Integer>> reqs = Arrays.asList(
+        BlobReadRequest.range("f.bin", 0, 20, 1),
+        BlobReadRequest.range("f.bin", 10, 20, 2)
+    );
+    assertThrows(IllegalArgumentException.class,
+        () -> BlobRangeReader.groupSortMerge(reqs, 0));
+  }
+
+  // -------------------------------------------------------------------------
+  //  readBatched tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testReadBatchedEmptyReturnsEmptyMap() throws IOException {
+    HoodieStorage storage = mock(HoodieStorage.class);
+    Map<Integer, byte[]> result = BlobRangeReader.readBatched(
+        Collections.emptyList(), storage, 0);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testReadBatchedSingleRangeReadsCorrectBytes() throws IOException {
+    byte[] fileContent = new byte[100];
+    for (int i = 0; i < fileContent.length; i++) {
+      fileContent[i] = (byte) i;
+    }
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(storage.openSeekable(any(StoragePath.class), eq(false)))
+        .thenReturn(makeSeekable(fileContent));
+
+    Map<Integer, byte[]> result = BlobRangeReader.readBatched(
+        Collections.singletonList(BlobReadRequest.range("f.bin", 10, 20, 42)),
+        storage, 0);
+
+    assertEquals(1, result.size());
+    assertArrayEquals(Arrays.copyOfRange(fileContent, 10, 30), result.get(42));
+  }
+
+  @Test
+  public void testReadBatchedTwoNearbyRangesOnlyOneSeek() throws IOException {
+    byte[] fileContent = new byte[200];
+    HoodieStorage storage = mock(HoodieStorage.class);
+    SeekableDataInputStream stream = makeSeekable(fileContent);
+    when(storage.openSeekable(any(StoragePath.class), eq(false))).thenReturn(stream);
+
+    List<BlobReadRequest<Integer>> reqs = Arrays.asList(
+        BlobReadRequest.range("f.bin", 0, 30, 1),
+        BlobReadRequest.range("f.bin", 50, 40, 2)
+    );
+    Map<Integer, byte[]> result = BlobRangeReader.readBatched(reqs, storage, 100);
+
+    assertEquals(2, result.size());
+    assertArrayEquals(Arrays.copyOfRange(fileContent, 0, 30), result.get(1));
+    assertArrayEquals(Arrays.copyOfRange(fileContent, 50, 90), result.get(2));
+    // Both ranges merged → one openSeekable call
+    verify(storage, times(1)).openSeekable(any(StoragePath.class), eq(false));
+  }
+
+  @Test
+  public void testReadBatchedWholeFileUsesOpen() throws IOException {
+    byte[] fileContent = {10, 20, 30};
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(storage.open(any(StoragePath.class)))
+        .thenReturn(new ByteArrayInputStream(fileContent));
+
+    Map<Integer, byte[]> result = BlobRangeReader.readBatched(
+        Collections.singletonList(BlobReadRequest.wholeFile("f.bin", 99)),
+        storage, 0);
+
+    assertEquals(1, result.size());
+    assertArrayEquals(fileContent, result.get(99));
+    verify(storage, times(1)).open(any(StoragePath.class));
+  }
+
+  @Test
+  public void testReadBatchedDifferentFilesOneSeekEach() throws IOException {
+    byte[] fa = new byte[50];
+    byte[] fb = new byte[50];
+    Arrays.fill(fa, (byte) 'A');
+    Arrays.fill(fb, (byte) 'B');
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(storage.openSeekable(eq(new StoragePath("a.bin")), eq(false))).thenReturn(makeSeekable(fa));
+    when(storage.openSeekable(eq(new StoragePath("b.bin")), eq(false))).thenReturn(makeSeekable(fb));
+
+    List<BlobReadRequest<String>> reqs = Arrays.asList(
+        BlobReadRequest.range("a.bin", 0, 10, "a"),
+        BlobReadRequest.range("b.bin", 5, 10, "b")
+    );
+    Map<String, byte[]> result = BlobRangeReader.readBatched(reqs, storage, 0);
+
+    assertArrayEquals(Arrays.copyOfRange(fa, 0, 10), result.get("a"));
+    assertArrayEquals(Arrays.copyOfRange(fb, 5, 15), result.get("b"));
+    verify(storage, times(1)).openSeekable(eq(new StoragePath("a.bin")), eq(false));
+    verify(storage, times(1)).openSeekable(eq(new StoragePath("b.bin")), eq(false));
+  }
+
+  // -------------------------------------------------------------------------
+  //  BlobReadRequest tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testWholeFileRequestIsWholeFile() {
+    BlobReadRequest<String> req = BlobReadRequest.wholeFile("f.bin", "tag");
+    assertTrue(req.isWholeFile());
+    assertEquals("f.bin", req.filePath);
+    assertEquals("tag", req.tag);
+  }
+
+  @Test
+  public void testRangeRequestNegativeOffsetThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> BlobReadRequest.range("f.bin", -1, 10, "x"));
+  }
+
+  @Test
+  public void testRangeRequestNegativeLengthThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> BlobReadRequest.range("f.bin", 0, -5, "x"));
+  }
+
+  // -------------------------------------------------------------------------
+  //  Helpers
+  // -------------------------------------------------------------------------
+
+  private static SeekableDataInputStream makeSeekable(byte[] content) {
+    return new SeekableDataInputStream(new ByteArrayInputStream(content)) {
+      private int pos = 0;
+
+      @Override
+      public long getPos() {
+        return pos;
+      }
+
+      @Override
+      public void seek(long newPos) {
+        this.pos = (int) newPos;
+        this.in = new ByteArrayInputStream(content, this.pos, content.length - this.pos);
+      }
+    };
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -1478,6 +1478,38 @@ public class FlinkOptions extends HoodieConfig {
               + "The directory is cleaned up when the lookup function is closed.");
 
   // -------------------------------------------------------------------------
+  //  Blob read options
+  // -------------------------------------------------------------------------
+
+  public static final ConfigOption<Boolean> BLOB_READ_MATERIALIZE =
+      key("read.blob.materialize")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to materialize out-of-line (OOL) BLOB fields during source reads. "
+              + "When true, the source iterator fetches the byte payload from the external path "
+              + "referenced in each OOL blob struct and replaces the struct with an INLINE blob "
+              + "(type=INLINE, data=<bytes>, reference=null) before emitting the row. "
+              + "Requires that blob field positions are detectable from the committed table schema.");
+
+  public static final ConfigOption<Integer> BLOB_BATCHING_MAX_GAP_BYTES =
+      key("read.blob.batching.max.gap.bytes")
+          .intType()
+          .defaultValue(4096)
+          .withDescription("Maximum byte gap between two OOL blob byte ranges from the same file "
+              + "that are still coalesced into a single batched read. "
+              + "Higher values reduce seek overhead at the cost of reading more bytes. "
+              + "Only effective when '" + BLOB_READ_MATERIALIZE.key() + "' is true.");
+
+  public static final ConfigOption<Integer> BLOB_BATCHING_LOOKAHEAD_SIZE =
+      key("read.blob.batching.lookahead.size")
+          .intType()
+          .defaultValue(50)
+          .withDescription("Number of rows to buffer as a lookahead window for grouping OOL blob "
+              + "references before issuing batched reads. "
+              + "Higher values increase batching opportunities at the cost of memory. "
+              + "Only effective when '" + BLOB_READ_MATERIALIZE.key() + "' is true.");
+
+  // -------------------------------------------------------------------------
   //  Utilities
   // -------------------------------------------------------------------------
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/BlobMaterializingIterator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/BlobMaterializingIterator.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source;
+
+import org.apache.hudi.common.blob.BlobRangeReader;
+import org.apache.hudi.common.blob.BlobReadRequest;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.storage.HoodieStorage;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * A {@link ClosableIterator}{@code <RowData>} decorator that materializes out-of-line (OOL)
+ * BLOB fields in batches.
+ *
+ * <h3>Algorithm</h3>
+ * <ol>
+ *   <li>Buffer up to {@code lookaheadSize} rows from the inner iterator (shallow-copied to
+ *       prevent row-buffer aliasing in upstream iterators).
+ *   <li>For every BLOB field in each row, check the {@code type} discriminator:
+ *       {@code INLINE} passes through; {@code OUT_OF_LINE} is collected as a
+ *       {@link BlobReadRequest} tagged with a {@code (rowIndex, blobFieldPosition)} key.
+ *   <li>Delegate all I/O to {@link BlobRangeReader#readBatched}: it groups requests by file
+ *       path, merges nearby ranges within {@code maxGapBytes}, and issues one
+ *       seek+readFully per merged range.
+ *   <li>Replace each materialized blob struct with {@code (INLINE, <bytes>, null)} and emit
+ *       rows in their original order.
+ * </ol>
+ *
+ * <p>Rows whose BLOB field is {@code null} or already {@code INLINE} are passed through unchanged.
+ */
+public class BlobMaterializingIterator implements ClosableIterator<RowData> {
+
+  private final ClosableIterator<RowData> inner;
+  private final HoodieStorage storage;
+  private final int maxGapBytes;
+  private final int lookaheadSize;
+
+  // Primitive int[] follows the same convention as CopyOnWriteInputFormat.selectedFields and
+  // RowDataProjection.positions — avoids Integer boxing in a per-row hot path.
+  private final int[] blobFieldPositions;
+  private final RowData.FieldGetter[] fieldGetters;
+  private final int numFields;
+
+  private final Deque<RowData> outputQueue = new ArrayDeque<>();
+
+  /**
+   * @param inner              raw iterator from the file group reader
+   * @param requiredRowType    Flink RowType matching the rows emitted by {@code inner}
+   * @param blobFieldPositions field indices in {@code requiredRowType} that are BLOB structs
+   * @param storage            HoodieStorage instance for DFS I/O
+   * @param maxGapBytes        max byte gap between two OOL ranges in the same file to merge
+   * @param lookaheadSize      rows to buffer per batch
+   */
+  public BlobMaterializingIterator(
+      ClosableIterator<RowData> inner,
+      RowType requiredRowType,
+      int[] blobFieldPositions,
+      HoodieStorage storage,
+      int maxGapBytes,
+      int lookaheadSize) {
+    this.inner = inner;
+    this.storage = storage;
+    this.maxGapBytes = maxGapBytes;
+    this.lookaheadSize = lookaheadSize;
+    this.blobFieldPositions = blobFieldPositions;
+    this.numFields = requiredRowType.getFieldCount();
+    this.fieldGetters = buildFieldGetters(requiredRowType);
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (outputQueue.isEmpty()) {
+      fillBatch();
+    }
+    return !outputQueue.isEmpty();
+  }
+
+  @Override
+  public RowData next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    return outputQueue.poll();
+  }
+
+  @Override
+  public void close() {
+    inner.close();
+  }
+
+  // -------------------------------------------------------------------------
+  //  Batch fill
+  // -------------------------------------------------------------------------
+
+  private void fillBatch() {
+    // Collect up to lookaheadSize rows; shallow-copy to guard against row-buffer reuse.
+    List<RowData> lookaheadBuffer = new ArrayList<>(lookaheadSize);
+    while (lookaheadBuffer.size() < lookaheadSize && inner.hasNext()) {
+      lookaheadBuffer.add(shallowCopyRow(inner.next()));
+    }
+    if (lookaheadBuffer.isEmpty()) {
+      return;
+    }
+
+    // Build BlobReadRequests for every OOL blob field in the lookahead buffer.
+    List<BlobReadRequest<RowFieldKey>> readRequests = collectReadRequests(lookaheadBuffer);
+
+    // Delegate all I/O to the common utility.
+    Map<RowFieldKey, byte[]> dataMap = BlobRangeReader.readBatched(readRequests, storage, maxGapBytes);
+
+    // Reconstruct rows, replacing OOL structs with INLINE ones; pass others through unchanged.
+    for (int rowIndex = 0; rowIndex < lookaheadBuffer.size(); rowIndex++) {
+      RowData row = lookaheadBuffer.get(rowIndex);
+      if (!hasMaterializedBlob(rowIndex, dataMap)) {
+        outputQueue.add(row);
+        continue;
+      }
+      GenericRowData newRow = new GenericRowData(row.getRowKind(), numFields);
+      for (int i = 0; i < numFields; i++) {
+        newRow.setField(i, fieldGetters[i].getFieldOrNull(row));
+      }
+      for (int blobFieldPosition : blobFieldPositions) {
+        byte[] data = dataMap.get(new RowFieldKey(rowIndex, blobFieldPosition));
+        if (data != null) {
+          newRow.setField(blobFieldPosition, buildInlineBlob(data));
+        }
+      }
+      outputQueue.add(newRow);
+    }
+  }
+
+  private boolean hasMaterializedBlob(int rowIndex, Map<RowFieldKey, byte[]> dataMap) {
+    for (int blobFieldPosition : blobFieldPositions) {
+      if (dataMap.containsKey(new RowFieldKey(rowIndex, blobFieldPosition))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private List<BlobReadRequest<RowFieldKey>> collectReadRequests(List<RowData> lookaheadBuffer) {
+    List<BlobReadRequest<RowFieldKey>> requests = new ArrayList<>();
+    for (int rowIndex = 0; rowIndex < lookaheadBuffer.size(); rowIndex++) {
+      RowData row = lookaheadBuffer.get(rowIndex);
+      for (int blobFieldPosition : blobFieldPositions) {
+        if (row.isNullAt(blobFieldPosition)) {
+          continue;
+        }
+        RowData blobRow = row.getRow(blobFieldPosition, HoodieSchema.Blob.getFieldCount());
+        if (blobRow == null || blobRow.isNullAt(0)) {
+          continue;
+        }
+        String storageType = blobRow.getString(0).toString();
+        if (!HoodieSchema.Blob.OUT_OF_LINE.equals(storageType)) {
+          continue;
+        }
+        if (blobRow.isNullAt(2)) {
+          throw new IllegalStateException(
+              "OUT_OF_LINE blob is missing its reference struct at row " + rowIndex);
+        }
+        RowData refRow = blobRow.getRow(2, HoodieSchema.Blob.getReferenceFieldCount());
+        String externalPath = refRow.getString(0).toString();
+        boolean noOffset = refRow.isNullAt(1);
+        boolean noLength = refRow.isNullAt(2);
+        RowFieldKey key = new RowFieldKey(rowIndex, blobFieldPosition);
+        if (noOffset && noLength) {
+          requests.add(BlobReadRequest.wholeFile(externalPath, key));
+        } else if (noOffset || noLength) {
+          throw new IllegalArgumentException(
+              "Blob reference for '" + externalPath
+                  + "' must set both offset and length, or neither");
+        } else {
+          requests.add(BlobReadRequest.range(externalPath, refRow.getLong(1), refRow.getLong(2), key));
+        }
+      }
+    }
+    return requests;
+  }
+
+  // -------------------------------------------------------------------------
+  //  Row helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Shallow-copies {@code row} into a {@link GenericRowData} so that upstream iterators that
+   * reuse a single row buffer cannot alias entries in our lookahead batch.
+   */
+  private RowData shallowCopyRow(RowData row) {
+    GenericRowData copy = new GenericRowData(row.getRowKind(), numFields);
+    for (int i = 0; i < numFields; i++) {
+      copy.setField(i, fieldGetters[i].getFieldOrNull(row));
+    }
+    return copy;
+  }
+
+  private static GenericRowData buildInlineBlob(byte[] data) {
+    GenericRowData blob = new GenericRowData(HoodieSchema.Blob.getFieldCount());
+    blob.setField(0, StringData.fromString(HoodieSchema.Blob.INLINE));
+    blob.setField(1, data);
+    blob.setField(2, null);
+    return blob;
+  }
+
+  /**
+   * Pre-computes one {@link RowData.FieldGetter} per field for cheap, type-safe extraction
+   * without a runtime switch over every {@link LogicalType} in {@link #shallowCopyRow}.
+   *
+   * <p>This follows the same pattern as {@link org.apache.hudi.util.RowDataProjection}, which
+   * centralises field-getter construction for projection in the Flink connector; we replicate
+   * it here so {@code BlobMaterializingIterator} has no dependency on a Flink-specific utility
+   * class from a different package and remains self-contained.
+   */
+  private static RowData.FieldGetter[] buildFieldGetters(RowType rowType) {
+    List<LogicalType> children = rowType.getChildren();
+    RowData.FieldGetter[] getters = new RowData.FieldGetter[children.size()];
+    for (int i = 0; i < children.size(); i++) {
+      getters[i] = RowData.createFieldGetter(children.get(i), i);
+    }
+    return getters;
+  }
+
+  /**
+   * Identifies a single blob field within the lookahead batch by its row index and field position.
+   * Used as the tag type for {@link BlobReadRequest} so results can be correlated back to the
+   * correct cell after I/O completes.
+   */
+  private static final class RowFieldKey {
+    final int rowIndex;
+    final int blobFieldPosition;
+
+    RowFieldKey(int rowIndex, int blobFieldPosition) {
+      this.rowIndex = rowIndex;
+      this.blobFieldPosition = blobFieldPosition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof RowFieldKey)) {
+        return false;
+      }
+      RowFieldKey other = (RowFieldKey) o;
+      return rowIndex == other.rowIndex && blobFieldPosition == other.blobFieldPosition;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(rowIndex, blobFieldPosition);
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieSplitReaderFunction.java
@@ -23,13 +23,19 @@ import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.read.HoodieRecordReader;
+import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.source.BlobMaterializingIterator;
 import org.apache.hudi.source.ExpressionPredicates;
 import org.apache.hudi.source.split.HoodieSourceSplit;
+import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.util.HoodieSchemaConverter;
@@ -40,6 +46,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -81,7 +88,7 @@ public class HoodieSplitReaderFunction extends AbstractSplitReaderFunction {
     // would close it. Keep it in a local and close it in the failure path.
     HoodieRecordReader<RowData> fileGroupReader = createRecordReader(split, metaClient);
     try {
-      return fileGroupReader.getClosableIterator();
+      return maybeMaterialize(fileGroupReader.getClosableIterator());
     } catch (IOException e) {
       closeSuppressing(fileGroupReader, e);
       throw new HoodieIOException("Failed to read from file group: " + split.getFileId(), e);
@@ -89,6 +96,45 @@ public class HoodieSplitReaderFunction extends AbstractSplitReaderFunction {
       closeSuppressing(fileGroupReader, e);
       throw e;
     }
+  }
+
+  /**
+   * Wraps the raw iterator with {@link BlobMaterializingIterator} when
+   * {@link FlinkOptions#BLOB_READ_MATERIALIZE} is enabled and the required schema contains
+   * at least one BLOB field.
+   */
+  private ClosableIterator<RowData> maybeMaterialize(ClosableIterator<RowData> iter) {
+    if (!conf.get(FlinkOptions.BLOB_READ_MATERIALIZE)) {
+      return iter;
+    }
+    int[] blobPositions = detectBlobFieldPositions(requiredSchema);
+    if (blobPositions.length == 0) {
+      return iter;
+    }
+    RowType requiredRowType = HoodieSchemaConverter.convertToRowType(requiredSchema);
+    HoodieStorage storage = HoodieStorageUtils.getStorage(
+        conf.get(FlinkOptions.PATH), HadoopFSUtils.getStorageConf(getHadoopConf()));
+    return new BlobMaterializingIterator(
+        iter,
+        requiredRowType,
+        blobPositions,
+        storage,
+        conf.get(FlinkOptions.BLOB_BATCHING_MAX_GAP_BYTES),
+        conf.get(FlinkOptions.BLOB_BATCHING_LOOKAHEAD_SIZE));
+  }
+
+  /**
+   * Returns the field positions in {@code schema} whose type is a BLOB field.
+   */
+  private static int[] detectBlobFieldPositions(HoodieSchema schema) {
+    List<HoodieSchemaField> fields = schema.getFields();
+    List<Integer> positions = new ArrayList<>();
+    for (int i = 0; i < fields.size(); i++) {
+      if (fields.get(i).schema().isBlobField()) {
+        positions.add(i);
+      }
+    }
+    return positions.stream().mapToInt(Integer::intValue).toArray();
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -673,7 +673,8 @@ public class HoodieTableSource extends FileIndexReader implements
         getParquetConf(this.conf, this.hadoopConf.unwrap()),
         this.conf.get(FlinkOptions.READ_UTC_TIMEZONE),
         this.internalSchemaManager,
-        tableSchema
+        tableSchema,
+        this.conf
     );
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cow/CopyOnWriteInputFormat.java
@@ -20,9 +20,15 @@ package org.apache.hudi.table.format.cow;
 
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.util.HoodieStorageUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.source.BlobMaterializingIterator;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
+import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
@@ -39,6 +45,8 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.utils.SerializableConfiguration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
@@ -84,6 +92,13 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
   private final List<Predicate> predicates;
   private final long limit;
 
+  /** Flink configuration used for blob-materialization options; may be {@code null}. */
+  private final org.apache.flink.configuration.Configuration flinkConf;
+  /** Output positions of BLOB fields; empty when no BLOB fields or materialization is disabled. */
+  private final int[] blobFieldPositions;
+  /** Output RowType derived from selectedFields; used by {@link BlobMaterializingIterator}. */
+  private final RowType requiredOutputRowType;
+
   private transient ClosableIterator<RowData> itr;
   private transient long currentReadCount;
 
@@ -107,7 +122,8 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
       Configuration conf,
       boolean utcTimestamp,
       InternalSchemaManager internalSchemaManager,
-      HoodieSchema tableSchema) {
+      HoodieSchema tableSchema,
+      org.apache.flink.configuration.Configuration flinkConf) {
     super.setFilePaths(paths);
     this.predicates = predicates;
     this.limit = limit;
@@ -122,6 +138,9 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     this.conf = new SerializableConfiguration(conf);
     this.utcTimestamp = utcTimestamp;
     this.internalSchemaManager = internalSchemaManager;
+    this.flinkConf = flinkConf;
+    this.blobFieldPositions = detectBlobPositions(fullFieldNames, selectedFields, tableSchema);
+    this.requiredOutputRowType = buildRequiredOutputRowType(fullFieldNames, fullFieldTypes, selectedFields);
   }
 
   @Override
@@ -153,6 +172,18 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
           fileSplit.getLength(),
           predicates);
       this.itr = vectorColumnInfo.isEmpty() ? rowDataItr : VectorConversionUtils.wrapVectorColumnIterator(rowDataItr, fullFieldTypes, selectedFields, vectorColumnInfo);
+    }
+    if (flinkConf != null && flinkConf.get(FlinkOptions.BLOB_READ_MATERIALIZE)
+        && blobFieldPositions.length > 0) {
+      HoodieStorage storage = HoodieStorageUtils.getStorage(
+          flinkConf.get(FlinkOptions.PATH), HadoopFSUtils.getStorageConf(conf.conf()));
+      this.itr = new BlobMaterializingIterator(
+          this.itr,
+          requiredOutputRowType,
+          blobFieldPositions,
+          storage,
+          flinkConf.get(FlinkOptions.BLOB_BATCHING_MAX_GAP_BYTES),
+          flinkConf.get(FlinkOptions.BLOB_BATCHING_LOOKAHEAD_SIZE));
     }
     this.currentReadCount = 0L;
   }
@@ -417,6 +448,43 @@ public class CopyOnWriteInputFormat extends FileInputFormat<RowData> {
     } else {
       return null;
     }
+  }
+
+  /**
+   * Detects blob field positions in the output (selected) row by looking up each selected field
+   * name in the table schema and checking whether its schema {@link HoodieSchema#isBlobField()}.
+   */
+  private static int[] detectBlobPositions(
+      String[] fullFieldNames,
+      int[] selectedFields,
+      HoodieSchema tableSchema) {
+    List<Integer> positions = new ArrayList<>();
+    for (int i = 0; i < selectedFields.length; i++) {
+      String fieldName = fullFieldNames[selectedFields[i]];
+      Option<HoodieSchemaField> field = tableSchema.getField(fieldName);
+      if (field.isPresent() && field.get().schema().isBlobField()) {
+        positions.add(i);
+      }
+    }
+    return positions.stream().mapToInt(Integer::intValue).toArray();
+  }
+
+  /**
+   * Builds the output {@link RowType} (selected fields only) needed by
+   * {@link BlobMaterializingIterator} for field-getter construction.
+   */
+  private static RowType buildRequiredOutputRowType(
+      String[] fullFieldNames,
+      DataType[] fullFieldTypes,
+      int[] selectedFields) {
+    LogicalType[] logicalTypes = new LogicalType[selectedFields.length];
+    String[] names = new String[selectedFields.length];
+    for (int i = 0; i < selectedFields.length; i++) {
+      int idx = selectedFields[i];
+      logicalTypes[i] = fullFieldTypes[idx].getLogicalType();
+      names[i] = fullFieldNames[idx];
+    }
+    return RowType.of(logicalTypes, names);
   }
 
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/mor/MergeOnReadInputFormat.java
@@ -25,15 +25,20 @@ import org.apache.hudi.common.model.HoodieFileGroupId;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaCache;
+import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.read.HoodieRecordReader;
+import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.configuration.HadoopConfigurations;
 import org.apache.hudi.configuration.OptionsResolver;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.source.BlobMaterializingIterator;
 import org.apache.hudi.source.ExpressionPredicates.Predicate;
+import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.table.format.FilePathUtils;
 import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.InternalSchemaManager;
@@ -50,8 +55,10 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -201,7 +208,45 @@ public class MergeOnReadInputFormat
         HoodieSchema.parse(tableState.getTableSchema()));
     final HoodieSchema requiredSchema = HoodieSchemaCache.intern(
         HoodieSchema.parse(tableState.getRequiredSchema()));
-    return getSplitRowIterator(split, tableSchema, requiredSchema, mergeType, emitDelete);
+    ClosableIterator<RowData> iter = getSplitRowIterator(split, tableSchema, requiredSchema, mergeType, emitDelete);
+    return maybeMaterialize(iter, requiredSchema, tableState.getRequiredRowType());
+  }
+
+  /**
+   * Wraps {@code iter} with {@link BlobMaterializingIterator} when
+   * {@link FlinkOptions#BLOB_READ_MATERIALIZE} is enabled and the required schema has blob fields.
+   */
+  private ClosableIterator<RowData> maybeMaterialize(
+      ClosableIterator<RowData> iter,
+      HoodieSchema requiredSchema,
+      RowType requiredRowType) {
+    if (!conf.get(FlinkOptions.BLOB_READ_MATERIALIZE)) {
+      return iter;
+    }
+    int[] blobPositions = detectBlobFieldPositions(requiredSchema);
+    if (blobPositions.length == 0) {
+      return iter;
+    }
+    HoodieStorage storage = HoodieStorageUtils.getStorage(
+        conf.get(FlinkOptions.PATH), HadoopFSUtils.getStorageConf(hadoopConf));
+    return new BlobMaterializingIterator(
+        iter,
+        requiredRowType,
+        blobPositions,
+        storage,
+        conf.get(FlinkOptions.BLOB_BATCHING_MAX_GAP_BYTES),
+        conf.get(FlinkOptions.BLOB_BATCHING_LOOKAHEAD_SIZE));
+  }
+
+  private static int[] detectBlobFieldPositions(HoodieSchema schema) {
+    List<HoodieSchemaField> fields = schema.getFields();
+    List<Integer> positions = new ArrayList<>();
+    for (int i = 0; i < fields.size(); i++) {
+      if (fields.get(i).schema().isBlobField()) {
+        positions.add(i);
+      }
+    }
+    return positions.stream().mapToInt(Integer::intValue).toArray();
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestBlobMaterializingIterator.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestBlobMaterializingIterator.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.io.SeekableDataInputStream;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link BlobMaterializingIterator}.
+ *
+ * <p>Each test builds a small RowData schema with one BLOB field (field index 2) and wires up a
+ * mock {@link HoodieStorage} to assert that:
+ * <ul>
+ *   <li>INLINE blobs pass through unchanged.
+ *   <li>OOL range-refs are batch-read and materialized as INLINE.
+ *   <li>Nearby ranges within {@code maxGapBytes} are merged into a single read.
+ *   <li>Whole-file OOL refs are read via {@link HoodieStorage#open(StoragePath)}.
+ *   <li>Null blob fields pass through unchanged.
+ *   <li>Original row order is preserved.
+ * </ul>
+ */
+public class TestBlobMaterializingIterator {
+
+  // -------------------------------------------------------------------------
+  //  Schema helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Builds a RowType with fields: [id BIGINT, name VARCHAR, blob_col BLOB_ROW_TYPE, ts BIGINT].
+   * The blob_col sub-type is the 3-field struct: (type VARCHAR, data VARBINARY, reference ROW(...)).
+   */
+  private static RowType buildRowType() {
+    RowType referenceType = RowType.of(
+        new LogicalType[] {
+            new VarCharType(Integer.MAX_VALUE),
+            new BigIntType(),
+            new BigIntType(),
+            new BooleanType()
+        },
+        new String[] {"external_path", "offset", "length", "managed"}
+    );
+    RowType blobType = RowType.of(
+        new LogicalType[] {
+            new VarCharType(Integer.MAX_VALUE),
+            new VarBinaryType(Integer.MAX_VALUE),
+            referenceType
+        },
+        new String[] {"type", "data", "reference"}
+    );
+    return RowType.of(
+        new LogicalType[] {
+            new BigIntType(),
+            new VarCharType(Integer.MAX_VALUE),
+            blobType,
+            new BigIntType()
+        },
+        new String[] {"id", "name", "blob_col", "ts"}
+    );
+  }
+
+  private static final int BLOB_FIELD_POS = 2;
+  private static final int[] BLOB_POSITIONS = {BLOB_FIELD_POS};
+
+  // -------------------------------------------------------------------------
+  //  Row-building helpers
+  // -------------------------------------------------------------------------
+
+  private static RowData blobRowWithOolRange(long id, String name, String path, long offset, long length) {
+    GenericRowData refRow = new GenericRowData(HoodieSchema.Blob.getReferenceFieldCount());
+    refRow.setField(0, StringData.fromString(path));
+    refRow.setField(1, offset);
+    refRow.setField(2, length);
+    refRow.setField(3, false);
+
+    GenericRowData blobRow = new GenericRowData(HoodieSchema.Blob.getFieldCount());
+    blobRow.setField(0, StringData.fromString(HoodieSchema.Blob.OUT_OF_LINE));
+    blobRow.setField(1, null);
+    blobRow.setField(2, refRow);
+
+    GenericRowData row = new GenericRowData(4);
+    row.setField(0, id);
+    row.setField(1, StringData.fromString(name));
+    row.setField(2, blobRow);
+    row.setField(3, id * 1000L);
+    return row;
+  }
+
+  private static RowData blobRowWithInline(long id, String name, byte[] data) {
+    GenericRowData blobRow = new GenericRowData(HoodieSchema.Blob.getFieldCount());
+    blobRow.setField(0, StringData.fromString(HoodieSchema.Blob.INLINE));
+    blobRow.setField(1, data);
+    blobRow.setField(2, null);
+
+    GenericRowData row = new GenericRowData(4);
+    row.setField(0, id);
+    row.setField(1, StringData.fromString(name));
+    row.setField(2, blobRow);
+    row.setField(3, id * 1000L);
+    return row;
+  }
+
+  private static RowData blobRowWithNullBlob(long id) {
+    GenericRowData row = new GenericRowData(4);
+    row.setField(0, id);
+    row.setField(1, StringData.fromString("null-blob"));
+    row.setField(2, null);
+    row.setField(3, 999L);
+    return row;
+  }
+
+  // -------------------------------------------------------------------------
+  //  Tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testInlineBlobPassesThrough() throws IOException {
+    byte[] data = {1, 2, 3};
+    RowData inlineRow = blobRowWithInline(1L, "doc", data);
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(inlineRow), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    List<RowData> results = drain(iter);
+    assertEquals(1, results.size());
+    RowData blobStruct = results.get(0).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount());
+    assertEquals(HoodieSchema.Blob.INLINE, blobStruct.getString(0).toString());
+    assertArrayEquals(data, blobStruct.getBinary(1));
+  }
+
+  @Test
+  public void testNullBlobPassesThrough() throws IOException {
+    RowData nullRow = blobRowWithNullBlob(5L);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(nullRow), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    List<RowData> results = drain(iter);
+    assertEquals(1, results.size());
+    assertNull(results.get(0).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()));
+  }
+
+  @Test
+  public void testSingleOolRangeIsMaterialized() throws IOException {
+    byte[] fileContent = new byte[200];
+    for (int i = 0; i < fileContent.length; i++) {
+      fileContent[i] = (byte) i;
+    }
+    RowData oolRow = blobRowWithOolRange(1L, "doc", "file1.bin", 10, 50);
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    SeekableDataInputStream seekable = makeSeekableStream(fileContent);
+    when(storage.openSeekable(any(StoragePath.class), eq(false))).thenReturn(seekable);
+
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(oolRow), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    List<RowData> results = drain(iter);
+    assertEquals(1, results.size());
+    RowData blobStruct = results.get(0).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount());
+    assertEquals(HoodieSchema.Blob.INLINE, blobStruct.getString(0).toString());
+    assertArrayEquals(
+        Arrays.copyOfRange(fileContent, 10, 60),
+        blobStruct.getBinary(1));
+  }
+
+  @Test
+  public void testTwoNearbyRangesAreMergedIntoOnePread() throws IOException {
+    // Two refs in the same file at offsets 0 and 50, gap=50 within maxGapBytes=100.
+    byte[] fileContent = new byte[200];
+    for (int i = 0; i < fileContent.length; i++) {
+      fileContent[i] = (byte) (i + 1);
+    }
+    RowData row1 = blobRowWithOolRange(1L, "a", "file1.bin", 0, 30);
+    RowData row2 = blobRowWithOolRange(2L, "b", "file1.bin", 50, 40);
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    SeekableDataInputStream seekable = spy(makeSeekableStream(fileContent));
+    when(storage.openSeekable(any(StoragePath.class), eq(false))).thenReturn(seekable);
+
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(row1, row2), buildRowType(), BLOB_POSITIONS, storage, 100, 10);
+
+    List<RowData> results = drain(iter);
+    assertEquals(2, results.size());
+
+    assertArrayEquals(Arrays.copyOfRange(fileContent, 0, 30),
+        results.get(0).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()).getBinary(1));
+    assertArrayEquals(Arrays.copyOfRange(fileContent, 50, 90),
+        results.get(1).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()).getBinary(1));
+
+    // Both refs were merged → only one openSeekable call.
+    verify(storage, times(1)).openSeekable(any(StoragePath.class), eq(false));
+  }
+
+  @Test
+  public void testTwoFarRangesAreNotMerged() throws IOException {
+    byte[] fileContent = new byte[500];
+    RowData row1 = blobRowWithOolRange(1L, "a", "file1.bin", 0, 10);
+    RowData row2 = blobRowWithOolRange(2L, "b", "file1.bin", 400, 10);
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    // Use a fresh seekable stream each call since seek() moves the position.
+    when(storage.openSeekable(any(StoragePath.class), eq(false)))
+        .thenReturn(makeSeekableStream(fileContent));
+
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(row1, row2), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    List<RowData> results = drain(iter);
+    assertEquals(2, results.size());
+  }
+
+  @Test
+  public void testOriginalRowOrderPreserved() throws IOException {
+    // Three OOL refs from two different files; rows should come back in original (insertion) order.
+    byte[] fileA = new byte[100];
+    byte[] fileB = new byte[100];
+    Arrays.fill(fileA, (byte) 'A');
+    Arrays.fill(fileB, (byte) 'B');
+
+    RowData row1 = blobRowWithOolRange(1L, "a", "fileA.bin", 0, 10);
+    RowData row2 = blobRowWithOolRange(2L, "b", "fileB.bin", 0, 10);
+    RowData row3 = blobRowWithOolRange(3L, "c", "fileA.bin", 20, 10);
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(storage.openSeekable(eq(new StoragePath("fileA.bin")), eq(false)))
+        .thenReturn(makeSeekableStream(fileA));
+    when(storage.openSeekable(eq(new StoragePath("fileB.bin")), eq(false)))
+        .thenReturn(makeSeekableStream(fileB));
+
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(row1, row2, row3), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    List<RowData> results = drain(iter);
+    assertEquals(3, results.size());
+    // Row order preserved.
+    assertEquals(1L, results.get(0).getLong(0));
+    assertEquals(2L, results.get(1).getLong(0));
+    assertEquals(3L, results.get(2).getLong(0));
+    // Bytes correct.
+    assertArrayEquals(Arrays.copyOfRange(fileA, 0, 10),
+        results.get(0).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()).getBinary(1));
+    assertArrayEquals(Arrays.copyOfRange(fileB, 0, 10),
+        results.get(1).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()).getBinary(1));
+    assertArrayEquals(Arrays.copyOfRange(fileA, 20, 30),
+        results.get(2).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()).getBinary(1));
+  }
+
+  @Test
+  public void testMixedInlineAndOolInSameBatch() throws IOException {
+    byte[] inlineData = {9, 8, 7};
+    byte[] fileContent = new byte[100];
+    Arrays.fill(fileContent, (byte) 42);
+
+    RowData inlineRow = blobRowWithInline(1L, "inline", inlineData);
+    RowData oolRow = blobRowWithOolRange(2L, "ool", "file.bin", 5, 10);
+    RowData nullRow = blobRowWithNullBlob(3L);
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(storage.openSeekable(any(StoragePath.class), eq(false)))
+        .thenReturn(makeSeekableStream(fileContent));
+
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(inlineRow, oolRow, nullRow), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    List<RowData> results = drain(iter);
+    assertEquals(3, results.size());
+
+    // inline: unchanged bytes
+    assertArrayEquals(inlineData,
+        results.get(0).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()).getBinary(1));
+    // ool: materialized
+    assertArrayEquals(Arrays.copyOfRange(fileContent, 5, 15),
+        results.get(1).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()).getBinary(1));
+    // null: blob field is null
+    assertNull(results.get(2).getRow(BLOB_FIELD_POS, HoodieSchema.Blob.getFieldCount()));
+  }
+
+  @Test
+  public void testNonBlobFieldsArePreserved() throws IOException {
+    byte[] fileContent = new byte[50];
+    RowData oolRow = blobRowWithOolRange(42L, "preserved-name", "file.bin", 0, 10);
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(storage.openSeekable(any(StoragePath.class), eq(false)))
+        .thenReturn(makeSeekableStream(fileContent));
+
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(oolRow), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    List<RowData> results = drain(iter);
+    assertEquals(1, results.size());
+    assertEquals(42L, results.get(0).getLong(0));
+    assertEquals("preserved-name", results.get(0).getString(1).toString());
+    assertEquals(42_000L, results.get(0).getLong(3));
+  }
+
+  @Test
+  public void testEmptyInputProducesNoRows() {
+    HoodieStorage storage = mock(HoodieStorage.class);
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void testMissingReferenceThrowsOnOolBlob() {
+    // OOL blob with null reference struct should throw IllegalStateException.
+    GenericRowData blobRow = new GenericRowData(HoodieSchema.Blob.getFieldCount());
+    blobRow.setField(0, StringData.fromString(HoodieSchema.Blob.OUT_OF_LINE));
+    blobRow.setField(1, null);
+    blobRow.setField(2, null); // reference is null → error
+
+    GenericRowData row = new GenericRowData(4);
+    row.setField(0, 1L);
+    row.setField(1, StringData.fromString("x"));
+    row.setField(2, blobRow);
+    row.setField(3, 1000L);
+
+    HoodieStorage storage = mock(HoodieStorage.class);
+    BlobMaterializingIterator iter = new BlobMaterializingIterator(
+        listIterator(row), buildRowType(), BLOB_POSITIONS, storage, 0, 10);
+
+    assertThrows(IllegalStateException.class, iter::hasNext);
+  }
+
+  // -------------------------------------------------------------------------
+  //  Helpers
+  // -------------------------------------------------------------------------
+
+  private static ClosableIterator<RowData> listIterator(RowData... rows) {
+    List<RowData> list = Arrays.asList(rows);
+    return new ClosableIterator<RowData>() {
+      int idx = 0;
+
+      @Override
+      public boolean hasNext() {
+        return idx < list.size();
+      }
+
+      @Override
+      public RowData next() {
+        return list.get(idx++);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private static List<RowData> drain(BlobMaterializingIterator iter) {
+    List<RowData> result = new ArrayList<>();
+    while (iter.hasNext()) {
+      result.add(iter.next());
+    }
+    iter.close();
+    return result;
+  }
+
+  /**
+   * Returns a {@link SeekableDataInputStream} backed by {@code content}.
+   * Supports {@code seek()} by re-creating the ByteArrayInputStream at the given offset.
+   */
+  private static SeekableDataInputStream makeSeekableStream(byte[] content) {
+    return new SeekableDataInputStream(new ByteArrayInputStream(content)) {
+      private int pos = 0;
+
+      @Override
+      public long getPos() {
+        return pos;
+      }
+
+      @Override
+      public void seek(long newPos) {
+        this.pos = (int) newPos;
+        this.in = new ByteArrayInputStream(content, this.pos, content.length - this.pos);
+      }
+    };
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestBlobWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestBlobWrite.java
@@ -42,9 +42,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -222,5 +224,171 @@ public class ITTestBlobWrite {
   private static void execInsert(TableEnvironment tableEnv, String insertSql) throws Exception {
     TableResult result = tableEnv.executeSql(insertSql);
     result.getJobClient().get().getJobExecutionResult().get(120, TimeUnit.SECONDS);
+  }
+
+  // -------------------------------------------------------------------------
+  //  Blob read materialization IT
+  // -------------------------------------------------------------------------
+
+  /**
+   * Writes an OOL blob reference pointing to a real local temp file, then reads the table back
+   * with {@code read.blob.materialize=true} and asserts the BLOB struct is materialized
+   * (type=INLINE, data=<original bytes>, reference=null).
+   *
+   * <p>Both COW and MOR table types are tested. The MOR variant also exercises an upsert so that
+   * at least one row lives in an Avro log file and must be merged before materialization.
+   */
+  @ParameterizedTest
+  @EnumSource(value = HoodieTableType.class)
+  public void testReadMaterializesOutOfLineBlob(HoodieTableType tableType) throws Exception {
+    // Write two small payloads to a temp file that the OOL reference will point to.
+    byte[] payload1 = {10, 20, 30, 40, 50};
+    byte[] payload2 = {60, 70, 80, 90};
+    File blobFile = new File(tempFile, "blobs.bin");
+    try (FileOutputStream fos = new FileOutputStream(blobFile)) {
+      fos.write(payload1);
+      fos.write(payload2);
+    }
+    String blobFilePath = blobFile.getAbsolutePath();
+
+    TableEnvironment tableEnv = batchEnv();
+    String tablePath = new File(tempFile, "blob_materialize_" + tableType.name()).getAbsolutePath();
+    createTableWithMaterialize(tableEnv, tablePath, tableType);
+
+    // Insert two rows with OOL refs pointing into the temp file.
+    execInsert(tableEnv,
+        "INSERT INTO blob_mat_table VALUES\n"
+            + "(1, 'doc-1', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('" + blobFilePath + "', CAST(0 AS BIGINT), CAST(5 AS BIGINT), false)), 1000),\n"
+            + "(2, 'doc-2', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('" + blobFilePath + "', CAST(5 AS BIGINT), CAST(4 AS BIGINT), false)), 2000)");
+
+    // For MOR: upsert row 1 so it has an Avro log entry that must be merged before materialization.
+    if (tableType == HoodieTableType.MERGE_ON_READ) {
+      execInsert(tableEnv,
+          "INSERT INTO blob_mat_table VALUES\n"
+              + "(1, 'doc-1-updated', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+              + "ROW('" + blobFilePath + "', CAST(0 AS BIGINT), CAST(5 AS BIGINT), false)), 3000)");
+    }
+
+    List<Row> rows = CollectionUtil.iteratorToList(
+        tableEnv.executeSql("SELECT id, name, blob_col, ts FROM blob_mat_table ORDER BY id").collect());
+
+    assertEquals(2, rows.size(), "Expected 2 rows after materialization");
+
+    // Row 1 — payload1
+    Row row1 = rows.get(0);
+    assertEquals(1L, row1.getField(0));
+    Row blob1 = (Row) row1.getField(2);
+    assertNotNull(blob1, "Blob struct for row 1 must not be null");
+    assertEquals("INLINE", blob1.getField(0), "type must be INLINE after materialization");
+    assertArrayEquals(payload1, (byte[]) blob1.getField(1), "Inline data must match original payload1");
+    assertNull(blob1.getField(2), "reference must be null after materialization");
+
+    // Row 2 — payload2
+    Row row2 = rows.get(1);
+    assertEquals(2L, row2.getField(0));
+    Row blob2 = (Row) row2.getField(2);
+    assertNotNull(blob2, "Blob struct for row 2 must not be null");
+    assertEquals("INLINE", blob2.getField(0), "type must be INLINE after materialization");
+    assertArrayEquals(payload2, (byte[]) blob2.getField(1), "Inline data must match original payload2");
+    assertNull(blob2.getField(2), "reference must be null after materialization");
+
+    tableEnv.executeSql("DROP TABLE blob_mat_table");
+  }
+
+  /**
+   * Verifies that when {@code read.blob.materialize=false} (default), OOL blob structs are
+   * returned as-is with the original OUT_OF_LINE type and reference intact.
+   */
+  @Test
+  public void testReadWithMaterializeDisabledReturnsOolStructAsIs() throws Exception {
+    File blobFile = new File(tempFile, "no_mat_blobs.bin");
+    try (FileOutputStream fos = new FileOutputStream(blobFile)) {
+      fos.write(new byte[]{1, 2, 3});
+    }
+    String blobFilePath = blobFile.getAbsolutePath();
+
+    TableEnvironment tableEnv = batchEnv();
+    String tablePath = new File(tempFile, "no_mat_cow").getAbsolutePath();
+    createTable(tableEnv, tablePath, HoodieTableType.COPY_ON_WRITE);
+
+    execInsert(tableEnv,
+        "INSERT INTO blob_table VALUES\n"
+            + "(1, 'doc-1', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('" + blobFilePath + "', CAST(0 AS BIGINT), CAST(3 AS BIGINT), false)), 1000)");
+
+    List<Row> rows = readOrdered(tableEnv);
+    assertEquals(1, rows.size());
+    // Without materialize, the blob struct remains OUT_OF_LINE.
+    assertOutOfLineRow(rows.get(0), 1L, "doc-1", blobFilePath, 0L, 3L, 1000L);
+
+    tableEnv.executeSql("DROP TABLE blob_table");
+  }
+
+  /**
+   * Verifies that nearby OOL ranges from the same file are coalesced into a single read when
+   * {@code read.blob.batching.max.gap.bytes} is large enough, and that the bytes are still
+   * correct for each row.
+   */
+  @ParameterizedTest
+  @EnumSource(value = HoodieTableType.class)
+  public void testBatchingCoalescesNearbyRanges(HoodieTableType tableType) throws Exception {
+    // Write 30 bytes; row1 → [0,10), row2 → [15,25) — gap of 5 bytes, well within any default.
+    byte[] fileBytes = new byte[30];
+    for (int i = 0; i < fileBytes.length; i++) {
+      fileBytes[i] = (byte) (i + 1);
+    }
+    File blobFile = new File(tempFile, "batch_" + tableType.name() + ".bin");
+    try (FileOutputStream fos = new FileOutputStream(blobFile)) {
+      fos.write(fileBytes);
+    }
+    String blobFilePath = blobFile.getAbsolutePath();
+
+    TableEnvironment tableEnv = batchEnv();
+    String tablePath = new File(tempFile, "batch_test_" + tableType.name()).getAbsolutePath();
+    createTableWithMaterialize(tableEnv, tablePath, tableType);
+
+    execInsert(tableEnv,
+        "INSERT INTO blob_mat_table VALUES\n"
+            + "(1, 'r1', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('" + blobFilePath + "', CAST(0 AS BIGINT), CAST(10 AS BIGINT), false)), 1000),\n"
+            + "(2, 'r2', ROW('OUT_OF_LINE', CAST(NULL AS BYTES), "
+            + "ROW('" + blobFilePath + "', CAST(15 AS BIGINT), CAST(10 AS BIGINT), false)), 2000)");
+
+    List<Row> rows = CollectionUtil.iteratorToList(
+        tableEnv.executeSql("SELECT id, blob_col FROM blob_mat_table ORDER BY id").collect());
+
+    assertEquals(2, rows.size());
+
+    byte[] expected1 = java.util.Arrays.copyOfRange(fileBytes, 0, 10);
+    byte[] expected2 = java.util.Arrays.copyOfRange(fileBytes, 15, 25);
+
+    assertArrayEquals(expected1, (byte[]) ((Row) rows.get(0).getField(1)).getField(1));
+    assertArrayEquals(expected2, (byte[]) ((Row) rows.get(1).getField(1)).getField(1));
+
+    tableEnv.executeSql("DROP TABLE blob_mat_table");
+  }
+
+  private void createTableWithMaterialize(
+      TableEnvironment tableEnv, String tablePath, HoodieTableType tableType) {
+    String createTableDdl = String.format(
+        "CREATE TABLE blob_mat_table (\n"
+            + "  id BIGINT,\n"
+            + "  name STRING,\n"
+            + BLOB_COLUMN_DDL
+            + "  ts BIGINT,\n"
+            + "  PRIMARY KEY (id) NOT ENFORCED\n"
+            + ") WITH (\n"
+            + "  'connector' = 'hudi',\n"
+            + "  'path' = '%s',\n"
+            + "  'table.type' = '%s',\n"
+            + "  'ordering.fields' = 'ts',\n"
+            + "  'read.blob.materialize' = 'true',\n"
+            + "  'read.blob.batching.max.gap.bytes' = '128',\n"
+            + "  'read.blob.batching.lookahead.size' = '20'\n"
+            + ");",
+        tablePath, tableType.name());
+    tableEnv.executeSql(createTableDdl);
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cow/TestCopyOnWriteInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cow/TestCopyOnWriteInputFormat.java
@@ -171,7 +171,8 @@ class TestCopyOnWriteInputFormat {
         true,
         InternalSchemaManager.DISABLED,
         HoodieSchemaConverter.convertToSchema(
-            TestConfigurations.ROW_TYPE.copy()));
+            TestConfigurations.ROW_TYPE.copy()),
+        new org.apache.flink.configuration.Configuration());
   }
 
   private static FileStatus fileStatus(String name) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19032.

This change adds opt-in OOL BLOB materialization directly in the Flink source, matching the batched read behavior that Spark achieves via `BatchedBlobReader` / `ReadBlobRule`.

### Summary and Changelog

**User-facing outcome:** When `read.blob.materialize=true` is set in the Flink DDL `WITH` options, the source iterator materializes every OOL BLOB field before emitting each row: the blob struct is replaced with an INLINE blob (`type=INLINE, data=<bytes>, reference=null`). Nearby byte ranges from the same external file are coalesced into a single seek+readFully, controlled by `read.blob.batching.max.gap.bytes` and `read.blob.batching.lookahead.size`.

#### Changes

- **`BlobMaterializingIterator`** (new)
  - A `ClosableIterator<RowData>` decorator that ports Spark's `BatchedBlobReader` algorithm to Flink's `RowData` API.
  - Buffers `lookaheadSize` rows per batch (shallow-copied to avoid aliasing), classifies each BLOB field as INLINE (pass-through) or OOL (collect `external_path`, `offset`, `length`), groups OOL refs by file path, sorts by offset, merges ranges within `maxGapBytes` into a single `seek + readFully`, then re-emits rows in original order with blob structs replaced by `(INLINE, <bytes>, null)`.
  - Whole-file OOL refs (no offset/length) are handled via `HoodieStorage#open` per file.

- **`FlinkOptions`** (3 new config keys)
  - `read.blob.materialize` (boolean, default `false`): enable OOL materialization at the source.
  - `read.blob.batching.max.gap.bytes` (int, default `4096`): max byte gap between two OOL ranges in the same file to coalesce into one read.
  - `read.blob.batching.lookahead.size` (int, default `50`): row lookahead buffer size per batch.

- **`HoodieSplitReaderFunction`** (FLIP-27 / new source path)
  - After `fileGroupReader.getClosableIterator()`, wraps the raw iterator with `BlobMaterializingIterator` when `read.blob.materialize=true` and the required schema contains at least one BLOB field (detected via `HoodieSchema#isBlobField()`).

- **`MergeOnReadInputFormat`** (legacy streaming path)
  - Same `maybeMaterialize()` injection at the end of `initIterator()`, using `tableState.getRequiredRowType()` (already available) for field getter construction.

#### Tests

- **`TestBlobMaterializingIterator`** (new, unit)
  - 9 focused unit tests using a mock `HoodieStorage` and in-memory `SeekableDataInputStream`:
    - INLINE blobs pass through unchanged.
    - Null blob fields pass through unchanged.
    - Single OOL range is materialized with correct bytes.
    - Two nearby ranges (gap ≤ `maxGapBytes`) are merged → single `openSeekable` call (verified with Mockito `verify`).
    - Two far-apart ranges are not merged.
    - Original row order is preserved across multiple files.
    - Mixed INLINE + OOL + null in the same batch.
    - Non-blob fields (id, name, ts) are preserved in the output row.
    - Missing OOL reference struct throws `IllegalStateException`.

- **`ITTestBlobWrite`** (extended)
  - `testReadMaterializesOutOfLineBlob` (COW + MOR, `@EnumSource`): writes a real temp binary file, inserts two OOL references, reads back with `read.blob.materialize=true`, asserts `type=INLINE`, `data=<expected bytes>`, `reference=null`. For MOR, also upserts so that merge + materialization is exercised end-to-end.
  - `testReadWithMaterializeDisabledReturnsOolStructAsIs`: same write, but without `read.blob.materialize`; asserts the struct is still `OUT_OF_LINE` — ensures the feature is strictly opt-in.
  - `testBatchingCoalescesNearbyRanges` (COW + MOR): two OOL refs into the same file with a 5-byte gap, `max.gap.bytes=128`; verifies both rows receive correct byte arrays.

### Impact

- **Read path:** OOL BLOB fields can now be materialized at the Flink source level with batched I/O, matching Spark's `BatchedBlobReader` behavior.
- **Write path:** unchanged.
- **On-disk layout:** unchanged.
- **No public API change.** Managed-blob cleaning, dynamic inline/OOL placement, and a Flink `read_blob` UDF remain out of scope.

### Risk Level

**Low**

- Materialization is entirely opt-in (`read.blob.materialize=false` by default). The existing read path is unaffected when the flag is unset.
- The `detectBlobFieldPositions` check short-circuits to a no-op if the required schema has no BLOB fields, so non-BLOB tables are unaffected.
- `BlobMaterializingIterator` is a pure decorator: it does not modify the underlying iterator, table state, or schema.

### Test plan

- [ ] `-Pflink2.1` CI: `TestBlobMaterializingIterator`
- [ ] `-Pflink2.1` CI: `ITTestBlobWrite` (COW + MOR + materialize variants)

### Documentation Update

Add documentation for Flink DDL read.blob.materialize=true

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

