### PR TITLE
fix(mdt): use native log format for file group initialization

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodieListData;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.function.SerializableFunction;
@@ -41,16 +42,11 @@ import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieFileGroupId;
-import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.log.HoodieLogFormat;
-import org.apache.hudi.common.table.log.HoodieLogFormatWriter;
-import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
-import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
@@ -117,6 +113,7 @@ import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTE
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
+import static org.apache.hudi.metadata.HoodieMetadataWriteUtils.createEmptyFileGroupLogFile;
 import static org.apache.hudi.metadata.HoodieMetadataWriteUtils.createMetadataWriteConfig;
 import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_SUFFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
@@ -692,27 +689,18 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         .collect(Collectors.toList());
     ValidationUtils.checkArgument(fileGroupFileIds.size() == fileGroupCount);
     engineContext.setJobStatus(this.getClass().getSimpleName(), msg);
+    final TaskContextSupplier taskContextSupplier = engineContext.getTaskContextSupplier();
     engineContext.foreach(fileGroupFileIds, fileGroupFileId -> {
       try {
-        final Map<HeaderMetadataType, String> blockHeader = Collections.singletonMap(HeaderMetadataType.INSTANT_TIME, instantTime);
-
-        final HoodieDeleteBlock block = new HoodieDeleteBlock(Collections.emptyList(), blockHeader);
-
-        try (HoodieLogFormat.Writer writer = HoodieLogFormatWriter.builder()
-            .withParentPath(FSUtils.constructAbsolutePath(metadataWriteConfig.getBasePath(), relativePartitionPath))
-            .withLogFileId(fileGroupFileId)
-            .withInstantTime(instantTime)
-            .withLogVersion(HoodieLogFile.LOGFILE_BASE_VERSION)
-            .withFileSize(0L)
-            .withSizeThreshold(metadataWriteConfig.getLogFileMaxSize())
-            .withStorage(dataMetaClient.getStorage())
-            .withLogWriteToken(HoodieLogFormat.DEFAULT_WRITE_TOKEN)
-            .withTableVersion(metadataWriteConfig.getWriteVersion())
-            .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build()) {
-          writer.appendBlock(block);
-        }
-      } catch (InterruptedException e) {
-        throw new HoodieException(String.format("Failed to created fileGroup %s for partition %s", fileGroupFileId, relativePartitionPath), e);
+        createEmptyFileGroupLogFile(
+            dataMetaClient.getStorage(),
+            FSUtils.constructAbsolutePath(metadataWriteConfig.getBasePath(), relativePartitionPath),
+            fileGroupFileId,
+            instantTime,
+            taskContextSupplier,
+            metadataWriteConfig);
+      } catch (IOException | InterruptedException e) {
+        throw new HoodieException(String.format("Failed to create file group %s for partition %s", fileGroupFileId, relativePartitionPath), e);
       }
     }, fileGroupFileIds.size());
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -32,21 +32,32 @@ import org.apache.hudi.common.config.metrics.HoodieMetricsJmxConfig;
 import org.apache.hudi.common.config.metrics.HoodieMetricsM3Config;
 import org.apache.hudi.common.config.metrics.HoodieMetricsPrometheusConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.HoodieAvroRecordMerger;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.HoodieLogFormatWriter;
+import org.apache.hudi.common.table.log.NativeLogFooterMetadata;
+import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
@@ -62,20 +73,26 @@ import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodiePayloadConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.core.io.storage.HoodieFileWriter;
+import org.apache.hudi.core.io.storage.HoodieFileWriterFactory;
 import org.apache.hudi.core.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.metadata.stats.HoodieColumnRangeMetadata;
+import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
 import org.apache.hudi.table.action.compact.strategy.UnBoundedCompactionStrategy;
+import org.apache.hudi.util.CommonClientUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -88,6 +105,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_ASYNC_CLEAN;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_CLEANER_COMMITS_RETAINED;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_POPULATE_META_FIELDS;
+import static org.apache.hudi.common.model.LogExtensions.DATA_LOG_EXTENSION;
 import static org.apache.hudi.common.util.StringUtils.nonEmpty;
 import static org.apache.hudi.common.util.ValidationUtils.checkState;
 import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_SUFFIX;
@@ -113,6 +131,67 @@ public class HoodieMetadataWriteUtils {
   // ever. Hence, we use a very large basefile size in metadata table. The actual size of the HFiles created will
   // eventually depend on the number of file groups selected for each partition (See estimateFileGroupCount function)
   private static final long MDT_MAX_HFILE_SIZE_BYTES = 10 * 1024 * 1024 * 1024L; // 10GB
+
+  /**
+   * Creates the initial empty log file for a metadata table file group so that the file group can be discovered by
+   * the file-system view before any records are written to it. Native log format uses a zero-record HFile containing
+   * the instant time and writer schema in its footer, while legacy inline log format uses an empty delete block.
+   *
+   * @param storage storage used to create the log file
+   * @param parentPath metadata partition containing the file group
+   * @param fileGroupFileId file ID of the metadata table file group
+   * @param instantTime instant time used as the base commit time of the log file
+   * @param taskContextSupplier task context supplier used by the native file writer
+   * @param writeConfig metadata table write configuration
+   */
+  static void createEmptyFileGroupLogFile(HoodieStorage storage,
+                                          StoragePath parentPath,
+                                          String fileGroupFileId,
+                                          String instantTime,
+                                          TaskContextSupplier taskContextSupplier,
+                                          HoodieWriteConfig writeConfig) throws IOException, InterruptedException {
+    if (CommonClientUtils.shouldWriteNativeLogs(writeConfig)) {
+      HoodieSchema writeSchema = HoodieSchemaUtils.createHoodieWriteSchema(
+          writeConfig.getWriteSchema(), writeConfig.allowOperationMetadataField());
+      StoragePath nativeLogPath = new StoragePath(parentPath, FSUtils.makeNativeLogFileName(
+          fileGroupFileId,
+          HoodieLogFormat.DEFAULT_WRITE_TOKEN,
+          instantTime,
+          HoodieLogFile.LOGFILE_BASE_VERSION,
+          DATA_LOG_EXTENSION,
+          HoodieFileFormat.HFILE));
+      Map<HeaderMetadataType, String> footerHeader = new HashMap<>();
+      footerHeader.put(HeaderMetadataType.INSTANT_TIME, instantTime);
+      footerHeader.put(HeaderMetadataType.SCHEMA, writeSchema.toString());
+      try (HoodieFileWriter<?> writer = HoodieFileWriterFactory.getFileWriter(
+          instantTime,
+          nativeLogPath,
+          storage,
+          writeConfig,
+          writeSchema,
+          taskContextSupplier,
+          HoodieRecord.HoodieRecordType.AVRO)) {
+        writer.addFooterMetadata(NativeLogFooterMetadata.toFooterMetadata(footerHeader));
+      }
+    } else {
+      Map<HeaderMetadataType, String> blockHeader = Collections.singletonMap(HeaderMetadataType.INSTANT_TIME, instantTime);
+      HoodieDeleteBlock block = new HoodieDeleteBlock(Collections.emptyList(), blockHeader);
+      try (HoodieLogFormat.Writer writer = HoodieLogFormatWriter.builder()
+          .withParentPath(parentPath)
+          .withLogFileId(fileGroupFileId)
+          .withInstantTime(instantTime)
+          .withLogVersion(HoodieLogFile.LOGFILE_BASE_VERSION)
+          .withFileSize(0L)
+          .withSizeThreshold(writeConfig.getLogFileMaxSize())
+          .withStorage(storage)
+          .withLogWriteToken(HoodieLogFormat.DEFAULT_WRITE_TOKEN)
+          .withTableVersion(writeConfig.getWriteVersion())
+          .withFileExtension(HoodieLogFile.DELTA_EXTENSION)
+          .build()) {
+        writer.appendBlock(block);
+      }
+    }
+  }
 
   /**
    * Create a {@code HoodieWriteConfig} to use for the Metadata Table.

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
@@ -24,23 +24,41 @@ import org.apache.hudi.client.transaction.lock.ZookeeperBasedImplicitBasePathLoc
 import org.apache.hudi.client.transaction.lock.ZookeeperBasedLockProvider;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.engine.TaskContextSupplier;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.ActionType;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
+import org.apache.hudi.common.table.log.NativeLogFooterMetadata;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
+import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.core.io.storage.HoodieIOFactory;
 import org.apache.hudi.core.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StoragePath;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.file.Path;
+import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -49,6 +67,47 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieMetadataWriteUtils {
+
+  @Test
+  void testCreateEmptyNativeLogFile(@TempDir Path tempDir) throws Exception {
+    String instantTime = "20260717120000000";
+    String fileId = "files-0000";
+    HoodieSchema writeSchema = HoodieSchema.parse(
+        "{\"type\":\"record\",\"name\":\"metadata\",\"fields\":[]}");
+    StoragePath parentPath = new StoragePath(tempDir.resolve("files").toString());
+    HoodieStorage storage = HoodieStorageUtils.getStorage(parentPath, getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath(tempDir.toString())
+        .withSchema(writeSchema.toString())
+        .withWriteTableVersion(HoodieTableVersion.TEN.versionCode())
+        .withPopulateMetaFields(false)
+        .build();
+    TaskContextSupplier taskContextSupplier =
+        new HoodieLocalEngineContext(getDefaultStorageConf()).getTaskContextSupplier();
+    StoragePath nativeLogPath = new StoragePath(parentPath, FSUtils.makeNativeLogFileName(
+        fileId,
+        HoodieLogFormat.DEFAULT_WRITE_TOKEN,
+        instantTime,
+        HoodieLogFile.LOGFILE_BASE_VERSION,
+        "log",
+        HoodieFileFormat.HFILE));
+
+    HoodieMetadataWriteUtils.createEmptyFileGroupLogFile(
+        storage, parentPath, fileId, instantTime, taskContextSupplier, writeConfig);
+
+    assertTrue(nativeLogPath.getName().endsWith(".log.hfile"));
+    assertTrue(FSUtils.isNativeLogFile(nativeLogPath.getName()));
+    assertTrue(storage.exists(nativeLogPath));
+    assertTrue(storage.getPathInfo(nativeLogPath).getLength() > 0);
+    Map<String, String> footer = HoodieIOFactory.getIOFactory(storage)
+        .getFileFormatUtils(HoodieFileFormat.HFILE)
+        .readFooter(storage, false, nativeLogPath, NativeLogFooterMetadata.FOOTER_METADATA_KEY);
+    Map<HeaderMetadataType, String> footerHeader = NativeLogFooterMetadata.fromFooterMetadata(footer);
+    assertEquals(instantTime, footerHeader.get(HeaderMetadataType.INSTANT_TIME));
+    assertEquals(HoodieSchemaUtils.createHoodieWriteSchema(writeConfig.getWriteSchema(), false).toString(),
+        footerHeader.get(HeaderMetadataType.SCHEMA));
+    assertEquals(String.valueOf(HoodieLogFormat.CURRENT_VERSION), footerHeader.get(HeaderMetadataType.VERSION));
+  }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/TestInputFormat.java
@@ -219,21 +219,21 @@ public class TestInputFormat {
         .collect(Collectors.toList());
 
     assertFalse(logFiles.isEmpty(), "The MDT record index partition should contain log files");
-    int hfileDataBlockCount = 0;
+    int nonEmptyHfileDataBlockCount = 0;
     for (StoragePathInfo logFile : logFiles) {
       HoodieSchema schema = TableSchemaResolver.readSchemaFromLogFile(metaClient, logFile.getPath());
       try (HoodieLogFormat.Reader reader =
                HoodieLogFormat.newReader(metaClient, new HoodieLogFile(logFile), schema)) {
         while (reader.hasNext()) {
           HoodieLogBlock logBlock = reader.next();
-          if (!(logBlock instanceof HoodieDeleteBlock)) {
-            assertBloomFilterContainsWrittenKey(storage, logBlock);
-            hfileDataBlockCount++;
+          if (!(logBlock instanceof HoodieDeleteBlock)
+              && assertBloomFilterContainsWrittenKey(storage, logBlock)) {
+            nonEmptyHfileDataBlockCount++;
           }
         }
       }
     }
-    assertTrue(hfileDataBlockCount > 0, "The MDT record index log files should contain HFile data blocks");
+    assertTrue(nonEmptyHfileDataBlockCount > 0, "The MDT record index log files should contain non-empty HFile data blocks");
 
     HoodieTableMetadata metadataTable = StreamerUtil.createMetaClient(conf).getTableFormat().getMetadataFactory().create(
         HoodieFlinkEngineContext.DEFAULT,
@@ -1599,7 +1599,12 @@ public class TestInputFormat {
         conf);
   }
 
-  private static void assertBloomFilterContainsWrittenKey(
+  /**
+   * Verifies that the block's bloom filter contains its first key when the block has records.
+   *
+   * @return {@code true} for a non-empty block, or {@code false} for an initialized empty native HFile block
+   */
+  private static boolean assertBloomFilterContainsWrittenKey(
       HoodieStorage storage, HoodieLogBlock logBlock) throws IOException {
     HoodieLogBlock.HoodieLogBlockContentLocation contentLocation =
         logBlock.getBlockContentLocation().get();
@@ -1620,9 +1625,12 @@ public class TestInputFormat {
           new UTF8StringKey(HoodieAvroHFileReaderImplBase.KEY_BLOOM_FILTER_TYPE_CODE)).get());
       BloomFilter bloomFilter = BloomFilterFactory.fromByteBuffer(bloomFilterBuffer, bloomFilterType);
 
-      assertTrue(hfileReader.seekTo(), "The HFile data block should contain at least one record");
+      if (!hfileReader.seekTo()) {
+        return false;
+      }
       String writtenKey = hfileReader.getKeyValue().get().getKey().getContentInString();
       assertTrue(bloomFilter.mightContain(writtenKey));
+      return true;
     }
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19311

When native log format is enabled, MDT file-group initialization still creates a legacy inline log containing an empty delete block. Empty file groups therefore do not have the native `.log.hfile` expected by the file-system view and may not be discovered before receiving records.

### Summary and Changelog

- Create a zero-record native `.log.hfile` for each empty MDT file group when native log format is enabled.
- Store the instant time and writer schema in native footer metadata; the native log version is added by the footer metadata utility.
- Keep the existing empty delete-block initialization for legacy inline log format.
- Centralize both initialization paths in `HoodieMetadataWriteUtils`.
- Add a test that opens the generated HFile and verifies its footer metadata.

### Impact

Empty MDT file groups are discoverable by the file-system view when native log format is enabled. There are no public API or configuration changes.

### Risk Level

Low. The change is limited to initial empty MDT file-group creation, preserves the legacy inline path, and includes native HFile footer read coverage.

### Documentation Update

None. There are no user-facing API or configuration changes.

### Contributor's checklist

- [x] Read through contributor's guide
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
