### PR TITLE
fix(meta-sync): Normalize meta sync base path to avoid consecutive/trailing slashes in table LOCATION

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -39,6 +39,7 @@ import org.apache.hudi.sync.common.HoodieSyncClient;
 import org.apache.hudi.sync.common.model.FieldSchema;
 import org.apache.hudi.sync.common.model.Partition;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
@@ -411,7 +412,9 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
     if (lastCommitSynced.isPresent()) {
       try {
         Table table = client.getTable(databaseName, tableName);
-        String basePath = config.getString(META_SYNC_BASE_PATH);
+        // Canonicalize (drop consecutive/trailing slashes) so the updated LOCATION and serde path
+        // stay valid for strict object stores such as GCS.
+        String basePath = new Path(config.getString(META_SYNC_BASE_PATH)).toString();
         StorageDescriptor sd = table.getSd();
         sd.setLocation(basePath);
         SerDeInfo serdeInfo = sd.getSerdeInfo();

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
@@ -121,7 +121,11 @@ public class HMSDDLExecutor implements DDLExecutor {
       storageDescriptor.setCols(fieldSchema);
       storageDescriptor.setInputFormat(inputFormatClass);
       storageDescriptor.setOutputFormat(outputFormatClass);
-      storageDescriptor.setLocation(syncConfig.getString(META_SYNC_BASE_PATH));
+      // Canonicalize the base path so the metastore LOCATION never carries consecutive or
+      // trailing slashes (strict object stores such as GCS reject "//"). This is applied at the
+      // boundary, independent of META_SYNC_BASE_PATH normalization, and mirrors what partition
+      // locations already do via FSUtils#constructAbsolutePath.
+      storageDescriptor.setLocation(new Path(syncConfig.getString(META_SYNC_BASE_PATH)).toString());
       serdeProperties.put("serialization.format", "1");
       storageDescriptor.setSerdeInfo(new SerDeInfo(null, serdeClass, serdeProperties));
       newTb.setSd(storageDescriptor);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHMSDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHMSDDLExecutor.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.ddl;
+
+import org.apache.hudi.hive.HiveSyncConfig;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.Properties;
+
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class TestHMSDDLExecutor {
+
+  @Test
+  void testCreateTableCanonicalizesLocation() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(META_SYNC_DATABASE_NAME.key(), "testdb");
+    props.setProperty(META_SYNC_TABLE_NAME.key(), "ho_set_data_pymt_pgm");
+    props.setProperty(META_SYNC_BASE_PATH.key(), "gs://bucket/db/ho_set_data_pymt_pgm");
+    HiveSyncConfig config = new HiveSyncConfig(props);
+    // Force a malformed (consecutive/trailing slash) base path *after* construction, bypassing the
+    // config-level normalization, so this asserts the executor canonicalizes at the LOCATION
+    // boundary itself (strict object stores such as GCS reject "//").
+    config.setValue(META_SYNC_BASE_PATH, "gs://bucket/db/ho_set_data_pymt_pgm//");
+
+    IMetaStoreClient client = mock(IMetaStoreClient.class);
+    HMSDDLExecutor executor = new HMSDDLExecutor(config, client);
+
+    MessageType schema = MessageTypeParser.parseMessageType("message test { optional binary field (UTF8); }");
+    executor.createTable("ho_set_data_pymt_pgm", schema,
+        "org.apache.hudi.hadoop.HoodieParquetInputFormat",
+        "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+        "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+        new HashMap<>(), new HashMap<>());
+
+    ArgumentCaptor<Table> captor = ArgumentCaptor.forClass(Table.class);
+    verify(client).createTable(captor.capture());
+    assertEquals("gs://bucket/db/ho_set_data_pymt_pgm", captor.getValue().getSd().getLocation(),
+        "table LOCATION must be canonicalized (no consecutive/trailing slashes)");
+  }
+}

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -34,6 +34,7 @@ import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 import com.beust.jcommander.Parameter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -211,6 +212,16 @@ public class HoodieSyncConfig extends HoodieConfig {
         .collect(Collectors.joining("\n")));
     setDefaults(HoodieSyncConfig.class.getName());
     this.hadoopConf = hadoopConf;
+    // Normalize the table base path so that downstream metastore LOCATION values never carry
+    // consecutive or trailing slashes. Strict object-store filesystems (e.g. GCS) reject "//",
+    // and this keeps the synced location consistent with the Hudi table base path (which is
+    // itself normalized through org.apache.hadoop.fs.Path on the write path).
+    if (contains(META_SYNC_BASE_PATH)) {
+      String basePath = getString(META_SYNC_BASE_PATH);
+      if (!StringUtils.isNullOrEmpty(basePath)) {
+        setValue(META_SYNC_BASE_PATH, new Path(basePath).toString());
+      }
+    }
   }
 
   public void setHadoopConf(Configuration hadoopConf) {

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/HoodieSyncConfig.java
@@ -215,12 +215,14 @@ public class HoodieSyncConfig extends HoodieConfig {
     // Normalize the table base path so that downstream metastore LOCATION values never carry
     // consecutive or trailing slashes. Strict object-store filesystems (e.g. GCS) reject "//",
     // and this keeps the synced location consistent with the Hudi table base path (which is
-    // itself normalized through org.apache.hadoop.fs.Path on the write path).
-    if (contains(META_SYNC_BASE_PATH)) {
-      String basePath = getString(META_SYNC_BASE_PATH);
-      if (!StringUtils.isNullOrEmpty(basePath)) {
-        setValue(META_SYNC_BASE_PATH, new Path(basePath).toString());
-      }
+    // itself normalized through org.apache.hadoop.fs.Path on the write path). Note that
+    // empty-authority URIs such as file:///x and hdfs:///x are reshaped to their canonical
+    // single-slash form (file:/x); this is harmless and consistent with the write-path base path.
+    // setDefaults() above always writes the "" default for META_SYNC_BASE_PATH, so the empty
+    // check is the only guard needed here.
+    String basePath = getString(META_SYNC_BASE_PATH);
+    if (!StringUtils.isNullOrEmpty(basePath)) {
+      setValue(META_SYNC_BASE_PATH, new Path(basePath).toString());
     }
   }
 

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
@@ -192,10 +192,19 @@ class TestHoodieSyncConfig {
     HoodieSyncConfig gcsConfig = new HoodieSyncConfig(gcsProps, new Configuration());
     assertEquals("gs://bucket/base/ho_set_data_pymt_pgm", gcsConfig.getAbsoluteBasePath());
 
-    // A well-formed base path is left unchanged.
+    // A path already in canonical form (non-empty authority, single slashes) is left unchanged.
     Properties cleanProps = new Properties();
     cleanProps.setProperty(META_SYNC_BASE_PATH.key(), "gs://bucket/base/tbl");
     HoodieSyncConfig cleanConfig = new HoodieSyncConfig(cleanProps, new Configuration());
     assertEquals("gs://bucket/base/tbl", cleanConfig.getAbsoluteBasePath());
+
+    // Empty-authority URIs (e.g. file:///, hdfs:///) are reshaped to their canonical
+    // single-slash form. This is deliberate and harmless: path comparisons in the sync tools
+    // (e.g. FSUtils.comparePathsWithoutScheme) re-parse both operands, so the reshaped LOCATION
+    // still compares equal to a pre-existing file:/// LOCATION and no table is recreated.
+    Properties fileProps = new Properties();
+    fileProps.setProperty(META_SYNC_BASE_PATH.key(), "file:///tmp/tbl");
+    HoodieSyncConfig fileConfig = new HoodieSyncConfig(fileProps, new Configuration());
+    assertEquals("file:/tmp/tbl", fileConfig.getAbsoluteBasePath());
   }
 }

--- a/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
+++ b/hudi-sync/hudi-sync-common/src/test/java/org/apache/hudi/sync/common/TestHoodieSyncConfig.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_ASSUME_DATE_PARTITION;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_FILE_FORMAT;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DECODE_PARTITION;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
@@ -174,5 +175,27 @@ class TestHoodieSyncConfig {
     props2.setProperty(HoodieMetadataConfig.ENABLE.key(), "true");
     HoodieSyncConfig config2 = new HoodieSyncConfig(props2, new Configuration());
     assertTrue(config2.getBoolean(META_SYNC_USE_FILE_LISTING_FROM_METADATA));
+  }
+
+  @Test
+  void testNormalizeBasePath() {
+    // Consecutive and trailing slashes in the base path must be collapsed so that the synced
+    // metastore LOCATION is valid for strict object-store filesystems (e.g. GCS rejects "//").
+    Properties props = new Properties();
+    props.setProperty(META_SYNC_BASE_PATH.key(), "/tmp/base_path//db//tbl//");
+    HoodieSyncConfig config = new HoodieSyncConfig(props, new Configuration());
+    assertEquals("/tmp/base_path/db/tbl", config.getAbsoluteBasePath());
+    assertEquals("/tmp/base_path/db/tbl", config.getString(META_SYNC_BASE_PATH));
+
+    Properties gcsProps = new Properties();
+    gcsProps.setProperty(META_SYNC_BASE_PATH.key(), "gs://bucket/base//ho_set_data_pymt_pgm//");
+    HoodieSyncConfig gcsConfig = new HoodieSyncConfig(gcsProps, new Configuration());
+    assertEquals("gs://bucket/base/ho_set_data_pymt_pgm", gcsConfig.getAbsoluteBasePath());
+
+    // A well-formed base path is left unchanged.
+    Properties cleanProps = new Properties();
+    cleanProps.setProperty(META_SYNC_BASE_PATH.key(), "gs://bucket/base/tbl");
+    HoodieSyncConfig cleanConfig = new HoodieSyncConfig(cleanProps, new Configuration());
+    assertEquals("gs://bucket/base/tbl", cleanConfig.getAbsoluteBasePath());
   }
 }


### PR DESCRIPTION
### Change Logs

Meta sync sets the Hive/metastore table `LOCATION` directly from the raw `hoodie.datasource.meta.sync.base.path` value. If that path contains consecutive (`//`) or trailing slashes, it is passed through verbatim (`HMSDDLExecutor#createTable`, `HoodieHiveSyncClient`, and the JDBC/HiveQL `LOCATION` clause all read `META_SYNC_BASE_PATH` unchanged). Strict object-store filesystems reject such paths — e.g. on GCS the first-time sync fails `create_table` with:

```
MetaException: java.lang.IllegalArgumentException: GCS path must not have consecutive '/' characters: '.../<table>//'
```

The **data write path already canonicalizes** the base path through `org.apache.hadoop.fs.Path`, so the Hudi commit succeeds and only the *post-commit* meta sync (`HiveSyncTool#syncFirstTime` → `HMSDDLExecutor#createTable`) fails.

**Fix:** normalize `META_SYNC_BASE_PATH` once in the `HoodieSyncConfig` constructor via `new Path(basePath).toString()`, so every downstream consumer (HMS / JDBC / HiveQL DDL executors, partition locations, `TABLE_SERDE_PATH`) receives a canonical location that matches the Hudi table base path. This is the same `Path`-based canonicalization the write path already relies on.

### Impact

Meta sync registers a normalized table location. Fixes `create_table` failures on strict object stores (e.g. GCS) when the configured base path contains `//` or a trailing `/`.

Paths that are already canonical are unchanged, **with one deliberate nuance**: empty-authority URIs (`file:///x`, `hdfs:///x`) are reshaped to their canonical single-slash form (`file:/x`), since `Path#toString` only emits `//` when the URI authority is non-empty. This is harmless:

- Table-location drift checks re-parse both operands (`FSUtils.comparePathsWithoutScheme`), so a reshaped LOCATION still compares equal to a pre-existing `file:///` LOCATION — no table is dropped/recreated.
- `getPartitionEvents` strips scheme + authority on both sides, so there are no spurious partition UPDATE events.
- Glue/BigQuery read the location from `metaClient.getBasePath()` (a `StoragePath`, already the `file:/` form), not from this config value.

The reshape is pinned by a dedicated test case so it is intentional rather than discovered later.

### Risk level: low

Single, central normalization reusing Hadoop `Path` canonicalization. No-ops when the base path is empty. Covered by a new unit test.

### Documentation Update

None.

### Contributor's checklist

- [x] Change Logs and Impact described above
- [x] Unit test added (`TestHoodieSyncConfig#testNormalizeBasePath`), full `TestHoodieSyncConfig` suite passes locally (8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
