### PR TITLE
fix(common): name the offending expression in BindVisitor's unsupported-predicate error

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/expression/BindVisitor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/expression/BindVisitor.java
@@ -182,6 +182,6 @@ public class BindVisitor implements ExpressionVisitor<Expression>  {
       return Predicates.contains(left, right);
     }
 
-    throw new IllegalArgumentException("The expression " + this + "cannot be visited as predicate");
+    throw new IllegalArgumentException("The expression " + predicate + " cannot be visited as predicate");
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/expression/Predicates.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/expression/Predicates.java
@@ -486,6 +486,13 @@ public class Predicates {
       return false;
     }
 
+    @Override
+    public String toString() {
+      // The left expression is absent for the metadata table key filters, so it must not be dereferenced.
+      return left + ".startsWithAny("
+          + right.stream().map(Expression::toString).collect(Collectors.joining(",", "(", ")")) + ")";
+    }
+
     public List<Expression> getRightChildren() {
       return right;
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/expression/Predicates.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/expression/Predicates.java
@@ -263,7 +263,7 @@ public class Predicates {
 
     @Override
     public String toString() {
-      return getLeft().toString() + ".startWith(" + getRight().toString() + ")";
+      return getLeft().toString() + ".startsWith(" + getRight().toString() + ")";
     }
 
     @Override
@@ -488,9 +488,10 @@ public class Predicates {
 
     @Override
     public String toString() {
-      // The left expression is absent for the metadata table key filters, so it must not be dereferenced.
+      // Only the left expression is absent: HoodieBackedTableMetadata passes null for the metadata table
+      // key filters, so it must not be dereferenced. The right operands are always non-null literals.
       return left + ".startsWithAny("
-          + right.stream().map(Expression::toString).collect(Collectors.joining(",", "(", ")")) + ")";
+          + right.stream().map(Expression::toString).collect(Collectors.joining(",")) + ")";
     }
 
     public List<Expression> getRightChildren() {

--- a/hudi-common/src/test/java/org/apache/hudi/common/expression/TestBindVisitor.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/expression/TestBindVisitor.java
@@ -46,7 +46,7 @@ class TestBindVisitor {
     IllegalArgumentException e =
         assertThrows(IllegalArgumentException.class, () -> startsWithAny.accept(bindVisitor));
 
-    assertTrue(e.getMessage().contains("NameReference(name=a).startsWithAny((Ja))"), e::getMessage);
+    assertTrue(e.getMessage().contains("NameReference(name=a).startsWithAny(Ja)"), e::getMessage);
     assertFalse(e.getMessage().contains(BindVisitor.class.getName()), e::getMessage);
     assertTrue(e.getMessage().contains(" cannot be visited as predicate"), e::getMessage);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/expression/TestBindVisitor.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/expression/TestBindVisitor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.expression;
+
+import org.apache.hudi.common.schema.internal.Types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestBindVisitor {
+
+  private static Types.RecordType schema() {
+    ArrayList<Types.Field> fields = new ArrayList<>(1);
+    fields.add(Types.Field.get(0, true, "a", Types.StringType.get()));
+    return Types.RecordType.get(fields, "schema");
+  }
+
+  @Test
+  void testUnsupportedPredicateErrorNamesTheExpression() {
+    BindVisitor bindVisitor = new BindVisitor(schema(), true);
+    Predicates.StringStartsWithAny startsWithAny =
+        Predicates.startsWithAny(new NameReference("a"), Collections.singletonList(Literal.from("Ja")));
+
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> startsWithAny.accept(bindVisitor));
+
+    assertTrue(e.getMessage().contains("NameReference(name=a).startsWithAny((Ja))"), e::getMessage);
+    assertFalse(e.getMessage().contains(BindVisitor.class.getName()), e::getMessage);
+    assertTrue(e.getMessage().contains(" cannot be visited as predicate"), e::getMessage);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/expression/TestPredicates.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/expression/TestPredicates.java
@@ -22,6 +22,7 @@ package org.apache.hudi.common.expression;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,5 +52,19 @@ class TestPredicates {
     Predicates.StringStartsWithAny predicate = Predicates.startsWithAny(left, right);
     assertEquals(Expression.Operator.STARTS_WITH, predicate.getOperator());
     assertFalse((boolean) predicate.eval(null));
+  }
+
+  @Test
+  void testStringStartsWithAnyToString() {
+    Predicates.StringStartsWithAny predicate =
+        Predicates.startsWithAny(Literal.from("key"), Arrays.asList(Literal.from("k1"), Literal.from("k2")));
+    assertEquals("key.startsWithAny((k1,k2))", predicate.toString());
+  }
+
+  @Test
+  void testStringStartsWithAnyToStringIsNullSafeForAbsentLeft() {
+    Predicates.StringStartsWithAny predicate =
+        Predicates.startsWithAny(null, Collections.singletonList(Literal.from("key1")));
+    assertEquals("null.startsWithAny((key1))", predicate.toString());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/expression/TestPredicates.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/expression/TestPredicates.java
@@ -31,6 +31,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestPredicates {
   @Test
+  void testStringStartsWithToString() {
+    Predicates.StringStartsWith predicate = Predicates.startsWith(Literal.from("key"), Literal.from("k1"));
+    assertEquals("key.startsWith(k1)", predicate.toString());
+  }
+
+  @Test
   void testStringStartsWithAnyWhenMatched() {
     Expression left = Literal.from("key2_any");
     List<Expression> right = Arrays.asList(
@@ -58,13 +64,13 @@ class TestPredicates {
   void testStringStartsWithAnyToString() {
     Predicates.StringStartsWithAny predicate =
         Predicates.startsWithAny(Literal.from("key"), Arrays.asList(Literal.from("k1"), Literal.from("k2")));
-    assertEquals("key.startsWithAny((k1,k2))", predicate.toString());
+    assertEquals("key.startsWithAny(k1,k2)", predicate.toString());
   }
 
   @Test
   void testStringStartsWithAnyToStringIsNullSafeForAbsentLeft() {
     Predicates.StringStartsWithAny predicate =
         Predicates.startsWithAny(null, Collections.singletonList(Literal.from("key1")));
-    assertEquals("null.startsWithAny((key1))", predicate.toString());
+    assertEquals("null.startsWithAny(key1)", predicate.toString());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19240

`BindVisitor#visitPredicate` interpolates `this`, the visitor, rather than the offending predicate into the `IllegalArgumentException` it throws for an unsupported predicate, and it omits the space before `cannot`. `BindVisitor` has no `toString()` override, so the message reads:

```
The expression org.apache.hudi.common.expression.BindVisitor@41a90fa8cannot be visited as predicate
```

The sibling `PartialBindVisitor#visitPredicate` already interpolates `predicate` correctly, which is what makes this a typo rather than a deliberate choice.

### Summary and Changelog

Fixed the message so it names the expression that could not be bound, matching `PartialBindVisitor`. Fixes #19240.

- `BindVisitor#visitPredicate` now interpolates `predicate` instead of `this`, and restores the missing space before `cannot`.
- Added a null-safe `toString()` to `Predicates.StringStartsWithAny`. It is the only `Predicate` that can reach the guard, because every other implementation is either handled earlier in `visitPredicate` or overrides `accept` and never enters it, and it is the only class in `Predicates.java` without a `toString()`. Without it the corrected message would still print an identity hash. It is deliberately null safe because `HoodieBackedTableMetadata` constructs it with a `null` left operand for metadata table key filters.
- Corrected a typo in the sibling `Predicates.StringStartsWith#toString()`, which rendered `.startWith(` with the `s` missing, so that it now matches its class name, its `Operator.STARTS_WITH`, and the `String.startsWith` call in its own `eval`.
- Added `TestBindVisitor` with a regression test that fails on the current `master` on each of its three assertions and passes with this change.
- Added three `TestPredicates` cases: two for the new `StringStartsWithAny#toString()`, one of which covers the `null` left operand shape that production actually constructs, and one that pins the corrected `StringStartsWith#toString()` rendering.

No code was copied from elsewhere.

Note: the regression test naturally belongs in a new `TestBindVisitor`, which the open PR #19204 also creates, and both PRs append to `TestPredicates`. Whichever lands second needs a trivial merge that keeps both sets of tests.

### Impact

None on behavior. The guard is a defensive branch, and as far as I can tell no current call site can reach it: `BindVisitor` is only constructed for partition pruning in `HoodieBackedTableMetadata` and `FileSystemBackedTableMetadata`, while `StringStartsWithAny` is only constructed as a metadata table key filter. I did not trace every engine-side filter translation path, so treat that as an inference rather than a proven fact. The only user-visible difference is the text of an exception that nothing currently throws, plus a readable `toString()` on `StringStartsWithAny`.

The typo fix changes what `StringStartsWith#toString()` produces, from `key.startWith(k1)` to `key.startsWith(k1)`. That rendering is diagnostic only. Nothing in the repository parses it or asserts on it, and predicate equality comes from Lombok's `@EqualsAndHashCode` rather than from the string, so the change is confined to log and exception text.

No public API, config, or performance impact.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
