### PR TITLE
fix(debezium): keep Postgres toasted columns on MOR read (v6/v8)

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/PostgresDebeziumAvroPayload.java
@@ -29,7 +29,6 @@ import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.Properties;
 
 import static org.apache.hudi.common.util.StringUtils.fromUTF8Bytes;
@@ -83,7 +82,7 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
     Option<IndexedRecord> insertOrDeleteRecord = super.combineAndGetUpdateValue(currentValue, schema, properties);
 
     if (insertOrDeleteRecord.isPresent()) {
-      mergeToastedValuesIfPresent(insertOrDeleteRecord.get(), currentValue);
+      return Option.of(mergeToastedValuesIfPresent(insertOrDeleteRecord.get(), currentValue));
     }
     return insertOrDeleteRecord;
   }
@@ -96,22 +95,31 @@ public class PostgresDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
     Option<IndexedRecord> insertOrDeleteRecord = super.combineAndGetUpdateValue(currentValue, schema);
 
     if (insertOrDeleteRecord.isPresent()) {
-      mergeToastedValuesIfPresent(insertOrDeleteRecord.get(), currentValue);
+      return Option.of(mergeToastedValuesIfPresent(insertOrDeleteRecord.get(), currentValue));
     }
     return insertOrDeleteRecord;
   }
 
-  private void mergeToastedValuesIfPresent(IndexedRecord incomingRecord, IndexedRecord currentRecord) {
-    List<Schema.Field> fields = incomingRecord.getSchema().getFields();
-
-    fields.forEach(field -> {
+  /**
+   * Fills any TOASTed sentinel columns in {@code incomingRecord} with the value from
+   * {@code currentRecord}. Returns a NEW record when a fill occurs, so a caller (e.g. the record
+   * merger) does not mistake the result for the unchanged incoming record and discard the fill;
+   * returns {@code incomingRecord} unchanged when there is nothing to fill.
+   */
+  private IndexedRecord mergeToastedValuesIfPresent(IndexedRecord incomingRecord, IndexedRecord currentRecord) {
+    GenericData.Record filled = null;
+    for (Schema.Field field : incomingRecord.getSchema().getFields()) {
       // There are only four avro data types that have unconstrained sizes, which are
       // NON-NULLABLE STRING, NULLABLE STRING, NON-NULLABLE BYTES, NULLABLE BYTES
       if (((GenericRecord) incomingRecord).get(field.name()) != null
           && (containsStringToastedValues(incomingRecord, field) || containsBytesToastedValues(incomingRecord, field))) {
-        ((GenericRecord) incomingRecord).put(field.name(), ((GenericData.Record) currentRecord).get(field.name()));
+        if (filled == null) {
+          filled = new GenericData.Record((GenericData.Record) incomingRecord, false);
+        }
+        filled.put(field.name(), ((GenericData.Record) currentRecord).get(field.name()));
       }
-    });
+    }
+    return filled != null ? filled : incomingRecord;
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDebeziumToastedValue.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDebeziumToastedValue.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.DataSourceWriteOptions.{OPERATION, ORDERING_FIELDS, RECORDKEY_FIELD, TABLE_TYPE}
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.model.debezium.{DebeziumConstants, PostgresDebeziumAvroPayload}
+import org.apache.hudi.common.table.HoodieTableMetaClient
+import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * Functional test for [[PostgresDebeziumAvroPayload]]'s toasted / unavailable-value handling on a
+ * Merge-on-Read table.
+ *
+ * Postgres TOAST semantics: when a Debezium UPDATE cannot capture a large STRING/BYTES column that
+ * did not change, it ships the sentinel [[PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE]]
+ * (`__debezium_unavailable_value`) for that column. When the base file and delta log are merged at
+ * read time, such columns must KEEP the prior (base) value rather than be overwritten with the
+ * sentinel.
+ *
+ * Covers table versions 6, 8 and 9.
+ */
+class TestDebeziumToastedValue extends SparkClientFunctionalTestHarness {
+
+  private val sentinel = PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE
+  private val columns = Seq(
+    "id",
+    "name",
+    "city",
+    DebeziumConstants.FLATTENED_OP_COL_NAME,
+    DebeziumConstants.FLATTENED_LSN_COL_NAME)
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("6", "8", "9"))
+  def testToastedColumnKeepsPriorValueOnRead(tableVersion: String): Unit = {
+    val opts = Map(
+      HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> classOf[PostgresDebeziumAvroPayload].getName,
+      HoodieMetadataConfig.ENABLE.key() -> "false",
+      // Preserve the table version across writes: disable auto-upgrade and pin the write version so
+      // a later write cannot migrate the table to a newer version mid-test.
+      HoodieWriteConfig.AUTO_UPGRADE_VERSION.key() -> "false",
+      HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> tableVersion)
+
+    // 1. Base records at LSN 10.
+    val base = Seq(
+      (1, "alice", "NYC", "c", 10L),
+      (2, "bob", "LA", "c", 10L))
+    spark.createDataFrame(base).toDF(columns: _*).write.format("hudi")
+      .option(RECORDKEY_FIELD.key(), "id")
+      .option(ORDERING_FIELDS.key(), DebeziumConstants.FLATTENED_LSN_COL_NAME)
+      .option(TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name())
+      .option(DataSourceWriteOptions.TABLE_NAME.key(), "toasted_table")
+      .option(OPERATION.key(), DataSourceWriteOptions.BULK_INSERT_OPERATION_OPT_VAL)
+      .option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false")
+      .options(opts)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    // 2. Newer log records at LSN 20, each carrying the toasted sentinel in one column:
+    //    id=1 -> name updated, `city` toasted (must keep base "NYC")
+    //    id=2 -> name toasted (must keep base "bob"), `city` updated
+    val update = Seq(
+      (1, "alice2", sentinel, "u", 20L),
+      (2, sentinel, "SF", "u", 20L))
+    spark.createDataFrame(update).toDF(columns: _*).write.format("hudi")
+      .option(OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false")
+      .options(opts)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    // Sanity: the table is at the requested version.
+    val metaClient = HoodieTableMetaClient.builder()
+      .setBasePath(basePath)
+      .setConf(storageConf())
+      .build()
+    assertEquals(tableVersion.toInt, metaClient.getTableConfig.getTableVersion.versionCode())
+
+    // 3. Snapshot read merges base + log; sentinel columns must retain the prior base value.
+    val rows = spark.read.format("hudi").load(basePath)
+      .select("id", "name", "city")
+      .orderBy("id")
+      .collect()
+      .map(r => (r.getInt(0), r.getString(1), r.getString(2)))
+      .toSeq
+
+    assertEquals(
+      Seq((1, "alice2", "NYC"), (2, "bob", "SF")),
+      rows,
+      s"toasted columns must keep the prior base value (tableVersion=$tableVersion)")
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

On a Merge-on-Read table written with `PostgresDebeziumAvroPayload`, a snapshot read could return the raw sentinel string `__debezium_unavailable_value` for TOASTed columns (large STRING/BYTES columns Debezium could not capture in an UPDATE) instead of the real value. This affected pre-9 table versions (6 and 8); version 9 resolves toasted values through the `FILL_UNAVAILABLE` partial-update handler and was unaffected.

Root cause: the payload fills toasted columns from the base value by mutating the incoming avro record in place and returning that same reference. `HoodieAvroRecordMerger` has an identity short-circuit — when the payload returns the same object it was handed, the merger returns the engine-backed `newer` record rather than rebuilding. Since `newer` is a separate avro conversion of the same row, the in-place fill was dropped and the sentinel survived into the merged result.

### Summary and Changelog

Make the payload return a new record only when it actually fills a toasted column (a lazy shallow copy), leaving the record untouched otherwise. The merger's identity short-circuit then still fires for every normal merge, and only the toasted case falls through to rebuild, so the fill survives. `HoodieAvroRecordMerger` is unchanged.

- `PostgresDebeziumAvroPayload.mergeToastedValuesIfPresent` now returns an `IndexedRecord` (a distinct shallow copy when it fills a toasted column, else the original) instead of mutating in place; both `combineAndGetUpdateValue` overloads return that record.
- Adds `TestDebeziumToastedValue`, a parameterized functional test over table versions 6, 8 and 9.

### Impact

Fixes wrong data (sentinel placeholder leaking into query results) for Postgres Debezium toasted columns on MOR snapshot reads for table versions 6 and 8. No public API change. The common merge path is unchanged (the merger's zero-copy short-circuit still applies); only a toasted-column merge does one extra shallow record copy.

### Risk Level

low

The change is confined to `PostgresDebeziumAvroPayload`; the record merger is untouched. Covered by the new parameterized functional test across table versions 6, 8 and 9.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
