### PR TITLE
fix(spark): match the staged table, not LogicalWriteInfo, in BasicStagedTable.newWriteBuilder

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/BasicStagedTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/BasicStagedTable.scala
@@ -38,7 +38,7 @@ case class BasicStagedTable(ident: Identifier,
                             table: Table,
                             catalog: TableCatalog) extends SupportsWrite with StagedTable {
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
-    info match {
+    table match {
       case supportsWrite: SupportsWrite => supportsWrite.newWriteBuilder(info)
       case _ => throw new HoodieException(s"Table `${ident.name}` does not support writes.")
     }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/catalog/HoodieCatalog.scala
@@ -74,7 +74,7 @@ class HoodieCatalog extends DelegatingCatalogExtension
     } else {
       BasicStagedTable(
         ident,
-        super.createTable(ident, schema, partitions, properties),
+        createOrLoadTable(ident, schema, partitions, properties),
         this)
     }
   }
@@ -92,7 +92,7 @@ class HoodieCatalog extends DelegatingCatalogExtension
       super.dropTable(ident)
       BasicStagedTable(
         ident,
-        super.createTable(ident, schema, partitions, properties),
+        createOrLoadTable(ident, schema, partitions, properties),
         this)
     }
   }
@@ -115,9 +115,23 @@ class HoodieCatalog extends DelegatingCatalogExtension
       }
       BasicStagedTable(
         ident,
-        super.createTable(ident, schema, partitions, properties),
+        createOrLoadTable(ident, schema, partitions, properties),
         this)
     }
+  }
+
+  /**
+   * Creates the table in the delegate catalog and returns it, never null.
+   *
+   * A delegate is allowed to return null from `createTable`: `V2SessionCatalog` does so deliberately, to save the
+   * `loadTable` round-trip for a `CREATE TABLE` without `AS SELECT`. Load the table that was just created in that
+   * case, so that the staged table is never backed by a null table. Spark guards its own staging the same way.
+   */
+  private def createOrLoadTable(ident: Identifier,
+                                schema: StructType,
+                                partitions: Array[Transform],
+                                properties: util.Map[String, String]): Table = {
+    Option(super.createTable(ident, schema, partitions, properties)).getOrElse(loadTable(ident))
   }
 
   override def loadTable(ident: Identifier): Table = {

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/catalog/TestBasicStagedTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/catalog/TestBasicStagedTable.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.connector.catalog.{Identifier, SupportsWrite, Table,
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.junit.jupiter.api.Assertions.{assertSame, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.{mock, verify, when}
+import org.mockito.Mockito.{mock, when}
 
 class TestBasicStagedTable {
 
@@ -39,7 +39,6 @@ class TestBasicStagedTable {
     val staged = BasicStagedTable(ident, table, mock(classOf[TableCatalog]))
 
     assertSame(writeBuilder, staged.newWriteBuilder(info))
-    verify(table).newWriteBuilder(info)
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/catalog/TestBasicStagedTable.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/catalog/TestBasicStagedTable.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.catalog
+
+import org.apache.hudi.exception.HoodieException
+
+import org.apache.spark.sql.connector.catalog.{Identifier, SupportsWrite, Table, TableCatalog}
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.junit.jupiter.api.Assertions.{assertSame, assertThrows, assertTrue}
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.{mock, verify, when}
+
+class TestBasicStagedTable {
+
+  private val ident = Identifier.of(Array("db"), "tbl")
+
+  @Test
+  def testNewWriteBuilderDelegatesToWritableTable(): Unit = {
+    val table = mock(classOf[SupportsWrite])
+    val info = mock(classOf[LogicalWriteInfo])
+    val writeBuilder = mock(classOf[WriteBuilder])
+    when(table.newWriteBuilder(info)).thenReturn(writeBuilder)
+
+    val staged = BasicStagedTable(ident, table, mock(classOf[TableCatalog]))
+
+    assertSame(writeBuilder, staged.newWriteBuilder(info))
+    verify(table).newWriteBuilder(info)
+  }
+
+  @Test
+  def testNewWriteBuilderThrowsWhenTableIsNotWritable(): Unit = {
+    val staged = BasicStagedTable(ident, mock(classOf[Table]), mock(classOf[TableCatalog]))
+
+    val ex = assertThrows(classOf[HoodieException],
+      () => staged.newWriteBuilder(mock(classOf[LogicalWriteInfo])))
+    assertTrue(ex.getMessage.contains("`tbl` does not support writes"))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/catalog/TestHoodieCatalogStagedTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/catalog/TestHoodieCatalogStagedTable.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.catalog
+
+import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.testutils.HoodieClientTestUtils
+
+import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.{Identifier, StagedTable, SupportsWrite, Table, TableCatalog}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+import org.junit.jupiter.api.{AfterAll, BeforeAll, TestInstance}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertSame, assertThrows, assertTrue}
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.Mockito.{mock, when}
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+/**
+ * Tests the staging methods of {@link HoodieCatalog} for a non-Hudi table, which stage through
+ * {@link BasicStagedTable} and hand the write off to the delegate catalog's table.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+class TestHoodieCatalogStagedTable {
+
+  private val ident = Identifier.of(Array("default"), "tbl")
+  private val schema = StructType(Seq(StructField("id", IntegerType)))
+  private val partitions = Array.empty[Transform]
+  // Not a Hudi provider, so the staging methods take the BasicStagedTable branch
+  private val properties: util.Map[String, String] = Map("provider" -> "parquet").asJava
+
+  private var sparkSession: SparkSession = _
+
+  @BeforeAll
+  def setUp(): Unit = {
+    val jsc = new JavaSparkContext(
+      HoodieClientTestUtils.getSparkConfForTest(classOf[TestHoodieCatalogStagedTable].getName))
+    jsc.setLogLevel("ERROR")
+    // HoodieCatalog resolves SparkSession.active in its constructor
+    sparkSession = SparkSession.builder.config(jsc.getConf).getOrCreate
+  }
+
+  @AfterAll
+  def tearDown(): Unit = {
+    sparkSession.close()
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("stageCreate", "stageReplace", "stageCreateOrReplace"))
+  def testStagedWriteIsDelegatedToWritableTable(stagingMethod: String): Unit = {
+    val delegateTable = mock(classOf[SupportsWrite])
+    val info = mock(classOf[LogicalWriteInfo])
+    val writeBuilder = mock(classOf[WriteBuilder])
+    when(delegateTable.newWriteBuilder(info)).thenReturn(writeBuilder)
+    val delegate = mock(classOf[TableCatalog])
+    when(delegate.createTable(ident, schema, partitions, properties)).thenReturn(delegateTable)
+
+    val staged = stage(stagingMethod, delegate)
+
+    assertSame(writeBuilder, staged.asInstanceOf[SupportsWrite].newWriteBuilder(info))
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("stageCreate", "stageReplace", "stageCreateOrReplace"))
+  def testStagedTableIsLoadedWhenDelegateCreateTableReturnsNull(stagingMethod: String): Unit = {
+    // V2SessionCatalog, the default delegate, returns null from createTable by design, to save the loadTable call
+    val delegate = mock(classOf[TableCatalog])
+    val loadedTable = mock(classOf[Table])
+    when(loadedTable.schema()).thenReturn(schema)
+    when(delegate.loadTable(ident)).thenReturn(loadedTable)
+
+    val staged = stage(stagingMethod, delegate)
+
+    // The staged table is backed by the table that was just created, rather than by null
+    assertEquals(schema, staged.schema())
+    // It is not writable, so the write is rejected instead of being delegated
+    val ex = assertThrows(classOf[HoodieException],
+      () => staged.asInstanceOf[SupportsWrite].newWriteBuilder(mock(classOf[LogicalWriteInfo])))
+    assertTrue(ex.getMessage.contains("`tbl` does not support writes"))
+  }
+
+  private def stage(stagingMethod: String, delegate: TableCatalog): StagedTable = {
+    val catalog = new HoodieCatalog()
+    catalog.setDelegateCatalog(delegate)
+    stagingMethod match {
+      case "stageCreate" => catalog.stageCreate(ident, schema, partitions, properties)
+      case "stageReplace" => catalog.stageReplace(ident, schema, partitions, properties)
+      case "stageCreateOrReplace" => catalog.stageCreateOrReplace(ident, schema, partitions, properties)
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Fixes #19250

`BasicStagedTable.newWriteBuilder` pattern-matches the `LogicalWriteInfo` argument against `SupportsWrite` instead of matching the staged `Table`. `SupportsWrite` is a `Table` mixin (`SupportsWrite extends Table`), and `LogicalWriteInfo` is an unrelated interface, so the delegating branch can never be taken: the method throws `HoodieException("Table `x` does not support writes.")` for every input, including one whose underlying table is writable. Present since #4611.

`BasicStagedTable` is what `HoodieCatalog` returns from `stageCreate`, `stageReplace` and `stageCreateOrReplace` for non-Hudi tables, so an atomic CTAS or RTAS against a writable V2 table goes through this method.

Scala compiles a match between two unrelated interfaces without a warning (a class could in principle implement both), and no test ever exercised the class, which is why this went unnoticed.

The same path carries a second defect. `HoodieCatalog` passes the result of `super.createTable(...)` straight into `BasicStagedTable`, but a delegate catalog is allowed to return `null` from `createTable`, and the default `V2SessionCatalog` does exactly that ("Return null to save the `loadTable` call for CREATE TABLE without AS SELECT"). The staged table is then backed by `null` and throws an NPE out of `BasicStagedTable.schema()`, which Spark reaches from `DataSourceV2Relation.create` before it ever asks for a `WriteBuilder`.

### Summary and Changelog

- Match on `table` rather than on `info` in `BasicStagedTable.newWriteBuilder`, so a writable underlying table is delegated to and only a genuinely non-writable one is rejected.
- Guard the three staging methods of `HoodieCatalog` against a `null` result from the delegate's `createTable` by loading the table that was just created. This is what Spark's own `CreateTableAsSelectExec` and `ReplaceTableAsSelectExec` do with `Option(catalog.createTable(...)).getOrElse(catalog.loadTable(...))`.
- Add `TestBasicStagedTable`, covering both branches of `newWriteBuilder`, and `TestHoodieCatalogStagedTable`, which drives `stageCreate`, `stageReplace` and `stageCreateOrReplace` against a mock delegate catalog and covers both the delegation path and the null-`createTable` path.

### Impact

The match fix takes effect when the delegate catalog returns a writable table, for instance a Polaris-style catalog plugged in under `HoodieCatalog`: a write staged for a non-Hudi table now reaches that table's `WriteBuilder` instead of being rejected unconditionally. A table that genuinely does not support writes is still rejected with the same exception and message.

With the default `V2SessionCatalog` delegate, `createTable` returns `null`, so that same path previously failed with an NPE out of `BasicStagedTable.schema()`. It now stages the table that was just created, and reports the intended `HoodieException` if that table is not writable.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
