### PR TITLE
fix(DNM): adjust the native log format metadata as separate entries in footer

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieNativeLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieNativeLogFileReader.java
@@ -122,7 +122,8 @@ public class HoodieNativeLogFileReader implements HoodieLogFormat.Reader {
   private Map<HeaderMetadataType, String> getLogBlockHeader(HoodieFileFormat fileFormat) {
     Map<String, String> keyValueMetadata = HoodieIOFactory.getIOFactory(storage)
         .getFileFormatUtils(fileFormat)
-        .readFooter(storage, false, logFile.getPath(), NativeLogFooterMetadata.FOOTER_METADATA_KEY);
+        .readFooterWithPrefix(
+            storage, false, logFile.getPath(), NativeLogFooterMetadata.FOOTER_METADATA_KEY_PREFIX);
     Map<HeaderMetadataType, String> header = NativeLogFooterMetadata.fromFooterMetadata(keyValueMetadata);
     header.putIfAbsent(HeaderMetadataType.INSTANT_TIME, logFile.getDeltaCommitTime());
     return header;
@@ -132,8 +133,8 @@ public class HoodieNativeLogFileReader implements HoodieLogFormat.Reader {
     if (!header.containsKey(HeaderMetadataType.SCHEMA)) {
       throw new HoodieIOException("Missing required native log block header metadata '"
           + HeaderMetadataType.SCHEMA.name() + "' for " + logFile
-          + ". Native log files must store log block metadata in footer key '"
-          + NativeLogFooterMetadata.FOOTER_METADATA_KEY + "'");
+          + ". Native log files must store the schema in footer key '"
+          + NativeLogFooterMetadata.getFooterMetadataKey(HeaderMetadataType.SCHEMA) + "'");
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/NativeLogFooterMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/NativeLogFooterMetadata.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.LogExtensions;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
-import org.apache.hudi.common.util.JsonUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.core.io.storage.HoodieIOFactory;
 import org.apache.hudi.exception.HoodieIOException;
@@ -32,76 +31,52 @@ import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
-import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Shared on-disk contract for RFC-103 native log files. The log block header (schema, instant time,
- * etc.) is persisted as a single JSON entry in the native file footer, keyed by
- * {@link #FOOTER_METADATA_KEY}. This is the single source of truth used by both the write path
- * ({@code HoodieNativeLogFormatWriter}) and the read path ({@code HoodieNativeLogFileReader}) so the
- * two cannot drift apart.
+ * Shared on-disk contract for RFC-103 native log files. Each log block header entry (schema,
+ * instant time, etc.) is persisted as a separate, namespaced entry in the native file footer.
+ * This is the single source of truth used by both the write path ({@code HoodieNativeLogFormatWriter})
+ * and the read path ({@code HoodieNativeLogFileReader}) so the two cannot drift apart.
  */
 public class NativeLogFooterMetadata {
 
   /**
-   * Footer key under which the serialized log block header is stored in a native log file.
+   * Prefix for log format metadata entries stored in a native log file footer.
    */
-  public static final String FOOTER_METADATA_KEY = "hudi.log.format.metadata";
-
-  private static final TypeReference<LinkedHashMap<String, String>> MAP_TYPE =
-      new TypeReference<LinkedHashMap<String, String>>() {
-      };
+  public static final String FOOTER_METADATA_KEY_PREFIX = "hudi.log.format.";
 
   private NativeLogFooterMetadata() {
   }
 
   /**
-   * Serializes the log block header into the footer key/value map written to the native file.
+   * Converts the log block header into the footer key/value map written to the native file.
    * The {@link HeaderMetadataType#VERSION} entry is injected automatically.
    */
   public static Map<String, String> toFooterMetadata(Map<HeaderMetadataType, String> header) {
-    Map<String, String> logFormatMetadata = new LinkedHashMap<>();
-    logFormatMetadata.put(HeaderMetadataType.VERSION.name(), String.valueOf(HoodieLogFormat.CURRENT_VERSION));
-    header.forEach((key, value) -> {
+    Map<String, String> footer = new LinkedHashMap<>();
+    footer.put(getFooterMetadataKey(HeaderMetadataType.VERSION), String.valueOf(HoodieLogFormat.CURRENT_VERSION));
+    header.forEach((type, value) -> {
       if (value != null) {
-        logFormatMetadata.put(key.name(), value);
+        footer.put(getFooterMetadataKey(type), value);
       }
     });
-    String serialized;
-    try {
-      serialized = JsonUtils.getObjectMapper().writeValueAsString(logFormatMetadata);
-    } catch (IOException e) {
-      throw new HoodieIOException("Failed to serialize native log footer metadata", e);
-    }
-    Map<String, String> footer = new LinkedHashMap<>();
-    footer.put(FOOTER_METADATA_KEY, serialized);
     return footer;
   }
 
   /**
-   * Parses the log block header back from the native file footer key/value map. Unknown header
-   * types are ignored so that files written by newer minor versions remain readable.
+   * Converts the native file footer key/value map back into a log block header. Unknown footer
+   * entries are ignored so that files written by newer minor versions remain readable.
    */
   public static Map<HeaderMetadataType, String> fromFooterMetadata(Map<String, String> footerMetadata) {
     Map<HeaderMetadataType, String> header = new LinkedHashMap<>();
-    String serialized = footerMetadata.get(FOOTER_METADATA_KEY);
-    if (serialized == null) {
-      return header;
-    }
-    Map<String, String> logFormatMetadata;
-    try {
-      logFormatMetadata = JsonUtils.getObjectMapper().readValue(serialized, MAP_TYPE);
-    } catch (IOException e) {
-      throw new HoodieIOException("Failed to parse native log footer metadata: " + serialized, e);
-    }
-    logFormatMetadata.forEach((name, value) -> {
-      HeaderMetadataType type = headerTypeOrNull(name);
-      if (type != null) {
-        header.put(type, value);
+    footerMetadata.forEach((key, value) -> {
+      if (key.startsWith(FOOTER_METADATA_KEY_PREFIX) && value != null) {
+        HeaderMetadataType type = headerTypeOrNull(key.substring(FOOTER_METADATA_KEY_PREFIX.length()));
+        if (type != null) {
+          header.put(type, value);
+        }
       }
     });
     validateFormatVersion(header);
@@ -109,10 +84,17 @@ public class NativeLogFooterMetadata {
   }
 
   /**
+   * Returns the stable native log footer key for the given header metadata type.
+   */
+  public static String getFooterMetadataKey(HeaderMetadataType type) {
+    return FOOTER_METADATA_KEY_PREFIX + type.name();
+  }
+
+  /**
    * Reads the table schema embedded in a native data log file footer.
    *
    * <p>Native data logs persist the synthetic log-block header, including {@link HeaderMetadataType#SCHEMA},
-   * in the footer metadata entry keyed by {@link #FOOTER_METADATA_KEY}. This method is intended for
+   * in namespaced footer metadata entries. This method is intended for
    * schema discovery paths that do not have a {@code HoodieReaderContext} and therefore cannot construct
    * a {@code HoodieNativeLogFileReader}. Native delete logs do not expose a generic table schema through
    * this API because their schema depends on the table schema and configured ordering fields; those files
@@ -132,13 +114,13 @@ public class NativeLogFooterMetadata {
     HoodieFileFormat fileFormat = HoodieFileFormat.fromFileExtension("." + nativeLogFileName.getSuffix());
     Map<String, String> footer = HoodieIOFactory.getIOFactory(storage)
         .getFileFormatUtils(fileFormat)
-        .readFooter(storage, false, path, FOOTER_METADATA_KEY);
+        .readFooterWithPrefix(storage, false, path, FOOTER_METADATA_KEY_PREFIX);
     Map<HeaderMetadataType, String> header = fromFooterMetadata(footer);
     String schema = header.get(HeaderMetadataType.SCHEMA);
     if (StringUtils.isNullOrEmpty(schema)) {
       throw new HoodieIOException("Missing required native log schema metadata '"
           + HeaderMetadataType.SCHEMA.name() + "' in footer key '"
-          + FOOTER_METADATA_KEY + "' for " + path);
+          + getFooterMetadataKey(HeaderMetadataType.SCHEMA) + "' for " + path);
     }
     return HoodieSchema.parse(schema);
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FileFormatUtils.java
@@ -232,6 +232,18 @@ public abstract class FileFormatUtils {
                                                  String... footerNames);
 
   /**
+   * Read data file footer entries whose keys start with the given prefix.
+   *
+   * @param storage      {@link HoodieStorage} instance
+   * @param required     require at least one matching footer entry
+   * @param filePath     data file path
+   * @param footerPrefix prefix of the footer entries to read
+   * @return matching footer entries keyed by their full names
+   */
+  public abstract Map<String, String> readFooterWithPrefix(
+      HoodieStorage storage, boolean required, StoragePath filePath, String footerPrefix);
+
+  /**
    * Returns the number of records in the data file.
    *
    * @param storage  {@link HoodieStorage} instance.

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HFileUtils.java
@@ -129,6 +129,31 @@ public class HFileUtils extends FileFormatUtils {
   }
 
   @Override
+  public Map<String, String> readFooterWithPrefix(
+      HoodieStorage storage, boolean required, StoragePath filePath, String footerPrefix) {
+    Map<String, String> footerVals = new HashMap<>();
+    try (HFileReader reader = HFileReaderFactory.builder()
+        .withStorage(storage)
+        .withPath(filePath)
+        .build()
+        .createHFileReader()) {
+      reader.getMetaInfo().forEach((key, value) -> {
+        String footerName = fromUTF8Bytes(key.getBytes());
+        if (footerName.startsWith(footerPrefix)) {
+          footerVals.put(footerName, fromUTF8Bytes(value));
+        }
+      });
+      if (required && footerVals.isEmpty()) {
+        throw new MetadataNotFoundException(
+            "Could not find metadata in HFile footer with prefix " + footerPrefix + " in " + filePath);
+      }
+      return footerVals;
+    } catch (IOException io) {
+      throw new HoodieIOException("Unable to read footer for HFile: " + filePath, io);
+    }
+  }
+
+  @Override
   public long getRowCount(HoodieStorage storage, StoragePath filePath) {
     throw new UnsupportedOperationException("HFileUtils does not support getRowCount");
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/VortexUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/VortexUtils.java
@@ -138,6 +138,12 @@ public class VortexUtils extends FileFormatUtils {
   }
 
   @Override
+  public Map<String, String> readFooterWithPrefix(
+      HoodieStorage storage, boolean required, StoragePath filePath, String footerPrefix) {
+    throw new UnsupportedOperationException("readFooterWithPrefix is not yet supported for Vortex format");
+  }
+
+  @Override
   public long getRowCount(HoodieStorage storage, StoragePath filePath) {
     try (HoodieFileReader fileReader =
                  HoodieIOFactory.getIOFactory(storage)

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestHoodieNativeLogFileReader.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestHoodieNativeLogFileReader.java
@@ -45,7 +45,8 @@ class TestHoodieNativeLogFileReader {
         () -> HoodieNativeLogFileReader.validateDataBlockHeader(logFile, header));
 
     assertTrue(exception.getMessage().contains(HeaderMetadataType.SCHEMA.name()));
-    assertTrue(exception.getMessage().contains(NativeLogFooterMetadata.FOOTER_METADATA_KEY));
+    assertTrue(exception.getMessage().contains(
+        NativeLogFooterMetadata.getFooterMetadataKey(HeaderMetadataType.SCHEMA)));
     assertTrue(exception.getMessage().contains(logFile.toString()));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestNativeLogFooterMetadata.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/log/TestNativeLogFooterMetadata.java
@@ -43,7 +43,12 @@ class TestNativeLogFooterMetadata {
 
     // Footer produced by the write path must be readable by the read path.
     Map<String, String> footer = NativeLogFooterMetadata.toFooterMetadata(header);
-    assertTrue(footer.containsKey(NativeLogFooterMetadata.FOOTER_METADATA_KEY));
+    assertEquals(String.valueOf(HoodieLogFormat.CURRENT_VERSION), footer.get("hudi.log.format.VERSION"));
+    assertEquals("001", footer.get("hudi.log.format.INSTANT_TIME"));
+    assertEquals("{\"type\":\"record\",\"name\":\"test\",\"fields\":[]}",
+        footer.get("hudi.log.format.SCHEMA"));
+    assertEquals("true", footer.get("hudi.log.format.IS_PARTIAL"));
+    assertEquals(4, footer.size());
 
     Map<HeaderMetadataType, String> parsed = NativeLogFooterMetadata.fromFooterMetadata(footer);
     assertEquals("001", parsed.get(HeaderMetadataType.INSTANT_TIME));
@@ -67,15 +72,16 @@ class TestNativeLogFooterMetadata {
   }
 
   @Test
-  void testMissingFooterKeyReturnsEmptyHeader() {
+  void testMissingFooterMetadataReturnsEmptyHeader() {
     assertTrue(NativeLogFooterMetadata.fromFooterMetadata(new HashMap<>()).isEmpty());
   }
 
   @Test
   void testUnknownHeaderTypesAreIgnored() {
     Map<String, String> footer = new HashMap<>();
-    footer.put(NativeLogFooterMetadata.FOOTER_METADATA_KEY,
-        "{\"VERSION\":\"2\",\"INSTANT_TIME\":\"001\",\"SOME_FUTURE_KEY\":\"v\"}");
+    footer.put(NativeLogFooterMetadata.getFooterMetadataKey(HeaderMetadataType.VERSION), "2");
+    footer.put(NativeLogFooterMetadata.getFooterMetadataKey(HeaderMetadataType.INSTANT_TIME), "001");
+    footer.put(NativeLogFooterMetadata.FOOTER_METADATA_KEY_PREFIX + "some_future_key", "v");
 
     Map<HeaderMetadataType, String> parsed = NativeLogFooterMetadata.fromFooterMetadata(footer);
     assertEquals("001", parsed.get(HeaderMetadataType.INSTANT_TIME));
@@ -85,8 +91,9 @@ class TestNativeLogFooterMetadata {
   @Test
   void testNewerFormatVersionIsRejected() {
     Map<String, String> footer = new HashMap<>();
-    footer.put(NativeLogFooterMetadata.FOOTER_METADATA_KEY,
-        "{\"VERSION\":\"" + (HoodieLogFormat.CURRENT_VERSION + 1) + "\",\"INSTANT_TIME\":\"001\"}");
+    footer.put(NativeLogFooterMetadata.getFooterMetadataKey(HeaderMetadataType.VERSION),
+        String.valueOf(HoodieLogFormat.CURRENT_VERSION + 1));
+    footer.put(NativeLogFooterMetadata.getFooterMetadataKey(HeaderMetadataType.INSTANT_TIME), "001");
 
     assertThrows(HoodieNotSupportedException.class,
         () -> NativeLogFooterMetadata.fromFooterMetadata(footer));

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/LanceUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/LanceUtils.java
@@ -167,6 +167,37 @@ public class LanceUtils extends FileFormatUtils {
   }
 
   @Override
+  public Map<String, String> readFooterWithPrefix(
+      HoodieStorage storage, boolean required, StoragePath filePath, String footerPrefix) {
+    Map<String, String> footerVals = new HashMap<>();
+    long metadataAllocatorSize = Long.parseLong(
+        HoodieStorageConfig.LANCE_READ_METADATA_ALLOCATOR_SIZE_BYTES.defaultValue());
+    try (BufferAllocator allocator = HoodieArrowAllocator.newChildAllocator(
+        getClass().getSimpleName() + "-metadata-" + filePath.getName(), metadataAllocatorSize);
+         LanceFileReader reader = LanceFileReader.open(filePath.toString(), allocator)) {
+      Map<String, String> metadata = reader.schema().getCustomMetadata();
+      if (metadata != null) {
+        metadata.forEach((key, value) -> {
+          if (key.startsWith(footerPrefix)) {
+            footerVals.put(key, value);
+          }
+        });
+      }
+      if (required && footerVals.isEmpty()) {
+        throw new MetadataNotFoundException(
+            "Could not find metadata in Lance footer with prefix " + footerPrefix + " in " + filePath);
+      }
+      return footerVals;
+    } catch (MetadataNotFoundException e) {
+      throw e;
+    } catch (IOException e) {
+      throw new HoodieIOException("Unable to read footer for Lance: " + filePath, e);
+    } catch (Exception e) {
+      throw new HoodieException("Unable to close Lance footer reader: " + filePath, e);
+    }
+  }
+
+  @Override
   public long getRowCount(HoodieStorage storage, StoragePath filePath) {
     try (HoodieFileReader fileReader =
              HoodieIOFactory.getIOFactory(storage)

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/OrcUtils.java
@@ -242,6 +242,27 @@ public class OrcUtils extends FileFormatUtils {
   }
 
   @Override
+  public Map<String, String> readFooterWithPrefix(
+      HoodieStorage storage, boolean required, StoragePath filePath, String footerPrefix) {
+    try (Reader reader = OrcFile.createReader(
+        convertToHadoopPath(filePath), OrcFile.readerOptions(storage.getConf().unwrapAs(Configuration.class)))) {
+      Map<String, String> footerVals = new HashMap<>();
+      reader.getFileTail().getFooter().getMetadataList().forEach(metadataItem -> {
+        if (metadataItem.getName().startsWith(footerPrefix)) {
+          footerVals.put(metadataItem.getName(), metadataItem.getValue().toStringUtf8());
+        }
+      });
+      if (required && footerVals.isEmpty()) {
+        throw new MetadataNotFoundException(
+            "Could not find metadata in ORC footer with prefix " + footerPrefix + " in " + filePath);
+      }
+      return footerVals;
+    } catch (IOException io) {
+      throw new HoodieIOException("Unable to read footer for ORC file:" + filePath, io);
+    }
+  }
+
+  @Override
   public HoodieSchema readSchema(HoodieStorage storage, StoragePath filePath) {
     try (Reader reader = OrcFile.createReader(
         convertToHadoopPath(filePath), OrcFile.readerOptions(storage.getConf().unwrapAs(Configuration.class)))) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -279,6 +279,23 @@ public class ParquetUtils extends FileFormatUtils {
   }
 
   @Override
+  public Map<String, String> readFooterWithPrefix(
+      HoodieStorage storage, boolean required, StoragePath filePath, String footerPrefix) {
+    Map<String, String> footerVals = new HashMap<>();
+    ParquetMetadata footer = readFileMetadataOnly(storage, filePath);
+    footer.getFileMetaData().getKeyValueMetaData().forEach((key, value) -> {
+      if (key.startsWith(footerPrefix)) {
+        footerVals.put(key, value);
+      }
+    });
+    if (required && footerVals.isEmpty()) {
+      throw new MetadataNotFoundException(
+          "Could not find metadata in Parquet footer with prefix " + footerPrefix + " in " + filePath);
+    }
+    return footerVals;
+  }
+
+  @Override
   public HoodieSchema readSchema(HoodieStorage storage, StoragePath filePath) {
     MessageType parquetSchema = readMessageType(storage, filePath);
     return getAvroSchemaConverter(storage.getConf().unwrapAs(Configuration.class)).convert(parquetSchema);

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestTableSchemaResolver.java
@@ -180,7 +180,8 @@ class TestTableSchemaResolver {
     HoodieIOFactory ioFactory = mock(HoodieIOFactory.class);
     FileFormatUtils fileFormatUtils = mock(FileFormatUtils.class);
     when(ioFactory.getFileFormatUtils(HoodieFileFormat.PARQUET)).thenReturn(fileFormatUtils);
-    when(fileFormatUtils.readFooter(storage, false, logFilePath, NativeLogFooterMetadata.FOOTER_METADATA_KEY))
+    when(fileFormatUtils.readFooterWithPrefix(
+        storage, false, logFilePath, NativeLogFooterMetadata.FOOTER_METADATA_KEY_PREFIX))
         .thenReturn(new HashMap<>());
 
     try (MockedStatic<HoodieIOFactory> ioFactoryMockedStatic = mockStatic(HoodieIOFactory.class)) {
@@ -189,7 +190,8 @@ class TestTableSchemaResolver {
       HoodieIOException exception = assertThrows(HoodieIOException.class,
           () -> TableSchemaResolver.readSchemaFromLogFile(metaClient, logFilePath));
       assertTrue(exception.getMessage().contains(HoodieLogBlock.HeaderMetadataType.SCHEMA.name()));
-      assertTrue(exception.getMessage().contains(NativeLogFooterMetadata.FOOTER_METADATA_KEY));
+      assertTrue(exception.getMessage().contains(
+          NativeLogFooterMetadata.getFooterMetadataKey(HoodieLogBlock.HeaderMetadataType.SCHEMA)));
       assertTrue(exception.getMessage().contains(logFilePath.toString()));
     }
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieHFileReaderWriter.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.log.NativeLogFooterMetadata;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.HFileUtils;
 import org.apache.hudi.common.util.Option;
@@ -208,19 +209,25 @@ public class TestHoodieHFileReaderWriter extends TestHoodieReaderWriterBase {
   public void testReadFooterMetadata() throws Exception {
     HoodieSchema schema = getSchemaFromResource(TestHoodieOrcReaderWriter.class, "/exampleSchemaWithMetaFields.avsc");
     HoodieAvroHFileWriter writer = createWriter(schema, false);
+    String schemaMetadataKey = NativeLogFooterMetadata.getFooterMetadataKey(HeaderMetadataType.SCHEMA);
     Map<String, String> footerMetadata = new TreeMap<>();
-    footerMetadata.put(NativeLogFooterMetadata.FOOTER_METADATA_KEY, "{\"SCHEMA\":\"schema\"}");
+    footerMetadata.put(schemaMetadataKey, "schema");
     footerMetadata.put("custom", "value");
     writer.addFooterMetadata(footerMetadata);
     writer.close();
 
     HoodieStorage storage = HoodieTestUtils.getStorage(getFilePath());
     Map<String, String> footer = new HFileUtils().readFooter(
-        storage, false, getFilePath(), NativeLogFooterMetadata.FOOTER_METADATA_KEY, "custom", "missing");
+        storage, false, getFilePath(), schemaMetadataKey, "custom", "missing");
 
     assertEquals(2, footer.size());
-    assertEquals("{\"SCHEMA\":\"schema\"}", footer.get(NativeLogFooterMetadata.FOOTER_METADATA_KEY));
+    assertEquals("schema", footer.get(schemaMetadataKey));
     assertEquals("value", footer.get("custom"));
+
+    Map<String, String> footerByPrefix = new HFileUtils().readFooterWithPrefix(
+        storage, true, getFilePath(), NativeLogFooterMetadata.FOOTER_METADATA_KEY_PREFIX);
+    assertEquals(Collections.singletonMap(schemaMetadataKey, "schema"), footerByPrefix);
+
     assertThrows(MetadataNotFoundException.class,
         () -> new HFileUtils().readFooter(storage, true, getFilePath(), "missing"));
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieOrcReaderWriter.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/io/hadoop/TestHoodieOrcReaderWriter.java
@@ -121,5 +121,10 @@ public class TestHoodieOrcReaderWriter extends TestHoodieReaderWriterBase {
         .getFileFormatUtils(HoodieFileFormat.ORC)
         .readFooter(storage, true, getFilePath(), "custom.footer.key");
     assertEquals("custom-footer-value", footer.get("custom.footer.key"));
+
+    Map<String, String> footerByPrefix = HoodieIOFactory.getIOFactory(storage)
+        .getFileFormatUtils(HoodieFileFormat.ORC)
+        .readFooterWithPrefix(storage, true, getFilePath(), "custom.footer.");
+    assertEquals(footer, footerByPrefix);
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileInfo.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileInfo.java
@@ -25,6 +25,7 @@ import org.apache.hudi.io.util.IOUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -66,6 +67,10 @@ public class HFileInfo {
 
   public byte[] get(UTF8StringKey key) {
     return infoMap.get(key);
+  }
+
+  public Map<UTF8StringKey, byte[]> getInfoMap() {
+    return Collections.unmodifiableMap(infoMap);
   }
 
   private long parseFileCreationTime() {

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileReader.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileReader.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.util.Option;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 /**
  * HFile reader that supports seeks.
@@ -77,6 +78,14 @@ public interface HFileReader extends Closeable {
    * @throws IOException upon read errors.
    */
   Option<byte[]> getMetaInfo(UTF8StringKey key) throws IOException;
+
+  /**
+   * Gets all entries from the file info block.
+   *
+   * @return all file info entries
+   * @throws IOException upon read errors
+   */
+  Map<UTF8StringKey, byte[]> getMetaInfo() throws IOException;
 
   /**
    * Gets the content of a meta block from HFile.

--- a/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileReaderImpl.java
+++ b/hudi-io/src/main/java/org/apache/hudi/io/hfile/HFileReaderImpl.java
@@ -99,6 +99,12 @@ public class HFileReaderImpl implements HFileReader {
   }
 
   @Override
+  public Map<UTF8StringKey, byte[]> getMetaInfo() throws IOException {
+    initializeMetadata();
+    return fileInfo.getInfoMap();
+  }
+
+  @Override
   public Option<ByteBuffer> getMetaBlock(String metaBlockName) throws IOException {
     initializeMetadata();
     BlockIndexEntry blockIndexEntry = metaBlockIndexEntryMap.get(new UTF8StringKey(metaBlockName));

--- a/rfc/rfc-103/rfc-103.md
+++ b/rfc/rfc-103/rfc-103.md
@@ -223,19 +223,21 @@ Footer
   - key-value metadata <-- Hudi log format metadata goes in here
 ```
 
-Hudi log format metadata can be stored as a single entry in the Parquet footer with key = `hudi.log.format.metadata` and value being a serialized JSON of the metadata entries:
+Each Hudi log format metadata value is stored as a separate Parquet footer entry under the
+`hudi.log.format.` namespace:
 
-| Hudi log format metadata                     |
-|:---------------------------------------------|
-| `VERSION`                                    |
-| `INSTANT_TIME`                               |
-| `TARGET_INSTANT_TIME`                        |
-| `COMMAND_BLOCK_TYPE`                         |
-| `COMPACTED_BLOCK_TIMES`                      |
-| `RECORD_POSITIONS`                           |
-| `BLOCK_IDENTIFIER`                           |
-| `IS_PARTIAL`                                 |
-| `BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS` |
+| Hudi log format metadata                     | Parquet footer key                                             |
+|:---------------------------------------------|:---------------------------------------------------------------|
+| `VERSION`                                    | `hudi.log.format.VERSION`                                      |
+| `INSTANT_TIME`                               | `hudi.log.format.INSTANT_TIME`                                 |
+| `TARGET_INSTANT_TIME`                        | `hudi.log.format.TARGET_INSTANT_TIME`                          |
+| `SCHEMA`                                     | `hudi.log.format.SCHEMA`                                       |
+| `COMMAND_BLOCK_TYPE`                         | `hudi.log.format.COMMAND_BLOCK_TYPE`                           |
+| `COMPACTED_BLOCK_TIMES`                      | `hudi.log.format.COMPACTED_BLOCK_TIMES`                        |
+| `RECORD_POSITIONS`                           | `hudi.log.format.RECORD_POSITIONS`                             |
+| `BLOCK_IDENTIFIER`                           | `hudi.log.format.BLOCK_IDENTIFIER`                             |
+| `IS_PARTIAL`                                 | `hudi.log.format.IS_PARTIAL`                                   |
+| `BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS` | `hudi.log.format.BASE_FILE_INSTANT_TIME_OF_RECORD_POSITIONS`   |
 
 When using native log format, the log file name uses a suffix like `.log.<native format>`, for e.g., `.log.parquet`.
 
@@ -257,9 +259,11 @@ Using native log file format can also be extended to other file format, like [La
 ### Block type handling
 
 **Data log**: The Parquet schema is the writer's table schema, including Hudi metadata columns (`_hoodie_commit_time`, `_hoodie_commit_seqno`, `_hoodie_record_key`, `_hoodie_partition_path`, `_hoodie_file_name`), followed by the user-defined data columns.
-The schema is stored natively in the Parquet footer (no duplication with header metadata). The `hudi.log.format.metadata` footer entry carries the serialized metadata map as described above.
+The physical schema is stored natively in the Parquet footer. The `hudi.log.format.SCHEMA` entry
+preserves the Hudi logical schema used to reconstruct the log block header, and the remaining
+`hudi.log.format.*` footer entries carry the other log block metadata described above.
 
-**Delete log**: Store delete records as Parquet rows using a fixed delete schema. The delete file is written in the same native Parquet format as data blocks — only the schema and block type differ. The `hudi.log.format.metadata` footer entry carries the same serialized metadata map.
+**Delete log**: Store delete records as Parquet rows using a fixed delete schema. The delete file is written in the same native Parquet format as data blocks — only the schema and block type differ. The `hudi.log.format.*` footer entries carry the same log block metadata.
 
 Delete block Parquet schema:
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This closes #19246 

Native log format metadata is currently serialized as a JSON object under the single footer key `hudi.log.format.metadata`. This makes individual metadata entries opaque to native file-format tooling and requires Hudi-specific JSON serialization and parsing.

This PR changes the native log storage contract so each header value is stored as an independent, namespaced footer entry such as `hudi.log.format.VERSION` and `hudi.log.format.SCHEMA`. This is an on-disk format change: readers no longer fall back to the previous single-JSON-entry representation.

### Summary and Changelog

Native log metadata can now be discovered by prefix and consumed directly from native file footers without an intermediate JSON envelope.

- Replaced `hudi.log.format.metadata` JSON serialization with separate `hudi.log.format.<HeaderMetadataType>` entries.
- Added `FileFormatUtils.readFooterWithPrefix` implementations for Parquet, ORC, HFile, and Lance.
- Extended `HFileReader` to expose file-info entries needed for prefix filtering.
- Updated `HoodieNativeLogFileReader` and native-log schema discovery to read the `hudi.log.format.` namespace.
- Improved missing-schema diagnostics to report the exact `hudi.log.format.SCHEMA` key.
- Preserved format-version validation and forward compatibility for unknown header types.
- Updated RFC-103 and tests for the new footer representation.

### Impact

This changes the on-disk metadata representation for native log files. Files written with the previous interim `hudi.log.format.metadata` JSON representation are not readable through the new metadata path.

The change also adds methods to the `FileFormatUtils` and `HFileReader` abstractions. Parquet, ORC, HFile, and Lance support prefix-based reads; Vortex remains unsupported, consistent with its existing footer-read behavior.

There are no configuration changes. Footer metadata is still loaded through the native format reader and filtered in memory, so no significant performance impact is expected.

### Risk Level

medium

The change affects the native log storage contract and shared footer APIs. Risk is limited to native log metadata handling and is mitigated by focused validation:

- `TestNativeLogFooterMetadata`
- `TestHoodieNativeLogFileReader`
- `TestTableSchemaResolver#testReadSchemaFromNativeDataLogFile`
- `TestHoodieHFileReaderWriter#testReadFooterMetadata`
- `TestHoodieOrcReaderWriter#testAddFooterMetadata`

### Documentation Update

RFC-103 was updated to document the individual `hudi.log.format.*` footer entries and clarify storage of the physical and logical schemas. No additional user-facing documentation is required.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
