### PR TITLE
fix(spark): shade parquet-variant into the spark bundle for Spark 4.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,9 @@
               <!-- afterburner module for jackson performance -->
               <include>com.fasterxml.jackson.module:jackson-module-afterburner</include>
               <include>com.fasterxml.jackson.module:jackson-module-scala_${scala.binary.version}</include>
+              <!-- Parquet 1.16.0+ (Spark 4.1+) splits VariantConverters into parquet-variant,
+                   which parquet-avro needs at runtime. No-op for older Spark. See apache/hudi#19234. -->
+              <include>org.apache.parquet:parquet-variant</include>
             </includes>
           </artifactSet>
           <relocations>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes #19234.

On Spark 4.1, every read-modify write (`UPDATE` / `MERGE INTO` / `DELETE`) aborts with `NoClassDefFoundError: org.apache.parquet.variant.VariantConverters$ParentConverter`; only the initial `INSERT` succeeds. This surfaced as the Spark 4.1 hive-sync E2E (`ITTestCustomTypeHiveSync`) failing on `SHOW PARTITIONS`, the second partition was never committed, masked by the fixtures' unconditional success markers.

The hive-sync E2E harness was introduced in #19203; the failing Spark 4.1 matrix row was added in #19216. This PR fixes that failure.

### Summary and Changelog

Parquet **1.16.0** (used by Spark 4.1) split VARIANT support into a separate `org.apache.parquet:parquet-variant` module that carries `VariantConverters`. `parquet-avro:1.16.0`, which `hoodie-spark-bundle` shades and uses on the read path, references it, but the bundle's `maven-shade-plugin` `<artifactSet><includes>` allowlist listed `parquet-avro` and not `parquet-variant`, so the class was dropped from the bundle (and it's not on the Spark runtime classpath either).

- Add `org.apache.parquet:parquet-variant` to the `hoodie-spark-bundle` shade include list. It is already a transitive compile dependency of `parquet-avro` for Parquet 1.16.0+, so the include shades it for Spark 4.1/4.2 and is a **no-op for older Spark** (the artifact does not exist before 1.16.0, so the include matches nothing).

### Impact

Fixes the Spark 4.1 hive-sync E2E (`ITTestCustomTypeHiveSync`) failure introduced with the Spark 4.1 matrix row in #19216. No effect on Spark 3.x / 4.0. Verified: the rebuilt Spark 4.1 bundle now contains `VariantConverters$ParentConverter`.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
