### PR TITLE
feat(metadata): MDT posting-block schema foundation for vector index

### DIFF
--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -554,6 +554,117 @@
                 }
             ],
             "default" : null
+        },
+        {
+            "name": "VectorIndexMetadata",
+            "doc": "Typed metadata records for the MDT-backed IVF + RaBitQ vector index.",
+            "type": [
+                "null",
+                {
+                    "type": "record",
+                    "name": "HoodieVectorIndexManifest",
+                    "fields": [
+                        {"name": "indexVersion", "type": "int"},
+                        {"name": "generationId", "type": "string", "doc": "Creating Hudi instant + optional human tag. The gen ordinal lives in the key."},
+                        {"name": "state", "type": "string", "doc": "BUILDING | ACTIVE | RETIRED. Readers serve the max-ordinal ACTIVE generation."},
+                        {"name": "dim", "type": "int"},
+                        {"name": "dimPadded", "type": "int", "doc": "nextPow2(dim) for hadamard quantizers, else dim. Authoritative for codeRowBytes."},
+                        {"name": "codeRowBytes", "type": "int", "doc": "ceil(dimPadded/64)*8. Long-aligned per-plane row width."},
+                        {"name": "bitsTotal", "type": "int", "doc": "B = 1 + numExPlanes."},
+                        {"name": "numExPlanes", "type": "int"},
+                        {"name": "numClusters", "type": "int"},
+                        {"name": "shardCount", "type": "int"},
+                        {"name": "metric", "type": "string", "doc": "L2 | DOT | COSINE."},
+                        {"name": "assumeNormalized", "type": "boolean"},
+                        {"name": "residualEncoding", "type": "boolean", "default": false, "doc": "True when posting codes encode x - centroid and readers must use residual scoring."},
+                        {"name": "vectorColumn", "type": "string", "doc": "Authoritative base-table vector column used for bootstrap and exact rerank."},
+                        {"name": "targetBlockBytes", "type": "int", "doc": "Config input, e.g. 524288."},
+                        {"name": "vectorsPerBlock", "type": "int", "doc": "Resolved N. Frozen per generation; readers never re-derive."},
+                        {"name": "splitLimit", "type": "int"},
+                        {"name": "mergeFloor", "type": "int"},
+                        {"name": "centroidEpoch", "type": "long"},
+                        {"name": "createdTs", "type": "long"}
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "HoodieVectorIndexQuantizer",
+                    "fields": [
+                        {"name": "quantizerType", "type": "string", "doc": "rb-rotation-explicit | rb-rotation-hadamard."},
+                        {"name": "randomSeed", "type": "long"},
+                        {"name": "rotationBytes", "type": ["null", "bytes"], "default": null,
+                         "doc": "Explicit path: rows of the D x D float32 LE orthogonal matrix. Null for hadamard."}
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "HoodieVectorIndexCentroids",
+                    "fields": [
+                        {"name": "centroidEpoch", "type": "long"},
+                        {"name": "clusterIds", "type": "bytes", "doc": "k x u32 LE cluster ids in this chunk, parallel to centroidBytes rows."},
+                        {"name": "centroidBytes", "type": "bytes", "doc": "k x dimPadded float32 LE, row-major, in rotated space."},
+                        {"name": "clusterRadii", "type": "bytes", "doc": "k x float32 LE max residual norm per cluster."}
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "HoodieVectorIndexPostingBlock",
+                    "fields": [
+                        {"name": "blockFormatVersion", "type": "int"},
+                        {"name": "numVectors", "type": "int"},
+                        {"name": "codeRowBytes", "type": "int", "doc": "Duplicated from manifest for self-description; MUST match."},
+                        {"name": "signPlane", "type": "bytes", "doc": "S1: N x codeRowBytes, row-major. Bit plane B-1 (MSB)."},
+                        {"name": "exPlanes", "type": "bytes", "doc": "S2: N x numExPlanes x codeRowBytes. Vector-major; planes MSB-first."},
+                        {"name": "scalarFactors", "type": "bytes", "doc": "S3: fAdd1 | fRescale1 | err1 | fAddEx | fRescaleEx | residualNorm | optional vectorNorm, float32 LE SoA."},
+                        {"name": "rowLocators", "type": "bytes", "doc": "S4: N x 8 B LE structs: fgDictIdx u16 | instantDictIdx u16 | rowPosition u32."},
+                        {"name": "fileGroupDict", "type": {"type": "array", "items": "string"}},
+                        {"name": "instantTimeDict", "type": {"type": "array", "items": "string"}},
+                        {"name": "partitionDict", "type": {"type": "array", "items": "string"}, "doc": "Parallel indexing with fileGroupDict."},
+                        {"name": "recordKeyOffsets", "type": "bytes", "doc": "S6a: (N+1) x u32 LE offsets into recordKeyBytes."},
+                        {"name": "recordKeyBytes", "type": "bytes", "doc": "S6b: concatenated UTF-8 keys. Must remain final field."}
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "HoodieVectorIndexPostingDelta",
+                    "fields": [
+                        {"name": "recordKey", "type": "string"},
+                        {"name": "binaryCode", "type": "bytes", "doc": "MSB row followed by ex rows, identical row encoding and plane order as blocks."},
+                        {"name": "fAdd1", "type": "float"},
+                        {"name": "fRescale1", "type": "float"},
+                        {"name": "err1", "type": "float"},
+                        {"name": "fAddEx", "type": "float"},
+                        {"name": "fRescaleEx", "type": "float"},
+                        {"name": "residualNorm", "type": "float"},
+                        {"name": "vectorNorm", "type": ["null", "float"], "default": null},
+                        {"name": "fileGroupId", "type": "string"},
+                        {"name": "partitionPath", "type": "string"},
+                        {"name": "baseInstantTime", "type": "string"},
+                        {"name": "rowPosition", "type": "long"}
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "HoodieVectorIndexClusterStats",
+                    "fields": [
+                        {"name": "liveCount", "type": "long"},
+                        {"name": "deltaCount", "type": "long"},
+                        {"name": "tombstoneCount", "type": "long"},
+                        {"name": "centroidEpoch", "type": "long"},
+                        {"name": "lastRebalanceInstant", "type": ["null", "string"], "default": null},
+                        {"name": "lastUpdatedTs", "type": "long"}
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "HoodieVectorIndexTombstone",
+                    "fields": [
+                        {"name": "deleteInstant", "type": "string"},
+                        {"name": "deleteReason", "type": "string", "doc": "SPLIT | MERGE | REBALANCE | GC | MANUAL."}
+                    ]
+                }
+            ],
+            "default" : null
         }
     ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/PostingBlockBuilder.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/PostingBlockBuilder.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import org.apache.hudi.avro.model.HoodieVectorIndexPostingBlock;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+
+/**
+ * Streaming-friendly builder for one immutable vector posting block.
+ */
+public final class PostingBlockBuilder {
+
+  public static final int BLOCK_FORMAT_VERSION = 1;
+  public static final int SCALAR_FACTOR_COUNT = 6;
+  public static final int SCALAR_FACTOR_COUNT_WITH_VECTOR_NORM = 7;
+  public static final int ROW_LOCATOR_BYTES = 8;
+
+  private final int codeRowBytes;
+  private final int numExPlanes;
+  private final boolean includeVectorNorm;
+  private final List<Row> rows = new ArrayList<>();
+  private final Map<String, Integer> fileGroupDict = new LinkedHashMap<>();
+  private final Map<String, Integer> instantTimeDict = new LinkedHashMap<>();
+  private final List<String> partitionDict = new ArrayList<>();
+
+  public PostingBlockBuilder(int codeRowBytes, int numExPlanes) {
+    this(codeRowBytes, numExPlanes, false);
+  }
+
+  public PostingBlockBuilder(int codeRowBytes, int numExPlanes, boolean includeVectorNorm) {
+    checkArgument(codeRowBytes > 0 && codeRowBytes % Long.BYTES == 0,
+        "codeRowBytes must be positive and long-aligned: " + codeRowBytes);
+    checkArgument(numExPlanes >= 0, "numExPlanes must be non-negative: " + numExPlanes);
+    this.codeRowBytes = codeRowBytes;
+    this.numExPlanes = numExPlanes;
+    this.includeVectorNorm = includeVectorNorm;
+  }
+
+  public PostingBlockBuilder addRow(String recordKey,
+                                    byte[] signPlane,
+                                    byte[] exPlanes,
+                                    float fAdd1,
+                                    float fRescale1,
+                                    float err1,
+                                    float fAddEx,
+                                    float fRescaleEx,
+                                    float residualNorm,
+                                    String fileGroupId,
+                                    String instantTime,
+                                    String partitionPath,
+                                    long rowPosition) {
+    return addRow(
+        recordKey,
+        signPlane,
+        exPlanes,
+        fAdd1,
+        fRescale1,
+        err1,
+        fAddEx,
+        fRescaleEx,
+        residualNorm,
+        null,
+        fileGroupId,
+        instantTime,
+        partitionPath,
+        rowPosition);
+  }
+
+  public PostingBlockBuilder addRow(String recordKey,
+                                    byte[] signPlane,
+                                    byte[] exPlanes,
+                                    float fAdd1,
+                                    float fRescale1,
+                                    float err1,
+                                    float fAddEx,
+                                    float fRescaleEx,
+                                    float residualNorm,
+                                    Float vectorNorm,
+                                    String fileGroupId,
+                                    String instantTime,
+                                    String partitionPath,
+                                    long rowPosition) {
+    checkArgument(recordKey != null, "recordKey must not be null");
+    checkArgument(signPlane != null && signPlane.length == codeRowBytes,
+        "signPlane must be exactly codeRowBytes");
+    checkArgument(exPlanes != null && exPlanes.length == numExPlanes * codeRowBytes,
+        "exPlanes must be numExPlanes * codeRowBytes");
+    checkArgument(rowPosition >= 0 && rowPosition <= 0xFFFFFFFFL,
+        "rowPosition must fit in unsigned int: " + rowPosition);
+    checkArgument(includeVectorNorm == (vectorNorm != null),
+        "vectorNorm presence must match block scalar layout");
+
+    int fileGroupIdx = fileGroupDictionaryIndex(fileGroupId, partitionPath);
+    int instantIdx = dictionaryIndex(instantTimeDict, instantTime);
+    rows.add(new Row(
+        recordKey,
+        signPlane.clone(),
+        exPlanes.clone(),
+        fAdd1,
+        fRescale1,
+        err1,
+        fAddEx,
+        fRescaleEx,
+        residualNorm,
+        vectorNorm == null ? 0.0f : vectorNorm,
+        fileGroupIdx,
+        instantIdx,
+        rowPosition));
+    return this;
+  }
+
+  public HoodieVectorIndexPostingBlock build() {
+    int numVectors = rows.size();
+    ByteBuffer signPlane = allocateLittleEndian(numVectors * codeRowBytes);
+    ByteBuffer exPlanes = allocateLittleEndian(numVectors * numExPlanes * codeRowBytes);
+    ByteBuffer scalarFactors = allocateLittleEndian(numVectors * scalarFactorCount() * Float.BYTES);
+    ByteBuffer rowLocators = allocateLittleEndian(numVectors * ROW_LOCATOR_BYTES);
+    ByteBuffer recordKeyOffsets = allocateLittleEndian((numVectors + 1) * Integer.BYTES);
+    ByteBuffer recordKeyBytes = allocateLittleEndian(totalRecordKeyBytes());
+
+    for (Row row : rows) {
+      signPlane.put(row.signPlane);
+      exPlanes.put(row.exPlanes);
+    }
+
+    writeScalarArray(scalarFactors, ScalarFactor.F_ADD_1);
+    writeScalarArray(scalarFactors, ScalarFactor.F_RESCALE_1);
+    writeScalarArray(scalarFactors, ScalarFactor.ERR_1);
+    writeScalarArray(scalarFactors, ScalarFactor.F_ADD_EX);
+    writeScalarArray(scalarFactors, ScalarFactor.F_RESCALE_EX);
+    writeScalarArray(scalarFactors, ScalarFactor.RESIDUAL_NORM);
+    if (includeVectorNorm) {
+      writeScalarArray(scalarFactors, ScalarFactor.VECTOR_NORM);
+    }
+
+    int currentKeyOffset = 0;
+    recordKeyOffsets.putInt(currentKeyOffset);
+    for (Row row : rows) {
+      rowLocators.putShort((short) row.fileGroupIdx);
+      rowLocators.putShort((short) row.instantIdx);
+      rowLocators.putInt((int) row.rowPosition);
+
+      byte[] keyBytes = row.recordKey.getBytes(StandardCharsets.UTF_8);
+      recordKeyBytes.put(keyBytes);
+      currentKeyOffset += keyBytes.length;
+      recordKeyOffsets.putInt(currentKeyOffset);
+    }
+
+    return new HoodieVectorIndexPostingBlock(
+        BLOCK_FORMAT_VERSION,
+        numVectors,
+        codeRowBytes,
+        flip(signPlane),
+        flip(exPlanes),
+        flip(scalarFactors),
+        flip(rowLocators),
+        new ArrayList<>(fileGroupDict.keySet()),
+        new ArrayList<>(instantTimeDict.keySet()),
+        new ArrayList<>(partitionDict),
+        flip(recordKeyOffsets),
+        flip(recordKeyBytes));
+  }
+
+  public int rowCount() {
+    return rows.size();
+  }
+
+  public void reset() {
+    rows.clear();
+    fileGroupDict.clear();
+    instantTimeDict.clear();
+    partitionDict.clear();
+  }
+
+  public static int deriveVectorsPerBlock(int targetBlockBytes, int dimPadded, int bitsTotal, int avgKeyLen) {
+    return deriveVectorsPerBlock(targetBlockBytes, dimPadded, bitsTotal, avgKeyLen, false);
+  }
+
+  public static int deriveVectorsPerBlock(int targetBlockBytes, int dimPadded, int bitsTotal, int avgKeyLen, boolean includeVectorNorm) {
+    checkArgument(targetBlockBytes > 0, "targetBlockBytes must be positive");
+    checkArgument(dimPadded > 0, "dimPadded must be positive");
+    checkArgument(bitsTotal > 0, "bitsTotal must be positive");
+    int codeRowBytes = ((dimPadded + 63) / 64) * Long.BYTES;
+    int scalarFactorCount = includeVectorNorm ? SCALAR_FACTOR_COUNT_WITH_VECTOR_NORM : SCALAR_FACTOR_COUNT;
+    int perVectorBytes = bitsTotal * codeRowBytes + scalarFactorCount * Float.BYTES
+        + ROW_LOCATOR_BYTES + Math.max(0, avgKeyLen) + Integer.BYTES;
+    int raw = targetBlockBytes / perVectorBytes;
+    int prevPowerOfTwo = Integer.highestOneBit(Math.max(1, raw));
+    return Math.max(256, Math.min(4096, prevPowerOfTwo));
+  }
+
+  private void writeScalarArray(ByteBuffer scalarFactors, ScalarFactor factor) {
+    for (Row row : rows) {
+      scalarFactors.putFloat(row.scalar(factor));
+    }
+  }
+
+  private int scalarFactorCount() {
+    return includeVectorNorm ? SCALAR_FACTOR_COUNT_WITH_VECTOR_NORM : SCALAR_FACTOR_COUNT;
+  }
+
+  private int totalRecordKeyBytes() {
+    int total = 0;
+    for (Row row : rows) {
+      total += row.recordKey.getBytes(StandardCharsets.UTF_8).length;
+    }
+    return total;
+  }
+
+  private static int dictionaryIndex(Map<String, Integer> dictionary, String value) {
+    checkArgument(value != null, "dictionary value must not be null");
+    Integer existing = dictionary.get(value);
+    if (existing != null) {
+      return existing;
+    }
+    int index = dictionary.size();
+    checkArgument(index <= 0xFFFF, "block-local dictionary cannot exceed unsigned short cardinality");
+    dictionary.put(value, index);
+    return index;
+  }
+
+  private int fileGroupDictionaryIndex(String fileGroupId, String partitionPath) {
+    checkArgument(fileGroupId != null, "fileGroupId must not be null");
+    checkArgument(partitionPath != null, "partitionPath must not be null");
+    Integer existing = fileGroupDict.get(fileGroupId);
+    if (existing != null) {
+      checkArgument(partitionDict.get(existing).equals(partitionPath),
+          "fileGroupId cannot map to multiple partition paths in one block: " + fileGroupId);
+      return existing;
+    }
+    int index = fileGroupDict.size();
+    checkArgument(index <= 0xFFFF, "block-local dictionary cannot exceed unsigned short cardinality");
+    fileGroupDict.put(fileGroupId, index);
+    partitionDict.add(partitionPath);
+    return index;
+  }
+
+  private static ByteBuffer allocateLittleEndian(int size) {
+    return ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  private static ByteBuffer flip(ByteBuffer buffer) {
+    buffer.flip();
+    return buffer;
+  }
+
+  private enum ScalarFactor {
+    F_ADD_1,
+    F_RESCALE_1,
+    ERR_1,
+    F_ADD_EX,
+    F_RESCALE_EX,
+    RESIDUAL_NORM,
+    VECTOR_NORM
+  }
+
+  private static final class Row {
+    private final String recordKey;
+    private final byte[] signPlane;
+    private final byte[] exPlanes;
+    private final float fAdd1;
+    private final float fRescale1;
+    private final float err1;
+    private final float fAddEx;
+    private final float fRescaleEx;
+    private final float residualNorm;
+    private final float vectorNorm;
+    private final int fileGroupIdx;
+    private final int instantIdx;
+    private final long rowPosition;
+
+    private Row(String recordKey,
+                byte[] signPlane,
+                byte[] exPlanes,
+                float fAdd1,
+                float fRescale1,
+                float err1,
+                float fAddEx,
+                float fRescaleEx,
+                float residualNorm,
+                float vectorNorm,
+                int fileGroupIdx,
+                int instantIdx,
+                long rowPosition) {
+      this.recordKey = recordKey;
+      this.signPlane = signPlane;
+      this.exPlanes = exPlanes;
+      this.fAdd1 = fAdd1;
+      this.fRescale1 = fRescale1;
+      this.err1 = err1;
+      this.fAddEx = fAddEx;
+      this.fRescaleEx = fRescaleEx;
+      this.residualNorm = residualNorm;
+      this.vectorNorm = vectorNorm;
+      this.fileGroupIdx = fileGroupIdx;
+      this.instantIdx = instantIdx;
+      this.rowPosition = rowPosition;
+    }
+
+    private float scalar(ScalarFactor factor) {
+      switch (factor) {
+        case F_ADD_1:
+          return fAdd1;
+        case F_RESCALE_1:
+          return fRescale1;
+        case ERR_1:
+          return err1;
+        case F_ADD_EX:
+          return fAddEx;
+        case F_RESCALE_EX:
+          return fRescaleEx;
+        case RESIDUAL_NORM:
+          return residualNorm;
+        case VECTOR_NORM:
+          return vectorNorm;
+        default:
+          throw new IllegalArgumentException("Unknown scalar factor: " + factor);
+      }
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/PostingBlockView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/PostingBlockView.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import org.apache.hudi.avro.model.HoodieVectorIndexPostingBlock;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
+
+/**
+ * Zero-copy section view over a vector posting block payload.
+ */
+public final class PostingBlockView {
+
+  private final HoodieVectorIndexPostingBlock block;
+  private final int numVectors;
+  private final int codeRowBytes;
+  private final int numExPlanes;
+  private final ByteBuffer signPlane;
+  private final ByteBuffer exPlanes;
+  private final ByteBuffer scalarFactors;
+  private final int scalarFactorCount;
+  private final ByteBuffer rowLocators;
+  private final ByteBuffer recordKeyOffsets;
+  private final ByteBuffer recordKeyBytes;
+
+  public PostingBlockView(HoodieVectorIndexPostingBlock block) {
+    checkArgument(block != null, "posting block must not be null");
+    this.block = block;
+    this.numVectors = block.getNumVectors();
+    this.codeRowBytes = block.getCodeRowBytes();
+    this.signPlane = littleEndian(block.getSignPlane());
+    this.exPlanes = littleEndian(block.getExPlanes());
+    this.scalarFactors = littleEndian(block.getScalarFactors());
+    this.rowLocators = littleEndian(block.getRowLocators());
+    this.recordKeyOffsets = littleEndian(block.getRecordKeyOffsets());
+    this.recordKeyBytes = littleEndian(block.getRecordKeyBytes());
+
+    checkArgument(block.getBlockFormatVersion() == PostingBlockBuilder.BLOCK_FORMAT_VERSION,
+        "Unsupported posting block format version: " + block.getBlockFormatVersion());
+    checkArgument(numVectors >= 0, "numVectors must be non-negative");
+    checkArgument(codeRowBytes > 0 && codeRowBytes % Long.BYTES == 0,
+        "codeRowBytes must be positive and long-aligned");
+    checkArgument(signPlane.remaining() == numVectors * codeRowBytes,
+        "signPlane length does not match numVectors * codeRowBytes");
+    checkArgument(exPlanes.remaining() % Math.max(1, numVectors * codeRowBytes) == 0,
+        "exPlanes length is not row aligned");
+    this.numExPlanes = numVectors == 0 ? 0 : exPlanes.remaining() / (numVectors * codeRowBytes);
+    int scalarArrayBytes = numVectors * Float.BYTES;
+    checkArgument(numVectors == 0 || scalarFactors.remaining() % scalarArrayBytes == 0,
+        "scalarFactors length must be a whole number of float arrays");
+    this.scalarFactorCount = numVectors == 0
+        ? PostingBlockBuilder.SCALAR_FACTOR_COUNT
+        : scalarFactors.remaining() / scalarArrayBytes;
+    checkArgument(scalarFactorCount == PostingBlockBuilder.SCALAR_FACTOR_COUNT
+            || scalarFactorCount == PostingBlockBuilder.SCALAR_FACTOR_COUNT_WITH_VECTOR_NORM,
+        "scalarFactors length must contain six or seven float arrays");
+    checkArgument(rowLocators.remaining() == numVectors * PostingBlockBuilder.ROW_LOCATOR_BYTES,
+        "rowLocators length must use 8-byte locator stride");
+    checkArgument(recordKeyOffsets.remaining() == (numVectors + 1) * Integer.BYTES,
+        "recordKeyOffsets length must be (numVectors + 1) * 4");
+  }
+
+  public int numVectors() {
+    return numVectors;
+  }
+
+  public int codeRowBytes() {
+    return codeRowBytes;
+  }
+
+  public int numExPlanes() {
+    return numExPlanes;
+  }
+
+  public boolean hasVectorNorm() {
+    return scalarFactorCount == PostingBlockBuilder.SCALAR_FACTOR_COUNT_WITH_VECTOR_NORM;
+  }
+
+  public int signPlaneOffset(int vectorIndex) {
+    checkVectorIndex(vectorIndex);
+    return vectorIndex * codeRowBytes;
+  }
+
+  public int exPlaneOffset(int vectorIndex, int exPlaneIndex) {
+    checkVectorIndex(vectorIndex);
+    checkArgument(exPlaneIndex >= 0 && exPlaneIndex < numExPlanes,
+        "exPlaneIndex out of bounds: " + exPlaneIndex);
+    return vectorIndex * numExPlanes * codeRowBytes + exPlaneIndex * codeRowBytes;
+  }
+
+  public ByteBuffer signPlaneRow(int vectorIndex) {
+    return slice(signPlane, signPlaneOffset(vectorIndex), codeRowBytes);
+  }
+
+  /**
+   * Returns a duplicate of the whole sign-plane section. Hot scan loops should
+   * use absolute {@code get(offset)} reads from this buffer instead of slicing
+   * per vector.
+   */
+  public ByteBuffer signPlaneBuffer() {
+    return signPlane.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  /**
+   * Returns a duplicate of the whole extended-plane section for survivor-only
+   * repacking.
+   */
+  public ByteBuffer exPlanesBuffer() {
+    return exPlanes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  public ByteBuffer exPlaneRow(int vectorIndex, int exPlaneIndex) {
+    return slice(exPlanes, exPlaneOffset(vectorIndex, exPlaneIndex), codeRowBytes);
+  }
+
+  public float scalarFactor(ScalarFactor factor, int vectorIndex) {
+    checkVectorIndex(vectorIndex);
+    checkScalarFactor(factor);
+    int offset = scalarFactorOffset(factor, vectorIndex);
+    return scalarFactors.getFloat(offset);
+  }
+
+  public float vectorNormOrNaN(int vectorIndex) {
+    return hasVectorNorm() ? scalarFactor(ScalarFactor.VECTOR_NORM, vectorIndex) : Float.NaN;
+  }
+
+  public int scalarFactorOffset(ScalarFactor factor, int vectorIndex) {
+    checkVectorIndex(vectorIndex);
+    checkScalarFactor(factor);
+    return factor.ordinal() * numVectors * Float.BYTES + vectorIndex * Float.BYTES;
+  }
+
+  public RowLocator rowLocator(int vectorIndex) {
+    checkVectorIndex(vectorIndex);
+    int offset = vectorIndex * PostingBlockBuilder.ROW_LOCATOR_BYTES;
+    int fileGroupIdx = Short.toUnsignedInt(rowLocators.getShort(offset));
+    int instantIdx = Short.toUnsignedInt(rowLocators.getShort(offset + Short.BYTES));
+    long rowPosition = Integer.toUnsignedLong(rowLocators.getInt(offset + 2 * Short.BYTES));
+    return new RowLocator(
+        fileGroupIdx,
+        instantIdx,
+        rowPosition,
+        block.getFileGroupDict().get(fileGroupIdx),
+        block.getInstantTimeDict().get(instantIdx),
+        partitionForFileGroup(fileGroupIdx));
+  }
+
+  public String recordKey(int vectorIndex) {
+    checkVectorIndex(vectorIndex);
+    int start = recordKeyOffsets.getInt(vectorIndex * Integer.BYTES);
+    int end = recordKeyOffsets.getInt((vectorIndex + 1) * Integer.BYTES);
+    checkArgument(start >= 0 && end >= start && end <= recordKeyBytes.remaining(),
+        "Invalid record key offset range");
+    ByteBuffer keySlice = slice(recordKeyBytes, start, end - start);
+    byte[] bytes = new byte[keySlice.remaining()];
+    keySlice.get(bytes);
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  public List<String> fileGroupDict() {
+    return block.getFileGroupDict();
+  }
+
+  public List<String> instantTimeDict() {
+    return block.getInstantTimeDict();
+  }
+
+  public List<String> partitionDict() {
+    return block.getPartitionDict();
+  }
+
+  private String partitionForFileGroup(int fileGroupIdx) {
+    return block.getPartitionDict().isEmpty() ? "" : block.getPartitionDict().get(fileGroupIdx);
+  }
+
+  private void checkVectorIndex(int vectorIndex) {
+    checkArgument(vectorIndex >= 0 && vectorIndex < numVectors, "vectorIndex out of bounds: " + vectorIndex);
+  }
+
+  private void checkScalarFactor(ScalarFactor factor) {
+    checkArgument(factor.ordinal() < scalarFactorCount,
+        "Scalar factor is absent from this block layout: " + factor);
+  }
+
+  private static ByteBuffer littleEndian(ByteBuffer buffer) {
+    ByteBuffer duplicate = buffer.duplicate();
+    duplicate.order(ByteOrder.LITTLE_ENDIAN);
+    return duplicate;
+  }
+
+  private static ByteBuffer slice(ByteBuffer buffer, int offset, int length) {
+    ByteBuffer duplicate = buffer.duplicate();
+    duplicate.position(offset);
+    duplicate.limit(offset + length);
+    ByteBuffer slice = duplicate.slice();
+    slice.order(ByteOrder.LITTLE_ENDIAN);
+    return slice;
+  }
+
+  public enum ScalarFactor {
+    F_ADD_1,
+    F_RESCALE_1,
+    ERR_1,
+    F_ADD_EX,
+    F_RESCALE_EX,
+    RESIDUAL_NORM,
+    VECTOR_NORM
+  }
+
+  public static final class RowLocator {
+    private final int fileGroupDictIndex;
+    private final int instantTimeDictIndex;
+    private final long rowPosition;
+    private final String fileGroupId;
+    private final String instantTime;
+    private final String partitionPath;
+
+    private RowLocator(int fileGroupDictIndex,
+                       int instantTimeDictIndex,
+                       long rowPosition,
+                       String fileGroupId,
+                       String instantTime,
+                       String partitionPath) {
+      this.fileGroupDictIndex = fileGroupDictIndex;
+      this.instantTimeDictIndex = instantTimeDictIndex;
+      this.rowPosition = rowPosition;
+      this.fileGroupId = fileGroupId;
+      this.instantTime = instantTime;
+      this.partitionPath = partitionPath;
+    }
+
+    public int getFileGroupDictIndex() {
+      return fileGroupDictIndex;
+    }
+
+    public int getInstantTimeDictIndex() {
+      return instantTimeDictIndex;
+    }
+
+    public long getRowPosition() {
+      return rowPosition;
+    }
+
+    public String getFileGroupId() {
+      return fileGroupId;
+    }
+
+    public String getInstantTime() {
+      return instantTime;
+    }
+
+    public String getPartitionPath() {
+      return partitionPath;
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorDistanceMetric.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorDistanceMetric.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import java.io.Serializable;
+
+/**
+ * Distance metrics for vector similarity search.
+ *
+ * <p>All metrics are returned as distances (smaller = more similar),
+ * so they can be compared uniformly with a min-heap.
+ */
+public enum VectorDistanceMetric implements Serializable {
+
+  /**
+   * Cosine distance: 1 - cosine_similarity.
+   * Range: [0, 2]. 0 = identical direction, 2 = opposite.
+   */
+  COSINE {
+    @Override
+    public float compute(float[] a, float[] b) {
+      checkDimensions(a, b);
+      double dot = 0;
+      double normA = 0;
+      double normB = 0;
+      for (int i = 0; i < a.length; i++) {
+        dot   += (double) a[i] * b[i];
+        normA += (double) a[i] * a[i];
+        normB += (double) b[i] * b[i];
+      }
+      double denom = Math.sqrt(normA) * Math.sqrt(normB);
+      return denom == 0.0 ? 1.0f : (float) (1.0 - dot / denom);
+    }
+  },
+
+  /**
+   * Euclidean (L2) distance.
+   * Range: [0, ∞). 0 = identical.
+   */
+  L2 {
+    @Override
+    public float compute(float[] a, float[] b) {
+      checkDimensions(a, b);
+      double sum = 0;
+      for (int i = 0; i < a.length; i++) {
+        double d = (double) a[i] - b[i];
+        sum += d * d;
+      }
+      return (float) Math.sqrt(sum);
+    }
+  },
+
+  /**
+   * Maximum inner product distance: negated dot product.
+   * Negated so smaller = higher similarity, consistent with the min-heap contract.
+   */
+  DOT_PRODUCT {
+    @Override
+    public float compute(float[] a, float[] b) {
+      checkDimensions(a, b);
+      double dot = 0;
+      for (int i = 0; i < a.length; i++) {
+        dot += (double) a[i] * b[i];
+      }
+      return (float) -dot;
+    }
+  };
+
+  /**
+   * Compute the distance between two float vectors.
+   *
+   * @param a first vector
+   * @param b second vector
+   * @return non-negative distance (smaller = more similar)
+   */
+  public abstract float compute(float[] a, float[] b);
+
+  /**
+   * Parse a metric name (case-insensitive).
+   *
+   * @param name e.g. "cosine", "l2", "dot_product"
+   * @return matching enum constant
+   */
+  public static VectorDistanceMetric fromString(String name) {
+    return valueOf(name.toUpperCase().replace(" ", "_").replace("-", "_"));
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  private static void checkDimensions(float[] a, float[] b) {
+    if (a.length != b.length) {
+      throw new IllegalArgumentException(
+          "Vector dimension mismatch: " + a.length + " vs " + b.length);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorIndexOptions.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorIndexOptions.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import java.util.Map;
+
+/**
+ * Option keys accepted in the OPTIONS clause of
+ * {@code CREATE INDEX … USING VECTOR}.
+ *
+ * <pre>{@code
+ * CREATE INDEX my_idx ON products USING VECTOR (embedding)
+ * OPTIONS (
+ *   'vector.dimension'              = '768',
+ *   'vector.metric'                 = 'cosine',
+ *   'vector.algorithm'              = 'ivfflat',
+ *   'vector.quantizer'              = 'IVF_RABITQ',
+ *   'vector.num_clusters'           = '4096',
+ *   'vector.num_probes'             = '40',
+ *   'vector.refine_factor'          = '10',
+ *   'vector.max_iter'               = '20',
+ *   'vector.rabitq.random_seed'     = '42',
+ *   'vector.rabitq.assume_normalized' = 'false'
+ * );
+ * }</pre>
+ */
+public final class VectorIndexOptions {
+
+  private VectorIndexOptions() {
+  }
+
+  // ---- core options -------------------------------------------------------
+
+  /** Number of dimensions in the embedding vector. Required. */
+  public static final String DIMENSION = "vector.dimension";
+
+  /**
+   * Distance metric: {@code cosine} | {@code l2} | {@code dot_product}. Default:
+   * cosine.
+   */
+  public static final String METRIC = "vector.metric";
+
+  /**
+   * Routing algorithm: {@code ivfflat} | {@code ivfpq_hnsw}. Default: ivfflat.
+   */
+  public static final String ALGORITHM = "vector.algorithm";
+
+  /**
+   * Fine-grained quantizer within clusters.
+   * {@code IVF_RABITQ} (default) uses binary code popcount scan.
+   * {@code IVF_PQ} uses product quantization.
+   */
+  public static final String QUANTIZER = "vector.quantizer";
+
+  /**
+   * Number of IVF clusters K. Default: min(sqrt(N), 16384). Set explicitly for
+   * large tables.
+   */
+  public static final String NUM_CLUSTERS = "vector.num_clusters";
+
+  /** Number of clusters probed at query time. Default: 8. */
+  public static final String NUM_PROBES = "vector.num_probes";
+
+  /**
+   * Re-rank factor: fetch refine_factor * K candidates from RaBitQ scan,
+   * then exact-distance re-rank to produce final top-K. Default: 10.
+   */
+  public static final String REFINE_FACTOR = "vector.refine_factor";
+
+  /** K-Means max iterations during index build. Default: 20. */
+  public static final String MAX_ITER = "vector.max_iter";
+
+  // ---- RaBitQ-specific options --------------------------------------------
+
+  /**
+   * Seed for the random orthogonal rotation matrix R.
+   * R is deterministic given (seed, dimension) — no retraining ever needed.
+   * Default: 42.
+   */
+  public static final String RABITQ_RANDOM_SEED = "vector.rabitq.random_seed";
+
+  /**
+   * Total RaBitQ bit width per dimension. {@code 1} is sign-only RaBitQ;
+   * {@code >1} enables packed lower-bit planes for higher-accuracy MDT scoring.
+   * Default: 2.
+   */
+  public static final String RABITQ_BITS = "vector.rabitq.bits";
+
+  /**
+   * When {@code true}, skips writing the scalar_factor (||v||) alongside binary
+   * codes.
+   * Only safe when all vectors are guaranteed to have unit norm.
+   * Default: false.
+   */
+  public static final String RABITQ_ASSUME_NORMALIZED = "vector.rabitq.assume_normalized";
+
+  /**
+   * When {@code true}, {@code CREATE INDEX ... USING VECTOR} will trigger a
+   * full-table rewrite
+   * after bootstrap completes so RaBitQ hidden columns are materialized
+   * immediately for existing rows.
+   * Default: false.
+   */
+  public static final String RABITQ_MATERIALIZE_ON_CREATE = "vector.rabitq.materialize.on.create";
+
+  /**
+   * Controls where RaBitQ codes are persisted.
+   * {@code hidden_columns} keeps the base-file hidden-column path.
+   * {@code mdt_lookup} stores codes only in MDT posting rows.
+   * {@code both} writes MDT posting rows in addition to the hidden-column path.
+   * Default: mdt_lookup for the fresh MDT-native multibit implementation.
+   */
+  public static final String RABITQ_STORAGE = "vector.rabitq.storage";
+
+  /**
+   * Target number of posting rows per MDT shard inside a single IVF cluster.
+   * The actual shard count per cluster is computed as
+   * {@code ceil(cluster_population / target_rows_per_shard)}, bounded by
+   * {@link #RABITQ_POSTING_MAX_SHARDS_PER_CLUSTER}.
+   */
+  public static final String RABITQ_POSTING_TARGET_ROWS_PER_SHARD = "vector.rabitq.posting.target_rows_per_shard";
+
+  /**
+   * Maximum number of MDT posting shards to create for a single IVF cluster.
+   */
+  public static final String RABITQ_POSTING_MAX_SHARDS_PER_CLUSTER = "vector.rabitq.posting.max_shards_per_cluster";
+
+  /**
+   * Target encoded posting-block payload size. The writer resolves this into a power-of-two
+   * vectors-per-block value and freezes that value in the generation manifest.
+   */
+  public static final String RABITQ_POSTING_TARGET_BLOCK_BYTES = "vector.rabitq.posting.target_block_bytes";
+
+  /**
+   * Number of IVF clusters packed into a single MDT vector-index file group.
+   *
+   * <p>The MDT vector partition is laid out so that posting rows are physically co-located by
+   * IVF cluster: a query that probes cluster {@code c} opens only the file group(s) holding
+   * {@code c}'s postings. The number of MDT file groups is derived as
+   * {@code ceil(num_clusters / clusters_per_file_group)} and posting rows are routed by
+   * {@code clusterId % fileGroupCount} (see
+   * {@code HoodieTableMetadataUtil.mapVectorPostingKeyToFileGroupIndex}).
+   *
+   * <ul>
+   *   <li>{@code 1} (default) — one IVF cluster per MDT file group: tightest probe pruning
+   *       and the most localized LIRE maintenance, at the cost of {@code num_clusters} file
+   *       groups.</li>
+   *   <li>{@code >1} — pack several clusters per file group to bound the total file count
+   *       for very large {@code num_clusters} (e.g. the 1B-vector case), trading a little
+   *       pruning precision for fewer/larger files.</li>
+   * </ul>
+   *
+   */
+  public static final String CLUSTERS_PER_FILE_GROUP = "vector.clusters_per_file_group";
+
+  // ---- search-time options ------------------------------------------------
+
+  /**
+   * Controls the exact-read behaviour of {@code hudi_vector_search}.
+   * <ul>
+   * <li>{@code exact} (default) — reads base-table rows and computes exact
+   * vector distances for the top-K candidates.</li>
+   * <li>{@code approximate} — skips the base-table read entirely and returns
+   * RaBitQ approximate distances. Much faster (no Parquet I/O) but
+   * distances are estimates and only record-key / partition-path columns
+   * are returned.</li>
+   * </ul>
+   */
+  public static final String SEARCH_MODE = "vector.search.mode";
+  public static final String DEFAULT_SEARCH_MODE = "exact";
+
+  /**
+   * Controls exact positional fetch behavior when a base Parquet file is missing page indexes.
+   * <ul>
+   * <li>{@code fallback} (default) — read the target row group and count
+   * {@code offsetIndexMissing}; availability is preferred over page-level pruning.</li>
+   * <li>{@code fail} — fail the query immediately. Useful for validation runs that require
+   * page-index honoring.</li>
+   * </ul>
+   */
+  public static final String EXACT_FETCH_OFFSET_INDEX_MISSING_POLICY = "vector.exact_fetch.offset_index_missing_policy";
+  public static final String DEFAULT_EXACT_FETCH_OFFSET_INDEX_MISSING_POLICY = "fallback";
+
+  /**
+   * When {@code true}, Hudi clustering on the <b>main data table</b> will sort
+   * records by their IVF K-Means cluster assignment (read from vector index
+   * posting records in the MDT). This co-locates vectors that belong to the
+   * same IVF cluster in the same data-table file groups, so the exact-read
+   * phase of {@code hudi_vector_search} opens far fewer files (probed clusters
+   * map to a handful of file groups instead of being scattered across all of
+   * them).
+   *
+   * <p>
+   * To use this, set this option on the vector index definition and then
+   * configure Hudi clustering on the main data table. The clustering
+   * execution strategy will look up each record's cluster ID from the MDT and
+   * use it as the sort key.
+   */
+  public static final String CLUSTERING_DATA_TABLE_BY_IVF = "vector.data_table.cluster_by_ivf";
+
+  /**
+   * When {@code true}, RaBitQ stores and scores IVF-cluster residuals ({@code x - centroid})
+   * instead of full vectors. This is often a better fit for non-normalized L2 data because
+   * approximate ranking happens inside a probed cluster, where residual directions/magnitudes can
+   * be much more faithful than full-vector directions dominated by global norms. Default: false.
+   */
+  public static final String RABITQ_RESIDUAL_ENCODING = "vector.rabitq.residual";
+
+  /**
+   * When {@code true}, RaBitQ approximate scoring uses the lower-variance <i>asymmetric</i>
+   * estimator (full-precision rotated query dotted against the ±1 data signs) instead of the
+   * default binary-symmetric Hamming estimator. Higher recall for the same posting scan, at the
+   * cost of ~D adds/posting instead of D/8 popcount bytes (compute, not the IO bottleneck).
+   * Independent of {@code vector.metric}: both estimators feed the same metric reconstruction.
+   * Default: false.
+   */
+  public static final String RABITQ_ASYMMETRIC_SCORING = "vector.rabitq.asymmetric";
+
+  /**
+   * Read-side policy for stale finalists — a posting whose locator no longer matches the record's
+   * current RLI location (rewritten by compaction/clustering/upsert on the base table):
+   * {@code fallback} (default) routes the candidate to a key-based fallback fetch at its live
+   * location; {@code fail} retains the hard throw. See RFC-104 "Upsert and Delete Support".
+   */
+  public static final String STALE_POLICY = "vector.read.stale.policy";
+  public static final String STALE_POLICY_FALLBACK = "fallback";
+  public static final String STALE_POLICY_FAIL = "fail";
+
+  /**
+   * Enables the RFC-104 RLI finalist arbiter (freshness gate) on the read path. When {@code true},
+   * finalists are classified against the record-level index so stale (rewritten/moved) and deleted
+   * postings are excluded (approx mode) or key-fallback-fetched (exact mode). Default {@code false}:
+   * dormant until the commit-time delta writer (upsert/delete work-stream item 2) lands, at which
+   * point it becomes load-bearing. Off = the pre-upsert positional-trust behaviour, with no extra
+   * RLI lookup per query. MUST NOT be enabled on a table without a record-level index.
+   */
+  public static final String READ_FINALIST_ARBITER = "vector.read.finalist_arbiter";
+  public static final boolean DEFAULT_READ_FINALIST_ARBITER = false;
+  // ---- defaults ----------------------------------------------------------
+
+  public static final String DEFAULT_METRIC = "cosine";
+  public static final String DEFAULT_ALGORITHM = "ivfflat";
+  public static final String DEFAULT_QUANTIZER = "IVF_RABITQ";
+  public static final int DEFAULT_NUM_CLUSTERS = 256;
+  public static final int DEFAULT_NUM_PROBES = 8;
+  public static final int DEFAULT_REFINE_FACTOR = 10;
+  public static final int DEFAULT_MAX_ITER = 20;
+  public static final long DEFAULT_RABITQ_SEED = 42L;
+  public static final int DEFAULT_RABITQ_BITS = 2;
+  public static final String DEFAULT_RABITQ_STORAGE = "mdt_lookup";
+  public static final int DEFAULT_RABITQ_POSTING_TARGET_ROWS_PER_SHARD = 4096;
+  public static final int    DEFAULT_RABITQ_POSTING_MAX_SHARDS_PER_CLUSTER = 64;
+  public static final int    DEFAULT_RABITQ_POSTING_TARGET_BLOCK_BYTES = 524288;
+  public static final int    DEFAULT_CLUSTERS_PER_FILE_GROUP = 1;
+
+  // ---- helpers -----------------------------------------------------------
+
+  public static int getDimension(Map<String, String> opts) {
+    String v = opts.get(DIMENSION);
+    if (v == null || v.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Vector index requires '" + DIMENSION + "' in OPTIONS");
+    }
+    return Integer.parseInt(v);
+  }
+
+  public static VectorDistanceMetric getMetric(Map<String, String> opts) {
+    return VectorDistanceMetric.fromString(opts.getOrDefault(METRIC, DEFAULT_METRIC));
+  }
+
+  public static VectorIndexType getAlgorithm(Map<String, String> opts) {
+    return VectorIndexType.fromString(opts.getOrDefault(ALGORITHM, DEFAULT_ALGORITHM));
+  }
+
+  public static String getQuantizer(Map<String, String> opts) {
+    return opts.getOrDefault(QUANTIZER, DEFAULT_QUANTIZER).toUpperCase();
+  }
+
+  public static int getNumClusters(Map<String, String> opts) {
+    return Integer.parseInt(
+        opts.getOrDefault(NUM_CLUSTERS, String.valueOf(DEFAULT_NUM_CLUSTERS)));
+  }
+
+  public static int getClustersPerFileGroup(Map<String, String> opts) {
+    return Math.max(1, Integer.parseInt(
+        opts.getOrDefault(
+            CLUSTERS_PER_FILE_GROUP,
+            String.valueOf(DEFAULT_CLUSTERS_PER_FILE_GROUP))));
+  }
+
+  public static int getNumProbes(Map<String, String> opts) {
+    return Integer.parseInt(
+        opts.getOrDefault(NUM_PROBES, String.valueOf(DEFAULT_NUM_PROBES)));
+  }
+
+  public static int getRefineFactor(Map<String, String> opts) {
+    return Integer.parseInt(
+        opts.getOrDefault(REFINE_FACTOR, String.valueOf(DEFAULT_REFINE_FACTOR)));
+  }
+
+  public static int getMaxIter(Map<String, String> opts) {
+    return Integer.parseInt(
+        opts.getOrDefault(MAX_ITER, String.valueOf(DEFAULT_MAX_ITER)));
+  }
+
+  public static long getRaBitQSeed(Map<String, String> opts) {
+    return Long.parseLong(
+        opts.getOrDefault(RABITQ_RANDOM_SEED, String.valueOf(DEFAULT_RABITQ_SEED)));
+  }
+
+  public static int getRaBitQBits(Map<String, String> opts) {
+    int bits = Integer.parseInt(
+        opts.getOrDefault(RABITQ_BITS, String.valueOf(DEFAULT_RABITQ_BITS)));
+    if (bits <= 0 || bits > 8) {
+      throw new IllegalArgumentException("RaBitQ bits must be in [1, 8], got: " + bits);
+    }
+    return bits;
+  }
+
+  public static boolean isRaBitQAssumeNormalized(Map<String, String> opts) {
+    return Boolean.parseBoolean(opts.getOrDefault(RABITQ_ASSUME_NORMALIZED, "false"));
+  }
+
+  public static boolean shouldMaterializeRaBitQColumnsOnCreate(Map<String, String> opts) {
+    return Boolean.parseBoolean(opts.getOrDefault(RABITQ_MATERIALIZE_ON_CREATE, "false"));
+  }
+
+  public static String getRaBitQStorage(Map<String, String> opts) {
+    return opts.getOrDefault(RABITQ_STORAGE, DEFAULT_RABITQ_STORAGE).toLowerCase();
+  }
+
+  public static boolean shouldStoreRaBitQCodesInMdt(Map<String, String> opts) {
+    String storage = getRaBitQStorage(opts);
+    return "mdt_lookup".equals(storage) || "both".equals(storage);
+  }
+
+  public static int getRaBitQPostingTargetRowsPerShard(Map<String, String> opts) {
+    return Integer.parseInt(
+        opts.getOrDefault(
+            RABITQ_POSTING_TARGET_ROWS_PER_SHARD,
+            String.valueOf(DEFAULT_RABITQ_POSTING_TARGET_ROWS_PER_SHARD)));
+  }
+
+  public static int getRaBitQPostingMaxShardsPerCluster(Map<String, String> opts) {
+    return Integer.parseInt(
+        opts.getOrDefault(
+            RABITQ_POSTING_MAX_SHARDS_PER_CLUSTER,
+            String.valueOf(DEFAULT_RABITQ_POSTING_MAX_SHARDS_PER_CLUSTER)));
+  }
+
+  public static int getRaBitQPostingTargetBlockBytes(Map<String, String> opts) {
+    return Integer.parseInt(
+        opts.getOrDefault(
+            RABITQ_POSTING_TARGET_BLOCK_BYTES,
+            String.valueOf(DEFAULT_RABITQ_POSTING_TARGET_BLOCK_BYTES)));
+  }
+
+  public static String getSearchMode(Map<String, String> opts) {
+    return opts.getOrDefault(SEARCH_MODE, DEFAULT_SEARCH_MODE).toLowerCase();
+  }
+
+  public static boolean shouldFailOnMissingExactFetchOffsetIndex(Map<String, String> opts) {
+    return "fail".equalsIgnoreCase(opts.getOrDefault(
+        EXACT_FETCH_OFFSET_INDEX_MISSING_POLICY,
+        DEFAULT_EXACT_FETCH_OFFSET_INDEX_MISSING_POLICY));
+  }
+
+  public static boolean isApproximateSearchMode(Map<String, String> opts) {
+    return "approximate".equals(getSearchMode(opts));
+  }
+
+  public static boolean isDataTableClusterByIvf(Map<String, String> opts) {
+    return Boolean.parseBoolean(opts.getOrDefault(CLUSTERING_DATA_TABLE_BY_IVF, "false"));
+  }
+
+  public static boolean isRaBitQResidualEncoding(Map<String, String> opts) {
+    return Boolean.parseBoolean(opts.getOrDefault(RABITQ_RESIDUAL_ENCODING, "false"));
+  }
+
+  public static boolean isRaBitQAsymmetricScoring(Map<String, String> opts) {
+    return Boolean.parseBoolean(opts.getOrDefault(RABITQ_ASYMMETRIC_SCORING, "false"));
+  }
+
+  /**
+   * @return {@code true} when the stale-finalist policy is {@code fail} (retain the hard throw);
+   *     {@code false} (default) routes stale finalists to key-based fallback via the RLI arbiter.
+   */
+  public static boolean isStalePolicyFail(Map<String, String> opts) {
+    return STALE_POLICY_FAIL.equalsIgnoreCase(opts.getOrDefault(STALE_POLICY, STALE_POLICY_FALLBACK));
+  }
+
+  /**
+   * @return {@code true} when the RLI finalist arbiter is enabled (default {@code false}). See
+   *     {@link #READ_FINALIST_ARBITER}.
+   */
+  public static boolean isFinalistArbiterEnabled(Map<String, String> opts) {
+    return Boolean.parseBoolean(
+        opts.getOrDefault(READ_FINALIST_ARBITER, String.valueOf(DEFAULT_READ_FINALIST_ARBITER)));
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorIndexType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorIndexType.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+/**
+ * Routing algorithms for Hudi vector indexes (RFC-vector-search §7).
+ *
+ * <p>The routing algorithm controls how the coarse quantizer maps query vectors
+ * to a candidate set of IVF clusters. The fine-grained quantizer (RaBitQ or PQ)
+ * is a separate configuration via {@link VectorIndexOptions#QUANTIZER}.
+ *
+ * <ul>
+ *   <li>{@link #IVFFLAT}    – Phase 1: linear O(K) centroid scan, exact or RaBitQ
+ *       compressed scan within selected clusters. No external deps.</li>
+ *   <li>{@link #IVFPQ_HNSW} – Phase 2: O(log K) HNSW graph for centroid routing
+ *       when K &gt; 10,000. Requires JVector dependency.</li>
+ * </ul>
+ */
+public enum VectorIndexType {
+
+  /**
+   * Inverted-file with linear centroid probe (Phase 1).
+   * Quantizer within clusters is controlled by {@link VectorIndexOptions#QUANTIZER}.
+   */
+  IVFFLAT,
+
+  /**
+   * IVF with HNSW graph over centroids for O(log K) routing (Phase 2).
+   * Quantizer within clusters is controlled by {@link VectorIndexOptions#QUANTIZER}.
+   */
+  IVFPQ_HNSW;
+
+  /**
+   * Parse algorithm name (case-insensitive, hyphens or underscores both accepted).
+   *
+   * @param name e.g. "ivfflat", "ivfpq_hnsw", "ivfpq-hnsw"
+   * @return matching constant
+   */
+  public static VectorIndexType fromString(String name) {
+    return valueOf(name.toUpperCase().replace("-", "_").replace(" ", "_"));
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -25,6 +25,13 @@ import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.avro.model.HoodieRecordIndexInfo;
 import org.apache.hudi.avro.model.HoodieSecondaryIndexInfo;
 import org.apache.hudi.common.avro.AvroSchemaCache;
+import org.apache.hudi.avro.model.HoodieVectorIndexCentroids;
+import org.apache.hudi.avro.model.HoodieVectorIndexClusterStats;
+import org.apache.hudi.avro.model.HoodieVectorIndexManifest;
+import org.apache.hudi.avro.model.HoodieVectorIndexPostingBlock;
+import org.apache.hudi.avro.model.HoodieVectorIndexPostingDelta;
+import org.apache.hudi.avro.model.HoodieVectorIndexQuantizer;
+import org.apache.hudi.avro.model.HoodieVectorIndexTombstone;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieAvroRecord;
@@ -121,6 +128,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   private static final int COLUMN_STATS_METADATA_FIELD_OFFSET = BLOOM_FILTER_METADATA_FIELD_OFFSET + 1;
   private static final int RECORD_INDEX_METADATA_FIELD_OFFSET = COLUMN_STATS_METADATA_FIELD_OFFSET + 1;
   private static final int SECONDARY_INDEX_METADATA_FIELD_OFFSET = RECORD_INDEX_METADATA_FIELD_OFFSET + 1;
+  private static final int VECTOR_INDEX_METADATA_FIELD_OFFSET = SECONDARY_INDEX_METADATA_FIELD_OFFSET + 1;
 
   /**
    * HoodieMetadata schema field ids
@@ -132,6 +140,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   public static final String SCHEMA_FIELD_ID_BLOOM_FILTER = "BloomFilterMetadata";
   public static final String SCHEMA_FIELD_ID_RECORD_INDEX = "recordIndexMetadata";
   public static final String SCHEMA_FIELD_ID_SECONDARY_INDEX = "SecondaryIndexMetadata";
+  public static final String SCHEMA_FIELD_ID_VECTOR_INDEX = "VectorIndexMetadata";
 
   /**
    * HoodieMetadata bloom filter payload field ids
@@ -141,6 +150,40 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   public static final String BLOOM_FILTER_FIELD_TIMESTAMP = "timestamp";
   public static final String BLOOM_FILTER_FIELD_BLOOM_FILTER = "bloomFilter";
   public static final String BLOOM_FILTER_FIELD_IS_DELETED = FIELD_IS_DELETED;
+
+  /**
+   * HoodieMetadata vector index payload field ids
+   */
+  public static final String VECTOR_INDEX_FIELD_ENTRY_TYPE = "entryType";
+  public static final String VECTOR_INDEX_FIELD_GENERATION_ID = "generationId";
+  public static final String VECTOR_INDEX_FIELD_RECORD_KEY = "recordKey";
+  public static final String VECTOR_INDEX_FIELD_SHARD_ID = "shardId";
+  public static final String VECTOR_INDEX_FIELD_SHARD_COUNT = "shardCount";
+  public static final String VECTOR_INDEX_FIELD_CLUSTER_ID = "clusterId";
+  public static final String VECTOR_INDEX_FIELD_CENTROID_BYTES = "centroidBytes";
+  public static final String VECTOR_INDEX_FIELD_FILE_GROUP_ID = "fileGroupId";
+  public static final String VECTOR_INDEX_FIELD_PARTITION_PATH = "partitionPath";
+  public static final String VECTOR_INDEX_FIELD_BASE_INSTANT_TIME = "baseInstantTime";
+  public static final String VECTOR_INDEX_FIELD_FILE_GROUP_IDS = "fileGroupIds";
+  public static final String VECTOR_INDEX_FIELD_VECTOR_COUNT = "vectorCount";
+  public static final String VECTOR_INDEX_FIELD_LAST_UPDATED_TS = "lastUpdatedTs";
+  public static final String VECTOR_INDEX_FIELD_QUANTIZER_TYPE = "quantizerType";
+  public static final String VECTOR_INDEX_FIELD_QUANTIZED_CODE_BYTES = "quantizedCodeBytes";
+  public static final String VECTOR_INDEX_FIELD_RABITQ_BITS = "rabitqBits";
+  public static final String VECTOR_INDEX_FIELD_RANDOM_SEED = "randomSeed";
+  public static final String VECTOR_INDEX_FIELD_ASSUME_NORMALIZED = "assumeNormalized";
+  public static final String VECTOR_INDEX_FIELD_BINARY_CODE = "binaryCode";
+  public static final String VECTOR_INDEX_FIELD_EXTENDED_CODE = "extendedCode";
+  public static final String VECTOR_INDEX_FIELD_SCALAR = "scalar";
+  public static final String VECTOR_INDEX_FIELD_ADDITIVE_FACTOR = "additiveFactor";
+  public static final String VECTOR_INDEX_FIELD_RESCALE_FACTOR = "rescaleFactor";
+  public static final String VECTOR_INDEX_FIELD_IS_DELETED = FIELD_IS_DELETED;
+
+  public static final String VECTOR_INDEX_ENTRY_TYPE_CENTROIDS = "CENTROIDS";
+  public static final String VECTOR_INDEX_ENTRY_TYPE_QUANTIZER = "QUANTIZER";
+  public static final String VECTOR_INDEX_ENTRY_TYPE_MANIFEST = "MANIFEST";
+  public static final String VECTOR_INDEX_ENTRY_TYPE_CLUSTER = "CLUSTER";
+  public static final String VECTOR_INDEX_ENTRY_TYPE_POSTING = "POSTING";
 
   /**
    * HoodieMetadata column stats payload field ids
@@ -210,6 +253,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   protected HoodieMetadataColumnStats columnStatMetadata = null;
   protected HoodieRecordIndexInfo recordIndexMetadata;
   protected HoodieSecondaryIndexInfo secondaryIndexMetadata;
+  protected Object vectorIndexMetadata;
   private boolean isDeletedRecord = false;
 
   public HoodieMetadataPayload(@Nullable GenericRecord record, Comparable<?> orderingVal) {
@@ -251,6 +295,444 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
 
   protected HoodieMetadataPayload(String key, HoodieSecondaryIndexInfo secondaryIndexMetadata) {
     this(key, MetadataPartitionType.SECONDARY_INDEX.getRecordType(), null, null, null, null, secondaryIndexMetadata, secondaryIndexMetadata.getIsDeleted());
+  }
+
+  protected HoodieMetadataPayload(String key, Object vectorIndexInfo) {
+    this.key = key;
+    this.type = MetadataPartitionType.VECTOR_INDEX.getRecordType();
+    this.vectorIndexMetadata = vectorIndexInfo;
+    this.isDeletedRecord = vectorIndexInfo instanceof HoodieVectorIndexTombstone;
+  }
+
+  /**
+   * Create the special centroid-dump record for the given index partition.
+   * Key is always {@link HoodieTableMetadataUtil#VECTOR_INDEX_CENTROIDS_KEY}.
+   */
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexCentroidsRecord(
+      ByteBuffer centroidBytes, String partitionPath) {
+    HoodieVectorIndexCentroids centroids = new HoodieVectorIndexCentroids(
+        0L,
+        ByteBuffer.allocate(0),
+        centroidBytes,
+        ByteBuffer.allocate(0));
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(VectorIndexMetadataKey.centroids(1, 0L, 0), centroids);
+    HoodieKey key = new HoodieKey(VectorIndexMetadataKey.centroids(1, 0L, 0), partitionPath);
+    return new HoodieAvroRecord<>(key, payload);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexCentroidsRecord(
+      int generation,
+      long centroidEpoch,
+      int chunk,
+      ByteBuffer clusterIds,
+      ByteBuffer centroidBytes,
+      ByteBuffer clusterRadii,
+      String partitionPath) {
+    String recordKey = VectorIndexMetadataKey.centroids(generation, centroidEpoch, chunk);
+    HoodieVectorIndexCentroids centroids = new HoodieVectorIndexCentroids(
+        centroidEpoch, clusterIds, centroidBytes, clusterRadii);
+    return new HoodieAvroRecord<>(
+        new HoodieKey(recordKey, partitionPath),
+        new HoodieMetadataPayload(recordKey, centroids));
+  }
+
+  /**
+   * Create the special quantizer-metadata record for the given index partition.
+   * Key is always {@link HoodieTableMetadataUtil#VECTOR_INDEX_QUANTIZER_KEY}.
+   */
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexQuantizerMetadataRecord(
+      String quantizerType,
+      int quantizedCodeBytes,
+      long randomSeed,
+      boolean assumeNormalized,
+      String partitionPath) {
+    return createVectorIndexQuantizerMetadataRecord(
+        quantizerType,
+        quantizedCodeBytes,
+        1,
+        randomSeed,
+        assumeNormalized,
+        partitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexQuantizerMetadataRecord(
+      String quantizerType,
+      int quantizedCodeBytes,
+      int rabitqBits,
+      long randomSeed,
+      boolean assumeNormalized,
+      String partitionPath) {
+    return createVectorIndexQuantizerMetadataRecord(1, 0, quantizerType, randomSeed, null, partitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexQuantizerMetadataRecord(
+      int generation,
+      int chunk,
+      String quantizerType,
+      long randomSeed,
+      ByteBuffer rotationBytes,
+      String partitionPath) {
+    String recordKey = VectorIndexMetadataKey.quantizer(generation, chunk);
+    HoodieVectorIndexQuantizer quantizer = new HoodieVectorIndexQuantizer(quantizerType, randomSeed, rotationBytes);
+    return new HoodieAvroRecord<>(
+        new HoodieKey(recordKey, partitionPath),
+        new HoodieMetadataPayload(recordKey, quantizer));
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexManifestRecord(
+      int generation,
+      String quantizerType,
+      int quantizedCodeBytes,
+      long randomSeed,
+      boolean assumeNormalized,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    return createVectorIndexManifestRecord(
+        generation,
+        quantizerType,
+        quantizedCodeBytes,
+        1,
+        randomSeed,
+        assumeNormalized,
+        lastUpdatedTs,
+        metadataPartitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexManifestRecord(
+      int generation,
+      String quantizerType,
+      int quantizedCodeBytes,
+      int rabitqBits,
+      long randomSeed,
+      boolean assumeNormalized,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    return createVectorIndexManifestRecord(
+        generation,
+        String.valueOf(generation),
+        "ACTIVE",
+        0,
+        0,
+        quantizedCodeBytes,
+        rabitqBits,
+        Math.max(0, rabitqBits - 1),
+        0,
+        0,
+        "COSINE",
+        assumeNormalized,
+        false,
+        "",
+        524288,
+        0,
+        0,
+        0,
+        0L,
+        lastUpdatedTs,
+        metadataPartitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexManifestRecord(
+      int generation,
+      String generationOrdinalText,
+      String state,
+      int dim,
+      int dimPadded,
+      int codeRowBytes,
+      int bitsTotal,
+      int numExPlanes,
+      int numClusters,
+      int shardCount,
+      String metric,
+      boolean assumeNormalized,
+      boolean residualEncoding,
+      String vectorColumn,
+      int targetBlockBytes,
+      int vectorsPerBlock,
+      int splitLimit,
+      int mergeFloor,
+      long centroidEpoch,
+      long createdTs,
+      String metadataPartitionPath) {
+    String recordKey = VectorIndexMetadataKey.manifest(generation);
+    HoodieVectorIndexManifest manifest = new HoodieVectorIndexManifest(
+        1,
+        generationOrdinalText,
+        state,
+        dim,
+        dimPadded,
+        codeRowBytes,
+        bitsTotal,
+        numExPlanes,
+        numClusters,
+        shardCount,
+        metric,
+        assumeNormalized,
+        residualEncoding,
+        vectorColumn == null ? "" : vectorColumn,
+        targetBlockBytes,
+        vectorsPerBlock,
+        splitLimit,
+        mergeFloor,
+        centroidEpoch,
+        createdTs);
+    return new HoodieAvroRecord<>(
+        new HoodieKey(recordKey, metadataPartitionPath),
+        new HoodieMetadataPayload(recordKey, manifest));
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexGenerationManifestRecord(
+      int generation,
+      String quantizerType,
+      int quantizedCodeBytes,
+      long randomSeed,
+      boolean assumeNormalized,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    return createVectorIndexGenerationManifestRecord(
+        generation,
+        quantizerType,
+        quantizedCodeBytes,
+        1,
+        randomSeed,
+        assumeNormalized,
+        lastUpdatedTs,
+        metadataPartitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexGenerationManifestRecord(
+      int generation,
+      String quantizerType,
+      int quantizedCodeBytes,
+      int rabitqBits,
+      long randomSeed,
+      boolean assumeNormalized,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    return createVectorIndexManifestRecord(
+        generation,
+        quantizerType,
+        quantizedCodeBytes,
+        rabitqBits,
+        randomSeed,
+        assumeNormalized,
+        lastUpdatedTs,
+        metadataPartitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexClusterManifestRecord(
+      int generation,
+      int clusterId,
+      int shardCount,
+      Collection<String> fileGroupIds,
+      long vectorCount,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    String recordKey = VectorIndexMetadataKey.clusterStats(generation, clusterId);
+    HoodieVectorIndexClusterStats stats = new HoodieVectorIndexClusterStats(
+        vectorCount,
+        0L,
+        0L,
+        0L,
+        null,
+        lastUpdatedTs);
+    return new HoodieAvroRecord<>(
+        new HoodieKey(recordKey, metadataPartitionPath),
+        new HoodieMetadataPayload(recordKey, stats));
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexClusterStatsRecord(
+      int generation,
+      int clusterId,
+      long liveCount,
+      long deltaCount,
+      long tombstoneCount,
+      String metadataPartitionPath) {
+    String recordKey = VectorIndexMetadataKey.clusterStats(generation, clusterId);
+    HoodieVectorIndexClusterStats stats = new HoodieVectorIndexClusterStats(
+        liveCount,
+        deltaCount,
+        tombstoneCount,
+        0L,
+        null,
+        0L);
+    return new HoodieAvroRecord<>(
+        new HoodieKey(recordKey, metadataPartitionPath),
+        new HoodieMetadataPayload(recordKey, stats));
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexPostingRecord(
+      int generation,
+      String recordKey,
+      int clusterId,
+      String fileGroupId,
+      String dataPartitionPath,
+      String baseInstantTime,
+      byte[] binaryCode,
+      Float scalar,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    return createVectorIndexPostingRecord(
+        generation,
+        recordKey,
+        clusterId,
+        0,
+        fileGroupId,
+        dataPartitionPath,
+        baseInstantTime,
+        binaryCode,
+        null,
+        scalar,
+        null,
+        null,
+        lastUpdatedTs,
+        metadataPartitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexPostingRecord(
+      int generation,
+      String recordKey,
+      int clusterId,
+      int shardId,
+      String fileGroupId,
+      String dataPartitionPath,
+      String baseInstantTime,
+      byte[] binaryCode,
+      Float scalar,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    return createVectorIndexPostingRecord(
+        generation,
+        recordKey,
+        clusterId,
+        shardId,
+        fileGroupId,
+        dataPartitionPath,
+        baseInstantTime,
+        binaryCode,
+        null,
+        scalar,
+        null,
+        null,
+        lastUpdatedTs,
+        metadataPartitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexPostingRecord(
+      int generation,
+      String recordKey,
+      int clusterId,
+      int shardId,
+      String fileGroupId,
+      String dataPartitionPath,
+      String baseInstantTime,
+      byte[] binaryCode,
+      byte[] extendedCode,
+      Float scalar,
+      Float additiveFactor,
+      Float rescaleFactor,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    return createVectorIndexPostingRecord(
+        generation,
+        recordKey,
+        clusterId,
+        shardId,
+        fileGroupId,
+        dataPartitionPath,
+        baseInstantTime,
+        binaryCode,
+        extendedCode,
+        scalar,
+        additiveFactor,
+        rescaleFactor,
+        0.0f,
+        0.0f,
+        0.0f,
+        lastUpdatedTs,
+        metadataPartitionPath);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexPostingRecord(
+      int generation,
+      String recordKey,
+      int clusterId,
+      int shardId,
+      String fileGroupId,
+      String dataPartitionPath,
+      String baseInstantTime,
+      byte[] binaryCode,
+      byte[] extendedCode,
+      Float scalar,
+      Float additiveFactor,
+      Float rescaleFactor,
+      Float additiveFactor1,
+      Float rescaleFactor1,
+      Float error1,
+      long lastUpdatedTs,
+      String metadataPartitionPath) {
+    String metadataRecordKey = VectorIndexMetadataKey.postingDelta(generation, clusterId, shardId, recordKey);
+    byte[] code = mergeCodeRows(binaryCode, extendedCode);
+    HoodieVectorIndexPostingDelta delta = new HoodieVectorIndexPostingDelta(
+        recordKey,
+        ByteBuffer.wrap(code),
+        additiveFactor1 == null ? 0.0f : additiveFactor1,
+        rescaleFactor1 == null ? 0.0f : rescaleFactor1,
+        error1 == null ? 0.0f : error1,
+        additiveFactor == null ? 0.0f : additiveFactor,
+        rescaleFactor == null ? 0.0f : rescaleFactor,
+        scalar == null ? 0.0f : scalar,
+        null,
+        fileGroupId == null ? "" : fileGroupId,
+        dataPartitionPath == null ? "" : dataPartitionPath,
+        baseInstantTime == null ? "" : baseInstantTime,
+        -1L);
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(metadataRecordKey, delta);
+    HoodieKey key = new HoodieKey(metadataRecordKey, metadataPartitionPath);
+    return new HoodieAvroRecord<>(key, payload);
+  }
+
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexPostingBlockRecord(
+      int generation,
+      int clusterId,
+      int shardId,
+      long blockId,
+      HoodieVectorIndexPostingBlock postingBlock,
+      String metadataPartitionPath) {
+    String metadataRecordKey = VectorIndexMetadataKey.postingBlock(generation, clusterId, shardId, blockId);
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(metadataRecordKey, postingBlock);
+    HoodieKey key = new HoodieKey(metadataRecordKey, metadataPartitionPath);
+    return new HoodieAvroRecord<>(key, payload);
+  }
+
+  /**
+   * Create a tombstone for a canonical vector posting record.
+   */
+  public static HoodieRecord<HoodieMetadataPayload> createVectorIndexPostingDeleteRecord(
+      int generation,
+      String recordKey,
+      int clusterId,
+      int shardId,
+      String metadataPartitionPath) {
+    String metadataRecordKey = VectorIndexMetadataKey.postingDelta(generation, clusterId, shardId, recordKey);
+    HoodieVectorIndexTombstone tombstone = new HoodieVectorIndexTombstone("", "MANUAL");
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(metadataRecordKey, tombstone);
+    HoodieKey key = new HoodieKey(metadataRecordKey, metadataPartitionPath);
+    return new HoodieAvroRecord<>(key, payload);
+  }
+
+  /**
+   * Return the vector index metadata if present.
+   */
+  public Option<Object> getVectorIndexMetadata() {
+    return Option.ofNullable(vectorIndexMetadata);
+  }
+
+  private static byte[] mergeCodeRows(byte[] binaryCode, byte[] extendedCode) {
+    byte[] first = binaryCode == null ? new byte[0] : binaryCode;
+    byte[] second = extendedCode == null ? new byte[0] : extendedCode;
+    byte[] merged = Arrays.copyOf(first, first.length + second.length);
+    System.arraycopy(second, 0, merged, first.length, second.length);
+    return merged;
   }
 
   protected HoodieMetadataPayload(String key, int type,
@@ -425,33 +907,46 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     }
 
     // TODO: feature(schema): Swap this over to HOODIE_METADATA_SCHEMA after HoodieRecordPayload implementations are using HoodieSchema
-    // Uses cached Avro schema reference for O(1) equality check.
-    if (schema == null || schema == HOODIE_METADATA_AVRO_SCHEMA) {
+    // Accept equivalent schema instances as well; callers can legitimately pass a parsed copy of
+    // HoodieMetadataRecord's schema, and treating it as a meta-fields schema would shift field
+    // writes by Hoodie meta column offsets and leave the required "key" field unset.
+    if (schema == null || schema == HOODIE_METADATA_AVRO_SCHEMA || schema.equals(HOODIE_METADATA_AVRO_SCHEMA)) {
       // If the schema is same or none is provided, we can return the record directly
       HoodieMetadataRecord record = new HoodieMetadataRecord(key, type, filesystemMetadata, bloomFilterMetadata,
-          columnStatMetadata, recordIndexMetadata, secondaryIndexMetadata);
+          columnStatMetadata, recordIndexMetadata, secondaryIndexMetadata, vectorIndexMetadata);
       return Option.of(record);
     } else {
-      // Otherwise, the assumption is that the schema required contains the metadata fields so we construct a new GenericRecord with these fields
+      // Otherwise, populate the requested schema by field-name. This covers both schemas with
+      // prepended Hudi meta fields as well as older/newer metadata-table schema variants.
       GenericData.Record record = new GenericData.Record(schema);
-      record.put(KEY_FIELD_OFFSET, key);
-      record.put(TYPE_FIELD_OFFSET, type);
+      putFieldIfPresent(record, schema, KEY_FIELD_NAME, key);
+      putFieldIfPresent(record, schema, SCHEMA_FIELD_NAME_TYPE, type);
       if (filesystemMetadata != null) {
-        record.put(FILESYSTEM_METADATA_FIELD_OFFSET, filesystemMetadata);
+        putFieldIfPresent(record, schema, SCHEMA_FIELD_NAME_METADATA, filesystemMetadata);
       }
       if (bloomFilterMetadata != null) {
-        record.put(BLOOM_FILTER_METADATA_FIELD_OFFSET, bloomFilterMetadata);
+        putFieldIfPresent(record, schema, SCHEMA_FIELD_ID_BLOOM_FILTER, bloomFilterMetadata);
       }
       if (columnStatMetadata != null) {
-        record.put(COLUMN_STATS_METADATA_FIELD_OFFSET, columnStatMetadata);
+        putFieldIfPresent(record, schema, SCHEMA_FIELD_ID_COLUMN_STATS, columnStatMetadata);
       }
       if (recordIndexMetadata != null) {
-        record.put(RECORD_INDEX_METADATA_FIELD_OFFSET, recordIndexMetadata);
+        putFieldIfPresent(record, schema, SCHEMA_FIELD_ID_RECORD_INDEX, recordIndexMetadata);
       }
       if (secondaryIndexMetadata != null) {
-        record.put(SECONDARY_INDEX_METADATA_FIELD_OFFSET, secondaryIndexMetadata);
+        putFieldIfPresent(record, schema, SCHEMA_FIELD_ID_SECONDARY_INDEX, secondaryIndexMetadata);
+      }
+      if (vectorIndexMetadata != null) {
+        putFieldIfPresent(record, schema, SCHEMA_FIELD_ID_VECTOR_INDEX, vectorIndexMetadata);
       }
       return Option.of(record);
+    }
+  }
+
+  private static void putFieldIfPresent(GenericData.Record record, Schema schema, String fieldName, Object value) {
+    Schema.Field field = schema.getField(fieldName);
+    if (field != null) {
+      record.put(field.pos(), value);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -208,10 +208,77 @@ public class HoodieTableMetadataUtil {
   // for block size (1MB), compression (GZ) and disabling the hudi metadata fields.
   public static final int RECORD_INDEX_AVERAGE_RECORD_SIZE = 48;
 
+  public static final String PARTITION_NAME_VECTOR_INDEX = "vector_index";
+  public static final String PARTITION_NAME_VECTOR_INDEX_PREFIX = "vector_index_";
+  /** Special record key inside a vector-index MDT partition that holds serialised centroids. */
+  public static final String VECTOR_INDEX_CENTROIDS_KEY = "__centroids__";
+  /** Special record key inside a vector-index MDT partition that holds quantizer metadata. */
+  public static final String VECTOR_INDEX_QUANTIZER_KEY = "__quantizer__";
+  /** Special record key inside a vector-index MDT partition that points to the active MDT posting generation. */
+  public static final String VECTOR_INDEX_MANIFEST_KEY = "__manifest__";
+  /** Fixed-width key family prefix for immutable generation manifest rows. */
+  public static final String VECTOR_INDEX_GENERATION_MANIFEST_KEY_PREFIX = "M|";
+  /** Fixed-width key family prefix for cluster metadata rows. */
+  public static final String VECTOR_INDEX_CLUSTER_KEY_PREFIX = "C|";
+  /** Fixed-width key family prefix for MDT-native posting rows. */
+  public static final String VECTOR_INDEX_POSTING_KEY_PREFIX = "P|";
   public static final Set<String> SUPPORTED_META_FIELDS_PARTITION_STATS = new HashSet<>(Arrays.asList(
       HoodieRecord.HoodieMetadataField.RECORD_KEY_METADATA_FIELD.getFieldName(),
       HoodieRecord.HoodieMetadataField.PARTITION_PATH_METADATA_FIELD.getFieldName(),
       HoodieRecord.HoodieMetadataField.COMMIT_TIME_METADATA_FIELD.getFieldName()));
+
+  public static String getVectorIndexGenerationManifestKey(int generationId) {
+    return VectorIndexMetadataKey.manifest(generationId);
+  }
+
+  public static boolean isVectorIndexGenerationManifestKey(String recordKey) {
+    return recordKey != null && recordKey.startsWith(VectorIndexMetadataKey.manifest(0).substring(0, 1));
+  }
+
+  public static String getVectorIndexClusterKey(int generationId, int clusterId) {
+    return VectorIndexMetadataKey.clusterStats(generationId, clusterId);
+  }
+
+  public static boolean isVectorIndexClusterKey(String recordKey) {
+    return recordKey != null && recordKey.startsWith(VECTOR_INDEX_CLUSTER_KEY_PREFIX);
+  }
+
+  public static String getVectorIndexPostingKey(int generationId, int clusterId, int shardId, String recordKey) {
+    return VectorIndexMetadataKey.postingDelta(generationId, clusterId, shardId, recordKey);
+  }
+
+  public static String getVectorIndexPostingPrefix(int generationId, int clusterId) {
+    return VectorIndexMetadataKey.postingPrefix(generationId, clusterId, 0).substring(0, 9);
+  }
+
+  public static int toVectorGenerationId(String generationId) {
+    try {
+      int parsed = Integer.parseInt(generationId);
+      if (parsed <= 0) {
+        throw new IllegalArgumentException(
+            "Vector generation id must be a positive ordinal, got: " + generationId);
+      }
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Vector generation id must be a positive integer ordinal, got: " + generationId, e);
+    }
+  }
+
+  public static String getVectorIndexPostingPrefix(int generationId, int clusterId, int shardId) {
+    return VectorIndexMetadataKey.postingPrefix(generationId, clusterId, shardId);
+  }
+
+  public static boolean isVectorIndexPostingKey(String recordKey) {
+    return recordKey != null && !recordKey.isEmpty()
+        && VectorIndexMetadataKey.decode(recordKey)[0] == (byte) VectorIndexMetadataKey.FAMILY_POSTING;
+  }
+
+  public static String getVectorIndexPostingRecordKey(String metadataRecordKey) {
+    return isVectorIndexPostingKey(metadataRecordKey)
+        ? VectorIndexMetadataKey.postingRecordKey(metadataRecordKey)
+        : null;
+  }
 
   // The maximum allowed precision and scale as per the payload schema. See DecimalWrapper in HoodieMetadata.avsc:
   // https://github.com/apache/hudi/blob/45dedd819e56e521148bde51a3dfa4e472ea70cd/hudi-common/src/main/avro/HoodieMetadata.avsc#L247
@@ -958,6 +1025,39 @@ public class HoodieTableMetadataUtil {
     }
 
     return Math.abs(Math.abs(h) % numFileGroups);
+  }
+
+  public static int mapVectorPostingKeyToFileGroupIndex(String recordKey, int numFileGroups) {
+    if (numFileGroups <= 1) {
+      return 0;
+    }
+    // Route by the IVF cluster id so that all postings of a cluster (every shard, every
+    // record key) land in the same MDT file group. With fileGroupCount == num_clusters this
+    // yields exactly one cluster per file group; with fewer file groups, clusters are spread
+    // round-robin (clusterId % numFileGroups) while a single cluster still stays whole.
+    int clusterId = extractVectorClusterId(recordKey);
+    if (clusterId < 0) {
+      // Not a cluster-bearing posting key (e.g. manifest/centroid rows): fall back to stable
+      // string hashing on the routing key prefix.
+      return mapRecordKeyToFileGroupIndex(getVectorIndexPostingRoutingKey(recordKey), numFileGroups);
+    }
+    return Math.floorMod(clusterId, numFileGroups);
+  }
+
+  /**
+   * Extract the IVF cluster id from a vector posting key/prefix of the form
+   * {@code P|<generation>|<cluster>|...}. Returns {@code -1} when {@code recordKey} is not a
+   * vector posting key or the cluster segment cannot be parsed.
+   */
+  public static int extractVectorClusterId(String recordKey) {
+    return isVectorIndexPostingKey(recordKey) ? VectorIndexMetadataKey.postingClusterId(recordKey) : -1;
+  }
+
+  public static String getVectorIndexPostingRoutingKey(String metadataRecordKey) {
+    if (!isVectorIndexPostingKey(metadataRecordKey)) {
+      return metadataRecordKey;
+    }
+    return metadataRecordKey.length() >= 9 ? metadataRecordKey.substring(0, 9) : metadataRecordKey;
   }
 
   /**
@@ -2487,6 +2587,10 @@ public class HoodieTableMetadataUtil {
         PARTITION_NAME_SECONDARY_INDEX_PREFIX,
         PARTITION_NAME_SECONDARY_INDEX
     );
+  }
+
+  public static Set<String> getVectorIndexPartitionsToInit(MetadataPartitionType partitionType, HoodieTableMetaClient dataMetaClient) {
+    return getIndexPartitionsToInitBasedOnIndexDefinition(partitionType, dataMetaClient);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -35,7 +35,6 @@ import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.core.index.expression.HoodieExpressionIndex;
 import org.apache.hudi.metadata.stats.ValueMetadata;
 
-import lombok.Getter;
 import org.apache.avro.generic.GenericRecord;
 
 import java.nio.ByteBuffer;
@@ -77,18 +76,19 @@ import static org.apache.hudi.metadata.HoodieMetadataPayload.SCHEMA_FIELD_ID_BLO
 import static org.apache.hudi.metadata.HoodieMetadataPayload.SCHEMA_FIELD_ID_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieMetadataPayload.SCHEMA_FIELD_ID_RECORD_INDEX;
 import static org.apache.hudi.metadata.HoodieMetadataPayload.SCHEMA_FIELD_ID_SECONDARY_INDEX;
+import static org.apache.hudi.metadata.HoodieMetadataPayload.SCHEMA_FIELD_ID_VECTOR_INDEX;
 import static org.apache.hudi.metadata.HoodieMetadataPayload.SCHEMA_FIELD_NAME_METADATA;
 import static org.apache.hudi.metadata.HoodieMetadataPayload.SECONDARY_INDEX_FIELD_IS_DELETED;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.combineFileSystemMetadata;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.mergeColumnStatsRecords;
 
 /**
  * Partition types for metadata table.
  */
-@Getter
 public enum MetadataPartitionType {
   FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-", 2) {
     @Override
@@ -244,6 +244,42 @@ public enum MetadataPartitionType {
       return HoodieTableMetadataUtil.getSecondaryKeyToFileGroupMappingFunction(indexVersion.greaterThanOrEquals(HoodieIndexVersion.V2));
     }
   },
+  VECTOR_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX_PREFIX, "vector-index-", 8) {
+    @Override
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
+      // Vector index is enabled explicitly via CREATE INDEX, not via metadata config flags.
+      return false;
+    }
+
+    @Override
+    public boolean isMetadataPartitionAvailable(HoodieTableMetaClient metaClient) {
+      if (metaClient.getIndexMetadata().isPresent()) {
+        return metaClient.getIndexMetadata().get().getIndexDefinitions().values().stream()
+            .anyMatch(indexDef -> indexDef.getIndexName().startsWith(PARTITION_NAME_VECTOR_INDEX_PREFIX));
+      }
+      return false;
+    }
+
+    @Override
+    public void constructMetadataPayload(HoodieMetadataPayload payload, GenericRecord record) {
+      GenericRecord vectorIndexRecord = getNestedFieldValue(record, SCHEMA_FIELD_ID_VECTOR_INDEX);
+      checkState(vectorIndexRecord != null,
+          "Valid VectorIndexMetadata record expected for type: " + MetadataPartitionType.VECTOR_INDEX.getRecordType());
+      payload.vectorIndexMetadata = vectorIndexRecord;
+    }
+
+    @Override
+    public String getPartitionPath(HoodieTableMetaClient metaClient, String indexName) {
+      return metaClient.getIndexForMetadataPartition(indexName)
+          .map(HoodieIndexDefinition::getIndexName)
+          .orElseThrow(() -> new IllegalArgumentException("Index definition is not present for index: " + indexName));
+    }
+
+    @Override
+    public SerializableBiFunction<String, Integer, Integer> getFileGroupMappingFunction(HoodieIndexVersion indexVersion) {
+      return HoodieTableMetadataUtil::mapVectorPostingKeyToFileGroupIndex;
+    }
+  },
   PARTITION_STATS(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, "partition-stats-", 6) {
     @Override
     public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
@@ -383,6 +419,24 @@ public enum MetadataPartitionType {
     this.partitionPath = partitionPath;
     this.fileIdPrefix = fileIdPrefix;
     this.recordType = recordType;
+  }
+
+  /**
+   * Base partition path (or prefix) for this metadata partition type.
+   * <p>
+   * Explicit accessors are required because Lombok does not emit a no-arg {@code getPartitionPath()}
+   * when a {@link #getPartitionPath(HoodieTableMetaClient, String)} overload exists.
+   */
+  public String getPartitionPath() {
+    return partitionPath;
+  }
+
+  public String getFileIdPrefix() {
+    return fileIdPrefix;
+  }
+
+  public int getRecordType() {
+    return recordType;
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/VectorClusterRawKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/VectorClusterRawKey.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import lombok.Value;
+
+/**
+ * Raw key for vector cluster metadata records.
+ */
+@Value
+public class VectorClusterRawKey implements RawKey {
+
+  int generationId;
+  int clusterId;
+
+  @Override
+  public String encode() {
+    return VectorIndexMetadataKey.clusterStats(generationId, clusterId);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/VectorGenerationManifestRawKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/VectorGenerationManifestRawKey.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import lombok.Value;
+
+/**
+ * Raw key for vector generation manifest records.
+ */
+@Value
+public class VectorGenerationManifestRawKey implements RawKey {
+
+  int generationId;
+
+  @Override
+  public String encode() {
+    return VectorIndexMetadataKey.manifest(generationId);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/VectorIndexMetadataKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/VectorIndexMetadataKey.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * Binary-sortable key contract for records in the vector-index metadata partition.
+ *
+ * <p>Hudi metadata record keys are strings today, so the fixed binary prefix is represented as
+ * ISO-8859-1 characters. That preserves the unsigned byte value of each component and keeps the
+ * HFile key bytes lexicographically sortable by family, generation, cluster, shard, and block.
+ */
+public final class VectorIndexMetadataKey {
+
+  public static final int FAMILY_MANIFEST = 0x01;
+  public static final int FAMILY_QUANTIZER = 0x02;
+  public static final int FAMILY_CENTROIDS = 0x03;
+  public static final int FAMILY_CLUSTER_STATS = 0x04;
+  public static final int FAMILY_POSTING = 0x10;
+
+  public static final long MAX_PACKED_BLOCK_ID = 0xFFFDFFFFL;
+  public static final long FIRST_RESERVED_BLOCK_ID = 0xFFFE0000L;
+  public static final long LAST_RESERVED_BLOCK_ID = 0xFFFEFFFFL;
+  public static final long DELTA_BLOCK_ID = 0xFFFFFFFFL;
+
+  private VectorIndexMetadataKey() {
+  }
+
+  public static String manifest(int generation) {
+    return encode(putUnsignedInt(ByteBuffer.allocate(5).put((byte) FAMILY_MANIFEST), Integer.toUnsignedLong(generation)));
+  }
+
+  public static String quantizer(int generation, int chunk) {
+    ByteBuffer buffer = ByteBuffer.allocate(7).order(ByteOrder.BIG_ENDIAN);
+    buffer.put((byte) FAMILY_QUANTIZER);
+    putUnsignedInt(buffer, Integer.toUnsignedLong(generation));
+    putUnsignedShort(buffer, chunk);
+    return encode(buffer);
+  }
+
+  public static String centroids(int generation, long centroidEpoch, int chunk) {
+    ByteBuffer buffer = ByteBuffer.allocate(15).order(ByteOrder.BIG_ENDIAN);
+    buffer.put((byte) FAMILY_CENTROIDS);
+    putUnsignedInt(buffer, Integer.toUnsignedLong(generation));
+    buffer.putLong(centroidEpoch);
+    putUnsignedShort(buffer, chunk);
+    return encode(buffer);
+  }
+
+  public static String clusterStats(int generation, int clusterId) {
+    ByteBuffer buffer = ByteBuffer.allocate(9).order(ByteOrder.BIG_ENDIAN);
+    buffer.put((byte) FAMILY_CLUSTER_STATS);
+    putUnsignedInt(buffer, Integer.toUnsignedLong(generation));
+    putUnsignedInt(buffer, Integer.toUnsignedLong(clusterId));
+    return encode(buffer);
+  }
+
+  public static String postingBlock(int generation, int clusterId, int shard, long blockId) {
+    checkUnsignedInt(blockId, "blockId");
+    ByteBuffer buffer = postingPrefixBuffer(generation, clusterId, shard, 4);
+    putUnsignedInt(buffer, blockId);
+    return encode(buffer);
+  }
+
+  public static String postingDelta(int generation, int clusterId, int shard, String recordKey) {
+    byte[] recordKeyBytes = recordKey.getBytes(StandardCharsets.UTF_8);
+    ByteBuffer buffer = postingPrefixBuffer(generation, clusterId, shard, 4 + recordKeyBytes.length);
+    putUnsignedInt(buffer, DELTA_BLOCK_ID);
+    buffer.put(recordKeyBytes);
+    return encode(buffer);
+  }
+
+  public static String postingPrefix(int generation, int clusterId, int shard) {
+    return encode(postingPrefixBuffer(generation, clusterId, shard, 0));
+  }
+
+  public static String exclusiveEnd(String prefix) {
+    byte[] bytes = decode(prefix);
+    for (int i = bytes.length - 1; i >= 0; i--) {
+      int value = Byte.toUnsignedInt(bytes[i]);
+      if (value != 0xFF) {
+        bytes[i] = (byte) (value + 1);
+        return encode(Arrays.copyOf(bytes, i + 1));
+      }
+    }
+    return null;
+  }
+
+  public static byte[] decode(String key) {
+    return key.getBytes(StandardCharsets.ISO_8859_1);
+  }
+
+  public static int postingClusterId(String key) {
+    byte[] bytes = decode(key);
+    if (bytes.length < 9 || Byte.toUnsignedInt(bytes[0]) != FAMILY_POSTING) {
+      return -1;
+    }
+    return readInt(bytes, 5);
+  }
+
+  public static int postingShard(String key) {
+    byte[] bytes = decode(key);
+    if (bytes.length < 11 || Byte.toUnsignedInt(bytes[0]) != FAMILY_POSTING) {
+      return -1;
+    }
+    return (Byte.toUnsignedInt(bytes[9]) << 8) | Byte.toUnsignedInt(bytes[10]);
+  }
+
+  public static String postingRecordKey(String key) {
+    byte[] bytes = decode(key);
+    if (bytes.length <= 15 || Byte.toUnsignedInt(bytes[0]) != FAMILY_POSTING
+        || Integer.toUnsignedLong(readInt(bytes, 11)) != DELTA_BLOCK_ID) {
+      return null;
+    }
+    return new String(bytes, 15, bytes.length - 15, StandardCharsets.UTF_8);
+  }
+
+  static int compareUnsigned(String left, String right) {
+    byte[] leftBytes = decode(left);
+    byte[] rightBytes = decode(right);
+    int length = Math.min(leftBytes.length, rightBytes.length);
+    for (int i = 0; i < length; i++) {
+      int comparison = Integer.compare(Byte.toUnsignedInt(leftBytes[i]), Byte.toUnsignedInt(rightBytes[i]));
+      if (comparison != 0) {
+        return comparison;
+      }
+    }
+    return Integer.compare(leftBytes.length, rightBytes.length);
+  }
+
+  private static int readInt(byte[] bytes, int offset) {
+    return (Byte.toUnsignedInt(bytes[offset]) << 24)
+        | (Byte.toUnsignedInt(bytes[offset + 1]) << 16)
+        | (Byte.toUnsignedInt(bytes[offset + 2]) << 8)
+        | Byte.toUnsignedInt(bytes[offset + 3]);
+  }
+
+  private static ByteBuffer postingPrefixBuffer(int generation, int clusterId, int shard, int suffixBytes) {
+    ByteBuffer buffer = ByteBuffer.allocate(11 + suffixBytes).order(ByteOrder.BIG_ENDIAN);
+    buffer.put((byte) FAMILY_POSTING);
+    putUnsignedInt(buffer, Integer.toUnsignedLong(generation));
+    putUnsignedInt(buffer, Integer.toUnsignedLong(clusterId));
+    putUnsignedShort(buffer, shard);
+    return buffer;
+  }
+
+  private static ByteBuffer putUnsignedInt(ByteBuffer buffer, long value) {
+    checkUnsignedInt(value, "value");
+    buffer.putInt((int) value);
+    return buffer;
+  }
+
+  private static void putUnsignedShort(ByteBuffer buffer, int value) {
+    if (value < 0 || value > 0xFFFF) {
+      throw new IllegalArgumentException("value must fit in unsigned short: " + value);
+    }
+    buffer.putShort((short) value);
+  }
+
+  private static void checkUnsignedInt(long value, String name) {
+    if (value < 0 || value > 0xFFFFFFFFL) {
+      throw new IllegalArgumentException(name + " must fit in unsigned int: " + value);
+    }
+  }
+
+  private static String encode(ByteBuffer buffer) {
+    return new String(buffer.array(), StandardCharsets.ISO_8859_1);
+  }
+
+  private static String encode(byte[] bytes) {
+    return new String(bytes, StandardCharsets.ISO_8859_1);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/VectorPostingPrefixRawKey.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/VectorPostingPrefixRawKey.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import lombok.Value;
+
+/**
+ * Raw key prefix for vector posting scans.
+ */
+@Value
+public class VectorPostingPrefixRawKey implements RawKey {
+
+  int generationId;
+  int clusterId;
+  Integer shardId;
+
+  @Override
+  public String encode() {
+    return shardId == null
+        ? VectorIndexMetadataKey.postingPrefix(generationId, clusterId, 0).substring(0, 9)
+        : VectorIndexMetadataKey.postingPrefix(generationId, clusterId, shardId);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/avro/TestAvroRecordSizeEstimator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/avro/TestAvroRecordSizeEstimator.java
@@ -49,7 +49,7 @@ public class TestAvroRecordSizeEstimator {
     Assertions.assertTrue(size < 400 && size > 0);
 
     // testing generated IndexedRecord
-    HoodieMetadataRecord metadataRecord = new HoodieMetadataRecord("__all_partitions__", 1, new HashMap<>(), null, null, null, null);
+    HoodieMetadataRecord metadataRecord = new HoodieMetadataRecord("__all_partitions__", 1, new HashMap<>(), null, null, null, null, null);
     bufferedRecord = new BufferedRecord<>("__all_partitions__", 0, metadataRecord, 1, null);
     size = estimator.sizeEstimate(bufferedRecord);
     // size can be various for different OS / JVM version

--- a/hudi-common/src/test/java/org/apache/hudi/common/index/vector/TestVectorDistanceMetric.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/index/vector/TestVectorDistanceMetric.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link VectorDistanceMetric}.
+ */
+class TestVectorDistanceMetric {
+
+  @Test
+  void cosineIdenticalVectors() {
+    float[] v = {1f, 2f, 3f};
+    assertEquals(0f, VectorDistanceMetric.COSINE.compute(v, v), 1e-6f);
+  }
+
+  @Test
+  void cosineOrthogonal() {
+    float[] a = {1f, 0f};
+    float[] b = {0f, 1f};
+    assertEquals(1f, VectorDistanceMetric.COSINE.compute(a, b), 1e-6f);
+  }
+
+  @Test
+  void cosineOpposite() {
+    float[] a = {1f, 0f};
+    float[] b = {-1f, 0f};
+    assertEquals(2f, VectorDistanceMetric.COSINE.compute(a, b), 1e-6f);
+  }
+
+  @Test
+  void l2ZeroDistance() {
+    float[] v = {3f, 4f};
+    assertEquals(0f, VectorDistanceMetric.L2.compute(v, v), 1e-6f);
+  }
+
+  @Test
+  void l2KnownDistance() {
+    float[] a = {0f, 0f};
+    float[] b = {3f, 4f};
+    assertEquals(5f, VectorDistanceMetric.L2.compute(a, b), 1e-6f);
+  }
+
+  @Test
+  void dotProductSameDirection() {
+    float[] a = {1f, 0f};
+    float[] b = {2f, 0f};
+    // dot = 2, negated distance = -2
+    assertEquals(-2f, VectorDistanceMetric.DOT_PRODUCT.compute(a, b), 1e-6f);
+  }
+
+  @Test
+  void dotProductOrthogonal() {
+    float[] a = {1f, 0f};
+    float[] b = {0f, 1f};
+    assertEquals(0f, VectorDistanceMetric.DOT_PRODUCT.compute(a, b), 1e-6f);
+  }
+
+  @Test
+  void dimensionMismatchThrows() {
+    float[] a = {1f, 2f};
+    float[] b = {1f};
+    assertThrows(IllegalArgumentException.class,
+        () -> VectorDistanceMetric.L2.compute(a, b));
+  }
+
+  @Test
+  void fromStringCaseInsensitive() {
+    assertEquals(VectorDistanceMetric.COSINE, VectorDistanceMetric.fromString("cosine"));
+    assertEquals(VectorDistanceMetric.L2, VectorDistanceMetric.fromString("L2"));
+    assertEquals(VectorDistanceMetric.DOT_PRODUCT, VectorDistanceMetric.fromString("dot_product"));
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestBufferedRecordSerializer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/serialization/TestBufferedRecordSerializer.java
@@ -54,7 +54,7 @@ public class TestBufferedRecordSerializer {
     Assertions.assertEquals(record, result);
 
     avroRecordSerializer = new AvroRecordSerializer(integer -> HoodieMetadataRecord.SCHEMA$);
-    HoodieMetadataRecord metadataRecord = new HoodieMetadataRecord("__all_partitions__", 1, new HashMap<>(), null, null, null, null);
+    HoodieMetadataRecord metadataRecord = new HoodieMetadataRecord("__all_partitions__", 1, new HashMap<>(), null, null, null, null, null);
     avroBytes = avroRecordSerializer.serialize(metadataRecord);
     result = avroRecordSerializer.deserialize(avroBytes, 1);
     for (int i = 0; i < metadataRecord.getSchema().getFields().size(); i++) {
@@ -80,7 +80,7 @@ public class TestBufferedRecordSerializer {
 
     avroRecordSerializer = new AvroRecordSerializer(integer -> HoodieMetadataRecord.SCHEMA$);
     bufferedRecordSerializer = new BufferedRecordSerializer<>(avroRecordSerializer);
-    HoodieMetadataRecord metadataRecord = new HoodieMetadataRecord("__all_partitions__", 1, new HashMap<>(), null, null, null, null);
+    HoodieMetadataRecord metadataRecord = new HoodieMetadataRecord("__all_partitions__", 1, new HashMap<>(), null, null, null, null, null);
     bufferedRecord = new BufferedRecord<>("__all_partitions__", 0, metadataRecord, 1, null);
     bytes = bufferedRecordSerializer.serialize(bufferedRecord);
     result = bufferedRecordSerializer.deserialize(bytes);

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestVectorIndexMetadataKey.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestVectorIndexMetadataKey.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestVectorIndexMetadataKey {
+
+  @Test
+  void testBlockReservedAndDeltaRangesSortInSinglePrefixScan() {
+    assertOrdered(
+        VectorIndexMetadataKey.postingBlock(1, 7, 0, 0x00000000L),
+        VectorIndexMetadataKey.postingBlock(1, 7, 0, 0x00000001L),
+        VectorIndexMetadataKey.postingBlock(1, 7, 0, VectorIndexMetadataKey.MAX_PACKED_BLOCK_ID),
+        VectorIndexMetadataKey.postingBlock(1, 7, 0, VectorIndexMetadataKey.FIRST_RESERVED_BLOCK_ID),
+        VectorIndexMetadataKey.postingBlock(1, 7, 0, VectorIndexMetadataKey.LAST_RESERVED_BLOCK_ID),
+        VectorIndexMetadataKey.postingDelta(1, 7, 0, "any"));
+  }
+
+  @Test
+  void testUnsignedComponentBoundaries() {
+    assertOrdered(
+        VectorIndexMetadataKey.postingBlock(1, 0x7FFFFFFF, 0, 0),
+        VectorIndexMetadataKey.postingBlock(1, 0x80000000, 0, 0),
+        VectorIndexMetadataKey.postingBlock(1, 0xFFFFFFFF, 0, 0));
+    assertOrdered(
+        VectorIndexMetadataKey.postingBlock(1, 7, 0x7FFF, 0),
+        VectorIndexMetadataKey.postingBlock(1, 7, 0x8000, 0));
+    assertOrdered(
+        VectorIndexMetadataKey.postingBlock(1, 7, 0, 0x7FFFFFFFL),
+        VectorIndexMetadataKey.postingBlock(1, 7, 0, 0x80000000L));
+  }
+
+  @Test
+  void testBigEndianCarryBoundaries() {
+    assertOrdered(
+        VectorIndexMetadataKey.postingBlock(1, 0x000000FF, 0xFFFF, VectorIndexMetadataKey.DELTA_BLOCK_ID),
+        VectorIndexMetadataKey.postingBlock(1, 0x00000100, 0x0000, 0));
+    assertOrdered(
+        VectorIndexMetadataKey.postingBlock(1, 7, 0x00FF, VectorIndexMetadataKey.DELTA_BLOCK_ID),
+        VectorIndexMetadataKey.postingBlock(1, 7, 0x0100, 0));
+  }
+
+  @Test
+  void testDeltaKeyTailUtf8OrderingAndDecode() {
+    String a = VectorIndexMetadataKey.postingDelta(1, 7, 0, "a");
+    String aa = VectorIndexMetadataKey.postingDelta(1, 7, 0, "aa");
+    String b = VectorIndexMetadataKey.postingDelta(1, 7, 0, "b");
+    String eAcute = VectorIndexMetadataKey.postingDelta(1, 7, 0, "é");
+
+    assertOrdered(a, aa, b, eAcute);
+    assertEquals("é", VectorIndexMetadataKey.postingRecordKey(eAcute));
+    assertEquals(7, VectorIndexMetadataKey.postingClusterId(eAcute));
+    assertEquals(0, VectorIndexMetadataKey.postingShard(eAcute));
+  }
+
+  @Test
+  void testFamilyMajorOrdering() {
+    assertOrdered(
+        VectorIndexMetadataKey.manifest(1),
+        VectorIndexMetadataKey.manifest(2),
+        VectorIndexMetadataKey.quantizer(1, 0),
+        VectorIndexMetadataKey.centroids(1, 10L, 0),
+        VectorIndexMetadataKey.clusterStats(1, 7),
+        VectorIndexMetadataKey.postingBlock(1, 7, 0, 0));
+  }
+
+  @Test
+  void testPrefixScanExclusiveEnd() {
+    String prefix = VectorIndexMetadataKey.postingPrefix(1, 7, 0);
+    String end = VectorIndexMetadataKey.exclusiveEnd(prefix);
+
+    assertTrue(VectorIndexMetadataKey.compareUnsigned(prefix, end) < 0);
+    assertTrue(VectorIndexMetadataKey.compareUnsigned(
+        VectorIndexMetadataKey.postingDelta(1, 7, 0, "z"), end) < 0);
+    assertTrue(VectorIndexMetadataKey.compareUnsigned(
+        VectorIndexMetadataKey.postingBlock(1, 7, 1, 0), end) >= 0);
+    assertNull(VectorIndexMetadataKey.exclusiveEnd(new String(new byte[] {(byte) 0xFF}, StandardCharsets.ISO_8859_1)));
+  }
+
+  private static void assertOrdered(String... keys) {
+    for (int i = 1; i < keys.length; i++) {
+      assertTrue(VectorIndexMetadataKey.compareUnsigned(keys[i - 1], keys[i]) < 0,
+          "key " + (i - 1) + " should sort before key " + i);
+    }
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestVectorIndexMetadataPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestVectorIndexMetadataPayload.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata;
+
+import org.apache.hudi.avro.model.HoodieVectorIndexPostingDelta;
+import org.apache.hudi.avro.model.HoodieVectorIndexQuantizer;
+import org.apache.hudi.common.model.HoodieRecord;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestVectorIndexMetadataPayload {
+
+  @Test
+  void testPostingRecordCarriesCanonicalLookupMetadata() {
+    HoodieRecord<HoodieMetadataPayload> record = HoodieMetadataPayload.createVectorIndexPostingRecord(
+        7,
+        "rk-1",
+        3,
+        1,
+        "file-group-1",
+        "dt=2026-04-01",
+        "20260603120000",
+        new byte[] {0x01, 0x02},
+        1.5f,
+        123456789L,
+        "vector_index_demo");
+
+    assertTrue(record.getData().getVectorIndexMetadata().isPresent());
+    HoodieVectorIndexPostingDelta delta =
+        (HoodieVectorIndexPostingDelta) record.getData().getVectorIndexMetadata().get();
+    assertEquals("rk-1", delta.getRecordKey());
+    assertEquals(3, VectorIndexMetadataKey.postingClusterId(record.getRecordKey()));
+    assertEquals(1, VectorIndexMetadataKey.postingShard(record.getRecordKey()));
+    assertEquals("file-group-1", delta.getFileGroupId());
+    assertEquals("dt=2026-04-01", delta.getPartitionPath());
+    assertEquals("20260603120000", delta.getBaseInstantTime());
+  }
+
+  @Test
+  void testQuantizerMetadataRecordCarriesRaBitQConfig() {
+    HoodieRecord<HoodieMetadataPayload> record = HoodieMetadataPayload.createVectorIndexQuantizerMetadataRecord(
+        "IVF_RABITQ",
+        96,
+        42L,
+        true,
+        "vector_index_demo");
+
+    assertTrue(record.getData().getVectorIndexMetadata().isPresent());
+    HoodieVectorIndexQuantizer quantizer =
+        (HoodieVectorIndexQuantizer) record.getData().getVectorIndexMetadata().get();
+    assertEquals("IVF_RABITQ", quantizer.getQuantizerType());
+    assertEquals(42L, quantizer.getRandomSeed());
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Adds the Metadata Table (MDT) storage foundation for native vector search proposed in RFC-104 (umbrella #19094): the Avro record types, payload wiring, partition type, and posting-block codec that later PRs (encoder, bootstrap, read path) build on.

Closes #19097

### Summary and Changelog

Users gain no behavior change yet; this establishes the on-disk/serde contract for the vector index so subsequent PRs can encode, write, and read it.

Changes (all in `hudi-common`, additive):
- `HoodieMetadata.avsc`: seven vector index record types — centroids, quantizer, manifest, cluster stats, posting block, posting delta, tombstone.
- `HoodieMetadataPayload`: new `VectorIndexMetadata` field, entry-type constants, and serde for the vector records (co-exists with existing record-index logic).
- `MetadataPartitionType.VECTOR_INDEX`: new partition type plus record-type wiring.
- `HoodieTableMetadataUtil`: posting-key → file-group mapping.
- Posting block codec: `PostingBlockBuilder` / `PostingBlockView` (structure-of-arrays packing of ~1–4K vectors per record).
- Vector index enums: `VectorIndexOptions`, `VectorIndexType`, `VectorDistanceMetric`.
- MDT raw keys: `VectorIndexMetadataKey`, `VectorPostingPrefixRawKey`, `VectorClusterRawKey`, `VectorGenerationManifestRawKey`.
- Tests: `TestVectorDistanceMetric`, `TestVectorIndexMetadataKey`, `TestVectorIndexMetadataPayload` (17 cases). Existing `HoodieMetadataRecord` all-args callers (`TestAvroRecordSizeEstimator`, `TestBufferedRecordSerializer`) updated for the appended field.

### Impact

Adds one nullable field (`VectorIndexMetadata`) to the `HoodieMetadataRecord` Avro schema and a new `MetadataPartitionType`. The field is optional/defaulted, so existing MDT records and readers are unaffected; the new partition type is inert until a vector index is created (later PRs). No public API removed. No performance impact on existing partitions.

### Risk Level

low

Schema change is purely additive (new nullable field + new record types + new partition type), exercised by unit tests; existing metadata read/write paths are untouched apart from the appended constructor arg, which is covered by the updated tests. Full `hudi-common` compiles and tests pass on current master under JDK17.

### Documentation Update

none (user-facing docs land with the feature-complete read/write PRs). The design is documented in RFC-104 (#19291).

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
