### PR TITLE
refactor(io): extract shared Arrow writer base for Lance and Vortex

### DIFF
--- a/hudi-hadoop-common/src/main/java-vortex/org/apache/hudi/io/vortex/HoodieBaseVortexWriter.java
+++ b/hudi-hadoop-common/src/main/java-vortex/org/apache/hudi/io/vortex/HoodieBaseVortexWriter.java
@@ -21,27 +21,22 @@ package org.apache.hudi.io.vortex;
 
 import org.apache.hudi.common.avro.HoodieBloomFilterWriteSupport;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.io.memory.HoodieArrowAllocator;
+import org.apache.hudi.io.arrow.HoodieBaseArrowWriter;
 import org.apache.hudi.storage.StoragePath;
 
 import dev.vortex.api.Session;
 import dev.vortex.api.VortexWriter;
-import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -50,16 +45,16 @@ import java.util.Collections;
 /**
  * Base class for Hudi Vortex file writers supporting different record types.
  *
- * This class handles common Vortex file operations including:
+ * This class handles the Vortex-specific file operations:
  * - {@link VortexWriter} lifecycle management (vortex-jni {@code dev.vortex.api})
- * - BufferAllocator management
- * - Record buffering and batch flushing. Each flushed batch is exported through the Arrow C Data
- *   Interface and handed to {@link VortexWriter#writeBatch(long, long)}; because vortex copies the
- *   batch without invoking the C release callback, {@link ArrowArray#release()} is called after each
- *   write so the exported buffers are freed.
- * - File size checks
+ * - Writing flushed Arrow batches: each batch is exported through the Arrow C Data Interface and
+ *   handed to {@link VortexWriter#writeBatch(long, long)}; because vortex copies the batch without
+ *   invoking the C release callback, {@link ArrowArray#release()} is called after each write so
+ *   the exported buffers are freed.
  *
- * Subclasses must implement type-specific conversion to Arrow format and provide the Arrow schema.
+ * Record buffering, batch flushing, allocator management, and close ordering are inherited from
+ * {@link HoodieBaseArrowWriter}. Subclasses must implement type-specific conversion to Arrow
+ * format and provide the Arrow schema.
  *
  * <p>NOTE: vortex-jni 0.76.0 exposes no file-level custom-metadata API, so Hudi's bloom filter and
  * min/max record-key footers cannot be persisted into the Vortex file yet. Record keys are still
@@ -70,22 +65,9 @@ import java.util.Collections;
  */
 @Slf4j
 @NotThreadSafe
-public abstract class HoodieBaseVortexWriter<R, K extends Comparable<K>> implements Closeable {
-  protected static final int DEFAULT_BATCH_SIZE = 1000;
-  private final StoragePath path;
-  private final BufferAllocator allocator;
-  private final int batchSize;
-  private final long flushByteWatermark;
-  @Getter(value = AccessLevel.PROTECTED)
-  private long writtenRecordCount = 0;
-  private long totalFlushedDataSize = 0;
-  private int currentBatchSize = 0;
-  private VectorSchemaRoot root;
-  private ArrowWriter<R> arrowWriter;
-  protected final Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt;
-
+public abstract class HoodieBaseVortexWriter<R, K extends Comparable<K>> extends HoodieBaseArrowWriter<R, K> {
   // Held for the writer's lifetime. session/nativeAllocator back the native writer; nativeAllocator
-  // is a dedicated allocator isolated from the strict data allocator (see initializeWriter).
+  // is a dedicated allocator isolated from the strict data allocator (see initializeFormatWriter).
   private Session session;
   private VortexWriter writer;
   private BufferAllocator nativeAllocator;
@@ -104,191 +86,17 @@ public abstract class HoodieBaseVortexWriter<R, K extends Comparable<K>> impleme
    */
   protected HoodieBaseVortexWriter(StoragePath path, int batchSize, long allocatorSize, long flushByteWatermark,
                                    Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt) {
-    this.path = path;
-    this.allocator = HoodieArrowAllocator.newChildAllocator(
-        getClass().getSimpleName() + "-data-" + path.getName(), allocatorSize);
-    this.batchSize = batchSize;
-    this.flushByteWatermark = flushByteWatermark;
-    this.bloomFilterWriteSupportOpt = bloomFilterWriteSupportOpt;
+    super(path, batchSize, allocatorSize, flushByteWatermark, bloomFilterWriteSupportOpt);
   }
 
-  /**
-   * Create and initialize the arrow writer for writing records to VectorSchemaRoot.
-   * Called once during lazy initialization when the first record is written.
-   *
-   * @param root The VectorSchemaRoot to write into
-   * @return An arrow writer implementation that writes records of type R to the root
-   */
-  protected abstract ArrowWriter<R> createArrowWriter(VectorSchemaRoot root);
-
-  /**
-   * Get the Arrow schema for this writer. It is passed directly to {@link VortexWriter} and each
-   * written batch must conform to it.
-   *
-   * @return Arrow schema
-   */
-  protected abstract Schema getArrowSchema();
-
-  /**
-   * Write a single record. Records are buffered and flushed in batches.
-   *
-   * @param record Record to write
-   * @throws IOException if write fails
-   */
-  public void write(R record) throws IOException {
-    // Lazy initialization on first write
-    if (writer == null) {
-      initializeWriter();
-    }
-    if (root == null) {
-      root = VectorSchemaRoot.create(getArrowSchema(), allocator);
-    }
-    if (arrowWriter == null) {
-      arrowWriter = createArrowWriter(root);
-    }
-
-    // Reset arrow writer at the start of each new batch
-    if (currentBatchSize == 0) {
-      arrowWriter.reset();
-    }
-
-    arrowWriter.write(record);
-    currentBatchSize++;
-    writtenRecordCount++;
-
-    // Flush when row-count batch is full OR in-flight Arrow buffers cross the byte watermark.
-    if (currentBatchSize >= batchSize || currentBufferBytes() >= flushByteWatermark) {
-      flushBatch();
-    }
-  }
-
-  /**
-   * Bytes currently held by the writer's Arrow child allocator.
-   */
-  private long currentBufferBytes() {
-    return allocator.getAllocatedMemory();
-  }
-
-  /**
-   * Close the writer, flushing any remaining buffered records.
-   *
-   * @throws IOException if close fails
-   */
   @Override
-  public void close() throws IOException {
-    Exception primaryException = null;
-
-    // 1. Flush remaining records
-    try {
-      if (currentBatchSize > 0) {
-        flushBatch();
-      }
-
-      // Ensure the file is created even if no data was written, by emitting a single empty batch.
-      if (writer == null) {
-        initializeWriter();
-        try (VectorSchemaRoot emptyRoot = VectorSchemaRoot.create(getArrowSchema(), allocator)) {
-          emptyRoot.setRowCount(0);
-          writeBatchFfi(emptyRoot);
-        }
-      }
-    } catch (Exception e) {
-      primaryException = e;
-    }
-
-    // Close Vortex writer (finalizes the file)
-    if (writer != null) {
-      try {
-        writer.close();
-      } catch (Exception e) {
-        primaryException = addSuppressed(primaryException, e);
-      }
-    }
-
-    // Close the exported schema handle.
-    if (exportedSchema != null) {
-      try {
-        exportedSchema.release();
-        exportedSchema.close();
-      } catch (Exception e) {
-        primaryException = addSuppressed(primaryException, e);
-      }
-    }
-
-    // Close VectorSchemaRoot
-    if (root != null) {
-      try {
-        root.close();
-      } catch (Exception e) {
-        primaryException = addSuppressed(primaryException, e);
-      }
-    }
-
-    // Close the strict data allocator (per-batch exports are released, so this should be clean).
-    try {
-      allocator.close();
-    } catch (Exception e) {
-      primaryException = addSuppressed(primaryException, e);
-    }
-
-    // Close the native allocator last. vortex-jni 0.76.0's VortexWriter.create exports the file
-    // schema into this allocator and relies on GC/Cleaner-based cleanup rather than freeing it on
-    // close(), so a small one-time amount can still be outstanding here; tolerate it (it is freed
-    // when the native writer is reclaimed) rather than failing the whole write.
-    // TODO(#18623): drop this once vortex-jni frees the create() schema export on writer close.
-    if (nativeAllocator != null) {
-      try {
-        nativeAllocator.close();
-      } catch (IllegalStateException e) {
-        log.warn("Vortex native allocator retained memory at close for {} (vortex-jni create() "
-            + "schema export, reclaimed on GC): {}", path, e.getMessage());
-      }
-    }
-
-    if (primaryException != null) {
-      throw new HoodieException("Failed to close Vortex writer: " + path, primaryException);
-    }
+  protected String getFormatName() {
+    return "Vortex";
   }
 
-  private static Exception addSuppressed(Exception primary, Exception e) {
-    if (primary == null) {
-      return e;
-    }
-    primary.addSuppressed(e);
-    return primary;
-  }
-
-  /**
-   * Returns the estimated data size in bytes, including both flushed batches and the current
-   * in-progress batch.
-   */
-  protected long getDataSize() {
-    long currentBufferSize = currentBatchSize > 0 ? allocator.getAllocatedMemory() : 0;
-    return totalFlushedDataSize + currentBufferSize;
-  }
-
-  /**
-   * Flush buffered records to Vortex file.
-   */
-  private void flushBatch() throws IOException {
-    if (currentBatchSize == 0) {
-      return;
-    }
-
-    arrowWriter.finishBatch();
-
-    for (FieldVector vector : root.getFieldVectors()) {
-      totalFlushedDataSize += vector.getBufferSize();
-    }
-
-    writeBatchFfi(root);
-
-    // Release Arrow buffers so capacity does not accumulate across batches.
-    root.close();
-    root = null;
-    arrowWriter = null;
-
-    currentBatchSize = 0;
+  @Override
+  protected boolean isFormatWriterInitialized() {
+    return writer != null;
   }
 
   /**
@@ -296,7 +104,9 @@ public abstract class HoodieBaseVortexWriter<R, K extends Comparable<K>> impleme
    * file. The array is exported from the strict data allocator and released after the write (vortex
    * copies the batch but does not invoke the C release callback), so no data-allocator memory leaks.
    */
-  private void writeBatchFfi(VectorSchemaRoot batch) throws IOException {
+  @Override
+  protected void writeBatch(VectorSchemaRoot batch) throws IOException {
+    BufferAllocator allocator = getAllocator();
     try (ArrowArray cArray = ArrowArray.allocateNew(allocator)) {
       Data.exportVectorSchemaRoot(allocator, batch, null, cArray);
       writer.writeBatch(cArray.memoryAddress(), exportedSchemaAddr);
@@ -309,14 +119,55 @@ public abstract class HoodieBaseVortexWriter<R, K extends Comparable<K>> impleme
    * use a dedicated {@link #nativeAllocator} so the native side's non-deterministic cleanup does
    * not pollute the strict per-batch data allocator.
    */
-  private void initializeWriter() throws IOException {
+  @Override
+  protected void initializeFormatWriter() throws IOException {
     session = Session.create();
     nativeAllocator = new RootAllocator();
     Schema arrowSchema = getArrowSchema();
-    writer = VortexWriter.create(session, toVortexUri(path), arrowSchema, Collections.emptyMap(), nativeAllocator);
+    writer = VortexWriter.create(session, toVortexUri(getPath()), arrowSchema, Collections.emptyMap(), nativeAllocator);
     exportedSchema = ArrowSchema.allocateNew(nativeAllocator);
     Data.exportSchema(nativeAllocator, arrowSchema, null, exportedSchema);
     exportedSchemaAddr = exportedSchema.memoryAddress();
+  }
+
+  /**
+   * Close the Vortex writer (finalizes the file).
+   */
+  @Override
+  protected void closeFormatWriter() throws IOException {
+    if (writer != null) {
+      writer.close();
+    }
+  }
+
+  /**
+   * Close the exported schema handle.
+   */
+  @Override
+  protected void closeFormatResources() throws Exception {
+    if (exportedSchema != null) {
+      exportedSchema.release();
+      exportedSchema.close();
+    }
+  }
+
+  /**
+   * Close the native allocator last. vortex-jni 0.76.0's VortexWriter.create exports the file
+   * schema into this allocator and relies on GC/Cleaner-based cleanup rather than freeing it on
+   * close(), so a small one-time amount can still be outstanding here; tolerate it (it is freed
+   * when the native writer is reclaimed) rather than failing the whole write.
+   * TODO(#18623): drop this once vortex-jni frees the create() schema export on writer close.
+   */
+  @Override
+  protected void closeAfterAllocator() {
+    if (nativeAllocator != null) {
+      try {
+        nativeAllocator.close();
+      } catch (IllegalStateException e) {
+        log.warn("Vortex native allocator retained memory at close for {} (vortex-jni create() "
+            + "schema export, reclaimed on GC): {}", getPath(), e.getMessage());
+      }
+    }
   }
 
   /**
@@ -329,17 +180,5 @@ public abstract class HoodieBaseVortexWriter<R, K extends Comparable<K>> impleme
       return new File(uri.getPath()).toURI().toString();
     }
     return uri.toString();
-  }
-
-  /**
-   * Arrow writer interface for writing records of type T to a VectorSchemaRoot.
-   * @param <T> the record type
-   */
-  protected interface ArrowWriter<T> {
-    void write(T row) throws IOException;
-
-    void finishBatch() throws IOException;
-
-    void reset();
   }
 }

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/arrow/HoodieBaseArrowWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/arrow/HoodieBaseArrowWriter.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.io.arrow;
+
+import org.apache.hudi.common.avro.HoodieBloomFilterWriteSupport;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.io.memory.HoodieArrowAllocator;
+import org.apache.hudi.storage.StoragePath;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Base class for Hudi file writers of Arrow-native formats (e.g. Lance, Vortex) supporting
+ * different record types.
+ *
+ * This class handles the format-independent parts of writing an Arrow-batched file:
+ * - BufferAllocator management
+ * - Record buffering into a {@link VectorSchemaRoot} and batch flushing
+ * - File size checks
+ * - Record key tracking for bloom filter / min-max metadata
+ * - Empty-file handling and close ordering
+ *
+ * Format subclasses (Lance, Vortex, ...) implement the hooks that create the native format
+ * writer, hand each flushed batch to it, and close it; engine subclasses (Spark, Flink, ...)
+ * implement the type-specific conversion to Arrow format and provide the Arrow schema.
+ *
+ * @param <R> The record type (e.g., GenericRecord, InternalRow)
+ * @param <K> The record key type used for bloom filter tracking
+ */
+@NotThreadSafe
+public abstract class HoodieBaseArrowWriter<R, K extends Comparable<K>> implements Closeable {
+  protected static final int DEFAULT_BATCH_SIZE = 1000;
+  @Getter(value = AccessLevel.PROTECTED)
+  private final StoragePath path;
+  @Getter(value = AccessLevel.PROTECTED)
+  private final BufferAllocator allocator;
+  private final int batchSize;
+  private final long flushByteWatermark;
+  @Getter(value = AccessLevel.PROTECTED)
+  private long writtenRecordCount = 0;
+  private long totalFlushedDataSize = 0;
+  private int currentBatchSize = 0;
+  private VectorSchemaRoot root;
+  private ArrowWriter<R> arrowWriter;
+  protected final Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt;
+
+  /**
+   * Constructor for base Arrow-format writer.
+   *
+   * @param path Path where the file will be written
+   * @param batchSize Row-count threshold; the current batch is flushed when this many records have been buffered
+   * @param allocatorSize Maximum bytes the per-writer Arrow child allocator may hold at once; sized so Arrow's
+   *                      power-of-2 buffer doubling never requests a chunk above this cap
+   * @param flushByteWatermark Byte-size threshold; the current batch is flushed when the sum of in-flight
+   *                           FieldVector buffer sizes reaches this value. Must be small enough that the next
+   *                           doubling step stays below {@code allocatorSize}.
+   * @param bloomFilterWriteSupportOpt Optional bloom filter write support for record key tracking
+   */
+  protected HoodieBaseArrowWriter(StoragePath path, int batchSize, long allocatorSize, long flushByteWatermark,
+                                  Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt) {
+    this.path = path;
+    this.allocator = HoodieArrowAllocator.newChildAllocator(
+        getClass().getSimpleName() + "-data-" + path.getName(), allocatorSize);
+    this.batchSize = batchSize;
+    this.flushByteWatermark = flushByteWatermark;
+    this.bloomFilterWriteSupportOpt = bloomFilterWriteSupportOpt;
+  }
+
+  /**
+   * Create and initialize the arrow writer for writing records to VectorSchemaRoot.
+   * Called once during lazy initialization when the first record is written.
+   *
+   * @param root The VectorSchemaRoot to write into
+   * @return An arrow writer implementation that writes records of type R to the root
+   */
+  protected abstract ArrowWriter<R> createArrowWriter(VectorSchemaRoot root);
+
+  /**
+   * Get the Arrow schema for this writer.
+   * Subclasses must provide the Arrow schema corresponding to their record type; each written
+   * batch must conform to it.
+   *
+   * @return Arrow schema
+   */
+  protected abstract Schema getArrowSchema();
+
+  /**
+   * The format name (e.g. "Lance", "Vortex") used in error messages.
+   */
+  protected abstract String getFormatName();
+
+  /**
+   * Whether the native format writer has been initialized. Used as the lazy-initialization
+   * sentinel: {@link #initializeFormatWriter()} is invoked on the first write (or on close for
+   * an empty file) only while this returns false.
+   */
+  protected abstract boolean isFormatWriterInitialized();
+
+  /**
+   * Create the native format writer (lazy initialization).
+   */
+  protected abstract void initializeFormatWriter() throws IOException;
+
+  /**
+   * Write one finished batch to the native format writer.
+   *
+   * @param batch The VectorSchemaRoot holding the batch; row count is already set
+   */
+  protected abstract void writeBatch(VectorSchemaRoot batch) throws IOException;
+
+  /**
+   * Close the native format writer, finalizing the file. Called unconditionally during
+   * {@link #close()}; implementations must no-op when the writer was never initialized.
+   */
+  protected abstract void closeFormatWriter() throws Exception;
+
+  /**
+   * Subclass hook invoked once during {@link #close()}, after remaining records are flushed and
+   * empty-file handling, before the format writer closes. Formats that support file-level
+   * key-value metadata persist footer entries (bloom filter, min/max keys, ...) here.
+   * Default implementation does nothing.
+   */
+  protected void finalizeFooterMetadata() throws IOException {
+  }
+
+  /**
+   * Subclass hook for closing format-specific resources that must be released after the format
+   * writer closes but before the Arrow data buffers are freed. Called unconditionally during
+   * {@link #close()} in its own try/catch, so failures here are recorded alongside (not instead
+   * of) other close failures. Default implementation does nothing.
+   */
+  protected void closeFormatResources() throws Exception {
+  }
+
+  /**
+   * Subclass hook for cleanup that must run after the data allocator has closed (e.g. a
+   * dedicated native-side allocator). Called last during {@link #close()}; exceptions thrown
+   * here propagate directly, so implementations should catch what they intend to tolerate.
+   * Default implementation does nothing.
+   */
+  protected void closeAfterAllocator() {
+  }
+
+  /**
+   * Write a single record. Records are buffered and flushed in batches.
+   *
+   * @param record Record to write
+   * @throws IOException if write fails
+   */
+  public void write(R record) throws IOException {
+    // Lazy initialization on first write
+    if (!isFormatWriterInitialized()) {
+      initializeFormatWriter();
+    }
+    if (root == null) {
+      root = VectorSchemaRoot.create(getArrowSchema(), allocator);
+    }
+    if (arrowWriter == null) {
+      arrowWriter = createArrowWriter(root);
+    }
+
+    // Reset arrow writer at the start of each new batch
+    if (currentBatchSize == 0) {
+      arrowWriter.reset();
+    }
+
+    arrowWriter.write(record);
+    currentBatchSize++;
+    writtenRecordCount++;
+
+    // Flush when row-count batch is full OR in-flight Arrow buffers cross the byte watermark.
+    // The byte-based check bounds in-flight memory so Arrow's power-of-2 vector reallocation
+    // can't escalate to a chunk size above the allocator cap regardless of per-row payload.
+    if (currentBatchSize >= batchSize || currentBufferBytes() >= flushByteWatermark) {
+      flushBatch();
+    }
+  }
+
+  /**
+   * Bytes currently held by the writer's Arrow child allocator. Used to drive the byte-aware
+   * flush.
+   *
+   * <p>Note: we deliberately do <em>not</em> use {@code FieldVector.getBufferSize()} here.
+   * For variable-width vectors (e.g. {@code BaseLargeVariableWidthVector} backing BLOB columns)
+   * that method short-circuits to 0 when {@code valueCount == 0}, and {@code valueCount} is only
+   * set during {@link ArrowWriter#finishBatch()} — i.e. at flush time. Mid-batch it always
+   * reports zero, so a watermark driven by it never fires. {@link BufferAllocator#getAllocatedMemory()}
+   * tracks the underlying ArrowBuf capacities directly and is exactly the quantity the allocator
+   * cap is enforced against.
+   */
+  private long currentBufferBytes() {
+    return allocator.getAllocatedMemory();
+  }
+
+  /**
+   * Close the writer, flushing any remaining buffered records.
+   *
+   * @throws IOException if close fails
+   */
+  @Override
+  public void close() throws IOException {
+    Exception primaryException = null;
+
+    // 1. Flush remaining records
+    try {
+      // Flush any remaining records in current batch
+      if (currentBatchSize > 0) {
+        flushBatch();
+      }
+
+      // Ensure writer is initialized even if no data was written
+      // This creates an empty file with just schema metadata
+      if (!isFormatWriterInitialized() && root == null) {
+        initializeFormatWriter();
+        root = VectorSchemaRoot.create(getArrowSchema(), allocator);
+        root.setRowCount(0);
+        writeBatch(root);
+      }
+
+      // Persist footer key-value metadata (bloom filter, min/max keys, ...) for formats
+      // that support it, before the format writer closes.
+      finalizeFooterMetadata();
+    } catch (Exception e) {
+      primaryException = e;
+    }
+
+    // Close the format writer (finalizes the file)
+    try {
+      closeFormatWriter();
+    } catch (Exception e) {
+      primaryException = addSuppressed(primaryException, e);
+    }
+
+    // Close format-specific resources that must be released before the Arrow buffers
+    try {
+      closeFormatResources();
+    } catch (Exception e) {
+      primaryException = addSuppressed(primaryException, e);
+    }
+
+    // Close VectorSchemaRoot
+    if (root != null) {
+      try {
+        root.close();
+      } catch (Exception e) {
+        primaryException = addSuppressed(primaryException, e);
+      }
+    }
+
+    // Always close allocator
+    try {
+      allocator.close();
+    } catch (Exception e) {
+      primaryException = addSuppressed(primaryException, e);
+    }
+
+    // Format-specific cleanup that must run after the data allocator closes
+    closeAfterAllocator();
+
+    if (primaryException != null) {
+      throw new HoodieException("Failed to close " + getFormatName() + " writer: " + path, primaryException);
+    }
+  }
+
+  private static Exception addSuppressed(Exception primary, Exception e) {
+    if (primary == null) {
+      return e;
+    }
+    primary.addSuppressed(e);
+    return primary;
+  }
+
+  /**
+   * Returns the estimated data size in bytes, including both flushed batches and the current
+   * in-progress batch. The in-progress portion uses {@link BufferAllocator#getAllocatedMemory()}
+   * — see {@link #currentBufferBytes()} for why per-vector {@code getBufferSize()} is unreliable
+   * mid-batch. This may slightly overestimate due to Arrow's pre-allocation overhead.
+   */
+  protected long getDataSize() {
+    long currentBufferSize = currentBatchSize > 0 ? allocator.getAllocatedMemory() : 0;
+    return totalFlushedDataSize + currentBufferSize;
+  }
+
+  /**
+   * Flush buffered records to the file.
+   */
+  private void flushBatch() throws IOException {
+    if (currentBatchSize == 0) {
+      return;  // Nothing to flush
+    }
+
+    // Finalize the arrow writer (sets row count on VectorSchemaRoot)
+    arrowWriter.finishBatch();
+
+    // Accumulate the uncompressed Arrow buffer sizes for this batch
+    for (FieldVector vector : root.getFieldVectors()) {
+      totalFlushedDataSize += vector.getBufferSize();
+    }
+
+    // Write VectorSchemaRoot to the file
+    writeBatch(root);
+
+    // Release Arrow buffers so capacity does not accumulate across batches.
+    // Arrow's BaseVariableWidthVector grows by doubling and never shrinks on its own;
+    // without releasing, a vector that doubled to 128MB on one batch would attempt
+    // to double to 256MB on the next, with the old 128MB still held — exceeding the
+    // allocator cap. Closing root here ensures each batch starts from the small
+    // initial capacity, so the watermark-bounded growth within a batch is the only
+    // memory the cap has to accommodate.
+    root.close();
+    root = null;
+    arrowWriter = null;
+
+    // Reset batch counter for next batch
+    currentBatchSize = 0;
+  }
+
+  /**
+   * Arrow writer interface for writing records of type T to a VectorSchemaRoot.
+   * Each engine can provide its own implementation for converting records from the engine specific format to Arrow format.
+   * @param <T> the record type
+   */
+  protected interface ArrowWriter<T> {
+    /**
+     * Write a single record to the VectorSchemaRoot.
+     * @param row Record to write
+     * @throws IOException if write fails
+     */
+    void write(T row) throws IOException;
+
+    /**
+     * Finalize the current batch including setting row count on VectorSchemaRoot.
+     * @throws IOException if finalization fails
+     */
+    void finishBatch() throws IOException;
+
+    /**
+     * Reset the writer state for a new batch.
+     */
+    void reset();
+  }
+}

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
@@ -21,21 +21,14 @@ package org.apache.hudi.io.lance;
 
 import org.apache.hudi.common.avro.HoodieBloomFilterWriteSupport;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.io.memory.HoodieArrowAllocator;
+import org.apache.hudi.io.arrow.HoodieBaseArrowWriter;
 import org.apache.hudi.storage.StoragePath;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.types.pojo.Schema;
 import org.lance.file.LanceFileWriter;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,31 +38,19 @@ import java.util.Map;
 /**
  * Base class for Hudi Lance file writers supporting different record types.
  *
- * This class handles common Lance file operations including:
- * - LanceFileWriter lifecycle management
- * - BufferAllocator management
- * - Record buffering and batch flushing
- * - File size checks
- * - Bloom filter metadata writing
+ * This class handles the Lance-specific file operations:
+ * - {@link LanceFileWriter} lifecycle management
+ * - Writing flushed Arrow batches through the Lance native writer API
+ * - Bloom filter and footer metadata writing
  *
- * Subclasses must implement type-specific conversion to Arrow format.
+ * Record buffering, batch flushing, allocator management, and close ordering are inherited from
+ * {@link HoodieBaseArrowWriter}. Subclasses must implement type-specific conversion to Arrow
+ * format.
  *
  * @param <R> The record type (e.g., GenericRecord, InternalRow)
  */
 @NotThreadSafe
-public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implements Closeable {
-  protected static final int DEFAULT_BATCH_SIZE = 1000;
-  private final StoragePath path;
-  private final BufferAllocator allocator;
-  private final int batchSize;
-  private final long flushByteWatermark;
-  @Getter(value = AccessLevel.PROTECTED)
-  private long writtenRecordCount = 0;
-  private long totalFlushedDataSize = 0;
-  private int currentBatchSize = 0;
-  private VectorSchemaRoot root;
-  private ArrowWriter<R> arrowWriter;
-  protected final Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt;
+public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> extends HoodieBaseArrowWriter<R, K> {
   private final Map<String, String> footerMetadata = new LinkedHashMap<>();
 
   private LanceFileWriter writer;
@@ -88,30 +69,8 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
    */
   protected HoodieBaseLanceWriter(StoragePath path, int batchSize, long allocatorSize, long flushByteWatermark,
                                   Option<HoodieBloomFilterWriteSupport<K>> bloomFilterWriteSupportOpt) {
-    this.path = path;
-    this.allocator = HoodieArrowAllocator.newChildAllocator(
-        getClass().getSimpleName() + "-data-" + path.getName(), allocatorSize);
-    this.batchSize = batchSize;
-    this.flushByteWatermark = flushByteWatermark;
-    this.bloomFilterWriteSupportOpt = bloomFilterWriteSupportOpt;
+    super(path, batchSize, allocatorSize, flushByteWatermark, bloomFilterWriteSupportOpt);
   }
-
-  /**
-   * Create and initialize the arrow writer for writing records to VectorSchemaRoot.
-   * Called once during lazy initialization when the first record is written.
-   *
-   * @param root The VectorSchemaRoot to write into
-   * @return An arrow writer implementation that writes records of type R to the root
-   */
-  protected abstract ArrowWriter<R> createArrowWriter(VectorSchemaRoot root);
-
-  /**
-   * Get the Arrow schema for this writer.
-   * Subclasses must provide the Arrow schema corresponding to their record type.
-   *
-   * @return Arrow schema
-   */
-  protected abstract Schema getArrowSchema();
 
   /**
    * Subclass hook for emitting additional Lance file-footer key-value metadata
@@ -140,223 +99,63 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
     }
   }
 
-  /**
-   * Write a single record. Records are buffered and flushed in batches.
-   *
-   * @param record Record to write
-   * @throws IOException if write fails
-   */
-  public void write(R record) throws IOException {
-    // Lazy initialization on first write
-    if (writer == null) {
-      initializeWriter();
-    }
-    if (root == null) {
-      root = VectorSchemaRoot.create(getArrowSchema(), allocator);
-    }
-    if (arrowWriter == null) {
-      arrowWriter = createArrowWriter(root);
-    }
-
-    // Reset arrow writer at the start of each new batch
-    if (currentBatchSize == 0) {
-      arrowWriter.reset();
-    }
-
-    arrowWriter.write(record);
-    currentBatchSize++;
-    writtenRecordCount++;
-
-    // Flush when row-count batch is full OR in-flight Arrow buffers cross the byte watermark.
-    // The byte-based check bounds in-flight memory so Arrow's power-of-2 vector reallocation
-    // can't escalate to a chunk size above the allocator cap regardless of per-row payload.
-    if (currentBatchSize >= batchSize || currentBufferBytes() >= flushByteWatermark) {
-      flushBatch();
-    }
-  }
-
-  /**
-   * Bytes currently held by the writer's Arrow child allocator. Used to drive the byte-aware
-   * flush.
-   *
-   * <p>Note: we deliberately do <em>not</em> use {@code FieldVector.getBufferSize()} here.
-   * For variable-width vectors (e.g. {@code BaseLargeVariableWidthVector} backing BLOB columns)
-   * that method short-circuits to 0 when {@code valueCount == 0}, and {@code valueCount} is only
-   * set during {@link ArrowWriter#finishBatch()} — i.e. at flush time. Mid-batch it always
-   * reports zero, so a watermark driven by it never fires. {@link BufferAllocator#getAllocatedMemory()}
-   * tracks the underlying ArrowBuf capacities directly and is exactly the quantity the allocator
-   * cap is enforced against.
-   */
-  private long currentBufferBytes() {
-    return allocator.getAllocatedMemory();
-  }
-
-  /**
-   * Close the writer, flushing any remaining buffered records.
-   *
-   * @throws IOException if close fails
-   */
   @Override
-  public void close() throws IOException {
-    Exception primaryException = null;
-
-    // 1. Flush remaining records
-    try {
-      // Flush any remaining records in current batch
-      if (currentBatchSize > 0) {
-        flushBatch();
-      }
-
-      // Ensure writer is initialized even if no data was written
-      // This creates an empty Lance file with just schema metadata
-      if (writer == null && root == null) {
-        initializeWriter();
-        root = VectorSchemaRoot.create(getArrowSchema(), allocator);
-        root.setRowCount(0);
-        writer.write(root);
-      }
-
-      if (writer != null) {
-        // Finalize and write bloom filter metadata
-        if (bloomFilterWriteSupportOpt.isPresent()) {
-          Map<String, String> metadata = bloomFilterWriteSupportOpt.get().finalizeMetadata();
-          if (!metadata.isEmpty()) {
-            writer.addSchemaMetadata(metadata);
-          }
-        }
-
-        // Allow subclasses to contribute additional footer key-value metadata
-        // (e.g. Spark writer emits `hoodie.vector.columns` for forward-compat read).
-        // Called unconditionally; returns an empty map when no VECTOR columns are present.
-        Map<String, String> extra = additionalSchemaMetadata();
-        if (extra != null && !extra.isEmpty()) {
-          writer.addSchemaMetadata(extra);
-        }
-
-        if (!footerMetadata.isEmpty()) {
-          writer.addSchemaMetadata(new HashMap<>(footerMetadata));
-        }
-      }
-    } catch (Exception e) {
-      primaryException = e;
-    }
-
-    // Close Lance writer
-    if (writer != null) {
-      try {
-        writer.close();
-      } catch (Exception e) {
-        if (primaryException == null) {
-          primaryException = e;
-        } else {
-          primaryException.addSuppressed(e);
-        }
-      }
-    }
-
-    // Close VectorSchemaRoot
-    if (root != null) {
-      try {
-        root.close();
-      } catch (Exception e) {
-        if (primaryException == null) {
-          primaryException = e;
-        } else {
-          primaryException.addSuppressed(e);
-        }
-      }
-    }
-
-    // Always close allocator
-    try {
-      allocator.close();
-    } catch (Exception e) {
-      if (primaryException == null) {
-        primaryException = e;
-      } else {
-        primaryException.addSuppressed(e);
-      }
-    }
-
-    if (primaryException != null) {
-      throw new HoodieException("Failed to close Lance writer: " + path, primaryException);
-    }
+  protected String getFormatName() {
+    return "Lance";
   }
 
-  /**
-   * Returns the estimated data size in bytes, including both flushed batches and the current
-   * in-progress batch. The in-progress portion uses {@link BufferAllocator#getAllocatedMemory()}
-   * — see {@link #currentBufferBytes()} for why per-vector {@code getBufferSize()} is unreliable
-   * mid-batch. This may slightly overestimate due to Arrow's pre-allocation overhead.
-   */
-  protected long getDataSize() {
-    long currentBufferSize = currentBatchSize > 0 ? allocator.getAllocatedMemory() : 0;
-    return totalFlushedDataSize + currentBufferSize;
-  }
-
-  /**
-   * Flush buffered records to Lance file.
-   */
-  private void flushBatch() throws IOException {
-    if (currentBatchSize == 0) {
-      return;  // Nothing to flush
-    }
-
-    // Finalize the arrow writer (sets row count on VectorSchemaRoot)
-    arrowWriter.finishBatch();
-
-    // Accumulate the uncompressed Arrow buffer sizes for this batch
-    for (FieldVector vector : root.getFieldVectors()) {
-      totalFlushedDataSize += vector.getBufferSize();
-    }
-
-    // Write VectorSchemaRoot to Lance file
-    writer.write(root);
-
-    // Release Arrow buffers so capacity does not accumulate across batches.
-    // Arrow's BaseVariableWidthVector grows by doubling and never shrinks on its own;
-    // without releasing, a vector that doubled to 128MB on one batch would attempt
-    // to double to 256MB on the next, with the old 128MB still held — exceeding the
-    // allocator cap. Closing root here ensures each batch starts from the small
-    // initial capacity, so the watermark-bounded growth within a batch is the only
-    // memory the cap has to accommodate.
-    root.close();
-    root = null;
-    arrowWriter = null;
-
-    // Reset batch counter for next batch
-    currentBatchSize = 0;
+  @Override
+  protected boolean isFormatWriterInitialized() {
+    return writer != null;
   }
 
   /**
    * Initialize LanceFileWriter (lazy initialization).
    */
-  private void initializeWriter() throws IOException {
-    writer = LanceFileWriter.open(path.toString(), allocator, null);
+  @Override
+  protected void initializeFormatWriter() throws IOException {
+    writer = LanceFileWriter.open(getPath().toString(), getAllocator(), null);
+  }
+
+  @Override
+  protected void writeBatch(VectorSchemaRoot batch) throws IOException {
+    writer.write(batch);
   }
 
   /**
-   * Arrow writer interface for writing records of type T to a VectorSchemaRoot.
-   * Each engine can provide its own implementation for converting records from the engine specific format to Arrow format.
-   * @param <T> the record type
+   * Finalize and write bloom filter and footer metadata before the Lance writer closes.
    */
-  protected interface ArrowWriter<T> {
-    /**
-     * Write a single record to the VectorSchemaRoot.
-     * @param row Record to write
-     * @throws IOException if write fails
-     */
-    void write(T row) throws IOException;
+  @Override
+  protected void finalizeFooterMetadata() throws IOException {
+    if (writer == null) {
+      return;
+    }
 
-    /**
-     * Finalize the current batch including setting row count on VectorSchemaRoot.
-     * @throws IOException if finalization fails
-     */
-    void finishBatch() throws IOException;
+    // Finalize and write bloom filter metadata
+    if (bloomFilterWriteSupportOpt.isPresent()) {
+      Map<String, String> metadata = bloomFilterWriteSupportOpt.get().finalizeMetadata();
+      if (!metadata.isEmpty()) {
+        writer.addSchemaMetadata(metadata);
+      }
+    }
 
-    /**
-     * Reset the writer state for a new batch.
-     */
-    void reset();
+    // Allow subclasses to contribute additional footer key-value metadata
+    // (e.g. Spark writer emits `hoodie.vector.columns` for forward-compat read).
+    // Called unconditionally; returns an empty map when no VECTOR columns are present.
+    Map<String, String> extra = additionalSchemaMetadata();
+    if (extra != null && !extra.isEmpty()) {
+      writer.addSchemaMetadata(extra);
+    }
+
+    if (!footerMetadata.isEmpty()) {
+      writer.addSchemaMetadata(new HashMap<>(footerMetadata));
+    }
+  }
+
+  @Override
+  protected void closeFormatWriter() throws Exception {
+    if (writer != null) {
+      writer.close();
+    }
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Lance and Vortex base writers duplicate ~85-90% of their structure (Arrow buffering, dual flush triggers, allocator lifecycle, bloom filter support, empty-file close handling): 362 and 345 lines that must be maintained in lockstep. This PR extracts the shared boilerplate so the next Arrow-native format only implements its FFI-specific hooks. Writer-side only; reader-side extraction is a follow-up.

### Summary and Changelog

- Add abstract `HoodieBaseArrowWriter` (`org.apache.hudi.io.arrow`, hudi-hadoop-common, ungated): owns the Arrow child-allocator lifecycle, `VectorSchemaRoot` management, row buffering, the dual flush trigger (row-count batch size or byte watermark), bloom-filter and min/max key support, `getDataSize`, empty-file-on-close handling, and close ordering with exception suppression. Imports only Arrow and Hudi types (no `dev.vortex`, no Lance native types), so it compiles on the Java 8 target.
- `HoodieBaseLanceWriter` shrinks 362 to 161 lines and `HoodieBaseVortexWriter` 345 to 184, each keeping only format-specific hooks (Lance native writer calls; Vortex C Data Interface export and the dedicated native allocator with its tolerated one-time schema-export retention). The Vortex writer stays in the JDK-17-gated source root.
- Format hooks: `initializeFormatWriter`, `writeBatch`, `closeFormatWriter`, `getFormatName`, `isFormatWriterInitialized`, plus optional `finalizeFooterMetadata` (Lance footer), `closeFormatResources`, and `closeAfterAllocator` (Vortex native allocator).
- No public or protected API changes: constructors, `addFooterMetadata`, `getWrittenRecordCount`, `getDataSize` are intact, the Spark/Flink subclasses are unmodified, and the reflective `HoodieSparkVortexWriter.newWriter` factory contract is untouched.

### Impact

Behavior-preserving deduplication of the Arrow writer path. Validated: Lance tests (TestLanceDataSource 61, TestHoodieSparkLanceWriter 23, TestHoodieSparkLanceReader 16) and the Vortex round-trip (2) all pass on JDK 17; the Java 11 Spark chain and Flink client compile; checkstyle clean.

### Risk Level

medium: touches the write path of two formats, mitigated by the full Lance and Vortex test runs above and an adversarial equivalence review of flush triggers, close ordering, and allocator lifecycle.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
