### PR TITLE
test(trino): de-flake testRecordLevelFileSkipping by setting the record-index wait timeout

### DIFF
--- a/hudi-trino-plugin/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/hudi-trino-plugin/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -801,7 +801,7 @@ public class TestHudiSmokeTest
                 .withRecordLevelIndexEnabled(true)
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
-                .withColumnStatsTimeout("10s")
+                .withRecordIndexTimeout("10s")
                 .build();
         MaterializedResult totalRes = getQueryRunner().execute(session, "SELECT * FROM " + table);
         MaterializedResult prunedRes = getQueryRunner().execute(session, "SELECT * FROM " + table


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`TestHudiSmokeTest.testRecordLevelFileSkipping` is flaky on the Trino Hudi plugin's record-level-index (RLI) file-skipping path. It intermittently fails with `expected: 1 but was: 2` at the `assertThat(prunedSplits).isEqualTo(1)` check: RLI-based file skipping should prune the query down to a single split, but occasionally scans two.

It was observed on the CI of an unrelated PR: https://github.com/apache/hudi/actions/runs/28803321393/job/85412721300 (the `test-hudi-trino-plugin` job); every other module in that run was green.

### Summary and Changelog

Root cause is an async index-readiness race, not a data-skipping bug. The test enables the record-level index (`withRecordLevelIndexEnabled(true)`) with column stats disabled (`withColStatsIndexEnabled(false)`), but the only timeout it sets is `withColumnStatsTimeout("10s")` - which is a no-op here because column stats is off. It never sets the record-index wait timeout, so the async RLI load falls back to the 2s default (`HudiConfig#recordIndexWaitTimeout`). Under CI load the RLI is not ready within 2s, so skipping is incomplete and the pruned query scans 2 splits instead of 1.

- `TestHudiSmokeTest#testRecordLevelFileSkipping`: replace the no-op `withColumnStatsTimeout("10s")` with `withRecordIndexTimeout("10s")`. This gives the async RLI load the same 10s budget the sibling RLI tests already use (`testRLIWithColumnNameUsingUppercaseLetters`, `testMultiKeyRLIWithColumnNameUsingUppercaseLetters`) and mirrors the earlier de-flake #13869, which bumped exactly these index-wait timeouts to 10s.

### Impact

No user-facing or public-API change. Removes a source of CI flakiness on the Trino plugin's RLI file-skipping test.

### Risk Level

low

Test-only change; it sets the correct wait-timeout knob for the index the test actually exercises, matching the sibling RLI tests that already pass reliably with a 10s record-index timeout.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
