### PR TITLE
fix(writer): skip unsupported native log column stats metadata

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieNativeLogAppendHandle.java
@@ -39,7 +39,6 @@ import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.HoodieTable;
-import org.apache.hudi.util.CommonClientUtils;
 
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 
@@ -85,7 +84,6 @@ public class HoodieNativeLogAppendHandle<T, I, K, O> extends HoodieAppendHandle<
                                       TaskContextSupplier taskContextSupplier, boolean preserveMetadata,
                                       Map<HeaderMetadataType, String> header) {
     super(config, instantTime, hoodieTable, partitionPath, fileId, recordItr, taskContextSupplier, preserveMetadata);
-    CommonClientUtils.validateIndexSupportForNativeLogFormat(config, hoodieTable.getBaseFileFormat());
     this.header.putAll(header);
   }
 
@@ -234,6 +232,10 @@ public class HoodieNativeLogAppendHandle<T, I, K, O> extends HoodieAppendHandle<
     if (dataFileFormatMetadata.isPresent()) {
       stat.putRecordsStats(collectNativeLogColumnRangeMetadata(
           stat.getPath(), dataFileFormatMetadata.get(), columnsToIndexSet, indexVersion));
+    } else {
+      // Mark column stats collection as handled so the metadata writer does not fall back to scanning this native
+      // log file. This is consistent with unsupported base-file formats, which contribute no column stats records.
+      stat.putRecordsStats(Collections.emptyMap());
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/cdc/HoodieNativeLogFormatWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/cdc/HoodieNativeLogFormatWriter.java
@@ -278,8 +278,17 @@ public class HoodieNativeLogFormatWriter extends HoodieLogFormat.Writer {
   private void closeFileWriters() throws IOException {
     if (dataFileWriter != null) {
       dataFileWriter.close();
-      lastDataFileFormatMetadata = writeConfig.isMetadataColumnStatsIndexEnabled()
-          ? Option.ofNullable(dataFileWriter.getFileFormatMetadata()) : Option.empty();
+      if (writeConfig.isMetadataColumnStatsIndexEnabled()) {
+        try {
+          lastDataFileFormatMetadata = Option.ofNullable(dataFileWriter.getFileFormatMetadata());
+        } catch (UnsupportedOperationException e) {
+          // File-format metadata is an optional writer capability. Unsupported formats can still produce valid
+          // native log files; they simply do not contribute column stats for this append.
+          lastDataFileFormatMetadata = Option.empty();
+        }
+      } else {
+        lastDataFileFormatMetadata = Option.empty();
+      }
       dataFileWriter = null;
     }
     if (deleteFileWriter != null) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
@@ -21,7 +21,6 @@
 package org.apache.hudi.util;
 
 import org.apache.hudi.avro.model.HoodieClusteringPlan;
-import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
@@ -151,19 +150,6 @@ public class CommonClientUtils {
       return false;
     }
     return writeConfig.getWriteVersion().greaterThanOrEquals(HoodieTableVersion.TEN);
-  }
-
-  public static void validateIndexSupportForNativeLogFormat(HoodieWriteConfig writeConfig, HoodieFileFormat nativeLogFileFormat) {
-    if (!writeConfig.isMetadataColumnStatsIndexEnabled()) {
-      return;
-    }
-
-    if (nativeLogFileFormat == HoodieFileFormat.ORC) {
-      throw new HoodieNotSupportedException(String.format(
-          "Column stats index is not supported for native %s log files because its HoodieFileWriter does not support file format metadata. "
-              + "Please disable %s.",
-          nativeLogFileFormat, HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key()));
-    }
   }
 
   public static String generateWriteToken(TaskContextSupplier taskContextSupplier) {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/cdc/TestHoodieNativeLogFormatWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/cdc/TestHoodieNativeLogFormatWriter.java
@@ -127,6 +127,87 @@ public class TestHoodieNativeLogFormatWriter {
     verify(record, never()).getOrderingValue(eq(schema), any(), any());
   }
 
+  @Test
+  public void testSkipsUnsupportedDataFileFormatMetadata() throws Exception {
+    Option<Object> metadata = writeDataLogAndGetFormatMetadata(
+        true, null, new UnsupportedOperationException("unsupported"));
+
+    assertFalse(metadata.isPresent());
+  }
+
+  @Test
+  public void testRetainsSupportedDataFileFormatMetadata() throws Exception {
+    Object expectedMetadata = new Object();
+
+    Option<Object> metadata = writeDataLogAndGetFormatMetadata(true, expectedMetadata, null);
+
+    assertEquals(expectedMetadata, metadata.get());
+  }
+
+  @Test
+  public void testSkipsDataFileFormatMetadataWhenColumnStatsDisabled() throws Exception {
+    Option<Object> metadata = writeDataLogAndGetFormatMetadata(
+        false, null, new AssertionError("metadata should not be requested"));
+
+    assertFalse(metadata.isPresent());
+  }
+
+  private static Option<Object> writeDataLogAndGetFormatMetadata(
+      boolean columnStatsEnabled, Object formatMetadata, Throwable metadataFailure) throws Exception {
+    String instantTime = "100";
+    HoodieStorage storage = mock(HoodieStorage.class);
+    HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+    HoodieSchema schema = mock(HoodieSchema.class);
+    HoodieRecordMerger merger = mock(HoodieRecordMerger.class);
+    HoodieFileWriter fileWriter = mock(HoodieFileWriter.class);
+    StoragePath parentPath = new StoragePath("/tmp/partition");
+
+    when(config.getProps()).thenReturn(new TypedProperties());
+    when(config.getRecordMerger()).thenReturn(merger);
+    when(config.isMetadataColumnStatsIndexEnabled()).thenReturn(columnStatsEnabled);
+    when(merger.getRecordType()).thenReturn(HoodieRecord.HoodieRecordType.AVRO);
+    when(storage.exists(any(StoragePath.class))).thenReturn(false);
+    when(storage.getPathInfo(any(StoragePath.class))).thenAnswer(invocation ->
+        new StoragePathInfo(invocation.getArgument(0), 1L, false, (short) 1, 1L, 1L));
+    if (metadataFailure != null) {
+      when(fileWriter.getFileFormatMetadata()).thenThrow(metadataFailure);
+    } else {
+      when(fileWriter.getFileFormatMetadata()).thenReturn(formatMetadata);
+    }
+
+    try (MockedStatic<HoodieFileWriterFactory> writerFactory = mockStatic(HoodieFileWriterFactory.class)) {
+      writerFactory.when(() -> HoodieFileWriterFactory.getFileWriter(
+              eq(instantTime), any(StoragePath.class), eq(storage), eq(config), eq(schema),
+              any(TaskContextSupplier.class), eq(HoodieRecord.HoodieRecordType.AVRO)))
+          .thenReturn(fileWriter);
+
+      HoodieNativeLogFormatWriter writer = new HoodieNativeLogFormatWriter(
+          4096,
+          storage,
+          parentPath,
+          "file-1",
+          instantTime,
+          1,
+          "1-0-1",
+          1024L,
+          new LogFileCreationCallback() {
+          },
+          HoodieTableVersion.current(),
+          config,
+          HoodieFileFormat.PARQUET,
+          schema,
+          mock(TaskContextSupplier.class),
+          mock(RecordContext.class),
+          new ArrayList<>(),
+          Option.empty());
+
+      writer.appendRecord(recordWithPosition("key-1", 1L, schema),
+          schema, HoodieRecord.RECORD_KEY_METADATA_FIELD);
+      writer.flushAppend(new HashMap<>());
+      return writer.getLastDataFileFormatMetadata();
+    }
+  }
+
   private static Map<HeaderMetadataType, String> writeDataLogFooterWithPositions(long... positions) throws Exception {
     String instantTime = "100";
     String schemaString = "{\"type\":\"record\",\"name\":\"test\",\"fields\":[]}";

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/columnstats/TestColumnStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/columnstats/TestColumnStatsIndexer.java
@@ -58,6 +58,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 class TestColumnStatsIndexer {
@@ -291,6 +292,40 @@ class TestColumnStatsIndexer {
     assertTrue(payload.getColumnStatMetadata().isPresent());
     assertEquals("c1", payload.getColumnStatMetadata().get().getColumnName());
     assertFalse(payload.getColumnStatMetadata().get().getIsDeleted());
+  }
+
+  @Test
+  void testBuildUpdateWithEmptyWriteStatColumnStatsSkipsFileFallback() {
+    HoodieEngineContext localEngineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    ColumnStatsIndexer indexer = new ColumnStatsIndexer(localEngineContext, writeConfig, metaClient);
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.UPSERT);
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath("p1/.fileid-1_014.log.1_1-0-1.orc");
+    writeStat.setRecordsStats(Collections.emptyMap());
+    commitMetadata.getPartitionToWriteStats().put("p1", Collections.singletonList(writeStat));
+
+    List<IndexPartitionAndRecords> result;
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      Map<String, HoodieSchema> columnsToIndex = Collections.singletonMap("c1", mock(HoodieSchema.class));
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(
+              any(HoodieCommitMetadata.class), any(HoodieTableMetaClient.class), any(HoodieMetadataConfig.class), any()))
+          .thenReturn(columnsToIndex);
+
+      result = indexer.buildUpdate(IndexUpdateContext.of(
+          "014",
+          mock(HoodieBackedTableMetadata.class),
+          Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+          commitMetadata));
+
+      mockedUtil.verify(() -> HoodieTableMetadataUtil.getColumnStatsRecords(
+          eq("p1"), any(), eq(metaClient), eq(Collections.singletonList("c1")), eq(false)), never());
+    }
+
+    assertEquals(1, result.size());
+    assertTrue(result.get(0).indexRecords().collectAsList().isEmpty());
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestCommonClientUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestCommonClientUtils.java
@@ -140,28 +140,6 @@ class TestCommonClientUtils {
     assertFalse(CommonClientUtils.shouldWriteNativeLogs(writeConfig, tableConfig));
   }
 
-  @ParameterizedTest(name = "{0} native log with column stats enabled {1} should throw: {2}")
-  @MethodSource("provideNativeLogColumnStatsExpectations")
-  void testValidateIndexSupportForNativeLogFormat(
-      HoodieFileFormat nativeLogFileFormat, boolean enableColumnStats, boolean expectThrow) {
-    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
-    when(writeConfig.isMetadataColumnStatsIndexEnabled()).thenReturn(enableColumnStats);
-
-    if (expectThrow) {
-      assertThrows(HoodieNotSupportedException.class,
-          () -> CommonClientUtils.validateIndexSupportForNativeLogFormat(writeConfig, nativeLogFileFormat));
-    } else {
-      CommonClientUtils.validateIndexSupportForNativeLogFormat(writeConfig, nativeLogFileFormat);
-    }
-  }
-
-  private static Stream<Arguments> provideNativeLogColumnStatsExpectations() {
-    return Stream.of(
-        Arguments.of(HoodieFileFormat.ORC, true, true),
-        Arguments.of(HoodieFileFormat.ORC, false, false)
-    );
-  }
-
   @ParameterizedTest(name = "Table version {0} with write version {1} should be valid: {2}")
   @MethodSource("provideValidTableVersionWriteVersionPairs")
   void testValidTableVersionWriteVersionPairs(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
@@ -21,7 +21,7 @@ package org.apache.hudi.common.table.read
 
 import org.apache.hudi.{AvroConversionUtils, DataSourceWriteOptions, DefaultSparkRecordMerger, HoodieSchemaConversionUtils, HoodieSparkUtils, SparkAdapterSupport, SparkFileFormatInternalRowReaderContext}
 import org.apache.hudi.DataSourceWriteOptions.{OPERATION, RECORDKEY_FIELD, TABLE_TYPE}
-import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig, RecordMergeMode, TypedProperties}
+import org.apache.hudi.common.config.{HoodieReaderConfig, RecordMergeMode, TypedProperties}
 import org.apache.hudi.common.engine.HoodieReaderContext
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{HoodieFileFormat, HoodieRecord}
@@ -135,14 +135,12 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
     // Check if Lance format is being used and add required configuration
     val baseFileFormat = options.getOrDefault(HoodieTableConfig.BASE_FILE_FORMAT.key(), "")
     val isLanceFormat = baseFileFormat.equalsIgnoreCase("LANCE")
-    val columnStatsEnabled = !baseFileFormat.equalsIgnoreCase("ORC") && !isLanceFormat
 
     var writer = inputDF.write.format("hudi")
       .options(options)
       .option("hoodie.compact.inline", "false") // else fails due to compaction & deltacommit instant times being same
       .option("hoodie.datasource.write.operation", operation)
       .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
-      .option(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), columnStatsEnabled.toString)
 
     // Lance requires DefaultSparkRecordMerger for Spark InternalRow compatibility
     if (isLanceFormat) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Native log writes fail when the column stats index is enabled for a file format whose `HoodieFileWriter` does not expose file-format metadata. For example, ORC throws `UnsupportedOperationException` during metadata collection even though the native log file itself was written successfully.

This PR aligns native ORC log behavior with the existing column stats behavior for ORC base files: ORC files that cannot provide column stats metadata are ignored instead of failing the write.

### Summary and Changelog
- Remove format-specific column stats validation from `HoodieNativeLogAppendHandle` and `CommonClientUtils`.
- Catch `UnsupportedOperationException` when `HoodieNativeLogFormatWriter` collects file-format metadata and return empty metadata for that append.
- Align native ORC log handling with ORC base files, which are ignored when column stats metadata is unavailable.
- Preserve metadata collection for supported writers and avoid requesting metadata when column stats are disabled.
- Add tests covering supported metadata, unsupported metadata, and disabled column stats.
- Re-enable the default column stats configuration in `TestHoodieFileGroupReaderOnSpark` for all tested formats.

### Impact

- **Functional impact**: Native log writes continue successfully when the underlying format does not support column stats metadata. Consistent with ORC base files, these native log files are ignored by column stats collection.
- **Maintainability**: Removes format-specific validation and handles the optional metadata capability at the writer boundary.
- **Extensibility**: Additional native log formats can omit file-format metadata without requiring new validation branches.

### Risk Level

Low. The change only suppresses `UnsupportedOperationException` from optional file-format metadata collection; other failures continue to propagate. Targeted `hudi-client-common` tests passed with 99 tests and no failures.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable