### PR TITLE
fix(ci): let validate-source's RAT check fail on unlicensed files outside Maven modules

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -84,15 +84,20 @@ jobs:
       # directory create_source_directory.sh produces - the same way validate_staged_release.sh
       # runs them inside an extracted source tarball. On the raw checkout they would see the
       # images under rfc/, docker/images/ and hudi-notebooks/, which the source release excludes.
+      #
+      # Stage the copy outside the workspace. `mvn apache-rat:check` in the RAT check step scans
+      # the filesystem from the repository root, so a copy of the tree left inside the workspace
+      # gets scanned too, and every root-anchored exclude in the root pom (such as
+      # `hudi-trino-plugin/**`) silently stops applying to it.
       - name: Create source release directory
-        run: ./scripts/release/create_source_directory.sh hudi-tmp-repo
+        run: ./scripts/release/create_source_directory.sh "${{ runner.temp }}/hudi-tmp-repo"
       - name: Check Binary Files
         run: |
-          cd hudi-tmp-repo
+          cd "${{ runner.temp }}/hudi-tmp-repo"
           ./scripts/release/validate_source_binary_files.sh
       - name: Check Copyright
         run: |
-          cd hudi-tmp-repo
+          cd "${{ runner.temp }}/hudi-tmp-repo"
           ./scripts/release/validate_source_copyright.sh
       - name: RAT check
         run: ./scripts/release/validate_source_rat.sh

--- a/pom.xml
+++ b/pom.xml
@@ -707,9 +707,7 @@
               <!-- local files not in version control -->
               <exclude>**/*.iml</exclude>
               <exclude>.mvn/**</exclude>
-              <!-- Match at any depth: the source-release checks copy the tree into a scratch
-                   directory, and a root-anchored pattern would not exclude the copy. -->
-              <exclude>**/hudi-trino-plugin/**</exclude>
+              <exclude>hudi-trino-plugin/**</exclude>
             </excludes>
           </configuration>
           <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -707,7 +707,9 @@
               <!-- local files not in version control -->
               <exclude>**/*.iml</exclude>
               <exclude>.mvn/**</exclude>
-              <exclude>hudi-trino-plugin/**</exclude>
+              <!-- Match at any depth: the source-release checks copy the tree into a scratch
+                   directory, and a root-anchored pattern would not exclude the copy. -->
+              <exclude>**/hudi-trino-plugin/**</exclude>
             </excludes>
           </configuration>
           <executions>

--- a/rfc/rfc-99/variant-appendix.md
+++ b/rfc/rfc-99/variant-appendix.md
@@ -1,3 +1,19 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 ### Spark 4.0 Write & Shredding Verification
 
 Spark 4.0 successfully writes VariantType in both Shredded and Unshredded modes.

--- a/rfc/rfc-99/vector-appendix.md
+++ b/rfc/rfc-99/vector-appendix.md
@@ -1,3 +1,19 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 The main implementation change would require replacing the Avro schema references with the new type system.
 
 

--- a/scripts/release/validate_source_rat.sh
+++ b/scripts/release/validate_source_rat.sh
@@ -20,5 +20,11 @@
 #
 
 echo "Running RAT Check"
-(bash -c "mvn apache-rat:check -DdeployArtifacts=true") || (echo -e "\t\t Rat Check Failed. [ERROR]\n\t\t Please run with --verbose to get details\n" && exit 1)
+# The failure branch must not run in a subshell: `... || ( ... && exit 1 )` exits the
+# subshell, not this script, so the check used to report the error and then fall through
+# to the success message and return 0.
+if ! mvn apache-rat:check -DdeployArtifacts=true; then
+  echo -e "\t\t Rat Check Failed. [ERROR]\n\t\t See the RAT report at target/rat.txt for the offending files\n"
+  exit 1
+fi
 echo -e "\t\tRAT Check Passed [OK]\n"


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19274

Inside a Maven module, RAT works. It is declared in the `<build><plugins>` of ~55 module poms and bound to the `compile` phase, so an ordinary build job does fail on a missing ASF header (verified: a header-less `.java` under `hudi-io/src/main/java/` makes `mvn -pl hudi-io compile` exit 1).

Outside a module there is no working gate. Each of those RAT runs is scoped to its own module's `basedir`, and the root aggregator does not declare the plugin in `<build><plugins>`, so the only run that ever scans the repository root is the direct `mvn apache-rat:check` goal invocation - and that lives in exactly one place, `scripts/release/validate_source_rat.sh`, which always exits 0 no matter what RAT reports (verified: a header-less file at the root is missed by `mvn -pl hudi-io compile` and caught by `mvn apache-rat:check`). So `rfc/`, `scripts/`, `docker/`, the root-level files, and any new non-Maven top-level directory are effectively unchecked.

**The failure does not propagate.** The script is `(mvn apache-rat:check) || (echo "Rat Check Failed. [ERROR]" && exit 1)` followed by the success message. The `exit 1` runs in a `( ... )` subshell, so it exits the subshell rather than the script, and with no `set -e` control falls straight through to `RAT Check Passed [OK]` and a 0 exit status. On current master the `validate-source` job prints `BUILD FAILURE`, then `Too many files with unapproved license: 19`, then `Rat Check Failed. [ERROR]`, then `RAT Check Passed [OK]`, and the job is green.

**17 of those 19 violations are phantom, because the job asks RAT to scan a copy of the tree.** `apache-rat:check` is a filesystem scan rooted at the repository root, and the preceding `Check Copyright` step runs `create_source_directory.sh hudi-tmp-repo`, which rsyncs the whole tree into `hudi-tmp-repo/` inside the workspace. RAT therefore audits the real tree and the copy. Nothing in the root pom's exclude list applies to the copy the way it does to the original: every root-anchored exclude (`hudi-trino-plugin/**` among them) silently stops matching once the same directory sits one level deeper. All 17 phantom entries are `hudi-tmp-repo/hudi-trino-plugin/...` test resources. On a plain checkout the count is exactly 2.

**The remaining 2 are real.** `rfc/rfc-99/variant-appendix.md` and `rfc/rfc-99/vector-appendix.md` carry no ASF header. They are the only 2 of the 54 `rfc/**/*.md` files without one, and being outside any Maven module, nothing has ever flagged them.

Found while fixing #19266, which is the same class of silently-inert guard in the sibling binary-file check in the same job.

### Summary and Changelog

The license gate for everything outside a Maven module can now actually fail CI, and it no longer reports violations that do not exist.

- `scripts/release/validate_source_rat.sh`: replace the subshell failure branch with `if ! mvn apache-rat:check ...; then ... exit 1; fi`, so a RAT failure fails the script. The error message now points at `target/rat.txt`, which lists the offending files, instead of suggesting a `--verbose` flag this script does not accept.
- `.github/workflows/bot.yml`: stage the source-directory copy in `${{ runner.temp }}` instead of inside the workspace, so the `RAT check` step scans the repository and not a duplicate of it. The release path already works this way: `validate_staged_release.sh` untars the source release, `cd`s into it and runs the same RAT script there, with no nested copy in sight. No RAT exclude needs to change, and license coverage of the real tree is exactly what it is on master.
- `rfc/rfc-99/variant-appendix.md`, `rfc/rfc-99/vector-appendix.md`: add the ASF header, copied verbatim from the sibling `rfc/rfc-99/rfc-99.md`.

Verified locally:

| Scenario | master's script | This PR |
| --- | --- | --- |
| Plain checkout | RAT fails with 2 unapproved -> **exit 0, `RAT Check Passed [OK]`** | 0 unapproved -> exit 0 |
| CI job sequence, copy staged by the copyright step | RAT fails with 19 unapproved -> **exit 0, `RAT Check Passed [OK]`** | copy lands outside the workspace, RAT reports 0 unapproved -> exit 0 |
| Header-less file planted at the repository root | RAT fails with 1 unapproved -> **exit 0, `RAT Check Passed [OK]`** | **exit 1**, `Rat Check Failed. [ERROR]` |
| Header-less file planted inside a Maven module | already caught by `mvn compile` (exit 1) | unchanged, still caught |

The copyright check itself is unaffected by the move: it is invoked from inside the copy, which still contains `scripts/`, and it passes on a pristine export of this branch.

### Impact

CI and release tooling only. No runtime, public API, config, storage format or user-facing change.

The `validate-source` job becomes able to go red on a missing ASF header outside a Maven module, which is its purpose. It passes on this branch because the only two genuine violations in the tree are fixed here.

### Risk Level

low

Confined to one release-validation script, the location of a scratch copy in one CI job, and two RFC markdown files. The root pom is untouched, so RAT's exclude list and the compile-phase RAT executions in the module poms behave exactly as they do on master. `mvn apache-rat:check` reports `Unapproved: 0` on this branch, and the `Check Copyright` step still runs against the same pruned copy of the tree, only from `${{ runner.temp }}` rather than from a subdirectory of the workspace.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
