### PR TITLE
fix(core): cover missed VORTEX dispatch in reader factory and log format selection

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
@@ -120,6 +120,7 @@ public class CommonClientUtils {
     HoodieFileFormat baseFileFormat = getBaseFileFormat(writeConfig, tableConfig);
     switch (getBaseFileFormat(writeConfig, tableConfig)) {
       case LANCE:
+      case VORTEX:
       case PARQUET:
       case ORC:
         return HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK;
@@ -135,19 +136,20 @@ public class CommonClientUtils {
    * Whether log blocks should be written in the native (v2) log format (standalone native
    * files written via {@code HoodieNativeLogFormatWriter}) instead of the legacy inline
    * log format. The native format is the default for write version &gt;= {@link HoodieTableVersion#TEN},
-   * except for Lance base files.
+   * except for Lance and Vortex base files.
    *
    * <p>This decision is keyed on the effective write version (i.e. {@code HoodieWriteConfig#getWriteVersion()})
    * and the effective base file format, consistent with how the inline log block layout is
    * selected, so that the on-disk format follows what the writer is targeting during
-   * upgrade/downgrade windows. Lance remains on the legacy inline log format until native Lance log
-   * support is complete.
+   * upgrade/downgrade windows. Lance and Vortex remain on the legacy inline log format until
+   * native log support for these formats is complete.
    *
    * @param writeConfig the writer configuration.
    * @param tableConfig the persisted table configuration.
    */
   public static boolean shouldWriteNativeLogs(HoodieWriteConfig writeConfig, HoodieTableConfig tableConfig) {
-    if (getBaseFileFormat(writeConfig, tableConfig) == HoodieFileFormat.LANCE) {
+    HoodieFileFormat baseFileFormat = getBaseFileFormat(writeConfig, tableConfig);
+    if (baseFileFormat == HoodieFileFormat.LANCE || baseFileFormat == HoodieFileFormat.VORTEX) {
       return false;
     }
     return writeConfig.getWriteVersion().greaterThanOrEquals(HoodieTableVersion.TEN);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestCommonClientUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestCommonClientUtils.java
@@ -24,6 +24,8 @@ import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.util.CommonClientUtils;
@@ -116,14 +118,36 @@ class TestCommonClientUtils {
   }
 
   private static Stream<Arguments> provideWriteVersionNativeLogExpectations() {
-    // Native log format is the default for write version >= TEN, except for Lance base files.
+    // Native log format is the default for write version >= TEN, except for Lance and Vortex base files.
     return Stream.of(
         Arguments.of(HoodieTableVersion.SIX, HoodieFileFormat.PARQUET, false),
         Arguments.of(HoodieTableVersion.EIGHT, HoodieFileFormat.PARQUET, false),
         Arguments.of(HoodieTableVersion.NINE, HoodieFileFormat.PARQUET, false),
         Arguments.of(HoodieTableVersion.TEN, HoodieFileFormat.PARQUET, true),
         Arguments.of(HoodieTableVersion.TEN, HoodieFileFormat.ORC, true),
-        Arguments.of(HoodieTableVersion.TEN, HoodieFileFormat.LANCE, false)
+        Arguments.of(HoodieTableVersion.TEN, HoodieFileFormat.LANCE, false),
+        Arguments.of(HoodieTableVersion.TEN, HoodieFileFormat.VORTEX, false)
+    );
+  }
+
+  @ParameterizedTest(name = "Base file format {0} should use log block type {1}")
+  @MethodSource("provideLogBlockTypeExpectations")
+  void testGetLogBlockType(HoodieFileFormat baseFileFormat, HoodieLogBlock.HoodieLogBlockType expected) {
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    when(writeConfig.getLogDataBlockFormat()).thenReturn(Option.empty());
+    when(tableConfig.getBaseFileFormat()).thenReturn(baseFileFormat);
+
+    assertEquals(expected, CommonClientUtils.getLogBlockType(writeConfig, tableConfig));
+  }
+
+  private static Stream<Arguments> provideLogBlockTypeExpectations() {
+    return Stream.of(
+        Arguments.of(HoodieFileFormat.PARQUET, HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK),
+        Arguments.of(HoodieFileFormat.ORC, HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK),
+        Arguments.of(HoodieFileFormat.LANCE, HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK),
+        Arguments.of(HoodieFileFormat.VORTEX, HoodieLogBlock.HoodieLogBlockType.AVRO_DATA_BLOCK),
+        Arguments.of(HoodieFileFormat.HFILE, HoodieLogBlock.HoodieLogBlockType.HFILE_DATA_BLOCK)
     );
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileReaderFactory.java
@@ -99,6 +99,8 @@ public class HoodieFileReaderFactory {
         return newOrcFileReader(pathInfo.getPath());
       case LANCE:
         return newLanceFileReader(hoodieConfig, pathInfo.getPath());
+      case VORTEX:
+        return newVortexFileReader(hoodieConfig, pathInfo.getPath());
       default:
         throw new UnsupportedOperationException(format + " format not supported yet.");
     }

--- a/hudi-spark-datasource/hudi-spark/src/test/java-vortex/org/apache/hudi/io/storage/TestVortexReaderWriterRoundTrip.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java-vortex/org/apache/hudi/io/storage/TestVortexReaderWriterRoundTrip.java
@@ -20,10 +20,14 @@ package org.apache.hudi.io.storage;
 
 import org.apache.hudi.HoodieSchemaConversionUtils;
 import org.apache.hudi.client.SparkTaskContextSupplier;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.core.io.storage.HoodieFileReader;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 
@@ -135,6 +139,40 @@ public class TestVortexReaderWriterRoundTrip {
           count++;
         }
         assertEquals(3, count, "projected rows");
+      }
+    }
+  }
+
+  @Test
+  public void testFactoryStoragePathInfoDispatch() throws Exception {
+    SparkTaskContextSupplier taskContextSupplier = new SparkTaskContextSupplier();
+
+    StructType schema = new StructType().add("id", DataTypes.LongType, false);
+    StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/dispatch.vortex");
+    try (HoodieStorage storage = HoodieTestUtils.getStorage(tempDir.getAbsolutePath())) {
+      try (HoodieSparkVortexWriter writer = HoodieSparkVortexWriter.builder()
+          .file(path).sparkSchema(schema).instantTime("20251201120000000")
+          .taskContextSupplier(taskContextSupplier).storage(storage).populateMetaFields(false).build()) {
+        for (int i = 0; i < 3; i++) {
+          writer.writeRow(new GenericInternalRow(new Object[] {(long) i}));
+        }
+      }
+
+      // Read back through the StoragePathInfo factory overload so the VORTEX dispatch case
+      // (used by base-file readers that start from a listed StoragePathInfo) is covered.
+      try (HoodieFileReader<InternalRow> reader =
+               (HoodieFileReader<InternalRow>) new HoodieSparkFileReaderFactory(storage).getFileReader(
+                   ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER, storage.getPathInfo(path),
+                   HoodieFileFormat.VORTEX, Option.empty())) {
+        assertEquals(3, reader.getTotalRecords(), "row count via StoragePathInfo dispatch");
+        int count = 0;
+        try (ClosableIterator<HoodieRecord<InternalRow>> it = reader.getRecordIterator()) {
+          while (it.hasNext()) {
+            assertEquals(count, it.next().getData().getLong(0), "id at row " + count);
+            count++;
+          }
+        }
+        assertEquals(3, count, "rows read via StoragePathInfo dispatch");
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -185,8 +185,9 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
                                       sqlConf: SQLConf,
                                       options: Map[String, String],
                                       hadoopConf: Configuration): Option[SparkColumnarFileReader] = {
-    // Vortex requires Java 17 (vortex-jni ships Java 17 bytecode) and is wired only through the
-    // Spark 4.x adapters. Spark 3.5 runs on Java 11, where SparkVortexReaderBase is not compiled.
+    // The Vortex datasource reader is wired only through the Spark 4.x adapters. This adapter must
+    // stay compilable on the Java 11 Spark 3.5 CI builds, where SparkVortexReaderBase is excluded
+    // (vortex-jni ships Java 17 bytecode), so it cannot reference the class even on JDK 17.
     None
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

issue: #18623

Follow-up to the merged Vortex integration (#19182). A self-review of the merged code found two dispatch sites that miss the VORTEX case.

### Summary and Changelog

- Add the missing `VORTEX` case to `HoodieFileReaderFactory#getFileReader(HoodieConfig, StoragePathInfo, HoodieFileFormat, Option)`, matching the `StoragePath` overload and the existing `LANCE` handling. Without it, a caller that starts from a listed `StoragePathInfo` gets `UnsupportedOperationException: VORTEX format not supported yet` instead of the Vortex reader.
- Cover VORTEX in `CommonClientUtils`: `getLogBlockType` now maps VORTEX to `AVRO_DATA_BLOCK` (it previously fell to the default branch and threw `HoodieException: Base file format VORTEX does not have associated log block type`, breaking MOR log writes), and `shouldWriteNativeLogs` keeps VORTEX on the legacy inline log format like Lance until native log support for these formats is complete (it previously fell through to the write-version check and enabled the untested native-log path on table version 10).
- Tests: `TestVortexReaderWriterRoundTrip#testFactoryStoragePathInfoDispatch` covers the factory overload end to end; `TestCommonClientUtils` gains a `getLogBlockType` parameterized test and VORTEX rows in the native-log expectations.
- Clarify the `Spark3_5Adapter.createVortexFileReader` comment: the reason it returns `None` is that the adapter must stay compilable on the Java 11 Spark 3.5 CI builds where `SparkVortexReaderBase` is excluded, not the runtime JDK of Spark 3.5.

### Impact

Fixes VORTEX dispatch gaps: base-file reads through the `StoragePathInfo` overload and MOR log-block writes on Vortex tables. Existing formats are unchanged; VORTEX MOR tables use the same inline Avro log blocks as Lance.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
