### PR TITLE
test(spark): add unit coverage for Spark row, schema and sort utilities

### DIFF
--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/stats/TestSparkValueMetadataUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/stats/TestSparkValueMetadataUtils.java
@@ -38,6 +38,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -49,6 +50,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * and the value conversion round-trips using only in-process objects.
  */
 class TestSparkValueMetadataUtils {
+
+  private static ValueMetadata metadataFor(DataType dataType) {
+    return SparkValueMetadataUtils.getValueMetadata(dataType, HoodieIndexVersion.V2);
+  }
 
   private static Stream<Arguments> dataTypeToValueType() {
     return Stream.of(
@@ -80,11 +85,8 @@ class TestSparkValueMetadataUtils {
     ValueMetadata metadata = SparkValueMetadataUtils.getValueMetadata(decimalType, HoodieIndexVersion.V2);
 
     assertEquals(ValueType.DECIMAL, metadata.getValueType());
-    assertTrue(metadata instanceof ValueMetadata.DecimalValueMetadata,
-        "decimal type must produce decimal-aware metadata");
-    ValueMetadata.DecimalValueMetadata decimalMetadata = (ValueMetadata.DecimalValueMetadata) metadata;
-    assertEquals(12, decimalMetadata.getPrecision(), "precision must be preserved");
-    assertEquals(4, decimalMetadata.getScale(), "scale must be preserved");
+    assertEquals("12,4", metadata.getValueTypeInfo().getAdditionalInfo(),
+        "precision and scale must be encoded in the value type info");
   }
 
   @Test
@@ -106,29 +108,29 @@ class TestSparkValueMetadataUtils {
 
   @Test
   void convertSparkToJavaReturnsNullForNullInput() {
-    ValueMetadata metadata = new ValueMetadata(ValueType.INT);
+    ValueMetadata metadata = metadataFor(DataTypes.IntegerType);
     assertNull(SparkValueMetadataUtils.convertSparkToJava(metadata, null));
   }
 
   @Test
   void convertSparkToJavaPassesThroughPrimitives() {
     assertEquals(Boolean.TRUE,
-        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.BOOLEAN), true));
+        SparkValueMetadataUtils.convertSparkToJava(metadataFor(DataTypes.BooleanType), true));
     assertEquals(42,
-        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.INT), 42));
+        SparkValueMetadataUtils.convertSparkToJava(metadataFor(DataTypes.IntegerType), 42));
     assertEquals(42L,
-        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.LONG), 42L));
+        SparkValueMetadataUtils.convertSparkToJava(metadataFor(DataTypes.LongType), 42L));
     assertEquals(1.5f,
-        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.FLOAT), 1.5f));
+        SparkValueMetadataUtils.convertSparkToJava(metadataFor(DataTypes.FloatType), 1.5f));
     assertEquals(2.5d,
-        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.DOUBLE), 2.5d));
+        SparkValueMetadataUtils.convertSparkToJava(metadataFor(DataTypes.DoubleType), 2.5d));
     assertEquals("hudi",
-        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.STRING), "hudi"));
+        SparkValueMetadataUtils.convertSparkToJava(metadataFor(DataTypes.StringType), "hudi"));
   }
 
   @Test
   void convertSparkToJavaHandlesDecimal() {
-    ValueMetadata metadata = SparkValueMetadataUtils.getValueMetadata(new DecimalType(10, 2), HoodieIndexVersion.V2);
+    ValueMetadata metadata = metadataFor(new DecimalType(10, 2));
     Decimal sparkDecimal = Decimal.apply(new BigDecimal("123.45"));
     Comparable<?> result = SparkValueMetadataUtils.convertSparkToJava(metadata, sparkDecimal);
     assertEquals(new BigDecimal("123.45"), result, "decimal must convert to a java BigDecimal of equal value");
@@ -136,20 +138,20 @@ class TestSparkValueMetadataUtils {
 
   @Test
   void convertSparkToJavaHandlesBytes() {
-    ValueMetadata metadata = new ValueMetadata(ValueType.BYTES);
+    ValueMetadata metadata = metadataFor(DataTypes.BinaryType);
     byte[] input = new byte[] {1, 2, 3, 4};
     Comparable<?> result = SparkValueMetadataUtils.convertSparkToJava(metadata, input);
     assertTrue(result instanceof ByteBuffer, "bytes must convert to a ByteBuffer");
     ByteBuffer buffer = (ByteBuffer) result;
     byte[] roundTripped = new byte[buffer.remaining()];
     buffer.get(roundTripped);
-    org.junit.jupiter.api.Assertions.assertArrayEquals(input, roundTripped,
+    assertArrayEquals(input, roundTripped,
         "byte content must survive the conversion");
   }
 
   @Test
   void convertSparkToJavaHandlesDateFromEpochDays() {
-    ValueMetadata metadata = new ValueMetadata(ValueType.DATE);
+    ValueMetadata metadata = metadataFor(DataTypes.DateType);
     // Spark stores dates internally as epoch-day integers.
     int epochDays = (int) LocalDate.of(2021, 3, 15).toEpochDay();
     Comparable<?> result = SparkValueMetadataUtils.convertSparkToJava(metadata, epochDays);
@@ -158,7 +160,7 @@ class TestSparkValueMetadataUtils {
 
   @Test
   void convertSparkToJavaHandlesTimestampMicros() {
-    ValueMetadata metadata = new ValueMetadata(ValueType.TIMESTAMP_MICROS);
+    ValueMetadata metadata = metadataFor(DataTypes.TimestampType);
     Instant expected = Instant.ofEpochSecond(1_600_000_000L);
     long micros = expected.getEpochSecond() * 1_000_000L;
     Comparable<?> result = SparkValueMetadataUtils.convertSparkToJava(metadata, micros);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/stats/TestSparkValueMetadataUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/metadata/stats/TestSparkValueMetadataUtils.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.stats;
+
+import org.apache.hudi.metadata.HoodieIndexVersion;
+
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit coverage for the Spark value-metadata conversion helpers. Exercises the
+ * Spark-type to {@link ValueType} matrix, decimal precision/scale carry-through,
+ * and the value conversion round-trips using only in-process objects.
+ */
+class TestSparkValueMetadataUtils {
+
+  private static Stream<Arguments> dataTypeToValueType() {
+    return Stream.of(
+        Arguments.of(DataTypes.BooleanType, ValueType.BOOLEAN),
+        Arguments.of(DataTypes.IntegerType, ValueType.INT),
+        Arguments.of(DataTypes.ShortType, ValueType.INT),
+        Arguments.of(DataTypes.ByteType, ValueType.INT),
+        Arguments.of(DataTypes.LongType, ValueType.LONG),
+        Arguments.of(DataTypes.FloatType, ValueType.FLOAT),
+        Arguments.of(DataTypes.DoubleType, ValueType.DOUBLE),
+        Arguments.of(DataTypes.StringType, ValueType.STRING),
+        Arguments.of(DataTypes.TimestampType, ValueType.TIMESTAMP_MICROS),
+        Arguments.of(DataTypes.DateType, ValueType.DATE),
+        Arguments.of(DataTypes.BinaryType, ValueType.BYTES),
+        Arguments.of(DataTypes.NullType, ValueType.NULL));
+  }
+
+  @ParameterizedTest
+  @MethodSource("dataTypeToValueType")
+  void getValueMetadataMapsSparkTypeToValueType(DataType dataType, ValueType expected) {
+    ValueMetadata metadata = SparkValueMetadataUtils.getValueMetadata(dataType, HoodieIndexVersion.V2);
+    assertEquals(expected, metadata.getValueType(),
+        "Spark type " + dataType.typeName() + " must map to value type " + expected);
+  }
+
+  @Test
+  void getValueMetadataCarriesDecimalPrecisionAndScale() {
+    DecimalType decimalType = new DecimalType(12, 4);
+    ValueMetadata metadata = SparkValueMetadataUtils.getValueMetadata(decimalType, HoodieIndexVersion.V2);
+
+    assertEquals(ValueType.DECIMAL, metadata.getValueType());
+    assertTrue(metadata instanceof ValueMetadata.DecimalValueMetadata,
+        "decimal type must produce decimal-aware metadata");
+    ValueMetadata.DecimalValueMetadata decimalMetadata = (ValueMetadata.DecimalValueMetadata) metadata;
+    assertEquals(12, decimalMetadata.getPrecision(), "precision must be preserved");
+    assertEquals(4, decimalMetadata.getScale(), "scale must be preserved");
+  }
+
+  @Test
+  void getValueMetadataReturnsV1EmptyBelowV2() {
+    // Any index version lower than V2 is unversioned column stats and yields the shared empty metadata.
+    ValueMetadata metadata = SparkValueMetadataUtils.getValueMetadata(DataTypes.IntegerType, HoodieIndexVersion.V1);
+    assertSame(ValueMetadata.V1EmptyMetadata.get(), metadata,
+        "index versions below V2 must return the shared V1 empty metadata");
+    assertTrue(metadata.isV1());
+  }
+
+  @Test
+  void getValueMetadataReturnsNullMetadataForNullType() {
+    // A null Spark data type is distinct from NullType and maps to the shared NULL metadata singleton.
+    ValueMetadata metadata = SparkValueMetadataUtils.getValueMetadata(null, HoodieIndexVersion.V2);
+    assertSame(ValueMetadata.NULL_METADATA, metadata);
+    assertEquals(ValueType.NULL, metadata.getValueType());
+  }
+
+  @Test
+  void convertSparkToJavaReturnsNullForNullInput() {
+    ValueMetadata metadata = new ValueMetadata(ValueType.INT);
+    assertNull(SparkValueMetadataUtils.convertSparkToJava(metadata, null));
+  }
+
+  @Test
+  void convertSparkToJavaPassesThroughPrimitives() {
+    assertEquals(Boolean.TRUE,
+        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.BOOLEAN), true));
+    assertEquals(42,
+        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.INT), 42));
+    assertEquals(42L,
+        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.LONG), 42L));
+    assertEquals(1.5f,
+        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.FLOAT), 1.5f));
+    assertEquals(2.5d,
+        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.DOUBLE), 2.5d));
+    assertEquals("hudi",
+        SparkValueMetadataUtils.convertSparkToJava(new ValueMetadata(ValueType.STRING), "hudi"));
+  }
+
+  @Test
+  void convertSparkToJavaHandlesDecimal() {
+    ValueMetadata metadata = SparkValueMetadataUtils.getValueMetadata(new DecimalType(10, 2), HoodieIndexVersion.V2);
+    Decimal sparkDecimal = Decimal.apply(new BigDecimal("123.45"));
+    Comparable<?> result = SparkValueMetadataUtils.convertSparkToJava(metadata, sparkDecimal);
+    assertEquals(new BigDecimal("123.45"), result, "decimal must convert to a java BigDecimal of equal value");
+  }
+
+  @Test
+  void convertSparkToJavaHandlesBytes() {
+    ValueMetadata metadata = new ValueMetadata(ValueType.BYTES);
+    byte[] input = new byte[] {1, 2, 3, 4};
+    Comparable<?> result = SparkValueMetadataUtils.convertSparkToJava(metadata, input);
+    assertTrue(result instanceof ByteBuffer, "bytes must convert to a ByteBuffer");
+    ByteBuffer buffer = (ByteBuffer) result;
+    byte[] roundTripped = new byte[buffer.remaining()];
+    buffer.get(roundTripped);
+    org.junit.jupiter.api.Assertions.assertArrayEquals(input, roundTripped,
+        "byte content must survive the conversion");
+  }
+
+  @Test
+  void convertSparkToJavaHandlesDateFromEpochDays() {
+    ValueMetadata metadata = new ValueMetadata(ValueType.DATE);
+    // Spark stores dates internally as epoch-day integers.
+    int epochDays = (int) LocalDate.of(2021, 3, 15).toEpochDay();
+    Comparable<?> result = SparkValueMetadataUtils.convertSparkToJava(metadata, epochDays);
+    assertEquals(LocalDate.of(2021, 3, 15), result, "epoch-day int must convert to the matching LocalDate");
+  }
+
+  @Test
+  void convertSparkToJavaHandlesTimestampMicros() {
+    ValueMetadata metadata = new ValueMetadata(ValueType.TIMESTAMP_MICROS);
+    Instant expected = Instant.ofEpochSecond(1_600_000_000L);
+    long micros = expected.getEpochSecond() * 1_000_000L;
+    Comparable<?> result = SparkValueMetadataUtils.convertSparkToJava(metadata, micros);
+    assertEquals(expected, result, "micros-since-epoch must convert to the matching Instant");
+  }
+
+  @Test
+  void convertJavaTypeToSparkTypeConvertsInstantWhenLegacyApi() {
+    Instant instant = Instant.ofEpochSecond(1_600_000_000L);
+    // With the java8 API disabled Spark expects java.sql.Timestamp for timestamp values.
+    Object legacy = SparkValueMetadataUtils.convertJavaTypeToSparkType(instant, false);
+    assertEquals(Timestamp.from(instant), legacy);
+
+    // With the java8 API enabled the Instant is passed through untouched.
+    assertSame(instant, SparkValueMetadataUtils.convertJavaTypeToSparkType(instant, true));
+  }
+
+  @Test
+  void convertJavaTypeToSparkTypeConvertsLocalDateWhenLegacyApi() {
+    LocalDate date = LocalDate.of(2022, 6, 1);
+    Object legacy = SparkValueMetadataUtils.convertJavaTypeToSparkType(date, false);
+    assertEquals(Date.valueOf(date), legacy);
+
+    assertSame(date, SparkValueMetadataUtils.convertJavaTypeToSparkType(date, true));
+  }
+
+  @Test
+  void convertJavaTypeToSparkTypeLeavesOtherTypesUntouched() {
+    assertSame("plain", SparkValueMetadataUtils.convertJavaTypeToSparkType("plain", false));
+    Integer value = 7;
+    assertSame(value, SparkValueMetadataUtils.convertJavaTypeToSparkType(value, false));
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/spark/sql/hudi/execution/TestRangeSampleSort.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/spark/sql/hudi/execution/TestRangeSampleSort.java
@@ -29,6 +29,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Assertions;
@@ -37,6 +38,9 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.spark.sql.functions.spark_partition_id;
 
 class TestRangeSampleSort extends HoodieClientTestBase {
 
@@ -64,13 +68,13 @@ class TestRangeSampleSort extends HoodieClientTestBase {
   }
 
   /**
-   * Builds a two-column integer frame with a single output partition so the
-   * space-curve ordering is fully deterministic and can be asserted row by row.
+   * Builds a two-column integer frame; call sites pass an explicit output partition
+   * count so the resulting ordering is deterministic and can be asserted row by row.
    */
   private Dataset<Row> buildTwoIntColumnFrame(List<Row> rows) {
     StructType schema = new StructType(new StructField[] {
-        new StructField("c1", DataTypes.IntegerType, true, org.apache.spark.sql.types.Metadata.empty()),
-        new StructField("c2", DataTypes.IntegerType, true, org.apache.spark.sql.types.Metadata.empty())
+        new StructField("c1", DataTypes.IntegerType, true, Metadata.empty()),
+        new StructField("c2", DataTypes.IntegerType, true, Metadata.empty())
     });
     return sparkSession.createDataFrame(rows, schema);
   }
@@ -83,16 +87,6 @@ class TestRangeSampleSort extends HoodieClientTestBase {
     byte[] b1 = BinaryUtil.intTo8Byte(c1 == null ? Integer.MAX_VALUE : c1);
     byte[] b2 = BinaryUtil.intTo8Byte(c2 == null ? Integer.MAX_VALUE : c2);
     return BinaryUtil.interleaving(new byte[][] {b1, b2}, 8);
-  }
-
-  private static int compareUnsigned(byte[] a, byte[] b) {
-    for (int i = 0; i < a.length && i < b.length; i++) {
-      int cmp = (a[i] & 0xFF) - (b[i] & 0xFF);
-      if (cmp != 0) {
-        return cmp;
-      }
-    }
-    return a.length - b.length;
   }
 
   @Test
@@ -119,7 +113,7 @@ class TestRangeSampleSort extends HoodieClientTestBase {
     for (int i = 1; i < result.size(); i++) {
       byte[] prev = expectedZOrdinal(result.get(i - 1).getInt(0), result.get(i - 1).getInt(1));
       byte[] curr = expectedZOrdinal(result.get(i).getInt(0), result.get(i).getInt(1));
-      Assertions.assertTrue(compareUnsigned(prev, curr) <= 0,
+      Assertions.assertTrue(BinaryUtil.compareTo(prev, 0, prev.length, curr, 0, curr.length) <= 0,
           "row " + i + " violates ascending Z-curve order");
     }
 
@@ -169,26 +163,52 @@ class TestRangeSampleSort extends HoodieClientTestBase {
   }
 
   @Test
-  void orderByMappingValuesSingleColumnIsLinearOrder() {
+  void orderByMappingValuesSingleColumnRangePartitionsRows() {
     List<Row> rows = Arrays.asList(
         RowFactory.create(3, 30),
         RowFactory.create(1, 10),
-        RowFactory.create(2, 20));
+        RowFactory.create(2, 20),
+        RowFactory.create(4, 40));
     Dataset<Row> df = buildTwoIntColumnFrame(rows);
 
-    // A single ordering column short-circuits space-curve mapping into a plain range repartition.
+    // A single ordering column short-circuits space-curve mapping into a plain range
+    // repartition. Spark's repartitionByRange does not sort rows within a partition,
+    // so only the cross-partition range contract can be asserted.
     Dataset<Row> ordered = SpaceCurveSortingHelper.orderDataFrameByMappingValues(
-        df, HoodieClusteringConfig.LayoutOptimizationStrategy.ZORDER, Arrays.asList("c1"), 1);
+        df, HoodieClusteringConfig.LayoutOptimizationStrategy.ZORDER, Arrays.asList("c1"), 2);
 
     Assertions.assertArrayEquals(new String[] {"c1", "c2"}, ordered.schema().fieldNames(),
         "single-column ordering must not add an Index column");
-    List<Row> result = ordered.collectAsList();
+
+    List<Row> result = ordered.withColumn("pid", spark_partition_id()).collectAsList();
+    Assertions.assertEquals(rows.size(), result.size(), "no rows should be dropped");
+
+    // Range partitioning must not overlap ranges across partitions: every c1 in a
+    // lower-numbered partition is <= every c1 in a higher-numbered partition.
+    for (Row left : result) {
+      for (Row right : result) {
+        if (left.getInt(2) < right.getInt(2)) {
+          Assertions.assertTrue(left.getInt(0) <= right.getInt(0),
+              "partition ranges must not overlap");
+        }
+      }
+    }
+
+    // With four distinct keys and two target partitions the deterministic range
+    // bounds split the rows across both partitions, so the check above is not vacuous.
+    Assertions.assertEquals(2,
+        result.stream().map(r -> r.getInt(2)).collect(Collectors.toSet()).size(),
+        "rows must be spread across both requested partitions");
+
+    // The row multiset must be preserved: each c1 appears once with its matching c2.
     List<Integer> c1Values = new ArrayList<>();
     for (Row r : result) {
+      Assertions.assertEquals(r.getInt(0) * 10, r.getInt(1), "row content must be unchanged");
       c1Values.add(r.getInt(0));
     }
-    Assertions.assertEquals(Arrays.asList(1, 2, 3), c1Values,
-        "single-column ordering must produce ascending values");
+    c1Values.sort(Integer::compareTo);
+    Assertions.assertEquals(Arrays.asList(1, 2, 3, 4), c1Values,
+        "range repartition must preserve all rows");
   }
 
   @Test

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/spark/sql/hudi/execution/TestRangeSampleSort.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/spark/sql/hudi/execution/TestRangeSampleSort.java
@@ -19,16 +19,24 @@
 
 package org.apache.spark.sql.hudi.execution;
 
+import org.apache.hudi.common.util.BinaryUtil;
 import org.apache.hudi.config.HoodieClusteringConfig;
+import org.apache.hudi.sort.SpaceCurveSortingHelper;
 import org.apache.hudi.testutils.HoodieClientTestBase;
 import org.apache.hudi.util.JavaScalaConverters;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 class TestRangeSampleSort extends HoodieClientTestBase {
 
@@ -53,5 +61,145 @@ class TestRangeSampleSort extends HoodieClientTestBase {
           RangeSampleSort$.MODULE$.sortDataFrameBySample(df.limit(limit), layoutOptStrategy,
               JavaScalaConverters.convertJavaListToScalaSeq(Arrays.asList("id", "content")), 1), "range sort shall not fail when 0 or 1 record incoming");
     }
+  }
+
+  /**
+   * Builds a two-column integer frame with a single output partition so the
+   * space-curve ordering is fully deterministic and can be asserted row by row.
+   */
+  private Dataset<Row> buildTwoIntColumnFrame(List<Row> rows) {
+    StructType schema = new StructType(new StructField[] {
+        new StructField("c1", DataTypes.IntegerType, true, org.apache.spark.sql.types.Metadata.empty()),
+        new StructField("c2", DataTypes.IntegerType, true, org.apache.spark.sql.types.Metadata.empty())
+    });
+    return sparkSession.createDataFrame(rows, schema);
+  }
+
+  /**
+   * Recomputes the Z-curve ordinal for a two-int row using the same public byte mapping
+   * the helper relies on, so the expected ordering is derived independently.
+   */
+  private byte[] expectedZOrdinal(Integer c1, Integer c2) {
+    byte[] b1 = BinaryUtil.intTo8Byte(c1 == null ? Integer.MAX_VALUE : c1);
+    byte[] b2 = BinaryUtil.intTo8Byte(c2 == null ? Integer.MAX_VALUE : c2);
+    return BinaryUtil.interleaving(new byte[][] {b1, b2}, 8);
+  }
+
+  private static int compareUnsigned(byte[] a, byte[] b) {
+    for (int i = 0; i < a.length && i < b.length; i++) {
+      int cmp = (a[i] & 0xFF) - (b[i] & 0xFF);
+      if (cmp != 0) {
+        return cmp;
+      }
+    }
+    return a.length - b.length;
+  }
+
+  @Test
+  void orderByMappingValuesZOrderPreservesSchemaAndSortsByCurve() {
+    List<Row> rows = Arrays.asList(
+        RowFactory.create(5, 5),
+        RowFactory.create(1, 9),
+        RowFactory.create(9, 1),
+        RowFactory.create(1, 1));
+    Dataset<Row> df = buildTwoIntColumnFrame(rows);
+
+    Dataset<Row> ordered = SpaceCurveSortingHelper.orderDataFrameByMappingValues(
+        df, HoodieClusteringConfig.LayoutOptimizationStrategy.ZORDER, Arrays.asList("c1", "c2"), 1);
+
+    // The helper drops the internal Index column, so the output schema must match the input exactly.
+    Assertions.assertArrayEquals(
+        new String[] {"c1", "c2"}, ordered.schema().fieldNames(),
+        "z-order output must retain only the original columns");
+
+    List<Row> result = ordered.collectAsList();
+    Assertions.assertEquals(rows.size(), result.size(), "no rows should be dropped");
+
+    // Every emitted row must be non-decreasing under the independently recomputed Z-curve ordinal.
+    for (int i = 1; i < result.size(); i++) {
+      byte[] prev = expectedZOrdinal(result.get(i - 1).getInt(0), result.get(i - 1).getInt(1));
+      byte[] curr = expectedZOrdinal(result.get(i).getInt(0), result.get(i).getInt(1));
+      Assertions.assertTrue(compareUnsigned(prev, curr) <= 0,
+          "row " + i + " violates ascending Z-curve order");
+    }
+
+    // (1,1) has the smallest interleaved ordinal, so it must sort first.
+    Row first = result.get(0);
+    Assertions.assertEquals(1, first.getInt(0));
+    Assertions.assertEquals(1, first.getInt(1));
+  }
+
+  @Test
+  void orderByMappingValuesZOrderPlacesNullLast() {
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(2, 2));
+    rows.add(RowFactory.create(null, null));
+    rows.add(RowFactory.create(1, 1));
+    Dataset<Row> df = buildTwoIntColumnFrame(rows);
+
+    Dataset<Row> ordered = SpaceCurveSortingHelper.orderDataFrameByMappingValues(
+        df, HoodieClusteringConfig.LayoutOptimizationStrategy.ZORDER, Arrays.asList("c1", "c2"), 1);
+
+    List<Row> result = ordered.collectAsList();
+    Assertions.assertEquals(3, result.size());
+    // Nulls map to Integer.MAX_VALUE in the byte mapping, so the all-null row sorts last.
+    Row last = result.get(result.size() - 1);
+    Assertions.assertTrue(last.isNullAt(0) && last.isNullAt(1),
+        "the all-null row must sort last under Z-curve mapping");
+  }
+
+  @Test
+  void orderByMappingValuesHilbertPreservesRowsAndSchema() {
+    List<Row> rows = Arrays.asList(
+        RowFactory.create(7, 3),
+        RowFactory.create(0, 0),
+        RowFactory.create(4, 4));
+    Dataset<Row> df = buildTwoIntColumnFrame(rows);
+
+    Dataset<Row> ordered = SpaceCurveSortingHelper.orderDataFrameByMappingValues(
+        df, HoodieClusteringConfig.LayoutOptimizationStrategy.HILBERT, Arrays.asList("c1", "c2"), 1);
+
+    Assertions.assertArrayEquals(new String[] {"c1", "c2"}, ordered.schema().fieldNames(),
+        "hilbert output must retain only the original columns");
+    List<Row> result = ordered.collectAsList();
+    Assertions.assertEquals(rows.size(), result.size(), "hilbert ordering must not drop rows");
+    // Origin (0,0) maps to the smallest Hilbert index, so it must sort first.
+    Assertions.assertEquals(0, result.get(0).getInt(0));
+    Assertions.assertEquals(0, result.get(0).getInt(1));
+  }
+
+  @Test
+  void orderByMappingValuesSingleColumnIsLinearOrder() {
+    List<Row> rows = Arrays.asList(
+        RowFactory.create(3, 30),
+        RowFactory.create(1, 10),
+        RowFactory.create(2, 20));
+    Dataset<Row> df = buildTwoIntColumnFrame(rows);
+
+    // A single ordering column short-circuits space-curve mapping into a plain range repartition.
+    Dataset<Row> ordered = SpaceCurveSortingHelper.orderDataFrameByMappingValues(
+        df, HoodieClusteringConfig.LayoutOptimizationStrategy.ZORDER, Arrays.asList("c1"), 1);
+
+    Assertions.assertArrayEquals(new String[] {"c1", "c2"}, ordered.schema().fieldNames(),
+        "single-column ordering must not add an Index column");
+    List<Row> result = ordered.collectAsList();
+    List<Integer> c1Values = new ArrayList<>();
+    for (Row r : result) {
+      c1Values.add(r.getInt(0));
+    }
+    Assertions.assertEquals(Arrays.asList(1, 2, 3), c1Values,
+        "single-column ordering must produce ascending values");
+  }
+
+  @Test
+  void orderByMappingValuesUnknownColumnReturnsInputUnchanged() {
+    List<Row> rows = Arrays.asList(RowFactory.create(2, 2), RowFactory.create(1, 1));
+    Dataset<Row> df = buildTwoIntColumnFrame(rows);
+
+    // Ordering by a column absent from the schema must be a no-op that returns the same frame.
+    Dataset<Row> ordered = SpaceCurveSortingHelper.orderDataFrameByMappingValues(
+        df, HoodieClusteringConfig.LayoutOptimizationStrategy.ZORDER, Arrays.asList("missing"), 1);
+
+    Assertions.assertSame(df, ordered, "missing order column must return the untouched input frame");
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The `hudi-spark-client` row, schema, and sort utility classes have thin unit-test coverage. This PR raises coverage of the space-curve sorting helper and the Spark value-metadata conversion helper using only a local `SparkSession`, with no cluster or table services.

### Summary and Changelog

Adds pure local-Spark unit tests for two `hudi-spark-client` utilities:

- `SpaceCurveSortingHelper.orderDataFrameByMappingValues` (extends the existing `TestRangeSampleSort`): asserts value-by-value that ZORDER and HILBERT ordering preserve the original schema (the internal `Index` column is dropped) and keep every row, that rows come out non-decreasing under an independently recomputed Z-curve ordinal, that all-null rows sort last, that the Hilbert origin sorts first, that a single ordering column short-circuits to a plain range repartition (asserted via the cross-partition range contract and row preservation, since `repartitionByRange` does not sort rows within a partition), and that an unknown order column returns the untouched input frame.
- `SparkValueMetadataUtils` (new `TestSparkValueMetadataUtils`): a parameterized matrix asserting each Spark data type maps to the expected `ValueType`, decimal precision/scale carry-through, the below-V2 index version returning the shared V1 empty metadata, null-type handling, and the `convertSparkToJava` / `convertJavaTypeToSparkType` round-trips for primitives, decimal, bytes, date (epoch-day), and timestamp (micros) including the legacy vs java8 date-time API branches.

Note: writing these tests surfaced that the single-column short-circuit in `SpaceCurveSortingHelper` only range-partitions and does not sort rows within partitions, unlike the multi-column paths which perform a full sort. That production behavior is out of scope here and is tracked separately.

No production code was changed. No code was copied.

### Impact

None. Test-only change; no public API or user-facing behavior is affected.

### Risk Level

low

Test-only additions that run against a local `SparkSession` with unique in-process fixtures and standard teardown, so there is no shared state or resource leakage.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
