### PR TITLE
fix(meta-sync): advance last commit time synced when it trails the active timeline midpoint

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -295,13 +295,13 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
   }
 
   /**
-   * Checks whether the last synced commit trails the midpoint of the active commits timeline.
-   * Under conditional sync, the marker advances only when a sync detects a schema, table
-   * property, or partition change; a sync that finds none of those leaves the marker in place,
-   * independent of whether the commit wrote data. Once the marker falls behind the start of the
-   * active timeline, every subsequent round reads the archived timeline to compute the written
-   * and dropped partitions since the marker. Advancing the marker when it crosses the midpoint
-   * bounds that staleness with an infrequent marker update.
+   * Checks whether last commit time synced trails the midpoint of the active commits timeline.
+   * Under conditional sync, last commit time synced advances only when a sync detects a schema,
+   * table property, or partition change; a sync that finds none of those leaves it unchanged,
+   * independent of whether the commit wrote data. Once last commit time synced falls behind the
+   * start of the active timeline, every subsequent round reads the archived timeline to compute
+   * the written and dropped partitions since that instant. Advancing it when it crosses the
+   * midpoint bounds that staleness with an infrequent table-property update.
    */
   private boolean isLastCommitTimeSyncedBehindTimelineMidpoint(String tableName) {
     Option<String> lastCommitTimeSynced = syncClient.getLastCommitTimeSynced(tableName);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -306,9 +306,10 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
     if (!lastCommitTimeSynced.isPresent()) {
       return false;
     }
-    // Narrow to completed commits: getCommitsTimeline() drops clean, rollback, and other non-commit actions.
+    // Completed commits only: getCommitsTimeline() excludes non-commit actions (clean, rollback),
+    // and filterCompletedInstants() excludes inflight instants.
     List<HoodieInstant> completedCommits =
-        syncClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().getInstants();
+        syncClient.getMetaClient().getCommitsTimeline().filterCompletedInstants().getInstants();
     if (completedCommits.isEmpty()) {
       return false;
     }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -296,13 +296,9 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
   }
 
   /**
-   * Checks whether last commit time synced trails the midpoint of the active commits timeline.
-   * Under conditional sync, last commit time synced advances only when a sync detects a schema,
-   * table property, or partition change; a sync that finds none of those leaves it unchanged,
-   * independent of whether the commit wrote data. Once last commit time synced falls behind the
-   * start of the active timeline, every subsequent round reads the archived timeline to compute
-   * the written and dropped partitions since that instant. Advancing it when it crosses the
-   * midpoint bounds that staleness with an infrequent table-property update.
+   * Whether last commit time synced trails the midpoint of the completed commit instants.
+   * Advancing it at the midpoint bounds how far it can fall behind, capping the archived-timeline
+   * scans a stale value forces on every conditional-sync round.
    */
   @VisibleForTesting
   boolean isLastCommitTimeSyncedBehindTimelineMidpoint(String tableName) {
@@ -310,14 +306,13 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
     if (!lastCommitTimeSynced.isPresent()) {
       return false;
     }
-    // Compute the midpoint over completed commits only: an inflight instant is not a candidate
-    // last commit time synced, and counting it would inflate the instant count and shift the midpoint.
-    List<HoodieInstant> completedInstants =
-        syncClient.getActiveTimeline().filterCompletedInstants().getInstants();
-    if (completedInstants.isEmpty()) {
+    // Narrow to completed commits: getCommitsTimeline() drops clean, rollback, and other non-commit actions.
+    List<HoodieInstant> completedCommits =
+        syncClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants().getInstants();
+    if (completedCommits.isEmpty()) {
       return false;
     }
-    String midpointInstantTime = completedInstants.get(completedInstants.size() / 2).requestedTime();
+    String midpointInstantTime = completedCommits.get(completedCommits.size() / 2).requestedTime();
     return compareTimestamps(lastCommitTimeSynced.get(), LESSER_THAN, midpointInstantTime);
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -51,6 +51,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
+import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.util.StringUtils.nonEmpty;
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getInputFormatClassName;
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.getOutputFormatClassName;
@@ -276,7 +278,8 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
 
       boolean partitionsChanged = validateAndSyncPartitions(tableName, tableExists);
       boolean meetSyncConditions = schemaChanged || propertiesChanged || partitionsChanged;
-      if (!config.getBoolean(META_SYNC_CONDITIONAL_SYNC) || meetSyncConditions) {
+      if (!config.getBoolean(META_SYNC_CONDITIONAL_SYNC) || meetSyncConditions
+          || isLastCommitTimeSyncedBehindTimelineMidpoint(tableName)) {
         syncClient.updateLastCommitTimeSynced(tableName);
       }
       syncClient.updateHoodieWriterVersion(tableName);
@@ -289,6 +292,26 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
         throw new HoodieHiveSyncException("failed to sync the table " + tableName, ex);
       }
     }
+  }
+
+  /**
+   * Checks whether the last synced commit trails the midpoint of the active commits timeline.
+   * Under conditional sync, no-op commits do not advance the sync marker, and once the marker
+   * falls behind the start of the active timeline, every subsequent round reads the archived
+   * timeline to compute the written and dropped partitions since the marker. Advancing the
+   * marker when it crosses the midpoint bounds that staleness with an infrequent marker update.
+   */
+  private boolean isLastCommitTimeSyncedBehindTimelineMidpoint(String tableName) {
+    Option<String> lastCommitTimeSynced = syncClient.getLastCommitTimeSynced(tableName);
+    if (!lastCommitTimeSynced.isPresent()) {
+      return false;
+    }
+    List<HoodieInstant> completedInstants = syncClient.getActiveTimeline().getInstants();
+    if (completedInstants.isEmpty()) {
+      return false;
+    }
+    String midpointInstantTime = completedInstants.get(completedInstants.size() / 2).requestedTime();
+    return compareTimestamps(lastCommitTimeSynced.get(), LESSER_THAN, midpointInstantTime);
   }
 
   private boolean isAlreadySynced(String tableName) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -296,10 +296,12 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
 
   /**
    * Checks whether the last synced commit trails the midpoint of the active commits timeline.
-   * Under conditional sync, no-op commits do not advance the sync marker, and once the marker
-   * falls behind the start of the active timeline, every subsequent round reads the archived
-   * timeline to compute the written and dropped partitions since the marker. Advancing the
-   * marker when it crosses the midpoint bounds that staleness with an infrequent marker update.
+   * Under conditional sync, the marker advances only when a sync detects a schema, table
+   * property, or partition change; a sync that finds none of those leaves the marker in place,
+   * independent of whether the commit wrote data. Once the marker falls behind the start of the
+   * active timeline, every subsequent round reads the archived timeline to compute the written
+   * and dropped partitions since the marker. Advancing the marker when it crosses the midpoint
+   * bounds that staleness with an infrequent marker update.
    */
   private boolean isLastCommitTimeSyncedBehindTimelineMidpoint(String tableName) {
     Option<String> lastCommitTimeSynced = syncClient.getLastCommitTimeSynced(tableName);

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.InvalidTableException;
 import org.apache.hudi.sync.common.HoodieSyncClient;
@@ -303,12 +304,16 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
    * the written and dropped partitions since that instant. Advancing it when it crosses the
    * midpoint bounds that staleness with an infrequent table-property update.
    */
-  private boolean isLastCommitTimeSyncedBehindTimelineMidpoint(String tableName) {
+  @VisibleForTesting
+  boolean isLastCommitTimeSyncedBehindTimelineMidpoint(String tableName) {
     Option<String> lastCommitTimeSynced = syncClient.getLastCommitTimeSynced(tableName);
     if (!lastCommitTimeSynced.isPresent()) {
       return false;
     }
-    List<HoodieInstant> completedInstants = syncClient.getActiveTimeline().getInstants();
+    // Compute the midpoint over completed commits only: an inflight instant is not a candidate
+    // last commit time synced, and counting it would inflate the instant count and shift the midpoint.
+    List<HoodieInstant> completedInstants =
+        syncClient.getActiveTimeline().filterCompletedInstants().getInstants();
     if (completedInstants.isEmpty()) {
       return false;
     }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -2536,12 +2536,16 @@ public class TestHiveSyncTool {
 
     HiveTestUtil.addMORPartitions(0, true, true, true, ZonedDateTime.now().plusDays(2), commitTime2, commitTime3);
 
+    // No sync condition is met, but the sync marker trails the midpoint of the active commits
+    // timeline ([100, 101, 102, 103] with midpoint 102), so it advances to the last commit.
+    reInitHiveSyncClient();
     reSyncHiveTable();
-    assertEquals(commitTime1, hiveClient.getLastCommitTimeSynced(tableName).get());
+    assertEquals(commitTime3, hiveClient.getLastCommitTimeSynced(tableName).get());
 
     // Let the last commit time synced to be before the start of the active timeline,
-    // to trigger the fallback of listing all partitions. There is no partition change
-    // and the last commit time synced should still be the same.
+    // to trigger the fallback of listing all partitions. There is no partition change,
+    // and the sync marker again trails the timeline midpoint, so it advances to the
+    // last commit instead of aging out further.
     HiveTestUtil.addMORPartitions(0, true, true, true, ZonedDateTime.now().plusDays(2), commitTime4, commitTime5);
     HiveTestUtil.removeCommitFromActiveTimeline(commitTime0, COMMIT_ACTION);
     HiveTestUtil.removeCommitFromActiveTimeline(commitTime1, DELTA_COMMIT_ACTION);
@@ -2549,7 +2553,7 @@ public class TestHiveSyncTool {
     HiveTestUtil.removeCommitFromActiveTimeline(commitTime3, DELTA_COMMIT_ACTION);
     reInitHiveSyncClient();
     reSyncHiveTable();
-    assertEquals(commitTime1, hiveClient.getLastCommitTimeSynced(tableName).get());
+    assertEquals(commitTime5, hiveClient.getLastCommitTimeSynced(tableName).get());
   }
 
   @ParameterizedTest

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolTimelineMidpoint.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolTimelineMidpoint.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.hive;
 
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.MockHoodieTimeline;
 import org.apache.hudi.common.util.Option;
@@ -35,7 +36,9 @@ import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link HiveSyncTool#isLastCommitTimeSyncedBehindTimelineMidpoint}, which decides
- * whether a no-change conditional sync should still advance last commit time synced.
+ * whether a no-change conditional sync should still advance last commit time synced. The helper
+ * reads the completed commits timeline, so these mock {@code getMetaClient().getCommitsTimeline()};
+ * a call to any other timeline would hit an unstubbed mock and fail.
  */
 class TestHiveSyncToolTimelineMidpoint {
 
@@ -43,14 +46,9 @@ class TestHiveSyncToolTimelineMidpoint {
 
   @Test
   void midpointIsTakenOverCompletedCommitsOnly() {
-    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
-    HoodieSyncClient syncClient = mock(HoodieSyncClient.class);
-    tool.syncClient = syncClient;
-
-    // Completed commits [100, 102, 104], completed midpoint 102; the later inflight 106 must not
-    // shift the midpoint to 104.
-    HoodieTimeline timeline = new MockHoodieTimeline(Stream.of("100", "102", "104"), Stream.of("106"));
-    when(syncClient.getActiveTimeline()).thenReturn(timeline);
+    // Completed commits [100, 102, 104], midpoint 102; the later inflight 106 must not shift it to 104.
+    HoodieSyncClient syncClient = mockSyncClient(new MockHoodieTimeline(Stream.of("100", "102", "104"), Stream.of("106")));
+    HiveSyncTool tool = toolWith(syncClient);
 
     // Not synced yet: nothing to advance.
     stubLastCommitTimeSynced(syncClient, Option.empty());
@@ -71,19 +69,17 @@ class TestHiveSyncToolTimelineMidpoint {
 
   @Test
   void midpointHandlesSmallTimelines() {
-    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
-    HoodieSyncClient syncClient = mock(HoodieSyncClient.class);
-    tool.syncClient = syncClient;
-
-    // Size 1: the sole instant is the midpoint.
-    when(syncClient.getActiveTimeline()).thenReturn(new MockHoodieTimeline(Stream.of("101"), Stream.empty()));
+    // Size 1: the sole commit is the midpoint.
+    HoodieSyncClient syncClient = mockSyncClient(new MockHoodieTimeline(Stream.of("101"), Stream.empty()));
+    HiveSyncTool tool = toolWith(syncClient);
     stubLastCommitTimeSynced(syncClient, Option.of("100"));
     assertTrue(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
     stubLastCommitTimeSynced(syncClient, Option.of("101"));
     assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
 
-    // Size 2: the midpoint (index 1) is the newer instant.
-    when(syncClient.getActiveTimeline()).thenReturn(new MockHoodieTimeline(Stream.of("100", "102"), Stream.empty()));
+    // Size 2: the midpoint (index 1) is the newer commit.
+    syncClient = mockSyncClient(new MockHoodieTimeline(Stream.of("100", "102"), Stream.empty()));
+    tool = toolWith(syncClient);
     stubLastCommitTimeSynced(syncClient, Option.of("101"));
     assertTrue(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
     stubLastCommitTimeSynced(syncClient, Option.of("102"));
@@ -91,34 +87,25 @@ class TestHiveSyncToolTimelineMidpoint {
   }
 
   @Test
-  void emptyActiveTimelineIsNotBehind() {
-    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
-    HoodieSyncClient syncClient = mock(HoodieSyncClient.class);
-    tool.syncClient = syncClient;
-
-    when(syncClient.getActiveTimeline()).thenReturn(new MockHoodieTimeline(Stream.empty(), Stream.empty()));
+  void emptyCommitsTimelineIsNotBehind() {
+    HoodieSyncClient syncClient = mockSyncClient(new MockHoodieTimeline(Stream.empty(), Stream.empty()));
+    HiveSyncTool tool = toolWith(syncClient);
     stubLastCommitTimeSynced(syncClient, Option.of("103"));
     assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
   }
 
-  @Test
-  void midpointNarrowsToCommitsTimeline() {
-    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
+  private static HoodieSyncClient mockSyncClient(HoodieTimeline commitsTimeline) {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getCommitsTimeline()).thenReturn(commitsTimeline);
     HoodieSyncClient syncClient = mock(HoodieSyncClient.class);
+    when(syncClient.getMetaClient()).thenReturn(metaClient);
+    return syncClient;
+  }
+
+  private static HiveSyncTool toolWith(HoodieSyncClient syncClient) {
+    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
     tool.syncClient = syncClient;
-
-    // The active timeline also carries clean, rollback, and other non-commit actions. The helper
-    // must narrow to getCommitsTimeline() so only completed commits [100, 102, 104] (midpoint 102)
-    // count; reading the active timeline directly would leave getCommitsTimeline() unstubbed and NPE.
-    HoodieTimeline activeTimeline = mock(HoodieTimeline.class);
-    when(activeTimeline.getCommitsTimeline())
-        .thenReturn(new MockHoodieTimeline(Stream.of("100", "102", "104"), Stream.empty()));
-    when(syncClient.getActiveTimeline()).thenReturn(activeTimeline);
-
-    stubLastCommitTimeSynced(syncClient, Option.of("101"));
-    assertTrue(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
-    stubLastCommitTimeSynced(syncClient, Option.of("102"));
-    assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+    return tool;
   }
 
   private static void stubLastCommitTimeSynced(HoodieSyncClient syncClient, Option<String> value) {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolTimelineMidpoint.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolTimelineMidpoint.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive;
+
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.testutils.MockHoodieTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.sync.common.HoodieSyncClient;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link HiveSyncTool#isLastCommitTimeSyncedBehindTimelineMidpoint}, which decides
+ * whether a no-change conditional sync should still advance last commit time synced.
+ */
+class TestHiveSyncToolTimelineMidpoint {
+
+  private static final String TABLE_NAME = "table";
+
+  @Test
+  void midpointIsTakenOverCompletedCommitsOnly() {
+    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
+    HoodieSyncClient syncClient = mock(HoodieSyncClient.class);
+    tool.syncClient = syncClient;
+
+    // Completed commits [100, 102, 104], completed midpoint 102; the later inflight 106 must not
+    // shift the midpoint to 104.
+    HoodieTimeline timeline = new MockHoodieTimeline(Stream.of("100", "102", "104"), Stream.of("106"));
+    when(syncClient.getActiveTimeline()).thenReturn(timeline);
+
+    // Not synced yet: nothing to advance.
+    stubLastCommitTimeSynced(syncClient, Option.empty());
+    assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+
+    // Trails the midpoint.
+    stubLastCommitTimeSynced(syncClient, Option.of("101"));
+    assertTrue(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+
+    // At the midpoint is not behind it.
+    stubLastCommitTimeSynced(syncClient, Option.of("102"));
+    assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+
+    // Past 102 but below 104: behind only if the inflight 106 is wrongly counted.
+    stubLastCommitTimeSynced(syncClient, Option.of("103"));
+    assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+  }
+
+  @Test
+  void midpointHandlesSmallTimelines() {
+    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
+    HoodieSyncClient syncClient = mock(HoodieSyncClient.class);
+    tool.syncClient = syncClient;
+
+    // Size 1: the sole instant is the midpoint.
+    when(syncClient.getActiveTimeline()).thenReturn(new MockHoodieTimeline(Stream.of("101"), Stream.empty()));
+    stubLastCommitTimeSynced(syncClient, Option.of("100"));
+    assertTrue(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+    stubLastCommitTimeSynced(syncClient, Option.of("101"));
+    assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+
+    // Size 2: the midpoint (index 1) is the newer instant.
+    when(syncClient.getActiveTimeline()).thenReturn(new MockHoodieTimeline(Stream.of("100", "102"), Stream.empty()));
+    stubLastCommitTimeSynced(syncClient, Option.of("101"));
+    assertTrue(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+    stubLastCommitTimeSynced(syncClient, Option.of("102"));
+    assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+  }
+
+  @Test
+  void emptyActiveTimelineIsNotBehind() {
+    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
+    HoodieSyncClient syncClient = mock(HoodieSyncClient.class);
+    tool.syncClient = syncClient;
+
+    when(syncClient.getActiveTimeline()).thenReturn(new MockHoodieTimeline(Stream.empty(), Stream.empty()));
+    stubLastCommitTimeSynced(syncClient, Option.of("103"));
+    assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+  }
+
+  private static void stubLastCommitTimeSynced(HoodieSyncClient syncClient, Option<String> value) {
+    when(syncClient.getLastCommitTimeSynced(TABLE_NAME)).thenReturn(value);
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolTimelineMidpoint.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolTimelineMidpoint.java
@@ -45,7 +45,7 @@ class TestHiveSyncToolTimelineMidpoint {
   private static final String TABLE_NAME = "table";
 
   @Test
-  void midpointIsTakenOverCompletedCommitsOnly() {
+  void midpointIsComputedFromCompletedCommitsOnly() {
     // Completed commits [100, 102, 104], midpoint 102; the later inflight 106 must not shift it to 104.
     HoodieSyncClient syncClient = mockSyncClient(new MockHoodieTimeline(Stream.of("100", "102", "104"), Stream.of("106")));
     HiveSyncTool tool = toolWith(syncClient);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolTimelineMidpoint.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncToolTimelineMidpoint.java
@@ -101,6 +101,26 @@ class TestHiveSyncToolTimelineMidpoint {
     assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
   }
 
+  @Test
+  void midpointNarrowsToCommitsTimeline() {
+    HiveSyncTool tool = mock(HiveSyncTool.class, CALLS_REAL_METHODS);
+    HoodieSyncClient syncClient = mock(HoodieSyncClient.class);
+    tool.syncClient = syncClient;
+
+    // The active timeline also carries clean, rollback, and other non-commit actions. The helper
+    // must narrow to getCommitsTimeline() so only completed commits [100, 102, 104] (midpoint 102)
+    // count; reading the active timeline directly would leave getCommitsTimeline() unstubbed and NPE.
+    HoodieTimeline activeTimeline = mock(HoodieTimeline.class);
+    when(activeTimeline.getCommitsTimeline())
+        .thenReturn(new MockHoodieTimeline(Stream.of("100", "102", "104"), Stream.empty()));
+    when(syncClient.getActiveTimeline()).thenReturn(activeTimeline);
+
+    stubLastCommitTimeSynced(syncClient, Option.of("101"));
+    assertTrue(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+    stubLastCommitTimeSynced(syncClient, Option.of("102"));
+    assertFalse(tool.isLastCommitTimeSyncedBehindTimelineMidpoint(TABLE_NAME));
+  }
+
   private static void stubLastCommitTimeSynced(HoodieSyncClient syncClient, Option<String> value) {
     when(syncClient.getLastCommitTimeSynced(TABLE_NAME)).thenReturn(value);
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

With `hoodie.datasource.meta.sync.condition.sync=true`, `HiveSyncTool` advances last commit time synced only when a sync detects a change to push to the catalog (`schemaChanged || propertiesChanged || partitionsChanged`). A table that keeps committing without any of those changes never advances last commit time synced, even when the commits write data (for example an append-only or otherwise idle table whose writes only touch existing partitions and schema). Once last commit time synced falls behind the start of the active timeline, `HoodieSyncClient.getDroppedPartitionsSince` via `TimelineUtils.getCommitsTimelineAfter` merges the archived timeline and reads commit metadata per instant on every subsequent sync round, which takes minutes on tables with large archived timelines.

### Summary and Changelog

When conditional sync would skip the update, advance last commit time synced anyway if it trails the midpoint of the active commits timeline:

- `HiveSyncTool.syncHoodieTable`: add `isLastCommitTimeSyncedBehindTimelineMidpoint(tableName)` to the update condition.
- The check compares the stored last commit time synced against the requested time of the middle instant of the completed commits timeline, so it always stays in the newer half of the active timeline and never ages into the archived timeline, while the catalog property write stays infrequent.
- Updated `testSyncWithoutDiffs` to the new semantics: last commit time synced advances to the latest commit once it trails the midpoint, both while still on the active timeline and after it has fallen behind the timeline start.
- The midpoint is taken over `getCommitsTimeline().filterCompletedInstants()` so non-commit actions (clean, rollback, and the like) and inflight instants are excluded and cannot shift it.
- Added `TestHiveSyncToolTimelineMidpoint` covering `isLastCommitTimeSyncedBehindTimelineMidpoint` directly: the not-present and empty-timeline guards, the trails/at/past-midpoint cases, the size-1 and size-2 boundaries, that the midpoint is taken over completed commits only so an inflight instant does not shift it, and that it narrows to the commits timeline so non-commit actions are excluded.

### Impact

Meta sync with conditional sync enabled now refreshes the `last_commit_time_sync` and `last_commit_completion_time_sync` table properties occasionally on no-change syncs (only when last commit time synced crosses the timeline midpoint), avoiding the archived-timeline reads in written and dropped partition computation. No API changes.

### Risk Level

low. Reuses the existing `updateLastCommitTimeSynced` path, and behavior without conditional sync is unchanged. Verified with the updated `testSyncWithoutDiffs` across sync modes.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable


