### PR TITLE
test(common): add unit coverage for config and utility classes

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/ConfigGroups.java
@@ -130,6 +130,10 @@ public class ConfigGroups {
             + "write schema, cleaning etc. Although Hudi provides sane defaults, from time-time "
             + "these configs may need to be tweaked to optimize for specific workloads.";
         break;
+      case READER:
+        description = "These set of configs control the behavior of reading Hudi tables, "
+            + "such as file group reading.";
+        break;
       case META_SYNC:
         description = "Configurations used by the Hudi to sync metadata to external metastores and catalogs.";
         break;

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieIndexingConfig.java
@@ -95,7 +95,7 @@ public class HoodieIndexingConfig extends HoodieConfig {
       .withDocumentation("Index definition checksum is used to guard against partial writes in HDFS. "
           + "It is added as the last entry in index.properties and then used to validate while reading table config.");
 
-  private static final String INDEX_DEFINITION_CHECKSUM_FORMAT = "%s.%s"; // <index_name>.<index_type>
+  private static final String INDEX_DEFINITION_CHECKSUM_FORMAT = "%s.%s"; // <index_type>.<index_name>
 
   public HoodieIndexingConfig() {
     super();
@@ -208,9 +208,9 @@ public class HoodieIndexingConfig extends HoodieConfig {
     if (!props.containsKey(INDEX_NAME.key())) {
       throw new IllegalArgumentException(INDEX_NAME.key() + " property needs to be specified");
     }
-    String table = props.getProperty(INDEX_NAME.key());
-    String database = props.getProperty(INDEX_TYPE.key(), "");
-    return BinaryUtil.generateChecksum(getUTF8Bytes(String.format(INDEX_DEFINITION_CHECKSUM_FORMAT, database, table)));
+    String indexName = props.getProperty(INDEX_NAME.key());
+    String indexType = props.getProperty(INDEX_TYPE.key(), "");
+    return BinaryUtil.generateChecksum(getUTF8Bytes(String.format(INDEX_DEFINITION_CHECKSUM_FORMAT, indexType, indexName)));
   }
 
   public static boolean validateChecksum(Properties props) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestConfigGroups.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestConfigGroups.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link ConfigGroups}.
+ */
+public class TestConfigGroups {
+
+  @ParameterizedTest
+  @EnumSource(ConfigGroups.Names.class)
+  public void testGetDescriptionReturnsNonPlaceholderForEveryName(ConfigGroups.Names name) {
+    String description = ConfigGroups.getDescription(name);
+    assertNotNull(description);
+    assertFalse(description.isEmpty(), "Description should not be empty for " + name);
+    assertFalse(description.startsWith("Please fill in the description"),
+        "Every enum constant should have a real description branch, missing for " + name);
+  }
+
+  @Test
+  public void testGetDescriptionSpecificValues() {
+    assertEquals("Basic Hudi Table configuration parameters.",
+        ConfigGroups.getDescription(ConfigGroups.Names.TABLE_CONFIG));
+    assertEquals("Configurations specific to Amazon Web Services.",
+        ConfigGroups.getDescription(ConfigGroups.Names.AWS));
+    assertTrue(ConfigGroups.getDescription(ConfigGroups.Names.ENVIRONMENT_CONFIG)
+        .contains("hudi-defaults.conf"));
+  }
+
+  @Test
+  public void testNamesCarryHumanReadableName() {
+    assertEquals("Hudi Table Config", ConfigGroups.Names.TABLE_CONFIG.name);
+    assertEquals("Metrics Configs", ConfigGroups.Names.METRICS.name);
+  }
+
+  @Test
+  public void testSubGroupNamesCarryNameAndDescription() {
+    assertEquals("Index Configs", ConfigGroups.SubGroupNames.INDEX.name);
+    assertTrue(ConfigGroups.SubGroupNames.INDEX.getDescription().contains("indexing behavior"));
+    assertEquals("None", ConfigGroups.SubGroupNames.NONE.name);
+    assertNotNull(ConfigGroups.SubGroupNames.LOCK.getDescription());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestConfigGroups.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestConfigGroups.java
@@ -30,11 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests {@link ConfigGroups}.
  */
-public class TestConfigGroups {
+class TestConfigGroups {
 
   @ParameterizedTest
   @EnumSource(ConfigGroups.Names.class)
-  public void testGetDescriptionReturnsNonPlaceholderForEveryName(ConfigGroups.Names name) {
+  void testGetDescriptionReturnsNonPlaceholderForEveryName(ConfigGroups.Names name) {
     String description = ConfigGroups.getDescription(name);
     assertNotNull(description);
     assertFalse(description.isEmpty(), "Description should not be empty for " + name);
@@ -43,7 +43,7 @@ public class TestConfigGroups {
   }
 
   @Test
-  public void testGetDescriptionSpecificValues() {
+  void testGetDescriptionSpecificValues() {
     assertEquals("Basic Hudi Table configuration parameters.",
         ConfigGroups.getDescription(ConfigGroups.Names.TABLE_CONFIG));
     assertEquals("Configurations specific to Amazon Web Services.",
@@ -53,13 +53,13 @@ public class TestConfigGroups {
   }
 
   @Test
-  public void testNamesCarryHumanReadableName() {
+  void testNamesCarryHumanReadableName() {
     assertEquals("Hudi Table Config", ConfigGroups.Names.TABLE_CONFIG.name);
     assertEquals("Metrics Configs", ConfigGroups.Names.METRICS.name);
   }
 
   @Test
-  public void testSubGroupNamesCarryNameAndDescription() {
+  void testSubGroupNamesCarryNameAndDescription() {
     assertEquals("Index Configs", ConfigGroups.SubGroupNames.INDEX.name);
     assertTrue(ConfigGroups.SubGroupNames.INDEX.getDescription().contains("indexing behavior"));
     assertEquals("None", ConfigGroups.SubGroupNames.NONE.name);

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieIndexingConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieIndexingConfig.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.config;
+
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.metadata.MetadataPartitionType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link HoodieIndexingConfig}.
+ */
+public class TestHoodieIndexingConfig {
+
+  @Test
+  public void testBuilderSetsProvidedValues() {
+    HoodieIndexingConfig config = HoodieIndexingConfig.newBuilder()
+        .withIndexName("column_stats")
+        .withIndexType(MetadataPartitionType.BLOOM_FILTERS.name())
+        .withIndexFunction("lower")
+        .build();
+
+    assertEquals("column_stats", config.getIndexName());
+    assertEquals(MetadataPartitionType.BLOOM_FILTERS.name(), config.getIndexType());
+    assertEquals("lower", config.getIndexFunction());
+  }
+
+  @Test
+  public void testBuildAppliesDefaultIndexType() {
+    HoodieIndexingConfig config = HoodieIndexingConfig.newBuilder()
+        .withIndexName("column_stats")
+        .build();
+
+    // INDEX_TYPE defaults to COLUMN_STATS, INDEX_NAME and INDEX_FUNCTION have no defaults.
+    assertEquals(MetadataPartitionType.COLUMN_STATS.name(), config.getIndexType());
+    assertEquals("column_stats", config.getIndexName());
+    assertNull(config.getIndexFunction());
+  }
+
+  @Test
+  public void testIsIndexUsingHelpers() {
+    HoodieIndexingConfig bloom = HoodieIndexingConfig.newBuilder()
+        .withIndexName("column_stats")
+        .withIndexType(MetadataPartitionType.BLOOM_FILTERS.name())
+        .build();
+    assertTrue(bloom.isIndexUsingBloomFilter());
+    assertFalse(bloom.isIndexUsingColumnStats());
+    assertFalse(bloom.isIndexUsingRecordIndex());
+
+    HoodieIndexingConfig columnStats = HoodieIndexingConfig.newBuilder()
+        .withIndexName("column_stats")
+        .withIndexType(MetadataPartitionType.COLUMN_STATS.name())
+        .build();
+    assertTrue(columnStats.isIndexUsingColumnStats());
+
+    HoodieIndexingConfig recordIndex = HoodieIndexingConfig.newBuilder()
+        .withIndexName("column_stats")
+        .withIndexType(MetadataPartitionType.RECORD_INDEX.name())
+        .build();
+    assertTrue(recordIndex.isIndexUsingRecordIndex());
+  }
+
+  @Test
+  public void testFromPropertiesCarriesOverValues() {
+    Properties props = new Properties();
+    props.setProperty(HoodieIndexingConfig.INDEX_NAME.key(), "column_stats");
+    props.setProperty(HoodieIndexingConfig.INDEX_FUNCTION.key(), "identity");
+
+    HoodieIndexingConfig config = HoodieIndexingConfig.newBuilder()
+        .fromProperties(props)
+        .build();
+
+    assertEquals("column_stats", config.getIndexName());
+    assertEquals("identity", config.getIndexFunction());
+  }
+
+  @Test
+  public void testCopyProducesEqualConfig() {
+    HoodieIndexingConfig source = HoodieIndexingConfig.newBuilder()
+        .withIndexName("column_stats")
+        .withIndexType(MetadataPartitionType.BLOOM_FILTERS.name())
+        .withIndexFunction("lower")
+        .build();
+
+    HoodieIndexingConfig copy = HoodieIndexingConfig.copy(source);
+    assertEquals(source.getIndexName(), copy.getIndexName());
+    assertEquals(source.getIndexType(), copy.getIndexType());
+    assertEquals(source.getIndexFunction(), copy.getIndexFunction());
+  }
+
+  @Test
+  public void testMergeLetsSecondConfigOverride() {
+    HoodieIndexingConfig first = HoodieIndexingConfig.newBuilder()
+        .withIndexName("column_stats")
+        .withIndexType(MetadataPartitionType.COLUMN_STATS.name())
+        .build();
+    HoodieIndexingConfig second = HoodieIndexingConfig.newBuilder()
+        .withIndexType(MetadataPartitionType.BLOOM_FILTERS.name())
+        .withIndexFunction("upper")
+        .build();
+
+    HoodieIndexingConfig merged = HoodieIndexingConfig.merge(first, second);
+    assertEquals("column_stats", merged.getIndexName());
+    assertEquals(MetadataPartitionType.BLOOM_FILTERS.name(), merged.getIndexType());
+    assertEquals("upper", merged.getIndexFunction());
+  }
+
+  @Test
+  public void testFromIndexDefinition() {
+    HoodieIndexDefinition definition = HoodieIndexDefinition.newBuilder()
+        .withIndexName("column_stats")
+        .withIndexType(MetadataPartitionType.COLUMN_STATS.name())
+        .withIndexFunction("identity")
+        .build();
+
+    HoodieIndexingConfig config = HoodieIndexingConfig.fromIndexDefinition(definition);
+    assertEquals("column_stats", config.getIndexName());
+    assertEquals(MetadataPartitionType.COLUMN_STATS.name(), config.getIndexType());
+    assertEquals("identity", config.getIndexFunction());
+  }
+
+  @Test
+  public void testGenerateAndValidateChecksum() {
+    Properties props = new Properties();
+    props.setProperty(HoodieIndexingConfig.INDEX_NAME.key(), "column_stats");
+    props.setProperty(HoodieIndexingConfig.INDEX_TYPE.key(), MetadataPartitionType.COLUMN_STATS.name());
+
+    long checksum = HoodieIndexingConfig.generateChecksum(props);
+    // Checksum must be deterministic for the same inputs.
+    assertEquals(checksum, HoodieIndexingConfig.generateChecksum(props));
+
+    props.setProperty(HoodieIndexingConfig.INDEX_DEFINITION_CHECKSUM.key(), String.valueOf(checksum));
+    assertTrue(HoodieIndexingConfig.validateChecksum(props));
+
+    props.setProperty(HoodieIndexingConfig.INDEX_DEFINITION_CHECKSUM.key(), String.valueOf(checksum + 1));
+    assertFalse(HoodieIndexingConfig.validateChecksum(props));
+  }
+
+  @Test
+  public void testGenerateChecksumRequiresIndexName() {
+    Properties props = new Properties();
+    props.setProperty(HoodieIndexingConfig.INDEX_TYPE.key(), MetadataPartitionType.COLUMN_STATS.name());
+    assertThrows(IllegalArgumentException.class, () -> HoodieIndexingConfig.generateChecksum(props));
+  }
+
+  @Test
+  public void testDefaultExpressionIndexRangeMetadataStorageLevel() {
+    HoodieIndexingConfig config = HoodieIndexingConfig.newBuilder()
+        .withIndexName("column_stats")
+        .build();
+    assertEquals("MEMORY_AND_DISK_SER", config.getExpressionIndexRangeMetadataStorageLevel());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieIndexingConfig.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/config/TestHoodieIndexingConfig.java
@@ -34,23 +34,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests {@link HoodieIndexingConfig}.
  */
-public class TestHoodieIndexingConfig {
+class TestHoodieIndexingConfig {
 
   @Test
-  public void testBuilderSetsProvidedValues() {
+  void testBuilderSetsProvidedValues() {
     HoodieIndexingConfig config = HoodieIndexingConfig.newBuilder()
-        .withIndexName("column_stats")
+        .withIndexName("idx_bloom")
         .withIndexType(MetadataPartitionType.BLOOM_FILTERS.name())
         .withIndexFunction("lower")
         .build();
 
-    assertEquals("column_stats", config.getIndexName());
+    assertEquals("idx_bloom", config.getIndexName());
     assertEquals(MetadataPartitionType.BLOOM_FILTERS.name(), config.getIndexType());
     assertEquals("lower", config.getIndexFunction());
   }
 
   @Test
-  public void testBuildAppliesDefaultIndexType() {
+  void testBuildAppliesDefaultIndexType() {
     HoodieIndexingConfig config = HoodieIndexingConfig.newBuilder()
         .withIndexName("column_stats")
         .build();
@@ -62,9 +62,9 @@ public class TestHoodieIndexingConfig {
   }
 
   @Test
-  public void testIsIndexUsingHelpers() {
+  void testIsIndexUsingHelpers() {
     HoodieIndexingConfig bloom = HoodieIndexingConfig.newBuilder()
-        .withIndexName("column_stats")
+        .withIndexName("idx_bloom")
         .withIndexType(MetadataPartitionType.BLOOM_FILTERS.name())
         .build();
     assertTrue(bloom.isIndexUsingBloomFilter());
@@ -78,14 +78,14 @@ public class TestHoodieIndexingConfig {
     assertTrue(columnStats.isIndexUsingColumnStats());
 
     HoodieIndexingConfig recordIndex = HoodieIndexingConfig.newBuilder()
-        .withIndexName("column_stats")
+        .withIndexName("idx_record")
         .withIndexType(MetadataPartitionType.RECORD_INDEX.name())
         .build();
     assertTrue(recordIndex.isIndexUsingRecordIndex());
   }
 
   @Test
-  public void testFromPropertiesCarriesOverValues() {
+  void testFromPropertiesCarriesOverValues() {
     Properties props = new Properties();
     props.setProperty(HoodieIndexingConfig.INDEX_NAME.key(), "column_stats");
     props.setProperty(HoodieIndexingConfig.INDEX_FUNCTION.key(), "identity");
@@ -99,9 +99,9 @@ public class TestHoodieIndexingConfig {
   }
 
   @Test
-  public void testCopyProducesEqualConfig() {
+  void testCopyProducesEqualConfig() {
     HoodieIndexingConfig source = HoodieIndexingConfig.newBuilder()
-        .withIndexName("column_stats")
+        .withIndexName("idx_bloom")
         .withIndexType(MetadataPartitionType.BLOOM_FILTERS.name())
         .withIndexFunction("lower")
         .build();
@@ -113,9 +113,9 @@ public class TestHoodieIndexingConfig {
   }
 
   @Test
-  public void testMergeLetsSecondConfigOverride() {
+  void testMergeLetsSecondConfigOverride() {
     HoodieIndexingConfig first = HoodieIndexingConfig.newBuilder()
-        .withIndexName("column_stats")
+        .withIndexName("idx_original")
         .withIndexType(MetadataPartitionType.COLUMN_STATS.name())
         .build();
     HoodieIndexingConfig second = HoodieIndexingConfig.newBuilder()
@@ -124,13 +124,13 @@ public class TestHoodieIndexingConfig {
         .build();
 
     HoodieIndexingConfig merged = HoodieIndexingConfig.merge(first, second);
-    assertEquals("column_stats", merged.getIndexName());
+    assertEquals("idx_original", merged.getIndexName());
     assertEquals(MetadataPartitionType.BLOOM_FILTERS.name(), merged.getIndexType());
     assertEquals("upper", merged.getIndexFunction());
   }
 
   @Test
-  public void testFromIndexDefinition() {
+  void testFromIndexDefinition() {
     HoodieIndexDefinition definition = HoodieIndexDefinition.newBuilder()
         .withIndexName("column_stats")
         .withIndexType(MetadataPartitionType.COLUMN_STATS.name())
@@ -144,7 +144,7 @@ public class TestHoodieIndexingConfig {
   }
 
   @Test
-  public void testGenerateAndValidateChecksum() {
+  void testGenerateAndValidateChecksum() {
     Properties props = new Properties();
     props.setProperty(HoodieIndexingConfig.INDEX_NAME.key(), "column_stats");
     props.setProperty(HoodieIndexingConfig.INDEX_TYPE.key(), MetadataPartitionType.COLUMN_STATS.name());
@@ -161,14 +161,14 @@ public class TestHoodieIndexingConfig {
   }
 
   @Test
-  public void testGenerateChecksumRequiresIndexName() {
+  void testGenerateChecksumRequiresIndexName() {
     Properties props = new Properties();
     props.setProperty(HoodieIndexingConfig.INDEX_TYPE.key(), MetadataPartitionType.COLUMN_STATS.name());
     assertThrows(IllegalArgumentException.class, () -> HoodieIndexingConfig.generateChecksum(props));
   }
 
   @Test
-  public void testDefaultExpressionIndexRangeMetadataStorageLevel() {
+  void testDefaultExpressionIndexRangeMetadataStorageLevel() {
     HoodieIndexingConfig config = HoodieIndexingConfig.newBuilder()
         .withIndexName("column_stats")
         .build();

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCollectionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCollectionUtils.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.util.CollectionUtils.append;
@@ -168,7 +169,7 @@ class TestCollectionUtils {
   void toStreamAndToListDrainIterator() {
     List<Integer> source = Arrays.asList(1, 2, 3);
     assertEquals(source, toList(source.iterator()));
-    assertEquals(source, toStream(source.iterator()).collect(java.util.stream.Collectors.toList()));
+    assertEquals(source, toStream(source.iterator()).collect(Collectors.toList()));
   }
 
   @Test
@@ -260,6 +261,7 @@ class TestCollectionUtils {
 
   @Test
   void emptyPropsReturnsSharedSingleton() {
+    // Emptiness also guards against illegal mutation of the shared singleton elsewhere.
     assertTrue(CollectionUtils.emptyProps().isEmpty());
     assertSame(CollectionUtils.emptyProps(), CollectionUtils.emptyProps());
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCollectionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCollectionUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.common.util.collection.Pair;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -28,14 +30,38 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.util.CollectionUtils.append;
 import static org.apache.hudi.common.util.CollectionUtils.batches;
+import static org.apache.hudi.common.util.CollectionUtils.combine;
 import static org.apache.hudi.common.util.CollectionUtils.containsAll;
+import static org.apache.hudi.common.util.CollectionUtils.copy;
+import static org.apache.hudi.common.util.CollectionUtils.createImmutableList;
+import static org.apache.hudi.common.util.CollectionUtils.createImmutableMap;
+import static org.apache.hudi.common.util.CollectionUtils.createImmutableSet;
+import static org.apache.hudi.common.util.CollectionUtils.createSet;
+import static org.apache.hudi.common.util.CollectionUtils.diff;
+import static org.apache.hudi.common.util.CollectionUtils.diffSet;
+import static org.apache.hudi.common.util.CollectionUtils.elementsEqual;
+import static org.apache.hudi.common.util.CollectionUtils.isNullOrEmpty;
+import static org.apache.hudi.common.util.CollectionUtils.nonEmpty;
+import static org.apache.hudi.common.util.CollectionUtils.reduce;
+import static org.apache.hudi.common.util.CollectionUtils.reverseMap;
+import static org.apache.hudi.common.util.CollectionUtils.tail;
+import static org.apache.hudi.common.util.CollectionUtils.toList;
+import static org.apache.hudi.common.util.CollectionUtils.toStream;
+import static org.apache.hudi.common.util.CollectionUtils.zipToMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestCollectionUtils {
 
@@ -94,5 +120,147 @@ class TestCollectionUtils {
     assertEquals(2, intsBatches2.size());
     assertEquals(Arrays.asList(1, 2, 3, 4, 5), intsBatches2.get(0));
     assertEquals(Collections.singletonList(6), intsBatches2.get(1));
+  }
+
+  @Test
+  void isNullOrEmptyAndNonEmptyForCollections() {
+    assertTrue(isNullOrEmpty((List<?>) null));
+    assertTrue(isNullOrEmpty(Collections.emptyList()));
+    assertFalse(isNullOrEmpty(Collections.singletonList("a")));
+    assertFalse(nonEmpty((List<?>) null));
+    assertFalse(nonEmpty(Collections.emptyList()));
+    assertTrue(nonEmpty(Collections.singletonList("a")));
+  }
+
+  @Test
+  void isNullOrEmptyAndNonEmptyForMaps() {
+    assertTrue(isNullOrEmpty((Map<?, ?>) null));
+    assertTrue(isNullOrEmpty(Collections.emptyMap()));
+    assertFalse(isNullOrEmpty(Collections.singletonMap("k", "v")));
+    assertFalse(nonEmpty((Map<?, ?>) null));
+    assertTrue(nonEmpty(Collections.singletonMap("k", "v")));
+  }
+
+  @Test
+  void reduceAppliesReducerSequentially() {
+    int sum = reduce(Arrays.asList(1, 2, 3, 4), 0, Integer::sum);
+    assertEquals(10, sum);
+    assertEquals(100, reduce(Collections.<Integer>emptyList(), 100, Integer::sum));
+  }
+
+  @Test
+  void copyReturnsIndependentProperties() {
+    Properties original = new Properties();
+    original.setProperty("k", "v");
+    Properties copied = copy(original);
+    assertEquals("v", copied.getProperty("k"));
+    copied.setProperty("k2", "v2");
+    assertFalse(original.containsKey("k2"), "Copy must not share state with the original");
+  }
+
+  @Test
+  void tailReturnsLastElementAndRejectsEmpty() {
+    assertEquals("c", tail(new String[] {"a", "b", "c"}));
+    assertThrows(IllegalArgumentException.class, () -> tail(new String[0]));
+  }
+
+  @Test
+  void toStreamAndToListDrainIterator() {
+    List<Integer> source = Arrays.asList(1, 2, 3);
+    assertEquals(source, toList(source.iterator()));
+    assertEquals(source, toStream(source.iterator()).collect(java.util.stream.Collectors.toList()));
+  }
+
+  @Test
+  void combineArraysAndAppendElement() {
+    Integer[] combined = combine(new Integer[] {1, 2}, new Integer[] {3, 4});
+    assertEquals(Arrays.asList(1, 2, 3, 4), Arrays.asList(combined));
+    Integer[] appended = append(new Integer[] {1, 2}, 3);
+    assertEquals(Arrays.asList(1, 2, 3), Arrays.asList(appended));
+  }
+
+  @Test
+  void combineListsAndMaps() {
+    assertEquals(Arrays.asList(1, 2, 3, 4), combine(Arrays.asList(1, 2), Arrays.asList(3, 4)));
+
+    Map<String, Integer> one = new HashMap<>();
+    one.put("a", 1);
+    one.put("b", 2);
+    Map<String, Integer> another = new HashMap<>();
+    another.put("b", 20);
+    another.put("c", 3);
+
+    Map<String, Integer> overridden = combine(one, another);
+    assertEquals(20, overridden.get("b"), "Second map should override on key conflict");
+    assertEquals(3, overridden.size());
+
+    Map<String, Integer> merged = combine(one, another, Integer::sum);
+    assertEquals(22, merged.get("b"), "Merge function should combine overlapping values");
+    assertEquals(1, merged.get("a"));
+    assertEquals(3, merged.get("c"));
+  }
+
+  @Test
+  void zipToMapPairsKeysAndValues() {
+    Map<String, Integer> zipped = zipToMap(Arrays.asList("a", "b"), Arrays.asList(1, 2));
+    assertEquals(1, zipped.get("a"));
+    assertEquals(2, zipped.get("b"));
+    assertThrows(IllegalArgumentException.class,
+        () -> zipToMap(Arrays.asList("a", "b"), Collections.singletonList(1)));
+  }
+
+  @Test
+  void diffAndDiffSetRemoveCommonElements() {
+    Set<Integer> setDiff = diffSet(Arrays.asList(1, 2, 3), new HashSet<>(Arrays.asList(2, 3)));
+    assertEquals(Collections.singleton(1), setDiff);
+
+    List<Integer> listDiff = diff(Arrays.asList(1, 2, 2, 3), Collections.singletonList(3));
+    assertEquals(Arrays.asList(1, 2, 2), listDiff);
+  }
+
+  @Test
+  void elementsEqualComparesInOrder() {
+    assertTrue(elementsEqual(Arrays.asList(1, 2, 3).iterator(), Arrays.asList(1, 2, 3).iterator()));
+    assertFalse(elementsEqual(Arrays.asList(1, 2).iterator(), Arrays.asList(1, 2, 3).iterator()));
+    assertFalse(elementsEqual(Arrays.asList(1, 2, 3).iterator(), Arrays.asList(1, 2).iterator()));
+    assertFalse(elementsEqual(Arrays.asList(1, 9).iterator(), Arrays.asList(1, 2).iterator()));
+  }
+
+  @Test
+  void createImmutableCollectionsRejectMutation() {
+    List<String> list = createImmutableList("a", "b");
+    assertEquals(Arrays.asList("a", "b"), list);
+    assertThrows(UnsupportedOperationException.class, () -> list.add("c"));
+
+    Set<String> set = createImmutableSet("a", "b");
+    assertEquals(new HashSet<>(Arrays.asList("a", "b")), set);
+    assertThrows(UnsupportedOperationException.class, () -> set.add("c"));
+
+    Map<String, Integer> map = createImmutableMap(Pair.of("a", 1), Pair.of("b", 2));
+    assertEquals(1, map.get("a"));
+    assertEquals(2, map.get("b"));
+    assertThrows(UnsupportedOperationException.class, () -> map.put("c", 3));
+  }
+
+  @Test
+  void createSetCollectsDistinctElements() {
+    assertEquals(new HashSet<>(Arrays.asList("a", "b")), createSet("a", "b", "a"));
+  }
+
+  @Test
+  void reverseMapSwapsKeysAndValues() {
+    Map<String, Integer> source = new HashMap<>();
+    source.put("a", 1);
+    source.put("b", 2);
+    Map<Integer, String> reversed = reverseMap(source);
+    assertEquals("a", reversed.get(1));
+    assertEquals("b", reversed.get(2));
+    assertThrows(UnsupportedOperationException.class, () -> reversed.put(3, "c"));
+  }
+
+  @Test
+  void emptyPropsReturnsSharedSingleton() {
+    assertTrue(CollectionUtils.emptyProps().isEmpty());
+    assertSame(CollectionUtils.emptyProps(), CollectionUtils.emptyProps());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestDateTimeUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestDateTimeUtils.java
@@ -21,11 +21,16 @@ package org.apache.hudi.common.util;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.time.format.DateTimeParseException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -54,5 +59,103 @@ public class TestDateTimeUtils {
     assertThrows(IllegalArgumentException.class, () -> {
       DateTimeUtils.parseDateTime(null);
     });
+  }
+
+  @Test
+  public void testParseDateTimeParsesEpochMillisAsMillis() {
+    // A numeric string is treated as epoch millis, not ISO-8601.
+    assertEquals(Instant.ofEpochMilli(1612542030000L), DateTimeUtils.parseDateTime("1612542030000"));
+  }
+
+  @Test
+  public void testMicrosInstantRoundTripForPositiveEpoch() {
+    Instant instant = Instant.ofEpochSecond(1, 2000);
+    assertEquals(1_000_002L, DateTimeUtils.instantToMicros(instant));
+    assertEquals(instant, DateTimeUtils.microsToInstant(1_000_002L));
+  }
+
+  @Test
+  public void testMicrosInstantForNegativeEpochWithNanos() {
+    // Before the epoch with a sub-second nano component exercises the negative-seconds branch.
+    Instant instant = Instant.ofEpochSecond(-2, 500_000_000);
+    long micros = DateTimeUtils.instantToMicros(instant);
+    assertEquals(-1_500_000L, micros);
+    assertEquals(instant, DateTimeUtils.microsToInstant(micros));
+  }
+
+  @Test
+  public void testNanosInstantRoundTripForPositiveEpoch() {
+    Instant instant = Instant.ofEpochSecond(3, 456);
+    assertEquals(3_000_000_456L, DateTimeUtils.instantToNanos(instant));
+    assertEquals(instant, DateTimeUtils.nanosToInstant(3_000_000_456L));
+  }
+
+  @Test
+  public void testNanosInstantForNegativeEpochWithNanos() {
+    Instant instant = Instant.ofEpochSecond(-2, 500_000_000);
+    long nanos = DateTimeUtils.instantToNanos(instant);
+    assertEquals(-1_500_000_000L, nanos);
+    assertEquals(instant, DateTimeUtils.nanosToInstant(nanos));
+  }
+
+  @Test
+  public void testMicrosMillisConversion() {
+    assertEquals(1234L, DateTimeUtils.microsToMillis(1_234_567L));
+    // floorDiv rounds towards negative infinity for negative micros.
+    assertEquals(-158L, DateTimeUtils.microsToMillis(-157_500L));
+    assertEquals(1_234_000L, DateTimeUtils.millisToMicros(1234L));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "123, 123",
+      "'123ms', 123",
+      "'321 s', 321000",
+      "'2 min', 120000",
+      "'1 day', 86400000"
+  })
+  public void testParseDurationValidLabels(String text, long expectedMillis) {
+    assertEquals(Duration.of(expectedMillis, ChronoUnit.MILLIS), DateTimeUtils.parseDuration(text));
+  }
+
+  @Test
+  public void testParseDurationDefaultsToMillisWhenUnitOmitted() {
+    assertEquals(Duration.of(500, ChronoUnit.MILLIS), DateTimeUtils.parseDuration("500"));
+  }
+
+  @Test
+  public void testParseDurationRejectsUnknownUnit() {
+    assertThrows(IllegalArgumentException.class, () -> DateTimeUtils.parseDuration("10 fortnights"));
+  }
+
+  @Test
+  public void testParseDurationRejectsMissingNumber() {
+    assertThrows(NumberFormatException.class, () -> DateTimeUtils.parseDuration("ms"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "   "})
+  public void testParseDurationRejectsBlank(String text) {
+    assertThrows(IllegalArgumentException.class, () -> DateTimeUtils.parseDuration(text));
+  }
+
+  @Test
+  public void testParseDurationRejectsNull() {
+    assertThrows(IllegalArgumentException.class, () -> DateTimeUtils.parseDuration(null));
+  }
+
+  @Test
+  public void testFormatUnixTimestamp() {
+    // Uses the system default zone, so validate by re-parsing the formatted output rather
+    // than hardcoding a zone-dependent string.
+    long unixTimestamp = 1_612_542_030L;
+    String formatted = DateTimeUtils.formatUnixTimestamp(unixTimestamp, "yyyy-MM-dd HH:mm:ss");
+    assertEquals(19, formatted.length());
+    assertDoesNotThrow(() -> DateTimeUtils.formatUnixTimestamp(unixTimestamp, "yyyy"));
+  }
+
+  @Test
+  public void testFormatUnixTimestampRejectsEmptyFormat() {
+    assertThrows(IllegalArgumentException.class, () -> DateTimeUtils.formatUnixTimestamp(0L, ""));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestDateTimeUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestDateTimeUtils.java
@@ -26,8 +26,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -149,8 +152,10 @@ public class TestDateTimeUtils {
     // Uses the system default zone, so validate by re-parsing the formatted output rather
     // than hardcoding a zone-dependent string.
     long unixTimestamp = 1_612_542_030L;
-    String formatted = DateTimeUtils.formatUnixTimestamp(unixTimestamp, "yyyy-MM-dd HH:mm:ss");
-    assertEquals(19, formatted.length());
+    String pattern = "yyyy-MM-dd HH:mm:ss";
+    String formatted = DateTimeUtils.formatUnixTimestamp(unixTimestamp, pattern);
+    LocalDateTime parsed = LocalDateTime.parse(formatted, DateTimeFormatter.ofPattern(pattern));
+    assertEquals(unixTimestamp, parsed.atZone(ZoneId.systemDefault()).toEpochSecond());
     assertDoesNotThrow(() -> DateTimeUtils.formatUnixTimestamp(unixTimestamp, "yyyy"));
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Several `hudi-common` configuration and utility classes had little or no unit-test coverage. This PR adds focused, pure JUnit 5 unit tests (no Spark, engine, or table fixtures) to raise coverage of previously untested branches in these classes, and fixes one gap in production the new tests surfaced.

### Summary and Changelog

Adds unit coverage for four `hudi-common` classes:

- `DateTimeUtils`: extends the existing test with micros/nanos/millis conversions (including the negative-epoch branches), `parseDuration` for valid unit labels, unit-omitted default, and invalid/blank/null inputs, and `formatUnixTimestamp` (validated by re-parsing the formatted output, so the assertion is independent of the system time zone).
- `CollectionUtils`: extends the existing test to cover previously untested helpers such as `isNullOrEmpty`/`nonEmpty`, `reduce`, `copy`, `tail`, `toStream`/`toList`, array/list/map `combine` and `append`, `zipToMap`, `diff`/`diffSet`, `elementsEqual`, the immutable-collection factories, `createSet`, `reverseMap`, and `emptyProps`.
- `ConfigGroups`: new test verifying `getDescription` returns a real description for every `Names` constant and that `Names`/`SubGroupNames` carry their human-readable name and description.
- `HoodieIndexingConfig`: new test covering builder paths, default application on `build`, `isIndexUsing*` helpers, `fromProperties`, `copy`, `merge` override semantics, `fromIndexDefinition`, and `generateChecksum`/`validateChecksum` including the missing-index-name error path.

Production changes surfaced by the new tests:

- `ConfigGroups.getDescription` had no `case` for `Names.READER`, so the Reader Configs group fell through to the "Please fill in the description" placeholder (visible in generated config docs). Added the missing description.
- `HoodieIndexingConfig.generateChecksum`: renamed copy-paste-leftover locals (`database`/`table` to `indexType`/`indexName`) and corrected the `INDEX_DEFINITION_CHECKSUM_FORMAT` comment to match the actual argument order. No behavior change; the produced checksum is byte-identical.

### Impact

Docs-only production impact: the Reader Configs group now shows a real description instead of the placeholder on the generated configuration docs. No API or runtime behavior change.

### Risk Level

low

Tests plus a config-description string and a behavior-preserving local-variable rename.

### Documentation Update

The Reader Configs group description on the configurations page will pick up the new text on the next docs regeneration.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
