### PR TITLE
feat(index): add vector index option validation

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorDistanceMetric.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorDistanceMetric.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import java.util.Locale;
+
+/**
+ * Distance metrics for vector similarity search.
+ *
+ * <p>All metrics are returned as distances (smaller = more similar),
+ * so they can be compared uniformly with a min-heap.
+ */
+public enum VectorDistanceMetric {
+
+  /**
+   * Cosine distance: 1 - cosine_similarity.
+   * Range: [0, 2]. 0 = identical direction, 2 = opposite.
+   */
+  COSINE {
+    @Override
+    public float compute(float[] a, float[] b) {
+      checkDimensions(a, b);
+      double dot = 0;
+      double normA = 0;
+      double normB = 0;
+      for (int i = 0; i < a.length; i++) {
+        dot   += (double) a[i] * b[i];
+        normA += (double) a[i] * a[i];
+        normB += (double) b[i] * b[i];
+      }
+      double denom = Math.sqrt(normA) * Math.sqrt(normB);
+      return denom == 0.0 ? 1.0f : (float) (1.0 - dot / denom);
+    }
+  },
+
+  /**
+   * Euclidean (L2) distance.
+   * Range: [0, ∞). 0 = identical.
+   */
+  L2 {
+    @Override
+    public float compute(float[] a, float[] b) {
+      checkDimensions(a, b);
+      double sum = 0;
+      for (int i = 0; i < a.length; i++) {
+        double d = (double) a[i] - b[i];
+        sum += d * d;
+      }
+      return (float) Math.sqrt(sum);
+    }
+  },
+
+  /**
+   * Maximum inner product distance: negated dot product.
+   * Negated so smaller = higher similarity, consistent with the min-heap contract.
+   */
+  DOT_PRODUCT {
+    @Override
+    public float compute(float[] a, float[] b) {
+      checkDimensions(a, b);
+      double dot = 0;
+      for (int i = 0; i < a.length; i++) {
+        dot += (double) a[i] * b[i];
+      }
+      return (float) -dot;
+    }
+  };
+
+  /**
+   * Compute the distance between two float vectors.
+   *
+   * @param a first vector
+   * @param b second vector
+   * @return non-negative distance (smaller = more similar)
+   */
+  public abstract float compute(float[] a, float[] b);
+
+  /**
+   * Parse a metric name (case-insensitive).
+   *
+   * @param name e.g. "cosine", "l2", "dot_product"
+   * @return matching enum constant
+   */
+  static VectorDistanceMetric fromString(String name) {
+    return valueOf(name.toUpperCase(Locale.ROOT).replace(" ", "_").replace("-", "_"));
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  private static void checkDimensions(float[] a, float[] b) {
+    if (a.length != b.length) {
+      throw new IllegalArgumentException(
+          "Vector dimension mismatch: " + a.length + " vs " + b.length);
+    }
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorIndexOptions.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorIndexOptions.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Options accepted by {@code CREATE INDEX ... USING VECTOR}.
+ *
+ * <p>The indexed column's Hudi {@code VECTOR(D[, elementType])} schema is authoritative for
+ * dimension and element type. Index options configure only the acceleration structure. DDL
+ * implementations must call {@link #validateAndNormalize(Map)} before persisting an index
+ * definition; individual parsing helpers are intentionally private so aggregate validation cannot
+ * be bypassed.
+ */
+public final class VectorIndexOptions {
+
+  public static final String METRIC = "vector.metric";
+  public static final String QUANTIZER = "vector.quantizer";
+  public static final String NUM_CLUSTERS = "vector.num_clusters";
+  public static final String MAX_ITER = "vector.max_iter";
+  public static final String RABITQ_BITS = "vector.rabitq.bits";
+  public static final String RABITQ_SEED = "vector.rabitq.seed";
+  public static final String RABITQ_ASSUME_NORMALIZED = "vector.rabitq.assume_normalized";
+  public static final String QUERY_NUM_PROBES = "vector.query.nprobes";
+  public static final String QUERY_REFINE_FACTOR = "vector.query.refine_factor";
+  public static final String QUERY_MODE = "vector.query.mode";
+  public static final String QUERY_STALE_POLICY = "vector.query.stale_policy";
+
+  public static final VectorDistanceMetric DEFAULT_METRIC = VectorDistanceMetric.COSINE;
+  public static final VectorQuantizer DEFAULT_QUANTIZER = VectorQuantizer.IVF_RABITQ;
+  public static final int DEFAULT_NUM_CLUSTERS = 256;
+  public static final int DEFAULT_MAX_ITER = 20;
+  public static final int DEFAULT_RABITQ_BITS = 4;
+  public static final long DEFAULT_RABITQ_SEED = 42L;
+  public static final int DEFAULT_NUM_PROBES = 32;
+  public static final int DEFAULT_REFINE_FACTOR = 50;
+  public static final VectorQueryMode DEFAULT_QUERY_MODE = VectorQueryMode.EXACT_RERANK;
+  public static final VectorStalePolicy DEFAULT_STALE_POLICY = VectorStalePolicy.FAIL;
+
+  private static final Set<String> SUPPORTED_OPTIONS = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          METRIC,
+          QUANTIZER,
+          NUM_CLUSTERS,
+          MAX_ITER,
+          RABITQ_BITS,
+          RABITQ_SEED,
+          RABITQ_ASSUME_NORMALIZED,
+          QUERY_NUM_PROBES,
+          QUERY_REFINE_FACTOR,
+          QUERY_MODE,
+          QUERY_STALE_POLICY)));
+
+  private VectorIndexOptions() {
+  }
+
+  /**
+   * Validates the complete option map and returns canonical values for persistence.
+   *
+   * <p>The returned map contains every supported option, including explicit defaults. Unknown,
+   * retired, misspelled, and invalid options are rejected instead of being silently ignored.
+   */
+  public static Map<String, String> validateAndNormalize(Map<String, String> options) {
+    Set<String> unknownOptions = new HashSet<>(options.keySet());
+    unknownOptions.removeAll(SUPPORTED_OPTIONS);
+    if (!unknownOptions.isEmpty()) {
+      throw new IllegalArgumentException("Unsupported vector index options: " + unknownOptions);
+    }
+
+    VectorDistanceMetric metric = getMetric(options);
+    VectorQuantizer quantizer = getQuantizer(options);
+    int numClusters = getNumClusters(options);
+    int maxIter = getMaxIter(options);
+    int bits = getRaBitQBits(options);
+    long seed = getRaBitQSeed(options);
+    boolean assumeNormalized = shouldAssumeNormalizedVectors(options);
+    int numProbes = getNumProbes(options);
+    int refineFactor = getRefineFactor(options);
+    VectorQueryMode queryMode = getQueryMode(options);
+    VectorStalePolicy stalePolicy = getStalePolicy(options);
+
+    if (numProbes > numClusters) {
+      throw new IllegalArgumentException(
+          "Option '" + QUERY_NUM_PROBES + "' must not exceed '" + NUM_CLUSTERS + "': "
+              + numProbes + " > " + numClusters);
+    }
+
+    Map<String, String> normalized = new LinkedHashMap<>();
+    normalized.put(METRIC, metric.name().toLowerCase(Locale.ROOT));
+    normalized.put(QUANTIZER, quantizer.name());
+    normalized.put(NUM_CLUSTERS, String.valueOf(numClusters));
+    normalized.put(MAX_ITER, String.valueOf(maxIter));
+    normalized.put(RABITQ_BITS, String.valueOf(bits));
+    normalized.put(RABITQ_SEED, String.valueOf(seed));
+    normalized.put(RABITQ_ASSUME_NORMALIZED, String.valueOf(assumeNormalized));
+    normalized.put(QUERY_NUM_PROBES, String.valueOf(numProbes));
+    normalized.put(QUERY_REFINE_FACTOR, String.valueOf(refineFactor));
+    normalized.put(QUERY_MODE, queryMode.name().toLowerCase(Locale.ROOT));
+    normalized.put(QUERY_STALE_POLICY, stalePolicy.name().toLowerCase(Locale.ROOT));
+    return Collections.unmodifiableMap(normalized);
+  }
+
+  private static VectorDistanceMetric getMetric(Map<String, String> options) {
+    String value = getOption(options, METRIC, DEFAULT_METRIC.name());
+    try {
+      return VectorDistanceMetric.fromString(value);
+    } catch (IllegalArgumentException e) {
+      throw unsupportedValue(METRIC, value, e);
+    }
+  }
+
+  private static VectorQuantizer getQuantizer(Map<String, String> options) {
+    String value = getOption(options, QUANTIZER, DEFAULT_QUANTIZER.name());
+    try {
+      return VectorQuantizer.fromString(value);
+    } catch (IllegalArgumentException e) {
+      throw unsupportedValue(QUANTIZER, value, e);
+    }
+  }
+
+  private static int getNumClusters(Map<String, String> options) {
+    return getPositiveInt(options, NUM_CLUSTERS, DEFAULT_NUM_CLUSTERS);
+  }
+
+  private static int getMaxIter(Map<String, String> options) {
+    return getPositiveInt(options, MAX_ITER, DEFAULT_MAX_ITER);
+  }
+
+  private static int getRaBitQBits(Map<String, String> options) {
+    int bits = getInt(options, RABITQ_BITS, DEFAULT_RABITQ_BITS);
+    if (bits < 1 || bits > 8) {
+      throw new IllegalArgumentException(
+          "Option '" + RABITQ_BITS + "' must be between 1 and 8: " + bits);
+    }
+    return bits;
+  }
+
+  private static long getRaBitQSeed(Map<String, String> options) {
+    String value = getOption(options, RABITQ_SEED, String.valueOf(DEFAULT_RABITQ_SEED));
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      throw invalidNumber(RABITQ_SEED, value, e);
+    }
+  }
+
+  private static boolean shouldAssumeNormalizedVectors(Map<String, String> options) {
+    String value = getOption(
+        options, RABITQ_ASSUME_NORMALIZED, String.valueOf(false)).toLowerCase(Locale.ROOT);
+    if (!"true".equals(value) && !"false".equals(value)) {
+      throw new IllegalArgumentException(
+          "Option '" + RABITQ_ASSUME_NORMALIZED + "' must be either 'true' or 'false': " + value);
+    }
+    return Boolean.parseBoolean(value);
+  }
+
+  private static int getNumProbes(Map<String, String> options) {
+    return getPositiveInt(options, QUERY_NUM_PROBES, DEFAULT_NUM_PROBES);
+  }
+
+  private static int getRefineFactor(Map<String, String> options) {
+    return getPositiveInt(options, QUERY_REFINE_FACTOR, DEFAULT_REFINE_FACTOR);
+  }
+
+  private static VectorQueryMode getQueryMode(Map<String, String> options) {
+    String value = getOption(options, QUERY_MODE, DEFAULT_QUERY_MODE.name());
+    try {
+      return VectorQueryMode.fromString(value);
+    } catch (IllegalArgumentException e) {
+      throw unsupportedValue(QUERY_MODE, value, e);
+    }
+  }
+
+  private static VectorStalePolicy getStalePolicy(Map<String, String> options) {
+    String value = getOption(options, QUERY_STALE_POLICY, DEFAULT_STALE_POLICY.name());
+    try {
+      return VectorStalePolicy.fromString(value);
+    } catch (IllegalArgumentException e) {
+      throw unsupportedValue(QUERY_STALE_POLICY, value, e);
+    }
+  }
+
+  private static int getPositiveInt(Map<String, String> options, String key, int defaultValue) {
+    int value = getInt(options, key, defaultValue);
+    if (value <= 0) {
+      throw new IllegalArgumentException("Option '" + key + "' must be greater than 0: " + value);
+    }
+    return value;
+  }
+
+  private static int getInt(Map<String, String> options, String key, int defaultValue) {
+    String value = getOption(options, key, String.valueOf(defaultValue));
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw invalidNumber(key, value, e);
+    }
+  }
+
+  private static IllegalArgumentException invalidNumber(
+      String key, String value, NumberFormatException cause) {
+    return new IllegalArgumentException(
+        "Option '" + key + "' must be a valid number: " + value, cause);
+  }
+
+  private static IllegalArgumentException unsupportedValue(
+      String key, String value, IllegalArgumentException cause) {
+    return new IllegalArgumentException(
+        "Unsupported value for option '" + key + "': " + value, cause);
+  }
+
+  private static String getOption(Map<String, String> options, String key, String defaultValue) {
+    String value = options.getOrDefault(key, defaultValue);
+    if (value == null || value.isEmpty()) {
+      throw new IllegalArgumentException("Option '" + key + "' must not be empty");
+    }
+    return value;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorQuantizer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorQuantizer.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import java.util.Locale;
+
+/** Supported vector-index quantizers. */
+public enum VectorQuantizer {
+  IVF_RABITQ;
+
+  static VectorQuantizer fromString(String value) {
+    return valueOf(value.toUpperCase(Locale.ROOT).replace('-', '_'));
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorQueryMode.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorQueryMode.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import java.util.Locale;
+
+/** Supported vector-query execution modes. */
+public enum VectorQueryMode {
+  APPROXIMATE,
+  EXACT_RERANK;
+
+  static VectorQueryMode fromString(String value) {
+    return valueOf(value.toUpperCase(Locale.ROOT).replace('-', '_'));
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorStalePolicy.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/index/vector/VectorStalePolicy.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import java.util.Locale;
+
+/** Policies applied when vector-index state is stale at the pinned snapshot. */
+public enum VectorStalePolicy {
+  FAIL,
+  WARN,
+  FALLBACK;
+
+  static VectorStalePolicy fromString(String value) {
+    return valueOf(value.toUpperCase(Locale.ROOT));
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -202,6 +202,8 @@ public class HoodieTableMetadataUtil {
   public static final String PARTITION_NAME_EXPRESSION_INDEX_PREFIX = "expr_index_";
   public static final String PARTITION_NAME_SECONDARY_INDEX = "secondary_index";
   public static final String PARTITION_NAME_SECONDARY_INDEX_PREFIX = "secondary_index_";
+  public static final String PARTITION_NAME_VECTOR_INDEX = "vector_index";
+  public static final String PARTITION_NAME_VECTOR_INDEX_PREFIX = "vector_index_";
 
   // Average size of a record saved within the record index.
   // Record index has a fixed size schema. This has been calculated based on experiments with default settings

--- a/hudi-common/src/test/java/org/apache/hudi/common/index/vector/TestVectorIndexOptions.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/index/vector/TestVectorIndexOptions.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.index.vector;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestVectorIndexOptions {
+
+  @Test
+  void testDefaultsAreCanonicalAndComplete() {
+    assertEquals(
+        opts(
+            VectorIndexOptions.METRIC, "cosine",
+            VectorIndexOptions.QUANTIZER, "IVF_RABITQ",
+            VectorIndexOptions.NUM_CLUSTERS, "256",
+            VectorIndexOptions.MAX_ITER, "20",
+            VectorIndexOptions.RABITQ_BITS, "4",
+            VectorIndexOptions.RABITQ_SEED, "42",
+            VectorIndexOptions.RABITQ_ASSUME_NORMALIZED, "false",
+            VectorIndexOptions.QUERY_NUM_PROBES, "32",
+            VectorIndexOptions.QUERY_REFINE_FACTOR, "50",
+            VectorIndexOptions.QUERY_MODE, "exact_rerank",
+            VectorIndexOptions.QUERY_STALE_POLICY, "fail"),
+        VectorIndexOptions.validateAndNormalize(opts()));
+  }
+
+  @Test
+  void testValuesAreNormalizedForPersistence() {
+    Map<String, String> normalized = VectorIndexOptions.validateAndNormalize(opts(
+        VectorIndexOptions.METRIC, "DOT-PRODUCT",
+        VectorIndexOptions.QUANTIZER, "ivf-rabitq",
+        VectorIndexOptions.RABITQ_ASSUME_NORMALIZED, "TRUE",
+        VectorIndexOptions.QUERY_MODE, "EXACT-RERANK",
+        VectorIndexOptions.QUERY_STALE_POLICY, "WARN"));
+
+    assertEquals("dot_product", normalized.get(VectorIndexOptions.METRIC));
+    assertEquals("IVF_RABITQ", normalized.get(VectorIndexOptions.QUANTIZER));
+    assertEquals("true", normalized.get(VectorIndexOptions.RABITQ_ASSUME_NORMALIZED));
+    assertEquals("exact_rerank", normalized.get(VectorIndexOptions.QUERY_MODE));
+    assertEquals("warn", normalized.get(VectorIndexOptions.QUERY_STALE_POLICY));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> normalized.put(VectorIndexOptions.METRIC, "l2"));
+  }
+
+  @Test
+  void testEveryMetricQueryModeAndStalePolicyIsAccepted() {
+    assertCanonical(VectorIndexOptions.METRIC, "cosine", "cosine");
+    assertCanonical(VectorIndexOptions.METRIC, "l2", "l2");
+    assertCanonical(VectorIndexOptions.METRIC, "dot_product", "dot_product");
+    assertCanonical(VectorIndexOptions.QUERY_MODE, "approximate", "approximate");
+    assertCanonical(VectorIndexOptions.QUERY_MODE, "exact_rerank", "exact_rerank");
+    assertCanonical(VectorIndexOptions.QUERY_STALE_POLICY, "fail", "fail");
+    assertCanonical(VectorIndexOptions.QUERY_STALE_POLICY, "warn", "warn");
+    assertCanonical(VectorIndexOptions.QUERY_STALE_POLICY, "fallback", "fallback");
+  }
+
+  @Test
+  void testUnknownRetiredAndMisspelledOptionsAreRejected() {
+    assertInvalidOption("vector.dimension", "128");
+    assertInvalidOption("vector.query.nprobe", "8");
+    assertInvalidOption("vector.unknown", "value");
+  }
+
+  @Test
+  void testUnsupportedEnumValuesAreRejectedWithOptionContext() {
+    assertInvalidValueContainsKey(VectorIndexOptions.METRIC, "manhattan");
+    assertInvalidValueContainsKey(VectorIndexOptions.QUANTIZER, "pq");
+    assertInvalidValueContainsKey(VectorIndexOptions.QUERY_MODE, "fast-ish");
+    assertInvalidValueContainsKey(VectorIndexOptions.QUERY_STALE_POLICY, "ignore");
+    assertInvalidValueContainsKey(VectorIndexOptions.RABITQ_ASSUME_NORMALIZED, "yes");
+  }
+
+  @Test
+  void testNumericOptionsAreValidatedWithOptionContext() {
+    assertCanonical(VectorIndexOptions.RABITQ_BITS, "1", "1");
+    assertCanonical(VectorIndexOptions.RABITQ_BITS, "8", "8");
+    assertInvalidValueContainsKey(VectorIndexOptions.NUM_CLUSTERS, "0");
+    assertInvalidValueContainsKey(VectorIndexOptions.MAX_ITER, "-1");
+    assertInvalidValueContainsKey(VectorIndexOptions.QUERY_NUM_PROBES, "0");
+    assertInvalidValueContainsKey(VectorIndexOptions.QUERY_REFINE_FACTOR, "-1");
+    assertInvalidValueContainsKey(VectorIndexOptions.RABITQ_BITS, "0");
+    assertInvalidValueContainsKey(VectorIndexOptions.RABITQ_BITS, "9");
+    assertInvalidValueContainsKey(VectorIndexOptions.RABITQ_SEED, "many");
+  }
+
+  @Test
+  void testNumProbesMustNotExceedNumClusters() {
+    assertCanonical(
+        opts(
+            VectorIndexOptions.NUM_CLUSTERS, "32",
+            VectorIndexOptions.QUERY_NUM_PROBES, "32"),
+        VectorIndexOptions.QUERY_NUM_PROBES,
+        "32");
+
+    IllegalArgumentException error = assertThrows(
+        IllegalArgumentException.class,
+        () -> VectorIndexOptions.validateAndNormalize(opts(
+            VectorIndexOptions.NUM_CLUSTERS, "4",
+            VectorIndexOptions.QUERY_NUM_PROBES, "5")));
+    assertTrue(error.getMessage().contains(VectorIndexOptions.QUERY_NUM_PROBES));
+    assertTrue(error.getMessage().contains(VectorIndexOptions.NUM_CLUSTERS));
+  }
+
+  private static void assertCanonical(String key, String input, String expected) {
+    assertCanonical(opts(key, input), key, expected);
+  }
+
+  private static void assertCanonical(
+      Map<String, String> options, String key, String expected) {
+    assertEquals(expected, VectorIndexOptions.validateAndNormalize(options).get(key));
+  }
+
+  private static void assertInvalidOption(String key, String value) {
+    IllegalArgumentException error = assertThrows(
+        IllegalArgumentException.class,
+        () -> VectorIndexOptions.validateAndNormalize(opts(key, value)));
+    assertTrue(error.getMessage().contains(key));
+  }
+
+  private static void assertInvalidValueContainsKey(String key, String value) {
+    IllegalArgumentException error = assertThrows(
+        IllegalArgumentException.class,
+        () -> VectorIndexOptions.validateAndNormalize(opts(key, value)));
+    assertTrue(error.getMessage().contains(key));
+  }
+
+  private static Map<String, String> opts(String... keyValues) {
+    Map<String, String> options = new HashMap<>();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      options.put(keyValues[i], keyValues[i + 1]);
+    }
+    return options;
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Part of #19096. RFC-109 needs one engine-neutral contract for persisted vector-index options before Spark DDL and index construction can depend on it. The previous draft duplicated vector dimension in OPTIONS and included speculative hidden-column, storage, and exact-fetch knobs that are not part of the revised MDT-owned design.

### Summary and Changelog

- Add MDT partition constants for `vector_index` and `vector_index_<name>`.
- Add exact cosine, L2, and dot-product distance metrics.
- Add typed closed sets for quantizer, query mode, and stale policy.
- Define the exact eleven-key RFC-109 option surface.
- Add a single public `validateAndNormalize` boundary that rejects unknown, misspelled, retired, and invalid options; checks `nprobes <= num_clusters`; and returns an immutable canonical map with explicit defaults.
- Keep vector dimension and element type out of OPTIONS; the indexed top-level `VECTOR(D[, elementType])` schema is authoritative.
- Add focused option/default/normalization/error-path tests.

No code was copied.

### Impact

Adds a new vector-index option API and MDT partition-name constants. It does not change common writer dispatch, timeline semantics, existing table properties, storage behavior, or non-vector readers/writers. The API is new and currently has no existing callers to break.

### Risk Level

low. The change is isolated to new vector option/metric types plus two constants. Validation passed with 7 focused tests, Java 8 source compilation, and zero Checkstyle violations.

### Documentation Update

RFC-109 PR #19309 documents the complete option table, explicit defaults, schema-authoritative dimension contract, and zero-core-coupling boundary.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
