### PR TITLE
fix(metadata-table): add config to skip zero-size data files on MDT initialization

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1077,6 +1077,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     StorageConfiguration<?> storageConf = dataMetaClient.getStorageConf();
     final String dirFilterRegex = dataWriteConfig.getMetadataConfig().getDirectoryFilterRegex();
     StoragePath storageBasePath = dataMetaClient.getBasePath();
+    long totalZeroSizeFiles = 0;
 
     while (!pathsToList.isEmpty()) {
       // In each round we will list a section of directories
@@ -1096,6 +1097,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       // If the listing reveals a directory, add it to queue. If the listing reveals a hoodie partition, add it to
       // the results.
       for (DirectoryInfo dirInfo : processedDirectories) {
+        totalZeroSizeFiles += dirInfo.getZeroSizeFileCount();
         if (!dirFilterRegex.isEmpty()) {
           final String relativePath = dirInfo.getRelativePath();
           if (!relativePath.isEmpty() && relativePath.matches(dirFilterRegex)) {
@@ -1114,6 +1116,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       }
     }
 
+    final long zeroSizeCount = totalZeroSizeFiles;
+    metrics.ifPresent(m -> m.incrementMetric("bootstrap_zero_size_files", zeroSizeCount));
     return partitionsToBootstrap;
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -428,7 +428,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     } else {
       // if auto initialization is enabled, then we need to list all partitions from the file system
       if (dataWriteConfig.getMetadataConfig().shouldAutoInitialize()) {
-        partitionInfoList = listAllPartitionsFromFilesystem(dataTableInstantTime, pendingDataInstants);
+        partitionInfoList = listAllPartitionsFromFilesystem(dataTableInstantTime, pendingDataInstants,
+            dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesOnInitialize());
       } else {
         // if auto initialization is disabled, we can return an empty list
         partitionInfoList = Collections.emptyList();
@@ -1063,9 +1064,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    *
    * @param initializationTime  Files which have a timestamp after this are neglected
    * @param pendingDataInstants Pending instants on data set
+   * @param skipZeroSizeFiles   Whether to skip zero-size files during listing
    * @return List consisting of {@code DirectoryInfo} for each partition found.
    */
-  private List<DirectoryInfo> listAllPartitionsFromFilesystem(String initializationTime, Set<String> pendingDataInstants) {
+  private List<DirectoryInfo> listAllPartitionsFromFilesystem(String initializationTime, Set<String> pendingDataInstants, boolean skipZeroSizeFiles) {
     if (dataMetaClient.getActiveTimeline().countInstants() == 0) {
       return Collections.emptyList();
     }
@@ -1076,7 +1078,6 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     final int fileListingParallelism = metadataWriteConfig.getFileListingParallelism();
     StorageConfiguration<?> storageConf = dataMetaClient.getStorageConf();
     final String dirFilterRegex = dataWriteConfig.getMetadataConfig().getDirectoryFilterRegex();
-    final boolean skipZeroSizeFiles = dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesOnInitialize();
     StoragePath storageBasePath = dataMetaClient.getBasePath();
     long totalZeroSizeFiles = 0;
 
@@ -1117,8 +1118,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       }
     }
 
-    final long zeroSizeCount = totalZeroSizeFiles;
-    metrics.ifPresent(m -> m.incrementMetric("skipped_zero_size_files_on_initialize", zeroSizeCount));
+    if (skipZeroSizeFiles) {
+      final long zeroSizeCount = totalZeroSizeFiles;
+      metrics.ifPresent(m -> m.incrementMetric("skipped_zero_size_files_on_initialize", zeroSizeCount));
+    }
     return partitionsToBootstrap;
   }
 
@@ -1741,7 +1744,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
     // Restore requires the existing pipelines to be shutdown. So we can safely scan the dataset to find the current
     // list of files in the filesystem.
-    List<DirectoryInfo> dirInfoList = listAllPartitionsFromFilesystem(instantTime, Collections.emptySet());
+    List<DirectoryInfo> dirInfoList = listAllPartitionsFromFilesystem(instantTime, Collections.emptySet(), false);
     Map<String, DirectoryInfo> dirInfoMap = dirInfoList.stream().collect(Collectors.toMap(DirectoryInfo::getRelativePath, Function.identity()));
     dirInfoList.clear();
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1076,6 +1076,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     final int fileListingParallelism = metadataWriteConfig.getFileListingParallelism();
     StorageConfiguration<?> storageConf = dataMetaClient.getStorageConf();
     final String dirFilterRegex = dataWriteConfig.getMetadataConfig().getDirectoryFilterRegex();
+    final boolean skipZeroSizeFiles = dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesDuringBootstrap();
     StoragePath storageBasePath = dataMetaClient.getBasePath();
     long totalZeroSizeFiles = 0;
 
@@ -1091,7 +1092,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       List<DirectoryInfo> processedDirectories = engineContext.map(pathsToProcess, path -> {
         HoodieStorage storage = HoodieStorageUtils.getStorage(path, storageConf);
         String relativeDirPath = FSUtils.getRelativePartitionPath(storageBasePath, path);
-        return new DirectoryInfo(relativeDirPath, storage.listDirectEntries(path), initializationTime, pendingDataInstants);
+        return new DirectoryInfo(relativeDirPath, storage.listDirectEntries(path), initializationTime, pendingDataInstants, true, skipZeroSizeFiles);
       }, numDirsToList);
 
       // If the listing reveals a directory, add it to queue. If the listing reveals a hoodie partition, add it to

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -1076,7 +1076,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     final int fileListingParallelism = metadataWriteConfig.getFileListingParallelism();
     StorageConfiguration<?> storageConf = dataMetaClient.getStorageConf();
     final String dirFilterRegex = dataWriteConfig.getMetadataConfig().getDirectoryFilterRegex();
-    final boolean skipZeroSizeFiles = dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesDuringBootstrap();
+    final boolean skipZeroSizeFiles = dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesOnInitialize();
     StoragePath storageBasePath = dataMetaClient.getBasePath();
     long totalZeroSizeFiles = 0;
 
@@ -1118,7 +1118,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     final long zeroSizeCount = totalZeroSizeFiles;
-    metrics.ifPresent(m -> m.incrementMetric("bootstrap_zero_size_files", zeroSizeCount));
+    metrics.ifPresent(m -> m.incrementMetric("skipped_zero_size_files_on_initialize", zeroSizeCount));
     return partitionsToBootstrap;
   }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -116,12 +116,16 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     doPreBootstrapWriteOperation(testTable, "0000002");
     // Add a zero-size base file — bootstrap should skip it without failing.
     String fileName = UUID.randomUUID().toString();
+    Path zeroSizeFilePath = FileCreateUtilsLegacy.getBaseFilePath(basePath, "p1", "0000003", fileName);
     FileCreateUtilsLegacy.createBaseFile(basePath, "p1", "0000003", fileName, 0);
 
     writeConfig = getWriteConfig(true, true);
     initWriteConfigAndMetatableWriter(writeConfig, true);
     syncTableMetadata(writeConfig);
 
+    // Delete the zero-size file before validation — it was skipped in MDT and must not
+    // exist on disk for the filesystem-vs-MDT consistency check to pass.
+    Files.delete(zeroSizeFilePath);
     validateMetadata(testTable);
     doWriteInsertAndUpsert(testTable);
     validateMetadata(testTable);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -108,6 +108,25 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     validateMetadata(testTable);
   }
 
+  @Test
+  public void testMetadataBootstrapSkipsZeroSizeFiles() throws Exception {
+    HoodieTableType tableType = COPY_ON_WRITE;
+    init(tableType, false);
+    doPreBootstrapWriteOperation(testTable, INSERT, "0000001");
+    doPreBootstrapWriteOperation(testTable, "0000002");
+    // Add a zero-size base file — bootstrap should skip it without failing.
+    String fileName = UUID.randomUUID().toString();
+    FileCreateUtilsLegacy.createBaseFile(basePath, "p1", "0000003", fileName, 0);
+
+    writeConfig = getWriteConfig(true, true);
+    initWriteConfigAndMetatableWriter(writeConfig, true);
+    syncTableMetadata(writeConfig);
+
+    validateMetadata(testTable);
+    doWriteInsertAndUpsert(testTable);
+    validateMetadata(testTable);
+  }
+
   @ParameterizedTest
   @EnumSource(HoodieTableType.class)
   public void testMetadataBootstrapInsertUpsertRollback(HoodieTableType tableType) throws Exception {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -109,7 +109,7 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
   }
 
   @Test
-  public void testMetadataBootstrapSkipsZeroSizeFiles() throws Exception {
+  public void testMetadataSkipsZeroSizeFilesOnInitialize() throws Exception {
     HoodieTableType tableType = COPY_ON_WRITE;
     init(tableType, false);
     doPreBootstrapWriteOperation(testTable, INSERT, "0000001");

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -122,7 +122,7 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     writeConfig = getWriteConfigBuilder(true, true, false)
         .withMetadataConfig(HoodieMetadataConfig.newBuilder()
             .enable(true)
-            .withSkipZeroSizeFilesDuringBootstrap(true)
+            .withSkipZeroSizeFilesOnInitialize(true)
             .build())
         .build();
     initWriteConfigAndMetatableWriter(writeConfig, true);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBootstrap.java
@@ -119,7 +119,12 @@ public class TestHoodieMetadataBootstrap extends TestHoodieMetadataBase {
     Path zeroSizeFilePath = FileCreateUtilsLegacy.getBaseFilePath(basePath, "p1", "0000003", fileName);
     FileCreateUtilsLegacy.createBaseFile(basePath, "p1", "0000003", fileName, 0);
 
-    writeConfig = getWriteConfig(true, true);
+    writeConfig = getWriteConfigBuilder(true, true, false)
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withSkipZeroSizeFilesDuringBootstrap(true)
+            .build())
+        .build();
     initWriteConfigAndMetatableWriter(writeConfig, true);
     syncTableMetadata(writeConfig);
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -195,6 +195,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Directories matching this regex, will be filtered out when initializing metadata table from lake storage for the first time.");
 
+  public static final ConfigProperty<Boolean> SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP = ConfigProperty
+      .key(METADATA_PREFIX + ".bootstrap.skip.zero.size.files")
+      .defaultValue(false)
+      .markAdvanced()
+      .sinceVersion("1.2.0")
+      .withDocumentation("When enabled, zero-size data files encountered while listing the data table during "
+          + "metadata table bootstrap are skipped instead of being recorded in the metadata table.");
+
   public static final ConfigProperty<Integer> FILE_LISTING_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.file.listing.parallelism")
       .defaultValue(200)
@@ -791,6 +799,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getString(DIR_FILTER_REGEX);
   }
 
+  public boolean shouldSkipZeroSizeFilesDuringBootstrap() {
+    return getBoolean(SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP);
+  }
+
   public boolean shouldIgnoreSpuriousDeletes() {
     return getBoolean(IGNORE_SPURIOUS_DELETES);
   }
@@ -1157,6 +1169,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withDirectoryFilterRegex(String regex) {
       metadataConfig.setValue(DIR_FILTER_REGEX, regex);
+      return this;
+    }
+
+    public Builder withSkipZeroSizeFilesDuringBootstrap(boolean skipZeroSizeFiles) {
+      metadataConfig.setValue(SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP, String.valueOf(skipZeroSizeFiles));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -195,13 +195,13 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.7.0")
       .withDocumentation("Directories matching this regex, will be filtered out when initializing metadata table from lake storage for the first time.");
 
-  public static final ConfigProperty<Boolean> SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP = ConfigProperty
-      .key(METADATA_PREFIX + ".bootstrap.skip.zero.size.files")
+  public static final ConfigProperty<Boolean> SKIP_ZERO_SIZE_FILES_ON_INITIALIZE = ConfigProperty
+      .key(METADATA_PREFIX + ".skip.zero.size.files.on.initialize")
       .defaultValue(false)
       .markAdvanced()
       .sinceVersion("1.2.0")
       .withDocumentation("When enabled, zero-size data files encountered while listing the data table during "
-          + "metadata table bootstrap are skipped instead of being recorded in the metadata table.");
+          + "metadata table initialization are skipped instead of being recorded in the metadata table.");
 
   public static final ConfigProperty<Integer> FILE_LISTING_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.file.listing.parallelism")
@@ -799,8 +799,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getString(DIR_FILTER_REGEX);
   }
 
-  public boolean shouldSkipZeroSizeFilesDuringBootstrap() {
-    return getBoolean(SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP);
+  public boolean shouldSkipZeroSizeFilesOnInitialize() {
+    return getBoolean(SKIP_ZERO_SIZE_FILES_ON_INITIALIZE);
   }
 
   public boolean shouldIgnoreSpuriousDeletes() {
@@ -1172,8 +1172,8 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       return this;
     }
 
-    public Builder withSkipZeroSizeFilesDuringBootstrap(boolean skipZeroSizeFiles) {
-      metadataConfig.setValue(SKIP_ZERO_SIZE_FILES_DURING_BOOTSTRAP, String.valueOf(skipZeroSizeFiles));
+    public Builder withSkipZeroSizeFilesOnInitialize(boolean skipZeroSizeFiles) {
+      metadataConfig.setValue(SKIP_ZERO_SIZE_FILES_ON_INITIALIZE, String.valueOf(skipZeroSizeFiles));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -3100,6 +3100,7 @@ public class HoodieTableMetadataUtil {
     private final List<StoragePath> subDirectories = new ArrayList<>();
     // Is this a hoodie partition
     private boolean isHoodiePartition = false;
+    private int zeroSizeFileCount = 0;
 
     public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants) {
       this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, true);
@@ -3130,10 +3131,19 @@ public class HoodieTableMetadataUtil {
           String dataFileCommitTime = FSUtils.getCommitTime(pathInfo.getPath().getName());
           // Limit the file listings to files which were created by successful commits before the maxInstant time.
           if (!pendingDataInstants.contains(dataFileCommitTime) && compareTimestamps(dataFileCommitTime, LESSER_THAN_OR_EQUALS, maxInstantTime)) {
-            filenameToSizeMap.put(pathInfo.getPath().getName(), pathInfo.getLength());
+            if (pathInfo.getLength() > 0) {
+              filenameToSizeMap.put(pathInfo.getPath().getName(), pathInfo.getLength());
+            } else {
+              log.warn("Skipping zero-size data file during MDT bootstrap: {}", pathInfo.getPath());
+              zeroSizeFileCount++;
+            }
           }
         }
       }
+    }
+
+    public int getZeroSizeFileCount() {
+      return zeroSizeFileCount;
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -3103,7 +3103,7 @@ public class HoodieTableMetadataUtil {
     private int zeroSizeFileCount = 0;
 
     public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants) {
-      this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, true);
+      this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, true, false);
     }
 
     /**
@@ -3111,6 +3111,11 @@ public class HoodieTableMetadataUtil {
      */
     public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants,
                          boolean validateHoodiePartitions) {
+      this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, validateHoodiePartitions, false);
+    }
+
+    public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants,
+                         boolean validateHoodiePartitions, boolean skipZeroSizeFiles) {
       this.relativePath = relativePath;
 
       // Pre-allocate with the maximum length possible
@@ -3131,7 +3136,7 @@ public class HoodieTableMetadataUtil {
           String dataFileCommitTime = FSUtils.getCommitTime(pathInfo.getPath().getName());
           // Limit the file listings to files which were created by successful commits before the maxInstant time.
           if (!pendingDataInstants.contains(dataFileCommitTime) && compareTimestamps(dataFileCommitTime, LESSER_THAN_OR_EQUALS, maxInstantTime)) {
-            if (pathInfo.getLength() > 0) {
+            if (pathInfo.getLength() > 0 || !skipZeroSizeFiles) {
               filenameToSizeMap.put(pathInfo.getPath().getName(), pathInfo.getLength());
             } else {
               log.warn("Skipping zero-size data file during MDT bootstrap: {}", pathInfo.getPath());

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -664,6 +664,108 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase with SparkDatasetMix
     }
   }
 
+  /**
+   * Tests that when a zero-size base file is skipped during MDT bootstrap, a subsequent upsert
+   * still succeeds and produces consistent data. Because the skipped file group is absent from MDT,
+   * the upsert treats those records as new inserts and writes them to a new file group. The test
+   * verifies the final record count and that every RLI entry points to a real, readable file.
+   */
+  @Test
+  def testUpsertAfterSkippingZeroSizeFileOnInitialize(): Unit = {
+    // Use a single-partition data generator so all inserts land in one parquet file.
+    val singlePartitionDataGen = HoodieTestDataGenerator.createTestGeneratorFirstPartition()
+    val singlePartition = HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH
+    val insertedRecords = 10
+    val inserts = singlePartitionDataGen.generateInserts("001", insertedRecords)
+    val insertDf = toDataset(spark, inserts)
+
+    val baseOptions = Map(
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.COPY_ON_WRITE.name(),
+      RECORDKEY_FIELD.key -> "_row_key",
+      PARTITIONPATH_FIELD.key -> "partition_path",
+      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+      HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "false",
+      HoodieMetadataConfig.RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "false",
+      HoodieCompactionConfig.INLINE_COMPACT.key() -> "false")
+
+    insertDf.write.format("hudi")
+      .options(baseOptions)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+    assertEquals(insertedRecords, spark.read.format("hudi").load(basePath).count())
+
+    // Confirm there is exactly one parquet base file in the single partition.
+    val partitionPath = new StoragePath(basePath, singlePartition)
+    val baseFilesBeforeCorruption = storage.listDirectEntries(partitionPath).asScala
+      .filter(_.getPath.getName.endsWith(".parquet"))
+      .toSeq
+    assertEquals(1, baseFilesBeforeCorruption.size, "Expected exactly one parquet file in the single partition")
+    val zeroSizeFileId = FSUtils.getFileId(baseFilesBeforeCorruption.head.getPath.getName)
+
+    // Replace the only base file with an empty (zero-size) file.
+    replaceOneBaseFileWithEmpty(Seq(singlePartition))
+
+    // Delete MDT to force a full rebootstrap.
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    HoodieTableMetadataUtil.deleteMetadataTable(metaClient, context, false)
+    assertFalse(storage.exists(new StoragePath(HoodieTableMetadata.getMetadataTableBasePath(basePath))),
+      "Metadata table should be absent before rebootstrap")
+
+    // The upsert triggers MDT rebootstrap (since MDT was deleted). Skip config is set so
+    // the zero-size file is skipped during bootstrap. Because RLI has no entries for these
+    // records (they were in the skipped file), the upsert treats them as new inserts.
+    // Use global RLI so that the MDT bootstraps at least minFileGroupCount (10) file groups
+    // for record_index even when all data files were skipped as zero-size.
+    metaClient.reloadActiveTimeline()
+    val latestSchema = new TableSchemaResolver(metaClient).getTableSchemaFromLatestCommit(false).get().toString
+    val optionsWithSkip = baseOptions ++ Map(
+      HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "true",
+      HoodieIndexConfig.INDEX_TYPE.key() -> "GLOBAL_RECORD_LEVEL_INDEX",
+      HoodieMetadataConfig.SKIP_ZERO_SIZE_FILES_ON_INITIALIZE.key() -> "true",
+      HoodieWriteConfig.AVRO_SCHEMA_STRING.key() -> latestSchema)
+
+    // Reuse the same 10 records for the upsert. Since RLI has no entries for these record keys
+    // (the original file was zero-size and skipped during bootstrap), the upsert treats them as
+    // new inserts and writes them to a brand-new file group — NOT the zero-size one.
+    val upsertDf = toDataset(spark, inserts)
+    // Upsert should succeed — any exception here fails the test.
+    upsertDf.write.format("hudi")
+      .options(optionsWithSkip)
+      .option(DataSourceWriteOptions.OPERATION.key(), UPSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    // Data consistency check: all 10 records must be readable in the new file group.
+    // (The zero-size base file contributes 0 readable records; the new file group has 10.)
+    val readDf = spark.read.format("hudi").load(basePath)
+    assertEquals(insertedRecords, readDf.count(),
+      "All records should be readable after upsert into a new file group")
+
+    // RLI consistency check: every live record must be indexed at the location where it actually lives.
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    val writeConfig = getWriteConfig(optionsWithSkip)
+    val postUpsertMetadata = metadataWriter(writeConfig).getTableMetadata.asInstanceOf[HoodieBackedTableMetadata]
+
+    // MDT files partition must not track the zero-size file group.
+    val allMdtFiles = getFilesInAllPartitions(postUpsertMetadata)
+    assertFalse(allMdtFiles.exists(_.getPath.getName.contains(zeroSizeFileId)),
+      s"MDT should not contain the zero-size file group $zeroSizeFileId after bootstrap with skip enabled")
+
+    // Global RLI: look up all record keys without a partition hint.
+    val recordKeys = inserts.asScala.map(_.getRecordKey).asJava.stream().collect(Collectors.toList())
+    val postUpsertLocations = readRecordIndex(postUpsertMetadata, recordKeys, HOption.empty())
+    assertEquals(insertedRecords, postUpsertLocations.size,
+      "All upserted records should have an RLI entry after upsert")
+    val df = readDf.collect()
+    validateDFWithLocations(df, postUpsertLocations, singlePartition)
+
+    // The zero-size file group must not have been selected as the write target — its file ID
+    // should not appear in any of the post-upsert RLI locations.
+    assertFalse(postUpsertLocations.values.exists(_.getFileId == zeroSizeFileId),
+      "The zero-size file group should not have been picked as a write target during upsert")
+  }
+
   private def replaceOneBaseFileWithEmpty(partitionPaths: Seq[String]): String = {
     val candidateBaseFile = partitionPaths.view.flatMap { partition =>
       storage.listDirectEntries(new StoragePath(basePath, partition)).asScala


### PR DESCRIPTION
### Describe

During MDT (Metadata Table) initialization, zero-size data files can be included in the filenameToSizeMap in DirectoryInfo, which could result in initialization job failures.

This change adds a new config hoodie.metadata.skip.zero.size.files.on.initialize (default false) that, when enabled, skips files with length == 0 while listing the data table during MDT initialization and logs a warning. A skipped_zero_size_files_on_initialize metric is emitted with the total count of skipped files across all partitions.

Closes #18612

### Impact

Opt-in via config; default behavior is unchanged. When enabled, reinitialize jobs that previously failed due to zero-size data files being included in MDT will succeed. The skipped_zero_size_files_on_initialize metric surfaces the count of skipped files.

### Risk level (write none, low medium or high below)

Low. The change only affects the MDT initialization file-listing path and is gated behind a config that defaults to off.

### Documentation Update

None required beyond the new advanced config, which is self-documented.

### Contributor's checklist

- [x] Read through contributor's guide (https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed