### PR TITLE
fix(trino): read uncompacted MDT HFILE log deltas and guard index pruning

### DIFF
--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/io/HudiTrinoIOFactory.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/io/HudiTrinoIOFactory.java
@@ -17,6 +17,7 @@ import org.apache.hudi.common.fs.ConsistencyGuard;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.FileFormatUtils;
+import org.apache.hudi.common.util.HFileUtils;
 import org.apache.hudi.core.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.core.io.storage.HoodieIOFactory;
@@ -47,7 +48,15 @@ public class HudiTrinoIOFactory
     public FileFormatUtils getFileFormatUtils(HoodieFileFormat fileFormat)
     {
         if (fileFormat == HoodieFileFormat.PARQUET) {
+            // Parquet needs a Trino-native implementation: hudi's own ParquetUtils lives in
+            // hudi-hadoop-common, which is excluded from the Trino runtime.
             return new HudiTrinoParquetFileFormatUtils();
+        }
+        if (fileFormat == HoodieFileFormat.HFILE) {
+            // hudi-common's HFileUtils is hadoop-free (it decodes via hudi-io's native HFile
+            // reader), so it is safe in the Trino runtime. This is what lets the connector read
+            // uncompacted metadata-table deltas, which are native HFILE log files.
+            return new HFileUtils();
         }
         throw new UnsupportedOperationException(
                 "Native " + fileFormat + " log files are not supported by the Hudi Trino connector");

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
@@ -21,12 +21,16 @@ import io.trino.plugin.hudi.query.index.HudiIndexSupport;
 import io.trino.plugin.hudi.query.index.IndexSupportFactory;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.HoodieTimer;
-import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.common.util.Lazy;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.NativeTableMetadataFactory;
 
 import java.util.List;
 import java.util.Optional;
@@ -54,9 +58,22 @@ public class HudiSnapshotDirectoryLister
         this.lazyFileSystemView = Lazy.lazily(() -> {
             HoodieTimer timer = HoodieTimer.start();
             HoodieTableMetaClient metaClient = tableHandle.getMetaClient();
-            HoodieTableFileSystemView fileSystemView = getFileSystemView(lazyTableMetadata.get(), metaClient);
-            if (enableMetadataTable) {
-                fileSystemView.loadAllPartitions();
+            HoodieTableFileSystemView fileSystemView = null;
+            try {
+                fileSystemView = getFileSystemView(lazyTableMetadata.get(), metaClient);
+                if (enableMetadataTable) {
+                    fileSystemView.loadAllPartitions();
+                }
+            }
+            catch (Exception e) {
+                // A failure here is a metadata-table read failure (the metastore/table itself is
+                // fine), so fall back to direct file listing instead of failing the query.
+                if (fileSystemView != null && !fileSystemView.isClosed()) {
+                    fileSystemView.close();
+                }
+                log.error(e, "Failed to load the file system view of table %s via the metadata table, falling back to direct file listing",
+                        schemaTableName);
+                fileSystemView = createDirectListingFileSystemView(metaClient);
             }
             log.info("Created file system view of table %s in %s ms", schemaTableName, timer.endTimer());
             return fileSystemView;
@@ -65,6 +82,22 @@ public class HudiSnapshotDirectoryLister
         Lazy<HoodieTableMetaClient> lazyMetaClient = Lazy.lazily(tableHandle::getMetaClient);
         this.indexSupportOpt = enableMetadataTable ?
                 IndexSupportFactory.createIndexSupport(tableHandle, lazyMetaClient, lazyTableMetadata, tableHandle.getRegularPredicates(), session) : Optional.empty();
+    }
+
+    /**
+     * Builds a file system view that lists files directly from storage, bypassing the metadata table.
+     * Used as the fallback when the metadata-table-backed view cannot be loaded (e.g. an MDT read
+     * failure); it lists lazily per partition, so no {@code loadAllPartitions()} here.
+     */
+    private static HoodieTableFileSystemView createDirectListingFileSystemView(HoodieTableMetaClient metaClient)
+    {
+        HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+                .enable(false)
+                .build();
+        HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorage().getConf());
+        HoodieTableMetadata tableMetadata = NativeTableMetadataFactory.getInstance().create(
+                engineContext, metaClient.getStorage(), metadataConfig, metaClient.getBasePath().toString(), true);
+        return getFileSystemView(tableMetadata, metaClient);
     }
 
     @Override

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
@@ -21,8 +21,6 @@ import io.trino.plugin.hudi.query.index.HudiIndexSupport;
 import io.trino.plugin.hudi.query.index.IndexSupportFactory;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
-import org.apache.hudi.common.config.HoodieMetadataConfig;
-import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -30,7 +28,6 @@ import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.metadata.HoodieTableMetadata;
-import org.apache.hudi.metadata.NativeTableMetadataFactory;
 
 import java.util.List;
 import java.util.Optional;
@@ -58,7 +55,7 @@ public class HudiSnapshotDirectoryLister
         this.lazyFileSystemView = Lazy.lazily(() -> {
             HoodieTimer timer = HoodieTimer.start();
             HoodieTableMetaClient metaClient = tableHandle.getMetaClient();
-            HoodieTableFileSystemView fileSystemView = null;
+            HoodieTableFileSystemView fileSystemView;
             try {
                 fileSystemView = getFileSystemView(lazyTableMetadata.get(), metaClient);
                 if (enableMetadataTable) {
@@ -67,10 +64,10 @@ public class HudiSnapshotDirectoryLister
             }
             catch (Exception e) {
                 // A failure here is a metadata-table read failure (the metastore/table itself is
-                // fine), so fall back to direct file listing instead of failing the query.
-                if (fileSystemView != null && !fileSystemView.isClosed()) {
-                    fileSystemView.close();
-                }
+                // fine), so fall back to direct file listing instead of failing the query. The
+                // failed view is deliberately not closed: closing it would also close the shared
+                // HoodieTableMetadata behind lazyTableMetadata, which the split loader and the
+                // index supports still read through.
                 log.error(e, "Failed to load the file system view of table %s via the metadata table, falling back to direct file listing",
                         schemaTableName);
                 fileSystemView = createDirectListingFileSystemView(metaClient);
@@ -91,13 +88,10 @@ public class HudiSnapshotDirectoryLister
      */
     private static HoodieTableFileSystemView createDirectListingFileSystemView(HoodieTableMetaClient metaClient)
     {
-        HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
-                .enable(false)
-                .build();
-        HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorage().getConf());
-        HoodieTableMetadata tableMetadata = NativeTableMetadataFactory.getInstance().create(
-                engineContext, metaClient.getStorage(), metadataConfig, metaClient.getBasePath().toString(), true);
-        return getFileSystemView(tableMetadata, metaClient);
+        return HoodieTableFileSystemView.fileListingBasedFileSystemView(
+                new HoodieLocalEngineContext(metaClient.getStorage().getConf()),
+                metaClient,
+                metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
     }
 
     @Override

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
@@ -214,9 +214,9 @@ public class HudiBackgroundSplitLoader
 
         List<String> allPartitions = new ArrayList<>(metadataPartitions.keySet());
 
-        List<String> effectivePartitions = Optional.ofNullable(useIndex && partitionIndexSupportOpt.isPresent()
-                ? partitionIndexSupportOpt.get().prunePartitions(allPartitions).orElse(null)
-                : null).orElse(allPartitions);
+        List<String> effectivePartitions = useIndex && partitionIndexSupportOpt.isPresent()
+                ? prunePartitionsSafely(allPartitions)
+                : allPartitions;
 
         Map<String, Partition> finalMetadataPartitions = metadataPartitions;
         List<HiveHudiPartitionInfo> hiveHudiPartitionInfos = effectivePartitions.stream()
@@ -225,6 +225,24 @@ public class HudiBackgroundSplitLoader
                 .toList();
 
         return new ConcurrentLinkedDeque<>(hiveHudiPartitionInfos);
+    }
+
+    /**
+     * Applies partition-stats index pruning, treating any failure as "no pruning". The pruning read
+     * goes through the metadata table and can fail for reasons unrelated to the query itself; index
+     * pruning is an optimization and must never fail the query, mirroring the metastore fallback of
+     * the metadata-table partition listing above.
+     */
+    private List<String> prunePartitionsSafely(List<String> allPartitions)
+    {
+        try {
+            return partitionIndexSupportOpt.get().prunePartitions(allPartitions).orElse(allPartitions);
+        }
+        catch (Exception e) {
+            log.error(e, "Failed to prune partitions via partition stats index on table %s.%s, proceeding without partition pruning",
+                    tableHandle.getSchemaName(), tableHandle.getTableName());
+            return allPartitions;
+        }
     }
 
     private HiveHudiPartitionInfo buildHiveHudiPartitionInfo(HudiTableHandle tableHandle, String partitionName, Partition partition)

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
@@ -52,7 +52,7 @@ public class TestHudiUncompactedMetadataTable
                 mdtEnabled(),
                 "SELECT id, name, price FROM " + TABLE_NAME + " ORDER BY id",
                 "VALUES ('k1', 'k1_c3', CAST(15 AS BIGINT)), ('k2', 'k2_c1', 1000), ('k3', 'k3_c2', 20), ('k4', 'k4_c2', 2000)");
-        assertThat(computeScalarWith(mdtEnabled(), "SELECT count(*) FROM " + TABLE_NAME)).isEqualTo(4L);
+        assertThat(computeScalar(mdtEnabled(), "SELECT count(*) FROM " + TABLE_NAME)).isEqualTo(4L);
     }
 
     @Test
@@ -113,10 +113,5 @@ public class TestHudiUncompactedMetadataTable
     private Session mdtDisabled()
     {
         return SessionBuilder.from(getSession()).withMdtEnabled(false).build();
-    }
-
-    private Object computeScalarWith(Session session, String query)
-    {
-        return getQueryRunner().execute(session, query).getOnlyValue();
     }
 }

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
@@ -118,18 +118,28 @@ public class TestHudiUncompactedMetadataTable
     @Test
     public void testColumnStatsFileSkippingOverUncompactedStats()
     {
-        // Column-stats file skipping reads the column_stats MDT partition's HFILE log deltas
+        // Column-stats file skipping reads the column_stats MDT partition's HFILE log deltas.
+        // The wait timeout must be raised above its 1s default (matching the col-stats tests in
+        // TestHudiSmokeTest): shouldSkipFileSlice keeps the file on any failure or timeout, so
+        // with the default a broken col-stats read would still return correct rows and a
+        // value-only assertion would pass without the deltas ever being read.
         Session session = SessionBuilder.from(getSession())
                 .withMdtEnabled(true)
                 .withColStatsIndexEnabled(true)
                 .withRecordLevelIndexEnabled(false)
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
+                .withColumnStatsTimeout("10s")
                 .build();
-        assertQuery(
-                session,
-                "SELECT id, price FROM " + TABLE_NAME + " WHERE price = 15",
-                "VALUES ('k1', CAST(15 AS BIGINT))");
+        MaterializedResult skipped = getQueryRunner().execute(session,
+                "SELECT id, price FROM " + TABLE_NAME + " WHERE price = 15");
+        assertThat(skipped.getMaterializedRows()).hasSize(1);
+        assertThat(skipped.getMaterializedRows().get(0).getFields()).containsExactly("k1", 15L);
+
+        // File skipping must drop at least p2's file group (its prices [1000, 2000] exclude 15),
+        // so the filtered scan uses strictly fewer splits than the unfiltered full scan
+        int fullScanSplits = totalSplits(mdtEnabled(), "SELECT id, price FROM " + TABLE_NAME);
+        assertThat(skipped.getStatementStats().get().getTotalSplits()).isLessThan(fullScanSplits);
     }
 
     private Session mdtEnabled()

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
@@ -29,8 +29,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * UNCOMPACTED delta commits. Those deltas are native HFILE log files, which the connector previously
  * rejected ("Native HFILE log files are not supported..."), failing every query through the unguarded
  * partition-stats pruning path. The table written by {@link UncompactedMetadataHudiTablesInitializer}
- * keeps its MDT deliberately uncompacted (the zip fixtures always compact after every commit), so the
- * queries below only succeed if the connector reads HFILE log deltas in the MDT's
+ * keeps its MDT deliberately uncompacted and its deltas are whole-file native HFILE logs (the zip
+ * fixtures predate that write path; their block-format deltas were always readable), so the queries
+ * below only succeed if the connector reads native HFILE log files in the MDT's
  * {@code files}/{@code column_stats}/{@code partition_stats} partitions.
  * <p>
  * The initializer also writes {@code CORRUPTED_TABLE_NAME}, an identical table whose MDT log files

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
@@ -20,6 +20,7 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.plugin.hudi.testing.UncompactedMetadataHudiTablesInitializer.CORRUPTED_TABLE_NAME;
 import static io.trino.plugin.hudi.testing.UncompactedMetadataHudiTablesInitializer.TABLE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +32,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * keeps its MDT deliberately uncompacted (the zip fixtures always compact after every commit), so the
  * queries below only succeed if the connector reads HFILE log deltas in the MDT's
  * {@code files}/{@code column_stats}/{@code partition_stats} partitions.
+ * <p>
+ * The initializer also writes {@code CORRUPTED_TABLE_NAME}, an identical table whose MDT log files
+ * are corrupted so every MDT read throws; queries on it pin the fallbacks (direct file listing,
+ * unpruned split generation) instead of only the clean-read path.
  */
 public class TestHudiUncompactedMetadataTable
         extends AbstractTestQueryFramework
@@ -70,22 +75,44 @@ public class TestHudiUncompactedMetadataTable
         // The exact crash from the issue: partition-stats pruning reads the partition_stats MDT
         // partition, whose deltas are uncompacted HFILE log files. Partition p2 holds prices
         // [1000, 2000], so `price < 100` lets the index prune it entirely.
-        Session session = SessionBuilder.from(getSession())
-                .withMdtEnabled(true)
-                .withColStatsIndexEnabled(false)
-                .withRecordLevelIndexEnabled(false)
-                .withSecondaryIndexEnabled(false)
-                .withPartitionStatsIndexEnabled(true)
-                .build();
-        MaterializedResult pruned = getQueryRunner().execute(session,
+        MaterializedResult pruned = getQueryRunner().execute(partitionStatsPruningOnly(),
                 "SELECT id, price FROM " + TABLE_NAME + " WHERE price < 100");
         assertThat(pruned.getMaterializedRows()).hasSize(2);
 
-        MaterializedResult unpruned = getQueryRunner().execute(mdtEnabled(),
-                "SELECT id, price FROM " + TABLE_NAME);
-        // Pruning must not scan more than the full table does; correctness is asserted above
-        assertThat(pruned.getStatementStats().get().getTotalSplits())
-                .isLessThanOrEqualTo(unpruned.getStatementStats().get().getTotalSplits());
+        // Index pruning must scan exactly p1's file groups: the same split count as a
+        // metastore-pruned scan of p1, strictly fewer than the full scan. Split counts are
+        // compared instead of hardcoded because the number of file groups per partition depends
+        // on the write client's small-file packing.
+        int fullScanSplits = totalSplits(mdtEnabled(), "SELECT id, price FROM " + TABLE_NAME);
+        int p1ScanSplits = totalSplits(mdtEnabled(), "SELECT id, price FROM " + TABLE_NAME + " WHERE part_col = 'p1'");
+        assertThat(p1ScanSplits).isLessThan(fullScanSplits);
+        assertThat(pruned.getStatementStats().get().getTotalSplits()).isEqualTo(p1ScanSplits);
+    }
+
+    @Test
+    public void testReadFallsBackToDirectListingOnUnreadableMetadataTable()
+    {
+        // The corrupted twin table's MDT log deltas cannot be decoded, so the MDT-backed
+        // file-system-view load throws; HudiSnapshotDirectoryLister must fall back to listing
+        // files directly from storage and still return complete, correct rows.
+        assertQuery(
+                mdtEnabled(),
+                "SELECT id, name, price FROM " + CORRUPTED_TABLE_NAME + " ORDER BY id",
+                "VALUES ('k1', 'k1_c3', CAST(15 AS BIGINT)), ('k2', 'k2_c1', 1000), ('k3', 'k3_c2', 20), ('k4', 'k4_c2', 2000)");
+    }
+
+    @Test
+    public void testPartitionStatsPruningFallsBackUnprunedOnUnreadableMetadataTable()
+    {
+        // Same pruning setup as above, but the partition_stats read throws on the corrupted
+        // table: prunePartitionsSafely must degrade to "no pruning", so the scan covers the
+        // same splits as a full scan instead of failing the query.
+        MaterializedResult unpruned = getQueryRunner().execute(partitionStatsPruningOnly(),
+                "SELECT id, price FROM " + CORRUPTED_TABLE_NAME + " WHERE price < 100");
+        assertThat(unpruned.getMaterializedRows()).hasSize(2);
+
+        int fullScanSplits = totalSplits(mdtDisabled(), "SELECT id, price FROM " + CORRUPTED_TABLE_NAME);
+        assertThat(unpruned.getStatementStats().get().getTotalSplits()).isEqualTo(fullScanSplits);
     }
 
     @Test
@@ -113,5 +140,22 @@ public class TestHudiUncompactedMetadataTable
     private Session mdtDisabled()
     {
         return SessionBuilder.from(getSession()).withMdtEnabled(false).build();
+    }
+
+    /** MDT on with only the partition-stats index enabled, isolating partition pruning. */
+    private Session partitionStatsPruningOnly()
+    {
+        return SessionBuilder.from(getSession())
+                .withMdtEnabled(true)
+                .withColStatsIndexEnabled(false)
+                .withRecordLevelIndexEnabled(false)
+                .withSecondaryIndexEnabled(false)
+                .withPartitionStatsIndexEnabled(true)
+                .build();
+    }
+
+    private int totalSplits(Session session, String query)
+    {
+        return getQueryRunner().execute(session, query).getStatementStats().get().getTotalSplits();
     }
 }

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiUncompactedMetadataTable.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi;
+
+import io.trino.Session;
+import io.trino.plugin.hudi.testing.UncompactedMetadataHudiTablesInitializer;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.plugin.hudi.testing.UncompactedMetadataHudiTablesInitializer.TABLE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for apache/hudi#19279: queries on tables whose metadata table (MDT) has
+ * UNCOMPACTED delta commits. Those deltas are native HFILE log files, which the connector previously
+ * rejected ("Native HFILE log files are not supported..."), failing every query through the unguarded
+ * partition-stats pruning path. The table written by {@link UncompactedMetadataHudiTablesInitializer}
+ * keeps its MDT deliberately uncompacted (the zip fixtures always compact after every commit), so the
+ * queries below only succeed if the connector reads HFILE log deltas in the MDT's
+ * {@code files}/{@code column_stats}/{@code partition_stats} partitions.
+ */
+public class TestHudiUncompactedMetadataTable
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HudiQueryRunner.builder()
+                .setDataLoader(new UncompactedMetadataHudiTablesInitializer())
+                .build();
+    }
+
+    @Test
+    public void testSnapshotReadWithUncompactedMetadataTable()
+    {
+        // MDT-backed file listing must read the files partition's HFILE log deltas
+        assertQuery(
+                mdtEnabled(),
+                "SELECT id, name, price FROM " + TABLE_NAME + " ORDER BY id",
+                "VALUES ('k1', 'k1_c3', CAST(15 AS BIGINT)), ('k2', 'k2_c1', 1000), ('k3', 'k3_c2', 20), ('k4', 'k4_c2', 2000)");
+        assertThat(computeScalarWith(mdtEnabled(), "SELECT count(*) FROM " + TABLE_NAME)).isEqualTo(4L);
+    }
+
+    @Test
+    public void testResultsMatchWithMetadataTableDisabled()
+    {
+        String query = "SELECT id, name, price, part_col FROM " + TABLE_NAME + " ORDER BY id";
+        MaterializedResult withMdt = getQueryRunner().execute(mdtEnabled(), query);
+        MaterializedResult withoutMdt = getQueryRunner().execute(mdtDisabled(), query);
+        assertThat(withMdt.getMaterializedRows()).isEqualTo(withoutMdt.getMaterializedRows());
+    }
+
+    @Test
+    public void testPartitionStatsIndexPruningOverUncompactedStats()
+    {
+        // The exact crash from the issue: partition-stats pruning reads the partition_stats MDT
+        // partition, whose deltas are uncompacted HFILE log files. Partition p2 holds prices
+        // [1000, 2000], so `price < 100` lets the index prune it entirely.
+        Session session = SessionBuilder.from(getSession())
+                .withMdtEnabled(true)
+                .withColStatsIndexEnabled(false)
+                .withRecordLevelIndexEnabled(false)
+                .withSecondaryIndexEnabled(false)
+                .withPartitionStatsIndexEnabled(true)
+                .build();
+        MaterializedResult pruned = getQueryRunner().execute(session,
+                "SELECT id, price FROM " + TABLE_NAME + " WHERE price < 100");
+        assertThat(pruned.getMaterializedRows()).hasSize(2);
+
+        MaterializedResult unpruned = getQueryRunner().execute(mdtEnabled(),
+                "SELECT id, price FROM " + TABLE_NAME);
+        // Pruning must not scan more than the full table does; correctness is asserted above
+        assertThat(pruned.getStatementStats().get().getTotalSplits())
+                .isLessThanOrEqualTo(unpruned.getStatementStats().get().getTotalSplits());
+    }
+
+    @Test
+    public void testColumnStatsFileSkippingOverUncompactedStats()
+    {
+        // Column-stats file skipping reads the column_stats MDT partition's HFILE log deltas
+        Session session = SessionBuilder.from(getSession())
+                .withMdtEnabled(true)
+                .withColStatsIndexEnabled(true)
+                .withRecordLevelIndexEnabled(false)
+                .withSecondaryIndexEnabled(false)
+                .withPartitionStatsIndexEnabled(false)
+                .build();
+        assertQuery(
+                session,
+                "SELECT id, price FROM " + TABLE_NAME + " WHERE price = 15",
+                "VALUES ('k1', CAST(15 AS BIGINT))");
+    }
+
+    private Session mdtEnabled()
+    {
+        return SessionBuilder.from(getSession()).withMdtEnabled(true).build();
+    }
+
+    private Session mdtDisabled()
+    {
+        return SessionBuilder.from(getSession()).withMdtEnabled(false).build();
+    }
+
+    private Object computeScalarWith(Session session, String query)
+    {
+        return getQueryRunner().execute(session, query).getOnlyValue();
+    }
+}

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/AbstractMergerHudiTablesInitializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/AbstractMergerHudiTablesInitializer.java
@@ -89,7 +89,7 @@ public abstract class AbstractMergerHudiTablesInitializer
     private static final String PARTITION_PATH = "";
 
     /** Hudi metadata columns, prepended to every table's data columns in the metastore definition. */
-    private static final List<Column> HUDI_META_COLUMNS = ImmutableList.of(
+    static final List<Column> HUDI_META_COLUMNS = ImmutableList.of(
             new Column("_hoodie_commit_time", HIVE_STRING, Optional.empty(), Map.of()),
             new Column("_hoodie_commit_seqno", HIVE_STRING, Optional.empty(), Map.of()),
             new Column("_hoodie_record_key", HIVE_STRING, Optional.empty(), Map.of()),

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
@@ -47,11 +47,14 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 
 import java.io.IOException;
@@ -144,6 +147,7 @@ public class UncompactedMetadataHudiTablesInitializer
                 writeTable(new Path(tempTableDir.toUri()), tableName);
                 if (tableName.equals(CORRUPTED_TABLE_NAME)) {
                     corruptMetadataLogFiles(tempTableDir);
+                    verifyMetadataTableUnreadable(new Path(tempTableDir.toUri()));
                 }
                 Location tableLocation = externalLocation.appendPath(tableName);
                 ResourceHudiTablesInitializer.copyDir(tempTableDir, fileSystem, tableLocation);
@@ -200,6 +204,32 @@ public class UncompactedMetadataHudiTablesInitializer
             corrupted++;
         }
         checkState(corrupted > 0, "No MDT log files corrupted under %s; the fallback tests would pass vacuously", metadataDir);
+    }
+
+    /**
+     * Proves the corruption is effective, not just that bytes were flipped: a metadata-table read
+     * of the corrupted table must throw. This guards the fallback tests against the fixed trailer
+     * offsets in {@link #corruptMetadataLogFiles} ever missing (e.g. after an HFile layout change),
+     * in which case those tests would pass vacuously against a clean MDT read.
+     */
+    private static void verifyMetadataTableUnreadable(Path tablePath)
+    {
+        HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration());
+        List<String> partitions;
+        try (HoodieTableMetadata metadata = new HoodieBackedTableMetadata(
+                new HoodieJavaEngineContext(storageConf),
+                HoodieStorageUtils.getStorage(tablePath.toString(), storageConf),
+                HoodieMetadataConfig.newBuilder().enable(true).build(),
+                tablePath.toString())) {
+            // The files partition backs getAllPartitionPaths; its log delta is corrupted like all others
+            partitions = metadata.getAllPartitionPaths();
+        }
+        catch (Exception expected) {
+            return;
+        }
+        throw new IllegalStateException(
+                "Metadata table of " + CORRUPTED_TABLE_NAME + " is still readable (partitions: " + partitions
+                        + "); corruptMetadataLogFiles no longer lands on the HFile trailer fields");
     }
 
     private static void writeTable(Path tablePath, String tableName)

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
@@ -55,11 +55,15 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.hive.formats.HiveClassNames.HUDI_PARQUET_INPUT_FORMAT;
@@ -91,27 +95,30 @@ import static java.nio.file.Files.createTempDirectory;
  * </pre>
  * Final rows: k1=15, k2=1000, k3=20, k4=2000. Partition p1 holds prices [15, 20] and p2 holds
  * [1000, 2000], so a predicate like {@code price < 100} lets the partition-stats index prune p2.
+ * <p>
+ * A second, identical table {@link #CORRUPTED_TABLE_NAME} is written whose MDT log files are
+ * corrupted in place before upload: every MDT read of it throws, pinning the connector's
+ * fallbacks (direct file listing in {@code HudiSnapshotDirectoryLister}, unpruned split
+ * generation in {@code HudiBackgroundSplitLoader}) instead of only the clean-read path.
  */
 public class UncompactedMetadataHudiTablesInitializer
         implements HudiTablesInitializer
 {
     public static final String TABLE_NAME = "hudi_uncompacted_mdt_pt_cow";
+    public static final String CORRUPTED_TABLE_NAME = "hudi_corrupted_mdt_pt_cow";
 
     private static final String RECORD_KEY_FIELD = "id";
     private static final String PARTITION_FIELD = "part_col";
     private static final String ORDERING_FIELD = "ts";
     private static final List<String> PARTITION_PATHS = ImmutableList.of(PARTITION_FIELD + "=p1", PARTITION_FIELD + "=p2");
 
-    private static final List<Column> DATA_COLUMNS = ImmutableList.of(
-            new Column("_hoodie_commit_time", HIVE_STRING, Optional.empty(), Map.of()),
-            new Column("_hoodie_commit_seqno", HIVE_STRING, Optional.empty(), Map.of()),
-            new Column("_hoodie_record_key", HIVE_STRING, Optional.empty(), Map.of()),
-            new Column("_hoodie_partition_path", HIVE_STRING, Optional.empty(), Map.of()),
-            new Column("_hoodie_file_name", HIVE_STRING, Optional.empty(), Map.of()),
-            new Column(RECORD_KEY_FIELD, HIVE_STRING, Optional.empty(), Map.of()),
-            new Column("name", HIVE_STRING, Optional.empty(), Map.of()),
-            new Column("price", HIVE_LONG, Optional.empty(), Map.of()),
-            new Column(ORDERING_FIELD, HIVE_LONG, Optional.empty(), Map.of()));
+    private static final List<Column> DATA_COLUMNS = ImmutableList.<Column>builder()
+            .addAll(AbstractMergerHudiTablesInitializer.HUDI_META_COLUMNS)
+            .add(new Column(RECORD_KEY_FIELD, HIVE_STRING, Optional.empty(), Map.of()))
+            .add(new Column("name", HIVE_STRING, Optional.empty(), Map.of()))
+            .add(new Column("price", HIVE_LONG, Optional.empty(), Map.of()))
+            .add(new Column(ORDERING_FIELD, HIVE_LONG, Optional.empty(), Map.of()))
+            .build();
 
     private static final List<Column> PARTITION_COLUMNS =
             ImmutableList.of(new Column(PARTITION_FIELD, HIVE_STRING, Optional.empty(), Map.of()));
@@ -127,26 +134,75 @@ public class UncompactedMetadataHudiTablesInitializer
                 .getInstance(HiveMetastoreFactory.class)
                 .createMetastore(Optional.empty());
 
-        Location tableLocation = externalLocation.appendPath(TABLE_NAME);
-
         java.nio.file.Path tempDir = createTempDirectory("uncompacted-mdt");
         try {
-            java.nio.file.Path tempTableDir = tempDir.resolve(TABLE_NAME);
-            writeTable(new Path(tempTableDir.toUri()));
-            ResourceHudiTablesInitializer.copyDir(tempTableDir, fileSystem, tableLocation);
+            for (String tableName : ImmutableList.of(TABLE_NAME, CORRUPTED_TABLE_NAME)) {
+                java.nio.file.Path tempTableDir = tempDir.resolve(tableName);
+                writeTable(new Path(tempTableDir.toUri()), tableName);
+                if (tableName.equals(CORRUPTED_TABLE_NAME)) {
+                    corruptMetadataLogFiles(tempTableDir);
+                }
+                Location tableLocation = externalLocation.appendPath(tableName);
+                ResourceHudiTablesInitializer.copyDir(tempTableDir, fileSystem, tableLocation);
 
-            metastore.createTable(createTableDefinition(schemaName, tableLocation), PrincipalPrivileges.NO_PRIVILEGES);
-            metastore.addPartitions(schemaName, TABLE_NAME, createPartitions(schemaName, tableLocation));
+                metastore.createTable(createTableDefinition(schemaName, tableName, tableLocation), PrincipalPrivileges.NO_PRIVILEGES);
+                metastore.addPartitions(schemaName, tableName, createPartitions(schemaName, tableName, tableLocation));
+            }
         }
         finally {
             deleteRecursively(tempDir, ALLOW_INSECURE);
         }
     }
 
-    private static void writeTable(Path tablePath)
+    /**
+     * Corrupts every MDT log file so that any metadata-table read of the table throws, without the
+     * log reader silently skipping the damage. The corrupted window targets the HFile TRAILER of
+     * the last block's content: hudi-io HFiles end with a fixed 4096-byte trailer whose magic and
+     * protobuf fields sit at the trailer's START, followed by padding, so the window is placed
+     * ~4KB before EOF to land on those fields (corrupting near EOF would only flip padding). The
+     * log block FRAMING -- the leading magic/block-size fields and the trailing footer plus
+     * reverse-pointer long, which {@code HoodieLogFileReader.isBlockCorrupted} validates -- stays
+     * intact on purpose: framing damage is classified as a {@code HoodieCorruptBlock} and skipped
+     * WITHOUT an exception, which would silently drop records instead of exercising the
+     * connector's fallbacks.
+     */
+    private static void corruptMetadataLogFiles(java.nio.file.Path tableDir)
+            throws IOException
+    {
+        java.nio.file.Path metadataDir = tableDir.resolve(".hoodie").resolve("metadata");
+        List<java.nio.file.Path> logFiles;
+        try (Stream<java.nio.file.Path> walk = Files.walk(metadataDir)) {
+            logFiles = walk
+                    .filter(Files::isRegularFile)
+                    .filter(file -> file.getFileName().toString().contains(".log."))
+                    .collect(toImmutableList());
+        }
+        int corrupted = 0;
+        for (java.nio.file.Path logFile : logFiles) {
+            byte[] bytes = Files.readAllBytes(logFile);
+            // The last block's content ends (up to the small log block footer) at EOF and its
+            // HFile trailer spans the content's final 4096 bytes, so the trailer's magic and
+            // fields sit just past EOF - 4160; a data-bearing block always reaches that deep
+            int start = bytes.length - 4160;
+            int end = bytes.length - 3648;
+            if (start < 64) {
+                // Too small to hold a data-bearing block (e.g. only the file-group bootstrap
+                // block, which carries no records); nothing worth corrupting
+                continue;
+            }
+            for (int i = start; i < end; i++) {
+                bytes[i] ^= 0x5A;
+            }
+            Files.write(logFile, bytes);
+            corrupted++;
+        }
+        checkState(corrupted > 0, "No MDT log files corrupted under %s; the fallback tests would pass vacuously", metadataDir);
+    }
+
+    private static void writeTable(Path tablePath, String tableName)
     {
         Schema schema = createAvroSchema();
-        try (HoodieJavaWriteClient<HoodieAvroPayload> writeClient = createWriteClient(schema, tablePath)) {
+        try (HoodieJavaWriteClient<HoodieAvroPayload> writeClient = createWriteClient(schema, tablePath, tableName)) {
             String firstCommit = writeClient.startCommit();
             List<WriteStatus> firstStatuses = writeClient.insert(ImmutableList.of(
                     record(schema, "k1", "k1_c1", 10L, 100L, PARTITION_PATHS.get(0)),
@@ -166,13 +222,13 @@ public class UncompactedMetadataHudiTablesInitializer
         }
     }
 
-    private static HoodieJavaWriteClient<HoodieAvroPayload> createWriteClient(Schema schema, Path tablePath)
+    private static HoodieJavaWriteClient<HoodieAvroPayload> createWriteClient(Schema schema, Path tablePath, String tableName)
     {
         Configuration conf = new Configuration();
         try {
             HoodieTableMetaClient.newTableBuilder()
                     .setTableType(HoodieTableType.COPY_ON_WRITE)
-                    .setTableName(TABLE_NAME)
+                    .setTableName(tableName)
                     .setTimelineLayoutVersion(1)
                     .setBootstrapIndexClass(NoOpBootstrapIndex.class.getName())
                     .setPayloadClassName(HoodieAvroPayload.class.getName())
@@ -183,7 +239,7 @@ public class UncompactedMetadataHudiTablesInitializer
                     .initTable(new HadoopStorageConfiguration(conf), tablePath.toString());
         }
         catch (IOException e) {
-            throw new RuntimeException("Could not init table " + TABLE_NAME, e);
+            throw new RuntimeException("Could not init table " + tableName, e);
         }
 
         HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder()
@@ -191,7 +247,7 @@ public class UncompactedMetadataHudiTablesInitializer
                 .withSchema(schema.toString())
                 .withParallelism(2, 2)
                 .withDeleteParallelism(2)
-                .forTable(TABLE_NAME)
+                .forTable(tableName)
                 .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
                 .withCompactionConfig(HoodieCompactionConfig.newBuilder()
                         .withInlineCompaction(false)
@@ -238,11 +294,11 @@ public class UncompactedMetadataHudiTablesInitializer
         return Schema.createRecord(TABLE_NAME, null, null, false, new ArrayList<>(fields));
     }
 
-    private static Table createTableDefinition(String schemaName, Location location)
+    private static Table createTableDefinition(String schemaName, String tableName, Location location)
     {
         return Table.builder()
                 .setDatabaseName(schemaName)
-                .setTableName(TABLE_NAME)
+                .setTableName(tableName)
                 .setTableType(EXTERNAL_TABLE.name())
                 .setOwner(Optional.of("public"))
                 .setDataColumns(DATA_COLUMNS)
@@ -254,14 +310,14 @@ public class UncompactedMetadataHudiTablesInitializer
                 .build();
     }
 
-    private static List<PartitionWithStatistics> createPartitions(String schemaName, Location tableLocation)
+    private static List<PartitionWithStatistics> createPartitions(String schemaName, String tableName, Location tableLocation)
     {
         List<PartitionWithStatistics> partitions = new ArrayList<>();
         for (String partitionName : PARTITION_PATHS) {
             // Hive-style partition paths, so the partition NAME and the relative PATH coincide
             Partition partition = Partition.builder()
                     .setDatabaseName(schemaName)
-                    .setTableName(TABLE_NAME)
+                    .setTableName(tableName)
                     .setValues(extractPartitionValues(partitionName))
                     .withStorage(storageBuilder -> storageBuilder
                             .setStorageFormat(storageFormat())

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
@@ -226,6 +226,7 @@ public class UncompactedMetadataHudiTablesInitializer
      * in which case those tests would pass vacuously against a clean MDT read.
      */
     private static void verifyMetadataTableUnreadable(Path tablePath)
+            throws Exception
     {
         HadoopStorageConfiguration storageConf = new HadoopStorageConfiguration(new Configuration());
         List<String> partitions;

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi.testing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.metastore.Column;
+import io.trino.metastore.HiveMetastore;
+import io.trino.metastore.HiveMetastoreFactory;
+import io.trino.metastore.Partition;
+import io.trino.metastore.PartitionStatistics;
+import io.trino.metastore.PartitionWithStatistics;
+import io.trino.metastore.PrincipalPrivileges;
+import io.trino.metastore.StorageFormat;
+import io.trino.metastore.Table;
+import io.trino.plugin.hudi.HudiConnector;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.QueryRunner;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.client.HoodieJavaWriteClient;
+import org.apache.hudi.client.WriteStatus;
+import org.apache.hudi.client.common.HoodieJavaEngineContext;
+import org.apache.hudi.common.bootstrap.index.NoOpBootstrapIndex;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieCompactionConfig;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.hive.formats.HiveClassNames.HUDI_PARQUET_INPUT_FORMAT;
+import static io.trino.hive.formats.HiveClassNames.MAPRED_PARQUET_OUTPUT_FORMAT_CLASS;
+import static io.trino.hive.formats.HiveClassNames.PARQUET_HIVE_SERDE_CLASS;
+import static io.trino.metastore.HiveType.HIVE_LONG;
+import static io.trino.metastore.HiveType.HIVE_STRING;
+import static io.trino.plugin.hive.HivePartitionManager.extractPartitionValues;
+import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
+import static java.nio.file.Files.createTempDirectory;
+
+/**
+ * Creates a partitioned COW table at test runtime with an ENABLED, UNCOMPACTED metadata table (MDT):
+ * {@code hoodie.metadata.compact.max.delta.commits} is set high (the zip fixtures use {@code =1}, so
+ * their MDTs are always freshly compacted) and several commits are written, leaving the MDT's
+ * {@code files}/{@code column_stats}/{@code partition_stats} partitions with native HFILE LOG deltas
+ * that the connector must read at query time (issue apache/hudi#19279).
+ * <p>
+ * Note: MDT writing here is fully native -- HFILE base files and log blocks are written via hudi-io's
+ * pure-Java {@code HFileWriterImpl}, so no hbase dependency is involved (the "requires hbase" note in
+ * older initializers is stale).
+ * <p>
+ * Data layout (partitions {@code part_col=p1} / {@code part_col=p2}, hive-style paths so the MDT
+ * partition listing and the metastore agree on names):
+ * <pre>
+ * commit 1 (insert): k1(p1, price 10,  ts 100), k2(p2, price 1000, ts 100)
+ * commit 2 (insert): k3(p1, price 20,  ts 200), k4(p2, price 2000, ts 200)
+ * commit 3 (upsert): k1(p1, price 15,  ts 300)
+ * </pre>
+ * Final rows: k1=15, k2=1000, k3=20, k4=2000. Partition p1 holds prices [15, 20] and p2 holds
+ * [1000, 2000], so a predicate like {@code price < 100} lets the partition-stats index prune p2.
+ */
+public class UncompactedMetadataHudiTablesInitializer
+        implements HudiTablesInitializer
+{
+    public static final String TABLE_NAME = "hudi_uncompacted_mdt_pt_cow";
+
+    private static final String RECORD_KEY_FIELD = "id";
+    private static final String PARTITION_FIELD = "part_col";
+    private static final String ORDERING_FIELD = "ts";
+    private static final List<String> PARTITION_PATHS = ImmutableList.of(PARTITION_FIELD + "=p1", PARTITION_FIELD + "=p2");
+
+    private static final List<Column> DATA_COLUMNS = ImmutableList.of(
+            new Column("_hoodie_commit_time", HIVE_STRING, Optional.empty(), Map.of()),
+            new Column("_hoodie_commit_seqno", HIVE_STRING, Optional.empty(), Map.of()),
+            new Column("_hoodie_record_key", HIVE_STRING, Optional.empty(), Map.of()),
+            new Column("_hoodie_partition_path", HIVE_STRING, Optional.empty(), Map.of()),
+            new Column("_hoodie_file_name", HIVE_STRING, Optional.empty(), Map.of()),
+            new Column(RECORD_KEY_FIELD, HIVE_STRING, Optional.empty(), Map.of()),
+            new Column("name", HIVE_STRING, Optional.empty(), Map.of()),
+            new Column("price", HIVE_LONG, Optional.empty(), Map.of()),
+            new Column(ORDERING_FIELD, HIVE_LONG, Optional.empty(), Map.of()));
+
+    private static final List<Column> PARTITION_COLUMNS =
+            ImmutableList.of(new Column(PARTITION_FIELD, HIVE_STRING, Optional.empty(), Map.of()));
+
+    @Override
+    public void initializeTables(QueryRunner queryRunner, Location externalLocation, String schemaName)
+            throws Exception
+    {
+        TrinoFileSystem fileSystem = ((HudiConnector) queryRunner.getCoordinator().getConnector("hudi")).getInjector()
+                .getInstance(TrinoFileSystemFactory.class)
+                .create(ConnectorIdentity.ofUser("test"));
+        HiveMetastore metastore = ((HudiConnector) queryRunner.getCoordinator().getConnector("hudi")).getInjector()
+                .getInstance(HiveMetastoreFactory.class)
+                .createMetastore(Optional.empty());
+
+        Location tableLocation = externalLocation.appendPath(TABLE_NAME);
+
+        java.nio.file.Path tempDir = createTempDirectory("uncompacted-mdt");
+        try {
+            java.nio.file.Path tempTableDir = tempDir.resolve(TABLE_NAME);
+            writeTable(new Path(tempTableDir.toUri()));
+            ResourceHudiTablesInitializer.copyDir(tempTableDir, fileSystem, tableLocation);
+
+            metastore.createTable(createTableDefinition(schemaName, tableLocation), PrincipalPrivileges.NO_PRIVILEGES);
+            metastore.addPartitions(schemaName, TABLE_NAME, createPartitions(schemaName, tableLocation));
+        }
+        finally {
+            deleteRecursively(tempDir, ALLOW_INSECURE);
+        }
+    }
+
+    private static void writeTable(Path tablePath)
+    {
+        Schema schema = createAvroSchema();
+        try (HoodieJavaWriteClient<HoodieAvroPayload> writeClient = createWriteClient(schema, tablePath)) {
+            String firstCommit = writeClient.startCommit();
+            List<WriteStatus> firstStatuses = writeClient.insert(ImmutableList.of(
+                    record(schema, "k1", "k1_c1", 10L, 100L, PARTITION_PATHS.get(0)),
+                    record(schema, "k2", "k2_c1", 1000L, 100L, PARTITION_PATHS.get(1))), firstCommit);
+            writeClient.commit(firstCommit, firstStatuses);
+
+            String secondCommit = writeClient.startCommit();
+            List<WriteStatus> secondStatuses = writeClient.insert(ImmutableList.of(
+                    record(schema, "k3", "k3_c2", 20L, 200L, PARTITION_PATHS.get(0)),
+                    record(schema, "k4", "k4_c2", 2000L, 200L, PARTITION_PATHS.get(1))), secondCommit);
+            writeClient.commit(secondCommit, secondStatuses);
+
+            String thirdCommit = writeClient.startCommit();
+            List<WriteStatus> thirdStatuses = writeClient.upsert(ImmutableList.of(
+                    record(schema, "k1", "k1_c3", 15L, 300L, PARTITION_PATHS.get(0))), thirdCommit);
+            writeClient.commit(thirdCommit, thirdStatuses);
+        }
+    }
+
+    private static HoodieJavaWriteClient<HoodieAvroPayload> createWriteClient(Schema schema, Path tablePath)
+    {
+        Configuration conf = new Configuration();
+        try {
+            HoodieTableMetaClient.newTableBuilder()
+                    .setTableType(HoodieTableType.COPY_ON_WRITE)
+                    .setTableName(TABLE_NAME)
+                    .setTimelineLayoutVersion(1)
+                    .setBootstrapIndexClass(NoOpBootstrapIndex.class.getName())
+                    .setPayloadClassName(HoodieAvroPayload.class.getName())
+                    .setRecordKeyFields(RECORD_KEY_FIELD)
+                    .setPartitionFields(PARTITION_FIELD)
+                    .setHiveStylePartitioningEnable(true)
+                    .setOrderingFields(ORDERING_FIELD)
+                    .initTable(new HadoopStorageConfiguration(conf), tablePath.toString());
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Could not init table " + TABLE_NAME, e);
+        }
+
+        HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder()
+                .withPath(tablePath.toString())
+                .withSchema(schema.toString())
+                .withParallelism(2, 2)
+                .withDeleteParallelism(2)
+                .forTable(TABLE_NAME)
+                .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
+                .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+                        .withInlineCompaction(false)
+                        .withMaxNumDeltaCommitsBeforeCompaction(100)
+                        .build())
+                .withEmbeddedTimelineServerEnabled(false)
+                .withMarkersType(MarkerType.DIRECT.name())
+                // The whole point of this initializer: an ENABLED metadata table with stats indexes,
+                // whose compaction never fires within this test (the zip fixtures use
+                // compact.max.delta.commits=1), so its partitions keep native HFILE log deltas.
+                // MDT HFILE writing is native (hudi-io HFileWriterImpl) -- no hbase involved.
+                .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+                        .enable(true)
+                        .withMetadataIndexColumnStats(true)
+                        .withMetadataIndexPartitionStats(true)
+                        .withMaxNumDeltaCommitsBeforeCompaction(100)
+                        .build())
+                .build();
+        return new HoodieJavaWriteClient<>(new HoodieJavaEngineContext(new HadoopStorageConfiguration(conf)), cfg);
+    }
+
+    private static HoodieRecord<HoodieAvroPayload> record(Schema schema, String key, String name, long price, long ts, String partitionPath)
+    {
+        GenericRecord record = new GenericData.Record(schema);
+        record.put(RECORD_KEY_FIELD, key);
+        record.put("name", name);
+        record.put("price", price);
+        record.put(ORDERING_FIELD, ts);
+        // Keep the partition column in the data files like Spark-written tables do; Trino reads its
+        // value from the metastore partition, not from parquet
+        record.put(PARTITION_FIELD, partitionPath.substring(partitionPath.indexOf('=') + 1));
+        HoodieKey hoodieKey = new HoodieKey(key, partitionPath);
+        return new HoodieAvroRecord<>(hoodieKey, new HoodieAvroPayload(Option.of(record)), null);
+    }
+
+    private static Schema createAvroSchema()
+    {
+        List<Schema.Field> fields = ImmutableList.of(
+                new Schema.Field(RECORD_KEY_FIELD, Schema.create(Schema.Type.STRING)),
+                new Schema.Field("name", Schema.create(Schema.Type.STRING)),
+                new Schema.Field("price", Schema.create(Schema.Type.LONG)),
+                new Schema.Field(ORDERING_FIELD, Schema.create(Schema.Type.LONG)),
+                new Schema.Field(PARTITION_FIELD, Schema.create(Schema.Type.STRING)));
+        return Schema.createRecord(TABLE_NAME, null, null, false, new ArrayList<>(fields));
+    }
+
+    private static Table createTableDefinition(String schemaName, Location location)
+    {
+        return Table.builder()
+                .setDatabaseName(schemaName)
+                .setTableName(TABLE_NAME)
+                .setTableType(EXTERNAL_TABLE.name())
+                .setOwner(Optional.of("public"))
+                .setDataColumns(DATA_COLUMNS)
+                .setPartitionColumns(PARTITION_COLUMNS)
+                .setParameters(ImmutableMap.of("serialization.format", "1", "EXTERNAL", "TRUE"))
+                .withStorage(storageBuilder -> storageBuilder
+                        .setStorageFormat(storageFormat())
+                        .setLocation(location.toString()))
+                .build();
+    }
+
+    private static List<PartitionWithStatistics> createPartitions(String schemaName, Location tableLocation)
+    {
+        List<PartitionWithStatistics> partitions = new ArrayList<>();
+        for (String partitionName : PARTITION_PATHS) {
+            // Hive-style partition paths, so the partition NAME and the relative PATH coincide
+            Partition partition = Partition.builder()
+                    .setDatabaseName(schemaName)
+                    .setTableName(TABLE_NAME)
+                    .setValues(extractPartitionValues(partitionName))
+                    .withStorage(storageBuilder -> storageBuilder
+                            .setStorageFormat(storageFormat())
+                            .setLocation(tableLocation.appendPath(partitionName).toString()))
+                    .setColumns(DATA_COLUMNS)
+                    .build();
+            partitions.add(new PartitionWithStatistics(partition, partitionName, PartitionStatistics.empty()));
+        }
+        return partitions;
+    }
+
+    private static StorageFormat storageFormat()
+    {
+        return StorageFormat.create(
+                PARQUET_HIVE_SERDE_CLASS,
+                HUDI_PARQUET_INPUT_FORMAT,
+                MAPRED_PARQUET_OUTPUT_FORMAT_CLASS);
+    }
+}

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
@@ -89,10 +89,13 @@ import static java.nio.file.Files.createTempDirectory;
  * Data layout (partitions {@code part_col=p1} / {@code part_col=p2}, hive-style paths so the MDT
  * partition listing and the metastore agree on names):
  * <pre>
- * commit 1 (insert): k1(p1, price 10,  ts 100), k2(p2, price 1000, ts 100)
- * commit 2 (insert): k3(p1, price 20,  ts 200), k4(p2, price 2000, ts 200)
- * commit 3 (upsert): k1(p1, price 15,  ts 300)
+ * commit 1 (insert, MDT off): k1(p1, price 10,  ts 100), k2(p2, price 1000, ts 100)
+ * commit 2 (insert, MDT on):  k3(p1, price 20,  ts 200), k4(p2, price 2000, ts 200)
+ * commit 3 (upsert, MDT on):  k1(p1, price 15,  ts 300)
  * </pre>
+ * The MDT is enabled only from commit 2 so its bootstrap sees existing data; a bootstrap over an
+ * empty table would register the col-stats index definition with no source fields, permanently
+ * disabling stats-based pruning in the connector (see {@code writeTable}).
  * Final rows: k1=15, k2=1000, k3=20, k4=2000. Partition p1 holds prices [15, 20] and p2 holds
  * [1000, 2000], so a predicate like {@code price < 100} lets the partition-stats index prune p2.
  * <p>
@@ -202,13 +205,24 @@ public class UncompactedMetadataHudiTablesInitializer
     private static void writeTable(Path tablePath, String tableName)
     {
         Schema schema = createAvroSchema();
-        try (HoodieJavaWriteClient<HoodieAvroPayload> writeClient = createWriteClient(schema, tablePath, tableName)) {
+        initTable(tablePath, tableName);
+
+        // Commit 1 runs with the MDT off so the MDT bootstraps AFTER data exists. Index
+        // definitions get their source fields from ColumnStatsIndexer.postInitialization, which
+        // registers an EMPTY field list when the bootstrap sees no records, and
+        // HoodieJavaWriteClient.updateColumnsToIndexWithColStats is a no-op (the Spark client
+        // refreshes the definition on each commit), so a definition registered over an empty
+        // table keeps empty source fields forever and the connector's canApply() then rejects
+        // the col-stats/partition-stats indexes, silently disabling pruning.
+        try (HoodieJavaWriteClient<HoodieAvroPayload> writeClient = createWriteClient(schema, tablePath, tableName, false)) {
             String firstCommit = writeClient.startCommit();
             List<WriteStatus> firstStatuses = writeClient.insert(ImmutableList.of(
                     record(schema, "k1", "k1_c1", 10L, 100L, PARTITION_PATHS.get(0)),
                     record(schema, "k2", "k2_c1", 1000L, 100L, PARTITION_PATHS.get(1))), firstCommit);
             writeClient.commit(firstCommit, firstStatuses);
+        }
 
+        try (HoodieJavaWriteClient<HoodieAvroPayload> writeClient = createWriteClient(schema, tablePath, tableName, true)) {
             String secondCommit = writeClient.startCommit();
             List<WriteStatus> secondStatuses = writeClient.insert(ImmutableList.of(
                     record(schema, "k3", "k3_c2", 20L, 200L, PARTITION_PATHS.get(0)),
@@ -222,9 +236,8 @@ public class UncompactedMetadataHudiTablesInitializer
         }
     }
 
-    private static HoodieJavaWriteClient<HoodieAvroPayload> createWriteClient(Schema schema, Path tablePath, String tableName)
+    private static void initTable(Path tablePath, String tableName)
     {
-        Configuration conf = new Configuration();
         try {
             HoodieTableMetaClient.newTableBuilder()
                     .setTableType(HoodieTableType.COPY_ON_WRITE)
@@ -236,12 +249,16 @@ public class UncompactedMetadataHudiTablesInitializer
                     .setPartitionFields(PARTITION_FIELD)
                     .setHiveStylePartitioningEnable(true)
                     .setOrderingFields(ORDERING_FIELD)
-                    .initTable(new HadoopStorageConfiguration(conf), tablePath.toString());
+                    .initTable(new HadoopStorageConfiguration(new Configuration()), tablePath.toString());
         }
         catch (IOException e) {
             throw new RuntimeException("Could not init table " + tableName, e);
         }
+    }
 
+    private static HoodieJavaWriteClient<HoodieAvroPayload> createWriteClient(Schema schema, Path tablePath, String tableName, boolean metadataEnabled)
+    {
+        Configuration conf = new Configuration();
         HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder()
                 .withPath(tablePath.toString())
                 .withSchema(schema.toString())
@@ -259,10 +276,11 @@ public class UncompactedMetadataHudiTablesInitializer
                 // whose compaction never fires within this test (the zip fixtures use
                 // compact.max.delta.commits=1), so its partitions keep native HFILE log deltas.
                 // MDT HFILE writing is native (hudi-io HFileWriterImpl) -- no hbase involved.
+                // metadataEnabled is false for the first commit only; see writeTable.
                 .withMetadataConfig(HoodieMetadataConfig.newBuilder()
-                        .enable(true)
-                        .withMetadataIndexColumnStats(true)
-                        .withMetadataIndexPartitionStats(true)
+                        .enable(metadataEnabled)
+                        .withMetadataIndexColumnStats(metadataEnabled)
+                        .withMetadataIndexPartitionStats(metadataEnabled)
                         .withMaxNumDeltaCommitsBeforeCompaction(100)
                         .build())
                 .build();

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
@@ -52,6 +52,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadata;
@@ -60,9 +61,11 @@ import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -80,12 +83,17 @@ import static java.nio.file.Files.createTempDirectory;
 
 /**
  * Creates a partitioned COW table at test runtime with an ENABLED, UNCOMPACTED metadata table (MDT):
- * {@code hoodie.metadata.compact.max.delta.commits} is set high (the zip fixtures use {@code =1}, so
- * their MDTs are always freshly compacted) and several commits are written, leaving the MDT's
- * {@code files}/{@code column_stats}/{@code partition_stats} partitions with native HFILE LOG deltas
- * that the connector must read at query time (issue apache/hudi#19279).
+ * {@code hoodie.metadata.compact.max.delta.commits} is set high and several commits are written,
+ * leaving the MDT's {@code files}/{@code column_stats}/{@code partition_stats} partitions with
+ * NATIVE HFILE log files that the connector must read at query time (issue apache/hudi#19279):
+ * {@code *.log.hfile} deltas where the whole file is an HFile, as current writers produce. The zip
+ * fixtures cannot cover this even where their MDTs are uncompacted (e.g. {@code hudi_trips_cow_v8}):
+ * they predate the native-log write path, so their MDT deltas are {@code #HUDI#} block-format logs
+ * carrying HFILE_DATA_BLOCKs, which the connector already read through its HFile content reader;
+ * only whole-file native HFILE logs hit the previously unimplemented
+ * {@code getFileFormatUtils(HFILE)} path.
  * <p>
- * Note: MDT writing here is fully native -- HFILE base files and log blocks are written via hudi-io's
+ * Note: MDT writing here is fully native -- HFILE base files and log files are written via hudi-io's
  * pure-Java {@code HFileWriterImpl}, so no hbase dependency is involved (the "requires hbase" note in
  * older initializers is stale).
  * <p>
@@ -162,16 +170,14 @@ public class UncompactedMetadataHudiTablesInitializer
     }
 
     /**
-     * Corrupts every MDT log file so that any metadata-table read of the table throws, without the
-     * log reader silently skipping the damage. The corrupted window targets the HFile TRAILER of
-     * the last block's content: hudi-io HFiles end with a fixed 4096-byte trailer whose magic and
-     * protobuf fields sit at the trailer's START, followed by padding, so the window is placed
-     * ~4KB before EOF to land on those fields (corrupting near EOF would only flip padding). The
-     * log block FRAMING -- the leading magic/block-size fields and the trailing footer plus
-     * reverse-pointer long, which {@code HoodieLogFileReader.isBlockCorrupted} validates -- stays
-     * intact on purpose: framing damage is classified as a {@code HoodieCorruptBlock} and skipped
-     * WITHOUT an exception, which would silently drop records instead of exercising the
-     * connector's fallbacks.
+     * Corrupts the MDT log files so that any metadata-table read of the table throws. The deltas
+     * here are NATIVE HFILE log files (the whole file is an HFile): hudi-io HFiles end with a
+     * fixed 4096-byte trailer whose magic and protobuf fields sit at the trailer's START, followed
+     * by padding, so the corrupted window is placed ~4KB before EOF to land on those fields --
+     * flipping bytes near EOF would only hit padding and reads would still succeed.
+     * {@link #verifyMetadataTableUnreadable} then proves the corruption took. Every MDT partition
+     * directory must end up with at least one corrupted log file, so that none of the read paths
+     * (files listing, col-stats skipping, partition-stats pruning) can see a clean partition.
      */
     private static void corruptMetadataLogFiles(java.nio.file.Path tableDir)
             throws IOException
@@ -182,28 +188,35 @@ public class UncompactedMetadataHudiTablesInitializer
             logFiles = walk
                     .filter(Files::isRegularFile)
                     .filter(file -> file.getFileName().toString().contains(".log."))
+                    // Only files directly inside an MDT partition directory, not timeline or
+                    // marker leftovers under the MDT's own .hoodie
+                    .filter(file -> metadataDir.equals(file.getParent().getParent()))
                     .collect(toImmutableList());
         }
-        int corrupted = 0;
+        Set<java.nio.file.Path> partitionsWithLogFiles = new HashSet<>();
+        Set<java.nio.file.Path> partitionsCorrupted = new HashSet<>();
         for (java.nio.file.Path logFile : logFiles) {
+            partitionsWithLogFiles.add(logFile.getParent());
             byte[] bytes = Files.readAllBytes(logFile);
-            // The last block's content ends (up to the small log block footer) at EOF and its
-            // HFile trailer spans the content's final 4096 bytes, so the trailer's magic and
-            // fields sit just past EOF - 4160; a data-bearing block always reaches that deep
             int start = bytes.length - 4160;
             int end = bytes.length - 3648;
             if (start < 64) {
-                // Too small to hold a data-bearing block (e.g. only the file-group bootstrap
-                // block, which carries no records); nothing worth corrupting
+                // Too small to even hold an HFile trailer: a record-less file-group bootstrap
+                // marker that no read decodes. The per-partition check below still requires a
+                // corrupted data-bearing file next to it.
                 continue;
             }
             for (int i = start; i < end; i++) {
                 bytes[i] ^= 0x5A;
             }
             Files.write(logFile, bytes);
-            corrupted++;
+            partitionsCorrupted.add(logFile.getParent());
         }
-        checkState(corrupted > 0, "No MDT log files corrupted under %s; the fallback tests would pass vacuously", metadataDir);
+        checkState(!partitionsWithLogFiles.isEmpty(), "No MDT log files found under %s", metadataDir);
+        Set<java.nio.file.Path> untouched = new HashSet<>(partitionsWithLogFiles);
+        untouched.removeAll(partitionsCorrupted);
+        checkState(untouched.isEmpty(),
+                "No MDT log file corrupted in partition(s) %s; reads of those partitions would still succeed and their fallback tests would pass vacuously", untouched);
     }
 
     /**
@@ -224,7 +237,10 @@ public class UncompactedMetadataHudiTablesInitializer
             // The files partition backs getAllPartitionPaths; its log delta is corrupted like all others
             partitions = metadata.getAllPartitionPaths();
         }
-        catch (Exception expected) {
+        catch (HoodieMetadataException expected) {
+            // Only the wrapper BaseTableMetadata puts around a genuine read failure counts: the
+            // bare IllegalArgumentException it throws for a never-initialized MDT must NOT pass,
+            // or this guard would go quiet if the fixture's MDT bootstrap ever stopped happening
             return;
         }
         throw new IllegalStateException(
@@ -240,10 +256,11 @@ public class UncompactedMetadataHudiTablesInitializer
         // Commit 1 runs with the MDT off so the MDT bootstraps AFTER data exists. Index
         // definitions get their source fields from ColumnStatsIndexer.postInitialization, which
         // registers an EMPTY field list when the bootstrap sees no records, and
-        // HoodieJavaWriteClient.updateColumnsToIndexWithColStats is a no-op (the Spark client
-        // refreshes the definition on each commit), so a definition registered over an empty
-        // table keeps empty source fields forever and the connector's canApply() then rejects
-        // the col-stats/partition-stats indexes, silently disabling pruning.
+        // HoodieJavaWriteClient.updateColumnsToIndexWithColStats is a no-op (HUDI-8801; the
+        // Spark client refreshes the definition on each commit), so a definition registered over
+        // an empty table keeps empty source fields forever and the connector's canApply() then
+        // rejects the col-stats/partition-stats indexes, silently disabling pruning. Once
+        // HUDI-8801 fixes the Java client, this two-client split can collapse back to one.
         try (HoodieJavaWriteClient<HoodieAvroPayload> writeClient = createWriteClient(schema, tablePath, tableName, false)) {
             String firstCommit = writeClient.startCommit();
             List<WriteStatus> firstStatuses = writeClient.insert(ImmutableList.of(

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/testing/UncompactedMetadataHudiTablesInitializer.java
@@ -320,11 +320,11 @@ public class UncompactedMetadataHudiTablesInitializer
                         .build())
                 .withEmbeddedTimelineServerEnabled(false)
                 .withMarkersType(MarkerType.DIRECT.name())
-                // The whole point of this initializer: an ENABLED metadata table with stats indexes,
-                // whose compaction never fires within this test (the zip fixtures use
-                // compact.max.delta.commits=1), so its partitions keep native HFILE log deltas.
-                // MDT HFILE writing is native (hudi-io HFileWriterImpl) -- no hbase involved.
-                // metadataEnabled is false for the first commit only; see writeTable.
+                // The whole point of this initializer: an ENABLED metadata table with stats
+                // indexes whose compaction never fires within this test, so its partitions keep
+                // native HFILE log deltas. MDT HFILE writing is native (hudi-io HFileWriterImpl)
+                // -- no hbase involved. metadataEnabled is false for the first commit only; see
+                // writeTable.
                 .withMetadataConfig(HoodieMetadataConfig.newBuilder()
                         .enable(metadataEnabled)
                         .withMetadataIndexColumnStats(metadataEnabled)


### PR DESCRIPTION
Stacked on #19295 (-> #19288 -> #18837) -- only the head commit is new here.

### Describe the issue this Pull Request addresses

Closes #19279

With the connector default `hudi.metadata-enabled=true`, any query on a table whose metadata table (MDT) has uncompacted delta commits fails with "Native HFILE log files are not supported by the Hudi Trino connector". MDT compaction only runs every 10 delta commits by default, so an actively written table spends most of its life in that state -- default Spark writer plus default catalog config meant every read failed. The E2E pipeline currently sets `hudi.metadata-enabled=false` to work around it.

### Summary and Changelog

The gap turned out to be small: the connector already reads HFile base files (compacted MDT) through hudi-io's native reader, and the native-log read path only needs `getFileFormatUtils(HFILE).readFooter`. hudi-common's `HFileUtils` is hadoop-free (it decodes via hudi-io), so unlike parquet there is no need for a Trino-native implementation.

- `HudiTrinoIOFactory.getFileFormatUtils` now returns `HFileUtils` for HFILE, making uncompacted MDT deltas (native HFILE log files) readable.
- Partition-stats pruning in `HudiBackgroundSplitLoader` no longer fails the query: on error it logs and proceeds unpruned, same as the metastore fallback the partition listing right above it already had. This was the unguarded path in the issue's stack.
- The MDT-backed file-system-view load in `HudiSnapshotDirectoryLister` (the other unguarded synchronous MDT read) falls back to direct file listing on error.

Tests: a new initializer writes two partitioned COW tables with the MDT enabled and `compact.max.delta.commits=100`, leaving real native HFILE log files (`*.log.hfile`, the whole file is an HFile) in the `files`/`column_stats`/`partition_stats` MDT partitions. The zip fixtures could not catch this even where their MDTs are uncompacted: they predate the native-log write path, so their MDT deltas are block-format logs carrying HFILE data blocks, which the connector already read through its HFile content reader. The second table is a corrupted twin: its MDT log deltas are damaged in place (targeting the HFile trailer fields, in every MDT partition, so any read throws), and the initializer asserts that a metadata-table read of it actually fails before uploading. `TestHudiUncompactedMetadataTable` covers, on the clean table: MDT-backed listing, MDT on/off result equality, partition-stats pruning with split-count assertions (the exact crash from the issue) and col-stats file skipping with split-count assertions (col-stats wait timeout raised so the skip decision actually consumes the stats); and on the corrupted twin, the two fallbacks: direct file listing when the MDT-backed file-system-view load throws, and unpruned split generation when the partition-stats read throws. Side note: MDT writing needs no hbase anymore (hudi-io's `HFileWriterImpl`), so the "requires hbase" comment in the older initializers is stale.

### Impact

Tables with uncompacted MDTs are readable under default configs, and index pruning / MDT listing degrade gracefully instead of failing queries. No API or config changes. Follow-up on the E2E branch: drop the `hudi.metadata-enabled=false` catalog workaround so the pipeline runs MDT-on.

### Risk Level

low -- the format support is a one-line dispatch to existing hudi-common/hudi-io code, and the two guards mirror fallback patterns already in the connector; all pinned by the new tests.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable


