### PR TITLE
fix(hive-sync): sync column and partition column comments to HMS

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -393,7 +393,8 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
     Map<String, String> tableProperties = ConfigUtils.toMap(config.getString(HIVE_TABLE_PROPERTIES));
     if (config.getBoolean(HIVE_SYNC_AS_DATA_SOURCE_TABLE)) {
       Map<String, String> sparkTableProperties = SparkDataSourceTableUtils.getSparkTableProperties(config.getSplitStrings(META_SYNC_PARTITION_FIELDS),
-          config.getStringOrDefault(META_SYNC_SPARK_VERSION), config.getIntOrDefault(HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD), schema);
+          config.getStringOrDefault(META_SYNC_SPARK_VERSION), config.getIntOrDefault(HIVE_SYNC_SCHEMA_STRING_LENGTH_THRESHOLD), schema,
+          config.getBoolean(HIVE_SYNC_COMMENT));
       tableProperties.putAll(sparkTableProperties);
     }
     return tableProperties;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -697,6 +697,17 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
         }
       }
     });
+    if (!ddlExecutor.supportsUpdatingPartitionColumnComments()) {
+      List<String> skippedPartitionFields = config.getSplitStrings(META_SYNC_PARTITION_FIELDS).stream()
+          .map(partitionField -> partitionField.toLowerCase(Locale.ROOT))
+          .filter(alterComments::containsKey)
+          .collect(Collectors.toList());
+      if (!skippedPartitionFields.isEmpty()) {
+        log.debug("Cannot update comments of partition columns {} of {} in query based sync modes, use hms sync mode instead",
+            skippedPartitionFields, tableName);
+        skippedPartitionFields.forEach(alterComments::remove);
+      }
+    }
     if (alterComments.isEmpty()) {
       log.info("No comment difference of {} ", tableName);
       return false;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/DDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/DDLExecutor.java
@@ -108,4 +108,11 @@ public interface DDLExecutor extends AutoCloseable {
    * @param newSchema Map key: field name, Map value: [field type, field comment]
    */
   void updateTableComments(String tableName, Map<String, Pair<String, String>> newSchema);
+
+  /**
+   * @return whether this executor can update the comments of partition columns of an existing table.
+   */
+  default boolean supportsUpdatingPartitionColumnComments() {
+    return true;
+  }
 }

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
@@ -52,12 +52,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_CREATE_MANAGED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_COMMENT;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
@@ -110,6 +112,12 @@ public class HMSDDLExecutor implements DDLExecutor {
         String partitionKeyType = HiveSchemaUtil.getPartitionKeyType(mapSchema, partitionKey);
         return new FieldSchema(partitionKey, partitionKeyType.toLowerCase(), "");
       }).collect(Collectors.toList());
+
+      if (syncConfig.getBoolean(HIVE_SYNC_COMMENT)) {
+        Map<String, String> fieldDocs = HiveSchemaUtil.getFieldDocs(storageSchema);
+        applyFieldDocs(fieldSchema, fieldDocs);
+        applyFieldDocs(partitionSchema, fieldDocs);
+      }
       Table newTb = new Table();
       newTb.setDbName(databaseName);
       newTb.setTableName(tableName);
@@ -266,19 +274,33 @@ public class HMSDDLExecutor implements DDLExecutor {
     try {
       Table table = client.getTable(databaseName, tableName);
       StorageDescriptor sd = new StorageDescriptor(table.getSd());
-      for (FieldSchema fieldSchema : sd.getCols()) {
-        if (alterSchema.containsKey(fieldSchema.getName())) {
-          String comment = alterSchema.get(fieldSchema.getName()).getRight();
-          fieldSchema.setComment(comment);
-        }
-      }
+      applyFieldComments(sd.getCols(), alterSchema);
       table.setSd(sd);
+      applyFieldComments(table.getPartitionKeys(), alterSchema);
       EnvironmentContext environmentContext = new EnvironmentContext();
       client.alter_table_with_environmentContext(databaseName, tableName, table, environmentContext);
       sd.clear();
     } catch (Exception e) {
       log.error("Failed to update table comments for {}", tableName, e);
       throw new HoodieHiveSyncException("Failed to update table comments for " + tableName, e);
+    }
+  }
+
+  private static void applyFieldComments(List<FieldSchema> fields, Map<String, Pair<String, String>> alterSchema) {
+    for (FieldSchema fieldSchema : fields) {
+      if (alterSchema.containsKey(fieldSchema.getName())) {
+        String comment = alterSchema.get(fieldSchema.getName()).getRight();
+        fieldSchema.setComment(comment);
+      }
+    }
+  }
+
+  private static void applyFieldDocs(List<FieldSchema> fields, Map<String, String> fieldDocs) {
+    for (FieldSchema fieldSchema : fields) {
+      String doc = fieldDocs.get(fieldSchema.getName().toLowerCase(Locale.ROOT));
+      if (doc != null) {
+        fieldSchema.setComment(doc);
+      }
     }
   }
 

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/QueryBasedDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/QueryBasedDDLExecutor.java
@@ -142,8 +142,7 @@ public abstract class QueryBasedDDLExecutor implements DDLExecutor {
       String name = field.getKey();
       StringBuilder sql = new StringBuilder();
       String type = field.getValue().getLeft();
-      String comment = field.getValue().getRight();
-      comment = comment.replace("'","");
+      String comment = HiveSchemaUtil.escapeSqlString(field.getValue().getRight());
       sql.append("ALTER TABLE ").append(HIVE_ESCAPE_CHARACTER)
               .append(databaseName).append(HIVE_ESCAPE_CHARACTER).append(".")
               .append(HIVE_ESCAPE_CHARACTER).append(tableName)
@@ -152,6 +151,13 @@ public abstract class QueryBasedDDLExecutor implements DDLExecutor {
               .append("` ").append(type).append(" comment '").append(comment).append("' ");
       runSQL(sql.toString());
     }
+  }
+
+  @Override
+  public boolean supportsUpdatingPartitionColumnComments() {
+    // ALTER TABLE ... CHANGE COLUMN fails on partition columns and HiveQL has no
+    // other DDL to modify them, only the HMS based executor can update their comments
+    return false;
   }
 
   private List<String> constructAddPartitions(String tableName, List<String> partitions) {

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/HiveSchemaUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/util/HiveSchemaUtil.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_CREATE_MANAGED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_COMMENT;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
 
@@ -336,12 +338,23 @@ public class HiveSchemaUtil {
   }
 
   public static String generateSchemaString(HoodieSchema storageSchema, List<String> colsToSkip, boolean supportTimestamp) throws IOException {
+    return generateSchemaString(storageSchema, colsToSkip, supportTimestamp, Collections.emptyMap());
+  }
+
+  public static String generateSchemaString(HoodieSchema storageSchema, List<String> colsToSkip, boolean supportTimestamp,
+                                            Map<String, String> fieldDocs) throws IOException {
     Map<String, String> hiveSchema = convertSchemaToHiveSchema(storageSchema, supportTimestamp);
     StringBuilder columns = new StringBuilder();
     for (Map.Entry<String, String> hiveSchemaEntry : hiveSchema.entrySet()) {
-      if (!colsToSkip.contains(removeSurroundingTick(hiveSchemaEntry.getKey()))) {
+      String fieldName = removeSurroundingTick(hiveSchemaEntry.getKey());
+      if (!colsToSkip.contains(fieldName)) {
         columns.append(hiveSchemaEntry.getKey()).append(" ");
-        columns.append(hiveSchemaEntry.getValue()).append(", ");
+        columns.append(hiveSchemaEntry.getValue());
+        String doc = fieldDocs.get(fieldName.toLowerCase(Locale.ROOT));
+        if (doc != null) {
+          columns.append(" COMMENT '").append(escapeSqlString(doc)).append("'");
+        }
+        columns.append(", ");
       }
     }
     // Remove the last ", "
@@ -349,17 +362,43 @@ public class HiveSchemaUtil {
     return columns.toString();
   }
 
+  /**
+   * Backslash-escapes backslashes and single quotes so the value survives as a Hive SQL string literal,
+   * e.g. in COMMENT clauses and TBLPROPERTIES values.
+   */
+  public static String escapeSqlString(String value) {
+    return value.replace("\\", "\\\\").replace("'", "\\'");
+  }
+
+  /**
+   * Returns the doc of each field of the schema keyed by lower-cased field name, fields without doc are skipped.
+   * If two field names collide case-insensitively, the doc of the first one wins; in practice this cannot
+   * happen for a synced table since Hive lower-cases all field names.
+   */
+  public static Map<String, String> getFieldDocs(HoodieSchema schema) {
+    return schema.getFields().stream()
+        .filter(field -> field.doc().map(doc -> !doc.isEmpty()).orElse(false))
+        .collect(Collectors.toMap(field -> field.name().toLowerCase(Locale.ROOT), field -> field.doc().get(), (existing, duplicate) -> existing));
+  }
+
   public static String generateCreateDDL(String tableName, HoodieSchema storageSchema, HiveSyncConfig config, String inputFormatClass,
                                          String outputFormatClass, String serdeClass, Map<String, String> serdeProperties,
                                          Map<String, String> tableProperties) throws IOException {
     Map<String, String> hiveSchema = convertSchemaToHiveSchema(storageSchema, config.getBoolean(HIVE_SUPPORT_TIMESTAMP_TYPE));
-    String columns = generateSchemaString(storageSchema, config.getSplitStrings(META_SYNC_PARTITION_FIELDS), config.getBoolean(HIVE_SUPPORT_TIMESTAMP_TYPE));
+    Map<String, String> fieldDocs = config.getBoolean(HIVE_SYNC_COMMENT) ? getFieldDocs(storageSchema) : Collections.emptyMap();
+    String columns = generateSchemaString(storageSchema, config.getSplitStrings(META_SYNC_PARTITION_FIELDS),
+        config.getBoolean(HIVE_SUPPORT_TIMESTAMP_TYPE), fieldDocs);
 
     List<String> partitionFields = new ArrayList<>();
     for (String partitionKey : config.getSplitStrings(META_SYNC_PARTITION_FIELDS)) {
       String partitionKeyWithTicks = tickSurround(partitionKey);
-      partitionFields.add(partitionKeyWithTicks + " "
-          + getPartitionKeyType(hiveSchema, partitionKeyWithTicks));
+      String partitionField = partitionKeyWithTicks + " "
+          + getPartitionKeyType(hiveSchema, partitionKeyWithTicks);
+      String doc = fieldDocs.get(partitionKey.toLowerCase(Locale.ROOT));
+      if (doc != null) {
+        partitionField += " COMMENT '" + escapeSqlString(doc) + "'";
+      }
+      partitionFields.add(partitionField);
     }
 
     String partitionsStr = String.join(",", partitionFields);
@@ -401,7 +440,7 @@ public class HiveSchemaUtil {
       if (!first) {
         sb.append(",");
       }
-      sb.append("'").append(entry.getKey()).append("'='").append(entry.getValue()).append("'");
+      sb.append("'").append(escapeSqlString(entry.getKey())).append("'='").append(escapeSqlString(entry.getValue())).append("'");
       first = false;
     }
     return sb.toString();

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -1032,6 +1032,186 @@ public class TestHiveSyncTool {
     assertEquals(2, commentCnt, "hive schema field comment numbers should match the avro schema field doc numbers");
   }
 
+  private static final String STANDARD_COLUMNS =
+      "{\"name\": \"name\", \"type\": \"string\", \"doc\": \"name_comment\"},"
+          + "{\"name\": \"favorite_number\", \"type\": \"int\", \"doc\": \"favorite_number_comment\"},"
+          + "{\"name\": \"favorite_color\", \"type\": \"string\", \"doc\": \"the person's favorite color\\\\\"}";
+
+  private static final String COMPLEX_COLUMNS =
+      "{\"name\": \"address\", \"type\": {\"type\": \"record\", \"name\": \"Address\", \"fields\": ["
+          + "{\"name\": \"city\", \"type\": \"string\", \"doc\": \"city_comment\"},"
+          + "{\"name\": \"zip\", \"type\": \"string\"}]}, \"doc\": \"address_comment\"},"
+          + "{\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}, \"doc\": \"tags_comment\"},"
+          + "{\"name\": \"scores\", \"type\": {\"type\": \"map\", \"values\": \"int\"}}";
+
+  private static final String SINGLE_PARTITION_COLUMN =
+      "{\"name\": \"datestr\", \"type\": \"string\", \"doc\": \"partition_datestr_comment\"}";
+
+  private static final String MULTI_PARTITION_COLUMNS =
+      "{\"name\": \"year\", \"type\": \"string\", \"doc\": \"partition_year_comment\"},"
+          + "{\"name\": \"month\", \"type\": \"string\"},"
+          + "{\"name\": \"day\", \"type\": \"string\", \"doc\": \"partition_day_comment\"}";
+
+  @ParameterizedTest
+  @MethodSource("syncMode")
+  public void testSyncCommentsForStandardColumnsWithSinglePartitionColumn(String syncMode) throws Exception {
+    Map<String, String> commentsByField = syncTableWithCommentedSchema(syncMode, STANDARD_COLUMNS, SINGLE_PARTITION_COLUMN);
+    assertStandardColumnComments(commentsByField);
+    assertEquals("partition_datestr_comment", commentsByField.get("datestr"),
+        "comment of the partition column should be synced on table creation");
+    assertSparkSchemaPropertyContainsComments("\"comment\":\"name_comment\"", "\"comment\":\"partition_datestr_comment\"");
+  }
+
+  @ParameterizedTest
+  @MethodSource("syncMode")
+  public void testSyncCommentsForComplexColumnsWithSinglePartitionColumn(String syncMode) throws Exception {
+    Map<String, String> commentsByField = syncTableWithCommentedSchema(syncMode, STANDARD_COLUMNS, COMPLEX_COLUMNS, SINGLE_PARTITION_COLUMN);
+    assertStandardColumnComments(commentsByField);
+    assertComplexColumnComments(commentsByField);
+    assertEquals("partition_datestr_comment", commentsByField.get("datestr"),
+        "comment of the partition column should be synced on table creation");
+    // docs of nested fields are only representable in the spark schema
+    assertSparkSchemaPropertyContainsComments("\"comment\":\"address_comment\"", "\"comment\":\"city_comment\"");
+  }
+
+  @ParameterizedTest
+  @MethodSource("syncMode")
+  public void testSyncCommentsForStandardColumnsWithMultiplePartitionColumns(String syncMode) throws Exception {
+    setMultiPartitionFields();
+    Map<String, String> commentsByField = syncTableWithCommentedSchema(syncMode, STANDARD_COLUMNS, MULTI_PARTITION_COLUMNS);
+    assertStandardColumnComments(commentsByField);
+    assertMultiPartitionColumnComments(commentsByField);
+    assertSparkSchemaPropertyContainsComments("\"comment\":\"name_comment\"", "\"comment\":\"partition_year_comment\"");
+  }
+
+  @ParameterizedTest
+  @MethodSource("syncMode")
+  public void testSyncCommentsForComplexColumnsWithMultiplePartitionColumns(String syncMode) throws Exception {
+    setMultiPartitionFields();
+    Map<String, String> commentsByField = syncTableWithCommentedSchema(syncMode, STANDARD_COLUMNS, COMPLEX_COLUMNS, MULTI_PARTITION_COLUMNS);
+    assertStandardColumnComments(commentsByField);
+    assertComplexColumnComments(commentsByField);
+    assertMultiPartitionColumnComments(commentsByField);
+  }
+
+  @ParameterizedTest
+  @MethodSource("syncMode")
+  public void testSyncCommentsWithSpecialCharacters(String syncMode) throws Exception {
+    String specialColumns =
+        "{\"name\": \"c_quote\", \"type\": \"string\", \"doc\": \"it's the person's 'favorite'\"},"
+            + "{\"name\": \"c_backslash\", \"type\": \"string\", \"doc\": \"back\\\\slash ending\\\\\"},"
+            + "{\"name\": \"c_double_quote\", \"type\": \"string\", \"doc\": \"he said \\\"hello\\\"\"},"
+            + "{\"name\": \"c_mixed\", \"type\": \"string\", \"doc\": \"semi;colon, comma=equals %percent _underscore\"},"
+            + "{\"name\": \"c_unicode\", \"type\": \"string\", \"doc\": \"unicode héllo 你好\"}";
+    Map<String, String> commentsByField = syncTableWithCommentedSchema(syncMode, specialColumns, SINGLE_PARTITION_COLUMN);
+    assertEquals("it's the person's 'favorite'", commentsByField.get("c_quote"),
+        "comment with single quotes should be synced unchanged");
+    assertEquals("back\\slash ending\\", commentsByField.get("c_backslash"),
+        "comment with backslashes should be synced unchanged");
+    assertEquals("he said \"hello\"", commentsByField.get("c_double_quote"),
+        "comment with double quotes should be synced unchanged");
+    assertEquals("semi;colon, comma=equals %percent _underscore", commentsByField.get("c_mixed"),
+        "comment with SQL separator characters should be synced unchanged");
+    assertEquals("unicode héllo 你好", commentsByField.get("c_unicode"),
+        "comment with non-ascii characters should be synced unchanged");
+    assertEquals("partition_datestr_comment", commentsByField.get("datestr"),
+        "comment of the partition column should be synced on table creation");
+  }
+
+  @ParameterizedTest
+  @MethodSource("syncMode")
+  public void testUpdateCommentsForPartitionColumns(String syncMode) throws Exception {
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), syncMode);
+    hiveSyncProps.setProperty(HIVE_SYNC_COMMENT.key(), "false");
+    setMultiPartitionFields();
+    String commitTime = "100";
+    HiveTestUtil.createCOWTableWithSchema(commitTime, commentedSchema(STANDARD_COLUMNS, MULTI_PARTITION_COLUMNS));
+
+    // table is created without comments, they are applied by the second sync
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+    hiveSyncProps.setProperty(HIVE_SYNC_COMMENT.key(), "true");
+    hiveSyncProps.setProperty(META_SYNC_INCREMENTAL.key(), "false");
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+
+    Map<String, String> commentsByField = metastoreFieldComments(HiveTestUtil.TABLE_NAME);
+    assertStandardColumnComments(commentsByField);
+    if (syncMode.equals(HiveSyncMode.HMS.name().toLowerCase())) {
+      assertMultiPartitionColumnComments(commentsByField);
+    } else {
+      assertEquals("", commentsByField.get("year"),
+          "comment of a partition column cannot be updated in query based sync modes");
+      assertEquals("", commentsByField.get("day"),
+          "comment of a partition column cannot be updated in query based sync modes");
+    }
+  }
+
+  private Map<String, String> syncTableWithCommentedSchema(String syncMode, String... fieldJsons) throws Exception {
+    hiveSyncProps.setProperty(HIVE_SYNC_MODE.key(), syncMode);
+    hiveSyncProps.setProperty(HIVE_SYNC_COMMENT.key(), "true");
+    HiveTestUtil.createCOWTableWithSchema("100", commentedSchema(fieldJsons));
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+    return metastoreFieldComments(HiveTestUtil.TABLE_NAME);
+  }
+
+  private static HoodieSchema commentedSchema(String... fieldJsons) {
+    return HoodieSchema.parse("{\"type\": \"record\", \"name\": \"User\", \"namespace\": \"example.avro\", \"fields\": ["
+        + String.join(",", fieldJsons) + "]}");
+  }
+
+  private void setMultiPartitionFields() {
+    hiveSyncProps.setProperty(META_SYNC_PARTITION_EXTRACTOR_CLASS.key(), MultiPartKeysValueExtractor.class.getCanonicalName());
+    hiveSyncProps.setProperty(META_SYNC_PARTITION_FIELDS.key(), "year,month,day");
+  }
+
+  private void assertStandardColumnComments(Map<String, String> commentsByField) {
+    assertEquals("name_comment", commentsByField.get("name"),
+        "comment of a regular column should be synced");
+    assertEquals("favorite_number_comment", commentsByField.get("favorite_number"),
+        "comment of a regular column should be synced");
+    assertEquals("the person's favorite color\\", commentsByField.get("favorite_color"),
+        "comment with a single quote and trailing backslash should be synced unchanged");
+  }
+
+  private void assertComplexColumnComments(Map<String, String> commentsByField) {
+    assertEquals("address_comment", commentsByField.get("address"),
+        "comment of a struct column should be synced");
+    assertEquals("tags_comment", commentsByField.get("tags"),
+        "comment of an array column should be synced");
+    assertEquals("", commentsByField.get("scores"),
+        "map column without a doc should have no comment");
+  }
+
+  private void assertMultiPartitionColumnComments(Map<String, String> commentsByField) {
+    assertEquals("partition_year_comment", commentsByField.get("year"),
+        "comment of the first partition column should be synced");
+    assertEquals("", commentsByField.get("month"),
+        "partition column without a doc should have no comment");
+    assertEquals("partition_day_comment", commentsByField.get("day"),
+        "comment of the last partition column should be synced");
+  }
+
+  private void assertSparkSchemaPropertyContainsComments(String... expectedComments) throws Exception {
+    SessionState.start(HiveTestUtil.getHiveConf());
+    Driver hiveDriver = new Driver(HiveTestUtil.getHiveConf());
+    hiveDriver.run(String.format("SHOW TBLPROPERTIES %s.%s", HiveTestUtil.DB_NAME, HiveTestUtil.TABLE_NAME));
+    List<String> results = new ArrayList<>();
+    hiveDriver.getResults(results);
+    String tableProperties = String.join("\n", results);
+    for (String expectedComment : expectedComments) {
+      assertTrue(tableProperties.contains(expectedComment),
+          "spark schema table property should contain " + expectedComment);
+    }
+  }
+
+  private Map<String, String> metastoreFieldComments(String tableName) {
+    return hiveClient.getMetastoreFieldSchemas(tableName)
+        .stream()
+        .collect(Collectors.toMap(FieldSchema::getName, FieldSchema::getCommentOrEmpty));
+  }
+
   @ParameterizedTest
   @MethodSource("syncModeAndSchemaFromCommitMetadata")
   public void testSyncMergeOnRead(boolean useSchemaFromCommitMetadata, String syncMode, String enablePushDown) throws Exception {

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestSparkSchemaUtils.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestSparkSchemaUtils.java
@@ -121,6 +121,31 @@ public class TestSparkSchemaUtils {
   }
 
   @Test
+  public void testConvertWithFieldDocs() {
+    HoodieSchema nestedSchema = HoodieSchema.createRecord("profile", null, null, false, Arrays.asList(
+        HoodieSchemaField.of("city", HoodieSchema.create(HoodieSchemaType.STRING), "City of the person", null),
+        HoodieSchemaField.of("zip", HoodieSchema.createNullable(HoodieSchemaType.STRING), null, null)));
+    HoodieSchema schema = HoodieSchema.createRecord("root", null, null, false, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.STRING), "Unique \"id\"\nof the record", null),
+        HoodieSchemaField.of("name", HoodieSchema.createNullable(HoodieSchemaType.STRING), "Name of the person", null),
+        HoodieSchemaField.of("age", HoodieSchema.createNullable(HoodieSchemaType.INT), null, null),
+        HoodieSchemaField.of("profile", nestedSchema, "Profile of the person", null)));
+
+    StructType withoutDocs = (StructType) StructType.fromJson(SparkSchemaUtils.convertToSparkSchemaJson(schema));
+    assertFalse(withoutDocs.fields()[0].getComment().isDefined());
+    assertFalse(((StructType) withoutDocs.fields()[3].dataType()).fields()[0].getComment().isDefined());
+
+    StructType withDocs = (StructType) StructType.fromJson(SparkSchemaUtils.convertToSparkSchemaJson(schema, true));
+    assertEquals("Unique \"id\"\nof the record", withDocs.fields()[0].getComment().get());
+    assertEquals("Name of the person", withDocs.fields()[1].getComment().get());
+    assertFalse(withDocs.fields()[2].getComment().isDefined());
+    assertEquals("Profile of the person", withDocs.fields()[3].getComment().get());
+    StructType nestedStruct = (StructType) withDocs.fields()[3].dataType();
+    assertEquals("City of the person", nestedStruct.fields()[0].getComment().get());
+    assertFalse(nestedStruct.fields()[1].getComment().isDefined());
+  }
+
+  @Test
   public void testConvertComplexType() {
     StructType sparkSchema = parser.parseTableSchema(
             "f0 int, f1 map<string, int>, f2 array<decimal(10,2)>"

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/testutils/HiveTestUtil.java
@@ -395,6 +395,11 @@ public class HiveTestUtil {
 
   public static void createCOWTableWithSchema(String instantTime, String schemaFileName)
       throws IOException, URISyntaxException {
+    createCOWTableWithSchema(instantTime, SchemaTestUtil.getSchemaFromResource(HiveTestUtil.class, schemaFileName));
+  }
+
+  public static void createCOWTableWithSchema(String instantTime, HoodieSchema schema)
+      throws IOException, URISyntaxException {
     Path path = new Path(basePath);
     FileIOUtils.deleteDirectory(new File(basePath));
     HoodieTableMetaClient.newTableBuilder()
@@ -417,7 +422,6 @@ public class HiveTestUtil {
     String fileId = UUID.randomUUID().toString();
     Path filePath = new Path(partPath.toString() + "/"
         + FSUtils.makeBaseFileName(instantTime, "1-0-1", fileId, HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().getFileExtension()));
-    HoodieSchema schema = SchemaTestUtil.getSchemaFromResource(HiveTestUtil.class, schemaFileName);
     generateParquetDataWithSchema(filePath, schema);
     HoodieWriteStat writeStat = new HoodieWriteStat();
     writeStat.setFileId(fileId);

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkDataSourceTableUtils.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkDataSourceTableUtils.java
@@ -38,6 +38,17 @@ public class SparkDataSourceTableUtils {
    */
   public static Map<String, String> getSparkTableProperties(List<String> partitionNames, String sparkVersion,
                                                             int schemaLengthThreshold, HoodieSchema schema) {
+    return getSparkTableProperties(partitionNames, sparkVersion, schemaLengthThreshold, schema, false);
+  }
+
+  /**
+   * Get Spark Sql related table properties. This is used for spark datasource table.
+   * @param schema           The schema to write to the table.
+   * @param includeFieldDocs Whether to include the field docs as column comments in the serialized spark schema.
+   * @return A new parameters added the spark's table properties.
+   */
+  public static Map<String, String> getSparkTableProperties(List<String> partitionNames, String sparkVersion,
+                                                            int schemaLengthThreshold, HoodieSchema schema, boolean includeFieldDocs) {
     // Convert the schema and partition info used by spark sql to hive table properties.
     // The following code refers to the spark code in
     // https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -73,7 +84,7 @@ public class SparkDataSourceTableUtils {
       sparkProperties.put("spark.sql.create.version", sparkVersion);
     }
     // Split the schema string to multi-parts according the schemaLengthThreshold size.
-    String schemaString = SparkSchemaUtils.convertToSparkSchemaJson(reOrderedSchema);
+    String schemaString = SparkSchemaUtils.convertToSparkSchemaJson(reOrderedSchema, includeFieldDocs);
     int numSchemaPart = (schemaString.length() + schemaLengthThreshold - 1) / schemaLengthThreshold;
     sparkProperties.put("spark.sql.sources.schema.numParts", String.valueOf(numSchemaPart));
     // Add each part of schema string to sparkProperties

--- a/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkSchemaUtils.java
+++ b/hudi-sync/hudi-sync-common/src/main/java/org/apache/hudi/sync/common/util/SparkSchemaUtils.java
@@ -19,7 +19,11 @@
 package org.apache.hudi.sync.common.util;
 
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Convert the Hoodie schema to spark schema' json string.
@@ -29,18 +33,69 @@ import org.apache.hudi.common.schema.HoodieSchemaType;
 public class SparkSchemaUtils {
 
   public static String convertToSparkSchemaJson(HoodieSchema schema) {
+    return convertToSparkSchemaJson(schema, false);
+  }
+
+  /**
+   * @param includeFieldDocs whether field docs should be included in the field metadata
+   *                         as {@code comment}, which spark displays as the column comment
+   */
+  public static String convertToSparkSchemaJson(HoodieSchema schema, boolean includeFieldDocs) {
     String fieldsJsonString = schema.getFields().stream().map(field -> {
-      String metadata = "{}";
-      if (field.getNonNullSchema().isBlobField()) {
-        metadata = String.format("{\"%s\":\"%s\"}", HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name());
-      }
-      return "{\"name\":\"" + field.name() + "\",\"type\":" + convertFieldType(field.getNonNullSchema())
+      String metadata = convertFieldMetadata(field, includeFieldDocs);
+      return "{\"name\":\"" + field.name() + "\",\"type\":" + convertFieldType(field.getNonNullSchema(), includeFieldDocs)
                 + ",\"nullable\":" + field.isNullable() + ",\"metadata\":" + metadata + "}";
     }).reduce((a, b) -> a + "," + b).orElse("");
     return "{\"type\":\"struct\",\"fields\":[" + fieldsJsonString + "]}";
   }
 
-  private static String convertFieldType(HoodieSchema originalFieldSchema) {
+  private static String convertFieldMetadata(HoodieSchemaField field, boolean includeFieldDocs) {
+    List<String> entries = new ArrayList<>(2);
+    if (includeFieldDocs) {
+      field.doc().ifPresent(doc -> {
+        if (!doc.isEmpty()) {
+          entries.add("\"comment\":\"" + escapeJsonString(doc) + "\"");
+        }
+      });
+    }
+    if (field.getNonNullSchema().isBlobField()) {
+      entries.add(String.format("\"%s\":\"%s\"", HoodieSchema.TYPE_METADATA_FIELD, HoodieSchemaType.BLOB.name()));
+    }
+    return "{" + String.join(",", entries) + "}";
+  }
+
+  private static String escapeJsonString(String value) {
+    StringBuilder sb = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"':
+          sb.append("\\\"");
+          break;
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        case '\r':
+          sb.append("\\r");
+          break;
+        case '\t':
+          sb.append("\\t");
+          break;
+        default:
+          if (c < 0x20) {
+            sb.append(String.format("\\u%04x", (int) c));
+          } else {
+            sb.append(c);
+          }
+      }
+    }
+    return sb.toString();
+  }
+
+  private static String convertFieldType(HoodieSchema originalFieldSchema, boolean includeFieldDocs) {
     HoodieSchema fieldSchema = originalFieldSchema.getNonNullType();
     switch (fieldSchema.getType()) {
       case BOOLEAN: return "\"boolean\"";
@@ -78,24 +133,24 @@ public class SparkSchemaUtils {
         HoodieSchema.Decimal decimal = (HoodieSchema.Decimal) fieldSchema;
         return "\"decimal(" + decimal.getPrecision() + "," + decimal.getScale() + ")\"";
       case ARRAY:
-        return arrayType(fieldSchema.getElementType());
+        return arrayType(fieldSchema.getElementType(), includeFieldDocs);
       case MAP:
         HoodieSchema keyType = fieldSchema.getKeyType();
         HoodieSchema valueType = fieldSchema.getValueType();
         boolean valueOptional = valueType.isNullable();
-        return "{\"type\":\"map\", \"keyType\":" + convertFieldType(keyType)
-            + ",\"valueType\":" + convertFieldType(valueType)
+        return "{\"type\":\"map\", \"keyType\":" + convertFieldType(keyType, includeFieldDocs)
+            + ",\"valueType\":" + convertFieldType(valueType, includeFieldDocs)
             + ",\"valueContainsNull\":" + valueOptional + "}";
       case RECORD:
       case BLOB:
       case VARIANT:
-        return convertToSparkSchemaJson(fieldSchema);
+        return convertToSparkSchemaJson(fieldSchema, includeFieldDocs);
       default:
         throw new UnsupportedOperationException("Cannot convert " + fieldSchema.getType() + " to spark sql type");
     }
   }
 
-  private static String arrayType(HoodieSchema elementType) {
-    return "{\"type\":\"array\", \"elementType\":" + convertFieldType(elementType) + ",\"containsNull\":" + elementType.isNullable() + "}";
+  private static String arrayType(HoodieSchema elementType, boolean includeFieldDocs) {
+    return "{\"type\":\"array\", \"elementType\":" + convertFieldType(elementType, includeFieldDocs) + ",\"containsNull\":" + elementType.isNullable() + "}";
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17359 (HUDI-8843), reported in #11922.

When `hoodie.datasource.hive_sync.sync_comment=true`, comments of partition columns were never synced to the Hive metastore:

- **hms** sync mode: `HMSDDLExecutor.updateTableComments` only updated the columns of the storage descriptor and ignored the table's partition keys, so partition column comments were silently dropped.
- **jdbc/hiveql** sync modes: the generated `ALTER TABLE ... CHANGE COLUMN` statement targeted the partition column, which Hive rejects with `Invalid column reference`, failing the entire sync.
- Additionally, `createTable` never populated any comments (regular or partition columns), so comments only appeared from the second sync onward.

The equivalent AWS Glue path is also broken (comments are silently dropped since the AWS SDK v2 upgrade) and is tracked separately in #19316; this PR only fixes the Hive paths.

### Summary and Changelog

With `sync_comment=true`, column and partition column comments are now synced to HMS when the table is created, and partition column comments are kept in sync afterwards in `hms` sync mode.

- `HMSDDLExecutor.createTable`: populates column and partition column comments from the storage schema field docs when `sync_comment=true`.
- `HMSDDLExecutor.updateTableComments`: also updates comments of the table's partition keys (comment-only changes pass HMS alter-table validation, which compares partition key names/types only).
- `HiveSchemaUtil.generateCreateDDL` (used by jdbc/hiveql sync modes): appends `COMMENT '...'` clauses to both regular and partition column definitions when `sync_comment=true`. Comments and `TBLPROPERTIES` keys/values are backslash-escaped (`HiveSchemaUtil.escapeSqlString`) so docs containing quotes or backslashes survive as SQL string literals; the same escaping is applied in `QueryBasedDDLExecutor.updateTableComments`, which previously stripped single quotes.
- `DDLExecutor.supportsUpdatingPartitionColumnComments()`: new capability, `false` for query based executors since `ALTER TABLE ... CHANGE COLUMN` fails on partition columns and HiveQL has no other DDL for them. `HoodieHiveSyncClient.updateTableComments` filters partition columns out of the comment diff when unsupported, so jdbc/hiveql syncs no longer fail and no longer report a schema change when nothing else was applied. Partition column comments are still applied at create time in these modes.
- `SparkSchemaUtils.convertToSparkSchemaJson` / `SparkDataSourceTableUtils.getSparkTableProperties`: new `includeFieldDocs` variant that carries field docs as `comment` in the field metadata of the serialized Spark schema (`spark.sql.sources.schema` table property). Spark rebuilds the schema of a datasource table from this property and ignores the HMS column comments, so without this Spark `DESCRIBE` showed no comments even though they were present in HMS. Enabled from `HiveSyncTool` when `sync_comment=true`; all other callers keep the previous behavior.
- Tests: new `testSyncCommentsForPartitionColumns` (create path, all sync modes expect comments) and `testUpdateCommentsForPartitionColumns` (alter path, `hms` expects the partition comments, query-based modes gracefully skip) in `TestHiveSyncTool`, with a fixture schema `partition-doced-test.avsc` using multiple partition columns (with and without docs) and a doc containing a single quote and a trailing backslash to exercise the SQL escaping; `TestSparkSchemaUtils#testConvertWithFieldDocs` covers flat and nested field docs.

### Impact

Users get column and partition column comments in HMS from the first sync when `hoodie.datasource.hive_sync.sync_comment=true`. No change when the config is disabled (default). Fixes a sync failure in jdbc/hiveql modes when the partition field has a doc in the table schema.

### Risk Level

Low. All changes are gated behind `hoodie.datasource.hive_sync.sync_comment` (default `false`), except the partition-column filtering (which turns a guaranteed sync failure into a no-op) and the SQL escaping of comments and table properties in the create DDL (which previously broke on quotes). Verified with `TestHiveSyncTool` comment tests across hms/jdbc/hiveql sync modes, `TestHiveSchemaUtil` and `TestSparkSchemaUtils`.

### Documentation Update

None. No new configs; behavior now matches the existing description of `hoodie.datasource.hive_sync.sync_comment`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
