### PR TITLE
feat(tools): add TimelineInspector standalone Java tool for timeline forensics

### DIFF
--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.java
@@ -155,53 +155,57 @@ public class TimelineInspector {
 
   static void run(String[] args) throws ExitException {
     try {
-      Args parsed = Args.parse(args);
-
-      if (parsed.helpRequested) {
-        return;
-      }
-
-      // parse-filename is a pure decode utility -- no metaclient needed.
-      if (parsed.mode == Mode.PARSE_FILENAME) {
-        new TimelineInspector().parseFilename(parsed);
-        return;
-      }
-
-      Configuration hadoopConf = new Configuration();
-      HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
-          .setConf(HadoopFSUtils.getStorageConfWithCopy(hadoopConf))
-          .setBasePath(parsed.basePath)
-          .build();
-
-      TimelineInspector inspector = new TimelineInspector();
-      switch (parsed.mode) {
-        case SHOW_INSTANT:
-          inspector.showInstant(metaClient, parsed);
-          break;
-        case FIND_FILE_ID:
-          inspector.findFileId(metaClient, parsed);
-          break;
-        case RAW_ARCHIVE:
-          inspector.rawArchive(metaClient, parsed);
-          break;
-        case COMMIT_STATS:
-          inspector.commitStats(metaClient, parsed);
-          break;
-        case PHASE_TIMINGS:
-          inspector.phaseTimings(metaClient, parsed);
-          break;
-        default:
-          throw new IllegalStateException("unknown mode " + parsed.mode);
-      }
+      runInternal(args);
     } catch (IllegalArgumentException e) {
       System.err.println("ERROR: " + e.getMessage());
       System.err.println();
       Args.printUsage();
       throw new ExitException(2, e.getMessage());
-    } catch (Exception e) {
+    } catch (IOException | RuntimeException e) {
       System.err.println("ERROR: " + e.getClass().getSimpleName() + ": " + e.getMessage());
       e.printStackTrace(System.err);
       throw new ExitException(1, e.getMessage());
+    }
+  }
+
+  private static void runInternal(String[] args) throws ExitException, IOException {
+    Args parsed = Args.parse(args);
+
+    if (parsed.helpRequested) {
+      return;
+    }
+
+    // parse-filename is a pure decode utility -- no metaclient needed.
+    if (parsed.mode == Mode.PARSE_FILENAME) {
+      new TimelineInspector().parseFilename(parsed);
+      return;
+    }
+
+    Configuration hadoopConf = new Configuration();
+    HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
+        .setConf(HadoopFSUtils.getStorageConfWithCopy(hadoopConf))
+        .setBasePath(parsed.basePath)
+        .build();
+
+    TimelineInspector inspector = new TimelineInspector();
+    switch (parsed.mode) {
+      case SHOW_INSTANT:
+        inspector.showInstant(metaClient, parsed);
+        break;
+      case FIND_FILE_ID:
+        inspector.findFileId(metaClient, parsed);
+        break;
+      case RAW_ARCHIVE:
+        inspector.rawArchive(metaClient, parsed);
+        break;
+      case COMMIT_STATS:
+        inspector.commitStats(metaClient, parsed);
+        break;
+      case PHASE_TIMINGS:
+        inspector.phaseTimings(metaClient, parsed);
+        break;
+      default:
+        throw new IllegalStateException("unknown mode " + parsed.mode);
     }
   }
 
@@ -608,8 +612,9 @@ public class TimelineInspector {
     org.apache.hudi.storage.HoodieStorage storage = metaClient.getStorage();
     org.apache.hudi.storage.StoragePath dataMetaDir =
         new org.apache.hudi.storage.StoragePath(metaClient.getTimelinePath().toString());
-    // Try to build an MDT metaClient so we resolve the correct timeline path for
-    // both V1 (`.hoodie/`) and V2 (`.hoodie/timeline/`) layout tables.
+    // Resolve the MDT timeline directory. Try building an MDT metaClient first (handles
+    // both V1 and V2 layout correctly); if that fails (e.g. no hoodie.properties in the
+    // MDT directory), probe known paths directly.
     String mdtBasePath = metaClient.getBasePath()
         + "/" + HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH;
     HoodieTableMetaClient mdtMetaClient = null;
@@ -624,8 +629,24 @@ public class TimelineInspector {
           mdtMetaClient.getTimelinePath().toString());
       mdtPresent = storage.exists(mdtMetaDir);
     } catch (Exception e) {
-      // MDT does not exist or its hoodie.properties is missing.
-      mdtPresent = false;
+      // MDT hoodie.properties missing — probe known paths directly.
+      // Try V2 path (<base>/.hoodie/metadata/.hoodie/timeline/) first, then V1 (<base>/.hoodie/metadata/.hoodie/).
+      org.apache.hudi.storage.StoragePath v2 = new org.apache.hudi.storage.StoragePath(
+          mdtBasePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME
+              + "/" + HoodieTableMetaClient.TIMELINEFOLDER_NAME);
+      org.apache.hudi.storage.StoragePath v1 = new org.apache.hudi.storage.StoragePath(
+          mdtBasePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME);
+      try {
+        if (storage.exists(v2)) {
+          mdtMetaDir = v2;
+          mdtPresent = true;
+        } else if (storage.exists(v1)) {
+          mdtMetaDir = v1;
+          mdtPresent = true;
+        }
+      } catch (IOException ioe) {
+        // leave mdtPresent = false
+      }
     }
 
     // Collect candidate completed instants from the active timeline.
@@ -707,10 +728,13 @@ public class TimelineInspector {
     Long t2 = null;
     Long t3 = null;
     Long t4 = null;
-    if (mdtPresent && mdtMetaClient != null) {
-      // Use the MDT metaClient's generators for correct filename construction.
-      org.apache.hudi.common.table.timeline.InstantGenerator mdtIg = mdtMetaClient.getInstantGenerator();
-      org.apache.hudi.common.table.timeline.InstantFileNameGenerator mdtFng = mdtMetaClient.getInstantFileNameGenerator();
+    if (mdtPresent) {
+      // Use MDT metaClient's generators when available; fall back to data table's generators
+      // (safe because MDT always shares the same table version as the data table).
+      org.apache.hudi.common.table.timeline.InstantGenerator mdtIg =
+          mdtMetaClient != null ? mdtMetaClient.getInstantGenerator() : ig;
+      org.apache.hudi.common.table.timeline.InstantFileNameGenerator mdtFng =
+          mdtMetaClient != null ? mdtMetaClient.getInstantFileNameGenerator() : fng;
       // MDT timeline always uses DELTA_COMMIT_ACTION regardless of data table type.
       String mdtAction = HoodieTimeline.DELTA_COMMIT_ACTION;
       HoodieInstant mdtReq = mdtIg.createNewInstant(HoodieInstant.State.REQUESTED, mdtAction, ts);
@@ -2388,9 +2412,6 @@ public class TimelineInspector {
           default:
             throw new IllegalArgumentException("unknown argument: " + k);
         }
-      }
-      if (a.helpRequested) {
-        return a;
       }
       if (a.mode == null) {
         throw new IllegalArgumentException(

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.java
@@ -67,8 +67,6 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.Path;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -138,9 +136,30 @@ public class TimelineInspector {
       JsonUtils.getObjectMapper().copy().enable(SerializationFeature.INDENT_OUTPUT);
   private static final int DEFAULT_LIMIT = 100;
 
+  static class ExitException extends Exception {
+    final int status;
+
+    ExitException(int status, String message) {
+      super(message);
+      this.status = status;
+    }
+  }
+
   public static void main(String[] args) {
     try {
+      run(args);
+    } catch (ExitException e) {
+      System.exit(e.status);
+    }
+  }
+
+  static void run(String[] args) throws ExitException {
+    try {
       Args parsed = Args.parse(args);
+
+      if (parsed.helpRequested) {
+        return;
+      }
 
       // parse-filename is a pure decode utility -- no metaclient needed.
       if (parsed.mode == Mode.PARSE_FILENAME) {
@@ -154,21 +173,22 @@ public class TimelineInspector {
           .setBasePath(parsed.basePath)
           .build();
 
+      TimelineInspector inspector = new TimelineInspector();
       switch (parsed.mode) {
         case SHOW_INSTANT:
-          new TimelineInspector().showInstant(metaClient, parsed);
+          inspector.showInstant(metaClient, parsed);
           break;
         case FIND_FILE_ID:
-          new TimelineInspector().findFileId(metaClient, parsed);
+          inspector.findFileId(metaClient, parsed);
           break;
         case RAW_ARCHIVE:
-          new TimelineInspector().rawArchive(metaClient, parsed);
+          inspector.rawArchive(metaClient, parsed);
           break;
         case COMMIT_STATS:
-          new TimelineInspector().commitStats(metaClient, parsed);
+          inspector.commitStats(metaClient, parsed);
           break;
         case PHASE_TIMINGS:
-          new TimelineInspector().phaseTimings(metaClient, parsed);
+          inspector.phaseTimings(metaClient, parsed);
           break;
         default:
           throw new IllegalStateException("unknown mode " + parsed.mode);
@@ -177,11 +197,11 @@ public class TimelineInspector {
       System.err.println("ERROR: " + e.getMessage());
       System.err.println();
       Args.printUsage();
-      System.exit(2);
+      throw new ExitException(2, e.getMessage());
     } catch (Exception e) {
       System.err.println("ERROR: " + e.getClass().getSimpleName() + ": " + e.getMessage());
       e.printStackTrace(System.err);
-      System.exit(1);
+      throw new ExitException(1, e.getMessage());
     }
   }
 
@@ -259,45 +279,39 @@ public class TimelineInspector {
    * useful when {@code --show-instant} reports "(no body)" but you want to confirm
    * whether the archive actually carried the metadata under a different field name.
    */
-  private void rawArchive(HoodieTableMetaClient metaClient, Args parsed) throws IOException {
+  private void rawArchive(HoodieTableMetaClient metaClient, Args parsed) throws IOException, ExitException {
     String needle = parsed.rawArchiveInstant;
-    Path archiveDir = new Path(metaClient.getArchivePath().toString());
-    org.apache.hadoop.fs.FileSystem hadoopFs =
-        (org.apache.hadoop.fs.FileSystem) metaClient.getStorage().getFileSystem();
-    FileStatus[] files;
+    org.apache.hudi.storage.StoragePath archiveDir =
+        new org.apache.hudi.storage.StoragePath(metaClient.getArchivePath().toString());
+    org.apache.hudi.storage.HoodieStorage storage = metaClient.getStorage();
+    List<org.apache.hudi.storage.StoragePathInfo> files;
     try {
-      files = hadoopFs.listStatus(archiveDir);
+      files = storage.listDirectEntries(archiveDir);
     } catch (java.io.FileNotFoundException nf) {
-      System.err.println("ERROR: archive dir not found: " + archiveDir);
-      System.exit(3);
-      return;
+      throw new ExitException(3, "archive dir not found: " + archiveDir);
     }
-    if (files == null || files.length == 0) {
-      System.err.println("ERROR: archive dir is empty: " + archiveDir);
-      System.exit(3);
-      return;
+    if (files == null || files.isEmpty()) {
+      throw new ExitException(3, "archive dir is empty: " + archiveDir);
     }
     // Filter to archive log files.
-    List<FileStatus> archiveFiles = new ArrayList<>();
-    for (FileStatus fs : files) {
-      if (fs.getPath().getName().startsWith("commits")) {
-        archiveFiles.add(fs);
+    List<org.apache.hudi.storage.StoragePathInfo> archiveFiles = new ArrayList<>();
+    for (org.apache.hudi.storage.StoragePathInfo spi : files) {
+      if (spi.getPath().getName().startsWith("commits")) {
+        archiveFiles.add(spi);
       }
     }
     if (archiveFiles.isEmpty()) {
-      System.err.println("ERROR: no archive log files found in " + archiveDir);
-      System.exit(3);
-      return;
+      throw new ExitException(3, "no archive log files found in " + archiveDir);
     }
 
     List<Map<String, Object>> hits = new ArrayList<>();
-    for (FileStatus fs : archiveFiles) {
+    for (org.apache.hudi.storage.StoragePathInfo spi : archiveFiles) {
       if (!parsed.quiet) {
-        System.err.println("scanning " + fs.getPath().getName());
+        System.err.println("scanning " + spi.getPath().getName());
       }
       try (HoodieLogFormat.Reader reader = HoodieLogFormat.newReader(
           metaClient,
-          new HoodieLogFile(fs.getPath().toString()),
+          new HoodieLogFile(spi.getPath().toString()),
           org.apache.hudi.common.schema.HoodieSchema.fromAvroSchema(
               HoodieArchivedMetaEntry.getClassSchema()))) {
         while (reader.hasNext()) {
@@ -313,7 +327,7 @@ public class TimelineInspector {
               Object ts = rec.get("commitTime");
               if (ts != null && ts.toString().equals(needle)) {
                 Map<String, Object> entry = new LinkedHashMap<>();
-                entry.put("archiveFile", fs.getPath().getName());
+                entry.put("archiveFile", spi.getPath().getName());
                 Map<String, Object> populatedFields = new LinkedHashMap<>();
                 Map<String, Object> nullFields = new LinkedHashMap<>();
                 for (Schema.Field f : rec.getSchema().getFields()) {
@@ -339,14 +353,14 @@ public class TimelineInspector {
         }
       } catch (Exception e) {
         if (!parsed.quiet) {
-          System.err.println("WARN: failed to read " + fs.getPath().getName() + ": " + e.getMessage());
+          System.err.println("WARN: failed to read " + spi.getPath().getName() + ": " + e.getMessage());
         }
       }
     }
 
     if (hits.isEmpty()) {
       System.out.println("(no archive entries with commitTime=" + needle + ")");
-      System.exit(3);
+      throw new ExitException(3, "no archive entries with commitTime=" + needle);
     }
 
     Map<String, Object> root = new LinkedHashMap<>();
@@ -403,7 +417,7 @@ public class TimelineInspector {
     rows.sort(byInstant);
     List<CommitStatsRow> capped = rows.size() > parsed.limit ? rows.subList(0, parsed.limit) : rows;
 
-    CommitStatsTotals totals = CommitStatsTotals.from(capped);
+    CommitStatsTotals totals = CommitStatsTotals.from(rows);
 
     if (parsed.output == OutputFormat.JSON) {
       Map<String, Object> root = new LinkedHashMap<>();
@@ -467,7 +481,7 @@ public class TimelineInspector {
     }
     System.out.println();
     System.out.printf("totals (over %d commits): inserts=%d updates=%d deletes=%d%n",
-        capped.size(), totals.totalInserts, totals.totalUpdates, totals.totalDeletes);
+        rows.size(), totals.totalInserts, totals.totalUpdates, totals.totalDeletes);
     System.out.printf("avg per commit:           inserts=%.2f updates=%.2f deletes=%.2f%n",
         totals.avgInserts(), totals.avgUpdates(), totals.avgDeletes());
   }
@@ -591,19 +605,26 @@ public class TimelineInspector {
       }
     }
 
-    org.apache.hadoop.fs.FileSystem fs =
-        (org.apache.hadoop.fs.FileSystem) metaClient.getStorage().getFileSystem();
-    Path dataMetaDir = new Path(metaClient.getTimelinePath().toString());
-    // MDT sub-table's timeline dir mirrors the data table's layout — under
-    // <base>/.hoodie/metadata/.hoodie/timeline/ for V2 layout tables.
-    Path mdtMetaDir = new Path(metaClient.getBasePath()
-        + Path.SEPARATOR + HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH
-        + Path.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME
-        + Path.SEPARATOR + HoodieTableMetaClient.TIMELINEFOLDER_NAME);
-    boolean mdtPresent;
+    org.apache.hudi.storage.HoodieStorage storage = metaClient.getStorage();
+    org.apache.hudi.storage.StoragePath dataMetaDir =
+        new org.apache.hudi.storage.StoragePath(metaClient.getTimelinePath().toString());
+    // Try to build an MDT metaClient so we resolve the correct timeline path for
+    // both V1 (`.hoodie/`) and V2 (`.hoodie/timeline/`) layout tables.
+    String mdtBasePath = metaClient.getBasePath()
+        + "/" + HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH;
+    HoodieTableMetaClient mdtMetaClient = null;
+    org.apache.hudi.storage.StoragePath mdtMetaDir = null;
+    boolean mdtPresent = false;
     try {
-      mdtPresent = fs.exists(mdtMetaDir);
-    } catch (IOException ioe) {
+      mdtMetaClient = HoodieTableMetaClient.builder()
+          .setConf(metaClient.getStorageConf())
+          .setBasePath(mdtBasePath)
+          .build();
+      mdtMetaDir = new org.apache.hudi.storage.StoragePath(
+          mdtMetaClient.getTimelinePath().toString());
+      mdtPresent = storage.exists(mdtMetaDir);
+    } catch (Exception e) {
+      // MDT does not exist or its hoodie.properties is missing.
       mdtPresent = false;
     }
 
@@ -621,10 +642,9 @@ public class TimelineInspector {
     int skipped = 0;
 
     for (HoodieInstant instant : candidates) {
-      PhaseTimingRow row = buildPhaseTimingRow(metaClient, fs, dataMetaDir, mdtMetaDir, mdtPresent,
-          instant, parsed);
+      PhaseTimingRow row = buildPhaseTimingRow(metaClient, mdtMetaClient, storage, dataMetaDir,
+          mdtMetaDir, mdtPresent, instant, skipReasons);
       if (row == null) {
-        // Already counted via skipReasons inside the builder.
         skipped++;
         continue;
       }
@@ -659,12 +679,13 @@ public class TimelineInspector {
    * row falls back to the 3-phase view.
    */
   private PhaseTimingRow buildPhaseTimingRow(HoodieTableMetaClient metaClient,
-                                             org.apache.hadoop.fs.FileSystem fs,
-                                             Path dataMetaDir,
-                                             Path mdtMetaDir,
+                                             HoodieTableMetaClient mdtMetaClient,
+                                             org.apache.hudi.storage.HoodieStorage storage,
+                                             org.apache.hudi.storage.StoragePath dataMetaDir,
+                                             org.apache.hudi.storage.StoragePath mdtMetaDir,
                                              boolean mdtPresent,
                                              HoodieInstant completed,
-                                             Args parsed) {
+                                             Map<String, Integer> skipReasons) {
     String ts = completed.requestedTime();
     String action = completed.getAction();
     org.apache.hudi.common.table.timeline.InstantGenerator ig = metaClient.getInstantGenerator();
@@ -672,34 +693,34 @@ public class TimelineInspector {
     HoodieInstant requested = ig.createNewInstant(HoodieInstant.State.REQUESTED, action, ts);
     HoodieInstant inflight = ig.createNewInstant(HoodieInstant.State.INFLIGHT, action, ts);
 
-    Long t0 = mtimeOrNull(fs, new Path(dataMetaDir, fng.getFileName(requested)));
-    Long t1 = mtimeOrNull(fs, new Path(dataMetaDir, fng.getFileName(inflight)));
-    Long t5 = mtimeOrNull(fs, new Path(dataMetaDir, fng.getFileName(completed)));
+    Long t0 = mtimeOrNull(storage, new org.apache.hudi.storage.StoragePath(dataMetaDir, fng.getFileName(requested)));
+    Long t1 = mtimeOrNull(storage, new org.apache.hudi.storage.StoragePath(dataMetaDir, fng.getFileName(inflight)));
+    Long t5 = mtimeOrNull(storage, new org.apache.hudi.storage.StoragePath(dataMetaDir, fng.getFileName(completed)));
 
     if (t0 == null || t1 == null || t5 == null) {
       String reason = (t0 == null ? "requested-missing"
           : t1 == null ? "inflight-missing" : "completed-missing");
-      // Note: parsed.phaseTimingsSkipReasons is populated via side-effect on the caller
-      // because we can't return more than one value here without an extra wrapper.
-      // (The caller will read the field after this returns null.)
-      recordSkipReason(parsed, reason);
+      skipReasons.merge(reason, 1, Integer::sum);
       return null;
     }
 
     Long t2 = null;
     Long t3 = null;
     Long t4 = null;
-    if (mdtPresent) {
+    if (mdtPresent && mdtMetaClient != null) {
+      // Use the MDT metaClient's generators for correct filename construction.
+      org.apache.hudi.common.table.timeline.InstantGenerator mdtIg = mdtMetaClient.getInstantGenerator();
+      org.apache.hudi.common.table.timeline.InstantFileNameGenerator mdtFng = mdtMetaClient.getInstantFileNameGenerator();
       // MDT timeline always uses DELTA_COMMIT_ACTION regardless of data table type.
       String mdtAction = HoodieTimeline.DELTA_COMMIT_ACTION;
-      HoodieInstant mdtReq = ig.createNewInstant(HoodieInstant.State.REQUESTED, mdtAction, ts);
-      HoodieInstant mdtInf = ig.createNewInstant(HoodieInstant.State.INFLIGHT, mdtAction, ts);
-      t2 = mtimeOrNull(fs, new Path(mdtMetaDir, fng.getFileName(mdtReq)));
-      t3 = mtimeOrNull(fs, new Path(mdtMetaDir, fng.getFileName(mdtInf)));
+      HoodieInstant mdtReq = mdtIg.createNewInstant(HoodieInstant.State.REQUESTED, mdtAction, ts);
+      HoodieInstant mdtInf = mdtIg.createNewInstant(HoodieInstant.State.INFLIGHT, mdtAction, ts);
+      t2 = mtimeOrNull(storage, new org.apache.hudi.storage.StoragePath(mdtMetaDir, mdtFng.getFileName(mdtReq)));
+      t3 = mtimeOrNull(storage, new org.apache.hudi.storage.StoragePath(mdtMetaDir, mdtFng.getFileName(mdtInf)));
       // The completed MDT file carries a completion-time suffix in V2 layout
       // (<ts>_<completionTime>.deltacommit), which we don't know a priori. Match by
       // prefix + extension in the MDT timeline dir instead of synthesizing the full name.
-      t4 = mtimeByPrefixOrNull(fs, mdtMetaDir, ts, "." + mdtAction);
+      t4 = mtimeByPrefixOrNull(storage, mdtMetaDir, ts, "." + mdtAction);
       // Partial MDT state for this instant → fall back to the 3-phase view (treat as if
       // MDT wasn't present for this row). Don't skip the row.
       if (t2 == null || t3 == null || t4 == null) {
@@ -712,9 +733,10 @@ public class TimelineInspector {
     return new PhaseTimingRow(ts, action, t0, t1, t2, t3, t4, t5);
   }
 
-  private static Long mtimeOrNull(org.apache.hadoop.fs.FileSystem fs, Path p) {
+  private static Long mtimeOrNull(org.apache.hudi.storage.HoodieStorage storage,
+                                   org.apache.hudi.storage.StoragePath p) {
     try {
-      return fs.getFileStatus(p).getModificationTime();
+      return storage.getPathInfo(p).getModificationTime();
     } catch (java.io.FileNotFoundException nf) {
       return null;
     } catch (IOException ioe) {
@@ -728,14 +750,15 @@ public class TimelineInspector {
    * files in V2 layout, where the on-disk name embeds a completion-time we don't know
    * a priori (e.g., "20260601000000000_20260601000000234.deltacommit").
    */
-  private static Long mtimeByPrefixOrNull(org.apache.hadoop.fs.FileSystem fs, Path dir,
+  private static Long mtimeByPrefixOrNull(org.apache.hudi.storage.HoodieStorage storage,
+                                          org.apache.hudi.storage.StoragePath dir,
                                           String namePrefix, String nameSuffix) {
     try {
-      org.apache.hadoop.fs.FileStatus[] entries = fs.listStatus(dir);
+      List<org.apache.hudi.storage.StoragePathInfo> entries = storage.listDirectEntries(dir);
       if (entries == null) {
         return null;
       }
-      for (org.apache.hadoop.fs.FileStatus e : entries) {
+      for (org.apache.hudi.storage.StoragePathInfo e : entries) {
         String n = e.getPath().getName();
         if (n.startsWith(namePrefix) && n.endsWith(nameSuffix)) {
           return e.getModificationTime();
@@ -745,10 +768,6 @@ public class TimelineInspector {
     } catch (IOException ioe) {
       return null;
     }
-  }
-
-  private static void recordSkipReason(Args parsed, String reason) {
-    parsed.phaseTimingsSkipReasons.merge(reason, 1, Integer::sum);
   }
 
   private void emitPhaseTimingsTable(Args parsed, boolean mdtPresent,
@@ -765,7 +784,7 @@ public class TimelineInspector {
       System.out.println("(no ingestion instants with complete phase timings in range)");
       if (skipped > 0) {
         System.out.println("skipped " + skipped + " instant(s): "
-            + formatSkipReasons(parsed.phaseTimingsSkipReasons));
+            + formatSkipReasons(skipReasons));
       }
       return;
     }
@@ -854,7 +873,7 @@ public class TimelineInspector {
     if (skipped > 0) {
       System.out.println();
       System.out.println("skipped " + skipped + " instant(s) with incomplete state-marker files: "
-          + formatSkipReasons(parsed.phaseTimingsSkipReasons));
+          + formatSkipReasons(skipReasons));
     }
   }
 
@@ -903,7 +922,7 @@ public class TimelineInspector {
     root.put("aggregates", aggBlock);
     Map<String, Object> skip = new LinkedHashMap<>();
     skip.put("count", skipped);
-    skip.put("reasons", parsed.phaseTimingsSkipReasons);
+    skip.put("reasons", skipReasons);
     root.put("skipped", skip);
     System.out.println(JSON_MAPPER.writeValueAsString(root));
   }
@@ -933,7 +952,7 @@ public class TimelineInspector {
 
   // ---- show-instant ---------------------------------------------------------
 
-  private void showInstant(HoodieTableMetaClient metaClient, Args parsed) throws IOException {
+  private void showInstant(HoodieTableMetaClient metaClient, Args parsed) throws IOException, ExitException {
     String instantTime = parsed.showInstantTime;
     List<InstantLocator> located = findInstantStates(metaClient, instantTime, parsed.actionFilter,
         parsed.stateFilter, parsed.includeArchived);
@@ -942,7 +961,7 @@ public class TimelineInspector {
           + " in active or archived timeline (action filter="
           + (parsed.actionFilter.isEmpty() ? "<any>" : String.join(",", parsed.actionFilter))
           + (parsed.stateFilter == null ? "" : ", state=" + parsed.stateFilter) + ")");
-      System.exit(3);
+      throw new ExitException(3, "No instant found with time=" + instantTime);
     }
 
     if (parsed.output == OutputFormat.JSON) {
@@ -1215,7 +1234,7 @@ public class TimelineInspector {
 
     for (HoodieInstant instant : (Iterable<HoodieInstant>) instants::iterator) {
       if (out.size() >= hardCap * 4L) {
-        // hard scan cap so a runaway match doesn't OOM; *4 leaves headroom for sorting
+        // 4x headroom so events from both timelines can be collected and sorted before capping.
         break;
       }
       try {
@@ -2268,8 +2287,7 @@ public class TimelineInspector {
     boolean sortDescending = true;
     // phase-timings: opt-in inclusion of replacecommit instants (default off).
     boolean includeReplacecommit = false;
-    // phase-timings: accumulated skip reasons, populated by the row builder for the footer.
-    Map<String, Integer> phaseTimingsSkipReasons = new LinkedHashMap<>();
+    boolean helpRequested = false;
 
     static Args parse(String[] argv) {
       Args a = new Args();
@@ -2365,11 +2383,14 @@ public class TimelineInspector {
           case "--help":
           case "-h":
             printUsage();
-            System.exit(0);
-            break;
+            a.helpRequested = true;
+            return a;
           default:
             throw new IllegalArgumentException("unknown argument: " + k);
         }
+      }
+      if (a.helpRequested) {
+        return a;
       }
       if (a.mode == null) {
         throw new IllegalArgumentException(

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.java
@@ -1,0 +1,2465 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.tools;
+
+import org.apache.hudi.avro.model.HoodieArchivedMetaEntry;
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanPartitionMetadata;
+import org.apache.hudi.avro.model.HoodieClusteringPlan;
+import org.apache.hudi.avro.model.HoodieInstantInfo;
+import org.apache.hudi.avro.model.HoodieRequestedReplaceMetadata;
+import org.apache.hudi.avro.model.HoodieRestoreMetadata;
+import org.apache.hudi.avro.model.HoodieRestorePlan;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPlan;
+import org.apache.hudi.avro.model.HoodieRollbackRequest;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.ClusteringUtils;
+import org.apache.hudi.common.util.JsonUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Standalone Java tool to inspect a Hudi table's active and archived timeline.
+ *
+ * <p>Modes:
+ * <ul>
+ *   <li>{@code --show-instant <instantTime> [--action <action>]} — deserialize the matching
+ *       instant's content and print all metadata as pretty JSON.</li>
+ *   <li>{@code --find-file-id <fileIdOrFileName>} — print a sorted table of timeline events
+ *       that mention the given file ID or filename (write stats, replace-commit replaced
+ *       file IDs, clustering input slices, clean delete patterns, rollback delete files).</li>
+ *   <li>{@code --commit-stats} — per-ingestion-commit records/files/bytes breakdown for a
+ *       time range, with a totals + per-commit-average footer.</li>
+ *   <li>{@code --phase-timings} — per-ingestion-instant wall-clock split (source read +
+ *       indexing + small-file handling, data write, MDT prep, MDT write, MDT-tail) derived
+ *       from {@code .hoodie/} state-marker file mtimes on the active timeline, with
+ *       per-action mean/p50/p95/max aggregates.</li>
+ *   <li>{@code --parse-filename <name>} — decode a Hudi parquet/log filename.</li>
+ *   <li>{@code --raw-archive <ts>} — dump the full HoodieArchivedMetaEntry for an instant.</li>
+ * </ul>
+ *
+ * <p>Common options:
+ * <pre>
+ *   --base-path &lt;path&gt;          (required) table base path (directory containing .hoodie/)
+ *   --include-archived          include archived timeline (default true)
+ *   --start-instant &lt;instant&gt;   only consider instants &gt;= this instant time
+ *   --end-instant &lt;instant&gt;     only consider instants &lt;= this instant time
+ *   --actions &lt;csv&gt;             restrict to these actions (commit,deltacommit,replacecommit,
+ *                               clean,rollback,compaction,savepoint)
+ *   --limit &lt;N&gt;                 cap rows in find-file-id output (default 100)
+ * </pre>
+ *
+ * <p>Example invocations:
+ * <pre>
+ *   java -cp hudi-common-0.14.1-rc2.jar:hudi-hadoop-common-...jar:... \
+ *     org.apache.hudi.tools.TimelineInspector \
+ *     --base-path /tmp/apna_table/tbl_path \
+ *     --show-instant 20260530092852891
+ *
+ *   java -cp ... org.apache.hudi.tools.TimelineInspector \
+ *     --base-path /tmp/apna_table/tbl_path \
+ *     --find-file-id 5d85210a-fc17-411e-a01f-3bb44d9a12cc-0 \
+ *     --actions commit,deltacommit,replacecommit,clean \
+ *     --start-instant 20260101000000000 \
+ *     --limit 500
+ * </pre>
+ */
+public class TimelineInspector {
+
+  private static final ObjectMapper JSON_MAPPER =
+      JsonUtils.getObjectMapper().copy().enable(SerializationFeature.INDENT_OUTPUT);
+  private static final int DEFAULT_LIMIT = 100;
+
+  public static void main(String[] args) {
+    try {
+      Args parsed = Args.parse(args);
+
+      // parse-filename is a pure decode utility -- no metaclient needed.
+      if (parsed.mode == Mode.PARSE_FILENAME) {
+        new TimelineInspector().parseFilename(parsed);
+        return;
+      }
+
+      Configuration hadoopConf = new Configuration();
+      HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder()
+          .setConf(HadoopFSUtils.getStorageConfWithCopy(hadoopConf))
+          .setBasePath(parsed.basePath)
+          .build();
+
+      switch (parsed.mode) {
+        case SHOW_INSTANT:
+          new TimelineInspector().showInstant(metaClient, parsed);
+          break;
+        case FIND_FILE_ID:
+          new TimelineInspector().findFileId(metaClient, parsed);
+          break;
+        case RAW_ARCHIVE:
+          new TimelineInspector().rawArchive(metaClient, parsed);
+          break;
+        case COMMIT_STATS:
+          new TimelineInspector().commitStats(metaClient, parsed);
+          break;
+        case PHASE_TIMINGS:
+          new TimelineInspector().phaseTimings(metaClient, parsed);
+          break;
+        default:
+          throw new IllegalStateException("unknown mode " + parsed.mode);
+      }
+    } catch (IllegalArgumentException e) {
+      System.err.println("ERROR: " + e.getMessage());
+      System.err.println();
+      Args.printUsage();
+      System.exit(2);
+    } catch (Exception e) {
+      System.err.println("ERROR: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+      e.printStackTrace(System.err);
+      System.exit(1);
+    }
+  }
+
+  // ---- parse-filename -------------------------------------------------------
+
+  /**
+   * Decodes a Hudi-conventional parquet or log filename into its constituent parts.
+   * Handles three flavors:
+   * <ul>
+   *   <li>Base file (parquet/hfile/orc): {@code <fileId>_<writeToken>_<instantTime>.<ext>}</li>
+   *   <li>Log file: {@code .<fileId>_<baseInstant>.log.<version>_<writeToken>}</li>
+   *   <li>Bare file ID: {@code <fileId>} on its own</li>
+   * </ul>
+   */
+  private void parseFilename(Args parsed) throws IOException {
+    String input = parsed.filenameToParse;
+    String name = input.contains("/") ? input.substring(input.lastIndexOf('/') + 1) : input;
+    Map<String, Object> out = new LinkedHashMap<>();
+    out.put("input", input);
+    out.put("filename", name);
+
+    try {
+      org.apache.hudi.storage.StoragePath sp = new org.apache.hudi.storage.StoragePath(name);
+      if (FSUtils.isLogFile(sp)) {
+        out.put("kind", "log");
+        out.put("fileId", FSUtils.getFileIdFromLogPath(sp));
+        out.put("baseInstantTime", FSUtils.getDeltaCommitTimeFromLogPath(sp));
+        out.put("logVersion", FSUtils.getFileVersionFromLog(name));
+        out.put("writeToken", FSUtils.getWriteTokenFromLogPath(sp));
+        out.put("logFileExtension", FSUtils.getFileExtensionFromLog(sp));
+      } else if (name.contains("_") && name.contains(".")) {
+        // Base file convention: <fileId>_<writeToken>_<commitTime>.<ext>
+        out.put("kind", "base");
+        out.put("fileId", FSUtils.getFileId(name));
+        out.put("commitTime", FSUtils.getCommitTime(name));
+        out.put("fileExtension", FSUtils.getFileExtension(name));
+        // writeToken is the token between fileId and commitTime; FSUtils doesn't expose
+        // a public getter, so reconstruct it.
+        String stem = name.substring(0, name.lastIndexOf('.'));
+        String[] parts = stem.split("_");
+        if (parts.length >= 3) {
+          // fileId may itself contain underscores (it doesn't with default key gen but
+          // be defensive). Take everything between the first '_' and the last '_'.
+          int firstUs = name.indexOf('_');
+          int lastUs = stem.lastIndexOf('_');
+          if (firstUs > 0 && lastUs > firstUs) {
+            out.put("writeToken", name.substring(firstUs + 1, lastUs));
+          }
+        }
+      } else {
+        // Looks like just a file ID with no commit/token.
+        out.put("kind", "fileIdOnly");
+        out.put("fileId", name);
+      }
+    } catch (Exception e) {
+      out.put("kind", "unrecognized");
+      out.put("error", e.getClass().getSimpleName() + ": " + e.getMessage());
+    }
+
+    if (parsed.output == OutputFormat.JSON) {
+      System.out.println(JSON_MAPPER.writeValueAsString(out));
+    } else {
+      for (Map.Entry<String, Object> e : out.entrySet()) {
+        System.out.printf("%-20s : %s%n", e.getKey(), e.getValue());
+      }
+    }
+  }
+
+  // ---- raw-archive ----------------------------------------------------------
+
+  /**
+   * Walks the archive log files under {@code .hoodie/archived/} and prints the full
+   * {@link HoodieArchivedMetaEntry} for the requested instant. Bypasses the in-memory
+   * cache built by {@link HoodieArchivedTimeline} so we can see every sibling field --
+   * useful when {@code --show-instant} reports "(no body)" but you want to confirm
+   * whether the archive actually carried the metadata under a different field name.
+   */
+  private void rawArchive(HoodieTableMetaClient metaClient, Args parsed) throws IOException {
+    String needle = parsed.rawArchiveInstant;
+    Path archiveDir = new Path(metaClient.getArchivePath().toString());
+    org.apache.hadoop.fs.FileSystem hadoopFs =
+        (org.apache.hadoop.fs.FileSystem) metaClient.getStorage().getFileSystem();
+    FileStatus[] files;
+    try {
+      files = hadoopFs.listStatus(archiveDir);
+    } catch (java.io.FileNotFoundException nf) {
+      System.err.println("ERROR: archive dir not found: " + archiveDir);
+      System.exit(3);
+      return;
+    }
+    if (files == null || files.length == 0) {
+      System.err.println("ERROR: archive dir is empty: " + archiveDir);
+      System.exit(3);
+      return;
+    }
+    // Filter to archive log files.
+    List<FileStatus> archiveFiles = new ArrayList<>();
+    for (FileStatus fs : files) {
+      if (fs.getPath().getName().startsWith("commits")) {
+        archiveFiles.add(fs);
+      }
+    }
+    if (archiveFiles.isEmpty()) {
+      System.err.println("ERROR: no archive log files found in " + archiveDir);
+      System.exit(3);
+      return;
+    }
+
+    List<Map<String, Object>> hits = new ArrayList<>();
+    for (FileStatus fs : archiveFiles) {
+      if (!parsed.quiet) {
+        System.err.println("scanning " + fs.getPath().getName());
+      }
+      try (HoodieLogFormat.Reader reader = HoodieLogFormat.newReader(
+          metaClient,
+          new HoodieLogFile(fs.getPath().toString()),
+          org.apache.hudi.common.schema.HoodieSchema.fromAvroSchema(
+              HoodieArchivedMetaEntry.getClassSchema()))) {
+        while (reader.hasNext()) {
+          HoodieLogBlock block = reader.next();
+          if (!(block instanceof HoodieAvroDataBlock)) {
+            continue;
+          }
+          HoodieAvroDataBlock avroBlock = (HoodieAvroDataBlock) block;
+          try (ClosableIterator<HoodieRecord<IndexedRecord>> itr =
+                   avroBlock.getRecordIterator(HoodieRecordType.AVRO)) {
+            while (itr.hasNext()) {
+              GenericRecord rec = (GenericRecord) itr.next().getData();
+              Object ts = rec.get("commitTime");
+              if (ts != null && ts.toString().equals(needle)) {
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("archiveFile", fs.getPath().getName());
+                Map<String, Object> populatedFields = new LinkedHashMap<>();
+                Map<String, Object> nullFields = new LinkedHashMap<>();
+                for (Schema.Field f : rec.getSchema().getFields()) {
+                  Object v = rec.get(f.name());
+                  if (v == null) {
+                    nullFields.put(f.name(), null);
+                  } else {
+                    // Avro GenericRecord's toString() emits Avro-JSON. Re-parse via Jackson
+                    // so the output is uniform JSON rather than Avro's quirky variant.
+                    try {
+                      populatedFields.put(f.name(), JSON_MAPPER.readTree(v.toString()));
+                    } catch (Exception parseFail) {
+                      populatedFields.put(f.name(), v.toString());
+                    }
+                  }
+                }
+                entry.put("populatedFields", populatedFields);
+                entry.put("nullFields", nullFields.keySet());
+                hits.add(entry);
+              }
+            }
+          }
+        }
+      } catch (Exception e) {
+        if (!parsed.quiet) {
+          System.err.println("WARN: failed to read " + fs.getPath().getName() + ": " + e.getMessage());
+        }
+      }
+    }
+
+    if (hits.isEmpty()) {
+      System.out.println("(no archive entries with commitTime=" + needle + ")");
+      System.exit(3);
+    }
+
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("instant", needle);
+    root.put("hitCount", hits.size());
+    root.put("entries", hits);
+    System.out.println(JSON_MAPPER.writeValueAsString(root));
+  }
+
+  // ---- commit-stats ---------------------------------------------------------
+
+  /**
+   * Lists per-ingestion-commit stats (records + files + bytes) across the active timeline
+   * and, when not suppressed, the archived timeline, restricted by the optional time range
+   * and action filter. Considers only completed commit/deltacommit/replacecommit instants.
+   * Prints a footer with totals and per-commit averages for inserts/updates/deletes.
+   *
+   * <p>"Files deleted" semantics: for a replacecommit, the count of file ids in
+   * {@code partitionToReplaceFileIds} (logical replacement). For plain commit/deltacommit,
+   * this is always 0 — physical deletions live on clean instants, not on commit metadata.
+   */
+  private void commitStats(HoodieTableMetaClient metaClient, Args parsed) throws IOException {
+    Set<String> actions = parsed.actionFilter.isEmpty()
+        ? new HashSet<>(Arrays.asList(HoodieTimeline.COMMIT_ACTION,
+            HoodieTimeline.DELTA_COMMIT_ACTION, HoodieTimeline.REPLACE_COMMIT_ACTION))
+        : parsed.actionFilter.stream()
+            .filter(a -> a.equals(HoodieTimeline.COMMIT_ACTION)
+                || a.equals(HoodieTimeline.DELTA_COMMIT_ACTION)
+                || a.equals(HoodieTimeline.REPLACE_COMMIT_ACTION))
+            .collect(Collectors.toCollection(HashSet::new));
+    if (actions.isEmpty()) {
+      throw new IllegalArgumentException("--commit-stats: --actions filter must include at least"
+          + " one of commit/deltacommit/replacecommit");
+    }
+
+    List<CommitStatsRow> rows = new ArrayList<>();
+    HoodieActiveTimeline active = metaClient.reloadActiveTimeline();
+    collectCommitStats(active, "ACTIVE", actions, parsed, rows);
+
+    if (parsed.includeArchived) {
+      HoodieArchivedTimeline archived = metaClient.getArchivedTimeline();
+      if (parsed.startInstant != null && parsed.endInstant != null) {
+        archived.loadInstantDetailsInMemory(parsed.startInstant, parsed.endInstant);
+      } else {
+        archived.loadCompletedInstantDetailsInMemory();
+      }
+      collectCommitStats(archived, "ARCHIVED", actions, parsed, rows);
+    }
+
+    Comparator<CommitStatsRow> byInstant = Comparator.comparing(r -> r.instant);
+    if (parsed.sortDescending) {
+      byInstant = byInstant.reversed();
+    }
+    rows.sort(byInstant);
+    List<CommitStatsRow> capped = rows.size() > parsed.limit ? rows.subList(0, parsed.limit) : rows;
+
+    CommitStatsTotals totals = CommitStatsTotals.from(capped);
+
+    if (parsed.output == OutputFormat.JSON) {
+      Map<String, Object> root = new LinkedHashMap<>();
+      root.put("startInstant", parsed.startInstant);
+      root.put("endInstant", parsed.endInstant);
+      root.put("actions", new ArrayList<>(actions));
+      root.put("totalCommits", rows.size());
+      root.put("returnedCommits", capped.size());
+      List<Map<String, Object>> commits = new ArrayList<>(capped.size());
+      for (CommitStatsRow r : capped) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("instant", r.instant);
+        m.put("timeline", r.timelineType);
+        m.put("action", r.action);
+        m.put("operation", r.operation);
+        m.put("numInserts", r.numInserts);
+        m.put("numUpdates", r.numUpdates);
+        m.put("numDeletes", r.numDeletes);
+        m.put("filesInserted", r.filesInserted);
+        m.put("filesUpdated", r.filesUpdated);
+        m.put("filesDeleted", r.filesDeleted);
+        m.put("bytesWritten", r.bytesWritten);
+        m.put("partitions", r.partitions);
+        commits.add(m);
+      }
+      root.put("commits", commits);
+      Map<String, Object> footer = new LinkedHashMap<>();
+      footer.put("totalInserts", totals.totalInserts);
+      footer.put("totalUpdates", totals.totalUpdates);
+      footer.put("totalDeletes", totals.totalDeletes);
+      footer.put("avgInsertsPerCommit", totals.avgInserts());
+      footer.put("avgUpdatesPerCommit", totals.avgUpdates());
+      footer.put("avgDeletesPerCommit", totals.avgDeletes());
+      root.put("totals", footer);
+      System.out.println(JSON_MAPPER.writeValueAsString(root));
+      return;
+    }
+
+    if (capped.isEmpty()) {
+      System.out.println("(no ingestion commits in range)");
+      return;
+    }
+    String[] headers = {"instant", "timeline", "action", "operation",
+        "numInserts", "numUpdates", "numDeletes",
+        "filesInserted", "filesUpdated", "filesDeleted",
+        "bytesWritten", "partitions"};
+    List<String[]> tableRows = new ArrayList<>(capped.size());
+    for (CommitStatsRow r : capped) {
+      tableRows.add(new String[] {
+          r.instant, r.timelineType, r.action, r.operation,
+          Long.toString(r.numInserts), Long.toString(r.numUpdates), Long.toString(r.numDeletes),
+          Long.toString(r.filesInserted), Long.toString(r.filesUpdated), Long.toString(r.filesDeleted),
+          Long.toString(r.bytesWritten), Long.toString(r.partitions)
+      });
+    }
+    printRowsWithHeaders(headers, tableRows);
+    if (rows.size() > parsed.limit) {
+      System.out.println();
+      System.out.println("(showing first " + parsed.limit + " of " + rows.size()
+          + " commits; raise with --limit to see more)");
+    }
+    System.out.println();
+    System.out.printf("totals (over %d commits): inserts=%d updates=%d deletes=%d%n",
+        capped.size(), totals.totalInserts, totals.totalUpdates, totals.totalDeletes);
+    System.out.printf("avg per commit:           inserts=%.2f updates=%.2f deletes=%.2f%n",
+        totals.avgInserts(), totals.avgUpdates(), totals.avgDeletes());
+  }
+
+  private void collectCommitStats(HoodieTimeline timeline, String timelineType,
+                                  Set<String> actions, Args parsed, List<CommitStatsRow> out) {
+    timeline.getInstantsAsStream()
+        .filter(HoodieInstant::isCompleted)
+        .filter(i -> actions.contains(i.getAction()))
+        .filter(i -> parsed.startInstant == null || i.requestedTime().compareTo(parsed.startInstant) >= 0)
+        .filter(i -> parsed.endInstant == null || i.requestedTime().compareTo(parsed.endInstant) <= 0)
+        .forEach(instant -> {
+          try {
+            out.add(buildCommitStatsRow(timeline, timelineType, instant));
+          } catch (Exception e) {
+            if (!parsed.quiet) {
+              System.err.println("WARN: failed to read " + timelineType + " " + instant
+                  + ": " + e.getMessage());
+            }
+          }
+        });
+  }
+
+  /**
+   * Builds a stats row by first trying the POJO path (works for the active timeline) and,
+   * if that yields an empty shell (which happens on the archived timeline where the bytes
+   * are an Avro-flavored JSON string Jackson can't bind cleanly), falling back to parsing
+   * the JSON tree and aggregating write-stat fields directly.
+   */
+  private CommitStatsRow buildCommitStatsRow(HoodieTimeline timeline,
+                                             String timelineType,
+                                             HoodieInstant instant) throws IOException {
+    boolean isReplace = instant.getAction().equals(HoodieTimeline.REPLACE_COMMIT_ACTION);
+
+    Option<byte[]> rawOpt = timeline.getInstantDetails(instant);
+    byte[] raw = rawOpt.isPresent() ? rawOpt.get() : new byte[0];
+
+    // First try the POJO path.
+    HoodieCommitMetadata pojo = null;
+    try {
+      if (raw.length > 0) {
+        pojo = isReplace
+            ? timeline.readInstantContent(instant, HoodieReplaceCommitMetadata.class)
+            : timeline.readInstantContent(instant, HoodieCommitMetadata.class);
+      }
+    } catch (Exception ignored) {
+      // fall through to JSON-tree path
+    }
+
+    if (pojo != null && pojo.getPartitionToWriteStats() != null
+        && !pojo.getPartitionToWriteStats().isEmpty()) {
+      return CommitStatsRow.fromPojo(instant, timelineType, pojo, isReplace);
+    }
+
+    // Archived-shell or empty body: aggregate from JSON.
+    if (raw.length == 0) {
+      return CommitStatsRow.empty(instant, timelineType);
+    }
+    return CommitStatsRow.fromJson(instant, timelineType, JSON_MAPPER.readTree(raw), isReplace);
+  }
+
+  // ---- phase-timings --------------------------------------------------------
+
+  /**
+   * Lists per-ingestion-instant wall-clock phase splits derived from the {@code .hoodie/}
+   * state-marker file modification times on the active timeline. The six phase boundaries
+   * follow the typical write sequence:
+   * <pre>
+   *   T0 = mtime of  &lt;basePath&gt;/.hoodie/&lt;ts&gt;.&lt;action&gt;.requested
+   *   T1 = mtime of  &lt;basePath&gt;/.hoodie/&lt;ts&gt;.&lt;action&gt;.inflight
+   *   T2 = mtime of  &lt;basePath&gt;/.hoodie/metadata/.hoodie/&lt;ts&gt;.deltacommit.requested  (MDT)
+   *   T3 = mtime of  &lt;basePath&gt;/.hoodie/metadata/.hoodie/&lt;ts&gt;.deltacommit.inflight    (MDT)
+   *   T4 = mtime of  &lt;basePath&gt;/.hoodie/metadata/.hoodie/&lt;ts&gt;.deltacommit              (MDT)
+   *   T5 = mtime of  &lt;basePath&gt;/.hoodie/&lt;ts&gt;.&lt;action&gt; (or .commit for compaction)
+   * </pre>
+   * Phase columns:
+   * <ul>
+   *   <li>sourceReadIndexSfh_ms = T1 - T0 (data table: source read + indexing + small-file handling)</li>
+   *   <li>dataWrite_ms = T2 - T1 (data table writes; when MDT is absent, T5 - T1)</li>
+   *   <li>mdtPrep_ms = T3 - T2 (metadata record preparation)</li>
+   *   <li>mdtWrite_ms = T4 - T3 (metadata writes)</li>
+   *   <li>mdtTail_ms = T5 - T4 (gap between MDT completion and data-table completion)</li>
+   *   <li>total_ms = T5 - T0</li>
+   * </ul>
+   *
+   * <p>Per-instant MDT detection: if the MDT timeline directory does not exist on the
+   * table at all, all rows fall back to the 3-phase view (sourceReadIndexSfh, dataWrite,
+   * total). Otherwise, MDT phases are populated when the three MDT state files exist for
+   * that instant, and left blank for instants that predate MDT enablement.
+   *
+   * <p>Rows where any expected data-table state file is missing (e.g. partial/rolled-back
+   * writes) are dropped from the output and counted in the footer's {@code skipped} block.
+   * Archived instants are skipped — their state-marker files no longer exist on disk.
+   *
+   * <p>S3/GCS caveat: object-store mtimes reflect server-side write-completion time, not
+   * the producer's wall clock. The relative phase durations are still accurate; clock-skew
+   * artifacts are bounded by the storage layer's commit granularity.
+   */
+  private void phaseTimings(HoodieTableMetaClient metaClient, Args parsed) throws IOException {
+    // Validate / build the action set. Default: deltacommit + commit (MOR + COW ingest).
+    Set<String> baseActions = new HashSet<>(Arrays.asList(
+        HoodieTimeline.COMMIT_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION));
+    if (parsed.includeReplacecommit) {
+      baseActions.add(HoodieTimeline.REPLACE_COMMIT_ACTION);
+    }
+    Set<String> actions;
+    if (parsed.actionFilter.isEmpty()) {
+      actions = baseActions;
+    } else {
+      // Explicit --actions overrides the default but is still restricted to ingest-style
+      // actions; phase semantics don't apply to clean/rollback/savepoint.
+      Set<String> validForPhaseTimings = new HashSet<>(Arrays.asList(
+          HoodieTimeline.COMMIT_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION,
+          HoodieTimeline.REPLACE_COMMIT_ACTION));
+      actions = parsed.actionFilter.stream()
+          .filter(validForPhaseTimings::contains)
+          .collect(Collectors.toCollection(HashSet::new));
+      if (actions.isEmpty()) {
+        throw new IllegalArgumentException("--phase-timings: --actions filter must include at"
+            + " least one of commit/deltacommit/replacecommit");
+      }
+    }
+
+    org.apache.hadoop.fs.FileSystem fs =
+        (org.apache.hadoop.fs.FileSystem) metaClient.getStorage().getFileSystem();
+    Path dataMetaDir = new Path(metaClient.getTimelinePath().toString());
+    // MDT sub-table's timeline dir mirrors the data table's layout — under
+    // <base>/.hoodie/metadata/.hoodie/timeline/ for V2 layout tables.
+    Path mdtMetaDir = new Path(metaClient.getBasePath()
+        + Path.SEPARATOR + HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH
+        + Path.SEPARATOR + HoodieTableMetaClient.METAFOLDER_NAME
+        + Path.SEPARATOR + HoodieTableMetaClient.TIMELINEFOLDER_NAME);
+    boolean mdtPresent;
+    try {
+      mdtPresent = fs.exists(mdtMetaDir);
+    } catch (IOException ioe) {
+      mdtPresent = false;
+    }
+
+    // Collect candidate completed instants from the active timeline.
+    HoodieActiveTimeline active = metaClient.reloadActiveTimeline();
+    List<HoodieInstant> candidates = active.getInstantsAsStream()
+        .filter(HoodieInstant::isCompleted)
+        .filter(i -> actions.contains(i.getAction()))
+        .filter(i -> parsed.startInstant == null || i.requestedTime().compareTo(parsed.startInstant) >= 0)
+        .filter(i -> parsed.endInstant == null || i.requestedTime().compareTo(parsed.endInstant) <= 0)
+        .collect(Collectors.toList());
+
+    List<PhaseTimingRow> rows = new ArrayList<>();
+    Map<String, Integer> skipReasons = new LinkedHashMap<>();
+    int skipped = 0;
+
+    for (HoodieInstant instant : candidates) {
+      PhaseTimingRow row = buildPhaseTimingRow(metaClient, fs, dataMetaDir, mdtMetaDir, mdtPresent,
+          instant, parsed);
+      if (row == null) {
+        // Already counted via skipReasons inside the builder.
+        skipped++;
+        continue;
+      }
+      rows.add(row);
+    }
+
+    // Sort + cap.
+    Comparator<PhaseTimingRow> byInstant = Comparator.comparing(r -> r.instant);
+    if (parsed.sortDescending) {
+      byInstant = byInstant.reversed();
+    }
+    rows.sort(byInstant);
+    List<PhaseTimingRow> capped = rows.size() > parsed.limit
+        ? rows.subList(0, parsed.limit) : rows;
+
+    Map<String, PhaseTimingAggregate> perAction = new LinkedHashMap<>();
+    for (PhaseTimingRow r : capped) {
+      perAction.computeIfAbsent(r.action, k -> new PhaseTimingAggregate(k)).add(r);
+    }
+
+    if (parsed.output == OutputFormat.JSON) {
+      emitPhaseTimingsJson(parsed, mdtPresent, rows, capped, perAction, skipReasons, skipped);
+      return;
+    }
+    emitPhaseTimingsTable(parsed, mdtPresent, rows, capped, perAction, skipReasons, skipped);
+  }
+
+  /**
+   * Builds one row by stat'ing the six expected state-marker files. Returns {@code null}
+   * if any data-table state file is missing; in that case, increments {@code skipReasons}
+   * accordingly so the caller can report a breakdown. MDT files being absent is fine — the
+   * row falls back to the 3-phase view.
+   */
+  private PhaseTimingRow buildPhaseTimingRow(HoodieTableMetaClient metaClient,
+                                             org.apache.hadoop.fs.FileSystem fs,
+                                             Path dataMetaDir,
+                                             Path mdtMetaDir,
+                                             boolean mdtPresent,
+                                             HoodieInstant completed,
+                                             Args parsed) {
+    String ts = completed.requestedTime();
+    String action = completed.getAction();
+    org.apache.hudi.common.table.timeline.InstantGenerator ig = metaClient.getInstantGenerator();
+    org.apache.hudi.common.table.timeline.InstantFileNameGenerator fng = metaClient.getInstantFileNameGenerator();
+    HoodieInstant requested = ig.createNewInstant(HoodieInstant.State.REQUESTED, action, ts);
+    HoodieInstant inflight = ig.createNewInstant(HoodieInstant.State.INFLIGHT, action, ts);
+
+    Long t0 = mtimeOrNull(fs, new Path(dataMetaDir, fng.getFileName(requested)));
+    Long t1 = mtimeOrNull(fs, new Path(dataMetaDir, fng.getFileName(inflight)));
+    Long t5 = mtimeOrNull(fs, new Path(dataMetaDir, fng.getFileName(completed)));
+
+    if (t0 == null || t1 == null || t5 == null) {
+      String reason = (t0 == null ? "requested-missing"
+          : t1 == null ? "inflight-missing" : "completed-missing");
+      // Note: parsed.phaseTimingsSkipReasons is populated via side-effect on the caller
+      // because we can't return more than one value here without an extra wrapper.
+      // (The caller will read the field after this returns null.)
+      recordSkipReason(parsed, reason);
+      return null;
+    }
+
+    Long t2 = null;
+    Long t3 = null;
+    Long t4 = null;
+    if (mdtPresent) {
+      // MDT timeline always uses DELTA_COMMIT_ACTION regardless of data table type.
+      String mdtAction = HoodieTimeline.DELTA_COMMIT_ACTION;
+      HoodieInstant mdtReq = ig.createNewInstant(HoodieInstant.State.REQUESTED, mdtAction, ts);
+      HoodieInstant mdtInf = ig.createNewInstant(HoodieInstant.State.INFLIGHT, mdtAction, ts);
+      t2 = mtimeOrNull(fs, new Path(mdtMetaDir, fng.getFileName(mdtReq)));
+      t3 = mtimeOrNull(fs, new Path(mdtMetaDir, fng.getFileName(mdtInf)));
+      // The completed MDT file carries a completion-time suffix in V2 layout
+      // (<ts>_<completionTime>.deltacommit), which we don't know a priori. Match by
+      // prefix + extension in the MDT timeline dir instead of synthesizing the full name.
+      t4 = mtimeByPrefixOrNull(fs, mdtMetaDir, ts, "." + mdtAction);
+      // Partial MDT state for this instant → fall back to the 3-phase view (treat as if
+      // MDT wasn't present for this row). Don't skip the row.
+      if (t2 == null || t3 == null || t4 == null) {
+        t2 = null;
+        t3 = null;
+        t4 = null;
+      }
+    }
+
+    return new PhaseTimingRow(ts, action, t0, t1, t2, t3, t4, t5);
+  }
+
+  private static Long mtimeOrNull(org.apache.hadoop.fs.FileSystem fs, Path p) {
+    try {
+      return fs.getFileStatus(p).getModificationTime();
+    } catch (java.io.FileNotFoundException nf) {
+      return null;
+    } catch (IOException ioe) {
+      return null;
+    }
+  }
+
+  /**
+   * Returns the mtime of the file under {@code dir} whose name starts with
+   * {@code namePrefix} and ends with {@code nameSuffix}. Used to locate completed instant
+   * files in V2 layout, where the on-disk name embeds a completion-time we don't know
+   * a priori (e.g., "20260601000000000_20260601000000234.deltacommit").
+   */
+  private static Long mtimeByPrefixOrNull(org.apache.hadoop.fs.FileSystem fs, Path dir,
+                                          String namePrefix, String nameSuffix) {
+    try {
+      org.apache.hadoop.fs.FileStatus[] entries = fs.listStatus(dir);
+      if (entries == null) {
+        return null;
+      }
+      for (org.apache.hadoop.fs.FileStatus e : entries) {
+        String n = e.getPath().getName();
+        if (n.startsWith(namePrefix) && n.endsWith(nameSuffix)) {
+          return e.getModificationTime();
+        }
+      }
+      return null;
+    } catch (IOException ioe) {
+      return null;
+    }
+  }
+
+  private static void recordSkipReason(Args parsed, String reason) {
+    parsed.phaseTimingsSkipReasons.merge(reason, 1, Integer::sum);
+  }
+
+  private void emitPhaseTimingsTable(Args parsed, boolean mdtPresent,
+                                     List<PhaseTimingRow> allRows,
+                                     List<PhaseTimingRow> capped,
+                                     Map<String, PhaseTimingAggregate> perAction,
+                                     Map<String, Integer> skipReasons,
+                                     int skipped) {
+    if (!mdtPresent) {
+      System.out.println("(metadata table directory not found — MDT phases will be blank)");
+      System.out.println();
+    }
+    if (capped.isEmpty()) {
+      System.out.println("(no ingestion instants with complete phase timings in range)");
+      if (skipped > 0) {
+        System.out.println("skipped " + skipped + " instant(s): "
+            + formatSkipReasons(parsed.phaseTimingsSkipReasons));
+      }
+      return;
+    }
+    String[] headers = {"instant", "action",
+        "sourceReadIndexSfh_ms", "dataWrite_ms", "mdtPrep_ms", "mdtWrite_ms",
+        "mdtTail_ms", "total_ms"};
+    List<String[]> tableRows = new ArrayList<>(capped.size());
+    for (PhaseTimingRow r : capped) {
+      tableRows.add(new String[]{
+          r.instant, r.action,
+          formatMs(r.sourceReadIndexSfhMs()),
+          formatMs(r.dataWriteMs()),
+          formatMs(r.mdtPrepMs()),
+          formatMs(r.mdtWriteMs()),
+          formatMs(r.mdtTailMs()),
+          formatMs(r.totalMs())
+      });
+    }
+    printRowsWithHeaders(headers, tableRows);
+
+    if (allRows.size() > parsed.limit) {
+      System.out.println();
+      System.out.println("(showing first " + parsed.limit + " of " + allRows.size()
+          + " instants; raise with --limit to see more)");
+    }
+    System.out.println();
+    System.out.println("aggregates (per action, ms):");
+    for (PhaseTimingAggregate agg : perAction.values()) {
+      System.out.println("  " + agg.action + " (n=" + agg.count() + "):");
+      System.out.printf("    sourceReadIndexSfh:  mean=%.0f p50=%d p95=%d max=%d%n",
+          agg.mean(PhaseTimingAggregate.Phase.SOURCE_READ),
+          agg.percentile(PhaseTimingAggregate.Phase.SOURCE_READ, 50),
+          agg.percentile(PhaseTimingAggregate.Phase.SOURCE_READ, 95),
+          agg.max(PhaseTimingAggregate.Phase.SOURCE_READ));
+      System.out.printf("    dataWrite:           mean=%.0f p50=%d p95=%d max=%d%n",
+          agg.mean(PhaseTimingAggregate.Phase.DATA_WRITE),
+          agg.percentile(PhaseTimingAggregate.Phase.DATA_WRITE, 50),
+          agg.percentile(PhaseTimingAggregate.Phase.DATA_WRITE, 95),
+          agg.max(PhaseTimingAggregate.Phase.DATA_WRITE));
+      if (agg.hasMdt()) {
+        System.out.printf("    mdtPrep:             mean=%.0f p50=%d p95=%d max=%d%n",
+            agg.mean(PhaseTimingAggregate.Phase.MDT_PREP),
+            agg.percentile(PhaseTimingAggregate.Phase.MDT_PREP, 50),
+            agg.percentile(PhaseTimingAggregate.Phase.MDT_PREP, 95),
+            agg.max(PhaseTimingAggregate.Phase.MDT_PREP));
+        System.out.printf("    mdtWrite:            mean=%.0f p50=%d p95=%d max=%d%n",
+            agg.mean(PhaseTimingAggregate.Phase.MDT_WRITE),
+            agg.percentile(PhaseTimingAggregate.Phase.MDT_WRITE, 50),
+            agg.percentile(PhaseTimingAggregate.Phase.MDT_WRITE, 95),
+            agg.max(PhaseTimingAggregate.Phase.MDT_WRITE));
+        System.out.printf("    mdtTail:             mean=%.0f p50=%d p95=%d max=%d%n",
+            agg.mean(PhaseTimingAggregate.Phase.MDT_TAIL),
+            agg.percentile(PhaseTimingAggregate.Phase.MDT_TAIL, 50),
+            agg.percentile(PhaseTimingAggregate.Phase.MDT_TAIL, 95),
+            agg.max(PhaseTimingAggregate.Phase.MDT_TAIL));
+      }
+      System.out.printf("    total:               mean=%.0f p50=%d p95=%d max=%d%n",
+          agg.mean(PhaseTimingAggregate.Phase.TOTAL),
+          agg.percentile(PhaseTimingAggregate.Phase.TOTAL, 50),
+          agg.percentile(PhaseTimingAggregate.Phase.TOTAL, 95),
+          agg.max(PhaseTimingAggregate.Phase.TOTAL));
+      // phaseShareOfTotal — fraction of mean total each phase consumes on average.
+      double totalMean = agg.mean(PhaseTimingAggregate.Phase.TOTAL);
+      if (totalMean > 0) {
+        StringBuilder share = new StringBuilder("    share of total (mean):  ");
+        share.append("sourceReadIndexSfh=")
+            .append(String.format("%.1f%%", 100.0 * agg.mean(
+                PhaseTimingAggregate.Phase.SOURCE_READ) / totalMean));
+        share.append(", dataWrite=")
+            .append(String.format("%.1f%%", 100.0 * agg.mean(
+                PhaseTimingAggregate.Phase.DATA_WRITE) / totalMean));
+        if (agg.hasMdt()) {
+          share.append(", mdtPrep=")
+              .append(String.format("%.1f%%", 100.0 * agg.mean(
+                  PhaseTimingAggregate.Phase.MDT_PREP) / totalMean));
+          share.append(", mdtWrite=")
+              .append(String.format("%.1f%%", 100.0 * agg.mean(
+                  PhaseTimingAggregate.Phase.MDT_WRITE) / totalMean));
+          share.append(", mdtTail=")
+              .append(String.format("%.1f%%", 100.0 * agg.mean(
+                  PhaseTimingAggregate.Phase.MDT_TAIL) / totalMean));
+        }
+        System.out.println(share);
+      }
+    }
+    if (skipped > 0) {
+      System.out.println();
+      System.out.println("skipped " + skipped + " instant(s) with incomplete state-marker files: "
+          + formatSkipReasons(parsed.phaseTimingsSkipReasons));
+    }
+  }
+
+  private void emitPhaseTimingsJson(Args parsed, boolean mdtPresent,
+                                    List<PhaseTimingRow> allRows,
+                                    List<PhaseTimingRow> capped,
+                                    Map<String, PhaseTimingAggregate> perAction,
+                                    Map<String, Integer> skipReasons,
+                                    int skipped) throws IOException {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("startInstant", parsed.startInstant);
+    root.put("endInstant", parsed.endInstant);
+    root.put("includeReplacecommit", parsed.includeReplacecommit);
+    root.put("mdtPresent", mdtPresent);
+    root.put("totalInstants", allRows.size());
+    root.put("returnedInstants", capped.size());
+    List<Map<String, Object>> rows = new ArrayList<>(capped.size());
+    for (PhaseTimingRow r : capped) {
+      Map<String, Object> m = new LinkedHashMap<>();
+      m.put("instant", r.instant);
+      m.put("action", r.action);
+      m.put("sourceReadIndexSfhMs", r.sourceReadIndexSfhMs());
+      m.put("dataWriteMs", r.dataWriteMs());
+      m.put("mdtPrepMs", r.mdtPrepMs());
+      m.put("mdtWriteMs", r.mdtWriteMs());
+      m.put("mdtTailMs", r.mdtTailMs());
+      m.put("totalMs", r.totalMs());
+      rows.add(m);
+    }
+    root.put("instants", rows);
+    Map<String, Object> aggBlock = new LinkedHashMap<>();
+    for (Map.Entry<String, PhaseTimingAggregate> e : perAction.entrySet()) {
+      Map<String, Object> a = new LinkedHashMap<>();
+      a.put("count", e.getValue().count());
+      a.put("hasMdt", e.getValue().hasMdt());
+      a.put("sourceReadIndexSfh", phaseStats(e.getValue(), PhaseTimingAggregate.Phase.SOURCE_READ));
+      a.put("dataWrite", phaseStats(e.getValue(), PhaseTimingAggregate.Phase.DATA_WRITE));
+      if (e.getValue().hasMdt()) {
+        a.put("mdtPrep", phaseStats(e.getValue(), PhaseTimingAggregate.Phase.MDT_PREP));
+        a.put("mdtWrite", phaseStats(e.getValue(), PhaseTimingAggregate.Phase.MDT_WRITE));
+        a.put("mdtTail", phaseStats(e.getValue(), PhaseTimingAggregate.Phase.MDT_TAIL));
+      }
+      a.put("total", phaseStats(e.getValue(), PhaseTimingAggregate.Phase.TOTAL));
+      aggBlock.put(e.getKey(), a);
+    }
+    root.put("aggregates", aggBlock);
+    Map<String, Object> skip = new LinkedHashMap<>();
+    skip.put("count", skipped);
+    skip.put("reasons", parsed.phaseTimingsSkipReasons);
+    root.put("skipped", skip);
+    System.out.println(JSON_MAPPER.writeValueAsString(root));
+  }
+
+  private static Map<String, Object> phaseStats(PhaseTimingAggregate agg,
+                                                PhaseTimingAggregate.Phase phase) {
+    Map<String, Object> m = new LinkedHashMap<>();
+    m.put("mean", agg.mean(phase));
+    m.put("p50", agg.percentile(phase, 50));
+    m.put("p95", agg.percentile(phase, 95));
+    m.put("max", agg.max(phase));
+    return m;
+  }
+
+  private static String formatMs(Long v) {
+    return v == null ? "-" : Long.toString(v);
+  }
+
+  private static String formatSkipReasons(Map<String, Integer> reasons) {
+    if (reasons == null || reasons.isEmpty()) {
+      return "(no breakdown)";
+    }
+    return reasons.entrySet().stream()
+        .map(e -> e.getKey() + "=" + e.getValue())
+        .collect(Collectors.joining(", "));
+  }
+
+  // ---- show-instant ---------------------------------------------------------
+
+  private void showInstant(HoodieTableMetaClient metaClient, Args parsed) throws IOException {
+    String instantTime = parsed.showInstantTime;
+    List<InstantLocator> located = findInstantStates(metaClient, instantTime, parsed.actionFilter,
+        parsed.stateFilter, parsed.includeArchived);
+    if (located.isEmpty()) {
+      System.err.println("No instant found with time=" + instantTime
+          + " in active or archived timeline (action filter="
+          + (parsed.actionFilter.isEmpty() ? "<any>" : String.join(",", parsed.actionFilter))
+          + (parsed.stateFilter == null ? "" : ", state=" + parsed.stateFilter) + ")");
+      System.exit(3);
+    }
+
+    if (parsed.output == OutputFormat.JSON) {
+      Map<String, Object> root = new LinkedHashMap<>();
+      root.put("instant", instantTime);
+      List<Map<String, Object>> states = new ArrayList<>();
+      for (InstantLocator loc : located) {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("action", loc.instant.getAction());
+        entry.put("state", loc.instant.getState().toString());
+        entry.put("timeline", loc.timelineType);
+        entry.put("completion", loc.instant.getCompletionTime());
+        try {
+          Object content = readContent(metaClient, loc);
+          entry.put("content", content);
+        } catch (Exception e) {
+          entry.put("error", e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+        states.add(entry);
+      }
+      root.put("states", states);
+      System.out.println(JSON_MAPPER.writeValueAsString(root));
+      return;
+    }
+
+    if (located.size() > 1) {
+      System.out.println("found " + located.size() + " state rows for instant=" + instantTime
+          + " (" + located.stream().map(l -> l.instant.getState().toString())
+              .collect(Collectors.joining(", ")) + ")");
+      System.out.println();
+    }
+    boolean first = true;
+    for (InstantLocator loc : located) {
+      if (!first) {
+        System.out.println();
+        System.out.println("================================================================");
+        System.out.println();
+      }
+      first = false;
+      System.out.println("instant       : " + loc.instant.requestedTime());
+      System.out.println("action        : " + loc.instant.getAction());
+      System.out.println("state         : " + loc.instant.getState());
+      System.out.println("timeline      : " + loc.timelineType);
+      System.out.println("completion    : " + loc.instant.getCompletionTime());
+      System.out.println();
+      System.out.println("---- content ----");
+      Object content;
+      try {
+        content = readContent(metaClient, loc);
+      } catch (Exception e) {
+        System.out.println("(failed to deserialize: " + e.getMessage() + ")");
+        continue;
+      }
+      if (content == null) {
+        System.out.println("(no content / instant has no body)");
+      } else {
+        System.out.println(JSON_MAPPER.writeValueAsString(content));
+      }
+    }
+  }
+
+  // ---- find-file-id ---------------------------------------------------------
+
+  private void findFileId(HoodieTableMetaClient metaClient, Args parsed) throws IOException {
+    String needle = parsed.fileIdNeedle;
+    int limit = parsed.limit;
+
+    HoodieActiveTimeline active = metaClient.reloadActiveTimeline();
+    List<Event> events = new ArrayList<>();
+    scanTimeline(metaClient, active, "ACTIVE", needle, parsed, events, limit);
+
+    if (parsed.includeArchived && events.size() < limit) {
+      HoodieArchivedTimeline archived = metaClient.getArchivedTimeline();
+      if (parsed.startInstant != null && parsed.endInstant != null) {
+        archived.loadInstantDetailsInMemory(parsed.startInstant, parsed.endInstant);
+      } else {
+        archived.loadCompletedInstantDetailsInMemory();
+      }
+      scanTimeline(metaClient, archived, "ARCHIVED", needle, parsed, events, limit);
+    }
+
+    events.sort(Comparator
+        .comparing((Event e) -> e.instantTime)
+        .thenComparing(e -> e.action)
+        .thenComparing(e -> e.matchType));
+
+    List<Event> capped = events.size() > limit ? events.subList(0, limit) : events;
+
+    if (parsed.lifecycle) {
+      emitLifecycle(needle, capped, events.size(), parsed);
+      return;
+    }
+
+    if (parsed.output == OutputFormat.JSON) {
+      Map<String, Object> root = new LinkedHashMap<>();
+      root.put("needle", needle);
+      root.put("totalEvents", events.size());
+      root.put("returnedEvents", capped.size());
+      List<Map<String, Object>> rows = new ArrayList<>(capped.size());
+      for (Event e : capped) {
+        Map<String, Object> r = new LinkedHashMap<>();
+        r.put("instant", e.instantTime);
+        r.put("timeline", e.timelineType);
+        r.put("action", e.action);
+        r.put("state", e.state);
+        r.put("matchType", e.matchType);
+        r.put("partition", e.partition);
+        r.put("detail", e.detail);
+        rows.add(r);
+      }
+      root.put("events", rows);
+      System.out.println(JSON_MAPPER.writeValueAsString(root));
+      return;
+    }
+
+    printEventTable(capped);
+    if (events.size() > limit) {
+      System.out.println();
+      System.out.println("(showing first " + limit + " of " + events.size()
+          + " events; raise with --limit to see more)");
+    }
+  }
+
+  /**
+   * Collapse the events list to lifecycle landmarks: created (first write-stat),
+   * replaced (replaceFileId / clustering), and removed (clean / rollback). Prints a
+   * focused table plus a summary line. Honors --output json|table.
+   */
+  private void emitLifecycle(String needle, List<Event> events, int totalEvents, Args parsed)
+      throws IOException {
+    Event created = null;
+    Event replaced = null;
+    Event cleaned = null;
+    Event rolledBack = null;
+    int writeStatCount = 0;
+
+    for (Event e : events) {
+      switch (e.matchType) {
+        case "writeStat":
+          writeStatCount++;
+          if (created == null) {
+            created = e;
+          }
+          break;
+        case "replaceFileId":
+        case "clusteringInputSlice":
+          if (replaced == null
+              || e.instantTime.compareTo(replaced.instantTime) < 0) {
+            replaced = e;
+          }
+          break;
+        case "cleanSuccessDelete":
+        case "cleanFailedDelete":
+        case "cleanDeletePattern":
+          if (cleaned == null
+              || e.instantTime.compareTo(cleaned.instantTime) < 0) {
+            cleaned = e;
+          }
+          break;
+        case "rollbackSuccessDelete":
+        case "rollbackFailedDelete":
+        case "rollbackPlanFile":
+        case "rollbackPlanLogBlock":
+        case "rollbackOfCommit":
+        case "rollbackPlanTargetCommit":
+          if (rolledBack == null
+              || e.instantTime.compareTo(rolledBack.instantTime) < 0) {
+            rolledBack = e;
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
+    List<String[]> rows = new ArrayList<>();
+    if (created != null) {
+      rows.add(landmarkRow("CREATED", created));
+    }
+    if (replaced != null) {
+      rows.add(landmarkRow("REPLACED", replaced));
+    }
+    if (cleaned != null) {
+      rows.add(landmarkRow("CLEANED", cleaned));
+    }
+    if (rolledBack != null) {
+      rows.add(landmarkRow("ROLLED_BACK", rolledBack));
+    }
+
+    if (parsed.output == OutputFormat.JSON) {
+      Map<String, Object> root = new LinkedHashMap<>();
+      root.put("needle", needle);
+      root.put("totalEvents", totalEvents);
+      root.put("writeStatHits", writeStatCount);
+      List<Map<String, Object>> landmarks = new ArrayList<>();
+      addLandmarkJson(landmarks, "CREATED", created);
+      addLandmarkJson(landmarks, "REPLACED", replaced);
+      addLandmarkJson(landmarks, "CLEANED", cleaned);
+      addLandmarkJson(landmarks, "ROLLED_BACK", rolledBack);
+      root.put("landmarks", landmarks);
+      System.out.println(JSON_MAPPER.writeValueAsString(root));
+      return;
+    }
+
+    if (rows.isEmpty()) {
+      System.out.println("(no lifecycle landmarks found for needle=" + needle + ")");
+      return;
+    }
+    String[] headers = {"landmark", "instant", "action", "state", "timeline", "match_type", "partition", "detail"};
+    printRowsWithHeaders(headers, rows);
+
+    System.out.println();
+    StringBuilder summary = new StringBuilder("summary: ");
+    summary.append(writeStatCount).append(" writeStat hit(s)");
+    if (created != null) {
+      summary.append("; created @ ").append(created.instantTime)
+          .append(" (").append(created.action).append(")");
+    }
+    if (replaced != null) {
+      summary.append("; replaced @ ").append(replaced.instantTime)
+          .append(" (").append(replaced.action).append(")");
+    }
+    if (cleaned != null) {
+      summary.append("; cleaned @ ").append(cleaned.instantTime)
+          .append(" (").append(cleaned.matchType).append(")");
+    }
+    if (rolledBack != null) {
+      summary.append("; rolled-back @ ").append(rolledBack.instantTime)
+          .append(" (").append(rolledBack.matchType).append(")");
+    }
+    summary.append("; ").append(totalEvents).append(" total matching events");
+    System.out.println(summary.toString());
+  }
+
+  private String[] landmarkRow(String label, Event e) {
+    return new String[]{
+        label, e.instantTime, e.action, e.state, e.timelineType,
+        e.matchType, e.partition == null ? "" : e.partition,
+        e.detail == null ? "" : e.detail
+    };
+  }
+
+  private void addLandmarkJson(List<Map<String, Object>> out, String label, Event e) {
+    if (e == null) {
+      return;
+    }
+    Map<String, Object> m = new LinkedHashMap<>();
+    m.put("landmark", label);
+    m.put("instant", e.instantTime);
+    m.put("action", e.action);
+    m.put("state", e.state);
+    m.put("timeline", e.timelineType);
+    m.put("matchType", e.matchType);
+    m.put("partition", e.partition);
+    m.put("detail", e.detail);
+    out.add(m);
+  }
+
+  private void scanTimeline(HoodieTableMetaClient metaClient,
+                            HoodieTimeline timeline,
+                            String timelineType,
+                            String needle,
+                            Args parsed,
+                            List<Event> out,
+                            int hardCap) {
+    Stream<HoodieInstant> instants = timeline.getInstantsAsStream()
+        .filter(i -> parsed.actionFilter.isEmpty() || parsed.actionFilter.contains(i.getAction()))
+        .filter(i -> parsed.startInstant == null || i.requestedTime().compareTo(parsed.startInstant) >= 0)
+        .filter(i -> parsed.endInstant == null || i.requestedTime().compareTo(parsed.endInstant) <= 0);
+
+    for (HoodieInstant instant : (Iterable<HoodieInstant>) instants::iterator) {
+      if (out.size() >= hardCap * 4L) {
+        // hard scan cap so a runaway match doesn't OOM; *4 leaves headroom for sorting
+        break;
+      }
+      try {
+        scanInstant(metaClient, timeline, timelineType, instant, needle, out);
+      } catch (Exception e) {
+        // Best-effort scan: bad bytes on a single instant shouldn't kill the whole run.
+        if (!parsed.quiet) {
+          System.err.println("WARN: failed to process " + timelineType + " " + instant + ": " + e.getMessage());
+        }
+      }
+    }
+  }
+
+  private void scanInstant(HoodieTableMetaClient metaClient,
+                           HoodieTimeline timeline,
+                           String timelineType,
+                           HoodieInstant instant,
+                           String needle,
+                           List<Event> out) throws IOException {
+    String action = instant.getAction();
+    boolean isCompleted = instant.isCompleted();
+    boolean isRequested = instant.isRequested();
+
+    switch (action) {
+      case HoodieTimeline.COMMIT_ACTION:
+      case HoodieTimeline.DELTA_COMMIT_ACTION:
+        if (isCompleted) {
+          HoodieCommitMetadata cm = readCommitMetadata(timeline, instant, HoodieCommitMetadata.class);
+          collectFromCommitMetadata(cm, instant, timelineType, needle, out);
+        }
+        break;
+
+      case HoodieTimeline.REPLACE_COMMIT_ACTION:
+        if (isCompleted) {
+          HoodieReplaceCommitMetadata rcm =
+              readCommitMetadata(timeline, instant, HoodieReplaceCommitMetadata.class);
+          collectFromCommitMetadata(rcm, instant, timelineType, needle, out);
+          if (rcm.getPartitionToReplaceFileIds() != null) {
+            for (Map.Entry<String, List<String>> e : rcm.getPartitionToReplaceFileIds().entrySet()) {
+              for (String replaced : e.getValue()) {
+                if (matches(replaced, needle)) {
+                  out.add(new Event(instant, timelineType, "replaceFileId", e.getKey(), replaced));
+                }
+              }
+            }
+          }
+        } else if (isRequested) {
+          // The requested-replace metadata may carry an embedded clustering plan.
+          Option<HoodieRequestedReplaceMetadata> rrm = Option.empty();
+          try {
+            rrm = Option.of(readSpecificRecord(timeline, instant,
+                HoodieRequestedReplaceMetadata.class, HoodieRequestedReplaceMetadata.getClassSchema()));
+          } catch (Exception ignored) {
+            // not all requested replacecommits carry a body
+          }
+          if (rrm.isPresent() && rrm.get().getClusteringPlan() != null) {
+            collectFromClusteringPlan(rrm.get().getClusteringPlan(), instant, timelineType, needle, out);
+          } else {
+            // Fallback to the metaClient-aware helper (works against active timeline only).
+            try {
+              Option<org.apache.hudi.common.util.collection.Pair<HoodieInstant, HoodieClusteringPlan>> cp =
+                  ClusteringUtils.getClusteringPlan(metaClient, instant);
+              if (cp.isPresent()) {
+                collectFromClusteringPlan(cp.get().getValue(), instant, timelineType, needle, out);
+              }
+            } catch (Exception ignored) {
+              // archived-timeline path; rrm above already covered it
+            }
+          }
+        }
+        break;
+
+      case HoodieTimeline.CLEAN_ACTION:
+        if (isCompleted) {
+          HoodieCleanMetadata cm = readSpecificRecord(timeline, instant,
+              HoodieCleanMetadata.class, HoodieCleanMetadata.getClassSchema());
+          collectFromCleanMetadata(cm, instant, timelineType, needle, out);
+        }
+        // Requested clean plan also lists files-to-delete, but the upstream commit
+        // didn't surface it -- skip for now to keep output focused on actual deletions.
+        break;
+
+      case HoodieTimeline.ROLLBACK_ACTION:
+        if (isCompleted) {
+          HoodieRollbackMetadata rm = readSpecificRecord(timeline, instant,
+              HoodieRollbackMetadata.class, HoodieRollbackMetadata.getClassSchema());
+          collectFromRollbackMetadata(rm, instant, timelineType, needle, out);
+        } else if (isRequested) {
+          try {
+            HoodieRollbackPlan plan = readSpecificRecord(timeline, instant,
+                HoodieRollbackPlan.class, HoodieRollbackPlan.getClassSchema());
+            collectFromRollbackPlan(plan, instant, timelineType, needle, out);
+          } catch (Exception ignored) {
+            // some old tables have empty requested rollback bodies
+          }
+        }
+        break;
+
+      case HoodieTimeline.RESTORE_ACTION:
+        if (isCompleted) {
+          try {
+            HoodieRestoreMetadata rm = readSpecificRecord(timeline, instant,
+                HoodieRestoreMetadata.class, HoodieRestoreMetadata.getClassSchema());
+            collectFromRestoreMetadata(rm, instant, timelineType, needle, out);
+          } catch (Exception ignored) {
+            // best-effort
+          }
+        } else if (isRequested) {
+          try {
+            HoodieRestorePlan plan = readSpecificRecord(timeline, instant,
+                HoodieRestorePlan.class, HoodieRestorePlan.getClassSchema());
+            collectFromRestorePlan(plan, instant, timelineType, needle, out);
+          } catch (Exception ignored) {
+            // best-effort
+          }
+        }
+        break;
+
+      default:
+        // savepoint, compaction (the .compaction.* files are themselves write stats once
+        // they complete as a regular commit), indexing, etc. -- not part of the file-id
+        // dragnet for now.
+        break;
+    }
+  }
+
+  private void collectFromCommitMetadata(HoodieCommitMetadata cm, HoodieInstant instant,
+                                         String timelineType, String needle, List<Event> out) {
+    if (cm == null || cm.getPartitionToWriteStats() == null) {
+      return;
+    }
+    for (Map.Entry<String, List<HoodieWriteStat>> e : cm.getPartitionToWriteStats().entrySet()) {
+      for (HoodieWriteStat ws : e.getValue()) {
+        if (matches(ws.getFileId(), needle) || matches(ws.getPath(), needle)) {
+          String detail = "path=" + ws.getPath()
+              + " numWrites=" + ws.getNumWrites()
+              + " numUpdates=" + ws.getNumUpdateWrites()
+              + " numDeletes=" + ws.getNumDeletes()
+              + " prevCommit=" + ws.getPrevCommit();
+          out.add(new Event(instant, timelineType, "writeStat", e.getKey(), detail));
+        }
+      }
+    }
+  }
+
+  private void collectFromClusteringPlan(HoodieClusteringPlan plan, HoodieInstant instant,
+                                         String timelineType, String needle, List<Event> out) {
+    if (plan == null || plan.getInputGroups() == null) {
+      return;
+    }
+    plan.getInputGroups().forEach(group -> group.getSlices().forEach(slice -> {
+      String dataFile = slice.getDataFilePath();
+      if (matches(dataFile, needle) || matches(slice.getFileId(), needle)) {
+        out.add(new Event(instant, timelineType, "clusteringInputSlice",
+            slice.getPartitionPath(),
+            "dataFile=" + dataFile + " fileId=" + slice.getFileId()));
+      }
+    }));
+  }
+
+  private void collectFromCleanMetadata(HoodieCleanMetadata cm, HoodieInstant instant,
+                                        String timelineType, String needle, List<Event> out) {
+    if (cm == null || cm.getPartitionMetadata() == null) {
+      return;
+    }
+    for (Map.Entry<String, HoodieCleanPartitionMetadata> e : cm.getPartitionMetadata().entrySet()) {
+      HoodieCleanPartitionMetadata pm = e.getValue();
+      collectFileMatches(instant, timelineType, "cleanSuccessDelete", e.getKey(),
+          pm.getSuccessDeleteFiles(), needle, out);
+      collectFileMatches(instant, timelineType, "cleanFailedDelete", e.getKey(),
+          pm.getFailedDeleteFiles(), needle, out);
+      collectFileMatches(instant, timelineType, "cleanDeletePattern", e.getKey(),
+          pm.getDeletePathPatterns(), needle, out);
+    }
+  }
+
+  private void collectFromRollbackMetadata(HoodieRollbackMetadata rm, HoodieInstant instant,
+                                           String timelineType, String needle, List<Event> out) {
+    if (rm == null) {
+      return;
+    }
+    // commitsRollback (legacy field; populated on most 0.14.x rollbacks but not all).
+    if (rm.getCommitsRollback() != null) {
+      for (String rolledBack : rm.getCommitsRollback()) {
+        if (matches(rolledBack, needle)) {
+          out.add(new Event(instant, timelineType, "rollbackOfCommit", "<any>",
+              "rolledBackCommit=" + rolledBack));
+        }
+      }
+    }
+    // instantsRollback (newer field; carries both commit time and action). The schema
+    // explicitly notes this "overlaps with commitsRollback" -- some rollbacks fill only
+    // this one. Check it independently so we don't miss matches.
+    if (rm.getInstantsRollback() != null) {
+      for (HoodieInstantInfo info : rm.getInstantsRollback()) {
+        if (info != null && matches(info.getCommitTime(), needle)) {
+          out.add(new Event(instant, timelineType, "rollbackOfCommit", "<any>",
+              "rolledBackCommit=" + info.getCommitTime() + " action=" + info.getAction()));
+        }
+      }
+    }
+    if (rm.getPartitionMetadata() != null) {
+      for (Map.Entry<String, HoodieRollbackPartitionMetadata> e : rm.getPartitionMetadata().entrySet()) {
+        HoodieRollbackPartitionMetadata pm = e.getValue();
+        collectFileMatches(instant, timelineType, "rollbackSuccessDelete", e.getKey(),
+            pm.getSuccessDeleteFiles(), needle, out);
+        collectFileMatches(instant, timelineType, "rollbackFailedDelete", e.getKey(),
+            pm.getFailedDeleteFiles(), needle, out);
+      }
+    }
+  }
+
+  private void collectFromRestoreMetadata(HoodieRestoreMetadata rm, HoodieInstant instant,
+                                          String timelineType, String needle, List<Event> out) {
+    if (rm == null) {
+      return;
+    }
+    if (rm.getInstantsToRollback() != null) {
+      for (String rolledBack : rm.getInstantsToRollback()) {
+        if (matches(rolledBack, needle)) {
+          out.add(new Event(instant, timelineType, "restoreOfCommit", "<any>",
+              "rolledBackCommit=" + rolledBack));
+        }
+      }
+    }
+    // hoodieRestoreMetadata = map of partition -> list of nested HoodieRollbackMetadata.
+    if (rm.getHoodieRestoreMetadata() != null) {
+      for (Map.Entry<String, List<HoodieRollbackMetadata>> e : rm.getHoodieRestoreMetadata().entrySet()) {
+        for (HoodieRollbackMetadata nested : e.getValue()) {
+          collectFromRollbackMetadata(nested, instant, timelineType, needle, out);
+        }
+      }
+    }
+  }
+
+  private void collectFromRestorePlan(HoodieRestorePlan plan, HoodieInstant instant,
+                                      String timelineType, String needle, List<Event> out) {
+    if (plan == null) {
+      return;
+    }
+    if (plan.getInstantsToRollback() != null) {
+      for (HoodieInstantInfo info : plan.getInstantsToRollback()) {
+        if (info != null && matches(info.getCommitTime(), needle)) {
+          out.add(new Event(instant, timelineType, "restorePlanTargetCommit", "<any>",
+              "rolledBackCommit=" + info.getCommitTime() + " action=" + info.getAction()));
+        }
+      }
+    }
+    if (matches(plan.getSavepointToRestoreTimestamp(), needle)) {
+      out.add(new Event(instant, timelineType, "restorePlanSavepoint", "<any>",
+          "savepointToRestore=" + plan.getSavepointToRestoreTimestamp()));
+    }
+  }
+
+  private void collectFromRollbackPlan(HoodieRollbackPlan plan, HoodieInstant instant,
+                                       String timelineType, String needle, List<Event> out) {
+    if (plan == null) {
+      return;
+    }
+    if (plan.getInstantToRollback() != null
+        && matches(plan.getInstantToRollback().getCommitTime(), needle)) {
+      out.add(new Event(instant, timelineType, "rollbackPlanTargetCommit", "<any>",
+          "rolledBackCommit=" + plan.getInstantToRollback().getCommitTime()));
+    }
+    if (plan.getRollbackRequests() != null) {
+      for (HoodieRollbackRequest req : plan.getRollbackRequests()) {
+        collectFileMatches(instant, timelineType, "rollbackPlanFile", req.getPartitionPath(),
+            req.getFilesToBeDeleted(), needle, out);
+        // Also include log-block scopes if present
+        if (req.getLogBlocksToBeDeleted() != null) {
+          for (String logFile : req.getLogBlocksToBeDeleted().keySet()) {
+            if (matches(logFile, needle)) {
+              out.add(new Event(instant, timelineType, "rollbackPlanLogBlock",
+                  req.getPartitionPath(), "logFile=" + logFile));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private void collectFileMatches(HoodieInstant instant, String timelineType, String matchType,
+                                  String partition, Collection<String> files,
+                                  String needle, List<Event> out) {
+    if (files == null) {
+      return;
+    }
+    for (String f : files) {
+      if (matches(f, needle)) {
+        out.add(new Event(instant, timelineType, matchType, partition, f));
+      }
+    }
+  }
+
+  private static boolean matches(String haystack, String needle) {
+    return haystack != null && !haystack.isEmpty() && haystack.contains(needle);
+  }
+
+  // ---- output ---------------------------------------------------------------
+
+  private void printEventTable(List<Event> events) {
+    if (events.isEmpty()) {
+      System.out.println("(no events)");
+      return;
+    }
+    String[] headers = {"instant", "timeline", "action", "state", "match_type", "partition", "detail"};
+    List<String[]> rows = new ArrayList<>(events.size());
+    for (Event e : events) {
+      rows.add(new String[]{
+          e.instantTime, e.timelineType, e.action, e.state, e.matchType,
+          e.partition == null ? "" : e.partition,
+          e.detail == null ? "" : e.detail
+      });
+    }
+    printRowsWithHeaders(headers, rows);
+  }
+
+  private void printRowsWithHeaders(String[] headers, List<String[]> rows) {
+    int[] widths = new int[headers.length];
+    for (int i = 0; i < headers.length; i++) {
+      widths[i] = headers[i].length();
+    }
+    for (String[] r : rows) {
+      for (int i = 0; i < headers.length; i++) {
+        if (r[i] != null && r[i].length() > widths[i]) {
+          widths[i] = Math.min(r[i].length(), 120);
+        }
+      }
+    }
+    printRow(headers, widths);
+    StringBuilder rule = new StringBuilder();
+    for (int w : widths) {
+      for (int i = 0; i < w; i++) {
+        rule.append('-');
+      }
+      rule.append("  ");
+    }
+    System.out.println(rule);
+    for (String[] r : rows) {
+      printRow(r, widths);
+    }
+  }
+
+  private void printRow(String[] cols, int[] widths) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < cols.length; i++) {
+      String c = cols[i] == null ? "" : cols[i];
+      if (c.length() > widths[i]) {
+        c = c.substring(0, widths[i] - 1) + "…";
+      }
+      sb.append(c);
+      for (int p = c.length(); p < widths[i]; p++) {
+        sb.append(' ');
+      }
+      sb.append("  ");
+    }
+    System.out.println(sb);
+  }
+
+  // ---- locator + readers ----------------------------------------------------
+
+  /**
+   * Finds every state of the given instant time across both timelines (subject to optional
+   * action + state filters), in REQUESTED → INFLIGHT → COMPLETED order. With no filters,
+   * an instant that completed normally will return all three rows.
+   */
+  private List<InstantLocator> findInstantStates(HoodieTableMetaClient metaClient,
+                                                 String instantTime,
+                                                 Set<String> actionFilter,
+                                                 HoodieInstant.State stateFilter,
+                                                 boolean includeArchived) {
+    List<InstantLocator> hits = new ArrayList<>();
+    HoodieActiveTimeline active = metaClient.reloadActiveTimeline();
+    active.getInstantsAsStream()
+        .filter(i -> i.requestedTime().equals(instantTime))
+        .filter(i -> actionFilter.isEmpty() || actionFilter.contains(i.getAction()))
+        .filter(i -> stateFilter == null || i.getState() == stateFilter)
+        .forEach(i -> hits.add(new InstantLocator(i, active, "ACTIVE")));
+    if (hits.isEmpty() && includeArchived) {
+      HoodieArchivedTimeline archived = metaClient.getArchivedTimeline();
+      archived.loadInstantDetailsInMemory(instantTime, instantTime);
+      archived.getInstantsAsStream()
+          .filter(i -> i.requestedTime().equals(instantTime))
+          .filter(i -> actionFilter.isEmpty() || actionFilter.contains(i.getAction()))
+          .filter(i -> stateFilter == null || i.getState() == stateFilter)
+          .forEach(i -> hits.add(new InstantLocator(i, archived, "ARCHIVED")));
+    }
+    hits.sort(Comparator.comparingInt(loc -> statePriority(loc.instant.getState())));
+    return hits;
+  }
+
+  /** REQUESTED → INFLIGHT → COMPLETED, so output reads in lifecycle order. */
+  private static int statePriority(HoodieInstant.State state) {
+    switch (state) {
+      case REQUESTED: return 0;
+      case INFLIGHT:  return 1;
+      case COMPLETED: return 2;
+      default:        return 99;
+    }
+  }
+
+  private Object readContent(HoodieTableMetaClient metaClient, InstantLocator loc) throws IOException {
+    HoodieInstant instant = loc.instant;
+    String action = instant.getAction();
+
+    switch (action) {
+      case HoodieTimeline.COMMIT_ACTION:
+      case HoodieTimeline.DELTA_COMMIT_ACTION:
+        return readCommitMetadataTolerant(loc, instant, HoodieCommitMetadata.class);
+      case HoodieTimeline.REPLACE_COMMIT_ACTION:
+        if (instant.isCompleted()) {
+          return readCommitMetadataTolerant(loc, instant, HoodieReplaceCommitMetadata.class);
+        } else if (instant.isRequested()) {
+          try {
+            return readSpecificRecord(loc.timeline, instant,
+                HoodieRequestedReplaceMetadata.class, HoodieRequestedReplaceMetadata.getClassSchema());
+          } catch (Exception e) {
+            return Collections.singletonMap("note", "no body or schema mismatch");
+          }
+        }
+        return null;
+      case HoodieTimeline.CLEAN_ACTION:
+        if (instant.isCompleted()) {
+          return readSpecificRecord(loc.timeline, instant,
+              HoodieCleanMetadata.class, HoodieCleanMetadata.getClassSchema());
+        }
+        return null;
+      case HoodieTimeline.ROLLBACK_ACTION:
+        if (instant.isCompleted()) {
+          return readSpecificRecord(loc.timeline, instant,
+              HoodieRollbackMetadata.class, HoodieRollbackMetadata.getClassSchema());
+        } else if (instant.isRequested()) {
+          return readSpecificRecord(loc.timeline, instant,
+              HoodieRollbackPlan.class, HoodieRollbackPlan.getClassSchema());
+        }
+        return null;
+      case HoodieTimeline.RESTORE_ACTION:
+        if (instant.isCompleted()) {
+          return readSpecificRecord(loc.timeline, instant,
+              HoodieRestoreMetadata.class, HoodieRestoreMetadata.getClassSchema());
+        } else if (instant.isRequested()) {
+          return readSpecificRecord(loc.timeline, instant,
+              HoodieRestorePlan.class, HoodieRestorePlan.getClassSchema());
+        }
+        return null;
+      default:
+        // Generic best-effort: print raw bytes length and a hex prefix.
+        Option<byte[]> bytes = loc.timeline.getInstantDetails(instant);
+        if (!bytes.isPresent() || bytes.get().length == 0) {
+          return null;
+        }
+        Map<String, Object> generic = new LinkedHashMap<>();
+        generic.put("byteLength", bytes.get().length);
+        generic.put("hexPrefix", toHex(bytes.get(), Math.min(64, bytes.get().length)));
+        return generic;
+    }
+  }
+
+  /**
+   * Reads a non-Avro-SpecificRecord commit metadata (HoodieCommitMetadata / its replace subclass)
+   * via Hudi's typed-content reader, which handles the JSON path that 0.14.1 uses on disk for
+   * both active and archived timelines.
+   */
+  private <T> T readCommitMetadata(HoodieTimeline timeline, HoodieInstant instant, Class<T> clazz)
+      throws IOException {
+    return timeline.readInstantContent(instant, clazz);
+  }
+
+  /**
+   * Reads commit/replace metadata for show-instant. The archived timeline stores these via
+   * {@code GenericRecord.toString()} -- an Avro-flavored JSON -- which Jackson cannot
+   * round-trip into the POJO {@code HoodieCommitMetadata}: it returns an empty shell
+   * (empty maps, {@code UNKNOWN} operationType). To avoid that data loss, if the bytes
+   * start with '{' we return the parsed JSON tree directly instead of the POJO.
+   */
+  private Object readCommitMetadataTolerant(InstantLocator loc, HoodieInstant instant, Class<?> clazz)
+      throws IOException {
+    Option<byte[]> rawOpt = loc.timeline.getInstantDetails(instant);
+    if (!rawOpt.isPresent() || rawOpt.get().length == 0) {
+      return null;
+    }
+    byte[] raw = rawOpt.get();
+    int firstNonWs = 0;
+    while (firstNonWs < raw.length && Character.isWhitespace((char) raw[firstNonWs])) {
+      firstNonWs++;
+    }
+    if (firstNonWs < raw.length && raw[firstNonWs] == '{') {
+      // Parse the JSON tree and return it as-is. Faithful to whatever the archive stored
+      // (which is Avro's toString() of the GenericRecord, lossless modulo whitespace).
+      try {
+        return JSON_MAPPER.readTree(raw);
+      } catch (Exception parseFail) {
+        // Fall through to the POJO path; better than nothing.
+      }
+    }
+    return loc.timeline.readInstantContent(instant, clazz);
+  }
+
+  /**
+   * Reads an Avro SpecificRecord (clean / rollback / requested-replace / rollback-plan) tolerating
+   * both Avro-container bytes (active timeline writes them as .avro) and JSON-string bytes (the
+   * HoodieArchivedTimeline in 0.14.1 stores non-compaction archived actions as JSON strings in
+   * its in-memory readCommits cache).
+   */
+  private <T extends SpecificRecordBase> T readSpecificRecord(HoodieTimeline timeline,
+                                                              HoodieInstant instant,
+                                                              Class<T> clazz,
+                                                              Schema schema) throws IOException {
+    byte[] bytes = timeline.getInstantDetails(instant).orElseGet(() -> new byte[0]);
+    if (bytes.length >= 4 && bytes[0] == 'O' && bytes[1] == 'b' && bytes[2] == 'j' && bytes[3] == 1) {
+      try (DataFileStream<T> reader =
+               new DataFileStream<>(new ByteArrayInputStream(bytes), new SpecificDatumReader<>(clazz))) {
+        if (!reader.hasNext()) {
+          throw new IOException("empty Avro container for instant " + instant);
+        }
+        return reader.next();
+      }
+    }
+    if (bytes.length == 0) {
+      throw new IOException("no body for instant " + instant);
+    }
+    // First-try: pristine Avro JSON encoding (tagged unions).
+    try {
+      return new SpecificDatumReader<T>(schema).read(null,
+          DecoderFactory.get().jsonDecoder(schema, new ByteArrayInputStream(bytes)));
+    } catch (AvroTypeException firstAttempt) {
+      // HoodieArchivedTimeline serializes non-compaction archived metadata via Avro's
+      // GenericData.toString() which emits union values as the raw branch value (e.g.
+      // "isPartitionDeleted": false) instead of Avro's spec-compliant tagged form
+      // ({"boolean": false}). Walk the JSON tree against the schema, tag-wrap any
+      // raw-branch union values, and retry. Falls back to throwing the original error
+      // if fixup itself fails.
+      JsonNode root;
+      try {
+        root = JSON_MAPPER.readTree(bytes);
+      } catch (Exception parseFail) {
+        throw firstAttempt;
+      }
+      JsonNode fixed = fixupUnionTags(root, schema);
+      byte[] rewritten = JSON_MAPPER.writeValueAsBytes(fixed);
+      return new SpecificDatumReader<T>(schema).read(null,
+          DecoderFactory.get().jsonDecoder(schema, new ByteArrayInputStream(rewritten)));
+    }
+  }
+
+  /**
+   * Walks a Jackson tree alongside the given Avro schema and rewrites any value that lands
+   * on a UNION whose declared form is {@code ["null", X]} but whose JSON form is the raw X
+   * branch value. Avro JsonDecoder needs the tagged form {@code {"X": value}} except for
+   * the null branch (which stays bare {@code null}). Records and arrays are recursed into.
+   */
+  private static JsonNode fixupUnionTags(JsonNode node, Schema schema) {
+    if (node == null || node.isMissingNode()) {
+      return node;
+    }
+    switch (schema.getType()) {
+      case UNION:
+        return fixupUnion(node, schema);
+      case RECORD: {
+        if (!node.isObject()) {
+          return node;
+        }
+        ObjectNode obj = (ObjectNode) node;
+        ObjectNode out = JsonNodeFactory.instance.objectNode();
+        for (Schema.Field field : schema.getFields()) {
+          JsonNode child = obj.get(field.name());
+          if (child != null) {
+            out.set(field.name(), fixupUnionTags(child, field.schema()));
+          }
+        }
+        return out;
+      }
+      case ARRAY: {
+        if (!node.isArray()) {
+          return node;
+        }
+        ArrayNode arr = (ArrayNode) node;
+        ArrayNode out = JsonNodeFactory.instance.arrayNode();
+        for (JsonNode el : arr) {
+          out.add(fixupUnionTags(el, schema.getElementType()));
+        }
+        return out;
+      }
+      case MAP: {
+        if (!node.isObject()) {
+          return node;
+        }
+        ObjectNode mapNode = (ObjectNode) node;
+        ObjectNode out = JsonNodeFactory.instance.objectNode();
+        java.util.Iterator<String> it = mapNode.fieldNames();
+        while (it.hasNext()) {
+          String k = it.next();
+          out.set(k, fixupUnionTags(mapNode.get(k), schema.getValueType()));
+        }
+        return out;
+      }
+      default:
+        // Primitive types pass through unchanged.
+        return node;
+    }
+  }
+
+  private static JsonNode fixupUnion(JsonNode node, Schema unionSchema) {
+    List<Schema> branches = unionSchema.getTypes();
+    boolean hasNull = false;
+    Schema nonNull = null;
+    for (Schema b : branches) {
+      if (b.getType() == Schema.Type.NULL) {
+        hasNull = true;
+      } else if (nonNull == null) {
+        nonNull = b;
+      } else {
+        // Multi-non-null unions are uncommon in Hudi metadata; bail and trust the input.
+        return node;
+      }
+    }
+    if (node.isNull()) {
+      return node;
+    }
+    if (node.isObject() && node.size() == 1) {
+      // Already tagged; recurse into the branch value to keep nested unions consistent.
+      String key = node.fieldNames().next();
+      Schema branch = null;
+      for (Schema b : branches) {
+        if (avroJsonBranchName(b).equals(key)) {
+          branch = b;
+          break;
+        }
+      }
+      if (branch != null) {
+        ObjectNode out = JsonNodeFactory.instance.objectNode();
+        out.set(key, fixupUnionTags(node.get(key), branch));
+        return out;
+      }
+      // Unrecognized tag — leave as-is.
+      return node;
+    }
+    if (hasNull && nonNull != null) {
+      // Raw branch value (the malformed-archive case). Recurse first so nested records
+      // also get their unions fixed.
+      JsonNode recursed = fixupUnionTags(node, nonNull);
+      ObjectNode wrapper = JsonNodeFactory.instance.objectNode();
+      wrapper.set(avroJsonBranchName(nonNull), recursed);
+      return wrapper;
+    }
+    return node;
+  }
+
+  /** Avro's JSON branch name for a non-null schema (matches DataFileWriter conventions). */
+  private static String avroJsonBranchName(Schema schema) {
+    switch (schema.getType()) {
+      case RECORD: case ENUM: case FIXED:
+        return schema.getFullName();
+      default:
+        return schema.getType().getName();
+    }
+  }
+
+  private static String toHex(byte[] bytes, int limit) {
+    StringBuilder sb = new StringBuilder(limit * 3);
+    for (int i = 0; i < limit; i++) {
+      sb.append(String.format("%02x ", bytes[i]));
+    }
+    return sb.toString().trim();
+  }
+
+  // ---- args + types ---------------------------------------------------------
+
+  enum Mode { SHOW_INSTANT, FIND_FILE_ID, PARSE_FILENAME, RAW_ARCHIVE, COMMIT_STATS, PHASE_TIMINGS }
+
+  enum OutputFormat { TABLE, JSON }
+
+  static class InstantLocator {
+    final HoodieInstant instant;
+    final HoodieTimeline timeline;
+    final String timelineType;
+
+    InstantLocator(HoodieInstant instant, HoodieTimeline timeline, String timelineType) {
+      this.instant = instant;
+      this.timeline = timeline;
+      this.timelineType = timelineType;
+    }
+  }
+
+  static class CommitStatsRow {
+    final String instant;
+    final String timelineType;
+    final String action;
+    final String operation;
+    final long numInserts;
+    final long numUpdates;
+    final long numDeletes;
+    final long filesInserted;
+    final long filesUpdated;
+    final long filesDeleted;
+    final long bytesWritten;
+    final long partitions;
+
+    CommitStatsRow(String instant, String timelineType, String action, String operation,
+                   long numInserts, long numUpdates, long numDeletes,
+                   long filesInserted, long filesUpdated, long filesDeleted,
+                   long bytesWritten, long partitions) {
+      this.instant = instant;
+      this.timelineType = timelineType;
+      this.action = action;
+      this.operation = operation;
+      this.numInserts = numInserts;
+      this.numUpdates = numUpdates;
+      this.numDeletes = numDeletes;
+      this.filesInserted = filesInserted;
+      this.filesUpdated = filesUpdated;
+      this.filesDeleted = filesDeleted;
+      this.bytesWritten = bytesWritten;
+      this.partitions = partitions;
+    }
+
+    static CommitStatsRow empty(HoodieInstant instant, String timelineType) {
+      return new CommitStatsRow(instant.requestedTime(), timelineType, instant.getAction(),
+          "UNKNOWN", 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    static CommitStatsRow fromPojo(HoodieInstant instant, String timelineType,
+                                   HoodieCommitMetadata cm, boolean isReplace) {
+      long filesDeleted = 0;
+      if (isReplace && cm instanceof HoodieReplaceCommitMetadata) {
+        Map<String, List<String>> replaced =
+            ((HoodieReplaceCommitMetadata) cm).getPartitionToReplaceFileIds();
+        if (replaced != null) {
+          for (List<String> ids : replaced.values()) {
+            filesDeleted += ids.size();
+          }
+        }
+      }
+      WriteOperationType op = cm.getOperationType();
+      return new CommitStatsRow(
+          instant.requestedTime(), timelineType, instant.getAction(),
+          op == null ? "UNKNOWN" : op.toString(),
+          cm.fetchTotalInsertRecordsWritten(),
+          cm.fetchTotalUpdateRecordsWritten(),
+          cm.getTotalRecordsDeleted(),
+          cm.fetchTotalFilesInsert(),
+          cm.fetchTotalFilesUpdated(),
+          filesDeleted,
+          cm.fetchTotalBytesWritten(),
+          cm.fetchTotalPartitionsWritten());
+    }
+
+    /**
+     * Aggregate stats from the archived-shell JSON. Walks {@code partitionToWriteStats} and
+     * sums per-stat fields directly, replicating the {@code fetchTotal*} helpers from
+     * {@link HoodieCommitMetadata}.
+     */
+    static CommitStatsRow fromJson(HoodieInstant instant, String timelineType,
+                                   JsonNode root, boolean isReplace) {
+      long numInserts = 0;
+      long numUpdates = 0;
+      long numDeletes = 0;
+      long filesInserted = 0;
+      long filesUpdated = 0;
+      long bytesWritten = 0;
+      long partitions = 0;
+      String operation = "UNKNOWN";
+      if (root.hasNonNull("operationType")) {
+        operation = root.get("operationType").asText();
+      }
+
+      JsonNode p2ws = root.get("partitionToWriteStats");
+      if (p2ws != null && p2ws.isObject()) {
+        partitions = p2ws.size();
+        java.util.Iterator<String> partIt = p2ws.fieldNames();
+        while (partIt.hasNext()) {
+          String partition = partIt.next();
+          JsonNode statsArr = p2ws.get(partition);
+          if (statsArr == null || !statsArr.isArray()) {
+            continue;
+          }
+          for (JsonNode ws : statsArr) {
+            long ins = ws.path("numInserts").asLong(0);
+            long upd = ws.path("numUpdateWrites").asLong(0);
+            long del = ws.path("numDeletes").asLong(0);
+            long bytes = ws.path("totalWriteBytes").asLong(0);
+            // prevCommit semantics (mirror HoodieCommitMetadata):
+            //  - missing/JSON-null  → field unset, file is neither inserted nor updated here
+            //  - literal string "null" → new file (file insert)
+            //  - any other string   → file update (writes against an existing file)
+            JsonNode prevCommitNode = ws.get("prevCommit");
+            boolean prevCommitFieldSet = prevCommitNode != null && !prevCommitNode.isNull();
+            String prevCommit = prevCommitFieldSet ? prevCommitNode.asText() : null;
+            numDeletes += del;
+            bytesWritten += bytes;
+            numUpdates += upd;
+            if (prevCommitFieldSet) {
+              numInserts += ins;
+              if (prevCommit.equalsIgnoreCase("null")) {
+                filesInserted++;
+              } else {
+                filesUpdated++;
+              }
+            }
+          }
+        }
+      }
+
+      long filesDeleted = 0;
+      if (isReplace) {
+        JsonNode replaced = root.get("partitionToReplaceFileIds");
+        if (replaced != null && replaced.isObject()) {
+          java.util.Iterator<String> it = replaced.fieldNames();
+          while (it.hasNext()) {
+            JsonNode ids = replaced.get(it.next());
+            if (ids != null && ids.isArray()) {
+              filesDeleted += ids.size();
+            }
+          }
+        }
+      }
+
+      return new CommitStatsRow(instant.requestedTime(), timelineType, instant.getAction(),
+          operation, numInserts, numUpdates, numDeletes,
+          filesInserted, filesUpdated, filesDeleted, bytesWritten, partitions);
+    }
+  }
+
+  /**
+   * One phase-timing row. Holds the six raw timestamps (epoch ms; nullable for MDT phases
+   * when the table has no MDT or this instant predates MDT enablement) and exposes the
+   * derived per-phase durations as nullable longs.
+   */
+  static class PhaseTimingRow {
+    final String instant;
+    final String action;
+    final long t0Requested;
+    final long t1Inflight;
+    final Long t2MdtRequested;
+    final Long t3MdtInflight;
+    final Long t4MdtCompleted;
+    final long t5Completed;
+
+    PhaseTimingRow(String instant, String action,
+                   long t0Requested, long t1Inflight,
+                   Long t2MdtRequested, Long t3MdtInflight, Long t4MdtCompleted,
+                   long t5Completed) {
+      this.instant = instant;
+      this.action = action;
+      this.t0Requested = t0Requested;
+      this.t1Inflight = t1Inflight;
+      this.t2MdtRequested = t2MdtRequested;
+      this.t3MdtInflight = t3MdtInflight;
+      this.t4MdtCompleted = t4MdtCompleted;
+      this.t5Completed = t5Completed;
+    }
+
+    boolean hasMdt() {
+      return t2MdtRequested != null && t3MdtInflight != null && t4MdtCompleted != null;
+    }
+
+    Long sourceReadIndexSfhMs() {
+      return t1Inflight - t0Requested;
+    }
+
+    Long dataWriteMs() {
+      // T2-T1 if MDT present; otherwise T5-T1 (data write extends until ingest completed).
+      return hasMdt() ? (t2MdtRequested - t1Inflight) : (t5Completed - t1Inflight);
+    }
+
+    Long mdtPrepMs() {
+      return hasMdt() ? (t3MdtInflight - t2MdtRequested) : null;
+    }
+
+    Long mdtWriteMs() {
+      return hasMdt() ? (t4MdtCompleted - t3MdtInflight) : null;
+    }
+
+    Long mdtTailMs() {
+      return hasMdt() ? (t5Completed - t4MdtCompleted) : null;
+    }
+
+    Long totalMs() {
+      return t5Completed - t0Requested;
+    }
+  }
+
+  /**
+   * Per-action aggregator for phase timings. Accumulates each phase's samples into a
+   * resizable list and exposes mean / percentile / max on demand. {@code hasMdt()}
+   * reflects whether *any* sample in this action's bucket had MDT phases populated —
+   * mixed populations are tolerated (early rows without MDT, later rows with).
+   */
+  static class PhaseTimingAggregate {
+    enum Phase { SOURCE_READ, DATA_WRITE, MDT_PREP, MDT_WRITE, MDT_TAIL, TOTAL }
+
+    final String action;
+    private final Map<Phase, List<Long>> samples = new LinkedHashMap<>();
+    private int rowCount = 0;
+    private boolean anyMdt = false;
+
+    PhaseTimingAggregate(String action) {
+      this.action = action;
+      for (Phase p : Phase.values()) {
+        samples.put(p, new ArrayList<>());
+      }
+    }
+
+    void add(PhaseTimingRow r) {
+      rowCount++;
+      samples.get(Phase.SOURCE_READ).add(r.sourceReadIndexSfhMs());
+      samples.get(Phase.DATA_WRITE).add(r.dataWriteMs());
+      samples.get(Phase.TOTAL).add(r.totalMs());
+      if (r.hasMdt()) {
+        anyMdt = true;
+        samples.get(Phase.MDT_PREP).add(r.mdtPrepMs());
+        samples.get(Phase.MDT_WRITE).add(r.mdtWriteMs());
+        samples.get(Phase.MDT_TAIL).add(r.mdtTailMs());
+      }
+    }
+
+    int count() {
+      return rowCount;
+    }
+
+    boolean hasMdt() {
+      return anyMdt;
+    }
+
+    double mean(Phase phase) {
+      List<Long> vs = samples.get(phase);
+      if (vs == null || vs.isEmpty()) {
+        return 0.0;
+      }
+      long sum = 0;
+      for (Long v : vs) {
+        sum += v;
+      }
+      return (double) sum / vs.size();
+    }
+
+    long max(Phase phase) {
+      List<Long> vs = samples.get(phase);
+      if (vs == null || vs.isEmpty()) {
+        return 0;
+      }
+      long m = Long.MIN_VALUE;
+      for (Long v : vs) {
+        if (v > m) {
+          m = v;
+        }
+      }
+      return m;
+    }
+
+    /**
+     * Nearest-rank percentile (no interpolation). For n=1 returns the single value at
+     * any pct; for n=10 and pct=95 returns the 10th-ranked (max) value. Good enough for
+     * the small-N forensic use case this tool targets.
+     */
+    long percentile(Phase phase, int pct) {
+      List<Long> vs = samples.get(phase);
+      if (vs == null || vs.isEmpty()) {
+        return 0;
+      }
+      List<Long> sorted = new ArrayList<>(vs);
+      Collections.sort(sorted);
+      int rank = (int) Math.ceil(pct / 100.0 * sorted.size());
+      if (rank < 1) {
+        rank = 1;
+      }
+      if (rank > sorted.size()) {
+        rank = sorted.size();
+      }
+      return sorted.get(rank - 1);
+    }
+  }
+
+  static class CommitStatsTotals {
+    final long totalInserts;
+    final long totalUpdates;
+    final long totalDeletes;
+    final int commitCount;
+
+    CommitStatsTotals(long ti, long tu, long td, int n) {
+      this.totalInserts = ti;
+      this.totalUpdates = tu;
+      this.totalDeletes = td;
+      this.commitCount = n;
+    }
+
+    double avgInserts() {
+      return commitCount == 0 ? 0.0 : (double) totalInserts / commitCount;
+    }
+
+    double avgUpdates() {
+      return commitCount == 0 ? 0.0 : (double) totalUpdates / commitCount;
+    }
+
+    double avgDeletes() {
+      return commitCount == 0 ? 0.0 : (double) totalDeletes / commitCount;
+    }
+
+    static CommitStatsTotals from(List<CommitStatsRow> rows) {
+      long ti = 0;
+      long tu = 0;
+      long td = 0;
+      for (CommitStatsRow r : rows) {
+        ti += r.numInserts;
+        tu += r.numUpdates;
+        td += r.numDeletes;
+      }
+      return new CommitStatsTotals(ti, tu, td, rows.size());
+    }
+  }
+
+  static class Event {
+    final String instantTime;
+    final String action;
+    final String state;
+    final String timelineType;
+    final String matchType;
+    final String partition;
+    final String detail;
+
+    Event(HoodieInstant instant, String timelineType, String matchType,
+          String partition, String detail) {
+      this.instantTime = instant.requestedTime();
+      this.action = instant.getAction();
+      this.state = instant.getState().toString();
+      this.timelineType = timelineType;
+      this.matchType = matchType;
+      this.partition = partition;
+      this.detail = detail;
+    }
+  }
+
+  static class Args {
+    Mode mode;
+    String basePath;
+    String showInstantTime;
+    String fileIdNeedle;
+    String filenameToParse;
+    String rawArchiveInstant;
+    boolean lifecycle = false;
+    OutputFormat output = OutputFormat.TABLE;
+    boolean includeArchived = true;
+    String startInstant;
+    String endInstant;
+    Set<String> actionFilter = new HashSet<>();
+    HoodieInstant.State stateFilter;
+    int limit = DEFAULT_LIMIT;
+    boolean quiet = false;
+    // commit-stats / phase-timings default: newest first, so --limit N returns the latest N.
+    boolean sortDescending = true;
+    // phase-timings: opt-in inclusion of replacecommit instants (default off).
+    boolean includeReplacecommit = false;
+    // phase-timings: accumulated skip reasons, populated by the row builder for the footer.
+    Map<String, Integer> phaseTimingsSkipReasons = new LinkedHashMap<>();
+
+    static Args parse(String[] argv) {
+      Args a = new Args();
+      for (int i = 0; i < argv.length; i++) {
+        String k = argv[i];
+        switch (k) {
+          case "--base-path":
+            a.basePath = require(argv, ++i, k);
+            break;
+          case "--show-instant":
+            a.mode = Mode.SHOW_INSTANT;
+            a.showInstantTime = require(argv, ++i, k);
+            break;
+          case "--find-file-id":
+            a.mode = Mode.FIND_FILE_ID;
+            a.fileIdNeedle = require(argv, ++i, k);
+            break;
+          case "--parse-filename":
+            a.mode = Mode.PARSE_FILENAME;
+            a.filenameToParse = require(argv, ++i, k);
+            break;
+          case "--raw-archive":
+            a.mode = Mode.RAW_ARCHIVE;
+            a.rawArchiveInstant = require(argv, ++i, k);
+            break;
+          case "--commit-stats":
+            a.mode = Mode.COMMIT_STATS;
+            break;
+          case "--phase-timings":
+            a.mode = Mode.PHASE_TIMINGS;
+            break;
+          case "--include-replacecommit":
+            a.includeReplacecommit = true;
+            break;
+          case "--lifecycle":
+            a.lifecycle = true;
+            break;
+          case "--output": {
+            String raw = require(argv, ++i, k).toUpperCase(Locale.ROOT);
+            try {
+              a.output = OutputFormat.valueOf(raw);
+            } catch (IllegalArgumentException ex) {
+              throw new IllegalArgumentException("--output must be one of TABLE|JSON (got " + raw + ")");
+            }
+            break;
+          }
+          case "--include-archived":
+            a.includeArchived = Boolean.parseBoolean(require(argv, ++i, k));
+            break;
+          case "--no-archived":
+            a.includeArchived = false;
+            break;
+          case "--start-instant":
+            a.startInstant = require(argv, ++i, k);
+            break;
+          case "--end-instant":
+            a.endInstant = require(argv, ++i, k);
+            break;
+          case "--actions":
+            a.actionFilter = new HashSet<>(Arrays.asList(require(argv, ++i, k).split(",")));
+            break;
+          case "--state": {
+            String raw = require(argv, ++i, k).toUpperCase(Locale.ROOT);
+            try {
+              a.stateFilter = HoodieInstant.State.valueOf(raw);
+            } catch (IllegalArgumentException ex) {
+              throw new IllegalArgumentException("--state must be one of REQUESTED|INFLIGHT|COMPLETED (got "
+                  + raw + ")");
+            }
+            break;
+          }
+          case "--limit":
+            a.limit = Integer.parseInt(require(argv, ++i, k));
+            if (a.limit <= 0) {
+              throw new IllegalArgumentException("--limit must be positive (got " + a.limit + ")");
+            }
+            break;
+          case "--quiet":
+          case "-q":
+            a.quiet = true;
+            break;
+          case "--sort": {
+            String raw = require(argv, ++i, k).toLowerCase(Locale.ROOT);
+            if (raw.equals("asc")) {
+              a.sortDescending = false;
+            } else if (raw.equals("desc")) {
+              a.sortDescending = true;
+            } else {
+              throw new IllegalArgumentException("--sort must be asc or desc (got " + raw + ")");
+            }
+            break;
+          }
+          case "--help":
+          case "-h":
+            printUsage();
+            System.exit(0);
+            break;
+          default:
+            throw new IllegalArgumentException("unknown argument: " + k);
+        }
+      }
+      if (a.mode == null) {
+        throw new IllegalArgumentException(
+            "specify --show-instant <ts>, --find-file-id <id>, --commit-stats, "
+                + "--parse-filename <name>, or --raw-archive <ts>");
+      }
+      if (a.mode != Mode.PARSE_FILENAME && a.basePath == null) {
+        throw new IllegalArgumentException("--base-path is required");
+      }
+      if (a.lifecycle && a.mode != Mode.FIND_FILE_ID) {
+        throw new IllegalArgumentException("--lifecycle is only valid with --find-file-id");
+      }
+      if (a.includeReplacecommit && a.mode != Mode.PHASE_TIMINGS) {
+        throw new IllegalArgumentException(
+            "--include-replacecommit is only valid with --phase-timings");
+      }
+      // Restrict action filter to a known set; reject typos early.
+      Set<String> validActions = new HashSet<>(Arrays.asList(
+          HoodieTimeline.COMMIT_ACTION, HoodieTimeline.DELTA_COMMIT_ACTION,
+          HoodieTimeline.REPLACE_COMMIT_ACTION, HoodieTimeline.CLEAN_ACTION,
+          HoodieTimeline.ROLLBACK_ACTION, HoodieTimeline.RESTORE_ACTION,
+          HoodieTimeline.SAVEPOINT_ACTION,
+          HoodieTimeline.COMPACTION_ACTION, HoodieTimeline.LOG_COMPACTION_ACTION));
+      List<String> unknown = a.actionFilter.stream()
+          .filter(act -> !validActions.contains(act)).collect(Collectors.toList());
+      if (!unknown.isEmpty()) {
+        throw new IllegalArgumentException("unknown actions in --actions: " + unknown
+            + " (valid: " + validActions + ")");
+      }
+      return a;
+    }
+
+    private static String require(String[] argv, int i, String flag) {
+      if (i >= argv.length) {
+        throw new IllegalArgumentException("missing value for " + flag);
+      }
+      return argv[i];
+    }
+
+    static void printUsage() {
+      System.err.println("Usage: TimelineInspector (one of the modes below) [options]");
+      System.err.println();
+      System.err.println("Modes:");
+      System.err.println("  --base-path <path> --show-instant <ts>");
+      System.err.println("       deserialize and print all-state rows for one instant");
+      System.err.println("  --base-path <path> --find-file-id <id>");
+      System.err.println("       table of all events touching the given file id/name");
+      System.err.println("  --parse-filename <name>");
+      System.err.println("       decode a Hudi parquet/log filename into its parts (no base path needed)");
+      System.err.println("  --base-path <path> --raw-archive <ts>");
+      System.err.println("       walk archive log files and dump the full HoodieArchivedMetaEntry for");
+      System.err.println("       an instant (shows every sibling field, even ones --show-instant skips)");
+      System.err.println("  --base-path <path> --commit-stats [--start-instant ts] [--end-instant ts]");
+      System.err.println("       per-ingestion-commit (commit/deltacommit/replacecommit) stats:");
+      System.err.println("       numInserts, numUpdates, numDeletes, files inserted/updated/deleted,");
+      System.err.println("       bytes written, partitions. Footer prints totals + per-commit averages");
+      System.err.println("       for inserts/updates/deletes. Honors --actions, --start/end-instant,");
+      System.err.println("       --no-archived, --output, --limit.");
+      System.err.println("  --base-path <path> --phase-timings [--include-replacecommit]");
+      System.err.println("       per-ingestion-instant wall-clock split derived from .hoodie/ state-marker");
+      System.err.println("       file mtimes on the active timeline. Phases: sourceReadIndexSfh,");
+      System.err.println("       dataWrite, mdtPrep, mdtWrite, mdtTail, total. MDT phases are populated");
+      System.err.println("       per-instant when the metadata-table instant exists; rows with any missing");
+      System.err.println("       state file are excluded from output and counted in the footer. Footer");
+      System.err.println("       reports per-action mean/p50/p95/max + phaseShareOfTotal. Active timeline");
+      System.err.println("       only (archived instants lack the .requested/.inflight files needed).");
+      System.err.println();
+      System.err.println("Options:");
+      System.err.println("  --base-path <path>        table base path (required for show/find modes)");
+      System.err.println("  --include-archived <bool> include archived timeline (default true)");
+      System.err.println("  --no-archived             shortcut for --include-archived false");
+      System.err.println("  --start-instant <ts>      only consider instants >= this timestamp");
+      System.err.println("  --end-instant <ts>        only consider instants <= this timestamp");
+      System.err.println("  --actions <csv>           restrict to these actions");
+      System.err.println("                            (commit,deltacommit,replacecommit,clean,rollback,");
+      System.err.println("                             restore,compaction,logcompaction,savepoint)");
+      System.err.println("  --state <state>           in --show-instant, restrict to one of");
+      System.err.println("                            REQUESTED|INFLIGHT|COMPLETED (default: show all)");
+      System.err.println("  --lifecycle               in --find-file-id, collapse to landmark rows");
+      System.err.println("                            (created / replaced / cleaned / rolled-back) plus summary");
+      System.err.println("  --output <fmt>            TABLE (default) or JSON output format");
+      System.err.println("  --limit <N>               max rows to print in find-file-id (default "
+          + DEFAULT_LIMIT + ")");
+      System.err.println("  --sort <asc|desc>         instant sort order for --commit-stats /");
+      System.err.println("                            --phase-timings (default desc — newest first,");
+      System.err.println("                            so --limit N returns the latest N in range)");
+      System.err.println("  --include-replacecommit   in --phase-timings, also report replacecommit");
+      System.err.println("                            instants (clustering / insert-overwrite); off by");
+      System.err.println("                            default since the focus is ingest cadence");
+      System.err.println("  --quiet (-q)              suppress per-instant deserialization warnings");
+    }
+  }
+}

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.md
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.md
@@ -211,7 +211,8 @@ considers **completed** commit / deltacommit / replacecommit instants.
 
 ### Footer
 
-Prints over the rows returned (after `--limit`):
+Prints totals and per-commit averages over **all** commits in the range
+(not just the rows returned after `--limit`):
 
 ```
 totals (over N commits): inserts=… updates=… deletes=…

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.md
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/tools/TimelineInspector.md
@@ -1,0 +1,540 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# TimelineInspector — Runbook
+
+Pure-Java CLI for inspecting a Hudi table's active and archived timeline without
+Spark. Lives at `org.apache.hudi.tools.TimelineInspector` in `hudi-common`.
+
+## Modes at a glance
+
+| Mode | What it does |
+|---|---|
+| `--show-instant <ts>` | Dump all states (REQUESTED / INFLIGHT / COMPLETED) of an instant with full metadata. |
+| `--find-file-id <id>` | Sorted event table for every timeline action touching a given file id / filename / instant. |
+| `--commit-stats` | Per-ingestion-commit records / files / bytes for a time range, with totals + averages. |
+| `--phase-timings` | Per-ingestion-instant wall-clock phase split (source read + indexing + small-file handling, data write, MDT prep, MDT write, MDT tail) derived from `.hoodie/` state-marker file mtimes. Active timeline only. |
+| `--parse-filename <name>` | Decode a Hudi parquet/log filename into its parts (no base path needed). |
+| `--raw-archive <ts>` | Walk archive log files and dump the full `HoodieArchivedMetaEntry` for an instant. |
+
+## Classpath
+
+The tool only needs `hudi-common` + Hadoop + Jackson on the classpath. The
+Hudi bundles mark Hadoop/Jackson as `provided`, so a bare
+`java -cp hudi-utilities-bundle.jar ...` will fail with
+`NoClassDefFoundError: org/apache/hadoop/fs/FileSystem` — those deps come
+from the host (Spark, Flink, Hadoop). Pick the option that matches where
+you're running.
+
+### Option 1 — `spark-submit` (recommended)
+
+Works inside any pod / container that already has Spark + Hudi, and works on a
+laptop with a local Spark install.
+`spark-submit` assembles `$SPARK_HOME/jars/*` + `$(hadoop classpath)` + the
+application jar before launching the JVM, so every dep is resolved
+automatically.
+
+```bash
+spark-submit \
+  --class org.apache.hudi.tools.TimelineInspector \
+  --master "local[1]" \
+  --conf spark.log.level=WARN \
+  /path/to/hudi-utilities-bundle_2.12-0.14.1-rc2.jar \
+  --base-path s3://my-bucket/lake/orders \
+  --commit-stats --no-archived
+```
+
+Notes:
+
+- `TimelineInspector.main` is a plain `main(String[])` and never touches
+  `SparkSession` — the Spark machinery just sits unused. `spark-submit` is
+  effectively being used as a classpath resolver.
+- `--master "local[1]"` keeps it from contacting a cluster manager. Do **not**
+  use `--master yarn` / `k8s://…` — you'd queue a real Spark app for no
+  reason.
+- `--deploy-mode client` (the default for `local[…]`) keeps stdout in the
+  terminal. `--deploy-mode cluster` would route the table output to driver
+  logs.
+- Set `--driver-memory 4g` (or `8g`) when archived timeline is included with
+  no time window — the tool calls `loadCompletedInstantDetailsInMemory()` in
+  that case.
+- `--conf spark.log.level=WARN` suppresses Spark's INFO banner so the table
+  output is readable. Alternatively redirect `2>/dev/null`.
+
+Equivalent bundles: `hudi-spark3.5-bundle_2.12-0.14.1-rc2.jar`,
+`hudi-cli-bundle_2.12-0.14.1-rc2.jar`, `hudi-utilities-slim-bundle_2.12-0.14.1-rc2.jar`.
+
+### Option 2 — Bundled jar with Hadoop on the classpath
+
+For environments where `spark-submit` isn't available but Hadoop or a Spark
+install is. Pick **one** of:
+
+```bash
+# 2a: hadoop jar prepends $(hadoop classpath) automatically
+hadoop jar hudi-utilities-bundle_2.12-0.14.1-rc2.jar \
+  org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/tbl --commit-stats
+
+# 2b: equivalent, explicit
+java -cp "hudi-utilities-bundle_2.12-0.14.1-rc2.jar:$(hadoop classpath)" \
+  org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/tbl --commit-stats
+
+# 2c: use Spark's bundled Hadoop jars without invoking spark-submit
+#     ($SPARK_HOME must point to a spark-X.Y.Z-bin-hadoopN build —
+#      NOT the "without-hadoop" flavor)
+java -cp "hudi-utilities-bundle_2.12-0.14.1-rc2.jar:$SPARK_HOME/jars/*" \
+  org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/tbl --commit-stats
+```
+
+Notes:
+
+- The `dir/*` form in `-cp` is a **JVM** glob, not a shell glob. Quote the
+  entire `-cp` value so the shell doesn't expand it; the JVM expands
+  `dir/*` to "every `.jar` in `dir`."
+- On Java 11+, if you hit `IllegalAccessError` / `module … does not "opens" …`,
+  add the same opens Spark uses:
+  `--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED`.
+  Java 8 needs nothing extra.
+
+### Option 3 — Build-tree classpath via Maven (laptop / dev only)
+
+For running directly out of a build tree without any Hadoop/Spark install
+(useful for local iteration / testing):
+
+```bash
+mvn -pl hudi-common dependency:build-classpath -DincludeScope=test \
+  -Dmdep.outputFile=/tmp/ti_cp.txt
+
+java -cp "hudi-common/target/hudi-common-0.14.1-rc2.jar:$(cat /tmp/ti_cp.txt)" \
+  org.apache.hudi.tools.TimelineInspector --help
+```
+
+- `-DincludeScope=test` resolves every transitive dep of `hudi-common` —
+  including the Hadoop and Jackson jars that are `provided`-scoped at
+  runtime. The Maven step is one-shot; the `$CP` string is reusable until
+  deps change.
+- Use `hudi-common` as the `-pl` target. On the `0.14.1-rc2` branch there is
+  no separate `hudi-hadoop-common` module — Hadoop FS classes come in
+  transitively from `hudi-common`'s `hadoop-client` dependency.
+
+### Option 4 — Cloud-backed base paths
+
+If `--base-path` points to `s3://`, `gs://`, or `abfs://`, the host's
+filesystem classpath needs the matching cloud connector. With
+`spark-submit`, the easiest path is `--packages`:
+
+```bash
+spark-submit \
+  --class org.apache.hudi.tools.TimelineInspector \
+  --master "local[1]" \
+  --packages org.apache.hadoop:hadoop-aws:3.3.4 \
+  /path/to/hudi-utilities-bundle_2.12-0.14.1-rc2.jar \
+  --base-path s3://my-bucket/lake/orders \
+  --commit-stats --no-archived
+```
+
+Equivalents: `hudi-gcp-bundle` for GCS, `hudi-azure-bundle` for Azure
+Blob / ADLS (or `--packages` with the matching `hadoop-azure` /
+`gcs-connector` artifact). Cloud credentials need to be wired the usual
+way — `AWS_*` env vars or an instance profile for S3,
+`GOOGLE_APPLICATION_CREDENTIALS` for GCS, etc.
+
+### Quick sanity check
+
+To confirm the classpath resolves without touching a real table:
+
+```bash
+spark-submit --class org.apache.hudi.tools.TimelineInspector --master "local[1]" \
+  hudi-utilities-bundle_2.12-0.14.1-rc2.jar --help
+```
+
+If usage prints, the classpath is good — `--help` doesn't open any files.
+
+## Common options
+
+| Flag | Meaning |
+|---|---|
+| `--base-path <path>` | Table base path (required for every mode except `--parse-filename`). |
+| `--start-instant <ts>` | Only consider instants `>= ts` (Hudi 17-digit `yyyyMMddHHmmssSSS`). |
+| `--end-instant <ts>` | Only consider instants `<= ts`. |
+| `--actions <csv>` | Restrict to actions; valid values: `commit,deltacommit,replacecommit,clean,rollback,restore,compaction,logcompaction,savepoint`. For `--commit-stats` and `--phase-timings` the set is restricted to `commit,deltacommit,replacecommit`. |
+| `--no-archived` | Skip the archived timeline (default: include it; ignored for `--phase-timings` which is active-only). |
+| `--include-archived <bool>` | Explicit form of the above. |
+| `--limit <N>` | Max rows to print (default 100). |
+| `--sort <asc\|desc>` | Instant sort order for `--commit-stats` and `--phase-timings` (default `desc` — newest first, so `--limit N` returns the latest N in range). |
+| `--include-replacecommit` | In `--phase-timings`, also include `replacecommit` instants (clustering / insert-overwrite). Off by default. |
+| `--output <table\|json>` | Output format (default `table`). |
+| `--quiet` / `-q` | Suppress per-instant deserialization warnings on stderr. |
+
+> When archived is included **and no time range is set**, the tool calls
+> `loadCompletedInstantDetailsInMemory()` — fine on small tables, but heavy on
+> long-lived ones. For large tables either set `--start-instant`/`--end-instant`
+> or pass `--no-archived`.
+
+## Mode: `--commit-stats`
+
+Lists per-commit ingestion stats — records, files, bytes — for any range. Only
+considers **completed** commit / deltacommit / replacecommit instants.
+
+### Columns
+
+| Column | Source / meaning |
+|---|---|
+| `instant` | 17-digit instant timestamp. |
+| `timeline` | `ACTIVE` or `ARCHIVED`. |
+| `action` | `commit` / `deltacommit` / `replacecommit`. |
+| `operation` | `WriteOperationType` from the commit metadata (`INSERT`, `UPSERT`, `BULK_INSERT`, `DELETE`, `CLUSTER`, …). |
+| `numInserts` | `HoodieCommitMetadata.fetchTotalInsertRecordsWritten()`. |
+| `numUpdates` | `HoodieCommitMetadata.fetchTotalUpdateRecordsWritten()`. |
+| `numDeletes` | `HoodieCommitMetadata.getTotalRecordsDeleted()`. |
+| `filesInserted` | `fetchTotalFilesInsert()` — write stats whose `prevCommit == "null"`. |
+| `filesUpdated` | `fetchTotalFilesUpdated()` — write stats whose `prevCommit` is set and not `"null"`. |
+| `filesDeleted` | Replacecommit only: count of file ids in `partitionToReplaceFileIds` (logical replacement). Always `0` for plain commit/deltacommit. |
+| `bytesWritten` | `fetchTotalBytesWritten()`. |
+| `partitions` | Number of partitions touched (`partitionToWriteStats.size()`). |
+
+### Footer
+
+Prints over the rows returned (after `--limit`):
+
+```
+totals (over N commits): inserts=… updates=… deletes=…
+avg per commit:           inserts=… updates=… deletes=…
+```
+
+### Examples
+
+**1. Latest 50 ingestion commits, active timeline only:**
+
+```bash
+java -cp hudi-utilities-bundle_2.12-0.14.1-rc2.jar \
+  org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/apna_table/tbl_path \
+  --commit-stats \
+  --no-archived \
+  --limit 50
+```
+
+**2. All commits in a calendar week (includes archived):**
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --base-path s3://my-bucket/lake/orders \
+  --commit-stats \
+  --start-instant 20260601000000000 \
+  --end-instant   20260608000000000
+```
+
+**3. Only deltacommits in a single day, JSON output:**
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/apna_table/tbl_path \
+  --commit-stats \
+  --actions deltacommit \
+  --start-instant 20260601000000000 \
+  --end-instant   20260601235959999 \
+  --output json
+```
+
+**4. Oldest-first sort for chronological analysis:**
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/apna_table/tbl_path \
+  --commit-stats \
+  --start-instant 20260101000000000 \
+  --sort asc \
+  --limit 200 \
+  --quiet
+```
+
+### Expected table output
+
+```
+instant            timeline  action         operation  numInserts  numUpdates  numDeletes  filesInserted  filesUpdated  filesDeleted  bytesWritten  partitions
+-----------------  --------  -------------  ---------  ----------  ----------  ----------  -------------  ------------  ------------  ------------  ----------
+20260604000000000  ACTIVE    replacecommit  CLUSTER    50          0           0           1              0             1             0             1
+20260601000000000  ACTIVE    commit         INSERT     100         0           0           1              0             0             0             1
+
+totals (over 2 commits): inserts=150 updates=0 deletes=0
+avg per commit:           inserts=75.00 updates=0.00 deletes=0.00
+```
+
+## Mode: `--phase-timings`
+
+Lists per-ingestion-instant wall-clock phase splits derived from the modification
+times of the `.hoodie/` state-marker files on the **active timeline**. Useful for
+checkpoint-SLA debugging and "where is the time going?" investigations.
+
+### How the phases are derived
+
+For each completed ingest instant, the tool stats six files:
+
+```
+T0 = mtime of  <base>/.hoodie/<ts>.<action>.requested
+T1 = mtime of  <base>/.hoodie/<ts>.<action>.inflight
+T2 = mtime of  <base>/.hoodie/metadata/.hoodie/<ts>.deltacommit.requested   (MDT)
+T3 = mtime of  <base>/.hoodie/metadata/.hoodie/<ts>.deltacommit.inflight    (MDT)
+T4 = mtime of  <base>/.hoodie/metadata/.hoodie/<ts>.deltacommit             (MDT, completed)
+T5 = mtime of  <base>/.hoodie/<ts>.<action>                                  (data-table completed)
+```
+
+The MDT timeline always uses `deltacommit` regardless of whether the data table
+is COW (`<action> = commit`) or MOR (`<action> = deltacommit`).
+
+### Columns
+
+| Column | Definition |
+|---|---|
+| `instant` | 17-digit instant timestamp. |
+| `action` | `deltacommit`, `commit`, or `replacecommit` (with `--include-replacecommit`). |
+| `sourceReadIndexSfh_ms` | `T1 − T0` — data table: source read + indexing + small-file handling. |
+| `dataWrite_ms` | `T2 − T1` when MDT present; otherwise `T5 − T1` (data write extends through completion). |
+| `mdtPrep_ms` | `T3 − T2` — metadata record preparation. Blank when MDT absent. |
+| `mdtWrite_ms` | `T4 − T3` — metadata writes. Blank when MDT absent. |
+| `mdtTail_ms` | `T5 − T4` — gap between MDT completion and data-table completion (often near-zero; non-trivial values indicate post-MDT bookkeeping). Blank when MDT absent. |
+| `total_ms` | `T5 − T0`. |
+
+### Behavior
+
+- **MDT detection is per-instant.** If `<base>/.hoodie/metadata/.hoodie/` exists,
+  the tool tries to stat all three MDT files for each instant; missing the MDT
+  files for a particular instant (e.g. it predates MDT enablement) falls back to
+  the 3-phase view for that row only. Other rows in the same output can still
+  report the full 6 phases.
+- **MDT absent entirely** → the report header says
+  `(metadata table directory not found — MDT phases will be blank)` and every
+  row uses the 3-phase view.
+- **Missing data-table state file** (e.g. `.requested` deleted by a rollback,
+  partial write) → the row is **excluded** from the body table and counted in
+  the footer's `skipped` block, with a per-reason breakdown.
+- **Archived instants are not supported.** Once an instant is archived, the
+  `.requested` / `.inflight` files no longer exist on disk and mtimes are
+  unrecoverable. `--phase-timings` always reads the active timeline only;
+  `--include-archived` / `--no-archived` are ignored.
+- **Default action set** is `deltacommit, commit` (the ingest actions).
+  Pass `--include-replacecommit` to also report clustering / insert-overwrite
+  replacecommits, which write to MDT the same way and fit the same 6-phase
+  model. Explicit `--actions <csv>` overrides the default but is still
+  restricted to commit / deltacommit / replacecommit.
+
+### Footer
+
+For each action present in the output:
+
+```
+aggregates (per action, ms):
+  deltacommit (n=10):
+    sourceReadIndexSfh:  mean=… p50=… p95=… max=…
+    dataWrite:           mean=… p50=… p95=… max=…
+    mdtPrep:             mean=… p50=… p95=… max=…
+    mdtWrite:            mean=… p50=… p95=… max=…
+    mdtTail:             mean=… p50=… p95=… max=…
+    total:               mean=… p50=… p95=… max=…
+    share of total (mean):  sourceReadIndexSfh=…%, dataWrite=…%, mdtPrep=…%, mdtWrite=…%, mdtTail=…%
+```
+
+Percentiles use nearest-rank (no interpolation). The `share of total` line uses
+mean values, so percentages sum to ~100% modulo rounding.
+
+If any instants were dropped, a trailing line reports them:
+
+```
+skipped 3 instant(s) with incomplete state-marker files: requested-missing=2, inflight-missing=1
+```
+
+### Caveats
+
+- **Object-store mtimes** (S3 / GCS / ABFS) reflect server-side write-completion
+  time, not the producer's wall clock. The relative phase durations are still
+  accurate; clock-skew artifacts are bounded by the storage layer's commit
+  granularity.
+- **Local FS mtime resolution** can be second-level on macOS / older Linux
+  setups; sub-second phase durations may round to 0 on those systems.
+- The mtime of the completed marker is approximately the moment the writer
+  finished — *not* when downstream readers observed the instant.
+
+### Examples
+
+**1. Latest 10 ingestion commits with phase splits:**
+
+```bash
+spark-submit --class org.apache.hudi.tools.TimelineInspector --master "local[1]" \
+  /path/to/hudi-utilities-bundle_2.12-0.14.1-rc2.jar \
+  --base-path /tmp/conductor_soong/conductor_june1/tbl_path/tbl_path \
+  --phase-timings --limit 10 --quiet
+```
+
+**2. Last hour of commits including clustering, JSON output:**
+
+```bash
+spark-submit --class org.apache.hudi.tools.TimelineInspector --master "local[1]" \
+  /path/to/hudi-utilities-bundle_2.12-0.14.1-rc2.jar \
+  --base-path s3://lake/orders \
+  --phase-timings --include-replacecommit \
+  --start-instant 20260601150000000 --end-instant 20260601160000000 \
+  --output json --quiet
+```
+
+### Expected table output
+
+```
+instant            action       sourceReadIndexSfh_ms  dataWrite_ms  mdtPrep_ms  mdtWrite_ms  mdtTail_ms  total_ms
+-----------------  -----------  ---------------------  ------------  ----------  -----------  ----------  --------
+20260609044441149  deltacommit  18234                  91200         4810         63450        2710        180404
+20260609042932195  deltacommit  17541                  84030         4632         60110        2105        168418
+
+aggregates (per action, ms):
+  deltacommit (n=2):
+    sourceReadIndexSfh:  mean=17888 p50=17541 p95=18234 max=18234
+    dataWrite:           mean=87615 p50=84030 p95=91200 max=91200
+    mdtPrep:             mean=4721  p50=4632  p95=4810  max=4810
+    mdtWrite:            mean=61780 p50=60110 p95=63450 max=63450
+    mdtTail:             mean=2408  p50=2105  p95=2710  max=2710
+    total:               mean=174411 p50=168418 p95=180404 max=180404
+    share of total (mean):  sourceReadIndexSfh=10.3%, dataWrite=50.2%, mdtPrep=2.7%, mdtWrite=35.4%, mdtTail=1.4%
+```
+
+## Mode: `--show-instant`
+
+Dumps every state of a single instant (REQUESTED, INFLIGHT, COMPLETED) with the
+deserialized metadata body. Works against both active and archived timelines.
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/apna_table/tbl_path \
+  --show-instant 20260530092852891
+```
+
+Filter to one state:
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/apna_table/tbl_path \
+  --show-instant 20260530092852891 \
+  --state COMPLETED \
+  --output json
+```
+
+When `--show-instant` returns "(no body)" but you suspect the archive carries
+more info, fall back to `--raw-archive` (below).
+
+## Mode: `--find-file-id`
+
+Prints every timeline event that mentions the given file id / filename / instant
+time across both timelines. Useful for forensic "where did this file come from
+and what happened to it" questions.
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/apna_table/tbl_path \
+  --find-file-id 5d85210a-fc17-411e-a01f-3bb44d9a12cc-0 \
+  --actions commit,deltacommit,replacecommit,clean \
+  --start-instant 20260101000000000 \
+  --limit 500
+```
+
+Add `--lifecycle` to collapse the output to landmark rows (CREATED / REPLACED /
+CLEANED / ROLLED_BACK) with a summary footer:
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/apna_table/tbl_path \
+  --find-file-id 5d85210a-fc17-411e-a01f-3bb44d9a12cc-0 \
+  --lifecycle
+```
+
+Match types reported in the events table:
+
+- `writeStat` — commit metadata write stat for the file.
+- `replaceFileId` — replacecommit's `partitionToReplaceFileIds`.
+- `clusteringInputSlice` — file is an input slice of a clustering plan.
+- `cleanSuccessDelete` / `cleanFailedDelete` / `cleanDeletePattern` — clean metadata.
+- `rollbackSuccessDelete` / `rollbackFailedDelete` / `rollbackPlanFile` / `rollbackPlanLogBlock` — rollback metadata / plan.
+- `rollbackOfCommit` / `restoreOfCommit` / `restorePlanTargetCommit` / `restorePlanSavepoint` — when the needle matches a rolled-back / restored instant time.
+
+## Mode: `--parse-filename`
+
+Decode a parquet or log filename to its parts. No table required.
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --parse-filename 5d85210a-fc17-411e-a01f-3bb44d9a12cc-0_0-1-1_20260530092852891.parquet
+```
+
+```
+input                : 5d85210a-fc17-411e-a01f-3bb44d9a12cc-0_0-1-1_20260530092852891.parquet
+filename             : 5d85210a-fc17-411e-a01f-3bb44d9a12cc-0_0-1-1_20260530092852891.parquet
+kind                 : base
+fileId               : 5d85210a-fc17-411e-a01f-3bb44d9a12cc-0
+commitTime           : 20260530092852891
+fileExtension        : .parquet
+writeToken           : 0-1-1
+```
+
+Log file:
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --parse-filename .5d85210a-fc17-411e-a01f-3bb44d9a12cc-0_20260530092852891.log.1_0-2-2
+```
+
+## Mode: `--raw-archive`
+
+Walks `.hoodie/archived/commits.*` and dumps the **entire**
+`HoodieArchivedMetaEntry` record for an instant — every sibling field, including
+ones `--show-instant` doesn't render. Useful when `--show-instant` reports
+"(no body)" against an archived instant: the actual metadata may be sitting on a
+field name `show-instant` doesn't read.
+
+```bash
+java -cp ... org.apache.hudi.tools.TimelineInspector \
+  --base-path /tmp/apna_table/tbl_path \
+  --raw-archive 20260530092852891
+```
+
+Output is always JSON, grouped into `populatedFields` and `nullFields` per
+archive entry.
+
+## Troubleshooting
+
+- **"WARN: failed to process … : …"** — a single instant's metadata couldn't be
+  deserialized. The tool keeps going; pass `-q` / `--quiet` to suppress these.
+- **"(no archive entries with commitTime=…)"** — the instant isn't in any
+  archive log file under `.hoodie/archived/`. It might still be in active
+  timeline — try `--show-instant` without `--no-archived`.
+- **Heap pressure on huge tables** — narrow the time window
+  (`--start-instant` + `--end-instant`) or pass `--no-archived`. Both
+  `--commit-stats` and `--find-file-id` honor those filters.
+- **`--state` only applies to `--show-instant`.** For `--find-file-id` and
+  `--commit-stats` the tool restricts to completed instants by construction.
+- **`--lifecycle` is `--find-file-id`-only**; it errors out otherwise.
+
+## Tests
+
+`TestTimelineInspector` in `hudi-common/src/test/java/org/apache/hudi/tools/`
+builds a synthetic CoW table in `@TempDir`, populates ingest / clean / rollback /
+replace instants, and exercises every mode end-to-end via `main(...)` with
+stdout capture. Run from the repo root:
+
+```bash
+SPARK_LOCAL_IP=127.0.0.1 \
+mvn test -pl hudi-common -Dtest="org.apache.hudi.tools.TestTimelineInspector"
+```

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/tools/TestTimelineInspector.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/tools/TestTimelineInspector.java
@@ -326,12 +326,9 @@ class TestTimelineInspector {
 
   @Test
   void showInstantMissingInstantPrintsNoInstantMessage() {
-    int code = runMainTrappingExit("--base-path", basePath, "--show-instant", "19990101000000000",
+    int code = runMainExpectingExit("--base-path", basePath, "--show-instant", "19990101000000000",
         "--no-archived");
-    // SecurityManager-trap catches every System.exit; main wraps the first exit(3) in its
-    // outer catch and ultimately fires exit(1). The user-observable signal is the stderr
-    // message itself, which is what we assert.
-    assertTrue(code == 1 || code == 3, "expected non-zero exit, got " + code);
+    assertTrue(code == 3, "expected exit code 3, got " + code);
     assertTrue(capturedAsString().contains("No instant found with time=19990101000000000"),
         capturedAsString());
   }
@@ -429,7 +426,7 @@ class TestTimelineInspector {
 
   @Test
   void commitStatsRejectsNonIngestionActionFilter() {
-    runMainTrappingExit("--base-path", basePath, "--commit-stats",
+    runMainExpectingExit("--base-path", basePath, "--commit-stats",
         "--actions", "clean", "--no-archived", "--quiet");
     assertTrue(capturedAsString().contains("--actions filter must include at least"),
         capturedAsString());
@@ -473,7 +470,7 @@ class TestTimelineInspector {
 
   @Test
   void commitStatsRejectsInvalidSortValue() {
-    runMainTrappingExit("--base-path", basePath, "--commit-stats",
+    runMainExpectingExit("--base-path", basePath, "--commit-stats",
         "--sort", "sideways", "--no-archived", "--quiet");
     assertTrue(capturedAsString().contains("--sort must be asc or desc"),
         capturedAsString());
@@ -657,20 +654,20 @@ class TestTimelineInspector {
 
   @Test
   void missingModePrintsUsage() {
-    runMainTrappingExit("--base-path", basePath);
+    runMainExpectingExit("--base-path", basePath);
     assertTrue(capturedAsString().contains("specify --show-instant"), capturedAsString());
   }
 
   @Test
   void invalidActionPrintsRejection() {
-    runMainTrappingExit("--base-path", basePath, "--find-file-id", "x",
+    runMainExpectingExit("--base-path", basePath, "--find-file-id", "x",
         "--actions", "ingest");
     assertTrue(capturedAsString().contains("unknown actions"), capturedAsString());
   }
 
   @Test
   void lifecycleWithoutFindFileIdPrintsRejection() {
-    runMainTrappingExit("--base-path", basePath, "--show-instant", INGEST_INSTANT,
+    runMainExpectingExit("--base-path", basePath, "--show-instant", INGEST_INSTANT,
         "--lifecycle");
     assertTrue(capturedAsString().contains("--lifecycle is only valid with --find-file-id"),
         capturedAsString());
@@ -680,27 +677,24 @@ class TestTimelineInspector {
 
   private void runMain(String... args) {
     captured.reset();
-    TimelineInspector.main(args);
+    try {
+      TimelineInspector.run(args);
+    } catch (TimelineInspector.ExitException e) {
+      // Swallow — tests that care about exit codes use runMainExpectingExit.
+    }
   }
 
   /**
-   * Variant that traps any {@code System.exit(N)} calls inside {@link TimelineInspector#main}
-   * so the test JVM survives. Returns the last exit status seen (which may be the inner
-   * exit's status or the outer catch's exit(1) -- callers that need a specific code should
-   * also assert on captured stderr text, since main's outer catch can re-wrap.
+   * Invokes {@link TimelineInspector#run} and returns the exit status from
+   * the thrown {@link TimelineInspector.ExitException}, or 0 if it returned normally.
    */
-  private int runMainTrappingExit(String... args) {
+  private int runMainExpectingExit(String... args) {
     captured.reset();
-    SecurityManager prior = System.getSecurityManager();
-    ExitInterceptingSecurityManager sm = new ExitInterceptingSecurityManager();
-    System.setSecurityManager(sm);
     try {
-      TimelineInspector.main(args);
+      TimelineInspector.run(args);
       return 0;
-    } catch (ExitTrappedException e) {
+    } catch (TimelineInspector.ExitException e) {
       return e.status;
-    } finally {
-      System.setSecurityManager(prior);
     }
   }
 
@@ -790,27 +784,6 @@ class TestTimelineInspector {
     System.out.flush();
     System.err.flush();
     return new String(captured.toByteArray(), StandardCharsets.UTF_8);
-  }
-
-  /** Trap System.exit so the test process survives non-zero exits. */
-  private static class ExitTrappedException extends SecurityException {
-    final int status;
-    ExitTrappedException(int status) {
-      super("System.exit(" + status + ")");
-      this.status = status;
-    }
-  }
-
-  private static class ExitInterceptingSecurityManager extends SecurityManager {
-    @Override
-    public void checkExit(int status) {
-      throw new ExitTrappedException(status);
-    }
-
-    @Override
-    public void checkPermission(java.security.Permission perm) {
-      // allow everything else
-    }
   }
 
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/tools/TestTimelineInspector.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/tools/TestTimelineInspector.java
@@ -1,0 +1,816 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.tools;
+
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanPartitionMetadata;
+import org.apache.hudi.avro.model.HoodieInstantInfo;
+import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.avro.model.HoodieRollbackPartitionMetadata;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.FileCreateUtils;
+import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration-style tests for {@link TimelineInspector}. Each test builds a tiny Hudi table
+ * in a {@link TempDir}, populates it with hand-crafted instants whose metadata mentions a
+ * known file id, then invokes the tool's {@code main(...)} via stdout capture.
+ *
+ * <p>No Spark; this lives in {@code hudi-common} so it runs alongside the other timeline
+ * tests and stays fast.
+ */
+class TestTimelineInspector {
+
+  private static final String PARTITION = "p0";
+  private static final String INGEST_INSTANT = "20260601000000000";
+  private static final String CLEAN_INSTANT  = "20260602000000000";
+  private static final String ROLLBACK_INSTANT = "20260603000000000";
+  private static final String REPLACE_INSTANT = "20260604000000000";
+  private static final String FILE_ID_KEEP    = "11111111-1111-1111-1111-111111111111-0";
+  private static final String FILE_ID_REPLACED = "22222222-2222-2222-2222-222222222222-0";
+  // Name of the parquet for FILE_ID_KEEP at the ingest commit.
+  private static final String BASE_FILE_KEEP =
+      FILE_ID_KEEP + "_0-1-1_" + INGEST_INSTANT + ".parquet";
+  // Log file for FILE_ID_KEEP rolled back by the rollback instant.
+  private static final String ROLLED_BACK_LOG =
+      "." + FILE_ID_KEEP + "_" + INGEST_INSTANT + ".log.1_0-2-2";
+  // Replaced base file (different file id) carried by the replace commit.
+  private static final String REPLACED_BASE_FILE =
+      FILE_ID_REPLACED + "_0-3-3_" + REPLACE_INSTANT + ".parquet";
+
+  private PrintStream originalOut;
+  private PrintStream originalErr;
+  private ByteArrayOutputStream captured;
+  private String basePath;
+
+  @BeforeEach
+  void setUp(@TempDir Path tempDir) throws Exception {
+    basePath = tempDir.resolve("hudi_table").toString();
+    HoodieTableMetaClient meta = HoodieTestUtils.init(basePath, HoodieTableType.COPY_ON_WRITE);
+
+    // Touch the partition directory so writers can land files there.
+    FileCreateUtils.createPartitionMetaFile(basePath, PARTITION);
+
+    HoodieActiveTimeline timeline = meta.getActiveTimeline();
+
+    // 1) Ingestion commit: writes BASE_FILE_KEEP under PARTITION for FILE_ID_KEEP.
+    HoodieCommitMetadata commit = new HoodieCommitMetadata();
+    commit.setOperationType(WriteOperationType.INSERT);
+    HoodieWriteStat stat = new HoodieWriteStat();
+    stat.setFileId(FILE_ID_KEEP);
+    stat.setPath(PARTITION + "/" + BASE_FILE_KEEP);
+    stat.setPartitionPath(PARTITION);
+    stat.setNumWrites(100);
+    stat.setNumInserts(100);
+    stat.setNumUpdateWrites(0);
+    stat.setNumDeletes(0);
+    stat.setPrevCommit("null");
+    commit.addWriteStat(PARTITION, stat);
+    HoodieInstant commitInstant = meta.getInstantGenerator().createNewInstant(
+        HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, INGEST_INSTANT);
+    timeline.createNewInstant(commitInstant);
+    timeline.transitionRequestedToInflight(commitInstant, Option.empty());
+    timeline.saveAsComplete(meta.getInstantGenerator().createNewInstant(
+        HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, INGEST_INSTANT),
+        Option.of(commit));
+
+    // 2) Clean instant: lists the base file under successDeleteFiles for PARTITION.
+    HoodieCleanMetadata clean = new HoodieCleanMetadata();
+    clean.setStartCleanTime(CLEAN_INSTANT);
+    clean.setTimeTakenInMillis(1L);
+    clean.setTotalFilesDeleted(1);
+    clean.setEarliestCommitToRetain(INGEST_INSTANT);
+    clean.setLastCompletedCommitTimestamp(INGEST_INSTANT);
+    clean.setVersion(2);
+    HoodieCleanPartitionMetadata cleanPartition = new HoodieCleanPartitionMetadata();
+    cleanPartition.setPartitionPath(PARTITION);
+    cleanPartition.setPolicy("KEEP_LATEST_FILE_VERSIONS");
+    cleanPartition.setDeletePathPatterns(Collections.singletonList(PARTITION + "/" + BASE_FILE_KEEP));
+    cleanPartition.setSuccessDeleteFiles(Collections.singletonList(PARTITION + "/" + BASE_FILE_KEEP));
+    cleanPartition.setFailedDeleteFiles(Collections.emptyList());
+    cleanPartition.setIsPartitionDeleted(false);
+    clean.setPartitionMetadata(Collections.singletonMap(PARTITION, cleanPartition));
+    clean.setBootstrapPartitionMetadata(Collections.emptyMap());
+    HoodieInstant cleanInstant = meta.getInstantGenerator().createNewInstant(
+        HoodieInstant.State.REQUESTED, HoodieTimeline.CLEAN_ACTION, CLEAN_INSTANT);
+    timeline.createNewInstant(cleanInstant);
+    timeline.transitionCleanRequestedToInflight(cleanInstant);
+    timeline.transitionCleanInflightToComplete(true,
+        meta.getInstantGenerator().createNewInstant(
+            HoodieInstant.State.INFLIGHT, HoodieTimeline.CLEAN_ACTION, CLEAN_INSTANT),
+        Option.of(clean));
+
+    // 3) Rollback instant: rolls back a hypothetical ingest commit and lists a log file.
+    HoodieRollbackMetadata rollback = new HoodieRollbackMetadata();
+    rollback.setStartRollbackTime(ROLLBACK_INSTANT);
+    rollback.setTimeTakenInMillis(2L);
+    rollback.setTotalFilesDeleted(1);
+    rollback.setCommitsRollback(Collections.singletonList("20260530000000000"));
+    rollback.setInstantsRollback(Collections.singletonList(
+        new HoodieInstantInfo("20260530000000000", HoodieTimeline.COMMIT_ACTION)));
+    HoodieRollbackPartitionMetadata rbp = new HoodieRollbackPartitionMetadata();
+    rbp.setPartitionPath(PARTITION);
+    rbp.setSuccessDeleteFiles(Collections.singletonList(PARTITION + "/" + ROLLED_BACK_LOG));
+    rbp.setFailedDeleteFiles(Collections.emptyList());
+    rollback.setPartitionMetadata(Collections.singletonMap(PARTITION, rbp));
+    HoodieInstant rollbackInstant = meta.getInstantGenerator().createNewInstant(
+        HoodieInstant.State.REQUESTED, HoodieTimeline.ROLLBACK_ACTION, ROLLBACK_INSTANT);
+    timeline.createNewInstant(rollbackInstant);
+    timeline.transitionRollbackRequestedToInflight(rollbackInstant);
+    timeline.transitionRollbackInflightToComplete(true,
+        meta.getInstantGenerator().createNewInstant(
+            HoodieInstant.State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, ROLLBACK_INSTANT),
+        rollback);
+
+    // 4) Replace commit: replaces FILE_ID_KEEP via partitionToReplaceFileIds; writes a new
+    // base file for FILE_ID_REPLACED.
+    HoodieReplaceCommitMetadata replace = new HoodieReplaceCommitMetadata();
+    replace.setOperationType(WriteOperationType.CLUSTER);
+    Map<String, java.util.List<String>> p2rfi = new HashMap<>();
+    p2rfi.put(PARTITION, Collections.singletonList(FILE_ID_KEEP));
+    replace.setPartitionToReplaceFileIds(p2rfi);
+    HoodieWriteStat rwStat = new HoodieWriteStat();
+    rwStat.setFileId(FILE_ID_REPLACED);
+    rwStat.setPath(PARTITION + "/" + REPLACED_BASE_FILE);
+    rwStat.setPartitionPath(PARTITION);
+    rwStat.setNumWrites(50);
+    rwStat.setNumInserts(50);
+    rwStat.setNumUpdateWrites(0);
+    rwStat.setNumDeletes(0);
+    rwStat.setPrevCommit("null");
+    replace.addWriteStat(PARTITION, rwStat);
+    HoodieInstant replaceInstant = meta.getInstantGenerator().createNewInstant(
+        HoodieInstant.State.REQUESTED, HoodieTimeline.REPLACE_COMMIT_ACTION, REPLACE_INSTANT);
+    timeline.createNewInstant(replaceInstant);
+    timeline.transitionReplaceRequestedToInflight(replaceInstant, Option.empty());
+    timeline.saveAsComplete(
+        meta.getInstantGenerator().createNewInstant(
+            HoodieInstant.State.INFLIGHT, HoodieTimeline.REPLACE_COMMIT_ACTION, REPLACE_INSTANT),
+        Option.of(replace));
+
+    originalOut = System.out;
+    originalErr = System.err;
+    captured = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(captured, true, "UTF-8"));
+    // Pipe stderr to the same buffer so warn lines don't escape during the test.
+    System.setErr(new PrintStream(captured, true, "UTF-8"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  // ---- parse-filename -------------------------------------------------------
+
+  @Test
+  void parseFilenameDecodesBaseFile() throws Exception {
+    runMain("--parse-filename", BASE_FILE_KEEP);
+    String out = capturedAsString();
+    assertTrue(out.contains("kind                 : base"), out);
+    assertTrue(out.contains("fileId               : " + FILE_ID_KEEP), out);
+    assertTrue(out.contains("commitTime           : " + INGEST_INSTANT), out);
+    assertTrue(out.contains("fileExtension        : .parquet"), out);
+    assertTrue(out.contains("writeToken           : 0-1-1"), out);
+  }
+
+  @Test
+  void parseFilenameDecodesLogFile() throws Exception {
+    runMain("--parse-filename", ROLLED_BACK_LOG);
+    String out = capturedAsString();
+    assertTrue(out.contains("kind                 : log"), out);
+    assertTrue(out.contains("fileId               : " + FILE_ID_KEEP), out);
+    assertTrue(out.contains("baseInstantTime      : " + INGEST_INSTANT), out);
+    assertTrue(out.contains("logVersion           : 1"), out);
+  }
+
+  @Test
+  void parseFilenameJsonOutput() throws Exception {
+    runMain("--parse-filename", BASE_FILE_KEEP, "--output", "json");
+    String out = capturedAsString();
+    assertTrue(out.contains("\"kind\""), out);
+    assertTrue(out.contains("\"fileId\" : \"" + FILE_ID_KEEP + "\""), out);
+    // Sanity: well-formed JSON object.
+    assertTrue(out.trim().startsWith("{") && out.trim().endsWith("}"), out);
+  }
+
+  // ---- find-file-id ---------------------------------------------------------
+
+  @Test
+  void findFileIdSurfacesIngestionWriteStat() throws Exception {
+    runMain("--base-path", basePath, "--find-file-id", FILE_ID_KEEP, "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains(INGEST_INSTANT), out);
+    assertTrue(out.contains("commit"), out);
+    assertTrue(out.contains("writeStat"), out);
+    // We should NOT match unrelated instants by accident.
+    assertFalse(out.contains(REPLACED_BASE_FILE), out);
+  }
+
+  @Test
+  void findFileIdSurfacesCleanAndRollbackAndReplace() throws Exception {
+    runMain("--base-path", basePath, "--find-file-id", FILE_ID_KEEP, "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains("cleanSuccessDelete"), out);
+    assertTrue(out.contains(CLEAN_INSTANT), out);
+    assertTrue(out.contains("replaceFileId"), out);
+    assertTrue(out.contains(REPLACE_INSTANT), out);
+  }
+
+  @Test
+  void findFileIdRollbackOfCommitMatchesByInstantTime() throws Exception {
+    runMain("--base-path", basePath, "--find-file-id", "20260530000000000",
+        "--actions", "rollback", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains("rollbackOfCommit"), out);
+    assertTrue(out.contains(ROLLBACK_INSTANT), out);
+  }
+
+  @Test
+  void findFileIdActionFilterRestrictsScope() throws Exception {
+    runMain("--base-path", basePath, "--find-file-id", FILE_ID_KEEP,
+        "--actions", "clean", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains("cleanSuccessDelete"), out);
+    // Without commit/replacecommit in the filter, those rows must not appear.
+    assertFalse(out.contains("writeStat"), out);
+    assertFalse(out.contains("replaceFileId"), out);
+  }
+
+  @Test
+  void findFileIdNoMatchEmitsEmptyMarker() throws Exception {
+    runMain("--base-path", basePath, "--find-file-id", "doesnotexist", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains("(no events)"), out);
+  }
+
+  // ---- --lifecycle ----------------------------------------------------------
+
+  @Test
+  void lifecycleCollapsesToLandmarks() throws Exception {
+    runMain("--base-path", basePath, "--find-file-id", FILE_ID_KEEP,
+        "--lifecycle", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains("CREATED"), out);
+    assertTrue(out.contains("CLEANED"), out);
+    assertTrue(out.contains("REPLACED"), out);
+    assertTrue(out.contains("summary:"), out);
+  }
+
+  // ---- show-instant ---------------------------------------------------------
+
+  @Test
+  void showInstantPrintsAllStatesForCommit() throws Exception {
+    runMain("--base-path", basePath, "--show-instant", INGEST_INSTANT, "--no-archived");
+    String out = capturedAsString();
+    assertTrue(out.contains(INGEST_INSTANT), out);
+    assertTrue(out.contains("action        : commit"), out);
+    assertTrue(out.contains("state         : COMPLETED"), out);
+    // Body content from the commit metadata.
+    assertTrue(out.contains(FILE_ID_KEEP), out);
+  }
+
+  @Test
+  void showInstantJsonOutputWrapsStates() throws Exception {
+    runMain("--base-path", basePath, "--show-instant", REPLACE_INSTANT,
+        "--no-archived", "--output", "json");
+    String out = capturedAsString();
+    assertTrue(out.contains("\"instant\""), out);
+    assertTrue(out.contains("\"states\""), out);
+    assertTrue(out.contains("\"COMPLETED\""), out);
+    assertTrue(out.contains(FILE_ID_REPLACED), out);
+  }
+
+  @Test
+  void showInstantMissingInstantPrintsNoInstantMessage() {
+    int code = runMainTrappingExit("--base-path", basePath, "--show-instant", "19990101000000000",
+        "--no-archived");
+    // SecurityManager-trap catches every System.exit; main wraps the first exit(3) in its
+    // outer catch and ultimately fires exit(1). The user-observable signal is the stderr
+    // message itself, which is what we assert.
+    assertTrue(code == 1 || code == 3, "expected non-zero exit, got " + code);
+    assertTrue(capturedAsString().contains("No instant found with time=19990101000000000"),
+        capturedAsString());
+  }
+
+  // ---- commit-stats ---------------------------------------------------------
+
+  @Test
+  void commitStatsListsIngestionCommitsWithTotals() throws Exception {
+    runMain("--base-path", basePath, "--commit-stats", "--no-archived", "--quiet");
+    String out = capturedAsString();
+    // Both ingestion commits surface as rows.
+    assertTrue(out.contains(INGEST_INSTANT), out);
+    assertTrue(out.contains(REPLACE_INSTANT), out);
+    // Commit metadata aggregates match the harness:
+    //   ingest:  100 inserts, 0 updates, 0 deletes, 1 file inserted, 0 updated, 0 deleted
+    //   replace: 50 inserts, 0 updates, 0 deletes, 1 file inserted, 0 updated, 1 replaced
+    assertTrue(out.contains("100"), out);
+    assertTrue(out.contains("50"), out);
+    assertTrue(out.contains("CLUSTER"), out);
+    assertTrue(out.contains("INSERT"), out);
+    // Footer shows totals + averages over 2 commits: 150/2 = 75.00
+    assertTrue(out.contains("totals (over 2 commits): inserts=150 updates=0 deletes=0"), out);
+    assertTrue(out.contains("avg per commit:           inserts=75.00 updates=0.00 deletes=0.00"), out);
+  }
+
+  @Test
+  void commitStatsRespectsTimeRange() throws Exception {
+    // Range covers only the replacecommit.
+    runMain("--base-path", basePath, "--commit-stats",
+        "--start-instant", REPLACE_INSTANT, "--end-instant", REPLACE_INSTANT,
+        "--no-archived", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains(REPLACE_INSTANT), out);
+    assertFalse(out.contains(INGEST_INSTANT), out);
+    // Single commit, footer divides by 1.
+    assertTrue(out.contains("totals (over 1 commits): inserts=50"), out);
+  }
+
+  @Test
+  void commitStatsReplaceCommitReportsFilesDeletedFromReplacedFileIds() throws Exception {
+    runMain("--base-path", basePath, "--commit-stats",
+        "--start-instant", REPLACE_INSTANT, "--end-instant", REPLACE_INSTANT,
+        "--no-archived", "--quiet");
+    String out = capturedAsString();
+    // The replacecommit replaces exactly 1 file id (FILE_ID_KEEP) — filesDeleted column must be 1.
+    // Find the row for REPLACE_INSTANT and verify the last few numeric columns:
+    // numInserts=50, numUpdates=0, numDeletes=0, filesInserted=1, filesUpdated=0, filesDeleted=1.
+    String replaceRow = null;
+    for (String line : out.split("\n")) {
+      if (line.contains(REPLACE_INSTANT) && line.contains("replacecommit")) {
+        replaceRow = line;
+        break;
+      }
+    }
+    assertTrue(replaceRow != null, "no replacecommit row in output:\n" + out);
+    // Column order: instant timeline action operation
+    //               numInserts numUpdates numDeletes filesInserted filesUpdated filesDeleted bytes partitions
+    String[] cols = replaceRow.trim().split("\\s+");
+    // Tail-anchored asserts so we don't get tripped up by the leading variable-width columns.
+    assertTrue(cols[cols.length - 3].equals("1"),
+        "expected filesDeleted=1, got cols=" + java.util.Arrays.toString(cols));
+  }
+
+  @Test
+  void commitStatsJsonOutputCarriesTotals() throws Exception {
+    runMain("--base-path", basePath, "--commit-stats", "--no-archived",
+        "--output", "json", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains("\"commits\""), out);
+    assertTrue(out.contains("\"totals\""), out);
+    assertTrue(out.contains("\"totalInserts\" : 150"), out);
+    assertTrue(out.contains("\"avgInsertsPerCommit\" : 75.0"), out);
+    // Per-commit stats are present.
+    assertTrue(out.contains("\"numInserts\" : 100"), out);
+    assertTrue(out.contains("\"numInserts\" : 50"), out);
+  }
+
+  @Test
+  void commitStatsActionFilterRestrictsScope() throws Exception {
+    runMain("--base-path", basePath, "--commit-stats",
+        "--actions", "replacecommit", "--no-archived", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains(REPLACE_INSTANT), out);
+    assertFalse(out.contains(INGEST_INSTANT), out);
+  }
+
+  @Test
+  void commitStatsEmptyRangeEmitsEmptyMarker() throws Exception {
+    runMain("--base-path", basePath, "--commit-stats",
+        "--start-instant", "19990101000000000", "--end-instant", "19990101000000001",
+        "--no-archived", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains("(no ingestion commits in range)"), out);
+  }
+
+  @Test
+  void commitStatsRejectsNonIngestionActionFilter() {
+    runMainTrappingExit("--base-path", basePath, "--commit-stats",
+        "--actions", "clean", "--no-archived", "--quiet");
+    assertTrue(capturedAsString().contains("--actions filter must include at least"),
+        capturedAsString());
+  }
+
+  @Test
+  void commitStatsDefaultsToDescendingByInstant() throws Exception {
+    runMain("--base-path", basePath, "--commit-stats", "--no-archived", "--quiet");
+    String out = capturedAsString();
+    int newer = out.indexOf(REPLACE_INSTANT);
+    int older = out.indexOf(INGEST_INSTANT);
+    assertTrue(newer >= 0 && older >= 0,
+        "expected both instants in output: " + out);
+    assertTrue(newer < older,
+        "default sort should put newer instant (" + REPLACE_INSTANT
+            + ") above older (" + INGEST_INSTANT + "); output:\n" + out);
+  }
+
+  @Test
+  void commitStatsAscendingSortPutsOldestFirst() throws Exception {
+    runMain("--base-path", basePath, "--commit-stats", "--no-archived",
+        "--sort", "asc", "--quiet");
+    String out = capturedAsString();
+    int newer = out.indexOf(REPLACE_INSTANT);
+    int older = out.indexOf(INGEST_INSTANT);
+    assertTrue(older >= 0 && newer >= 0,
+        "expected both instants in output: " + out);
+    assertTrue(older < newer,
+        "asc sort should put older instant first; output:\n" + out);
+  }
+
+  @Test
+  void commitStatsDescLimitReturnsLatest() throws Exception {
+    // With default desc sort and --limit 1, only the newer commit should appear.
+    runMain("--base-path", basePath, "--commit-stats", "--no-archived",
+        "--limit", "1", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains(REPLACE_INSTANT), out);
+    assertFalse(out.contains(INGEST_INSTANT), out);
+  }
+
+  @Test
+  void commitStatsRejectsInvalidSortValue() {
+    runMainTrappingExit("--base-path", basePath, "--commit-stats",
+        "--sort", "sideways", "--no-archived", "--quiet");
+    assertTrue(capturedAsString().contains("--sort must be asc or desc"),
+        capturedAsString());
+  }
+
+  // ---- phase-timings --------------------------------------------------------
+
+  @Test
+  void phaseTimingsHappyPathSixPhasesPerInstant(@TempDir Path tempDir) throws Exception {
+    // Use a dedicated table for this test so the existing harness's commit/clean/rollback
+    // mtimes don't leak into the aggregates.
+    String tablePath = tempDir.resolve("pt_table").toString();
+    HoodieTableMetaClient meta = HoodieTestUtils.init(tablePath, HoodieTableType.MERGE_ON_READ);
+
+    String i1 = "20260601000000000";
+    String i2 = "20260601001000000";
+    // Layout per instant (epoch ms):
+    //   T0 = 1000  T1 = 1500   (sourceReadIndexSfh = 500)
+    //   T2 = 2000  T3 = 2200   (dataWrite = 500, mdtPrep = 200)
+    //   T4 = 2900  T5 = 3000   (mdtWrite = 700, mdtTail = 100)
+    //                          (total = 2000)
+    // Spacing by whole seconds — local FS getModificationTime can have second-level resolution
+    // on macOS / some Linux setups, so sub-second deltas collapse.
+    long[] base1 = {1_000_000L, 1_005_000L, 1_010_000L, 1_012_000L, 1_019_000L, 1_020_000L};
+    long[] base2 = {2_000_000L, 2_005_000L, 2_010_000L, 2_012_000L, 2_019_000L, 2_020_000L};
+
+    writeIngestInstantWithMtimes(meta, i1, HoodieTimeline.DELTA_COMMIT_ACTION, base1);
+    writeMdtInstantWithMtimes(meta, i1, base1);
+    writeIngestInstantWithMtimes(meta, i2, HoodieTimeline.DELTA_COMMIT_ACTION, base2);
+    writeMdtInstantWithMtimes(meta, i2, base2);
+
+    runMain("--base-path", tablePath, "--phase-timings", "--quiet");
+    String out = capturedAsString();
+
+    // Both instants should appear with the exact phase durations we synthesized.
+    assertTrue(out.contains(i1), out);
+    assertTrue(out.contains(i2), out);
+    // Pick the line for i1 and verify the per-phase ms.
+    String i1Row = lineContaining(out, i1);
+    String[] cols = i1Row.trim().split("\\s+");
+    // Columns: instant, action, sourceReadIndexSfh_ms, dataWrite_ms, mdtPrep_ms,
+    //          mdtWrite_ms, mdtTail_ms, total_ms
+    assertTrue(cols.length >= 8, "expected 8 columns, got " + cols.length + ": " + i1Row);
+    assertTrue(cols[2].equals("5000"), "sourceReadIndexSfh=5000 expected, got " + cols[2]);
+    assertTrue(cols[3].equals("5000"), "dataWrite=5000 expected, got " + cols[3]);
+    assertTrue(cols[4].equals("2000"), "mdtPrep=2000 expected, got " + cols[4]);
+    assertTrue(cols[5].equals("7000"), "mdtWrite=7000 expected, got " + cols[5]);
+    assertTrue(cols[6].equals("1000"), "mdtTail=1000 expected, got " + cols[6]);
+    assertTrue(cols[7].equals("20000"), "total=20000 expected, got " + cols[7]);
+    // Aggregate footer present.
+    assertTrue(out.contains("aggregates (per action, ms):"), out);
+    assertTrue(out.contains("deltacommit (n=2)"), out);
+    assertTrue(out.contains("share of total (mean):"), out);
+  }
+
+  @Test
+  void phaseTimingsMdtAbsentFallsBackToThreePhases(@TempDir Path tempDir) throws Exception {
+    String tablePath = tempDir.resolve("pt_table_no_mdt").toString();
+    HoodieTableMetaClient meta = HoodieTestUtils.init(tablePath, HoodieTableType.MERGE_ON_READ);
+    String inst = "20260601000000000";
+    // Spacing by whole seconds; sub-second deltas can collapse on local FS.
+    long[] base = {1_000_000L, 1_005_000L, 0L, 0L, 0L, 1_020_000L};
+    writeIngestInstantWithMtimes(meta, inst, HoodieTimeline.DELTA_COMMIT_ACTION, base);
+    // No MDT writer; .hoodie/metadata/ does not exist.
+
+    runMain("--base-path", tablePath, "--phase-timings", "--quiet");
+    String out = capturedAsString();
+
+    assertTrue(out.contains("metadata table directory not found"), out);
+    assertTrue(out.contains(inst), out);
+    // MDT phase columns must be blank ('-'). dataWrite is T5-T1 = 15000. Total = 20000.
+    String row = lineContaining(out, inst);
+    String[] cols = row.trim().split("\\s+");
+    assertTrue(cols[2].equals("5000"), "sourceReadIndexSfh=5000 expected, got " + cols[2]);
+    assertTrue(cols[3].equals("15000"), "dataWrite=15000 expected (T5-T1), got " + cols[3]);
+    assertTrue(cols[4].equals("-"), "mdtPrep=- expected, got " + cols[4]);
+    assertTrue(cols[5].equals("-"), "mdtWrite=- expected, got " + cols[5]);
+    assertTrue(cols[6].equals("-"), "mdtTail=- expected, got " + cols[6]);
+    assertTrue(cols[7].equals("20000"), "total=20000 expected, got " + cols[7]);
+  }
+
+  @Test
+  void phaseTimingsDropsInstantWithMissingState(@TempDir Path tempDir) throws Exception {
+    String tablePath = tempDir.resolve("pt_table_partial").toString();
+    HoodieTableMetaClient meta = HoodieTestUtils.init(tablePath, HoodieTableType.MERGE_ON_READ);
+    String good = "20260601000000000";
+    String bad = "20260601001000000";
+    long[] g = {1_000_000L, 1_005_000L, 1_010_000L, 1_012_000L, 1_019_000L, 1_020_000L};
+    long[] b = {2_000_000L, 2_005_000L, 2_010_000L, 2_012_000L, 2_019_000L, 2_020_000L};
+    writeIngestInstantWithMtimes(meta, good, HoodieTimeline.DELTA_COMMIT_ACTION, g);
+    writeMdtInstantWithMtimes(meta, good, g);
+
+    // For the bad instant: leave the active timeline as completed but delete the .requested
+    // marker so the row builder skips it. Need to go through the full transition first.
+    writeIngestInstantWithMtimes(meta, bad, HoodieTimeline.DELTA_COMMIT_ACTION, b);
+    writeMdtInstantWithMtimes(meta, bad, b);
+    FileSystem fs = (FileSystem) meta.getStorage().getFileSystem();
+    org.apache.hadoop.fs.Path req = new org.apache.hadoop.fs.Path(meta.getTimelinePath().toString(),
+        bad + ".deltacommit.requested");
+    fs.delete(req, false);
+
+    runMain("--base-path", tablePath, "--phase-timings", "--quiet");
+    String out = capturedAsString();
+
+    assertTrue(out.contains(good), out);
+    // The bad row should not appear in the body table, and the skipped footer must mention it.
+    assertFalse(out.contains(bad + "  deltacommit"), out);
+    assertTrue(out.contains("skipped 1 instant(s)"), out);
+    assertTrue(out.contains("requested-missing=1"), out);
+  }
+
+  @Test
+  void phaseTimingsReplacecommitOptInIncludesReplaceRows(@TempDir Path tempDir) throws Exception {
+    String tablePath = tempDir.resolve("pt_table_replace").toString();
+    HoodieTableMetaClient meta = HoodieTestUtils.init(tablePath, HoodieTableType.MERGE_ON_READ);
+    String ingestTs = "20260601000000000";
+    String replaceTs = "20260601001000000";
+    long[] ig = {1_000_000L, 1_005_000L, 1_010_000L, 1_012_000L, 1_019_000L, 1_020_000L};
+    long[] rp = {2_000_000L, 2_005_000L, 2_010_000L, 2_012_000L, 2_019_000L, 2_020_000L};
+    writeIngestInstantWithMtimes(meta, ingestTs, HoodieTimeline.DELTA_COMMIT_ACTION, ig);
+    writeMdtInstantWithMtimes(meta, ingestTs, ig);
+    writeIngestInstantWithMtimes(meta, replaceTs, HoodieTimeline.REPLACE_COMMIT_ACTION, rp);
+    writeMdtInstantWithMtimes(meta, replaceTs, rp);
+
+    // Without --include-replacecommit: only the deltacommit row should appear.
+    runMain("--base-path", tablePath, "--phase-timings", "--quiet");
+    String outNoOpt = capturedAsString();
+    assertTrue(outNoOpt.contains(ingestTs), outNoOpt);
+    assertFalse(outNoOpt.contains(replaceTs), outNoOpt);
+
+    // With opt-in: both rows present, footer breaks them out per action.
+    runMain("--base-path", tablePath, "--phase-timings", "--include-replacecommit", "--quiet");
+    String outWithOpt = capturedAsString();
+    assertTrue(outWithOpt.contains(ingestTs), outWithOpt);
+    assertTrue(outWithOpt.contains(replaceTs), outWithOpt);
+    assertTrue(outWithOpt.contains("deltacommit (n=1)"), outWithOpt);
+    assertTrue(outWithOpt.contains("replacecommit (n=1)"), outWithOpt);
+  }
+
+  @Test
+  void phaseTimingsJsonOutputCarriesAggregates(@TempDir Path tempDir) throws Exception {
+    String tablePath = tempDir.resolve("pt_table_json").toString();
+    HoodieTableMetaClient meta = HoodieTestUtils.init(tablePath, HoodieTableType.MERGE_ON_READ);
+    String inst = "20260601000000000";
+    long[] base = {1_000_000L, 1_005_000L, 1_010_000L, 1_012_000L, 1_019_000L, 1_020_000L};
+    writeIngestInstantWithMtimes(meta, inst, HoodieTimeline.DELTA_COMMIT_ACTION, base);
+    writeMdtInstantWithMtimes(meta, inst, base);
+
+    runMain("--base-path", tablePath, "--phase-timings", "--output", "json", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains("\"instants\""), out);
+    assertTrue(out.contains("\"aggregates\""), out);
+    assertTrue(out.contains("\"deltacommit\""), out);
+    assertTrue(out.contains("\"mdtPresent\" : true"), out);
+    assertTrue(out.contains("\"sourceReadIndexSfhMs\" : 5000"), out);
+    assertTrue(out.contains("\"totalMs\" : 20000"), out);
+  }
+
+  @Test
+  void phaseTimingsLimitReturnsLatest(@TempDir Path tempDir) throws Exception {
+    String tablePath = tempDir.resolve("pt_table_limit").toString();
+    HoodieTableMetaClient meta = HoodieTestUtils.init(tablePath, HoodieTableType.MERGE_ON_READ);
+    String older = "20260601000000000";
+    String newer = "20260601001000000";
+    // Spacing by whole seconds — local FS getModificationTime can have second-level resolution
+    // on macOS / some Linux setups, so sub-second deltas collapse.
+    long[] base1 = {1_000_000L, 1_005_000L, 1_010_000L, 1_012_000L, 1_019_000L, 1_020_000L};
+    long[] base2 = {2_000_000L, 2_005_000L, 2_010_000L, 2_012_000L, 2_019_000L, 2_020_000L};
+    writeIngestInstantWithMtimes(meta, older, HoodieTimeline.DELTA_COMMIT_ACTION, base1);
+    writeMdtInstantWithMtimes(meta, older, base1);
+    writeIngestInstantWithMtimes(meta, newer, HoodieTimeline.DELTA_COMMIT_ACTION, base2);
+    writeMdtInstantWithMtimes(meta, newer, base2);
+
+    runMain("--base-path", tablePath, "--phase-timings", "--limit", "1", "--quiet");
+    String out = capturedAsString();
+    assertTrue(out.contains(newer), out);
+    assertFalse(out.contains(older), out);
+  }
+
+  // ---- argument validation --------------------------------------------------
+
+  @Test
+  void missingModePrintsUsage() {
+    runMainTrappingExit("--base-path", basePath);
+    assertTrue(capturedAsString().contains("specify --show-instant"), capturedAsString());
+  }
+
+  @Test
+  void invalidActionPrintsRejection() {
+    runMainTrappingExit("--base-path", basePath, "--find-file-id", "x",
+        "--actions", "ingest");
+    assertTrue(capturedAsString().contains("unknown actions"), capturedAsString());
+  }
+
+  @Test
+  void lifecycleWithoutFindFileIdPrintsRejection() {
+    runMainTrappingExit("--base-path", basePath, "--show-instant", INGEST_INSTANT,
+        "--lifecycle");
+    assertTrue(capturedAsString().contains("--lifecycle is only valid with --find-file-id"),
+        capturedAsString());
+  }
+
+  // ---- helpers --------------------------------------------------------------
+
+  private void runMain(String... args) {
+    captured.reset();
+    TimelineInspector.main(args);
+  }
+
+  /**
+   * Variant that traps any {@code System.exit(N)} calls inside {@link TimelineInspector#main}
+   * so the test JVM survives. Returns the last exit status seen (which may be the inner
+   * exit's status or the outer catch's exit(1) -- callers that need a specific code should
+   * also assert on captured stderr text, since main's outer catch can re-wrap.
+   */
+  private int runMainTrappingExit(String... args) {
+    captured.reset();
+    SecurityManager prior = System.getSecurityManager();
+    ExitInterceptingSecurityManager sm = new ExitInterceptingSecurityManager();
+    System.setSecurityManager(sm);
+    try {
+      TimelineInspector.main(args);
+      return 0;
+    } catch (ExitTrappedException e) {
+      return e.status;
+    } finally {
+      System.setSecurityManager(prior);
+    }
+  }
+
+  /**
+   * Builds a fully-formed ingest instant (requested → inflight → completed) on the active
+   * timeline, then forces the modification times of the three on-disk state files to the
+   * provided epochs. Used to synthesize phase-timing fixtures.
+   *
+   * @param mtimes  [t0Requested, t1Inflight, _unused_T2, _unused_T3, _unused_T4, t5Completed]
+   */
+  private void writeIngestInstantWithMtimes(HoodieTableMetaClient meta, String instantTime,
+                                            String action, long[] mtimes) throws Exception {
+    HoodieActiveTimeline timeline = meta.getActiveTimeline();
+    HoodieInstant requested = meta.getInstantGenerator().createNewInstant(
+        HoodieInstant.State.REQUESTED, action, instantTime);
+    timeline.createNewInstant(requested);
+    if (HoodieTimeline.REPLACE_COMMIT_ACTION.equals(action)) {
+      timeline.transitionReplaceRequestedToInflight(requested, Option.empty());
+      HoodieReplaceCommitMetadata rcm = new HoodieReplaceCommitMetadata();
+      rcm.setOperationType(WriteOperationType.CLUSTER);
+      timeline.saveAsComplete(meta.getInstantGenerator().createNewInstant(
+          HoodieInstant.State.INFLIGHT, action, instantTime), Option.of(rcm));
+    } else {
+      timeline.transitionRequestedToInflight(requested, Option.empty());
+      HoodieCommitMetadata cm = new HoodieCommitMetadata();
+      cm.setOperationType(WriteOperationType.UPSERT);
+      timeline.saveAsComplete(meta.getInstantGenerator().createNewInstant(
+          HoodieInstant.State.INFLIGHT, action, instantTime), Option.of(cm));
+    }
+    FileSystem fs = (FileSystem) meta.getStorage().getFileSystem();
+    // Reload to pick up the completion-time suffix in V2 layout — completed instant files
+    // are named "<requestedTime>_<completionTime>.<action>".
+    meta = HoodieTableMetaClient.reload(meta);
+    HoodieInstant completed = meta.getActiveTimeline().filterCompletedInstants().getInstantsAsStream()
+        .filter(i -> instantTime.equals(i.requestedTime()) && action.equals(i.getAction()))
+        .findFirst().orElseThrow(() -> new AssertionError("completed instant not found: " + instantTime));
+    String completedName = meta.getInstantFileNameGenerator().getFileName(completed);
+    setMtime(fs, meta.getTimelinePath() + "/" + instantTime + "." + action + ".requested",
+        mtimes[0]);
+    setMtime(fs, meta.getTimelinePath() + "/" + instantTime + "." + action + ".inflight",
+        mtimes[1]);
+    setMtime(fs, meta.getTimelinePath() + "/" + completedName, mtimes[5]);
+  }
+
+  /**
+   * Hand-writes the three MDT state files under {@code <base>/.hoodie/metadata/.hoodie/}
+   * for the given instant and forces their mtimes. We bypass the real MDT writer because
+   * all the row builder cares about is the existence and mtime of these files.
+   */
+  private void writeMdtInstantWithMtimes(HoodieTableMetaClient meta, String instantTime,
+                                         long[] mtimes) throws Exception {
+    FileSystem fs = (FileSystem) meta.getStorage().getFileSystem();
+    String mdtDotHoodie = meta.getBasePath() + "/"
+        + HoodieTableMetaClient.METADATA_TABLE_FOLDER_PATH + "/"
+        + HoodieTableMetaClient.METAFOLDER_NAME + "/"
+        + HoodieTableMetaClient.TIMELINEFOLDER_NAME;
+    fs.mkdirs(new org.apache.hadoop.fs.Path(mdtDotHoodie));
+    touch(fs, mdtDotHoodie + "/" + instantTime + ".deltacommit.requested");
+    touch(fs, mdtDotHoodie + "/" + instantTime + ".deltacommit.inflight");
+    touch(fs, mdtDotHoodie + "/" + instantTime + ".deltacommit");
+    setMtime(fs, mdtDotHoodie + "/" + instantTime + ".deltacommit.requested", mtimes[2]);
+    setMtime(fs, mdtDotHoodie + "/" + instantTime + ".deltacommit.inflight", mtimes[3]);
+    setMtime(fs, mdtDotHoodie + "/" + instantTime + ".deltacommit", mtimes[4]);
+  }
+
+  private static void touch(FileSystem fs, String pathStr) throws Exception {
+    org.apache.hadoop.fs.Path p = new org.apache.hadoop.fs.Path(pathStr);
+    if (!fs.exists(p)) {
+      fs.create(p, true).close();
+    }
+  }
+
+  private static void setMtime(FileSystem fs, String pathStr, long mtime) throws Exception {
+    fs.setTimes(new org.apache.hadoop.fs.Path(pathStr), mtime, -1);
+  }
+
+  private static String lineContaining(String haystack, String needle) {
+    for (String line : haystack.split("\n")) {
+      if (line.contains(needle)) {
+        return line;
+      }
+    }
+    throw new AssertionError("no line containing '" + needle + "' in:\n" + haystack);
+  }
+
+  private String capturedAsString() {
+    System.out.flush();
+    System.err.flush();
+    return new String(captured.toByteArray(), StandardCharsets.UTF_8);
+  }
+
+  /** Trap System.exit so the test process survives non-zero exits. */
+  private static class ExitTrappedException extends SecurityException {
+    final int status;
+    ExitTrappedException(int status) {
+      super("System.exit(" + status + ")");
+      this.status = status;
+    }
+  }
+
+  private static class ExitInterceptingSecurityManager extends SecurityManager {
+    @Override
+    public void checkExit(int status) {
+      throw new ExitTrappedException(status);
+    }
+
+    @Override
+    public void checkPermission(java.security.Permission perm) {
+      // allow everything else
+    }
+  }
+
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Adds `TimelineInspector`, a pure-Java CLI for inspecting a Hudi table's active + archived timeline without needing Spark, for better debuggability.

### Summary and Changelog

Adds `org.apache.hudi.tools.TimelineInspector`, a pure-Java CLI for inspecting a Hudi table's active + archived timeline without needing Spark. Lives in `hudi-hadoop-common` since it uses Hadoop `FileSystem` APIs for raw archive log scanning and per-instant mtime lookups.

**Modes**

- `--show-instant` — dump one instant's content (all states + timeline location)
- `--find-file-id` — find which instants touched a file id / partition / file group
- `--commit-stats` — per-instant stats (numWrites/numInserts/numUpdateWrites/numDeletes, bytes, partitions touched) with optional filters
- `--parse-filename` — decode a base or log file name into {fileId, commitTime, writeToken, ...}
- `--raw-archive` — dump raw archive log entries for a specific instant
- `--phase-timings` — per-instant phase durations (requested→inflight→completed for data table + MDT sub-table) for latency forensics

Modifiers: `--lifecycle`, `--output table|json`, `--state`, `--actions`, `--start-instant`, `--end-instant`, `--limit`, `--sort asc|desc`, `--quiet`, `--no-archived`.

**Robustness**

Handles archived-timeline storage quirks:
- Avro-container vs JSON-string sniff
- Union-tag fixup walker for malformed JSON
- `instantsRollback` checked alongside legacy `commitsRollback`
- JSON-tree aggregator fallback for `--commit-stats` when the POJO path yields an empty shell

Handles V2 timeline layout:
- Reads instant files under `<base>/.hoodie/timeline/`
- Resolves completed-instant filenames with the `_<completionTime>` suffix via the metaclient's `InstantFileNameGenerator`
- For `--phase-timings`, the MDT completed-file lookup globs the timeline dir by `<requestedTime>` prefix + `.deltacommit` suffix (we don't know the completion time a priori)

### Impact

- **New**: standalone CLI tool for timeline forensics. Useful for on-call debugging (what did commit X do?) and post-incident analysis (which commits touched file id Y?).
- **No breaking changes**: purely additive. No `@PublicAPIClass` / `@PublicAPIMethod` touched. No storage format changes. No new `hoodie.*` configs.

### Risk Level

low

New tool with no changes to existing code paths. CI passed locally: `mvn -pl hudi-hadoop-common -o test -Dtest=TestTimelineInspector` → **32/32 passing**

### Documentation Update

none

### Contributor's checklist

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable