### PR TITLE
refactor(core): consolidate per-format dispatch in file reader and writer factories

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileReaderFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileReaderFactory.java
@@ -30,10 +30,7 @@ import org.apache.hudi.storage.StoragePathInfo;
 import java.io.IOException;
 
 import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
-import static org.apache.hudi.common.model.HoodieFileFormat.LANCE;
-import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
-import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
-import static org.apache.hudi.common.model.HoodieFileFormat.VORTEX;
+import static org.apache.hudi.common.model.HoodieFileFormat.HOODIE_LOG;
 
 /**
  * Factory methods to create Hudi file reader.
@@ -41,28 +38,14 @@ import static org.apache.hudi.common.model.HoodieFileFormat.VORTEX;
 public class HoodieFileReaderFactory {
 
   protected final HoodieStorage storage;
+
   public HoodieFileReaderFactory(HoodieStorage storage) {
     this.storage = storage;
   }
 
   public HoodieFileReader getFileReader(HoodieConfig hoodieConfig, StoragePath path) throws IOException {
     final String extension = FSUtils.getFileExtension(path.toString());
-    if (PARQUET.getFileExtension().equals(extension)) {
-      return getFileReader(hoodieConfig, path, PARQUET, Option.empty());
-    }
-    if (HFILE.getFileExtension().equals(extension)) {
-      return getFileReader(hoodieConfig, path, HFILE, Option.empty());
-    }
-    if (ORC.getFileExtension().equals(extension)) {
-      return getFileReader(hoodieConfig, path, ORC, Option.empty());
-    }
-    if (LANCE.getFileExtension().equals(extension)) {
-      return getFileReader(hoodieConfig, path, LANCE, Option.empty());
-    }
-    if (VORTEX.getFileExtension().equals(extension)) {
-      return getFileReader(hoodieConfig, path, VORTEX, Option.empty());
-    }
-    throw new UnsupportedOperationException(extension + " format not supported yet.");
+    return getFileReader(hoodieConfig, path, getFormatByFileExtension(extension), Option.empty());
   }
 
   public HoodieFileReader getFileReader(HoodieConfig hoodieConfig, StoragePath path, HoodieFileFormat format)
@@ -72,6 +55,49 @@ public class HoodieFileReaderFactory {
 
   public HoodieFileReader getFileReader(HoodieConfig hoodieConfig, StoragePath path, HoodieFileFormat format,
                                         Option<HoodieSchema> schemaOption) throws IOException {
+    return newReaderByFormat(hoodieConfig, format, path, schemaOption);
+  }
+
+  public HoodieFileReader getFileReader(HoodieConfig hoodieConfig, StoragePathInfo pathInfo, HoodieFileFormat format,
+                                        Option<HoodieSchema> schemaOption) throws IOException {
+    if (format == HFILE) {
+      // The HFile reader can leverage the file size available in StoragePathInfo,
+      // so dispatch to the StoragePathInfo-specific hook instead of the path-based one.
+      return newHFileFileReader(hoodieConfig, pathInfo, schemaOption);
+    }
+    return newReaderByFormat(hoodieConfig, format, pathInfo.getPath(), schemaOption);
+  }
+
+  public HoodieFileReader getContentReader(HoodieConfig hoodieConfig, StoragePath path, HoodieFileFormat format,
+                                           HoodieStorage storage, byte[] content,
+                                           Option<HoodieSchema> schemaOption) throws IOException {
+    switch (format) {
+      case HFILE:
+        return newHFileFileReader(hoodieConfig, path, storage, content, schemaOption);
+      default:
+        throw new UnsupportedOperationException(format + " format not supported yet.");
+    }
+  }
+
+  /**
+   * Single dispatch point mapping a {@link HoodieFileFormat} to the corresponding reader creation hook.
+   *
+   * <p>Support for a new file format must be added HERE, and only here, by adding a case that calls
+   * the corresponding {@code newXxxFileReader} hook; every {@code getFileReader} overload funnels
+   * through this switch. The only format-specific dispatch outside this method is the
+   * {@link #newHFileFileReader(HoodieConfig, StoragePathInfo, Option)} hook invoked from
+   * {@link #getFileReader(HoodieConfig, StoragePathInfo, HoodieFileFormat, Option)}, which exists
+   * because the HFile reader can leverage the file size in {@link StoragePathInfo}.
+   *
+   * @param hoodieConfig Hudi configs.
+   * @param format       the base file format to create a reader for.
+   * @param path         the file path.
+   * @param schemaOption schema to read the file with, if present.
+   * @return a new file reader for the given format.
+   * @throws IOException upon reader creation error.
+   */
+  private HoodieFileReader newReaderByFormat(HoodieConfig hoodieConfig, HoodieFileFormat format, StoragePath path,
+                                             Option<HoodieSchema> schemaOption) throws IOException {
     switch (format) {
       case PARQUET:
         return newParquetFileReader(path);
@@ -88,31 +114,20 @@ public class HoodieFileReaderFactory {
     }
   }
 
-  public HoodieFileReader getFileReader(HoodieConfig hoodieConfig, StoragePathInfo pathInfo, HoodieFileFormat format,
-                                        Option<HoodieSchema> schemaOption) throws IOException {
-    switch (format) {
-      case PARQUET:
-        return newParquetFileReader(pathInfo.getPath());
-      case HFILE:
-        return newHFileFileReader(hoodieConfig, pathInfo, schemaOption);
-      case ORC:
-        return newOrcFileReader(pathInfo.getPath());
-      case LANCE:
-        return newLanceFileReader(hoodieConfig, pathInfo.getPath());
-      default:
-        throw new UnsupportedOperationException(format + " format not supported yet.");
+  /**
+   * Maps a base file extension to its {@link HoodieFileFormat}. This mapping is format-agnostic,
+   * so new formats do not require any change here.
+   *
+   * @param extension the file extension including the leading dot, e.g. ".parquet".
+   * @return the matching base file format.
+   */
+  private static HoodieFileFormat getFormatByFileExtension(String extension) {
+    for (HoodieFileFormat format : HoodieFileFormat.values()) {
+      if (format != HOODIE_LOG && format.getFileExtension().equals(extension)) {
+        return format;
+      }
     }
-  }
-
-  public HoodieFileReader getContentReader(HoodieConfig hoodieConfig, StoragePath path, HoodieFileFormat format,
-                                           HoodieStorage storage, byte[] content,
-                                           Option<HoodieSchema> schemaOption) throws IOException {
-    switch (format) {
-      case HFILE:
-        return newHFileFileReader(hoodieConfig, path, storage, content, schemaOption);
-      default:
-        throw new UnsupportedOperationException(format + " format not supported yet.");
-    }
+    throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
 
   protected HoodieFileReader newParquetFileReader(StoragePath path) {

--- a/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/core/io/storage/HoodieFileWriterFactory.java
@@ -33,11 +33,7 @@ import org.apache.hudi.storage.StoragePath;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
-import static org.apache.hudi.common.model.HoodieFileFormat.LANCE;
-import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
-import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
-import static org.apache.hudi.common.model.HoodieFileFormat.VORTEX;
+import static org.apache.hudi.common.model.HoodieFileFormat.HOODIE_LOG;
 
 public class HoodieFileWriterFactory {
   protected final HoodieStorage storage;
@@ -64,22 +60,8 @@ public class HoodieFileWriterFactory {
   protected <T, I, K, O> HoodieFileWriter getFileWriterByFormat(
       String extension, String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier) throws IOException {
-    if (PARQUET.getFileExtension().equals(extension)) {
-      return newParquetFileWriter(instantTime, path, config, schema, taskContextSupplier);
-    }
-    if (HFILE.getFileExtension().equals(extension)) {
-      return newHFileFileWriter(instantTime, path, config, schema, taskContextSupplier);
-    }
-    if (ORC.getFileExtension().equals(extension)) {
-      return newOrcFileWriter(instantTime, path, config, schema, taskContextSupplier);
-    }
-    if (LANCE.getFileExtension().equals(extension)) {
-      return newLanceFileWriter(instantTime, path, config, schema, taskContextSupplier);
-    }
-    if (VORTEX.getFileExtension().equals(extension)) {
-      return newVortexFileWriter(instantTime, path, config, schema, taskContextSupplier);
-    }
-    throw new UnsupportedOperationException(extension + " format not supported yet.");
+    return newWriterByFormat(getFormatByFileExtension(extension), instantTime, path, config, schema,
+        taskContextSupplier);
   }
 
   protected <T, I, K, O> HoodieFileWriter getFileWriterByFormat(HoodieFileFormat format, OutputStream outputStream,
@@ -90,6 +72,58 @@ public class HoodieFileWriterFactory {
       default:
         throw new UnsupportedOperationException(format + " format not supported yet.");
     }
+  }
+
+  /**
+   * Single dispatch point mapping a {@link HoodieFileFormat} to the corresponding writer creation hook.
+   *
+   * <p>Support for a new file format must be added HERE, and only here, by adding a case that calls
+   * the corresponding {@code newXxxFileWriter} hook; the path-based {@code getFileWriter} entry
+   * points funnel through this switch. The only dispatch outside this method is the
+   * {@link OutputStream}-based entry point, which only supports Parquet.
+   *
+   * @param format              the base file format to create a writer for.
+   * @param instantTime         instant time of the write.
+   * @param path                the file path.
+   * @param config              Hudi configs.
+   * @param schema              schema to write the file with.
+   * @param taskContextSupplier task context supplier.
+   * @return a new file writer for the given format.
+   * @throws IOException upon writer creation error.
+   */
+  private HoodieFileWriter newWriterByFormat(
+      HoodieFileFormat format, String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
+      TaskContextSupplier taskContextSupplier) throws IOException {
+    switch (format) {
+      case PARQUET:
+        return newParquetFileWriter(instantTime, path, config, schema, taskContextSupplier);
+      case HFILE:
+        return newHFileFileWriter(instantTime, path, config, schema, taskContextSupplier);
+      case ORC:
+        return newOrcFileWriter(instantTime, path, config, schema, taskContextSupplier);
+      case LANCE:
+        return newLanceFileWriter(instantTime, path, config, schema, taskContextSupplier);
+      case VORTEX:
+        return newVortexFileWriter(instantTime, path, config, schema, taskContextSupplier);
+      default:
+        throw new UnsupportedOperationException(format + " format not supported yet.");
+    }
+  }
+
+  /**
+   * Maps a base file extension to its {@link HoodieFileFormat}. This mapping is format-agnostic,
+   * so new formats do not require any change here.
+   *
+   * @param extension the file extension including the leading dot, e.g. ".parquet".
+   * @return the matching base file format.
+   */
+  private static HoodieFileFormat getFormatByFileExtension(String extension) {
+    for (HoodieFileFormat format : HoodieFileFormat.values()) {
+      if (format != HOODIE_LOG && format.getFileExtension().equals(extension)) {
+        return format;
+      }
+    }
+    throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
 
   protected HoodieFileWriter newParquetFileWriter(

--- a/hudi-common/src/test/java/org/apache/hudi/core/io/storage/TestHoodieFileReaderFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/core/io/storage/TestHoodieFileReaderFactory.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.core.io.storage;
+
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the format dispatch in {@link HoodieFileReaderFactory}, in particular that the
+ * {@link StoragePath} and {@link StoragePathInfo} entry points agree for every
+ * {@link HoodieFileFormat} value.
+ */
+class TestHoodieFileReaderFactory {
+
+  private static final HoodieConfig CONFIG = new HoodieConfig();
+
+  private enum ReaderHook {
+    PARQUET_PATH, HFILE_PATH, HFILE_PATH_INFO, ORC_PATH, LANCE_PATH, VORTEX_PATH
+  }
+
+  /**
+   * Overrides every reader creation hook to record which hook the factory dispatched to.
+   */
+  private static class TrackingFileReaderFactory extends HoodieFileReaderFactory {
+    private ReaderHook lastHook;
+    private StoragePath lastPath;
+
+    TrackingFileReaderFactory() {
+      super(mock(HoodieStorage.class));
+    }
+
+    private HoodieFileReader track(ReaderHook hook, StoragePath path) {
+      this.lastHook = hook;
+      this.lastPath = path;
+      return mock(HoodieFileReader.class);
+    }
+
+    @Override
+    protected HoodieFileReader newParquetFileReader(StoragePath path) {
+      return track(ReaderHook.PARQUET_PATH, path);
+    }
+
+    @Override
+    protected HoodieFileReader newHFileFileReader(HoodieConfig hoodieConfig, StoragePath path,
+                                                  Option<HoodieSchema> schemaOption) {
+      return track(ReaderHook.HFILE_PATH, path);
+    }
+
+    @Override
+    protected HoodieFileReader newHFileFileReader(HoodieConfig hoodieConfig, StoragePathInfo pathInfo,
+                                                  Option<HoodieSchema> schemaOption) {
+      return track(ReaderHook.HFILE_PATH_INFO, pathInfo.getPath());
+    }
+
+    @Override
+    protected HoodieFileReader newOrcFileReader(StoragePath path) {
+      return track(ReaderHook.ORC_PATH, path);
+    }
+
+    @Override
+    protected HoodieFileReader newLanceFileReader(HoodieConfig hoodieConfig, StoragePath path) {
+      return track(ReaderHook.LANCE_PATH, path);
+    }
+
+    @Override
+    protected HoodieFileReader newVortexFileReader(HoodieConfig hoodieConfig, StoragePath path) {
+      return track(ReaderHook.VORTEX_PATH, path);
+    }
+  }
+
+  private static ReaderHook expectedPathHook(HoodieFileFormat format) {
+    switch (format) {
+      case PARQUET:
+        return ReaderHook.PARQUET_PATH;
+      case HFILE:
+        return ReaderHook.HFILE_PATH;
+      case ORC:
+        return ReaderHook.ORC_PATH;
+      case LANCE:
+        return ReaderHook.LANCE_PATH;
+      case VORTEX:
+        return ReaderHook.VORTEX_PATH;
+      default:
+        throw new IllegalArgumentException("Unexpected format: " + format);
+    }
+  }
+
+  private static StoragePath filePath(HoodieFileFormat format) {
+    return new StoragePath("/partition/path/f1_1-0-1_000" + format.getFileExtension());
+  }
+
+  private static StoragePathInfo pathInfo(StoragePath path) {
+    return new StoragePathInfo(path, 100, false, (short) 0, 0, 0);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = HoodieFileFormat.class, names = {"HOODIE_LOG"}, mode = EnumSource.Mode.EXCLUDE)
+  void storagePathAndPathInfoEntryPointsAgree(HoodieFileFormat format) throws IOException {
+    StoragePath path = filePath(format);
+
+    TrackingFileReaderFactory pathFactory = new TrackingFileReaderFactory();
+    pathFactory.getFileReader(CONFIG, path, format, Option.empty());
+
+    TrackingFileReaderFactory pathInfoFactory = new TrackingFileReaderFactory();
+    pathInfoFactory.getFileReader(CONFIG, pathInfo(path), format, Option.empty());
+
+    assertEquals(expectedPathHook(format), pathFactory.lastHook);
+    // HFILE dispatches to the StoragePathInfo-specific hook; all other formats
+    // must dispatch to the same hook from both entry points.
+    ReaderHook expectedPathInfoHook =
+        format == HoodieFileFormat.HFILE ? ReaderHook.HFILE_PATH_INFO : expectedPathHook(format);
+    assertEquals(expectedPathInfoHook, pathInfoFactory.lastHook);
+    assertEquals(path, pathFactory.lastPath);
+    assertEquals(path, pathInfoFactory.lastPath);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = HoodieFileFormat.class, names = {"HOODIE_LOG"}, mode = EnumSource.Mode.EXCLUDE)
+  void extensionEntryPointDispatchesToFormatHook(HoodieFileFormat format) throws IOException {
+    TrackingFileReaderFactory factory = new TrackingFileReaderFactory();
+    factory.getFileReader(CONFIG, filePath(format));
+    assertEquals(expectedPathHook(format), factory.lastHook);
+  }
+
+  @Test
+  void logFormatThrowsForBothEntryPoints() {
+    StoragePath path = filePath(HoodieFileFormat.HOODIE_LOG);
+    TrackingFileReaderFactory factory = new TrackingFileReaderFactory();
+
+    Throwable viaPath = assertThrows(UnsupportedOperationException.class,
+        () -> factory.getFileReader(CONFIG, path, HoodieFileFormat.HOODIE_LOG, Option.empty()));
+    Throwable viaPathInfo = assertThrows(UnsupportedOperationException.class,
+        () -> factory.getFileReader(CONFIG, pathInfo(path), HoodieFileFormat.HOODIE_LOG, Option.empty()));
+    assertEquals("HOODIE_LOG format not supported yet.", viaPath.getMessage());
+    assertEquals(viaPath.getMessage(), viaPathInfo.getMessage());
+  }
+
+  @Test
+  void unsupportedExtensionThrows() {
+    TrackingFileReaderFactory factory = new TrackingFileReaderFactory();
+
+    Throwable unknown = assertThrows(UnsupportedOperationException.class,
+        () -> factory.getFileReader(CONFIG, new StoragePath("/partition/path/f1_1-0-1_000.xyz")));
+    assertEquals(".xyz format not supported yet.", unknown.getMessage());
+
+    Throwable logExtension = assertThrows(UnsupportedOperationException.class,
+        () -> factory.getFileReader(CONFIG, new StoragePath("/partition/path/f1_1-0-1_000.log")));
+    assertEquals(".log format not supported yet.", logExtension.getMessage());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/core/io/storage/TestHoodieFileWriterFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/core/io/storage/TestHoodieFileWriterFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.core.io.storage;
+
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the format dispatch in {@link HoodieFileWriterFactory}, asserting the extension-based
+ * entry point dispatches to the writer creation hook of the matching {@link HoodieFileFormat}.
+ */
+class TestHoodieFileWriterFactory {
+
+  private static final HoodieConfig CONFIG = new HoodieConfig();
+  private static final String INSTANT_TIME = "001";
+
+  private enum WriterHook {
+    PARQUET, HFILE, ORC, LANCE, VORTEX
+  }
+
+  /**
+   * Overrides every path-based writer creation hook to record which hook the factory dispatched to.
+   */
+  private static class TrackingFileWriterFactory extends HoodieFileWriterFactory {
+    private WriterHook lastHook;
+    private StoragePath lastPath;
+
+    TrackingFileWriterFactory() {
+      super(mock(HoodieStorage.class));
+    }
+
+    private HoodieFileWriter track(WriterHook hook, StoragePath path) {
+      this.lastHook = hook;
+      this.lastPath = path;
+      return mock(HoodieFileWriter.class);
+    }
+
+    @Override
+    protected HoodieFileWriter newParquetFileWriter(String instantTime, StoragePath path, HoodieConfig config,
+                                                    HoodieSchema schema, TaskContextSupplier taskContextSupplier) {
+      return track(WriterHook.PARQUET, path);
+    }
+
+    @Override
+    protected HoodieFileWriter newHFileFileWriter(String instantTime, StoragePath path, HoodieConfig config,
+                                                  HoodieSchema schema, TaskContextSupplier taskContextSupplier) {
+      return track(WriterHook.HFILE, path);
+    }
+
+    @Override
+    protected HoodieFileWriter newOrcFileWriter(String instantTime, StoragePath path, HoodieConfig config,
+                                                HoodieSchema schema, TaskContextSupplier taskContextSupplier) {
+      return track(WriterHook.ORC, path);
+    }
+
+    @Override
+    protected HoodieFileWriter newLanceFileWriter(String instantTime, StoragePath path, HoodieConfig config,
+                                                  HoodieSchema schema, TaskContextSupplier taskContextSupplier) {
+      return track(WriterHook.LANCE, path);
+    }
+
+    @Override
+    protected HoodieFileWriter newVortexFileWriter(String instantTime, StoragePath path, HoodieConfig config,
+                                                   HoodieSchema schema, TaskContextSupplier taskContextSupplier) {
+      return track(WriterHook.VORTEX, path);
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = HoodieFileFormat.class, names = {"HOODIE_LOG"}, mode = EnumSource.Mode.EXCLUDE)
+  void extensionEntryPointDispatchesToFormatHook(HoodieFileFormat format) throws IOException {
+    StoragePath path = new StoragePath("/partition/path/f1_1-0-1_000" + format.getFileExtension());
+    TrackingFileWriterFactory factory = new TrackingFileWriterFactory();
+    factory.getFileWriterByFormat(format.getFileExtension(), INSTANT_TIME, path, CONFIG, null, null);
+    assertEquals(WriterHook.valueOf(format.name()), factory.lastHook);
+    assertEquals(path, factory.lastPath);
+  }
+
+  @Test
+  void unsupportedExtensionThrows() {
+    TrackingFileWriterFactory factory = new TrackingFileWriterFactory();
+    StoragePath path = new StoragePath("/partition/path/f1_1-0-1_000.xyz");
+
+    Throwable unknown = assertThrows(UnsupportedOperationException.class,
+        () -> factory.getFileWriterByFormat(".xyz", INSTANT_TIME, path, CONFIG, null, null));
+    assertEquals(".xyz format not supported yet.", unknown.getMessage());
+
+    Throwable logExtension = assertThrows(UnsupportedOperationException.class,
+        () -> factory.getFileWriterByFormat(".log", INSTANT_TIME, path, CONFIG, null, null));
+    assertEquals(".log format not supported yet.", logExtension.getMessage());
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`HoodieFileReaderFactory` and `HoodieFileWriterFactory` each contain multiple independent per-format dispatch sites (extension if-chains plus one switch per overload). Adding a format means editing several switches, and missing one ships a latent bug: that happened twice with VORTEX (the `StoragePathInfo` reader overload and the log-block-type selection, see #19252). This PR makes that bug class structurally impossible inside the two factories.

### Summary and Changelog

- `HoodieFileReaderFactory`: a single private `newReaderByFormat` switch now backs every entry point. The extension entry maps the extension to a `HoodieFileFormat` via a format-agnostic helper (loops the enum, so new formats need zero edits there) and delegates. The `StoragePathInfo` overload dispatches HFILE to its `StoragePathInfo`-specific hook (overridden by engine factories to exploit the known file size) and normalizes every other format through the shared switch.
- `HoodieFileWriterFactory`: same treatment; the `OutputStream`-based parquet-only entry is preserved verbatim.
- All public and protected signatures unchanged; engine factories (Avro, Spark, Flink, Trino plugin) override only the per-format hooks, which are untouched.
- New `TestHoodieFileReaderFactory` and `TestHoodieFileWriterFactory` assert, for every `HoodieFileFormat` value, that all entry points dispatch to the same hook, plus exact error messages for unknown extensions and unsupported formats.

### Impact

One switch to edit per factory when adding a format. Single behavioral delta: `getFileReader(config, StoragePathInfo, VORTEX, schema)` now dispatches to the Vortex reader instead of throwing; this overlaps the same fix in #19252, and whichever lands second rebases trivially.

### Risk Level

low: behavior verified equivalent by exhaustive entry-point-by-format comparison and the new tests; the Vortex round-trip (Spark engine factory + reflection path) and existing factory tests pass, and the Java 11 Spark chain compiles.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
