### PR TITLE
docs: RFC-108 - Multi-dataset incremental reads in Hudi Streamer

### DIFF
--- a/rfc/rfc-108/rfc-108.md
+++ b/rfc/rfc-108/rfc-108.md
@@ -39,13 +39,17 @@ full-snapshot reads for all-but-one table. The multi-job approach has no cross-s
 boundary, so the tables it stitches together drift in time, produce incomplete/inconsistent joined
 output, and require backfills to repair; it also multiplies watermark and monitoring overhead.
 
-This RFC proposes **native multi-table incremental reads** in Hudi Streamer: a new source
-(`HoodieIncrMultiSource`) that reads N Hudi tables incrementally in a single batch with **independent
-per-table checkpoints**, a **multi-dataset transformer** contract (`MultiDatasetTransformer`,
-implemented by `SqlFileBasedTransformer`) that merges the datasets with a single SQL file referencing
-`<SRC_0>`, `<SRC_1>`, …, and a **backward-compatible multi-table checkpoint format** managed by
-`MultiTableCheckpointManager`. The result is a single, atomic ingestion job — one commit, one
-checkpoint — for related datasets.
+This RFC proposes **native multi-source incremental reads** in Hudi Streamer via a **composition**
+design: `InputBatch`, `Source`, and `SourceFormatAdapter` remain unchanged, and a new
+`MultiSourceFormatAdapter` composes N ordinary per-source `SourceFormatAdapter`s (one per configured
+Hudi table). `StreamSync.fetchNextBatchFromSource` branches once on adapter type at the top of the
+method; the rest of the pipeline — schema deduction, error-event processing, write, commit — is
+byte-for-byte identical for the single-source and multi-source paths. A new `MultiDatasetTransformer`
+contract (implemented by `SqlFileBasedTransformer`) merges the per-source datasets with a single SQL
+file referencing `<SRC_0>`, `<SRC_1>`, …, and a **backward-compatible indexed, path-fingerprinted
+checkpoint format** managed by `MultiTableCheckpointManager` records the per-source cursor set in a
+single commit. The result is a single, atomic ingestion job — one commit, one checkpoint — for
+related datasets, added without a public-API change to `InputBatch` or the `Source` hierarchy.
 
 ## Background
 
@@ -85,7 +89,8 @@ single timestamps stored in `deltastreamer.checkpoint.key` in the Streamer commi
   downstream merge, the merge step periodically observes fact rows whose dimension row has not yet
   been ingested and either drops them (inner join) or emits rows with null dimension fields (outer
   join) that must be repaired on a later run. A native multi-source incremental read advances both
-  tables under one commit, so the join always sees a consistent slice.
+  tables under one commit, so the join always sees a consistent slice (subject to the atomicity
+  contract in *Failure and atomicity* — this is transactional atomicity, not a distributed snapshot).
 - **Consolidating multiple partitioned or sharded upstreams into one target table.** When a logical
   entity is split across multiple Hudi tables — for example one table per shard, per region, or per
   legacy vs. new system during a data-platform migration — a downstream consumer typically wants a
@@ -103,100 +108,204 @@ single timestamps stored in `deltastreamer.checkpoint.key` in the Streamer commi
   reading many gigabytes per additional source — every batch. The proposed source removes that
   amplification because every source is read incrementally.
 
+## Scope
+
+**v1 scope: Hudi-to-Hudi only.** `MultiSourceFormatAdapter`'s v1 implementation reads exclusively
+from Hudi tables (per-source adapters wrap `HoodieIncrSource`). Extending multi-source semantics
+to Kafka, S3/GCS events, JSON/DFS, JDBC, or other non-Hudi sources is out of scope for this RFC
+and requires its own design work — specifically, per-source-type checkpoint serialization (Kafka
+per-partition offsets, S3 event-queue positions, JDBC watermark columns) that does not fit the
+`index=pathHash:instantTime` format used by `MultiTableCheckpointManager`.
+
+The composition design does not preclude future extension. `MultiSourceFormatAdapter` treats each
+per-source `InputBatch<Dataset<Row>>` opaquely — every `SourceFormatAdapter` already normalizes
+ROW / AVRO / JSON / PROTO to `Dataset<Row>` in `fetchNewDataInRowFormat` — so **homogeneous
+multi-source of any type** (N Kafka, N JSON, N JDBC …) and **heterogeneous multi-source** (mixed
+Hudi + Kafka + JSON in one pipeline) both fit the design architecturally. The outstanding work
+per new source type is checkpoint encoding and its resume semantics, not new adapter plumbing.
+
 ## Implementation
 
-The change is confined to `hudi-utilities` (Hudi Streamer). Four building blocks plus wiring.
+The change is confined to `hudi-utilities` (Hudi Streamer). The design is **composition-first**:
+`InputBatch`, `Source`, and `SourceFormatAdapter` are all unchanged; a new `MultiSourceFormatAdapter`
+composes N per-source `SourceFormatAdapter`s (one per configured Hudi table); `StreamSync` branches
+once on adapter type at the top of `fetchNextBatchFromSource`; the rest of the pipeline is identical
+for single-source and multi-source.
 
-### 1. Multi-dataset `InputBatch`
+### 1. `MultiSourceFormatAdapter` (composition)
 
-`InputBatch<T>` gains a `List<T> batches` alongside the existing `Option<T> batch`:
+A new class. **Composition, not inheritance** — `MultiSourceFormatAdapter` is *not* a subclass of
+`SourceFormatAdapter`; it is a peer class that composes N single-source `SourceFormatAdapter`
+instances.
 
-- New constructor `InputBatch(List<T> batches, String checkpointForNextBatch, SchemaProvider)`.
-- `getBatches(): List<T>` returns all datasets (defensive copy).
-- `getBatch(): Option<T>` is retained for single-dataset sources and now **fails loud** — it throws
-  via `ValidationUtils.checkState` if more than one batch is present, so a multi-dataset batch can
-  never be silently narrowed to one dataset. For single-dataset construction, `getBatches()` returns
-  a singleton and `getBatch()` returns that element (unchanged behavior).
+- Constructor takes `List<SourceFormatAdapter> perSourceAdapters` (one per configured index), a
+  `MultiTableCheckpointManager`, and the source-identifier registry (index → path, optional label).
+- `fetchNewDataInRowFormat(Option<Checkpoint>, long)` → `List<InputBatch<Dataset<Row>>>`:
+  1. Parses the composite `Checkpoint` via `MultiTableCheckpointManager` into `Map<Integer, Checkpoint>`.
+  2. For each configured index `i`, dispatches the corresponding per-source `Checkpoint`
+     (or `Option.empty()` if new) to `perSourceAdapters.get(i).fetchNewDataInRowFormat(...)` —
+     sequentially on the driver.
+  3. Collects the per-source `InputBatch<Dataset<Row>>` results in index order and returns the list.
+- `fetchNewDataInAvroFormat(...)` throws `UnsupportedOperationException`. v1 is row-only. Non-ROW
+  source types produce `Dataset<Row>` inside their own `SourceFormatAdapter.fetchNewDataInRowFormat`
+  today; the multi adapter is source-type-agnostic on the row path.
 
-This keeps every existing single-source source and transformer working unchanged.
+Per-source error events are handled inside each underlying `SourceFormatAdapter` — the existing
+single-source code path, invoked N times. No branching inside `SourceFormatAdapter` is required.
 
-### 2. `HoodieIncrMultiSource`
+### 2. Multi-source configuration and identifiers
 
-A new source extending `Source<Dataset<Row>>` (SourceType `ROW`). It extends `Source` directly rather
-than `RowSource` because `RowSource#fetchNextBatch` calls `SanitizationUtils` on the returned dataset
-(masking Avro-invalid field names) before wrapping the result in an `InputBatch` — that per-row scan
-would (a) run twice, once here and again after the transformer merges the datasets, and (b) only
-supports a single `Option<Dataset<Row>>` payload, not the multi-dataset list this source needs.
-Rows read from a Hudi table are already conformant with that table's Avro schema, so this bypass is
-safe; sanitization still applies at write time to the merged transformer output when the user has
-enabled it. Per batch the source:
+Each source is identified by a **zero-based index** — the *durable* identifier used everywhere the
+checkpoint, config keys, and SQL bindings reference a source. An optional human-readable `label`
+exists purely for logs, metrics, and error messages and is **not** part of the checkpoint.
 
-1. Parses `hoodie.streamer.source.multi.hudi.tables` (ordered, comma-separated) into per-table configs.
-2. Iterates the parsed tables **sequentially on the driver** and performs a `HoodieIncrSource`-equivalent
-   incremental read for each — its own `numInstantsPerFetch`, missing-checkpoint strategy, hollow-commit
-   handling, timeline management, and "already caught up" detection. Tables that ingest at different
-   rates never block one another; see *Scale and parallelism* below for the wall-clock implications.
-3. Returns a dataset for **every** configured table, in declaration order — an empty dataset carrying
-   the Hudi table's schema when a table has no new incremental data — so downstream `LEFT/FULL OUTER
-   JOIN`s always resolve against a valid relation.
-4. Packages all datasets into one `InputBatch` via the multi-dataset constructor, with the combined
-   multi-table checkpoint (or a plain timestamp when multi-table checkpointing is disabled). The
-   `InputBatch` carries a `NullSchemaProvider` — Streamer infers the write schema from the merged
-   transformer output rather than from any single input source (see *Per-table schema resolution*).
+```
+# How many Hudi sources are declared in this pipeline (triggers multi-source mode).
+hoodie.streamer.source.multi.hudi.count=2
 
-#### Per-table schema resolution
+# Per-index configuration
+hoodie.streamer.source.multi.hudi.0.path=/hudi/orders
+hoodie.streamer.source.multi.hudi.0.num_instants=5
+hoodie.streamer.source.multi.hudi.0.missing_checkpoint_strategy=READ_LATEST
+hoodie.streamer.source.multi.hudi.0.skip_on_schema_failure=false
 
-Each source table's read schema is resolved independently against that table's own Hudi metadata,
-so heterogeneous or independently-evolving source schemas are supported directly:
+hoodie.streamer.source.multi.hudi.1.path=/hudi/users
+hoodie.streamer.source.multi.hudi.1.num_instants=3
+hoodie.streamer.source.multi.hudi.1.missing_checkpoint_strategy=READ_LATEST
 
-- A table with new commits: the read produces rows conformant with the current commit's schema.
-- A table that is caught up or empty: the source emits an empty `Dataset<Row>` built from that table's
-  current Hudi schema, so downstream joins and column references remain valid rather than exploding
-  on an "unresolved column" error.
-- Placeholder-schema resolution failure for any table: controlled by
-  `hoodie.streamer.source.hudi.{table}.skip_on_schema_failure` (default `false` — fail loud so a real
-  failure does not silently advance the checkpoint; `true` returns an empty dataset for that table
-  and emits a `<table>.schema_resolution_failure` metric).
-- The target write schema is not tied to any single source: `HoodieIncrMultiSource` attaches a
-  `NullSchemaProvider` to the `InputBatch`, and Streamer resolves the final write schema from the
-  merged `Dataset<Row>` returned by the `MultiDatasetTransformer`. This lets the user's SQL freely
-  add/drop/rename columns across source-schema versions without needing a schema-provider override.
+# Optional non-durable label — used only in logs / metrics / error messages
+hoodie.streamer.source.multi.hudi.0.label=orders
+hoodie.streamer.source.multi.hudi.1.label=users
+```
 
-#### Scale and parallelism
+Design rationale for indexed identifiers (vs. dotted-name aliases with property-key mangling):
 
-Per-table reads run **sequentially on the driver** — one Hudi `beginInstant..endInstant` read at a time,
-not `N` reads in parallel. Wall-clock time for a batch is therefore the **sum** of per-table read
-times, not the maximum. Practical implications:
+- **No property-key collision by construction.** With a dotted-name scheme, `tables=db.orders,db_orders`
+  would mangle to the same property-key prefix (`...source.hudi.db_orders.*`) and one entry would
+  silently overwrite the other. Indices remove that failure mode entirely.
+- **`label` is decoupled from durability.** Operators can rename freely for log/metric clarity
+  without touching the checkpoint or invalidating a running pipeline.
+- **SQL bindings stay indexed** — `<SRC_0>`, `<SRC_1>`, … with `<SRC>` aliasing `<SRC_0>` for
+  backward compatibility with single-source `SqlFileBasedTransformer` SQL files. Silent misbinding
+  of `<SRC_N>` on a source reorder is caught at startup by the **checkpoint path-hash fingerprint**
+  (see *MultiTableCheckpointManager*), not by binding SQL by label.
 
-- Expected `N` for this feature is small — typically 2–5 related tables — so sequential reads keep the
-  design simple and avoid contention on the shared timeline server and driver-side timeline caches
-  without materially hurting throughput.
-- One slow source (e.g. a table with a large backlog or many small files) stretches the whole batch,
-  so per-table `num_instants` should be sized to keep the slowest source within an acceptable per-batch
-  budget.
-- If a pipeline needs cross-source consistency across a large `N` **or** truly parallel per-table
+**Bootstrap trigger.** Presence of `hoodie.streamer.source.multi.hudi.count` with a value `> 0`
+triggers multi-source mode: Streamer constructs a `MultiSourceFormatAdapter` wrapping N
+`SourceFormatAdapter(HoodieIncrSource)` instances — one per index — instead of the ordinary
+single-source `SourceFormatAdapter`. If `source.class` is also set, it must be a recognized
+multi-source marker; otherwise the job fails at startup with a clear error, so operators are never
+in a state where they think they set `source.class` but the count field was ignored (or vice versa).
+
+**Config compatibility.** All keys carry `hoodie.deltastreamer.*` alternatives for consistency with
+the existing Streamer config surface.
+
+### 3. Per-source incremental reads
+
+Each per-source `SourceFormatAdapter` wraps a stock `HoodieIncrSource` configured from that index's
+keys. That source runs the same per-table logic — `numInstantsPerFetch`, `missing_checkpoint_strategy`,
+hollow-commit handling, timeline management, and "already caught up" detection — that a single-source
+Streamer pipeline runs today. **No new `Source` subclass is introduced.**
+
+Per batch, `MultiSourceFormatAdapter`:
+
+1. Parses the composite checkpoint and dispatches per-source checkpoints in index order.
+2. Reads sources **sequentially on the driver** (see *Scale and parallelism* below).
+3. Returns the per-source `InputBatch<Dataset<Row>>` list in index order. Each entry is either:
+   - A dataset with new incremental rows for that source, or
+   - An **empty-but-schema'd** dataset (the source had no new instants in this window) — so
+     downstream `LEFT/FULL OUTER JOIN`s in the transformer SQL always resolve against a valid
+     relation and column references never explode on "unresolved column."
+
+### 4. Per-source schema resolution
+
+Each per-source `HoodieIncrSource` resolves its read schema independently against its own Hudi
+table's metadata — heterogeneous or independently-evolving source schemas are supported directly.
+
+- A source with new commits: the read produces rows conformant with the current commit's schema.
+- A source that is caught up: the read emits an empty `Dataset<Row>` built from that table's
+  current Hudi schema — **including the `_hoodie_*` meta columns and honoring
+  `hoodie.datasource.write.drop.all.meta.fields`** so the empty and non-empty shapes for the same
+  source are always identical. If they differed, `<SRC_K>` would change columns depending on
+  whether that source advanced in a given batch, and the merged output (plus the deduced write
+  schema) could flip batch-to-batch — a data-correctness hazard.
+- Placeholder-schema resolution failure for any source: controlled by
+  `hoodie.streamer.source.multi.hudi.{index}.skip_on_schema_failure` (default `false` — fail loud
+  so a real failure does not silently advance the checkpoint). When set `true`, the per-source
+  read returns an empty dataset for that batch and emits a `<label-or-index>.schema_resolution_failure`
+  counter metric.
+
+**All-sources-failed under `skip_on_schema_failure=true`.** When every configured source has
+`skip_on_schema_failure=true` and every source fails schema resolution in the same batch, the
+merged transformer output is empty and the batch **does not commit** by default (respecting
+Streamer's existing "commit on no-op batch" configuration) — no checkpoint advances, no timeline
+noise, the schema-failure metric fires N times, and operator alerting on that metric is the
+surface for detection. Users who have explicitly opted into committing empty batches (e.g. for
+downstream freshness heartbeats) get an empty commit at the previous composite checkpoint. Either
+way, no data is silently written and no cursor silently advances. The
+`<label-or-index>.schema_resolution_failure` metric should be treated as a **hard-alert** signal,
+not a soft one — a persistent non-zero value indicates a source is silently no-op'ing.
+
+**Checkpoint carry-forward invariant.** Whenever a source does not advance in a batch — whether
+because it had no new data, because `skip_on_schema_failure=true` swallowed a real failure, or
+because its previous entry was dropped by the lenient parser — its **previous checkpoint value
+is carried forward unchanged** into the next committed multi-source checkpoint. The composite
+checkpoint is always rebuilt from a full N-entry map covering every currently-configured source,
+never from only the sources that advanced this batch. This closes the silent-data-loss window
+that "no checkpoint → apply `missing_checkpoint_strategy` → `READ_LATEST` skips history" would
+otherwise open on subsequent batches for a source that failed schema resolution once.
+
+**Sanitization at write time.** `RowSource#fetchNextBatch`'s per-row Avro-field-name sanitization
+is bypassed at the per-source read (rows read from a Hudi table are already conformant with that
+table's Avro schema, so sanitization would be redundant and would run twice — once per source,
+once after the merge). Sanitization **at write time** on the merged transformer output continues
+to flow through Streamer's normal write path when the operator has enabled it — this bypass
+touches only the read side. This is covered by an integration test that writes the merged output
+with sanitization enabled and asserts the writer's sanitization codepath was taken.
+
+**Schema providers.** The multi-source composition deliberately does not accept per-source
+`SchemaProvider` configuration in v1. Every source is a Hudi table with a well-defined Avro
+schema in its own metadata; the read path derives each source dataset's shape from that. Unlike
+single-source Streamer inputs, there is no "source cannot describe itself" case to solve.
+Per-source shape normalization — renames, casts, null-fills, dropping/pinning columns during
+upstream evolution — is expressed in the transformer SQL against `<SRC_0>` / `<SRC_1>` / ….
+`SchemaProvider` targets Avro conformance, not arbitrary row-shape coercion, so SQL is the right
+layer.
+
+The merged output continues to honor the existing top-level `hoodie.streamer.schemaprovider.class`.
+When present with a non-null target schema it wins for the write, exactly as in single-source
+Streamer today (matching Sub-branch A of `getDeducedSchemaProvider`); when absent, the writer
+schema is deduced from the merged transformer output reconciled against the latest target-table
+schema. Registry-backed providers (`SchemaRegistryProvider` and variants) are not applicable to
+the multi-source read path — Hudi tables self-describe, the same as with `HoodieIncrSource` today.
+
+**Startup rejection of per-source schema-provider keys.** Per-source schema-provider keys
+(e.g. `hoodie.streamer.source.multi.hudi.{index}.schemaprovider.class`) are rejected at startup
+with a clear error so operators pattern-matching from single-source Streamer configuration are
+not surprised by a silent-ignore.
+
+**Future work.** If a real user need for per-source schema providers surfaces (e.g. registry-backed
+evolution across source *and* target under one Streamer job), a follow-up RFC can add it; the
+composition-based design does not preclude it.
+
+### 5. Scale and parallelism
+
+Per-source reads run **sequentially on the driver** — one Hudi `beginInstant..endInstant` read at
+a time, not `N` reads in parallel. Wall-clock time for a batch is therefore the **sum** of per-source
+read times, not the maximum. Practical implications:
+
+- Expected `N` for this feature is small — typically 2–5 related tables — so sequential reads
+  keep the design simple and avoid contention on the shared timeline server and driver-side
+  timeline caches without materially hurting throughput.
+- One slow source (e.g. a table with a large backlog or many small files) stretches the whole
+  batch, so per-source `num_instants` should be sized to keep the slowest source within an
+  acceptable per-batch budget.
+- If a pipeline needs cross-source consistency across a large `N` **or** truly parallel per-source
   reads, the right tradeoff today is still separate Streamer jobs plus a downstream merge — this
-  source is not a replacement for that at large fan-out. Parallel per-table reads can be added later
-  behind an opt-in config without changing the public contract if usage patterns demand it.
+  feature is not a replacement for that at large fan-out. Parallel per-source reads can be added
+  later behind an opt-in config without changing the public contract if usage patterns demand it.
 
-**Configuration** (`HoodieIncrMultiSourceConfig`, group `HUDI_STREAMER` / `DELTA_STREAMER_SOURCE`):
-
-| Key | Default | Purpose |
-|-----|---------|---------|
-| `hoodie.streamer.source.multi.hudi.tables` | (required) | Ordered, comma-separated source table names |
-| `hoodie.streamer.source.multi.hudi.checkpoint.enable` | `true` | Multi-table checkpoint format; `false` → legacy single-checkpoint behavior |
-| `hoodie.streamer.source.hudi.{table}.path` | (required) | Per-table base path |
-| `hoodie.streamer.source.hudi.{table}.num_instants` | `HoodieIncrSourceConfig.NUM_INSTANTS_PER_FETCH` default | Per-table instants per fetch |
-| `hoodie.streamer.source.hudi.{table}.missing_checkpoint_strategy` | `READ_LATEST` | `READ_LATEST` \| `READ_UPTO_LATEST_COMMIT` |
-| `hoodie.streamer.source.hudi.{table}.skip_on_schema_failure` | `false` | On placeholder-schema resolution failure: `false` fails loud (checkpoint not advanced past a real failure); `true` returns an empty dataset and emits a `<table>.schema_resolution_failure` metric |
-| `hoodie.streamer.source.hudi.{table}.partition.fields` / `.partition.extractor.class` | — | Optional per-table partitioning |
-
-All keys carry `hoodie.deltastreamer.*` alternatives for compatibility. **Table-name convention:** a
-dotted name (`db.orders`) has its dots replaced by underscores when building property keys
-(`...source.hudi.db_orders.path`) so property-file parsers don't split them; the original dotted name
-is always used inside the checkpoint map.
-
-### 3. `MultiDatasetTransformer` and `SqlFileBasedTransformer`
+### 6. `MultiDatasetTransformer` and `SqlFileBasedTransformer`
 
 `MultiDatasetTransformer extends Transformer` adds:
 
@@ -205,19 +314,36 @@ Dataset<Row> apply(JavaSparkContext jsc, SparkSession spark,
                    List<Dataset<Row>> datasets, TypedProperties props);
 ```
 
-Contract: list order matches `...source.multi.hudi.tables`; an entry is always present for each table
-(empty-but-schema'd when no new data); the single-dataset `Transformer#apply` remains implemented so
-the transformer still works in single-source pipelines.
+Contract: list order matches the per-index source declaration; an entry is always present for
+each configured source (empty-but-schema'd when no new data); the single-dataset `Transformer#apply`
+remains implemented so the transformer still works in single-source pipelines.
 
 `SqlFileBasedTransformer` implements it:
 
 - Registers each input dataset as a unique Spark temp view (`HOODIE_SRC_TMP_TABLE_<uuid>`).
-- SQL references datasets by index — `<SRC_0>`, `<SRC_1>`, … — with `<SRC>` kept as an alias for the
-  first dataset (backward compatible).
-- Supports multi-statement SQL files and `CREATE [OR REPLACE] TEMPORARY VIEW` (e.g. CTE-style setup);
-  user-created views are tracked and dropped alongside the source temp views in a `finally` block.
-- Validates inputs: rejects null/empty dataset lists and any dangling `<SRC_N>` placeholder that has
-  no corresponding dataset (typo guard), with clear error messages.
+- SQL references datasets by index — `<SRC_0>`, `<SRC_1>`, … — with `<SRC>` kept as an alias for
+  `<SRC_0>` (backward compatible with single-source SQL files).
+- Supports multi-statement SQL files and `CREATE [OR REPLACE] TEMPORARY VIEW` (e.g. CTE-style
+  setup); user-created views are tracked and dropped alongside the source temp views.
+- Validates inputs: rejects null/empty dataset lists and any dangling `<SRC_N>` placeholder that
+  has no corresponding dataset (typo guard), with clear error messages.
+
+**Temp-view namespace ownership and cleanup lifetime.**
+
+- **Cleanup runs in a `finally` block per batch** — the tracked view names accumulated during a
+  single `apply()` invocation are dropped at the end of that invocation whether it succeeds or
+  throws. A driver crash mid-batch will leak any views registered so far; this is accepted,
+  because on the next driver start every view registered in the leaked batch has a fresh UUID
+  and therefore cannot collide with anything a subsequent run registers.
+- **Source-view names cannot collide.** `HOODIE_SRC_TMP_TABLE_<uuid>` names are UUID-mangled per
+  invocation.
+- **User-created view names are not UUID-mangled.** `CREATE OR REPLACE TEMPORARY VIEW my_dim` in
+  the user's SQL creates a view called `my_dim` in the Spark session's global temp-view namespace.
+  The transformer takes **exclusive ownership of the Spark session's temp-view namespace during
+  `apply()`** — any pre-existing view with the same name will be replaced by the transformer's
+  `CREATE OR REPLACE` and cleaned up at the end of the batch. Operators who manage temp views
+  outside Streamer should namespace them (e.g. `myapp_dim`) to avoid this. This is documented as
+  a hard rule in the transformer's javadoc, not a soft convention.
 
 Example SQL (`<SRC_0>` = orders, `<SRC_1>` = users):
 
@@ -227,159 +353,334 @@ FROM <SRC_0> o
 FULL OUTER JOIN <SRC_1> u ON o.user_id = u.user_id;
 ```
 
-### 4. `MultiTableCheckpointManager`
+### 7. `MultiTableCheckpointManager`
 
-Parses, formats, and manipulates per-table checkpoints stored in `deltastreamer.checkpoint.key`:
+Parses, formats, and manipulates per-source checkpoints stored in `deltastreamer.checkpoint.key`.
+The checkpoint is **indexed with a path fingerprint**:
 
 ```
-Multi-table : "table1=20250606182826197,table2=20250606182830145,table3=20250606182828456"
+Multi-source : "0=abc123:20250606182826197,1=def456:20250606182830145"
 Single/legacy: "20250606182826197"
 ```
 
-- Any value containing `=` is parsed as multi-table via a lenient parser that skips malformed entries
-  while preserving valid ones (so a single corrupt entry never causes the whole string to be
-  misclassified as single-table and collapsed under a default key).
-- A bare value with no `=` is treated as a legacy single checkpoint (mapped to a default table),
-  giving automatic backward compatibility and a clean upgrade path from an existing single-source job.
-- The formatted output uses a deterministic key order (backed by a `TreeMap`) so the same set of
-  per-table checkpoints always serializes to the same string, making commits and diffs reproducible.
+Where `abc123` / `def456` are short truncated SHA-256 hashes of the source's base path — the
+**path fingerprint** — and the value after `:` is the source's next instant to read (the
+`HoodieIncrSource` checkpoint format is unchanged).
 
-#### Behavior when the parser skips a malformed entry
+- **Path fingerprint guards against silent misconfiguration.** On resume, the manager computes
+  the fingerprint of each currently-configured index's path and compares it to the stored
+  fingerprint. On mismatch, the job **fails at startup** with a clear diagnostic naming the
+  affected index and the two paths (previous vs. current), rather than silently resuming the
+  new source from an unrelated table's checkpoint. This catches source reorder and path-replace
+  at an existing index (see *Source-list evolution semantics*).
+- **Legacy-format detection.** Any value containing `=` is parsed as multi-source. A bare value
+  with no `=` is treated as a legacy single-source checkpoint and migrated on the next commit
+  as `0=<computed-hash>:<timestamp>` — clean upgrade from an existing single-source job with no
+  manual surgery.
+- **Deterministic serialization.** The formatted output uses a deterministic key order by
+  ascending index (backed by a `TreeMap`) so the same set of per-source checkpoints always
+  serializes to the same string, making commits and diffs reproducible.
+- **Lenient parsing** preserves valid entries while skipping malformed ones. A skipped entry
+  is logged as `WARN`, and the source emits a `multi_source_checkpoint.malformed_entries`
+  counter metric so the drop is observable in monitoring, not silent. **Skipped entries are
+  always paired with the checkpoint carry-forward invariant** (see *Per-source schema
+  resolution*): the previous batch's committed checkpoint is the canonical source, and any
+  index whose entry the parser dropped is rebuilt from its prior value rather than falling
+  through to `missing_checkpoint_strategy`. This closes the silent-data-loss window that
+  "no checkpoint → `READ_LATEST` → skip history" would otherwise open. The metric should be
+  alerted on with threshold `> 0` in any pipeline where re-reading history is not equivalent
+  to a resume.
 
-The lenient parser is designed to keep a single corrupt `table=ts` entry from taking down the whole
-job. That behavior has a data-correctness consequence that the operator must understand:
+**Operational checkpoint override / reset in multi-source mode.**
 
-- A skipped entry is logged as `WARN`, and the source emits a
-  `multi_table_checkpoint.malformed_entries` counter metric with the number of dropped entries so the
-  drop is observable in monitoring, not silent.
-- The affected table then has **no checkpoint** for the next batch, so `HoodieIncrMultiSource` treats
-  it as first-run and applies its `missing_checkpoint_strategy`. With the default `READ_LATEST` this
-  means the table jumps to the latest instant and **skips any data between the lost checkpoint and
-  latest** — a silent data-loss window sized by however long the corruption went unnoticed.
-- Operators who cannot tolerate that failure mode should set
-  `hoodie.streamer.source.hudi.{table}.missing_checkpoint_strategy=READ_UPTO_LATEST_COMMIT`, which
-  reads the whole table history up to latest instead — safer default for reprocessable / dedup-keyed
-  writes, but heavier.
-- The malformed-entries metric should be alerted on with threshold `> 0` in any pipeline that ingests
-  event streams where re-reading history is not equivalent to a resume.
+Streamer's `--checkpoint <value>` override and `hoodie.deltastreamer.checkpoint.reset_key` accept
+a **fully-formed composite** value in multi-source mode:
 
-### 5. Wiring into `StreamSync` and `SourceFormatAdapter`
+```
+--checkpoint "0=abc123:20250606182826197,1=def456:20250606182830145"
+```
 
-- **Startup validation.** If the source is `HoodieIncrMultiSource`, `StreamSync` requires a
-  `MultiDatasetTransformer` (resolved via `UtilHelpers.resolveMultiDatasetTransformer`, so it is found
-  even when wrapped in a `ChainedTransformer`). If none is configured, the job throws
-  `HoodieStreamerException` at startup — preventing the silent-data-loss failure mode where only the
-  last source table would be written.
-- **Routing.** In `fetchNextBatchFromSource`, when a multi-dataset transformer is present the full
-  `getBatches()` list is passed to `MultiDatasetTransformer#apply`; otherwise the existing
-  single-dataset path (`getBatch().map(...)`) is used unchanged. An empty-batch guard skips the
-  transformer when the source produced no data (rather than passing an empty list that would throw).
-- **`SourceFormatAdapter`.** Processes error events per-dataset on the multi-dataset row path.
+A bare-timestamp override (e.g. `--checkpoint 20250606182826197`) is **rejected at startup** in
+multi-source mode with a clear error message rather than silently mapped to a single default index
+and dropping the other sources' cursors. To reset only one source, the operator provides the
+composite string with only that source's timestamp updated (the other entries carried forward
+from the current checkpoint), which the manager accepts and validates against configured paths.
+
+### 8. Source-list evolution semantics
+
+The following operational events on a running multi-source pipeline are handled as:
+
+- **Adding a source** at a new index (increasing `count` and adding the per-index keys): no prior
+  checkpoint entry exists for the new index, so the source applies its configured
+  `missing_checkpoint_strategy`. Because the default `READ_LATEST` implies a silent history skip,
+  operators seeding a new source should either (a) accept the skip, (b) set the new index's
+  `missing_checkpoint_strategy=READ_UPTO_LATEST_COMMIT` for its first batch, or (c) hand-seed a
+  starting instant via `--checkpoint`.
+- **Removing a source** at an index (reducing `count` and removing the per-index keys): the stale
+  checkpoint entry for the removed index is pruned on the next commit — the composite is
+  serialized only from currently-configured indices. A `WARN` is logged on the first batch after
+  removal for auditability.
+- **Reordering the source list** (e.g. swapping what path lives at index 0 vs. index 1): the
+  SQL's `<SRC_0>` / `<SRC_1>` silently rebind to different sources, which is a data-correctness
+  bug. **The path fingerprint in the checkpoint catches this at startup** — the fingerprint
+  stored under index 0 no longer matches the path currently configured at index 0, and the job
+  fails with a clear diagnostic. Reordering therefore requires an explicit `--checkpoint`
+  override that presents the new correct mapping.
+- **Replacing a source's path at an existing index**: same failure mode as reordering — the path
+  fingerprint mismatches and the job fails at startup, rather than silently resuming from the
+  previous source's checkpoint (which would be meaningless for the new source and constitute
+  silent data loss or silent misuse). Operators consciously proceed by providing a `--checkpoint`
+  override for the affected index.
+
+### 9. Wiring into `StreamSync`
+
+`StreamSync.fetchNextBatchFromSource` gains a **single** `instanceof MultiSourceFormatAdapter`
+branch at the top of the method:
+
+- **Multi-source branch.** Calls
+  `((MultiSourceFormatAdapter) formatAdapter).fetchNewDataInRowFormat(compositeCheckpoint, sourceLimit)`
+  and receives `List<InputBatch<Dataset<Row>>>`. Extracts `List<Dataset<Row>>` from that list
+  (each source's `InputBatch` already has the right dataset — no `getBatch()` fail-loud contract
+  is needed because each per-source `InputBatch` is single-dataset by construction). Passes the
+  list to `MultiDatasetTransformer#apply` (validated present at startup — see below). Computes
+  the next composite checkpoint from each per-source `InputBatch#getCheckpointForNextBatch()`.
+- **Single-source branch.** Byte-for-byte the existing code path —
+  `formatAdapter.fetchNewDataInRowFormat(...)` returns one `InputBatch`,
+  `getBatch().map(transformer::apply)`, `getCheckpointForNextBatch()`. No changes.
+
+After the branch produces `transformed: Option<Dataset<Row>>` and `checkpoint: Checkpoint`, the
+rest of `fetchNextBatchFromSource` (transformer error-event processing, schema deduction,
+row-writer vs Avro path, write, commit) is **identical for both branches** — the branching
+lives at exactly one point.
+
+**Startup validations.**
+
+- If multi-source mode is enabled (`hoodie.streamer.source.multi.hudi.count > 0`), Streamer
+  requires a `MultiDatasetTransformer` (resolved via `UtilHelpers.resolveMultiDatasetTransformer`,
+  so it is found even when wrapped in a `ChainedTransformer`). If none is configured, the job
+  throws `HoodieStreamerException` at startup — preventing the silent-data-loss failure mode
+  where only one source's data would flow through to the write.
+- Per-source path fingerprints are validated against the resume-checkpoint (see
+  *MultiTableCheckpointManager*).
+- `source.class` (if set) must be a recognized multi-source marker consistent with `count > 0`.
+- Per-source schema-provider keys are rejected at startup.
+- Bare-timestamp `--checkpoint` / `checkpoint.reset_key` values are rejected in multi-source mode.
+
+**`SourceFormatAdapter` itself is unchanged.** No per-dataset error-event branch is added inside
+`SourceFormatAdapter`, and no `InputBatch#getBatches()` method exists — per-source error events
+are handled inside each underlying single-source `SourceFormatAdapter` exactly as today.
+
+**Empty-batch guard.** The multi-source branch emits datasets for **every** configured source in
+every batch — some datasets may individually be empty (a source with no new data), but the list
+itself is never empty and the transformer is always invoked when there is at least one non-empty
+dataset. When **every** dataset in the returned list is empty (all sources caught up in this
+batch), the transformer is skipped and the batch either commits with an unchanged composite
+checkpoint or no-ops entirely, depending on Streamer's "commit on no-op batch" configuration.
+This is distinct from the "all sources failed schema resolution" case (see *Per-source schema
+resolution*), which routes through the schema-failure metric path.
 
 ### Sequence (per batch)
 
 ```
-StreamSync.sync()
-  └─ HoodieIncrMultiSource.fetchNext()
-       ├─ read incrementally: db.orders (own ckpt), db.users (own ckpt), …  → List<Dataset<Row>>
-       └─ InputBatch(batches=[...], checkpoint="db.orders=ts1,db.users=ts2")
-  └─ SqlFileBasedTransformer.apply(jsc, spark, getBatches(), props)   // <SRC_0>,<SRC_1> → merged DF
-  └─ write merged DF + commit  (single atomic commit; multi-table checkpoint persisted)
+StreamSync.fetchNextBatchFromSource(...)
+  │
+  └─ if (formatAdapter instanceof MultiSourceFormatAdapter) {
+     │
+     │   ── MULTI-SOURCE BRANCH ──
+     │
+     ├─ List<InputBatch<Dataset<Row>>> perSourceBatches =
+     │       ((MultiSourceFormatAdapter) formatAdapter)
+     │           .fetchNewDataInRowFormat(compositeResumeCheckpoint, sourceLimit);
+     │
+     │   Inside MultiSourceFormatAdapter.fetchNewDataInRowFormat:
+     │     ├─ MultiTableCheckpointManager.parse("0=abc:t0,1=def:t1")
+     │     │     → validate path fingerprints, → Map<Integer, Checkpoint>
+     │     ├─ FOR EACH index i (sequential):
+     │     │     perSourceAdapters.get(i)
+     │     │         .fetchNewDataInRowFormat(Option.of(ckpt_i), sourceLimit)
+     │     │       └─ HoodieIncrSource: own num_instants, missing_ckpt_strategy, timeline read
+     │     └─ returns per-source InputBatch list, in index order
+     │
+     ├─ List<Dataset<Row>> datasets = perSourceBatches.stream()
+     │       .map(ib -> ib.getBatch().orElseGet(() -> emptySchemaShapedDf(...)))
+     │       .collect(toList());
+     │
+     ├─ Dataset<Row> merged = ((MultiDatasetTransformer) transformer.get())
+     │       .apply(jsc, spark, datasets, props);
+     │
+     ├─ Option<Dataset<Row>> transformed = Option.of(merged);
+     ├─ Checkpoint checkpoint = MultiTableCheckpointManager.format(
+     │       perSourceBatches, perSourceCheckpointCarryForward);
+     │
+     } else {
+     │
+     │   ── SINGLE-SOURCE BRANCH — completely unchanged ──
+     │
+     ├─ InputBatch<Dataset<Row>> dataAndCkpt =
+     │       formatAdapter.fetchNewDataInRowFormat(resumeCheckpoint, sourceLimit);
+     ├─ Option<Dataset<Row>> transformed = dataAndCkpt.getBatch()
+     │       .map(d -> transformer.get().apply(jsc, spark, d, props));
+     ├─ Checkpoint checkpoint = dataAndCkpt.getCheckpointForNextBatch();
+     }
+     │
+     │  ── FROM HERE, IDENTICAL CODE FOR BOTH BRANCHES ──
+     │
+     ├─ processErrorEvents(transformed, CUSTOM_TRANSFORMER_FAILURE)
+     ├─ deduce writer schema (Sub-branch A or B)
+     └─ row-writer or Avro branch → build final InputBatch for writer
 ```
 
-### Design decisions & risks
+## Failure and atomicity contract
 
-- **User-owned merge semantics (non-goal to automate).** Delayed data in a source means **inner joins
-  can silently miss rows**; the recommended pattern is **OUTER JOIN** on incremental sources. Overlapping
-  columns and partial/nested-field updates are resolved with a **merge payload** (e.g. a generic merge
-  payload, or a custom `HoodieRecordPayload` that merges non-null fields) rather than last-writer-wins
-  overwrite — otherwise fields from an earlier upsert are lost. These are documented, not enforced.
-- **Failure and atomicity contract.** A batch either advances every source's checkpoint together, or
-  advances none of them:
-  - Any per-table read failure (schema resolution, timeline read, etc. — unless the operator has
-    opted in per-table via `skip_on_schema_failure=true`) aborts the batch before the merged write is
-    attempted, and the checkpoint is not updated.
-  - The transformer step is invoked once against the whole `getBatches()` list; a transformer
-    exception aborts the batch, and the checkpoint is not updated.
-  - The write is a single Hudi commit. The full multi-table checkpoint string is written into the
-    commit's `deltastreamer.checkpoint.key` extra-metadata as part of that same commit, so the
-    per-table cursor advances **atomically with the data**. If the write fails or the commit does not
-    finalize, no source's cursor advances and the next batch re-reads the same window for every
-    source — exactly the atomic-across-sources guarantee that N separate Streamer jobs cannot offer.
-  - There is no partial-success mode where some sources commit and others do not. This is a
-    deliberate choice: cross-source consistency is the reason to use this source, and it would be
-    lost if a batch could half-succeed.
-- **Backward compatibility.** All Java API changes are additive; `getBatch()`, single-source sources,
-  and non-SQL transformers are unaffected. The checkpoint format degrades cleanly to legacy.
-- **Checkpoint correctness across failures/re-runs** is the main implementation risk and is covered by
-  the lenient multi-table parser and by the test plan below.
-- **Scope.** No change to Hudi's write/commit path or on-disk storage format; the only serialized
-  change is the contents of the Streamer's own `deltastreamer.checkpoint.key`.
+A batch either advances **every source's checkpoint together, or advances none of them**.
+
+- **Atomicity is transactional, not distributed-snapshot.** The batch commits every source's
+  checkpoint together, or none. It does **not** guarantee a globally consistent point-in-time
+  snapshot across sources: each source is read against its own timeline as
+  `MultiSourceFormatAdapter` iterates sequentially in index order, and a source can advance
+  between the moment the previous source's read starts and this source's read starts. Users who
+  need cross-source point-in-time consistency at the row level must layer their own snapshot
+  mechanism (e.g. as-of-time reads at a coordinated timestamp) on top of the merge SQL.
+- Any per-source read failure (schema resolution, timeline read, etc. — unless the operator has
+  opted in per-source via `skip_on_schema_failure=true`) aborts the batch before the merged
+  write is attempted; the composite checkpoint is not updated.
+- The transformer step is invoked once against the whole per-source dataset list; a transformer
+  exception aborts the batch, and the composite checkpoint is not updated.
+- The write is a single Hudi commit. The composite checkpoint string is written into the commit's
+  `deltastreamer.checkpoint.key` extra-metadata as part of that same commit, so per-source
+  cursors advance **atomically with the data**. If the write fails or the commit does not
+  finalize, no source's cursor advances and the next batch re-reads the same window for every
+  source — exactly the cross-source atomicity guarantee that N separate Streamer jobs cannot
+  offer.
+- There is no partial-success mode where some sources commit and others do not. This is a
+  deliberate choice: cross-source atomicity is the reason to use this feature, and it would be
+  lost if a batch could half-succeed.
+- Every configured source's checkpoint is **carried forward** across every batch — a source that
+  did not advance still appears in the committed composite checkpoint, at its previous value.
+  See the checkpoint carry-forward invariant in *Per-source schema resolution* for the specific
+  "skipped by lenient parser," "no new data," and "`skip_on_schema_failure=true` swallowed a
+  failure" cases.
+
+## Design decisions & risks
+
+- **User-owned merge semantics (non-goal to automate).** Delayed data in a source means **inner
+  joins can silently miss rows**; the recommended pattern is **OUTER JOIN** on incremental
+  sources. Overlapping columns and partial/nested-field updates are resolved with a **merge
+  payload** (e.g. a generic merge payload, or a custom `HoodieRecordPayload` that merges non-null
+  fields) rather than last-writer-wins overwrite — otherwise fields from an earlier upsert are
+  lost. These are documented, not enforced.
+- **Backward compatibility.** Zero changes to `InputBatch`, `Source`, or `SourceFormatAdapter`
+  public APIs — every existing single-source source, transformer, and third-party integration
+  continues to work unchanged. The checkpoint format degrades cleanly to legacy on the read
+  path, and the multi-source composite is only ever emitted when multi-source mode is enabled.
+- **Checkpoint correctness across failures/re-runs** is the main implementation risk and is
+  covered by the fingerprint-mismatch guard, the lenient-parse + carry-forward invariant, and
+  the test plan below.
+- **Scope.** No change to Hudi's write/commit path or on-disk storage format; the only
+  serialized change is the contents of the Streamer's own `deltastreamer.checkpoint.key`.
 
 ## Alternatives Considered
 
 - **N single-source Streamer jobs + downstream merge (status quo).** Simple to reason about
-  operationally but loses cross-source atomicity: sources advance independently, so any downstream
-  merge that reads the results sees inconsistent temporal cuts, and inner-join outputs silently miss
-  rows for late arrivals in one source. Also multiplies watermark tracking and monitoring surface
-  N-fold. This RFC's core motivation is to fix exactly this class of drift.
-- **Snapshot-scan all-but-one source + one incremental source (existing workaround).** Achievable
-  today without any new Hudi APIs, but the batch-time compute cost of the snapshot scans grows with
-  each source's retention window rather than with new data. Sized against real pipelines this is the
-  dominant cost of the workaround and the primary reason a native incremental multi-source read is
-  worth the API surface increase.
-- **Dedicated join/union source that returns a single `Dataset<Row>` (auto-merge in the source).**
-  Would avoid the `MultiDatasetTransformer` interface, but bakes the merge policy — inner vs outer
-  join, key resolution, precombine payload, column-conflict handling — into a source, which is the
-  wrong layer. Pipelines need the flexibility of expressing the merge as user SQL against the
-  per-source datasets, so the source stays merge-agnostic and the transformer contract is what grows.
+  operationally but loses cross-source atomicity: sources advance independently, so any
+  downstream merge that reads the results sees inconsistent temporal cuts, and inner-join
+  outputs silently miss rows for late arrivals in one source. Also multiplies watermark
+  tracking and monitoring surface N-fold. This RFC's core motivation is to fix exactly this
+  class of drift.
+- **Snapshot-scan all-but-one source + one incremental source (existing workaround).**
+  Achievable today without any new Hudi APIs, but the batch-time compute cost of the snapshot
+  scans grows with each source's retention window rather than with new data. Sized against real
+  pipelines this is the dominant cost of the workaround and the primary reason a native
+  incremental multi-source read is worth building.
+- **Extend `InputBatch` with `List<T> batches` + `getBatches()` and add `HoodieIncrMultiSource`
+  as a `Source` subclass.** Evaluated in detail; **rejected in favor of the composition-based
+  `MultiSourceFormatAdapter`**. Under that alternative, `InputBatch#getBatch()` would fail loud
+  when a multi-dataset batch is present — a runtime behavior change on a documented public API
+  used by every source, transformer, and third-party integration. Three call sites in the
+  critical path (`Source.fetchNext`, `SourceFormatAdapter.fetchNewDataInRowFormat`,
+  `StreamSync.fetchNextBatchFromSource`) all touch `getBatch()` unconditionally today, and each
+  would have to be patched to branch on `getBatches().size() > 1` — the compiler cannot enforce
+  completeness, so a missed patch throws at runtime for multi-source pipelines only. Third-party
+  sources / transformers that touch `getBatch()` on an `InputBatch` obtained from Streamer core
+  inherit the same runtime hazard. The composition approach eliminates the API change entirely,
+  collapses three branch points to one `instanceof` at a natural type boundary, and reuses the
+  existing well-tested `SourceFormatAdapter` code path N times inside the multi adapter rather
+  than reimplementing per-source coordination inside a new `Source` subclass whose contract is
+  naturally singular. As a side benefit, the composition design generalizes to homogeneous and
+  heterogeneous non-Hudi multi-source (see *Scope*) without further architectural work.
+- **Dedicated join/union source that returns a single `Dataset<Row>` (auto-merge in the
+  source).** Would avoid the `MultiDatasetTransformer` interface, but bakes the merge policy —
+  inner vs outer join, key resolution, precombine payload, column-conflict handling — into a
+  source, which is the wrong layer. Pipelines need the flexibility of expressing the merge as
+  user SQL against the per-source datasets, so the multi adapter stays merge-agnostic and the
+  transformer contract is what grows.
 - **Transformer-only approach (single source-of-record source + transformer reads sibling Hudi
-  tables directly).** Sidesteps changes to `Source`/`InputBatch`, but breaks the checkpoint model:
-  reads inside the transformer are opaque to Streamer, so they cannot participate in the
+  tables directly).** Sidesteps changes to `Source`/`InputBatch`, but breaks the checkpoint
+  model: reads inside the transformer are opaque to Streamer, so they cannot participate in the
   per-source `deltastreamer.checkpoint.key`. This effectively re-invents the snapshot-scan
-  workaround inside the transformer and loses the incremental / atomic semantics that motivate the
-  RFC.
-- **Extending `HoodieIncrSource` in place instead of a new source.** Multi-table semantics change
-  every stage of the source's contract (config surface, checkpoint format, `InputBatch` cardinality,
-  transformer contract, write-schema derivation). Overloading `HoodieIncrSource` risked
-  regressing single-source behavior and made the config surface confusing (which keys are per-table
-  vs. global). A new source class isolates the multi-source path behind an explicit opt-in.
-- **Parallel per-table reads on the driver / structured concurrency.** Deferred, not chosen. Expected
-  N is small (2–5), the shared timeline server prefers sequential access, and sequential reads keep
-  the failure-mode surface small (a mid-flight error aborts a single in-progress read, not N of them).
-  The `Source` contract does not preclude adding parallel reads later behind an opt-in config if a
-  compelling workload appears.
+  workaround inside the transformer and loses the incremental / atomic semantics that motivate
+  the RFC.
+- **Extend `HoodieIncrSource` in place instead of composing.** Multi-source semantics change
+  every stage of the pipeline (config surface, checkpoint format, cardinality of per-source
+  datasets, transformer contract, write-schema derivation). Overloading `HoodieIncrSource`
+  risked regressing single-source behavior and made the config surface confusing (which keys
+  are per-table vs. global). Composition via `MultiSourceFormatAdapter` isolates the
+  multi-source path behind an explicit opt-in without touching `HoodieIncrSource`.
+- **Parallel per-source reads on the driver / structured concurrency.** Deferred, not chosen.
+  Expected N is small (2–5), the shared timeline server prefers sequential access, and
+  sequential reads keep the failure-mode surface small (a mid-flight error aborts a single
+  in-progress read, not N of them). The composition design does not preclude adding parallel
+  reads later behind an opt-in config if a compelling workload appears.
 
-## Rollout/Adoption Plan
+## Rollout / Adoption Plan
 
 - **Impact on existing users.** None by default. The feature is inert unless a user sets
-  `source.class=HoodieIncrMultiSource` and declares source tables. Existing single-source jobs,
-  transformers, and checkpoints continue to work byte-for-byte.
+  `hoodie.streamer.source.multi.hudi.count > 0` and declares per-index sources. Existing
+  single-source jobs, transformers, and checkpoints continue to work byte-for-byte —
+  `InputBatch`, `Source`, and `SourceFormatAdapter` public APIs are unchanged.
 - **Behavior phase-out.** Nothing is deprecated or removed. `HoodieIncrSource` remains the
-  single-table path; `HoodieIncrMultiSource` is purely additive.
-- **Migration.** A user converting an existing single-source job keeps their legacy checkpoint: the
-  multi-table checkpoint manager reads a bare timestamp as a legacy value and begins emitting the
-  per-table format on the next commit. No manual checkpoint surgery required.
-- **Timeline.** Ship behind explicit opt-in configuration; document recommended join/merge patterns
-  alongside the source. No removal of legacy functionality is planned.
+  single-table path; `MultiSourceFormatAdapter` is purely additive.
+- **Migration.** A user converting an existing single-source job keeps their legacy checkpoint:
+  the multi-source checkpoint manager reads a bare timestamp as a legacy value and, on the next
+  commit, migrates it to `0=<computed-hash>:<timestamp>`. No manual checkpoint surgery required.
+- **Timeline.** Ship behind explicit opt-in configuration; document recommended join/merge
+  patterns alongside the feature. No removal of legacy functionality is planned.
 
 ## Test Plan
 
 - **Unit tests.**
-  - `InputBatch` multi-dataset construction, `getBatches()`, and the `getBatch()` fail-loud guard.
-  - `MultiTableCheckpointManager` parse/format round-trips, legacy single-value compatibility, and the
-    lenient parser preserving valid entries when one entry is corrupt.
-  - `SqlFileBasedTransformer` `<SRC>` / `<SRC_0..N>` substitution, multi-statement + CTE handling,
-    temp-view cleanup on success and on failure, and dangling-`<SRC_N>` validation.
-  - `UtilHelpers` resolution of a `MultiDatasetTransformer` (direct and inside `ChainedTransformer`).
-- **Source tests.** `HoodieIncrMultiSource` per-table checkpointing, empty-but-schema'd datasets for
-  tables with no new data, per-table `num_instants` / missing-checkpoint strategy, and
-  `skip_on_schema_failure` behavior + metric emission.
-- **End-to-end functional tests.** Multi-table Streamer runs merging N Hudi sources via a SQL file
-  (`TestHoodieIncrMultiSourceFunctional`), covering: independent per-table advancement, atomic single
-  commit, restart/replay from a persisted multi-table checkpoint, OUTER-JOIN correctness with delayed
-  data in one source, and the startup-validation failure when no `MultiDatasetTransformer` is
-  configured. Multi-dataset error-event handling is covered by `TestSourceFormatAdapterMultiDataset`.
+  - `MultiTableCheckpointManager` parse/format round-trips; legacy single-value compatibility
+    (bare timestamp → `0=<hash>:<ts>` on next commit); lenient-parse preserving valid entries
+    when one entry is corrupt; carry-forward rebuilding a dropped entry from the previous
+    committed checkpoint; path-fingerprint mismatch failing at startup with a clear diagnostic;
+    bare-timestamp `--checkpoint` / `checkpoint.reset_key` rejected in multi-source mode.
+  - `SqlFileBasedTransformer` `<SRC>` / `<SRC_0..N>` substitution; multi-statement + CTE
+    handling; temp-view cleanup on success and on failure (per-batch `finally`);
+    dangling-`<SRC_N>` validation; user-created-view namespace ownership (pre-existing view
+    with the same name is replaced and cleaned up).
+  - `UtilHelpers` resolution of a `MultiDatasetTransformer` (direct and inside
+    `ChainedTransformer`).
+- **`MultiSourceFormatAdapter` tests.** Composition wiring; per-index dispatch; per-source
+  `num_instants` / `missing_checkpoint_strategy` honored; `skip_on_schema_failure` behavior +
+  metric emission; **all-sources-failed schema resolution** does not commit by default and
+  fires N metrics; **empty-vs-non-empty schema-shape identity** (empty dataset for a caught-up
+  source includes the same columns as a non-empty read of the same source, including
+  `_hoodie_*` meta columns and `drop.all.meta.fields` honoring).
+- **Source-list evolution tests.** Add source (new index → `missing_checkpoint_strategy`
+  applied); remove source (stale entry pruned, WARN logged); reorder / replace-path fails at
+  startup on fingerprint mismatch with a clear diagnostic; explicit `--checkpoint` override
+  after reorder resumes correctly.
+- **End-to-end functional tests.** Multi-source Streamer runs merging N Hudi sources via a SQL
+  file (`TestMultiSourceFormatAdapterFunctional`), covering: independent per-source
+  advancement; atomic single commit; restart/replay from a persisted composite checkpoint;
+  OUTER-JOIN correctness with delayed data in one source; startup-validation failure when no
+  `MultiDatasetTransformer` is configured; startup-validation failure on
+  per-source-schema-provider keys; startup-validation failure on `source.class` inconsistent
+  with `count > 0`.
+- **Sanitization-at-write-time integration test.** Writes the merged output with
+  `hoodie.datasource.write.sanitize.avro.field.names=true` and asserts the writer's
+  sanitization codepath was taken on the merged rows even though per-source reads bypass it.
 - **Regression / "nothing broke."** Existing single-source `HoodieIncrSource` and
-  `SqlFileBasedTransformer` (`<SRC>`) tests continue to pass unchanged, confirming backward
-  compatibility of the API and checkpoint format.
+  `SqlFileBasedTransformer` (`<SRC>`) tests continue to pass unchanged; `InputBatch`,
+  `Source`, and `SourceFormatAdapter` public APIs verified unmodified by a build-time check on
+  their signatures, confirming backward compatibility of the public API.

--- a/rfc/rfc-108/rfc-108.md
+++ b/rfc/rfc-108/rfc-108.md
@@ -1,0 +1,385 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+# RFC-108: Multi-dataset incremental reads in Hudi Streamer
+
+## Proposers
+
+- @ashokkumar-allu
+
+## Approvers
+
+- @nsivabalan
+
+## Status
+
+Issue: https://github.com/apache/hudi/issues/19281
+
+> Please keep the status updated in `rfc/README.md`.
+
+## Abstract
+
+Apache Hudi Streamer (DeltaStreamer) can read incrementally from exactly one source per job. Pipelines
+that need to combine incremental changes from **several Hudi tables** into one target table must
+therefore run one Streamer job per source and merge the results downstream, or fall back to expensive
+full-snapshot reads for all-but-one table. The multi-job approach has no cross-source transaction
+boundary, so the tables it stitches together drift in time, produce incomplete/inconsistent joined
+output, and require backfills to repair; it also multiplies watermark and monitoring overhead.
+
+This RFC proposes **native multi-table incremental reads** in Hudi Streamer: a new source
+(`HoodieIncrMultiSource`) that reads N Hudi tables incrementally in a single batch with **independent
+per-table checkpoints**, a **multi-dataset transformer** contract (`MultiDatasetTransformer`,
+implemented by `SqlFileBasedTransformer`) that merges the datasets with a single SQL file referencing
+`<SRC_0>`, `<SRC_1>`, …, and a **backward-compatible multi-table checkpoint format** managed by
+`MultiTableCheckpointManager`. The result is a single, atomic ingestion job — one commit, one
+checkpoint — for related datasets.
+
+## Background
+
+### Current single-source flow
+
+```
+Streamer CLI
+  └─ StreamSync.sync()
+       └─ SourceFormatAdapter        (adapts ROW / JSON / AVRO to a common shape)
+            └─ HoodieIncrSource      (incremental read of ONE Hudi table via
+                                      hoodie.deltastreamer.source.hoodieincr.path)
+       └─ Transformer                (single Dataset<Row> in → Dataset<Row> out)
+       └─ write + commit             (checkpoint = single timestamp, e.g. "20250606182826197")
+```
+
+`InputBatch` carries a single `Option<T>` payload and one checkpoint string. Checkpoints are opaque
+single timestamps stored in `deltastreamer.checkpoint.key` in the Streamer commit metadata.
+
+### Why this is insufficient for multi-source pipelines
+
+- **Data inconsistency / silent failures.** N independent jobs advance at different rates. A join of
+  Table A (at T+10) and Table B (at T+7) yields incomplete or misleading data with no error raised —
+  discovered only later, and repaired only with backfills.
+- **No atomicity across sources.** There is no shared transaction boundary. If one job fails after
+  others commit, the unified downstream table is left partially updated.
+- **Operational overhead.** Each job maintains its own watermark (watermark drift complicates replay
+  and debugging) and its own monitoring/alerting surface.
+- **Expensive workaround.** Reading one table incrementally while snapshot-reading the last X days of
+  every other table consumes far more compute than a true incremental read.
+
+### Motivating use cases
+
+- **Cross-entity enrichment for analytics or serving.** A downstream table is populated by joining
+  two Hudi tables — e.g. a fact table (transactions, events, clicks, orders) with a dimension table
+  (accounts, users, products) on a foreign key. Both sources ingest continuously from different
+  upstreams and each is already a Hudi table. When run as two independent Streamer jobs plus a
+  downstream merge, the merge step periodically observes fact rows whose dimension row has not yet
+  been ingested and either drops them (inner join) or emits rows with null dimension fields (outer
+  join) that must be repaired on a later run. A native multi-source incremental read advances both
+  tables under one commit, so the join always sees a consistent slice.
+- **Consolidating multiple partitioned or sharded upstreams into one target table.** When a logical
+  entity is split across multiple Hudi tables — for example one table per shard, per region, or per
+  legacy vs. new system during a data-platform migration — a downstream consumer typically wants a
+  single unified view. Running one Streamer job per upstream leaves the unified table stale for
+  whichever upstream lagged in the most recent window; a single-batch multi-source read makes the
+  unified table advance atomically for all upstreams.
+- **Slowly-changing-dimension (SCD) style pipelines.** A pipeline that maintains an SCD table by
+  combining a change stream from a source-of-truth table with reference/lookup tables benefits from
+  reading all inputs in the same batch — inconsistent temporal cuts between the change stream and
+  the lookup tables are a common source of incorrect history rows.
+- **Compute cost of the current workaround.** Today, teams that need cross-source consistency fall
+  back to reading one table incrementally and snapshot-scanning the last N days of every other
+  table on every batch. That snapshot scan grows with the retention window rather than with the
+  new data, so a Streamer batch that would ingest a few thousand rows of true delta ends up
+  reading many gigabytes per additional source — every batch. The proposed source removes that
+  amplification because every source is read incrementally.
+
+## Implementation
+
+The change is confined to `hudi-utilities` (Hudi Streamer). Four building blocks plus wiring.
+
+### 1. Multi-dataset `InputBatch`
+
+`InputBatch<T>` gains a `List<T> batches` alongside the existing `Option<T> batch`:
+
+- New constructor `InputBatch(List<T> batches, String checkpointForNextBatch, SchemaProvider)`.
+- `getBatches(): List<T>` returns all datasets (defensive copy).
+- `getBatch(): Option<T>` is retained for single-dataset sources and now **fails loud** — it throws
+  via `ValidationUtils.checkState` if more than one batch is present, so a multi-dataset batch can
+  never be silently narrowed to one dataset. For single-dataset construction, `getBatches()` returns
+  a singleton and `getBatch()` returns that element (unchanged behavior).
+
+This keeps every existing single-source source and transformer working unchanged.
+
+### 2. `HoodieIncrMultiSource`
+
+A new source extending `Source<Dataset<Row>>` (SourceType `ROW`). It extends `Source` directly rather
+than `RowSource` because `RowSource#fetchNextBatch` calls `SanitizationUtils` on the returned dataset
+(masking Avro-invalid field names) before wrapping the result in an `InputBatch` — that per-row scan
+would (a) run twice, once here and again after the transformer merges the datasets, and (b) only
+supports a single `Option<Dataset<Row>>` payload, not the multi-dataset list this source needs.
+Rows read from a Hudi table are already conformant with that table's Avro schema, so this bypass is
+safe; sanitization still applies at write time to the merged transformer output when the user has
+enabled it. Per batch the source:
+
+1. Parses `hoodie.streamer.source.multi.hudi.tables` (ordered, comma-separated) into per-table configs.
+2. Iterates the parsed tables **sequentially on the driver** and performs a `HoodieIncrSource`-equivalent
+   incremental read for each — its own `numInstantsPerFetch`, missing-checkpoint strategy, hollow-commit
+   handling, timeline management, and "already caught up" detection. Tables that ingest at different
+   rates never block one another; see *Scale and parallelism* below for the wall-clock implications.
+3. Returns a dataset for **every** configured table, in declaration order — an empty dataset carrying
+   the Hudi table's schema when a table has no new incremental data — so downstream `LEFT/FULL OUTER
+   JOIN`s always resolve against a valid relation.
+4. Packages all datasets into one `InputBatch` via the multi-dataset constructor, with the combined
+   multi-table checkpoint (or a plain timestamp when multi-table checkpointing is disabled). The
+   `InputBatch` carries a `NullSchemaProvider` — Streamer infers the write schema from the merged
+   transformer output rather than from any single input source (see *Per-table schema resolution*).
+
+#### Per-table schema resolution
+
+Each source table's read schema is resolved independently against that table's own Hudi metadata,
+so heterogeneous or independently-evolving source schemas are supported directly:
+
+- A table with new commits: the read produces rows conformant with the current commit's schema.
+- A table that is caught up or empty: the source emits an empty `Dataset<Row>` built from that table's
+  current Hudi schema, so downstream joins and column references remain valid rather than exploding
+  on an "unresolved column" error.
+- Placeholder-schema resolution failure for any table: controlled by
+  `hoodie.streamer.source.hudi.{table}.skip_on_schema_failure` (default `false` — fail loud so a real
+  failure does not silently advance the checkpoint; `true` returns an empty dataset for that table
+  and emits a `<table>.schema_resolution_failure` metric).
+- The target write schema is not tied to any single source: `HoodieIncrMultiSource` attaches a
+  `NullSchemaProvider` to the `InputBatch`, and Streamer resolves the final write schema from the
+  merged `Dataset<Row>` returned by the `MultiDatasetTransformer`. This lets the user's SQL freely
+  add/drop/rename columns across source-schema versions without needing a schema-provider override.
+
+#### Scale and parallelism
+
+Per-table reads run **sequentially on the driver** — one Hudi `beginInstant..endInstant` read at a time,
+not `N` reads in parallel. Wall-clock time for a batch is therefore the **sum** of per-table read
+times, not the maximum. Practical implications:
+
+- Expected `N` for this feature is small — typically 2–5 related tables — so sequential reads keep the
+  design simple and avoid contention on the shared timeline server and driver-side timeline caches
+  without materially hurting throughput.
+- One slow source (e.g. a table with a large backlog or many small files) stretches the whole batch,
+  so per-table `num_instants` should be sized to keep the slowest source within an acceptable per-batch
+  budget.
+- If a pipeline needs cross-source consistency across a large `N` **or** truly parallel per-table
+  reads, the right tradeoff today is still separate Streamer jobs plus a downstream merge — this
+  source is not a replacement for that at large fan-out. Parallel per-table reads can be added later
+  behind an opt-in config without changing the public contract if usage patterns demand it.
+
+**Configuration** (`HoodieIncrMultiSourceConfig`, group `HUDI_STREAMER` / `DELTA_STREAMER_SOURCE`):
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `hoodie.streamer.source.multi.hudi.tables` | (required) | Ordered, comma-separated source table names |
+| `hoodie.streamer.source.multi.hudi.checkpoint.enable` | `true` | Multi-table checkpoint format; `false` → legacy single-checkpoint behavior |
+| `hoodie.streamer.source.hudi.{table}.path` | (required) | Per-table base path |
+| `hoodie.streamer.source.hudi.{table}.num_instants` | `HoodieIncrSourceConfig.NUM_INSTANTS_PER_FETCH` default | Per-table instants per fetch |
+| `hoodie.streamer.source.hudi.{table}.missing_checkpoint_strategy` | `READ_LATEST` | `READ_LATEST` \| `READ_UPTO_LATEST_COMMIT` |
+| `hoodie.streamer.source.hudi.{table}.skip_on_schema_failure` | `false` | On placeholder-schema resolution failure: `false` fails loud (checkpoint not advanced past a real failure); `true` returns an empty dataset and emits a `<table>.schema_resolution_failure` metric |
+| `hoodie.streamer.source.hudi.{table}.partition.fields` / `.partition.extractor.class` | — | Optional per-table partitioning |
+
+All keys carry `hoodie.deltastreamer.*` alternatives for compatibility. **Table-name convention:** a
+dotted name (`db.orders`) has its dots replaced by underscores when building property keys
+(`...source.hudi.db_orders.path`) so property-file parsers don't split them; the original dotted name
+is always used inside the checkpoint map.
+
+### 3. `MultiDatasetTransformer` and `SqlFileBasedTransformer`
+
+`MultiDatasetTransformer extends Transformer` adds:
+
+```java
+Dataset<Row> apply(JavaSparkContext jsc, SparkSession spark,
+                   List<Dataset<Row>> datasets, TypedProperties props);
+```
+
+Contract: list order matches `...source.multi.hudi.tables`; an entry is always present for each table
+(empty-but-schema'd when no new data); the single-dataset `Transformer#apply` remains implemented so
+the transformer still works in single-source pipelines.
+
+`SqlFileBasedTransformer` implements it:
+
+- Registers each input dataset as a unique Spark temp view (`HOODIE_SRC_TMP_TABLE_<uuid>`).
+- SQL references datasets by index — `<SRC_0>`, `<SRC_1>`, … — with `<SRC>` kept as an alias for the
+  first dataset (backward compatible).
+- Supports multi-statement SQL files and `CREATE [OR REPLACE] TEMPORARY VIEW` (e.g. CTE-style setup);
+  user-created views are tracked and dropped alongside the source temp views in a `finally` block.
+- Validates inputs: rejects null/empty dataset lists and any dangling `<SRC_N>` placeholder that has
+  no corresponding dataset (typo guard), with clear error messages.
+
+Example SQL (`<SRC_0>` = orders, `<SRC_1>` = users):
+
+```sql
+SELECT o.order_id, o.amount, o.user_id, u.user_name, u.email
+FROM <SRC_0> o
+FULL OUTER JOIN <SRC_1> u ON o.user_id = u.user_id;
+```
+
+### 4. `MultiTableCheckpointManager`
+
+Parses, formats, and manipulates per-table checkpoints stored in `deltastreamer.checkpoint.key`:
+
+```
+Multi-table : "table1=20250606182826197,table2=20250606182830145,table3=20250606182828456"
+Single/legacy: "20250606182826197"
+```
+
+- Any value containing `=` is parsed as multi-table via a lenient parser that skips malformed entries
+  while preserving valid ones (so a single corrupt entry never causes the whole string to be
+  misclassified as single-table and collapsed under a default key).
+- A bare value with no `=` is treated as a legacy single checkpoint (mapped to a default table),
+  giving automatic backward compatibility and a clean upgrade path from an existing single-source job.
+- The formatted output uses a deterministic key order (backed by a `TreeMap`) so the same set of
+  per-table checkpoints always serializes to the same string, making commits and diffs reproducible.
+
+#### Behavior when the parser skips a malformed entry
+
+The lenient parser is designed to keep a single corrupt `table=ts` entry from taking down the whole
+job. That behavior has a data-correctness consequence that the operator must understand:
+
+- A skipped entry is logged as `WARN`, and the source emits a
+  `multi_table_checkpoint.malformed_entries` counter metric with the number of dropped entries so the
+  drop is observable in monitoring, not silent.
+- The affected table then has **no checkpoint** for the next batch, so `HoodieIncrMultiSource` treats
+  it as first-run and applies its `missing_checkpoint_strategy`. With the default `READ_LATEST` this
+  means the table jumps to the latest instant and **skips any data between the lost checkpoint and
+  latest** — a silent data-loss window sized by however long the corruption went unnoticed.
+- Operators who cannot tolerate that failure mode should set
+  `hoodie.streamer.source.hudi.{table}.missing_checkpoint_strategy=READ_UPTO_LATEST_COMMIT`, which
+  reads the whole table history up to latest instead — safer default for reprocessable / dedup-keyed
+  writes, but heavier.
+- The malformed-entries metric should be alerted on with threshold `> 0` in any pipeline that ingests
+  event streams where re-reading history is not equivalent to a resume.
+
+### 5. Wiring into `StreamSync` and `SourceFormatAdapter`
+
+- **Startup validation.** If the source is `HoodieIncrMultiSource`, `StreamSync` requires a
+  `MultiDatasetTransformer` (resolved via `UtilHelpers.resolveMultiDatasetTransformer`, so it is found
+  even when wrapped in a `ChainedTransformer`). If none is configured, the job throws
+  `HoodieStreamerException` at startup — preventing the silent-data-loss failure mode where only the
+  last source table would be written.
+- **Routing.** In `fetchNextBatchFromSource`, when a multi-dataset transformer is present the full
+  `getBatches()` list is passed to `MultiDatasetTransformer#apply`; otherwise the existing
+  single-dataset path (`getBatch().map(...)`) is used unchanged. An empty-batch guard skips the
+  transformer when the source produced no data (rather than passing an empty list that would throw).
+- **`SourceFormatAdapter`.** Processes error events per-dataset on the multi-dataset row path.
+
+### Sequence (per batch)
+
+```
+StreamSync.sync()
+  └─ HoodieIncrMultiSource.fetchNext()
+       ├─ read incrementally: db.orders (own ckpt), db.users (own ckpt), …  → List<Dataset<Row>>
+       └─ InputBatch(batches=[...], checkpoint="db.orders=ts1,db.users=ts2")
+  └─ SqlFileBasedTransformer.apply(jsc, spark, getBatches(), props)   // <SRC_0>,<SRC_1> → merged DF
+  └─ write merged DF + commit  (single atomic commit; multi-table checkpoint persisted)
+```
+
+### Design decisions & risks
+
+- **User-owned merge semantics (non-goal to automate).** Delayed data in a source means **inner joins
+  can silently miss rows**; the recommended pattern is **OUTER JOIN** on incremental sources. Overlapping
+  columns and partial/nested-field updates are resolved with a **merge payload** (e.g. a generic merge
+  payload, or a custom `HoodieRecordPayload` that merges non-null fields) rather than last-writer-wins
+  overwrite — otherwise fields from an earlier upsert are lost. These are documented, not enforced.
+- **Failure and atomicity contract.** A batch either advances every source's checkpoint together, or
+  advances none of them:
+  - Any per-table read failure (schema resolution, timeline read, etc. — unless the operator has
+    opted in per-table via `skip_on_schema_failure=true`) aborts the batch before the merged write is
+    attempted, and the checkpoint is not updated.
+  - The transformer step is invoked once against the whole `getBatches()` list; a transformer
+    exception aborts the batch, and the checkpoint is not updated.
+  - The write is a single Hudi commit. The full multi-table checkpoint string is written into the
+    commit's `deltastreamer.checkpoint.key` extra-metadata as part of that same commit, so the
+    per-table cursor advances **atomically with the data**. If the write fails or the commit does not
+    finalize, no source's cursor advances and the next batch re-reads the same window for every
+    source — exactly the atomic-across-sources guarantee that N separate Streamer jobs cannot offer.
+  - There is no partial-success mode where some sources commit and others do not. This is a
+    deliberate choice: cross-source consistency is the reason to use this source, and it would be
+    lost if a batch could half-succeed.
+- **Backward compatibility.** All Java API changes are additive; `getBatch()`, single-source sources,
+  and non-SQL transformers are unaffected. The checkpoint format degrades cleanly to legacy.
+- **Checkpoint correctness across failures/re-runs** is the main implementation risk and is covered by
+  the lenient multi-table parser and by the test plan below.
+- **Scope.** No change to Hudi's write/commit path or on-disk storage format; the only serialized
+  change is the contents of the Streamer's own `deltastreamer.checkpoint.key`.
+
+## Alternatives Considered
+
+- **N single-source Streamer jobs + downstream merge (status quo).** Simple to reason about
+  operationally but loses cross-source atomicity: sources advance independently, so any downstream
+  merge that reads the results sees inconsistent temporal cuts, and inner-join outputs silently miss
+  rows for late arrivals in one source. Also multiplies watermark tracking and monitoring surface
+  N-fold. This RFC's core motivation is to fix exactly this class of drift.
+- **Snapshot-scan all-but-one source + one incremental source (existing workaround).** Achievable
+  today without any new Hudi APIs, but the batch-time compute cost of the snapshot scans grows with
+  each source's retention window rather than with new data. Sized against real pipelines this is the
+  dominant cost of the workaround and the primary reason a native incremental multi-source read is
+  worth the API surface increase.
+- **Dedicated join/union source that returns a single `Dataset<Row>` (auto-merge in the source).**
+  Would avoid the `MultiDatasetTransformer` interface, but bakes the merge policy — inner vs outer
+  join, key resolution, precombine payload, column-conflict handling — into a source, which is the
+  wrong layer. Pipelines need the flexibility of expressing the merge as user SQL against the
+  per-source datasets, so the source stays merge-agnostic and the transformer contract is what grows.
+- **Transformer-only approach (single source-of-record source + transformer reads sibling Hudi
+  tables directly).** Sidesteps changes to `Source`/`InputBatch`, but breaks the checkpoint model:
+  reads inside the transformer are opaque to Streamer, so they cannot participate in the
+  per-source `deltastreamer.checkpoint.key`. This effectively re-invents the snapshot-scan
+  workaround inside the transformer and loses the incremental / atomic semantics that motivate the
+  RFC.
+- **Extending `HoodieIncrSource` in place instead of a new source.** Multi-table semantics change
+  every stage of the source's contract (config surface, checkpoint format, `InputBatch` cardinality,
+  transformer contract, write-schema derivation). Overloading `HoodieIncrSource` risked
+  regressing single-source behavior and made the config surface confusing (which keys are per-table
+  vs. global). A new source class isolates the multi-source path behind an explicit opt-in.
+- **Parallel per-table reads on the driver / structured concurrency.** Deferred, not chosen. Expected
+  N is small (2–5), the shared timeline server prefers sequential access, and sequential reads keep
+  the failure-mode surface small (a mid-flight error aborts a single in-progress read, not N of them).
+  The `Source` contract does not preclude adding parallel reads later behind an opt-in config if a
+  compelling workload appears.
+
+## Rollout/Adoption Plan
+
+- **Impact on existing users.** None by default. The feature is inert unless a user sets
+  `source.class=HoodieIncrMultiSource` and declares source tables. Existing single-source jobs,
+  transformers, and checkpoints continue to work byte-for-byte.
+- **Behavior phase-out.** Nothing is deprecated or removed. `HoodieIncrSource` remains the
+  single-table path; `HoodieIncrMultiSource` is purely additive.
+- **Migration.** A user converting an existing single-source job keeps their legacy checkpoint: the
+  multi-table checkpoint manager reads a bare timestamp as a legacy value and begins emitting the
+  per-table format on the next commit. No manual checkpoint surgery required.
+- **Timeline.** Ship behind explicit opt-in configuration; document recommended join/merge patterns
+  alongside the source. No removal of legacy functionality is planned.
+
+## Test Plan
+
+- **Unit tests.**
+  - `InputBatch` multi-dataset construction, `getBatches()`, and the `getBatch()` fail-loud guard.
+  - `MultiTableCheckpointManager` parse/format round-trips, legacy single-value compatibility, and the
+    lenient parser preserving valid entries when one entry is corrupt.
+  - `SqlFileBasedTransformer` `<SRC>` / `<SRC_0..N>` substitution, multi-statement + CTE handling,
+    temp-view cleanup on success and on failure, and dangling-`<SRC_N>` validation.
+  - `UtilHelpers` resolution of a `MultiDatasetTransformer` (direct and inside `ChainedTransformer`).
+- **Source tests.** `HoodieIncrMultiSource` per-table checkpointing, empty-but-schema'd datasets for
+  tables with no new data, per-table `num_instants` / missing-checkpoint strategy, and
+  `skip_on_schema_failure` behavior + metric emission.
+- **End-to-end functional tests.** Multi-table Streamer runs merging N Hudi sources via a SQL file
+  (`TestHoodieIncrMultiSourceFunctional`), covering: independent per-table advancement, atomic single
+  commit, restart/replay from a persisted multi-table checkpoint, OUTER-JOIN correctness with delayed
+  data in one source, and the startup-validation failure when no `MultiDatasetTransformer` is
+  configured. Multi-dataset error-event handling is covered by `TestSourceFormatAdapterMultiDataset`.
+- **Regression / "nothing broke."** Existing single-source `HoodieIncrSource` and
+  `SqlFileBasedTransformer` (`<SRC>`) tests continue to pass unchanged, confirming backward
+  compatibility of the API and checkpoint format.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

This PR adds a new RFC — **RFC-108: Multi-dataset incremental reads in Hudi Streamer** — proposing native multi-table incremental reads in Hudi Streamer so that N Hudi tables can be read incrementally into a single, atomic ingestion job (one commit, one checkpoint).

Related feature issue: Closes #19281

### Summary and Changelog

Hudi Streamer (DeltaStreamer) can currently read incrementally from exactly one source per job. Pipelines that need to combine incremental changes from **several Hudi tables** into one target must run one Streamer job per source and merge downstream (drift, no cross-source atomicity, extra watermark/monitoring overhead) or fall back to expensive full-snapshot reads for all but one table.

This RFC proposes:

- **`HoodieIncrMultiSource`** — a new source that reads N Hudi tables incrementally in a single batch with **independent per-table checkpoints** (each table advances on its own `numInstantsPerFetch` / missing-checkpoint strategy).
- **Multi-dataset `InputBatch`** — additive `List<T> batches` alongside the existing `Option<T> batch`; `getBatch()` now fails loud if a multi-dataset batch would be silently narrowed, single-source callers are unaffected.
- **`MultiDatasetTransformer` contract**, implemented by **`SqlFileBasedTransformer`** — merges the per-source datasets with a single SQL file referencing `<SRC_0>`, `<SRC_1>`, …; `<SRC>` is kept as an alias for the first dataset for backward compatibility; supports multi-statement SQL and CTE-style `CREATE [OR REPLACE] TEMPORARY VIEW`, with temp-view cleanup on both success and failure.
- **`MultiTableCheckpointManager`** — persists per-table checkpoints as `table1=ts1,table2=ts2` in `deltastreamer.checkpoint.key`; a bare timestamp continues to be honored as a legacy single-source checkpoint, so existing jobs migrate without checkpoint surgery.
- **`StreamSync` / `SourceFormatAdapter` wiring** — startup validation that `HoodieIncrMultiSource` requires a `MultiDatasetTransformer` (resolved even inside a `ChainedTransformer`) to prevent a silent-data-loss path where only the last source would be written; per-dataset error-event handling on the multi-dataset row path.

Changelog:

- `rfc/rfc-108/rfc-108.md` — new RFC document (Abstract, Background, Implementation, Rollout/Adoption Plan, Test Plan).
- `rfc/README.md` — add RFC-108 entry with status `UNDER REVIEW`.

No code changes in this PR — this is the RFC document only.

### Impact

- **User-facing:** none from this PR (docs only). The proposed feature, when implemented, is opt-in via `source.class=HoodieIncrMultiSource` and does not alter behavior of existing single-source Streamer jobs, transformers, or checkpoints. API changes are additive; the checkpoint format degrades cleanly to the legacy single-timestamp form.
- **Performance:** none from this PR.

### Risk Level

none — RFC documentation only; no code or config changes.

### Documentation Update

This PR **is** the design documentation for the proposed feature. No website updates are required until the implementation lands; user-facing configuration and the recommended OUTER JOIN / merge-payload patterns will be documented on the Hudi website when the feature is shipped.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (n/a — RFC doc only; the Test Plan section of the RFC covers the tests that will accompany the implementation)
