### PR TITLE
feat(cdc): Oracle Debezium CDC transformer + v9 changed-columns partial merge (stacked on #19110)

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -35,7 +35,6 @@ import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.model.MetadataValues;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableVersion;
-import org.apache.hudi.common.table.PartialUpdateMode;
 import org.apache.hudi.common.table.log.AppendResult;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
@@ -128,21 +127,6 @@ public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T
             : Option.empty(),
         taskContextSupplier,
         preserveMetadata);
-    // A table whose read-side merge is driven by the changed-columns list (FILL_UNCHANGED) requires
-    // every log block to carry the full schema. A schema-partial log block (written when
-    // WRITE_PARTIAL_UPDATE_SCHEMA is set) flips the reader to the KEEP_VALUES partial merger, which
-    // drops the FILL_UNCHANGED changed-columns logic for the whole file group — letting CDC
-    // placeholder values silently win over the base. Reject that combination up front rather than
-    // corrupt data on read.
-    if (config.shouldWritePartialUpdates()
-        && hoodieTable.getMetaClient().getTableConfig().getPartialUpdateMode()
-            .map(mode -> mode == PartialUpdateMode.FILL_UNCHANGED).orElse(false)) {
-      throw new HoodieException(String.format(
-          "Partial-update writes (%s) are incompatible with a table configured for FILL_UNCHANGED "
-              + "partial-update merge (changed-columns based); such tables require full-schema writes. "
-              + "Remove the partial-update-schema write config or use a full-schema writer.",
-          HoodieWriteConfig.WRITE_PARTIAL_UPDATE_SCHEMA.key()));
-    }
     this.recordItr = recordItr;
     this.isLogCompaction = preserveMetadata;
     this.useWriterSchema = preserveMetadata;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.model.IOType;
 import org.apache.hudi.common.model.MetadataValues;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.PartialUpdateMode;
 import org.apache.hudi.common.table.log.AppendResult;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
@@ -127,6 +128,21 @@ public abstract class HoodieAppendHandle<T, I, K, O> extends HoodieWriteHandle<T
             : Option.empty(),
         taskContextSupplier,
         preserveMetadata);
+    // A table whose read-side merge is driven by the changed-columns list (FILL_UNCHANGED) requires
+    // every log block to carry the full schema. A schema-partial log block (written when
+    // WRITE_PARTIAL_UPDATE_SCHEMA is set) flips the reader to the KEEP_VALUES partial merger, which
+    // drops the FILL_UNCHANGED changed-columns logic for the whole file group — letting CDC
+    // placeholder values silently win over the base. Reject that combination up front rather than
+    // corrupt data on read.
+    if (config.shouldWritePartialUpdates()
+        && hoodieTable.getMetaClient().getTableConfig().getPartialUpdateMode()
+            .map(mode -> mode == PartialUpdateMode.FILL_UNCHANGED).orElse(false)) {
+      throw new HoodieException(String.format(
+          "Partial-update writes (%s) are incompatible with a table configured for FILL_UNCHANGED "
+              + "partial-update merge (changed-columns based); such tables require full-schema writes. "
+              + "Remove the partial-update-schema write config or use a full-schema writer.",
+          HoodieWriteConfig.WRITE_PARTIAL_UPDATE_SCHEMA.key()));
+    }
     this.recordItr = recordItr;
     this.isLogCompaction = preserveMetadata;
     this.useWriterSchema = preserveMetadata;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/util/CommonClientUtils.java
@@ -57,6 +57,19 @@ public class CommonClientUtils {
       throw new HoodieNotSupportedException("Partial updates are not supported for table versions < 8. "
           + "Please unset " + HoodieWriteConfig.WRITE_PARTIAL_UPDATE_SCHEMA.key());
     }
+    // A table configured with a value-level partial-update merge mode (IGNORE_DEFAULTS / FILL_UNAVAILABLE /
+    // FILL_UNCHANGED) expects FULL-SCHEMA records whose unchanged columns carry a default/sentinel/placeholder
+    // that the read-side merge resolves. A schema-partial write (WRITE_PARTIAL_UPDATE_SCHEMA, e.g. a Spark
+    // MERGE INTO with a partial UPDATE SET) writes an IS_PARTIAL log block, which flips the reader to the
+    // KEEP_VALUES partial merger and silently drops the configured mode for the whole file group -- letting the
+    // placeholder/sentinel/default win over the prior value (silent corruption). Reject the combination up front.
+    if (writeConfig.shouldWritePartialUpdates() && tableConfig.getPartialUpdateMode().isPresent()) {
+      throw new HoodieNotSupportedException(String.format(
+          "Partial-update writes (%s) are incompatible with a table configured for value-level partial-update "
+              + "merge (mode=%s); such tables require full-schema writes. Unset %s or use a full-schema writer.",
+          HoodieWriteConfig.WRITE_PARTIAL_UPDATE_SCHEMA.key(), tableConfig.getPartialUpdateMode().get(),
+          HoodieWriteConfig.WRITE_PARTIAL_UPDATE_SCHEMA.key()));
+    }
 
     if (tableConfig.getTableVersion().lesserThan(HoodieTableVersion.EIGHT) && writeConfig.isNonBlockingConcurrencyControl()) {
       throw new HoodieNotSupportedException("Non-blocking concurrency control is not supported for table versions < 8.");

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestCommonClientUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/utils/TestCommonClientUtils.java
@@ -22,6 +22,8 @@ package org.apache.hudi.utils;
 
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.PartialUpdateMode;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.util.CommonClientUtils;
@@ -52,6 +54,50 @@ class TestCommonClientUtils {
 
     // when-then:
     assertThrows(HoodieNotSupportedException.class, () -> CommonClientUtils.validateTableVersion(tConfig, wConfig));
+  }
+
+  @Test
+  void testDisallowPartialUpdateWriteOnValueLevelPartialUpdateMode() {
+    // A schema-partial write (WRITE_PARTIAL_UPDATE_SCHEMA) on a table configured with ANY value-level
+    // partial-update mode must be rejected (it would flip the reader to KEEP_VALUES and silently drop the
+    // mode). Uses FILL_UNAVAILABLE to prove the guard covers all such modes, not just FILL_UNCHANGED.
+    HoodieWriteConfig wConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tConfig = mock(HoodieTableConfig.class);
+    when(wConfig.getWriteVersion()).thenReturn(HoodieTableVersion.NINE);
+    when(tConfig.getTableVersion()).thenReturn(HoodieTableVersion.NINE);
+    when(wConfig.shouldWritePartialUpdates()).thenReturn(true);
+    when(tConfig.getPartialUpdateMode()).thenReturn(Option.of(PartialUpdateMode.FILL_UNAVAILABLE));
+
+    assertThrows(HoodieNotSupportedException.class, () -> CommonClientUtils.validateTableVersion(tConfig, wConfig));
+  }
+
+  @Test
+  void testAllowPartialUpdateWriteWhenNoPartialUpdateMode() {
+    // Partial-update writes are fine when the table has no value-level partial-update mode configured.
+    HoodieWriteConfig wConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tConfig = mock(HoodieTableConfig.class);
+    when(wConfig.getWriteVersion()).thenReturn(HoodieTableVersion.NINE);
+    when(tConfig.getTableVersion()).thenReturn(HoodieTableVersion.NINE);
+    when(wConfig.shouldWritePartialUpdates()).thenReturn(true);
+    when(tConfig.getPartialUpdateMode()).thenReturn(Option.empty());
+
+    // Should not throw.
+    CommonClientUtils.validateTableVersion(tConfig, wConfig);
+  }
+
+  @Test
+  void testAllowFullSchemaWriteOnValueLevelPartialUpdateMode() {
+    // A full-schema write (no WRITE_PARTIAL_UPDATE_SCHEMA) on a value-level partial-update table is the
+    // normal CDC ingestion path and must be allowed.
+    HoodieWriteConfig wConfig = mock(HoodieWriteConfig.class);
+    HoodieTableConfig tConfig = mock(HoodieTableConfig.class);
+    when(wConfig.getWriteVersion()).thenReturn(HoodieTableVersion.NINE);
+    when(tConfig.getTableVersion()).thenReturn(HoodieTableVersion.NINE);
+    when(wConfig.shouldWritePartialUpdates()).thenReturn(false);
+    when(tConfig.getPartialUpdateMode()).thenReturn(Option.of(PartialUpdateMode.FILL_UNCHANGED));
+
+    // Should not throw.
+    CommonClientUtils.validateTableVersion(tConfig, wConfig);
   }
 
   @Test

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
@@ -69,6 +69,9 @@ public class DebeziumConstants {
   // Other Constants
   public static final String DELETE_OP = "d";
 
+  // Struct column under which the Debezium metadata columns are grouped when nested fields are enabled.
+  public static final String DEBEZIUM_METADATA_FIELD = "_debezium_metadata";
+
   // List of meta data columns
   public static List<String> META_COLUMNS = Collections.unmodifiableList(Arrays.asList(
       FLATTENED_OP_COL_NAME,

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
@@ -48,6 +48,10 @@ public class DebeziumConstants {
   public static final String INCOMING_SOURCE_LSN_FIELD = "source.lsn";
   public static final String INCOMING_SOURCE_XMIN_FIELD = "source.xmin";
 
+  // INPUT COLUMNS SPECIFIC TO ORACLE
+  public static final String INCOMING_SOURCE_SCN_FIELD = "source.scn";
+  public static final String INCOMING_SOURCE_COMMIT_SCN_FIELD = "source.commit_scn";
+
   // OUTPUT COLUMNS
   public static final String FLATTENED_OP_COL_NAME = "_change_operation_type";
   public static final String UPSTREAM_PROCESSING_TS_COL_NAME = "_upstream_event_processed_ts_ms";
@@ -65,6 +69,15 @@ public class DebeziumConstants {
   // OUTPUT COLUMNS SPECIFIC TO POSTGRES
   public static final String FLATTENED_LSN_COL_NAME = "_event_lsn";
   public static final String FLATTENED_XMIN_COL_NAME = "_event_xmin";
+
+  // OUTPUT COLUMNS SPECIFIC TO ORACLE
+  public static final String FLATTENED_SCN_COL_NAME = "_event_scn";
+  public static final String FLATTENED_COMMIT_SCN_COL_NAME = "_event_commit_scn";
+  // Composite event-time ordering column for Oracle: zero-padded "commit_scn.scn", materialized at
+  // the root level by the transformer (so it is not nested even when metadata nesting is enabled).
+  public static final String FLATTENED_ORDERING_COL_NAME = "_event_ordering";
+  // Comma-separated list of data columns that changed in an Oracle CDC update event.
+  public static final String CHANGED_COLUMNS_FIELD = "_changed_columns";
 
   // Other Constants
   public static final String DELETE_OP = "d";
@@ -109,6 +122,11 @@ public class DebeziumConstants {
     if (MySqlDebeziumAvroPayload.class.getName().equals(payloadClassName)) {
       String prefix = nestedMetadataEnabled ? DEBEZIUM_METADATA_FIELD + "." : "";
       return prefix + FLATTENED_FILE_COL_NAME + "," + prefix + FLATTENED_POS_COL_NAME;
+    }
+    if (OracleDebeziumAvroPayload.class.getName().equals(payloadClassName)) {
+      // The Oracle composite ordering column is materialized at the root level regardless of metadata
+      // nesting, so it needs no _debezium_metadata prefix.
+      return FLATTENED_ORDERING_COL_NAME;
     }
     return null;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
@@ -68,6 +68,9 @@ public class DebeziumConstants {
 
   // Other Constants
   public static final String DELETE_OP = "d";
+  // Snapshot ("read") operation emitted by Debezium for rows captured during an initial or
+  // incremental snapshot rather than from the transaction log.
+  public static final String SNAPSHOT_OP = "r";
 
   // Struct column under which the Debezium metadata columns are grouped when nested fields are enabled.
   public static final String DEBEZIUM_METADATA_FIELD = "_debezium_metadata";
@@ -82,5 +85,32 @@ public class DebeziumConstants {
       FLATTENED_XMIN_COL_NAME,
       FLATTENED_SHARD_NAME
   ));
+
+  /**
+   * Resolves the canonical ordering field(s) for a Debezium payload, or {@code null} for any other
+   * payload (in which case the caller keeps its own ordering field). This is the single source of
+   * truth for the ordering field that the {@code *DebeziumAvroPayload} merge relies on, shared by
+   * every write path that creates a Debezium table (Hudi Streamer, Spark, Flink).
+   *
+   * <p>The Postgres LSN and the operation-type column stay at the root level even when the
+   * transformer groups the CDC metadata under the {@link #DEBEZIUM_METADATA_FIELD} struct, so the
+   * Postgres ordering field is always {@code _event_lsn}. The MySQL binlog coordinates move into that
+   * struct when nesting is enabled, so the MySQL ordering field is resolved against the nested path.
+   *
+   * @param payloadClassName fully-qualified payload class name (may be {@code null}).
+   * @param nestedMetadataEnabled whether the Debezium transformer nests the CDC metadata columns
+   *                              under the {@link #DEBEZIUM_METADATA_FIELD} struct.
+   * @return the ordering field(s) for a Debezium payload, or {@code null} for any other payload.
+   */
+  public static String resolveOrderingFields(String payloadClassName, boolean nestedMetadataEnabled) {
+    if (PostgresDebeziumAvroPayload.class.getName().equals(payloadClassName)) {
+      return FLATTENED_LSN_COL_NAME;
+    }
+    if (MySqlDebeziumAvroPayload.class.getName().equals(payloadClassName)) {
+      String prefix = nestedMetadataEnabled ? DEBEZIUM_METADATA_FIELD + "." : "";
+      return prefix + FLATTENED_FILE_COL_NAME + "," + prefix + FLATTENED_POS_COL_NAME;
+    }
+    return null;
+  }
 }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/OracleDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/OracleDebeziumAvroPayload.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.model.PartialUpdateAvroPayload;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.generic.IndexedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE;
+
+/**
+ * Payload for Oracle Debezium CDC events, designed to work with {@code OracleDebeziumTransformer}.
+ *
+ * <p>Extends {@link PartialUpdateAvroPayload} for preCombine scaffolding and ordering support,
+ * but <b>fully overrides</b> the merge logic in {@link #combineAndGetUpdateValue} and
+ * {@link #preCombine} with Oracle-specific handling:
+ * <ul>
+ *   <li><b>changed_columns awareness:</b> The transformer populates a {@code _changed_columns} field
+ *       with comma-separated names of columns whose before/after values differ. During merge, if a
+ *       field is in {@code _changed_columns}, the incoming value is used (even if null); otherwise the
+ *       previous stored value is preserved (the column was unchanged or absent from the after image).</li>
+ *   <li><b>Toasted value handling:</b> Columns with {@value PostgresDebeziumAvroPayload#DEBEZIUM_TOASTED_VALUE}
+ *       are replaced with the existing stored value.</li>
+ * </ul>
+ *
+ * <p>Ordering is based on the composite {@code _event_ordering} field (zero-padded commit_scn.scn),
+ * configured via {@code hoodie.payload.ordering.field}.
+ *
+ * <p><b>Note on table versions.</b> On table version 9 (and beyond) Oracle CDC merging is handled by
+ * the built-in {@code EVENT_TIME_ORDERING} merge mode combined with the {@code FILL_UNCHANGED} partial
+ * update mode (see {@code HoodieTableConfig.handlePartialUpdateModeConfigs}); this payload is not
+ * invoked at read time there. It remains the merge implementation for older (payload-based) tables and
+ * the identifier the table-config inference keys on to derive the v9 merge configuration.
+ *
+ * <p><b>Scope of use — Debezium ingestion only.</b> This payload's correctness arguments depend on
+ * source-side invariants that only the Oracle Debezium connector guarantees:
+ * <ul>
+ *   <li>Every record carries the Debezium envelope fields ({@code op}, {@code _changed_columns},
+ *       {@code _event_ordering}, {@code _hoodie_is_deleted}) populated by {@code OracleDebeziumTransformer}.</li>
+ *   <li>Event semantics follow Oracle redo-log DML: an INSERT (op='c') carries full real column
+ *       values in its {@code after} image; an UPDATE (op='u') carries the diff via
+ *       {@code _changed_columns}; a DELETE (op='d') under PK-only supplemental logging carries
+ *       only the PK plus placeholder zeros for other columns. In particular, an UPDATE is never
+ *       emitted for a non-existent PK — Oracle requires the row to exist, so any UPDATE has a
+ *       preceding INSERT.</li>
+ *   <li>Ordering values come from monotonically-increasing Oracle SCNs.</li>
+ * </ul>
+ * <b>Do not use this payload for non-Debezium write paths</b> — direct Spark SQL writes, the
+ * Hudi DataSource API, bulk inserts, backfills, custom transformer chains, or any path that
+ * doesn't go through {@code OracleDebeziumTransformer}. Such paths can easily violate the assumptions
+ * above (missing op field, missing {@code _changed_columns}, UPDATE emitted without a prior INSERT,
+ * non-SCN ordering values) and produce silently incorrect merge results. For non-CDC writes, use the
+ * standard Hudi payloads (e.g., {@link OverwriteWithLatestAvroPayload}).
+ */
+public class OracleDebeziumAvroPayload extends PartialUpdateAvroPayload {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OracleDebeziumAvroPayload.class);
+
+  /**
+   * Metadata/internal fields that are not user data columns. These should always take the newer
+   * record's value during merge since they reflect the event that was applied, not user data
+   * subject to supplemental logging fallbacks.
+   */
+  private static final Set<String> METADATA_FIELDS = new HashSet<>(Arrays.asList(
+      // Note: CHANGED_COLUMNS_FIELD is intentionally excluded — it has custom merge logic above.
+      DebeziumConstants.FLATTENED_SCN_COL_NAME,
+      DebeziumConstants.FLATTENED_COMMIT_SCN_COL_NAME,
+      DebeziumConstants.FLATTENED_ORDERING_COL_NAME,
+      // Nested-mode layout (the production default): scn/commit_scn/timestamps/shard arrive inside
+      // this single struct column instead of the flat columns above. It must take the newer event's
+      // value like the rest.
+      DebeziumConstants.DEBEZIUM_METADATA_FIELD,
+      DebeziumConstants.FLATTENED_OP_COL_NAME,
+      DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME,
+      DebeziumConstants.FLATTENED_SHARD_NAME,
+      DebeziumConstants.FLATTENED_TS_COL_NAME,
+      HoodieRecord.HOODIE_IS_DELETED_FIELD
+  ));
+
+  public OracleDebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {
+    super(record, orderingVal);
+  }
+
+  public OracleDebeziumAvroPayload(Option<GenericRecord> record) {
+    super(record);
+  }
+
+  /**
+   * Recognize a Debezium delete via the op field ({@code _change_operation_type == "d"}) in
+   * addition to the inherited {@code _hoodie_is_deleted}-based check. Mirrors
+   * {@code AbstractDebeziumAvroPayload}'s Postgres/MySQL behavior.
+   *
+   * <p>Why this is necessary: Hudi's MOR snapshot-read delete filter consults the table's
+   * read schema via {@code DeleteContext.hasBuiltInDeleteField}, which only fires when the
+   * read schema contains {@code _hoodie_is_deleted}. If a pipeline's schema provider strips
+   * that meta-field from the target schema for any reason, Debezium delete events flow
+   * through MOR snapshot reads as "zombie" rows (NULL data + the original recordkey) until
+   * compaction merges them away.
+   *
+   * <p>By overriding {@code isDeleteRecord} to also check the Debezium op field — which is
+   * always part of the data columns produced by {@code AbstractDebeziumTransformer} — the
+   * {@code isDeletedRecord} flag on {@code BaseAvroPayload} is set correctly at payload
+   * construction time, even if {@code _hoodie_is_deleted} is absent. That flag drives
+   * {@code BaseAvroPayload.isDeleted(schema, props)}, which the reader uses for snapshot-read
+   * filtering, so deletes are filtered before compaction.
+   *
+   * <p>{@link #mergeOldRecordWithModifiedColumns} also benefits via polymorphism: its
+   * {@code isDeleteRecord(newerRecord)} / {@code isDeleteRecord(olderRecord)} calls
+   * resolve to this override, so the compaction-time merge path picks up the op-based
+   * signal too.
+   */
+  @Override
+  protected boolean isDeleteRecord(GenericRecord record) {
+    return isDebeziumDeleteRecord(record) || super.isDeleteRecord(record);
+  }
+
+  private static boolean isDebeziumDeleteRecord(GenericRecord record) {
+    if (record == null) {
+      return false;
+    }
+    Schema.Field opField = record.getSchema().getField(DebeziumConstants.FLATTENED_OP_COL_NAME);
+    if (opField == null) {
+      return false;
+    }
+    Object value = record.get(DebeziumConstants.FLATTENED_OP_COL_NAME);
+    return value != null && DebeziumConstants.DELETE_OP.equalsIgnoreCase(value.toString());
+  }
+
+  /**
+   * Bypass the inherited delete-check for the (Schema, Properties) overload: return the actual
+   * record bytes even when the payload is flagged as a delete. This is a workaround for
+   * unchecked {@code .get()} call sites in {@code HoodieAvroRecord} that throw
+   * {@code NoSuchElementException} when a delete payload flows through schema-evolution paths
+   * ({@code rewriteRecordWithNewSchema}, {@code truncateRecordKey},
+   * {@code wrapIntoHoodieRecordPayloadWithParams}, {@code prependMetaFields}).
+   *
+   * <p>The delete marker ({@code _hoodie_is_deleted=true}) is preserved on the returned record,
+   * so downstream callers that check {@code BaseAvroPayload.isDeleted(...)} (used by
+   * {@code HoodieAvroRecord.isDelete} for BaseAvroPayload subclasses) still treat it as a
+   * delete. The single-argument {@code getInsertValue(Schema)} is unchanged — callers that
+   * rely on empty-return for delete filtering continue to get the standard behavior.
+   *
+   * <p>This override is a bandaid — the proper fix is to add {@code isPresent()} guards in
+   * {@code HoodieAvroRecord}. Remove this override once that fix ships.
+   */
+  @Override
+  public Option<IndexedRecord> getInsertValue(Schema schema, Properties props) throws IOException {
+    byte[] bytes = getRecordBytes();
+    if (bytes.length == 0) {
+      // Payload was constructed with a null record — genuinely nothing to return.
+      return Option.empty();
+    }
+    // Return the record regardless of isDeletedRecord flag.
+    return Option.of((IndexedRecord) HoodieAvroUtils.bytesToAvro(bytes, schema));
+  }
+
+  @Override
+  public OracleDebeziumAvroPayload preCombine(OverwriteWithLatestAvroPayload oldValue, Schema schema, Properties properties) {
+    if (isEmptyRecord()) {
+      return this;
+    }
+    final boolean shouldPickOldRecord = oldValue.getOrderingVal().compareTo(getOrderingVal()) > 0;
+    try {
+      Option<IndexedRecord> oldRecordOpt = oldValue.getInsertValue(schema);
+      if (!oldRecordOpt.isPresent()) {
+        // oldValue is a delete record
+        if (shouldPickOldRecord) {
+          // Delete has higher ordering — it should win. Return the delete payload as-is.
+          return (OracleDebeziumAvroPayload) oldValue;
+        }
+        // This (non-delete) has higher ordering — it wins
+        return this;
+      }
+      GenericRecord oldRecord = (GenericRecord) oldRecordOpt.get();
+      Option<IndexedRecord> mergedRecord = mergeOldRecordWithModifiedColumns(oldRecord, schema, shouldPickOldRecord, true);
+      if (mergedRecord.isPresent()) {
+        return new OracleDebeziumAvroPayload((GenericRecord) mergedRecord.get(),
+            shouldPickOldRecord ? oldValue.getOrderingVal() : this.getOrderingVal());
+      }
+    } catch (Exception ex) {
+      LOG.error("OracleDebeziumAvroPayload preCombine failed, falling back to incoming record", ex);
+      return this;
+    }
+    return this;
+  }
+
+  /**
+   * Merges incoming record with the current stored record. Without Properties, the ordering field
+   * cannot be extracted from the current record, so the incoming record is always treated as newer.
+   * Use the Properties overload for correct out-of-order handling.
+   */
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+    return mergeOldRecordWithModifiedColumns(currentValue, schema, false, false);
+  }
+
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Properties prop) throws IOException {
+    return mergeOldRecordWithModifiedColumns(currentValue, schema, isCurrentRecordNewer(currentValue, prop), false);
+  }
+
+  private boolean isCurrentRecordNewer(IndexedRecord currentRecord, Properties prop) {
+    String[] orderingFields = ConfigUtils.getOrderingFields(prop);
+    if (orderingFields != null) {
+      boolean consistentLogicalTimestampEnabled = Boolean.parseBoolean(prop.getProperty(
+          KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+          KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()));
+      Comparable currentOrderingVal = OrderingValues.create(
+          orderingFields,
+          field -> (Comparable) HoodieAvroUtils.getNestedFieldVal((GenericRecord) currentRecord, field, true, consistentLogicalTimestampEnabled));
+      return currentOrderingVal != null
+          && OrderingValues.isSameClass(currentOrderingVal, getOrderingVal())
+          && currentOrderingVal.compareTo(getOrderingVal()) > 0;
+    }
+    return false;
+  }
+
+  private Option<IndexedRecord> mergeOldRecordWithModifiedColumns(
+      IndexedRecord oldRecord, Schema schema, boolean isOldRecordNewer, boolean isPreCombining) throws IOException {
+    // Pass isPreCombining=true to bypass the inherited delete-check in
+    // PartialUpdateAvroPayload.getInsertValue, so a delete payload's content is still
+    // accessible here; actual delete signalling happens at the isDeleteRecord(newerRecord)
+    // branch below. Empty here means the payload was constructed with a null record (no
+    // bytes) — match Postgres/MySQL and signal delete via empty-return.
+    Option<IndexedRecord> recordOption = getInsertValue(schema, true);
+    if (!recordOption.isPresent()) {
+      return Option.empty();
+    }
+
+    GenericRecord incomingRecord = (GenericRecord) recordOption.get();
+    GenericRecord storedRecord = (GenericRecord) oldRecord;
+
+    // newerRecord: the record with higher _event_ordering — its non-null values take priority.
+    // olderRecord: provides fallback values when newerRecord's fields are null/toasted.
+    GenericRecord newerRecord = isOldRecordNewer ? storedRecord : incomingRecord;
+    GenericRecord olderRecord = isOldRecordNewer ? incomingRecord : storedRecord;
+
+    if (isDeleteRecord(newerRecord)) {
+      if (isPreCombining) {
+        // preCombine: propagate the delete marker forward in the in-memory buffer so it can
+        // be persisted as a tombstone and re-applied during the next merge.
+        return Option.of(newerRecord);
+      }
+      // combineAndGetUpdateValue: emit empty — this is Hudi's standard delete signal. The
+      // reader / compaction path drops the row from the output when the merge returns empty.
+      // Emitting a non-empty tombstone record instead would leave the row visible in reads
+      // (a soft-delete marker with _hoodie_is_deleted=true isn't filtered by default).
+      return Option.empty();
+    }
+
+    // If the older record is a delete tombstone, its non-PK field values are unreliable
+    // (Oracle PK-only supplemental logging leaves null / zero-value placeholders in the
+    // `before` image of delete events). Skip the field merge entirely and emit the newer
+    // record as-is. Under the Debezium CDC contract (see class-level javadoc), newerRecord
+    // in this branch is always an INSERT (op='c') or SNAPSHOT (op='r') because Oracle never
+    // emits an UPDATE for a non-existent PK — any UPDATE has a preceding INSERT that
+    // collapses the tombstone before this pairing occurs. Both INSERT and SNAPSHOT events
+    // carry full real column values in their `after` image (PK-only supplemental logging
+    // does not affect INSERTs), so emitting newerRecord as-is is correct.
+    // WARNING: this argument holds only for the Debezium ingestion path. If this payload
+    // is ever used with non-Debezium writes (Spark SQL, DataSource API, bulk inserts), the
+    // newerRecord-is-always-an-INSERT invariant no longer holds.
+    if (isDeleteRecord(olderRecord)) {
+      return Option.of(newerRecord);
+    }
+
+    // Extract _changed_columns from both records.
+    // newerChangedCols lists columns whose values changed in the newer record's CDC event.
+    Set<String> newerChangedCols = extractChangedColumns(newerRecord);
+    Set<String> olderChangedCols = extractChangedColumns(olderRecord);
+
+    GenericRecordBuilder builder = new GenericRecordBuilder(schema);
+    for (Schema.Field field : schema.getFields()) {
+      String fieldName = field.name();
+      Object newerValue = newerRecord.get(fieldName);
+      Object olderValue = olderRecord.get(fieldName);
+
+      if (fieldName.equals(DebeziumConstants.CHANGED_COLUMNS_FIELD)) {
+        // _changed_columns on the merged record = union of both sides' changed sets.
+        // See mergeChangedColumnsSets javadoc for why we do NOT trim columns here.
+        Set<String> resultChanged = mergeChangedColumnsSets(newerChangedCols, olderChangedCols);
+        builder.set(field, resultChanged.isEmpty() ? null : String.join(",", resultChanged));
+        continue;
+      }
+
+      if (METADATA_FIELDS.contains(fieldName)) {
+        // Metadata/internal fields always take the newer record's value — they reflect the
+        // event that was applied. The transformer guarantees these fields are populated.
+        builder.set(field, newerValue);
+      } else if (isToastedValue(newerValue, field)) {
+        // Toasted value in newer record -> fall back to older record's value.
+        builder.set(field, olderValue);
+      } else if (newerChangedCols.contains(fieldName)) {
+        // Field was changed in the newer CDC event -> use incoming value (even if null).
+        builder.set(field, newerValue);
+      } else if (!newerChangedCols.isEmpty()) {
+        // Update event (has _changed_columns) but this field is NOT in the changed set.
+        // Preserve the older value — the stored value is the source of truth for unchanged
+        // columns, including a legitimate null.
+        builder.set(field, olderValue);
+      } else {
+        // No _changed_columns present (insert, snapshot, or legacy record without change
+        // tracking). Inserts/snapshots are authoritative — the `after` image is the full row
+        // state. Use newerValue as-is, including a legitimate null.
+        builder.set(field, newerValue);
+      }
+    }
+
+    return Option.of(builder.build());
+  }
+
+  /**
+   * Extracts the set of column names from the {@code _changed_columns} field.
+   * These are columns whose values changed between before and after images.
+   */
+  private Set<String> extractChangedColumns(GenericRecord record) {
+    Schema.Field field = record.getSchema().getField(DebeziumConstants.CHANGED_COLUMNS_FIELD);
+    if (field == null) {
+      return Collections.emptySet();
+    }
+    Object value = record.get(DebeziumConstants.CHANGED_COLUMNS_FIELD);
+    if (value == null) {
+      return Collections.emptySet();
+    }
+    String str = value.toString();
+    if (str.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return new HashSet<>(Arrays.asList(str.split(",")));
+  }
+
+  /**
+   * Merges two sets of changed columns into the union. We intentionally do NOT trim columns
+   * that already have real values in the newer record: {@code _changed_columns} tracks which
+   * columns were reliably delivered by a CDC event, and downstream merges depend on this
+   * tracking to distinguish real values from placeholder values for non-PK columns under
+   * Oracle PK-only supplemental logging. Trimming it would cause unchanged NOT NULL columns
+   * to be overwritten by zero-value placeholders in subsequent merges (the next
+   * {@code mergeOldRecordWithModifiedColumns} call would see an empty
+   * {@code newerChangedCols} and fall into the insert/snapshot branch that emits
+   * {@code newerValue} as-is).
+   */
+  private Set<String> mergeChangedColumnsSets(Set<String> newerChanged, Set<String> olderChanged) {
+    Set<String> result = new HashSet<>(newerChanged);
+    result.addAll(olderChanged);
+    return result;
+  }
+
+  private boolean isToastedValue(Object value, Schema.Field field) {
+    if (value == null) {
+      return false;
+    }
+    return isStringToasted(value, field) || isBytesToasted(value, field);
+  }
+
+  private boolean isStringToasted(Object value, Schema.Field field) {
+    Schema.Type type = field.schema().getType();
+    if (type != Schema.Type.STRING
+        && !(type == Schema.Type.UNION && hasType(field.schema(), Schema.Type.STRING))) {
+      return false;
+    }
+    CharSequence charSeq = (CharSequence) value;
+    return charSeq.length() == DEBEZIUM_TOASTED_VALUE.length()
+        && DEBEZIUM_TOASTED_VALUE.equals(charSeq.toString());
+  }
+
+  private boolean isBytesToasted(Object value, Schema.Field field) {
+    Schema.Type type = field.schema().getType();
+    if (type != Schema.Type.BYTES
+        && !(type == Schema.Type.UNION && hasType(field.schema(), Schema.Type.BYTES))) {
+      return false;
+    }
+    byte[] bytes = ((ByteBuffer) value).array();
+    return bytes.length == DEBEZIUM_TOASTED_VALUE.length()
+        && DEBEZIUM_TOASTED_VALUE.equals(new String(bytes, StandardCharsets.UTF_8));
+  }
+
+  private static boolean hasType(Schema unionSchema, Schema.Type targetType) {
+    for (Schema s : unionSchema.getTypes()) {
+      if (s.getType() == targetType) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/OracleDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/OracleDebeziumAvroPayload.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.common.model.debezium;
 
-import org.apache.hudi.avro.HoodieAvroUtils;
+import org.apache.hudi.common.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -850,6 +850,16 @@ public class HoodieTableConfig extends HoodieConfig {
                                                                           String recordMergeStrategyId,
                                                                           String orderingFieldName,
                                                                           HoodieTableVersion tableVersion) {
+    return inferMergingConfigsForV9TableCreation(recordMergeMode, payloadClassName, recordMergeStrategyId,
+        orderingFieldName, tableVersion, false);
+  }
+
+  public static Map<String, String> inferMergingConfigsForV9TableCreation(RecordMergeMode recordMergeMode,
+                                                                          String payloadClassName,
+                                                                          String recordMergeStrategyId,
+                                                                          String orderingFieldName,
+                                                                          HoodieTableVersion tableVersion,
+                                                                          boolean nestedDebeziumMetadataEnabled) {
     Map<String, String> reconciledConfigs = new HashMap<>();
     if (tableVersion.lesserThan(HoodieTableVersion.NINE)) {
       throw new HoodieIOException("Unsupported flow for table versions less than 9");
@@ -895,7 +905,7 @@ public class HoodieTableConfig extends HoodieConfig {
         // Additional custom merge properties.s
         // Certain payloads are migrated to non payload way from 1.1 Hudi binary and the reader might need certain properties for the
         // merge to function as expected. Handing such special cases here.
-        handlePayloadAdhocConfigs(payloadClassName, reconciledConfigs);
+        handlePayloadAdhocConfigs(payloadClassName, reconciledConfigs, nestedDebeziumMetadataEnabled);
       }
     }
     return reconciledConfigs;
@@ -923,22 +933,37 @@ public class HoodieTableConfig extends HoodieConfig {
     }
   }
 
-  private static void handlePayloadAdhocConfigs(String payloadClassName, Map<String, String> reconciledConfigs) {
+  private static void handlePayloadAdhocConfigs(String payloadClassName, Map<String, String> reconciledConfigs,
+                                                boolean nestedDebeziumMetadataEnabled) {
     // Certain payloads are migrated to non payload way from 1.1 Hudi binary and the reader might need certain properties for the
     // merge to function as expected. Handing such special cases here.
     if (payloadClassName.equals(PostgresDebeziumAvroPayload.class.getName())) {
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + PARTIAL_UPDATE_UNAVAILABLE_VALUE, DEBEZIUM_UNAVAILABLE_VALUE);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, DebeziumConstants.FLATTENED_OP_COL_NAME);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER, DebeziumConstants.DELETE_OP);
+      // The Postgres ordering field (_event_lsn) and the operation-type column are kept at the root level
+      // even when nested fields are enabled, so they need no _debezium_metadata prefix.
       reconciledConfigs.put(ORDERING_FIELDS.key(), DebeziumConstants.FLATTENED_LSN_COL_NAME);
     } else if (payloadClassName.equals(MySqlDebeziumAvroPayload.class.getName())) {
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, DebeziumConstants.FLATTENED_OP_COL_NAME);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER, DebeziumConstants.DELETE_OP);
-      reconciledConfigs.put(ORDERING_FIELDS.key(), DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME);
+      // The MySQL ordering fields (_event_bin_file, _event_pos) are moved into the _debezium_metadata struct
+      // when nested fields are enabled, so the ordering field config must reference the nested path.
+      reconciledConfigs.put(ORDERING_FIELDS.key(),
+          maybeNestColumn(DebeziumConstants.FLATTENED_FILE_COL_NAME, nestedDebeziumMetadataEnabled)
+              + "," + maybeNestColumn(DebeziumConstants.FLATTENED_POS_COL_NAME, nestedDebeziumMetadataEnabled));
     } else if (payloadClassName.equals(AWSDmsAvroPayload.class.getName())) {
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, OP_FIELD);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER, DELETE_OPERATION_VALUE);
     }
+  }
+
+  /**
+   * Prefixes a flattened Debezium column with the {@link DebeziumConstants#DEBEZIUM_METADATA_FIELD} struct
+   * path when nested fields are enabled; returns the column unchanged otherwise.
+   */
+  private static String maybeNestColumn(String column, boolean nestedDebeziumMetadataEnabled) {
+    return nestedDebeziumMetadataEnabled ? DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + column : column;
   }
 
   /**
@@ -950,9 +975,24 @@ public class HoodieTableConfig extends HoodieConfig {
                                                                                      String recordMergeStrategyId,
                                                                                      String orderingFieldNamesAsString,
                                                                                      HoodieTableVersion tableVersion) {
+    return inferMergingConfigsForWrites(recordMergeMode, payloadClassName, recordMergeStrategyId,
+        orderingFieldNamesAsString, tableVersion, false);
+  }
+
+  /**
+   * @param nestedDebeziumMetadataEnabled when true, Debezium CDC metadata columns are nested under the
+   *     {@link DebeziumConstants#DEBEZIUM_METADATA_FIELD} struct, so the inferred ordering field(s) for
+   *     Debezium payloads must be resolved against that nested path.
+   */
+  public static Triple<RecordMergeMode, String, String> inferMergingConfigsForWrites(RecordMergeMode recordMergeMode,
+                                                                                     String payloadClassName,
+                                                                                     String recordMergeStrategyId,
+                                                                                     String orderingFieldNamesAsString,
+                                                                                     HoodieTableVersion tableVersion,
+                                                                                     boolean nestedDebeziumMetadataEnabled) {
     if (tableVersion.greaterThanOrEquals(HoodieTableVersion.NINE)) {
       Map<String, String> inferredMergingConfigs = inferMergingConfigsForV9TableCreation(
-          recordMergeMode, payloadClassName, recordMergeStrategyId, orderingFieldNamesAsString, tableVersion);
+          recordMergeMode, payloadClassName, recordMergeStrategyId, orderingFieldNamesAsString, tableVersion, nestedDebeziumMetadataEnabled);
       checkArgument(inferredMergingConfigs.containsKey(HoodieTableConfig.RECORD_MERGE_MODE.key()));
       return Triple.of(
           RecordMergeMode.valueOf(inferredMergingConfigs.get(RECORD_MERGE_MODE.key())),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -850,16 +850,6 @@ public class HoodieTableConfig extends HoodieConfig {
                                                                           String recordMergeStrategyId,
                                                                           String orderingFieldName,
                                                                           HoodieTableVersion tableVersion) {
-    return inferMergingConfigsForV9TableCreation(recordMergeMode, payloadClassName, recordMergeStrategyId,
-        orderingFieldName, tableVersion, false);
-  }
-
-  public static Map<String, String> inferMergingConfigsForV9TableCreation(RecordMergeMode recordMergeMode,
-                                                                          String payloadClassName,
-                                                                          String recordMergeStrategyId,
-                                                                          String orderingFieldName,
-                                                                          HoodieTableVersion tableVersion,
-                                                                          boolean nestedDebeziumMetadataEnabled) {
     Map<String, String> reconciledConfigs = new HashMap<>();
     if (tableVersion.lesserThan(HoodieTableVersion.NINE)) {
       throw new HoodieIOException("Unsupported flow for table versions less than 9");
@@ -902,10 +892,10 @@ public class HoodieTableConfig extends HoodieConfig {
         handleMergeModeConfigs(payloadClassName, reconciledConfigs);
         // Partial update mode config.
         handlePartialUpdateModeConfigs(payloadClassName, reconciledConfigs);
-        // Additional custom merge properties.s
+        // Additional custom merge properties.
         // Certain payloads are migrated to non payload way from 1.1 Hudi binary and the reader might need certain properties for the
         // merge to function as expected. Handing such special cases here.
-        handlePayloadAdhocConfigs(payloadClassName, reconciledConfigs, nestedDebeziumMetadataEnabled);
+        handlePayloadAdhocConfigs(payloadClassName, reconciledConfigs, orderingFieldName);
       }
     }
     return reconciledConfigs;
@@ -934,24 +924,18 @@ public class HoodieTableConfig extends HoodieConfig {
   }
 
   private static void handlePayloadAdhocConfigs(String payloadClassName, Map<String, String> reconciledConfigs,
-                                                boolean nestedDebeziumMetadataEnabled) {
+                                                String orderingFieldName) {
     // Certain payloads are migrated to non payload way from 1.1 Hudi binary and the reader might need certain properties for the
     // merge to function as expected. Handing such special cases here.
     if (payloadClassName.equals(PostgresDebeziumAvroPayload.class.getName())) {
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + PARTIAL_UPDATE_UNAVAILABLE_VALUE, DEBEZIUM_UNAVAILABLE_VALUE);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, DebeziumConstants.FLATTENED_OP_COL_NAME);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER, DebeziumConstants.DELETE_OP);
-      // The Postgres ordering field (_event_lsn) and the operation-type column are kept at the root level
-      // even when nested fields are enabled, so they need no _debezium_metadata prefix.
-      reconciledConfigs.put(ORDERING_FIELDS.key(), DebeziumConstants.FLATTENED_LSN_COL_NAME);
+      reconciledConfigs.put(ORDERING_FIELDS.key(), reconcileDebeziumOrderingFields(payloadClassName, orderingFieldName));
     } else if (payloadClassName.equals(MySqlDebeziumAvroPayload.class.getName())) {
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, DebeziumConstants.FLATTENED_OP_COL_NAME);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER, DebeziumConstants.DELETE_OP);
-      // The MySQL ordering fields (_event_bin_file, _event_pos) are moved into the _debezium_metadata struct
-      // when nested fields are enabled, so the ordering field config must reference the nested path.
-      reconciledConfigs.put(ORDERING_FIELDS.key(),
-          maybeNestColumn(DebeziumConstants.FLATTENED_FILE_COL_NAME, nestedDebeziumMetadataEnabled)
-              + "," + maybeNestColumn(DebeziumConstants.FLATTENED_POS_COL_NAME, nestedDebeziumMetadataEnabled));
+      reconciledConfigs.put(ORDERING_FIELDS.key(), reconcileDebeziumOrderingFields(payloadClassName, orderingFieldName));
     } else if (payloadClassName.equals(AWSDmsAvroPayload.class.getName())) {
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, OP_FIELD);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER, DELETE_OPERATION_VALUE);
@@ -959,11 +943,19 @@ public class HoodieTableConfig extends HoodieConfig {
   }
 
   /**
-   * Prefixes a flattened Debezium column with the {@link DebeziumConstants#DEBEZIUM_METADATA_FIELD} struct
-   * path when nested fields are enabled; returns the column unchanged otherwise.
+   * Forces a Debezium payload's ordering field to the canonical column(s) the payload merges on.
+   * The flat form ({@code _event_lsn}, or {@code _event_bin_file,_event_pos}) is used unless the
+   * caller already resolved the nested form — which only the Hudi Streamer does when its transformer
+   * groups the CDC metadata under the {@link DebeziumConstants#DEBEZIUM_METADATA_FIELD} struct — in
+   * which case the nested form is preserved so the payload orders against the nested columns.
+   * Keeping this here (rather than trusting {@code orderingFieldName} verbatim) preserves the
+   * long-standing auto-correction for every create path (Spark, Flink, Streamer).
    */
-  private static String maybeNestColumn(String column, boolean nestedDebeziumMetadataEnabled) {
-    return nestedDebeziumMetadataEnabled ? DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + column : column;
+  private static String reconcileDebeziumOrderingFields(String payloadClassName, String orderingFieldName) {
+    String nestedOrderingFields = DebeziumConstants.resolveOrderingFields(payloadClassName, true);
+    return nestedOrderingFields.equals(orderingFieldName)
+        ? nestedOrderingFields
+        : DebeziumConstants.resolveOrderingFields(payloadClassName, false);
   }
 
   /**
@@ -975,24 +967,9 @@ public class HoodieTableConfig extends HoodieConfig {
                                                                                      String recordMergeStrategyId,
                                                                                      String orderingFieldNamesAsString,
                                                                                      HoodieTableVersion tableVersion) {
-    return inferMergingConfigsForWrites(recordMergeMode, payloadClassName, recordMergeStrategyId,
-        orderingFieldNamesAsString, tableVersion, false);
-  }
-
-  /**
-   * @param nestedDebeziumMetadataEnabled when true, Debezium CDC metadata columns are nested under the
-   *     {@link DebeziumConstants#DEBEZIUM_METADATA_FIELD} struct, so the inferred ordering field(s) for
-   *     Debezium payloads must be resolved against that nested path.
-   */
-  public static Triple<RecordMergeMode, String, String> inferMergingConfigsForWrites(RecordMergeMode recordMergeMode,
-                                                                                     String payloadClassName,
-                                                                                     String recordMergeStrategyId,
-                                                                                     String orderingFieldNamesAsString,
-                                                                                     HoodieTableVersion tableVersion,
-                                                                                     boolean nestedDebeziumMetadataEnabled) {
     if (tableVersion.greaterThanOrEquals(HoodieTableVersion.NINE)) {
       Map<String, String> inferredMergingConfigs = inferMergingConfigsForV9TableCreation(
-          recordMergeMode, payloadClassName, recordMergeStrategyId, orderingFieldNamesAsString, tableVersion, nestedDebeziumMetadataEnabled);
+          recordMergeMode, payloadClassName, recordMergeStrategyId, orderingFieldNamesAsString, tableVersion);
       checkArgument(inferredMergingConfigs.containsKey(HoodieTableConfig.RECORD_MERGE_MODE.key()));
       return Triple.of(
           RecordMergeMode.valueOf(inferredMergingConfigs.get(RECORD_MERGE_MODE.key())),

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -44,6 +44,7 @@ import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
+import org.apache.hudi.common.model.debezium.OracleDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.cdc.HoodieCDCSupplementalLoggingMode;
@@ -137,6 +138,12 @@ public class HoodieTableConfig extends HoodieConfig {
   public static final String HOODIE_TABLE_NAME_KEY = "hoodie.table.name";
   public static final String PARTIAL_UPDATE_UNAVAILABLE_VALUE = "hoodie.write.partial.update.unavailable.value";
   public static final String DEBEZIUM_UNAVAILABLE_VALUE = "__debezium_unavailable_value";
+  // For the FILL_UNCHANGED partial update mode: the name of the record field holding the comma-separated list of data
+  // columns that actually changed in the incoming CDC update event (e.g. Oracle Debezium's `_changed_columns`).
+  public static final String PARTIAL_UPDATE_CHANGED_FIELDS = "hoodie.write.partial.update.changed.fields";
+  // For the FILL_UNCHANGED partial update mode: the comma-separated list of CDC metadata columns that must always be
+  // taken from the newer record (ordering/SCN/op columns) and are never overwritten by the previous version.
+  public static final String PARTIAL_UPDATE_RETAIN_FIELDS = "hoodie.write.partial.update.retain.fields";
   // This prefix is used to set merging related properties.
   // A reader might need to read some writer properties to function as expected,
   // and Hudi stores properties with this prefix so the reader parses these properties to fetch any custom property.
@@ -920,6 +927,10 @@ public class HoodieTableConfig extends HoodieConfig {
       reconciledConfigs.put(PARTIAL_UPDATE_MODE.key(), PartialUpdateMode.IGNORE_DEFAULTS.name());
     } else if (payloadClassName.equals(PostgresDebeziumAvroPayload.class.getName())) {
       reconciledConfigs.put(PARTIAL_UPDATE_MODE.key(), PartialUpdateMode.FILL_UNAVAILABLE.name());
+    } else if (payloadClassName.equals(OracleDebeziumAvroPayload.class.getName())) {
+      // Oracle CDC carries a positive changed-columns list (_changed_columns), so it uses the
+      // changed-columns-driven partial update instead of the sentinel-driven FILL_UNAVAILABLE.
+      reconciledConfigs.put(PARTIAL_UPDATE_MODE.key(), PartialUpdateMode.FILL_UNCHANGED.name());
     }
   }
 
@@ -935,6 +946,28 @@ public class HoodieTableConfig extends HoodieConfig {
     } else if (payloadClassName.equals(MySqlDebeziumAvroPayload.class.getName())) {
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, DebeziumConstants.FLATTENED_OP_COL_NAME);
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER, DebeziumConstants.DELETE_OP);
+      reconciledConfigs.put(ORDERING_FIELDS.key(), reconcileDebeziumOrderingFields(payloadClassName, orderingFieldName));
+    } else if (payloadClassName.equals(OracleDebeziumAvroPayload.class.getName())) {
+      reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, DebeziumConstants.FLATTENED_OP_COL_NAME);
+      reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER, DebeziumConstants.DELETE_OP);
+      // Oracle uses the FILL_UNCHANGED partial update mode driven by the positive changed-columns list. Surface the
+      // changed-columns field and the toasted/unavailable sentinel (a changed string/bytes column carrying the
+      // sentinel falls back to the previous value) to the reader.
+      reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + PARTIAL_UPDATE_UNAVAILABLE_VALUE, DEBEZIUM_UNAVAILABLE_VALUE);
+      reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + PARTIAL_UPDATE_CHANGED_FIELDS, DebeziumConstants.CHANGED_COLUMNS_FIELD);
+      // CDC metadata columns always taken from the newer record during a partial merge (both flat and nested-mode
+      // names are listed; names absent from the schema simply never match).
+      reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + PARTIAL_UPDATE_RETAIN_FIELDS,
+          String.join(",",
+              DebeziumConstants.FLATTENED_SCN_COL_NAME,
+              DebeziumConstants.FLATTENED_COMMIT_SCN_COL_NAME,
+              DebeziumConstants.FLATTENED_ORDERING_COL_NAME,
+              DebeziumConstants.DEBEZIUM_METADATA_FIELD,
+              DebeziumConstants.FLATTENED_OP_COL_NAME,
+              DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME,
+              DebeziumConstants.FLATTENED_SHARD_NAME,
+              DebeziumConstants.FLATTENED_TS_COL_NAME,
+              HoodieRecord.HOODIE_IS_DELETED_FIELD));
       reconciledConfigs.put(ORDERING_FIELDS.key(), reconcileDebeziumOrderingFields(payloadClassName, orderingFieldName));
     } else if (payloadClassName.equals(AWSDmsAvroPayload.class.getName())) {
       reconciledConfigs.put(RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY, OP_FIELD);
@@ -1574,6 +1607,7 @@ public class HoodieTableConfig extends HoodieConfig {
             DefaultHoodieRecordPayload.class.getName(),
             EventTimeAvroPayload.class.getName(),
             MySqlDebeziumAvroPayload.class.getName(),
+            OracleDebeziumAvroPayload.class.getName(),
             OverwriteNonDefaultsWithLatestAvroPayload.class.getName(),
             OverwriteWithLatestAvroPayload.class.getName(),
             PartialUpdateAvroPayload.class.getName(),
@@ -1584,6 +1618,7 @@ public class HoodieTableConfig extends HoodieConfig {
             DefaultHoodieRecordPayload.class.getName(),
             EventTimeAvroPayload.class.getName(),
             MySqlDebeziumAvroPayload.class.getName(),
+            OracleDebeziumAvroPayload.class.getName(),
             PartialUpdateAvroPayload.class.getName(),
             PostgresDebeziumAvroPayload.class.getName())));
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/PartialUpdateMode.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/PartialUpdateMode.java
@@ -40,5 +40,17 @@ public enum PartialUpdateMode {
       + "the changed-columns field is defined using `hoodie.write.partial.update.changed.fields` and the CDC metadata columns "
       + "that must always be taken from the newer record are defined using `hoodie.write.partial.update.retain.fields` in the "
       + "table property.")
+  // Contract and constraints:
+  //  - Records are FULL-SCHEMA, value-level partial: every data column is present, and columns not in the
+  //    changed-columns list carry a placeholder (null/zero) that must NOT win. This is distinct from a
+  //    schema-partial record (fewer columns), which is the IGNORE_DEFAULTS/schema-partial (IS_PARTIAL) path.
+  //  - Because the merge iterates the incoming record's schema, all columns exist in the merged output only
+  //    if the incoming record carries the full table schema. The Oracle Debezium transformer guarantees this
+  //    (it rebuilds the row with every column + the changed-columns list); do not feed genuinely schema-partial
+  //    records to a FILL_UNCHANGED table.
+  //  - INCOMPATIBLE with partial-update writes (`hoodie.write.partial.update.schema`, e.g. Spark MERGE INTO with a
+  //    partial UPDATE SET): a schema-partial IS_PARTIAL log block flips the reader to the KEEP_VALUES merger and
+  //    silently drops this changed-columns logic for the whole file group, letting placeholders win. This
+  //    combination is rejected at write time in HoodieAppendHandle. Write FILL_UNCHANGED tables full-schema only.
   FILL_UNCHANGED
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/PartialUpdateMode.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/PartialUpdateMode.java
@@ -31,5 +31,14 @@ public enum PartialUpdateMode {
   @EnumFieldDescription(
       "For columns having unavailable values in the current record, pick value from previous version of the record during write. "
          + "Unavailable value can be defined using `hoodie.write.partial.update.unavailable.value` in the table property.")
-  FILL_UNAVAILABLE
+  FILL_UNAVAILABLE,
+
+  @EnumFieldDescription(
+      "For change-data-capture sources that emit only the columns that actually changed in an update event (e.g. Oracle "
+      + "Debezium under primary-key-only supplemental logging), pick the incoming value only for the columns listed in the "
+      + "record's changed-columns field and preserve the previous version's value for every other data column. The name of "
+      + "the changed-columns field is defined using `hoodie.write.partial.update.changed.fields` and the CDC metadata columns "
+      + "that must always be taken from the newer record are defined using `hoodie.write.partial.update.retain.fields` in the "
+      + "table property.")
+  FILL_UNCHANGED
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
@@ -37,6 +37,7 @@ import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer;
 import org.apache.hudi.common.util.InternalSchemaCache;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.collection.Triple;
@@ -239,6 +240,16 @@ public class FileGroupReaderSchemaHandler<T> {
     if (mergeMode == RecordMergeMode.EVENT_TIME_ORDERING) {
       List<String> preCombineFields = cfg.getOrderingFields();
       requiredFields.addAll(preCombineFields);
+    }
+    // Add the partial-update changed-columns field (drives the FILL_UNCHANGED merge) so column
+    // pruning keeps it in the read schema. Unlike IGNORE_DEFAULTS / FILL_UNAVAILABLE (which inspect
+    // the data columns' own values), FILL_UNCHANGED reads a separate list column to decide which
+    // columns the incoming record actually changed; without it every unchanged column would fall back
+    // to the incoming placeholder.
+    String changedColumnsField = cfg.getString(
+        HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + HoodieTableConfig.PARTIAL_UPDATE_CHANGED_FIELDS);
+    if (!StringUtils.isNullOrEmpty(changedColumnsField) && tableSchema.getField(changedColumnsField).isPresent()) {
+      requiredFields.add(changedColumnsField);
     }
     // Add `HOODIE_IS_DELETED_FIELD` field if exists.
     if (hasBuiltInDelete) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateHandler.java
@@ -158,9 +158,9 @@ public class PartialUpdateHandler<T> implements Serializable {
     unionChanged.addAll(lowChanged);
     // Reuse an existing record's raw (engine-native) changed-columns value whenever it already equals
     // the union, so the value stored back matches the engine's field storage type exactly. Only the
-    // genuinely-disjoint case needs a synthesized value; materialize it via
-    // convertPartitionValueToEngineType, which yields the unwrapped engine storage form (e.g. a plain
-    // Spark UTF8String) rather than the comparison wrapper convertValueToEngineType would return.
+    // genuinely-disjoint case needs a synthesized value; materialize it via convertValueToEngineType,
+    // which returns the engine-native storage form (e.g. a plain Spark UTF8String) suitable for storing
+    // directly as a field value.
     Object mergedChangedValue;
     if (unionChanged.isEmpty()) {
       mergedChangedValue = null;
@@ -169,7 +169,7 @@ public class PartialUpdateHandler<T> implements Serializable {
     } else if (unionChanged.equals(lowChanged)) {
       mergedChangedValue = lowChangedRaw;
     } else {
-      mergedChangedValue = recordContext.convertPartitionValueToEngineType(String.join(",", unionChanged));
+      mergedChangedValue = recordContext.convertValueToEngineType(String.join(",", unionChanged));
     }
 
     List<HoodieSchemaField> fields = newSchema.getFields();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateHandler.java
@@ -153,10 +153,24 @@ public class PartialUpdateHandler<T> implements Serializable {
     // a column changed solely by the lower record (disjoint updates), letting the base overwrite it with a placeholder.
     // Mirrors the payload's mergeChangedColumnsSets (which likewise does not trim).
     Object lowChangedRaw = recordContext.getValue(lowOrderRecord.getRecord(), lowOrderSchema, changedFieldsCol);
+    Set<String> lowChanged = splitToSet(lowChangedRaw == null ? null : recordContext.getTypeConverter().castToString(lowChangedRaw));
     Set<String> unionChanged = new HashSet<>(changedColumns);
-    unionChanged.addAll(splitToSet(lowChangedRaw == null ? null : recordContext.getTypeConverter().castToString(lowChangedRaw)));
-    Object mergedChangedValue = unionChanged.isEmpty()
-        ? null : recordContext.convertValueToEngineType(String.join(",", unionChanged));
+    unionChanged.addAll(lowChanged);
+    // Reuse an existing record's raw (engine-native) changed-columns value whenever it already equals
+    // the union, so the value stored back matches the engine's field storage type exactly. Only the
+    // genuinely-disjoint case needs a synthesized value; materialize it via
+    // convertPartitionValueToEngineType, which yields the unwrapped engine storage form (e.g. a plain
+    // Spark UTF8String) rather than the comparison wrapper convertValueToEngineType would return.
+    Object mergedChangedValue;
+    if (unionChanged.isEmpty()) {
+      mergedChangedValue = null;
+    } else if (unionChanged.equals(changedColumns)) {
+      mergedChangedValue = changedRaw;
+    } else if (unionChanged.equals(lowChanged)) {
+      mergedChangedValue = lowChangedRaw;
+    } else {
+      mergedChangedValue = recordContext.convertPartitionValueToEngineType(String.join(",", unionChanged));
+    }
 
     List<HoodieSchemaField> fields = newSchema.getFields();
     Object[] fieldVals = new Object[fields.size()];

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/PartialUpdateHandler.java
@@ -26,14 +26,23 @@ import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.PartialUpdateMode;
+import org.apache.hudi.common.util.VisibleForTesting;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_CHANGED_FIELDS;
+import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_RETAIN_FIELDS;
 import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_UNAVAILABLE_VALUE;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX;
 import static org.apache.hudi.common.util.ConfigUtils.extractWithPrefix;
+import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 
 /**
  * This class implements the detailed partial update logic for different partial update modes,
@@ -88,9 +97,117 @@ public class PartialUpdateHandler<T> implements Serializable {
       case FILL_UNAVAILABLE:
         return reconcileMarkerValues(
             highOrderRecord, lowOrderRecord, highOrderSchema, lowOrderSchema, newSchema);
+      case FILL_UNCHANGED:
+        return reconcileChangedColumns(
+            highOrderRecord, lowOrderRecord, highOrderSchema, lowOrderSchema, newSchema);
       default:
         return highOrderRecord;
     }
+  }
+
+  /**
+   * Merge two records using an explicit changed-columns list emitted by the CDC source.
+   *
+   * <p>Unlike {@link #reconcileMarkerValues} (sentinel-driven, string/bytes columns only), this strategy consumes a
+   * comma-separated changed-columns field (e.g. Oracle Debezium's {@code _changed_columns}) carried on the higher-order
+   * record. Only columns listed there take the incoming value; every other data column preserves the previous version's
+   * value, for any column type. This restores partial-update correctness for CDC sources under primary-key-only
+   * supplemental logging, where unchanged columns arrive as null/zero placeholders rather than a marker value.
+   *
+   * <p>CDC metadata columns configured via {@code hoodie.write.partial.update.retain.fields} (ordering/SCN/op, etc.) are
+   * always taken from the higher-order record. When the changed-columns field is null or empty (insert / snapshot / full
+   * before-after image) the higher-order record is returned unchanged.
+   *
+   * @param highOrderRecord record with higher commit time or higher ordering value
+   * @param lowOrderRecord  record with lower commit time or lower ordering value
+   * @param highOrderSchema The schema of highOrderRecord
+   * @param lowOrderSchema  The schema of the older record
+   * @param newSchema       The schema of the new incoming record
+   * @return merged result preserving previous values for columns absent from the changed-columns list.
+   */
+  @VisibleForTesting
+  BufferedRecord<T> reconcileChangedColumns(BufferedRecord<T> highOrderRecord,
+                                            BufferedRecord<T> lowOrderRecord,
+                                            HoodieSchema highOrderSchema,
+                                            HoodieSchema lowOrderSchema,
+                                            HoodieSchema newSchema) {
+    String changedFieldsCol = mergeProperties.get(PARTIAL_UPDATE_CHANGED_FIELDS);
+    // Without a configured changed-columns field there is nothing to reconcile; keep the newer record.
+    if (isNullOrEmpty(changedFieldsCol)) {
+      return highOrderRecord;
+    }
+    Object changedRaw = recordContext.getValue(highOrderRecord.getRecord(), highOrderSchema, changedFieldsCol);
+    String changedStr = changedRaw == null ? null : recordContext.getTypeConverter().castToString(changedRaw);
+    // Null/empty changed-columns denotes an insert, snapshot or full before-after image: take the newer record as-is.
+    if (isNullOrEmpty(changedStr)) {
+      return highOrderRecord;
+    }
+
+    Set<String> changedColumns = splitToSet(changedStr);
+    Set<String> retainFromNewer = splitToSet(mergeProperties.get(PARTIAL_UPDATE_RETAIN_FIELDS));
+    String unavailableMarker = mergeProperties.get(PARTIAL_UPDATE_UNAVAILABLE_VALUE);
+
+    // The merged record's changed-columns field is the UNION of both records' changed sets, not just the higher
+    // record's. A log-vs-log deltaMerge produces an intermediate record later merged against the base, and that base
+    // merge uses this field to decide which columns are authoritative. Keeping only the higher record's set would drop
+    // a column changed solely by the lower record (disjoint updates), letting the base overwrite it with a placeholder.
+    // Mirrors the payload's mergeChangedColumnsSets (which likewise does not trim).
+    Object lowChangedRaw = recordContext.getValue(lowOrderRecord.getRecord(), lowOrderSchema, changedFieldsCol);
+    Set<String> unionChanged = new HashSet<>(changedColumns);
+    unionChanged.addAll(splitToSet(lowChangedRaw == null ? null : recordContext.getTypeConverter().castToString(lowChangedRaw)));
+    Object mergedChangedValue = unionChanged.isEmpty()
+        ? null : recordContext.convertValueToEngineType(String.join(",", unionChanged));
+
+    List<HoodieSchemaField> fields = newSchema.getFields();
+    Object[] fieldVals = new Object[fields.size()];
+    int idx = 0;
+    boolean updated = false;
+    for (HoodieSchemaField field : fields) {
+      String fieldName = field.name();
+      if (fieldName.equals(changedFieldsCol)) {
+        fieldVals[idx++] = mergedChangedValue;
+        updated = true;
+        continue;
+      }
+      boolean takeFromNewer = changedColumns.contains(fieldName) || retainFromNewer.contains(fieldName);
+      if (takeFromNewer) {
+        Object newValue = recordContext.getValue(highOrderRecord.getRecord(), highOrderSchema, fieldName);
+        // Toasted defense: a changed string/bytes column whose incoming value is the unavailable sentinel still falls
+        // back to the previous value (mirrors FILL_UNAVAILABLE).
+        if ((isStringTyped(field) || isBytesTyped(field))
+            && null != unavailableMarker
+            && unavailableMarker.equals(recordContext.getTypeConverter().castToString(newValue))) {
+          fieldVals[idx++] = recordContext.getValue(lowOrderRecord.getRecord(), lowOrderSchema, fieldName);
+          updated = true;
+        } else {
+          fieldVals[idx++] = newValue;
+        }
+      } else {
+        // An unchanged data column: preserve the previous version's value regardless of type.
+        fieldVals[idx++] = recordContext.getValue(lowOrderRecord.getRecord(), lowOrderSchema, fieldName);
+        updated = true;
+      }
+    }
+    if (!updated) {
+      return highOrderRecord;
+    }
+    T engineRecord = recordContext.constructEngineRecord(newSchema, fieldVals);
+    return new BufferedRecord<>(
+        highOrderRecord.getRecordKey(),
+        highOrderRecord.getOrderingValue(),
+        engineRecord,
+        newSchema == highOrderSchema ? highOrderRecord.getSchemaId() : lowOrderRecord.getSchemaId(),
+        highOrderRecord.getHoodieOperation());
+  }
+
+  private static Set<String> splitToSet(String csv) {
+    if (isNullOrEmpty(csv)) {
+      return Collections.emptySet();
+    }
+    return Arrays.stream(csv.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toCollection(HashSet::new));
   }
 
   /**

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestOracleDebeziumAvroPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/debezium/TestOracleDebeziumAvroPayload.java
@@ -1,0 +1,913 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.hudi.common.model.HoodiePayloadProps;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link OracleDebeziumAvroPayload}.
+ */
+class TestOracleDebeziumAvroPayload {
+
+  private Schema schema;
+  private Properties properties;
+
+  // Schema with: id (PK), name (string), amount (long), _changed_columns, _hoodie_is_deleted, _event_ordering
+  private static final String JSON_SCHEMA = "{\n"
+      + "  \"type\": \"record\",\n"
+      + "  \"name\": \"oracleDebeziumRecord\", \"namespace\":\"org.apache.hudi\",\n"
+      + "  \"fields\": [\n"
+      + "    {\"name\": \"id\", \"type\": \"string\"},\n"
+      + "    {\"name\": \"name\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+      + "    {\"name\": \"amount\", \"type\": [\"null\", \"long\"], \"default\": null},\n"
+      + "    {\"name\": \"_changed_columns\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+      + "    {\"name\": \"_hoodie_is_deleted\", \"type\": \"boolean\", \"default\": false},\n"
+      + "    {\"name\": \"_event_ordering\", \"type\": [\"null\", \"string\"], \"default\": null}\n"
+      + "  ]\n"
+      + "}";
+
+  @BeforeEach
+  void setUp() {
+    schema = new Schema.Parser().parse(JSON_SCHEMA);
+    properties = new Properties();
+    properties.put(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, "_event_ordering");
+  }
+
+  @Test
+  void testInsert() throws IOException {
+    GenericRecord record = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(record, (Comparable) record.get("_event_ordering"));
+
+    Option<IndexedRecord> result = payload.getInsertValue(schema);
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    assertEquals("alice", out.get("name").toString());
+    assertEquals(100L, out.get("amount"));
+    assertNull(out.get("_changed_columns"));
+  }
+
+  @Test
+  void testIncomingDeleteNewerThanHealthyExistingReturnsEmpty() throws IOException {
+    // Scenario A3 (incoming delete newer): the newer-resolved record is a delete. In
+    // combineAndGetUpdateValue this signals deletion via empty-return — Hudi's reader /
+    // compaction path drops the row from the output. (preCombine preserves the delete marker,
+    // so the tombstone still lands in log files ahead of this merge.)
+    GenericRecord deleteRecord = createRecord("1", "alice", 100L, null, true, "00000000000200.00000000000060");
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(deleteRecord, (Comparable) deleteRecord.get("_event_ordering"));
+
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(existing, schema, properties);
+    assertFalse(result.isPresent(),
+        "newer-resolved delete must signal deletion via empty-return so the reader drops the row");
+  }
+
+  @Test
+  void testIncomingDeleteOlderThanHealthyExistingEmitsHealthy() throws IOException {
+    // Scenario A3 (incoming delete older): existing healthy record has higher ordering and
+    // should win. The older delete is overruled — emit the merged healthy record.
+    GenericRecord deleteRecord = createRecord("1", "alice", 100L, null, true, "00000000000100.00000000000050");
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(deleteRecord, (Comparable) deleteRecord.get("_event_ordering"));
+
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000200.00000000000060");
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(existing, schema, properties);
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    assertEquals("alice", out.get("name").toString(), "newer healthy record wins");
+    assertFalse((Boolean) out.get("_hoodie_is_deleted"),
+        "older delete is overruled by newer healthy record");
+  }
+
+  @Test
+  void testHealthyAgainstStoredTombstoneIncomingNewerSkipsTombstoneFields() throws IOException {
+    // Scenario A4: stored is a delete tombstone with placeholder non-PK fields (simulating
+    // Oracle PK-only supplemental logging where the delete event's `before` image carries
+    // null/placeholder values for non-PK columns). Incoming healthy update has higher ordering
+    // and _changed_columns covers only some fields.
+    //
+    // Expected: incoming healthy wins; non-PK fields outside _changed_columns must NOT
+    // inherit values from the tombstone — fall back to newer's value (or null) instead.
+    GenericRecord storedTombstone = createRecord("1", null, 0L, null, true, "00000000000100.00000000000050");
+    GenericRecord incomingHealthy = createRecord("1", "bob", 0L, "name", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incomingHealthy, (Comparable) incomingHealthy.get("_event_ordering"));
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(storedTombstone, schema, properties);
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    assertEquals("1", out.get("id").toString());
+    assertEquals("bob", out.get("name").toString(), "name is in _changed_columns -> use incoming");
+    assertEquals(0L, out.get("amount"),
+        "amount not in _changed_columns -> tombstone garbage skipped, falls back to incoming");
+    assertFalse((Boolean) out.get("_hoodie_is_deleted"),
+        "newer healthy record overrides stored _hoodie_is_deleted=true");
+  }
+
+  @Test
+  void testHealthyAgainstStoredTombstoneStoredNewerReturnsEmpty() throws IOException {
+    // Scenario A5: stored delete tombstone has higher ordering than incoming healthy update.
+    // The tombstone wins and combineAndGetUpdateValue returns empty to signal deletion, so
+    // the row is dropped from the read output. (This is the same standard Hudi delete signal
+    // that Postgres/MySQL payloads use.)
+    GenericRecord storedTombstone = createRecord("1", null, 0L, null, true, "00000000000300.00000000000070");
+    GenericRecord incomingHealthy = createRecord("1", "bob", 200L, "name,amount", false, "00000000000100.00000000000050");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incomingHealthy, (Comparable) incomingHealthy.get("_event_ordering"));
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(storedTombstone, schema, properties);
+    assertFalse(result.isPresent(),
+        "stored-newer tombstone must signal deletion via empty-return");
+  }
+
+  @Test
+  void testBothDeleteReturnsEmpty() throws IOException {
+    // Scenario A6: both incoming and stored are delete tombstones. Newer-resolved record is
+    // a delete regardless of which side wins ordering, so combineAndGetUpdateValue returns
+    // empty — the row is dropped.
+    GenericRecord storedTombstone = createRecord("1", "alice", 100L, null, true, "00000000000100.00000000000050");
+    GenericRecord incomingDelete = createRecord("1", null, 0L, null, true, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incomingDelete, (Comparable) incomingDelete.get("_event_ordering"));
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(storedTombstone, schema, properties);
+    assertFalse(result.isPresent(), "delete-vs-delete must signal deletion via empty-return");
+  }
+
+  @Test
+  void testTombstoneOlderDoesNotPolluteUnchangedColumns() throws IOException {
+    // Targeted test: a stored tombstone with PLACEHOLDER values for non-PK fields
+    // (e.g., name="" from Oracle PK-only supplemental logging) must not leak those
+    // placeholders into the merged output for columns absent from _changed_columns.
+    // Without the tombstone-aware fix, name="" would be preserved as the "older value"
+    // since name is not in _changed_columns.
+    GenericRecord storedTombstone = createRecord("1", "" /* placeholder */, 0L /* placeholder */, null, true,
+        "00000000000100.00000000000050");
+    GenericRecord incomingHealthy = createRecord("1", null /* unchanged */, 500L, "amount", false,
+        "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incomingHealthy, (Comparable) incomingHealthy.get("_event_ordering"));
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(storedTombstone, schema, properties);
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    // Without the tombstone-aware fix, name would have been "" (the tombstone placeholder).
+    // With the fix, tombstone is treated as having no usable field values, so name falls
+    // back to incoming's null.
+    assertNull(out.get("name"),
+        "tombstone's placeholder value for unchanged column must NOT leak into merged output");
+    assertEquals(500L, out.get("amount"), "changed column from incoming");
+  }
+
+  @Test
+  void testUpdateWithAllColumnsChanged() throws IOException {
+    // Full update: both name and amount changed
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", "bob", 200L, "name,amount", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertEquals("bob", out.get("name").toString());
+    assertEquals(200L, out.get("amount"));
+  }
+
+  @Test
+  void testUpdateWithUnchangedColumnPreservesExisting() throws IOException {
+    // Only amount changed; name is not in _changed_columns and is null -> preserve existing "alice"
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", null, 200L, "amount", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertEquals("alice", out.get("name").toString(),
+        "name should be preserved from existing record since it's not in _changed_columns");
+    assertEquals(200L, out.get("amount"));
+  }
+
+  @Test
+  void testUpdateWithExplicitNullInChangedColumns() throws IOException {
+    // name changed to NULL (is in _changed_columns) -> keep null
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", null, 200L, "name,amount", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertNull(out.get("name"),
+        "name should be null since it's in _changed_columns (intentional SET NULL)");
+    assertEquals(200L, out.get("amount"));
+  }
+
+  @Test
+  void testUpdateWithZeroValueFallbackPreservesExisting() throws IOException {
+    // Simulates PK-only supplemental logging with NOT NULL columns:
+    // amount has zero-value fallback (0) but is NOT in _changed_columns -> preserve existing 100
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", null, 0L, "name", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertNull(out.get("name"), "name is in _changed_columns -> use incoming null");
+    assertEquals(100L, out.get("amount"),
+        "amount is NOT in _changed_columns -> preserve existing value, not the zero-value fallback");
+  }
+
+  @Test
+  void testUpdateWithEmptyStringFallbackPreservesExisting() throws IOException {
+    // Simulates PK-only supplemental logging with NOT NULL VARCHAR2 column:
+    // name has empty-string fallback ("") but is NOT in _changed_columns -> preserve existing "alice"
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", "", 200L, "amount", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertEquals("alice", out.get("name").toString(),
+        "name is NOT in _changed_columns -> preserve existing value, not the empty-string fallback");
+    assertEquals(200L, out.get("amount"));
+  }
+
+  @Test
+  void testUpdateWithMultipleChangedColumns() throws IOException {
+    // Both name and amount changed to NULL
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", null, null, "name,amount", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertNull(out.get("name"), "name should be null (in _changed_columns)");
+    assertNull(out.get("amount"), "amount should be null (in _changed_columns)");
+  }
+
+  @Test
+  void testUpdateWithToastedValue() throws IOException {
+    // name has __debezium_unavailable_value -> preserve existing value
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", DEBEZIUM_TOASTED_VALUE, 200L, "amount", false,
+        "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertEquals("alice", out.get("name").toString(),
+        "toasted value should be replaced with existing stored value");
+    assertEquals(200L, out.get("amount"));
+  }
+
+  @Test
+  void testUpdateWithNullExistingAndNullIncoming() throws IOException {
+    // Both existing and incoming are null, not in _changed_columns -> stays null (from existing)
+    GenericRecord existing = createRecord("1", null, 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", null, 200L, "amount", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertNull(out.get("name"), "null + null (not in changed) -> null from existing");
+    assertEquals(200L, out.get("amount"));
+  }
+
+  @Test
+  void testOrderingHigherWins() throws IOException {
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000300.00000000000070");
+    GenericRecord incoming = createRecord("1", "bob", 200L, "name,amount", false, "00000000000100.00000000000050");
+
+    // incoming has lower ordering -> existing should win for non-null fields
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertEquals("alice", out.get("name").toString(), "existing has higher ordering, should win");
+    assertEquals(100L, out.get("amount"), "existing has higher ordering, should win");
+    // Metadata fields should always come from the newer (existing) record
+    assertEquals("00000000000300.00000000000070", out.get("_event_ordering").toString(),
+        "_event_ordering should come from the newer record (existing)");
+  }
+
+  @Test
+  void testStoredNewerWithNullRespectsNull() throws IOException {
+    // Existing has higher ordering and name=null (legitimate null — not a tombstone, no toasted
+    // marker). Older incoming says name="bob" but it has lower ordering. The newer record is the
+    // source of truth, so the merged name must be null, NOT the older "bob".
+    //
+    // This is the null-is-real semantic: we don't fall back to older when newer's value is a
+    // legitimate null.
+    GenericRecord existing = createRecord("1", null, 100L, null, false, "00000000000300.00000000000070");
+    GenericRecord incoming = createRecord("1", "bob", 200L, "name,amount", false, "00000000000100.00000000000050");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertNull(out.get("name"),
+        "stored newer record's null is the truth — do not resurrect older 'bob'");
+    assertEquals(100L, out.get("amount"), "stored newer's amount wins");
+  }
+
+  @Test
+  void testUnchangedNullableColumnStoredAsNullStaysNull() throws IOException {
+    // Incoming is an UPDATE that changes only `amount`; `name` is not in _changed_columns.
+    // Stored has name=null (legitimate — the column is nullable and was never set). The
+    // merged output must keep name=null, not overwrite it with incoming's zero-value
+    // placeholder or any other non-null value.
+    GenericRecord existing = createRecord("1", null, 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", "", 500L, "amount", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertNull(out.get("name"),
+        "unchanged column with legitimate null in storage must stay null — "
+            + "do not fall back to incoming's placeholder \"\"");
+    assertEquals(500L, out.get("amount"));
+  }
+
+  @Test
+  void testInsertWithExplicitNullStaysNull() throws IOException {
+    // Incoming is an INSERT (no _changed_columns) with name explicitly null. There is a
+    // stored record for the same PK with name="alice" (unusual but possible via upsert or
+    // out-of-order replay). Under the null-is-real semantic, the insert's null wins — we
+    // do NOT resurrect the stored "alice".
+    GenericRecord existing = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", null, 500L, null, false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(incoming, (Comparable) incoming.get("_event_ordering"));
+    GenericRecord out = (GenericRecord) payload.combineAndGetUpdateValue(existing, schema, properties).get();
+
+    assertNull(out.get("name"),
+        "insert/snapshot with explicit null must stay null — no fallback to older's value");
+    assertEquals(500L, out.get("amount"));
+  }
+
+  @Test
+  void testPreCombinePicksHigherOrdering() throws IOException {
+    GenericRecord record1 = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord record2 = createRecord("1", null, 200L, "amount", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload1 = new OracleDebeziumAvroPayload(record1, (Comparable) record1.get("_event_ordering"));
+    OracleDebeziumAvroPayload payload2 = new OracleDebeziumAvroPayload(record2, (Comparable) record2.get("_event_ordering"));
+
+    // payload2 has higher ordering -> should win, but preserve name from payload1 since payload2.name is null
+    OracleDebeziumAvroPayload merged = payload2.preCombine(payload1, schema, properties);
+    GenericRecord out = (GenericRecord) merged.getInsertValue(schema).get();
+
+    assertEquals("alice", out.get("name").toString(), "name preserved from record1");
+    assertEquals(200L, out.get("amount"), "amount from record2 (higher ordering)");
+  }
+
+  @Test
+  void testPreCombineDeleteWithHigherOrdering() throws IOException {
+    // Delete record has higher ordering -> should win in preCombine
+    GenericRecord insertRecord = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord deleteRecord = createRecord("1", "alice", 100L, null, true, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload insertPayload = new OracleDebeziumAvroPayload(insertRecord, (Comparable) insertRecord.get("_event_ordering"));
+    OracleDebeziumAvroPayload deletePayload = new OracleDebeziumAvroPayload(deleteRecord, (Comparable) deleteRecord.get("_event_ordering"));
+
+    // delete has higher ordering -> delete wins
+    OracleDebeziumAvroPayload merged = insertPayload.preCombine(deletePayload, schema, properties);
+    assertTrue(merged.isDeleted(schema, properties), "Delete with higher ordering should win in preCombine");
+  }
+
+  @Test
+  void testPreCombineDeleteWithLowerOrdering() throws IOException {
+    // Delete record has lower ordering -> insert should win
+    GenericRecord insertRecord = createRecord("1", "alice", 100L, null, false, "00000000000200.00000000000060");
+    GenericRecord deleteRecord = createRecord("1", "alice", 100L, null, true, "00000000000100.00000000000050");
+
+    OracleDebeziumAvroPayload insertPayload = new OracleDebeziumAvroPayload(insertRecord, (Comparable) insertRecord.get("_event_ordering"));
+    OracleDebeziumAvroPayload deletePayload = new OracleDebeziumAvroPayload(deleteRecord, (Comparable) deleteRecord.get("_event_ordering"));
+
+    // insert has higher ordering -> insert wins
+    OracleDebeziumAvroPayload merged = insertPayload.preCombine(deletePayload, schema, properties);
+    assertFalse(merged.isDeleted(schema, properties), "Insert with higher ordering should win over delete in preCombine");
+    GenericRecord out = (GenericRecord) merged.getInsertValue(schema).get();
+    assertEquals("alice", out.get("name").toString());
+  }
+
+  @Test
+  void testCombinedScenario() throws IOException {
+    // Simulate a realistic sequence:
+    // 1. Insert: id=1, name=alice, amount=100
+    // 2. Update: name toasted (unchanged LOB), amount=200
+    // 3. Update: name explicitly set to NULL, amount=300
+
+    GenericRecord insert = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord update1 = createRecord("1", DEBEZIUM_TOASTED_VALUE, 200L, "amount", false,
+        "00000000000200.00000000000060");
+    GenericRecord update2 = createRecord("1", null, 300L, "name,amount", false, "00000000000300.00000000000070");
+
+    // Step 1 -> 2: toasted name preserved
+    OracleDebeziumAvroPayload payload1 = new OracleDebeziumAvroPayload(update1, (Comparable) update1.get("_event_ordering"));
+    GenericRecord after1 = (GenericRecord) payload1.combineAndGetUpdateValue(insert, schema, properties).get();
+    assertEquals("alice", after1.get("name").toString());
+    assertEquals(200L, after1.get("amount"));
+
+    // Step 2 -> 3: name explicitly set to NULL
+    OracleDebeziumAvroPayload payload2 = new OracleDebeziumAvroPayload(update2, (Comparable) update2.get("_event_ordering"));
+    GenericRecord after2 = (GenericRecord) payload2.combineAndGetUpdateValue(after1, schema, properties).get();
+    assertNull(after2.get("name"), "name was explicitly set to NULL via _changed_columns");
+    assertEquals(300L, after2.get("amount"));
+  }
+
+  @Test
+  void testTwoUpdatesPreCombinedThenMergedWithInsertPreservesUnchangedColumns() throws IOException {
+    // Regression test for the production bug where two CDC updates landing in the same
+    // deltastreamer sync cycle (preCombined together) caused the merged result to drop
+    // `_changed_columns` via the trim in mergeChangedColumnsSets. Downstream merge with the
+    // stored INSERT then fell into the insert/snapshot branch and overwrote unchanged NOT
+    // NULL columns with zero-value placeholders from the updates' PK-only supplemental
+    // logging payloads.
+    //
+    // Fix: mergeChangedColumnsSets no longer trims. The union is preserved so subsequent
+    // merges see newerChangedCols populated and take the older (stored) value for unchanged
+    // columns.
+
+    // Stored INSERT (bootstrap or prior INSERT already persisted in the base file).
+    GenericRecord stored = createRecord("1", "stored_name", 999L, null, false,
+        "00000000000000000100.00000000000000000050");
+
+    // Two UPDATEs. Each only changed `amount`. `name` in each is a placeholder (empty /
+    // null) simulating Oracle PK-only supplemental logging where unchanged columns arrive
+    // as zero-value placeholders.
+    GenericRecord update1 = createRecord("1", "", 100L, "amount", false,
+        "00000000000000000200.00000000000000000060");
+    GenericRecord update2 = createRecord("1", "", 200L, "amount", false,
+        "00000000000000000300.00000000000000000070");
+
+    OracleDebeziumAvroPayload p1 = new OracleDebeziumAvroPayload(
+        update1, (Comparable) update1.get("_event_ordering"));
+    OracleDebeziumAvroPayload p2 = new OracleDebeziumAvroPayload(
+        update2, (Comparable) update2.get("_event_ordering"));
+
+    // Step 1: preCombine the two updates (what deltastreamer does when both are in the
+    // same sync cycle).
+    OracleDebeziumAvroPayload precombined = p2.preCombine(p1, schema, properties);
+    GenericRecord precombinedRecord =
+        (GenericRecord) precombined.getInsertValue(schema).get();
+
+    // `_changed_columns` must still contain "amount" after preCombine — the old buggy
+    // trim would have removed it because update2.amount=200 was a real non-null value.
+    assertEquals("amount", precombinedRecord.get("_changed_columns").toString(),
+        "_changed_columns must survive preCombine so downstream merges know `amount` is real");
+
+    // Step 2: merge the preCombined payload against the stored INSERT.
+    GenericRecord finalRec =
+        (GenericRecord) precombined.combineAndGetUpdateValue(stored, schema, properties).get();
+
+    // The pre-existing values must be preserved. Before the fix, `name` would get the
+    // placeholder "" and `_changed_columns`-less merge would treat everything like an insert.
+    assertEquals("stored_name", finalRec.get("name").toString(),
+        "name was not changed by either update — must remain 'stored_name'");
+    assertEquals(200L, finalRec.get("amount"),
+        "amount is in _changed_columns — must be the newer update's value (200)");
+  }
+
+  @Test
+  void testDisjointUpdatesPreCombinedUnionsChangedColumns() throws IOException {
+    // Mirrors production validation ID=501 on the new image: two updates in the same sync
+    // cycle that touch DIFFERENT columns. preCombine must produce the union of changed_cols
+    // and carry each column's value from the update that actually changed it. Downstream
+    // merge with the stored INSERT must then preserve every column whose value has a
+    // trustworthy source.
+    GenericRecord stored = createRecord("1", "stored_name", 999L, null, false,
+        "00000000000000000100.00000000000000000050");
+
+    // U1 only changed `name`. `amount` in U1 is a placeholder 0 (PK-only supplemental logging).
+    GenericRecord update1 = createRecord("1", "u1_name", 0L, "name", false,
+        "00000000000000000200.00000000000000000060");
+    // U2 only changed `amount`. `name` in U2 is a placeholder "" (different placeholder — still
+    // unreliable). U2 is newer.
+    GenericRecord update2 = createRecord("1", "", 200L, "amount", false,
+        "00000000000000000300.00000000000000000070");
+
+    OracleDebeziumAvroPayload p1 = new OracleDebeziumAvroPayload(
+        update1, (Comparable) update1.get("_event_ordering"));
+    OracleDebeziumAvroPayload p2 = new OracleDebeziumAvroPayload(
+        update2, (Comparable) update2.get("_event_ordering"));
+
+    OracleDebeziumAvroPayload precombined = p2.preCombine(p1, schema, properties);
+    GenericRecord precombinedRecord =
+        (GenericRecord) precombined.getInsertValue(schema).get();
+
+    Set<String> changed = new HashSet<>(Arrays.asList(
+        precombinedRecord.get("_changed_columns").toString().split(",")));
+    assertEquals(new HashSet<>(Arrays.asList("name", "amount")), changed,
+        "_changed_columns must be the union {name, amount}");
+
+    GenericRecord finalRec =
+        (GenericRecord) precombined.combineAndGetUpdateValue(stored, schema, properties).get();
+    assertEquals("u1_name", finalRec.get("name").toString(),
+        "name came from U1 (changed there); not the stored 'stored_name'");
+    assertEquals(200L, finalRec.get("amount"),
+        "amount came from U2 (changed there); not the stored 999 nor U1's placeholder 0");
+  }
+
+  @Test
+  void testPreCombineNullThenRestoreLandsOnRestoredValue() throws IOException {
+    // Mirrors production validation ID=502 on the new image: U1 sets a nullable column to
+    // NULL (explicit delete-value), U2 restores it to a real value. Both in the same sync
+    // cycle. The newer event (U2) must win, the restored value must land, and the column must
+    // stay tracked in _changed_columns.
+    GenericRecord stored = createRecord("1", "NOT_NULL_INIT", 100L, null, false,
+        "00000000000000000100.00000000000000000050");
+
+    // U1 sets name=null (explicit SET NULL; name is in changed_cols).
+    GenericRecord update1 = createRecord("1", null, 0L, "name", false,
+        "00000000000000000200.00000000000000000060");
+    // U2 sets name="RESTORED" (same column, real value).
+    GenericRecord update2 = createRecord("1", "RESTORED", 0L, "name", false,
+        "00000000000000000300.00000000000000000070");
+
+    OracleDebeziumAvroPayload p1 = new OracleDebeziumAvroPayload(
+        update1, (Comparable) update1.get("_event_ordering"));
+    OracleDebeziumAvroPayload p2 = new OracleDebeziumAvroPayload(
+        update2, (Comparable) update2.get("_event_ordering"));
+
+    OracleDebeziumAvroPayload precombined = p2.preCombine(p1, schema, properties);
+    GenericRecord precombinedRecord =
+        (GenericRecord) precombined.getInsertValue(schema).get();
+
+    assertEquals("name", precombinedRecord.get("_changed_columns").toString(),
+        "_changed_columns must still contain `name` after preCombine");
+    assertEquals("RESTORED", precombinedRecord.get("name").toString(),
+        "preCombine picks the newer update's value; restore wins over null");
+
+    GenericRecord finalRec =
+        (GenericRecord) precombined.combineAndGetUpdateValue(stored, schema, properties).get();
+    assertEquals("RESTORED", finalRec.get("name").toString(),
+        "final merge must propagate the restored value");
+    assertEquals(100L, finalRec.get("amount"),
+        "amount was never in any changed_cols; must be preserved from stored");
+  }
+
+  @Test
+  void testThreeUpdatesPreCombinedMergedWithInsertKeepsAllChangedSourcesIntact() throws IOException {
+    // Chain of three updates in the same sync cycle:
+    //   U1 (oldest) changes `name` to "from_u1", `amount` placeholder.
+    //   U2 changes `amount` to 200, `name` placeholder.
+    //   U3 (newest) changes `name` to "from_u3", `amount` placeholder.
+    // Expected: merged _changed_columns = {name, amount}. Merged name = "from_u3" (newest
+    // event that touched name). Merged amount = 200 (only U2 touched it). Stored INSERT's
+    // `amount=999` must be overridden by U2's 200.
+    GenericRecord stored = createRecord("1", "stored_name", 999L, null, false,
+        "00000000000000000100.00000000000000000050");
+
+    GenericRecord u1 = createRecord("1", "from_u1", 0L, "name", false,
+        "00000000000000000200.00000000000000000060");
+    GenericRecord u2 = createRecord("1", "", 200L, "amount", false,
+        "00000000000000000300.00000000000000000070");
+    GenericRecord u3 = createRecord("1", "from_u3", 0L, "name", false,
+        "00000000000000000400.00000000000000000080");
+
+    OracleDebeziumAvroPayload p1 = new OracleDebeziumAvroPayload(u1, (Comparable) u1.get("_event_ordering"));
+    OracleDebeziumAvroPayload p2 = new OracleDebeziumAvroPayload(u2, (Comparable) u2.get("_event_ordering"));
+    OracleDebeziumAvroPayload p3 = new OracleDebeziumAvroPayload(u3, (Comparable) u3.get("_event_ordering"));
+
+    // Chain: preCombine(U2, U1) -> result; preCombine(U3, result)
+    OracleDebeziumAvroPayload after12 = p2.preCombine(p1, schema, properties);
+    OracleDebeziumAvroPayload after123 = p3.preCombine(after12, schema, properties);
+
+    GenericRecord chained = (GenericRecord) after123.getInsertValue(schema).get();
+    Set<String> changed = new HashSet<>(Arrays.asList(
+        chained.get("_changed_columns").toString().split(",")));
+    assertEquals(new HashSet<>(Arrays.asList("name", "amount")), changed,
+        "after 3-update chain, _changed_columns must be union {name, amount}");
+    assertEquals("from_u3", chained.get("name").toString(),
+        "name must be U3's value (newest event that touched it)");
+    assertEquals(200L, chained.get("amount"),
+        "amount must be U2's value (only U2 touched it; U1/U3 carried placeholders)");
+
+    GenericRecord finalRec =
+        (GenericRecord) after123.combineAndGetUpdateValue(stored, schema, properties).get();
+    assertEquals("from_u3", finalRec.get("name").toString());
+    assertEquals(200L, finalRec.get("amount"),
+        "stored's 999 must be overridden by U2's tracked 200");
+  }
+
+  /**
+   * Schema that intentionally OMITS {@code _hoodie_is_deleted} but includes
+   * {@code _change_operation_type}. Reproduces the customer's production read schema:
+   * a Hudi target schema where the meta-delete field is absent. Used to verify that
+   * {@link OracleDebeziumAvroPayload#isDeleteRecord} detects deletes via the Debezium
+   * op field as a fallback.
+   */
+  private static final String JSON_SCHEMA_NO_HOODIE_DELETE = "{\n"
+      + "  \"type\": \"record\",\n"
+      + "  \"name\": \"oracleDebeziumRecordNoHoodieDelete\", \"namespace\":\"org.apache.hudi\",\n"
+      + "  \"fields\": [\n"
+      + "    {\"name\": \"id\", \"type\": \"string\"},\n"
+      + "    {\"name\": \"_change_operation_type\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+      + "    {\"name\": \"_event_ordering\", \"type\": [\"null\", \"string\"], \"default\": null}\n"
+      + "  ]\n"
+      + "}";
+
+  @Test
+  void testDeleteDetectedViaOpFieldWhenHoodieIsDeletedAbsent() throws IOException {
+    // Reproduces the customer's production scenario: the read schema does not include
+    // _hoodie_is_deleted (the schemaprovider's target schema strips it). Without the
+    // op-field check in isDeleteRecord, this record would fail to be recognized as a
+    // delete and would surface as a NULL-padded "zombie" row in MOR snapshot reads
+    // until compaction merges it away.
+    //
+    // The op-field check restores delete-detection robustness in the same shape as
+    // AbstractDebeziumAvroPayload (Postgres/MySQL), which does not have this zombie
+    // problem because their payload checks the Debezium op field.
+    Schema schemaNoHoodieDelete = new Schema.Parser().parse(JSON_SCHEMA_NO_HOODIE_DELETE);
+    GenericRecord deleteRecord = new GenericData.Record(schemaNoHoodieDelete);
+    deleteRecord.put("id", "id_1");
+    deleteRecord.put("_change_operation_type", "d");
+    deleteRecord.put("_event_ordering", "00000000000100.00000000000050");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(
+        deleteRecord, (Comparable) deleteRecord.get("_event_ordering"));
+
+    Properties propsNoHoodieDelete = new Properties();
+    propsNoHoodieDelete.put(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, "_event_ordering");
+
+    assertTrue(payload.isDeleted(schemaNoHoodieDelete, propsNoHoodieDelete),
+        "Record with op='d' must be recognized as a delete even when _hoodie_is_deleted "
+            + "is absent from the schema (covers the MOR snapshot-read zombie scenario).");
+  }
+
+  @Test
+  void testNonDeleteOpNotRecognizedAsDelete() throws IOException {
+    // Negative case: op='u' (update) without _hoodie_is_deleted must NOT be flagged as
+    // a delete. Guards against the override over-firing.
+    Schema schemaNoHoodieDelete = new Schema.Parser().parse(JSON_SCHEMA_NO_HOODIE_DELETE);
+    GenericRecord updateRecord = new GenericData.Record(schemaNoHoodieDelete);
+    updateRecord.put("id", "id_1");
+    updateRecord.put("_change_operation_type", "u");
+    updateRecord.put("_event_ordering", "00000000000100.00000000000050");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(
+        updateRecord, (Comparable) updateRecord.get("_event_ordering"));
+
+    Properties propsNoHoodieDelete = new Properties();
+    propsNoHoodieDelete.put(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, "_event_ordering");
+
+    assertFalse(payload.isDeleted(schemaNoHoodieDelete, propsNoHoodieDelete),
+        "Record with op='u' must not be recognized as a delete.");
+  }
+
+  private GenericRecord createRecord(String id, String name, Long amount, String changedColumns,
+                                     boolean isDeleted, String eventOrdering) {
+    GenericRecord record = new GenericData.Record(schema);
+    record.put("id", id);
+    record.put("name", name);
+    record.put("amount", amount);
+    record.put("_changed_columns", changedColumns);
+    record.put("_hoodie_is_deleted", isDeleted);
+    record.put("_event_ordering", eventOrdering);
+    return record;
+  }
+
+  // ----------------------------------------------------------------------------------------
+  // Edge-case coverage: secondary constructors, single-arg overload, defensive branches.
+  // ----------------------------------------------------------------------------------------
+
+  @Test
+  void emptyOptionConstructorMarksPayloadEmpty() throws IOException {
+    OracleDebeziumAvroPayload empty = new OracleDebeziumAvroPayload(Option.empty());
+    // Empty payload should round-trip as an absent insert value via the standard overload.
+    assertFalse(empty.getInsertValue(schema).isPresent());
+  }
+
+  @Test
+  void singleArgCombineAndGetUpdateValueTreatsIncomingAsNewer() throws IOException {
+    // Covers the (IndexedRecord, Schema) overload that lacks Properties — incoming is
+    // always treated as newer, so a changed column on incoming should win over stored.
+    GenericRecord stored = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", "bob", null, "name", false, "00000000000200.00000000000060");
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(
+        incoming, (Comparable) incoming.get("_event_ordering"));
+
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(stored, schema);
+
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    assertEquals("bob", out.get("name").toString());
+    // Stored amount preserved because incoming did not list it in _changed_columns.
+    assertEquals(100L, out.get("amount"));
+  }
+
+  @Test
+  void getInsertValueWithPropertiesReturnsEmptyForEmptyPayload() throws IOException {
+    // Bandaid override: covers the bytes.length==0 branch returning Option.empty().
+    OracleDebeziumAvroPayload empty = new OracleDebeziumAvroPayload(Option.empty());
+    assertFalse(empty.getInsertValue(schema, properties).isPresent());
+  }
+
+  @Test
+  void getInsertValueWithPropertiesReturnsRecordEvenIfMarkedDeleted() throws IOException {
+    // Bandaid override: covers the non-empty branch and verifies that, unlike the single-arg
+    // overload, this one returns the record bytes even when the payload is flagged delete.
+    GenericRecord deleteRecord = createRecord("1", "alice", 100L, null, true, "00000000000200.00000000000060");
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(
+        deleteRecord, (Comparable) deleteRecord.get("_event_ordering"));
+
+    // Single-arg overload filters delete → empty.
+    assertFalse(payload.getInsertValue(schema).isPresent());
+    // Two-arg override returns the record bytes even for delete.
+    Option<IndexedRecord> twoArg = payload.getInsertValue(schema, properties);
+    assertTrue(twoArg.isPresent());
+    assertEquals("alice", ((GenericRecord) twoArg.get()).get("name").toString());
+  }
+
+  @Test
+  void preCombineShortCircuitsWhenIncomingIsEmpty() {
+    // Covers the isEmptyRecord() early-return branch in preCombine.
+    GenericRecord stored = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    OracleDebeziumAvroPayload incoming = new OracleDebeziumAvroPayload(Option.empty());
+    OracleDebeziumAvroPayload storedPayload = new OracleDebeziumAvroPayload(
+        stored, (Comparable) stored.get("_event_ordering"));
+
+    OracleDebeziumAvroPayload result = incoming.preCombine(storedPayload, schema, properties);
+    assertTrue(result == incoming, "Empty incoming must short-circuit and return itself");
+  }
+
+  @Test
+  void extractChangedColumnsHandlesEmptyString() throws IOException {
+    // Covers the str.isEmpty() branch in extractChangedColumns. Behavior contract: an
+    // empty _changed_columns string is equivalent to no _changed_columns at all — the merge
+    // treats the record as an insert/snapshot and uses the incoming values verbatim. This
+    // exercises both the empty-string branch in extractChangedColumns and the empty-set
+    // fall-through branch in mergeOldRecordWithModifiedColumns.
+    GenericRecord stored = createRecord("1", "alice", 100L, null, false, "00000000000100.00000000000050");
+    GenericRecord incoming = createRecord("1", "bob", 200L, "", false, "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(
+        incoming, (Comparable) incoming.get("_event_ordering"));
+
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(stored, schema, properties);
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    // Empty _changed_columns ⇒ insert/snapshot semantics ⇒ incoming wins for non-metadata fields.
+    assertEquals("bob", out.get("name").toString());
+    assertEquals(200L, out.get("amount"));
+  }
+
+  @Test
+  void bytesToastedValueFallsBackToStored() throws IOException {
+    // Covers isBytesToasted (bytes-typed columns with the toasted sentinel). Existing tests
+    // cover string-typed toasted; this exercises the bytes branch.
+    Schema bytesSchema = new Schema.Parser().parse(
+        "{\"type\":\"record\",\"name\":\"oracleDebeziumBytesRecord\",\"namespace\":\"org.apache.hudi\","
+            + "\"fields\":["
+            + "{\"name\":\"id\",\"type\":\"string\"},"
+            + "{\"name\":\"blob_col\",\"type\":[\"null\",\"bytes\"],\"default\":null},"
+            + "{\"name\":\"_changed_columns\",\"type\":[\"null\",\"string\"],\"default\":null},"
+            + "{\"name\":\"_hoodie_is_deleted\",\"type\":\"boolean\",\"default\":false},"
+            + "{\"name\":\"_event_ordering\",\"type\":[\"null\",\"string\"],\"default\":null}"
+            + "]}");
+
+    java.nio.ByteBuffer realBytes = java.nio.ByteBuffer.wrap(new byte[] {1, 2, 3, 4});
+    java.nio.ByteBuffer toastedBytes = java.nio.ByteBuffer.wrap(
+        DEBEZIUM_TOASTED_VALUE.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+    GenericRecord stored = new GenericData.Record(bytesSchema);
+    stored.put("id", "1");
+    stored.put("blob_col", realBytes);
+    stored.put("_changed_columns", null);
+    stored.put("_hoodie_is_deleted", false);
+    stored.put("_event_ordering", "00000000000100.00000000000050");
+
+    GenericRecord incoming = new GenericData.Record(bytesSchema);
+    incoming.put("id", "1");
+    incoming.put("blob_col", toastedBytes);
+    incoming.put("_changed_columns", "blob_col");
+    incoming.put("_hoodie_is_deleted", false);
+    incoming.put("_event_ordering", "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(
+        incoming, (Comparable) incoming.get("_event_ordering"));
+
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(stored, bytesSchema, properties);
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    // Incoming had a toasted bytes value → stored bytes must be preserved.
+    assertEquals(realBytes, out.get("blob_col"));
+  }
+
+  // Schema matching the production nested-metadata layout
+  // (onehousedataplane.debezium.enable.nested.fields=true): scn/commit_scn live inside the
+  // _debezium_metadata struct instead of flat root columns.
+  private static final String JSON_SCHEMA_NESTED_METADATA = "{\n"
+      + "  \"type\": \"record\",\n"
+      + "  \"name\": \"oracleDebeziumNestedRecord\", \"namespace\":\"org.apache.hudi\",\n"
+      + "  \"fields\": [\n"
+      + "    {\"name\": \"_debezium_metadata\", \"type\": [\"null\", {\n"
+      + "      \"type\": \"record\", \"name\": \"debeziumMetadata\", \"fields\": [\n"
+      + "        {\"name\": \"_event_scn\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+      + "        {\"name\": \"_event_commit_scn\", \"type\": [\"null\", \"string\"], \"default\": null}\n"
+      + "      ]}], \"default\": null},\n"
+      + "    {\"name\": \"id\", \"type\": \"string\"},\n"
+      + "    {\"name\": \"name\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+      + "    {\"name\": \"amount\", \"type\": [\"null\", \"long\"], \"default\": null},\n"
+      + "    {\"name\": \"_changed_columns\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+      + "    {\"name\": \"_hoodie_is_deleted\", \"type\": \"boolean\", \"default\": false},\n"
+      + "    {\"name\": \"_event_ordering\", \"type\": [\"null\", \"string\"], \"default\": null}\n"
+      + "  ]\n"
+      + "}";
+
+  @Test
+  void nestedDebeziumMetadataTakesNewerValueOnUpdateMerge() throws IOException {
+    // Regression: _debezium_metadata is in METADATA_FIELDS, so an update merge must carry the
+    // NEWER event's metadata struct. Without it, the struct falls into the
+    // preserve-older-value branch (it is never listed in _changed_columns) and the merged row
+    // reports the previous event's scn/commit_scn alongside the new _event_ordering.
+    Schema nestedSchema = new Schema.Parser().parse(JSON_SCHEMA_NESTED_METADATA);
+    Schema metadataSchema = nestedSchema.getField("_debezium_metadata").schema().getTypes().get(1);
+
+    GenericRecord stored = createNestedRecord(nestedSchema, metadataSchema,
+        "100", "alice", 100L, null, "00000000000100.00000000000050");
+    GenericRecord incoming = createNestedRecord(nestedSchema, metadataSchema,
+        "200", "bob", 100L, "name", "00000000000200.00000000000060");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(
+        incoming, (Comparable) incoming.get("_event_ordering"));
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(stored, nestedSchema, properties);
+
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    assertEquals("bob", out.get("name").toString(), "changed column takes incoming value");
+    assertEquals(100L, out.get("amount"), "unchanged column preserved");
+    GenericRecord outMetadata = (GenericRecord) out.get("_debezium_metadata");
+    assertEquals("200", outMetadata.get("_event_scn").toString(),
+        "_debezium_metadata must reflect the newer event, consistent with _event_ordering");
+    assertEquals("00000000000200.00000000000060", out.get("_event_ordering").toString());
+  }
+
+  @Test
+  void nestedDebeziumMetadataKeptFromStoredWhenIncomingIsOlder() throws IOException {
+    // Out-of-order arrival: stored has higher ordering, so the merged row must keep the
+    // stored (newer) event's metadata struct, not the late-arriving older one's.
+    Schema nestedSchema = new Schema.Parser().parse(JSON_SCHEMA_NESTED_METADATA);
+    Schema metadataSchema = nestedSchema.getField("_debezium_metadata").schema().getTypes().get(1);
+
+    GenericRecord stored = createNestedRecord(nestedSchema, metadataSchema,
+        "300", "carol", 100L, "name", "00000000000300.00000000000070");
+    GenericRecord lateIncoming = createNestedRecord(nestedSchema, metadataSchema,
+        "100", "alice", 50L, "amount", "00000000000100.00000000000050");
+
+    OracleDebeziumAvroPayload payload = new OracleDebeziumAvroPayload(
+        lateIncoming, (Comparable) lateIncoming.get("_event_ordering"));
+    Option<IndexedRecord> result = payload.combineAndGetUpdateValue(stored, nestedSchema, properties);
+
+    assertTrue(result.isPresent());
+    GenericRecord out = (GenericRecord) result.get();
+    GenericRecord outMetadata = (GenericRecord) out.get("_debezium_metadata");
+    assertEquals("300", outMetadata.get("_event_scn").toString(),
+        "stored record is newer — its metadata struct must win");
+    assertEquals("carol", out.get("name").toString(), "newer stored change preserved");
+    assertEquals(50L, out.get("amount"), "older event's changed column still applied");
+  }
+
+  private GenericRecord createNestedRecord(Schema nestedSchema, Schema metadataSchema, String scn,
+                                           String name, Long amount, String changedColumns, String eventOrdering) {
+    GenericRecord metadata = new GenericData.Record(metadataSchema);
+    metadata.put("_event_scn", scn);
+    metadata.put("_event_commit_scn", scn);
+    GenericRecord record = new GenericData.Record(nestedSchema);
+    record.put("_debezium_metadata", metadata);
+    record.put("id", "1");
+    record.put("name", name);
+    record.put("amount", amount);
+    record.put("_changed_columns", changedColumns);
+    record.put("_hoodie_is_deleted", false);
+    record.put("_event_ordering", eventOrdering);
+    return record;
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table;
+
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
+import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that {@link HoodieTableConfig#inferMergingConfigsForV9TableCreation} resolves the
+ * Debezium ordering field against the {@code _debezium_metadata} struct path when nested metadata
+ * is enabled. Kept in {@code hudi-common}'s own test source set (rather than alongside the larger
+ * {@code TestHoodieTableConfig} suite in {@code hudi-hadoop-common}) so coverage for this
+ * hudi-common-owned logic is attributed to the module that owns it.
+ */
+class TestHoodieTableConfigDebeziumOrdering {
+
+  @Test
+  void mysqlOrderingFieldsAreNestedWhenDebeziumMetadataIsNested() {
+    Map<String, String> flat = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, false);
+    assertEquals(DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME,
+        flat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+
+    Map<String, String> nested = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, true);
+    assertEquals(
+        DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_FILE_COL_NAME + ","
+            + DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_POS_COL_NAME,
+        nested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+  }
+
+  @Test
+  void postgresOrderingFieldStaysAtRootRegardlessOfNesting() {
+    Map<String, String> flat = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, PostgresDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, false);
+    Map<String, String> nested = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, PostgresDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, true);
+
+    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, flat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, nested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
@@ -18,9 +18,11 @@
 
 package org.apache.hudi.common.table;
 
+import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
+import org.apache.hudi.common.util.collection.Triple;
 
 import org.junit.jupiter.api.Test;
 
@@ -61,5 +63,27 @@ class TestHoodieTableConfigDebeziumOrdering {
 
     assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, flat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
     assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, nested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+  }
+
+  @Test
+  void fiveArgOverloadsDelegateToNestedFalse() {
+    // The pre-existing 5-arg inferMergingConfigsForV9TableCreation/inferMergingConfigsForWrites
+    // overloads must keep behaving exactly as if nestedDebeziumMetadataEnabled=false was passed,
+    // since existing callers (e.g. the reader path) are unaware of Debezium metadata nesting.
+    Map<String, String> viaFiveArg = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE);
+    Map<String, String> viaSixArgFalse = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, false);
+    assertEquals(viaSixArgFalse.get(HoodieTableConfig.ORDERING_FIELDS.key()), viaFiveArg.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+
+    Triple<RecordMergeMode, String, String> writesViaFiveArg = HoodieTableConfig.inferMergingConfigsForWrites(
+        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE);
+    Triple<RecordMergeMode, String, String> writesViaSixArgFalse = HoodieTableConfig.inferMergingConfigsForWrites(
+        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, false);
+    // Compare components individually: the payload class (middle) is legitimately null for V9
+    // tables, and Triple#equals NPEs on a null middle rather than short-circuiting.
+    assertEquals(writesViaSixArgFalse.getLeft(), writesViaFiveArg.getLeft());
+    assertEquals(writesViaSixArgFalse.getMiddle(), writesViaFiveArg.getMiddle());
+    assertEquals(writesViaSixArgFalse.getRight(), writesViaFiveArg.getRight());
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
@@ -18,16 +18,21 @@
 
 package org.apache.hudi.common.table;
 
+import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
+import org.apache.hudi.common.model.debezium.OracleDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY;
+import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that {@link HoodieTableConfig#inferMergingConfigsForV9TableCreation} reconciles a Debezium
@@ -75,6 +80,36 @@ class TestHoodieTableConfigDebeziumOrdering {
     assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, inferredOrderingFields(postgres, "ts"));
     assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME,
         inferredOrderingFields(postgres, DebeziumConstants.FLATTENED_LSN_COL_NAME));
+  }
+
+  @Test
+  void oracleUsesEventOrderingAndFillUnchanged() {
+    Map<String, String> cfg = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, OracleDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE);
+
+    // Oracle is an event-time-ordering CDC payload driven by the composite _event_ordering column
+    // (auto-corrected from the arbitrary caller value "ts"), with the changed-columns partial update.
+    assertEquals(RecordMergeMode.EVENT_TIME_ORDERING.name(), cfg.get(HoodieTableConfig.RECORD_MERGE_MODE.key()));
+    assertEquals(DebeziumConstants.FLATTENED_ORDERING_COL_NAME, cfg.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+    assertEquals(PartialUpdateMode.FILL_UNCHANGED.name(), cfg.get(HoodieTableConfig.PARTIAL_UPDATE_MODE.key()));
+    assertEquals(DebeziumConstants.CHANGED_COLUMNS_FIELD,
+        cfg.get(HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + HoodieTableConfig.PARTIAL_UPDATE_CHANGED_FIELDS));
+    assertEquals(HoodieTableConfig.DEBEZIUM_UNAVAILABLE_VALUE,
+        cfg.get(HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + HoodieTableConfig.PARTIAL_UPDATE_UNAVAILABLE_VALUE));
+    assertEquals(DebeziumConstants.FLATTENED_OP_COL_NAME,
+        cfg.get(HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + DELETE_KEY));
+    assertEquals(DebeziumConstants.DELETE_OP,
+        cfg.get(HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER));
+    String retain = cfg.get(HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + HoodieTableConfig.PARTIAL_UPDATE_RETAIN_FIELDS);
+    assertTrue(retain != null && retain.contains(DebeziumConstants.FLATTENED_ORDERING_COL_NAME));
+  }
+
+  @Test
+  void oracleOrderingResolvesToEventOrderingRegardlessOfNesting() {
+    assertEquals(DebeziumConstants.FLATTENED_ORDERING_COL_NAME,
+        DebeziumConstants.resolveOrderingFields(OracleDebeziumAvroPayload.class.getName(), false));
+    assertEquals(DebeziumConstants.FLATTENED_ORDERING_COL_NAME,
+        DebeziumConstants.resolveOrderingFields(OracleDebeziumAvroPayload.class.getName(), true));
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
@@ -18,72 +18,68 @@
 
 package org.apache.hudi.common.table;
 
-import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
-import org.apache.hudi.common.util.collection.Triple;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * Tests that {@link HoodieTableConfig#inferMergingConfigsForV9TableCreation} resolves the
- * Debezium ordering field against the {@code _debezium_metadata} struct path when nested metadata
- * is enabled. Kept in {@code hudi-common}'s own test source set (rather than alongside the larger
- * {@code TestHoodieTableConfig} suite in {@code hudi-hadoop-common}) so coverage for this
- * hudi-common-owned logic is attributed to the module that owns it.
+ * Tests that {@link HoodieTableConfig#inferMergingConfigsForV9TableCreation} reconciles a Debezium
+ * payload's ordering field to the canonical column(s) the payload merges on: the flat form by
+ * default (auto-correcting whatever the caller supplied), or the nested
+ * {@code _debezium_metadata.*} form when the caller already resolved it — which only the Hudi
+ * Streamer does when its transformer groups the CDC metadata under the nested struct.
  */
 class TestHoodieTableConfigDebeziumOrdering {
 
-  @Test
-  void mysqlOrderingFieldsAreNestedWhenDebeziumMetadataIsNested() {
-    Map<String, String> flat = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, false);
-    assertEquals(DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME,
-        flat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+  private static final String MYSQL_FLAT =
+      DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME;
+  private static final String MYSQL_NESTED =
+      DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_FILE_COL_NAME + ","
+          + DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_POS_COL_NAME;
 
-    Map<String, String> nested = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, true);
-    assertEquals(
-        DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_FILE_COL_NAME + ","
-            + DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_POS_COL_NAME,
-        nested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+  private static String inferredOrderingFields(String payloadClass, String callerOrderingFields) {
+    Map<String, String> configs = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, payloadClass, null, callerOrderingFields, HoodieTableVersion.NINE);
+    return configs.get(HoodieTableConfig.ORDERING_FIELDS.key());
   }
 
   @Test
-  void postgresOrderingFieldStaysAtRootRegardlessOfNesting() {
-    Map<String, String> flat = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, PostgresDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, false);
-    Map<String, String> nested = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, PostgresDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, true);
-
-    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, flat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
-    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, nested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+  void mysqlOrderingIsAutoCorrectedToFlatBinlogColumns() {
+    String mysql = MySqlDebeziumAvroPayload.class.getName();
+    // A non-canonical caller value (arbitrary field, or the legacy _event_seq) is corrected to the
+    // flat binlog coordinates the payload merges on.
+    assertEquals(MYSQL_FLAT, inferredOrderingFields(mysql, "ts"));
+    assertEquals(MYSQL_FLAT, inferredOrderingFields(mysql, DebeziumConstants.ADDED_SEQ_COL_NAME));
+    // Passing the flat form back through is idempotent.
+    assertEquals(MYSQL_FLAT, inferredOrderingFields(mysql, MYSQL_FLAT));
   }
 
   @Test
-  void fiveArgOverloadsDelegateToNestedFalse() {
-    // The pre-existing 5-arg inferMergingConfigsForV9TableCreation/inferMergingConfigsForWrites
-    // overloads must keep behaving exactly as if nestedDebeziumMetadataEnabled=false was passed,
-    // since existing callers (e.g. the reader path) are unaware of Debezium metadata nesting.
-    Map<String, String> viaFiveArg = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE);
-    Map<String, String> viaSixArgFalse = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, false);
-    assertEquals(viaSixArgFalse.get(HoodieTableConfig.ORDERING_FIELDS.key()), viaFiveArg.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+  void mysqlNestedOrderingIsPreservedWhenCallerResolvesIt() {
+    // The streamer passes the nested path when its transformer nests the CDC metadata; it must be
+    // preserved so the payload orders against the nested columns rather than the (absent) root ones.
+    assertEquals(MYSQL_NESTED, inferredOrderingFields(MySqlDebeziumAvroPayload.class.getName(), MYSQL_NESTED));
+  }
 
-    Triple<RecordMergeMode, String, String> writesViaFiveArg = HoodieTableConfig.inferMergingConfigsForWrites(
-        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE);
-    Triple<RecordMergeMode, String, String> writesViaSixArgFalse = HoodieTableConfig.inferMergingConfigsForWrites(
-        null, MySqlDebeziumAvroPayload.class.getName(), null, "ts", HoodieTableVersion.NINE, false);
-    // Compare components individually: the payload class (middle) is legitimately null for V9
-    // tables, and Triple#equals NPEs on a null middle rather than short-circuiting.
-    assertEquals(writesViaSixArgFalse.getLeft(), writesViaFiveArg.getLeft());
-    assertEquals(writesViaSixArgFalse.getMiddle(), writesViaFiveArg.getMiddle());
-    assertEquals(writesViaSixArgFalse.getRight(), writesViaFiveArg.getRight());
+  @Test
+  void postgresOrderingIsAlwaysLsn() {
+    String postgres = PostgresDebeziumAvroPayload.class.getName();
+    // The Postgres LSN stays at the root level even when nested, so the ordering field is always _event_lsn.
+    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, inferredOrderingFields(postgres, "ts"));
+    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME,
+        inferredOrderingFields(postgres, DebeziumConstants.FLATTENED_LSN_COL_NAME));
+  }
+
+  @Test
+  void resolveOrderingFieldsReturnsNullForNonDebeziumPayload() {
+    assertNull(DebeziumConstants.resolveOrderingFields("com.example.CustomPayload", false));
+    assertNull(DebeziumConstants.resolveOrderingFields(null, true));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfigDebeziumOrdering.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.OracleDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
+import org.apache.hudi.common.util.collection.Triple;
 
 import org.junit.jupiter.api.Test;
 
@@ -116,5 +117,29 @@ class TestHoodieTableConfigDebeziumOrdering {
   void resolveOrderingFieldsReturnsNullForNonDebeziumPayload() {
     assertNull(DebeziumConstants.resolveOrderingFields("com.example.CustomPayload", false));
     assertNull(DebeziumConstants.resolveOrderingFields(null, true));
+  }
+
+  @Test
+  void oracleWritePathPersistsFillUnchangedThroughTwoStepInference() {
+    // Replicates the actual DataSource write path exactly:
+    //   1. HoodieSparkSqlWriter.deduceWriterConfigs -> inferMergingConfigsForWrites(null, Oracle, "", ord)
+    //   2. HoodieTableMetaClient.build() -> inferMergingConfigsForV9TableCreation(mode, payload, strategy, ord)
+    // feeding step 1's resolved (mode, payload, strategy) into step 2.
+    String oracle = OracleDebeziumAvroPayload.class.getName();
+    String ord = DebeziumConstants.FLATTENED_ORDERING_COL_NAME;
+
+    Triple<RecordMergeMode, String, String> writes =
+        HoodieTableConfig.inferMergingConfigsForWrites(null, oracle, "", ord, HoodieTableVersion.NINE);
+    // The writer keeps the user-supplied payload when inference returns null for PAYLOAD_CLASS_NAME.
+    String payloadForCreate = writes.getMiddle() != null ? writes.getMiddle() : oracle;
+    Map<String, String> created = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        writes.getLeft(), payloadForCreate, writes.getRight(), ord, HoodieTableVersion.NINE);
+
+    assertEquals(PartialUpdateMode.FILL_UNCHANGED.name(),
+        created.get(HoodieTableConfig.PARTIAL_UPDATE_MODE.key()),
+        "the two-step write-path inference must still persist FILL_UNCHANGED");
+    assertEquals(DebeziumConstants.CHANGED_COLUMNS_FIELD,
+        created.get(HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + HoodieTableConfig.PARTIAL_UPDATE_CHANGED_FIELDS),
+        "the changed-fields merge property must survive the two-step write-path inference");
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestPartialUpdateHandler.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestPartialUpdateHandler.java
@@ -19,7 +19,7 @@
 
 package org.apache.hudi.common.table.read;
 
-import org.apache.hudi.avro.AvroRecordContext;
+import org.apache.hudi.common.avro.AvroRecordContext;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.schema.HoodieSchema;

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestPartialUpdateHandler.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestPartialUpdateHandler.java
@@ -19,19 +19,31 @@
 
 package org.apache.hudi.common.table.read;
 
+import org.apache.hudi.avro.AvroRecordContext;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.table.PartialUpdateMode;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.hudi.common.table.HoodieTableConfig.DEBEZIUM_UNAVAILABLE_VALUE;
 import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_UNAVAILABLE_VALUE;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestPartialUpdateHandler {
@@ -81,5 +93,150 @@ class TestPartialUpdateHandler {
   void testNonUnionNonTargetType() {
     HoodieSchema intSchema = HoodieSchema.create(HoodieSchemaType.INT);
     assertFalse(PartialUpdateHandler.hasTargetType(intSchema, HoodieSchemaType.STRING));
+  }
+
+  // ---------------------------------------------------------------------------
+  // FILL_UNCHANGED (reconcileChangedColumns) — direct unit tests over an Avro RecordContext.
+  // Records are built from an Avro schema; the handler is driven with the HoodieSchema wrapper.
+  // Fields: name (nullable string), amount (nullable long), _changed_columns (the changed list),
+  // _event_ordering (retained metadata).
+  // ---------------------------------------------------------------------------
+
+  private static final String CHANGED_COL = "_changed_columns";
+  private static final String ORDERING_COL = "_event_ordering";
+  private static final Schema AVRO = new Schema.Parser().parse(
+      "{\"type\":\"record\",\"name\":\"r\",\"fields\":["
+          + "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+          + "{\"name\":\"amount\",\"type\":[\"null\",\"long\"],\"default\":null},"
+          + "{\"name\":\"" + CHANGED_COL + "\",\"type\":[\"null\",\"string\"],\"default\":null},"
+          + "{\"name\":\"" + ORDERING_COL + "\",\"type\":[\"null\",\"string\"],\"default\":null}]}");
+  private static final HoodieSchema FU_SCHEMA = HoodieSchema.fromAvroSchema(AVRO);
+
+  private static PartialUpdateHandler<IndexedRecord> fillUnchangedHandler(boolean withChangedFieldConfig) {
+    TypedProperties props = new TypedProperties();
+    if (withChangedFieldConfig) {
+      props.put(RECORD_MERGE_PROPERTY_PREFIX + "hoodie.write.partial.update.changed.fields", CHANGED_COL);
+    }
+    props.put(RECORD_MERGE_PROPERTY_PREFIX + "hoodie.write.partial.update.retain.fields", ORDERING_COL);
+    props.put(RECORD_MERGE_PROPERTY_PREFIX + PARTIAL_UPDATE_UNAVAILABLE_VALUE, DEBEZIUM_UNAVAILABLE_VALUE);
+    return new PartialUpdateHandler<>(new AvroRecordContext(), PartialUpdateMode.FILL_UNCHANGED, props);
+  }
+
+  private static BufferedRecord<IndexedRecord> rec(String name, Long amount, String changed, String ordering,
+                                                   HoodieOperation op) {
+    GenericRecord g = new GenericData.Record(AVRO);
+    g.put("name", name);
+    g.put("amount", amount);
+    g.put(CHANGED_COL, changed);
+    g.put(ORDERING_COL, ordering);
+    return new BufferedRecord<>("k", ordering, g, 0, op);
+  }
+
+  private BufferedRecord<IndexedRecord> merge(BufferedRecord<IndexedRecord> high, BufferedRecord<IndexedRecord> low) {
+    return merge(high, low, true);
+  }
+
+  private BufferedRecord<IndexedRecord> merge(BufferedRecord<IndexedRecord> high, BufferedRecord<IndexedRecord> low,
+                                              boolean withChangedFieldConfig) {
+    return fillUnchangedHandler(withChangedFieldConfig).partialMerge(high, low, FU_SCHEMA, FU_SCHEMA, FU_SCHEMA);
+  }
+
+  private static String str(Object v) {
+    return v == null ? null : v.toString();
+  }
+
+  @Test
+  void changedColumnTakesNewerUnchangedTakesPrior() {
+    IndexedRecord out = merge(rec("bob", 999L, "name", "200", null), rec("alice", 100L, null, "100", null)).getRecord();
+    assertEquals("bob", str(((GenericRecord) out).get("name")));
+    assertEquals(100L, ((GenericRecord) out).get("amount"), "unchanged amount preserved from prior");
+  }
+
+  @Test
+  void unchangedNonStringColumnPreservedRegardlessOfPlaceholder() {
+    // The differentiator vs FILL_UNAVAILABLE: a numeric unchanged column keeps its prior value even
+    // though its incoming value is a non-sentinel placeholder (0).
+    IndexedRecord out = merge(rec("bob", 0L, "name", "200", null), rec("alice", 100L, null, "100", null)).getRecord();
+    assertEquals(100L, ((GenericRecord) out).get("amount"), "numeric placeholder must not overwrite prior");
+  }
+
+  @Test
+  void explicitNullInChangedSetStaysNull() {
+    IndexedRecord out = merge(rec(null, 100L, "name", "200", null), rec("alice", 100L, null, "100", null)).getRecord();
+    assertNull(((GenericRecord) out).get("name"), "name is in changed set -> explicit null wins");
+  }
+
+  @Test
+  void changedColumnsUnionedAcrossBothRecords() {
+    // Disjoint: higher changed "amount", lower changed "name". Result carries name (from lower) AND
+    // amount (from higher), and _changed_columns is the union.
+    IndexedRecord out = merge(rec("placeholder", 200L, "amount", "300", null),
+        rec("bob", 100L, "name", "200", null)).getRecord();
+    assertEquals(200L, ((GenericRecord) out).get("amount"));
+    assertEquals("bob", str(((GenericRecord) out).get("name")), "name changed only by lower -> preserved");
+    Set<String> union = new HashSet<>(Arrays.asList(str(((GenericRecord) out).get(CHANGED_COL)).split(",")));
+    assertTrue(union.contains("name") && union.contains("amount"), "changed set is the union");
+  }
+
+  @Test
+  void toastedValueInChangedColumnFallsBackToPrior() {
+    IndexedRecord out = merge(rec(DEBEZIUM_UNAVAILABLE_VALUE, 100L, "name", "200", null),
+        rec("alice", 100L, null, "100", null)).getRecord();
+    assertEquals("alice", str(((GenericRecord) out).get("name")), "toasted sentinel -> prior value");
+  }
+
+  @Test
+  void retainFieldAlwaysTakesNewer() {
+    IndexedRecord out = merge(rec("bob", 100L, "name", "300", null), rec("alice", 100L, null, "100", null)).getRecord();
+    assertEquals("300", str(((GenericRecord) out).get(ORDERING_COL)), "ordering (retain) always from newer");
+  }
+
+  @Test
+  void emptyChangedSetReturnsHigherRecordAsIs() {
+    BufferedRecord<IndexedRecord> high = rec("bob", 200L, null, "300", null);
+    assertSame(high, merge(high, rec("alice", 100L, "name", "100", null)), "no changed-columns -> return higher record");
+  }
+
+  @Test
+  void missingChangedFieldConfigReturnsHigherRecord() {
+    BufferedRecord<IndexedRecord> high = rec("bob", 200L, "name", "300", null);
+    assertSame(high, merge(high, rec("alice", 100L, null, "100", null), false), "no changed-fields config -> higher record");
+  }
+
+  @Test
+  void deleteRecordShortCircuitsPartialMerge() {
+    BufferedRecord<IndexedRecord> high = rec("bob", 200L, "name", "300", null);
+    assertSame(high, merge(high, rec("alice", 100L, null, "100", HoodieOperation.DELETE)),
+        "a delete on either side skips partial merge (guard in partialMerge)");
+  }
+
+  @Test
+  void changedColumnsListTrimsWhitespaceAroundNames() {
+    IndexedRecord out = merge(rec("bob", 200L, "name , amount ,", "300", null),
+        rec("alice", 100L, null, "100", null)).getRecord();
+    assertEquals("bob", str(((GenericRecord) out).get("name")));
+    assertEquals(200L, ((GenericRecord) out).get("amount"), "whitespace-padded name still matches -> newer value");
+  }
+
+  @Test
+  void unchangedColumnAbsentFromLowerSchemaResolvesToNull() {
+    // amount is unchanged so it is taken from the lower record, whose (older) schema has no amount
+    // field -> must resolve to null, not NPE.
+    Schema avroNoAmount = new Schema.Parser().parse(
+        "{\"type\":\"record\",\"name\":\"rOld\",\"fields\":["
+            + "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+            + "{\"name\":\"" + CHANGED_COL + "\",\"type\":[\"null\",\"string\"],\"default\":null},"
+            + "{\"name\":\"" + ORDERING_COL + "\",\"type\":[\"null\",\"string\"],\"default\":null}]}");
+    GenericRecord lowRec = new GenericData.Record(avroNoAmount);
+    lowRec.put("name", "alice");
+    lowRec.put(CHANGED_COL, null);
+    lowRec.put(ORDERING_COL, "100");
+    BufferedRecord<IndexedRecord> low = new BufferedRecord<>("k", "100", lowRec, 0, null);
+    BufferedRecord<IndexedRecord> high = rec("bob", 200L, "name", "300", null);
+
+    IndexedRecord out = fillUnchangedHandler(true)
+        .partialMerge(high, low, FU_SCHEMA, HoodieSchema.fromAvroSchema(avroNoAmount), FU_SCHEMA).getRecord();
+    assertEquals("bob", str(((GenericRecord) out).get("name")), "changed name -> newer value");
+    assertNull(((GenericRecord) out).get("amount"), "amount absent from lower schema resolves to null (no NPE)");
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.common.model.OverwriteNonDefaultsWithLatestAvroPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
@@ -732,6 +733,36 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
             "Custom merge property " + HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER + "  not expected to be set");
       }
     }
+  }
+
+  @Test
+  void testInferMergingConfigsNestedDebeziumOrderingFields() {
+    String mysqlPayload = MySqlDebeziumAvroPayload.class.getName();
+    String pgPayload = PostgresDebeziumAvroPayload.class.getName();
+
+    // MySQL, flat (default): ordering fields are the root-level binlog columns.
+    Map<String, String> mysqlFlat = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, mysqlPayload, null, "ts", HoodieTableVersion.NINE, false);
+    assertEquals(DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME,
+        mysqlFlat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+
+    // MySQL, nested: the binlog columns live under the _debezium_metadata struct, so the ordering
+    // fields must be resolved against that nested path.
+    Map<String, String> mysqlNested = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, mysqlPayload, null, "ts", HoodieTableVersion.NINE, true);
+    assertEquals(
+        DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_FILE_COL_NAME + ","
+            + DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_POS_COL_NAME,
+        mysqlNested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+
+    // Postgres: the ordering field (_event_lsn) is kept at the root level even when nested fields are
+    // enabled, so it is unchanged in both cases.
+    Map<String, String> pgFlat = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, pgPayload, null, "ts", HoodieTableVersion.NINE, false);
+    Map<String, String> pgNested = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
+        null, pgPayload, null, "ts", HoodieTableVersion.NINE, true);
+    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, pgFlat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, pgNested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
   }
 
   @Test

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -28,7 +28,6 @@ import org.apache.hudi.common.model.EventTimeAvroPayload;
 import org.apache.hudi.common.model.OverwriteNonDefaultsWithLatestAvroPayload;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
 import org.apache.hudi.common.model.PartialUpdateAvroPayload;
-import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.model.debezium.MySqlDebeziumAvroPayload;
 import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
@@ -733,36 +732,6 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
             "Custom merge property " + HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX + DELETE_MARKER + "  not expected to be set");
       }
     }
-  }
-
-  @Test
-  void testInferMergingConfigsNestedDebeziumOrderingFields() {
-    String mysqlPayload = MySqlDebeziumAvroPayload.class.getName();
-    String pgPayload = PostgresDebeziumAvroPayload.class.getName();
-
-    // MySQL, flat (default): ordering fields are the root-level binlog columns.
-    Map<String, String> mysqlFlat = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, mysqlPayload, null, "ts", HoodieTableVersion.NINE, false);
-    assertEquals(DebeziumConstants.FLATTENED_FILE_COL_NAME + "," + DebeziumConstants.FLATTENED_POS_COL_NAME,
-        mysqlFlat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
-
-    // MySQL, nested: the binlog columns live under the _debezium_metadata struct, so the ordering
-    // fields must be resolved against that nested path.
-    Map<String, String> mysqlNested = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, mysqlPayload, null, "ts", HoodieTableVersion.NINE, true);
-    assertEquals(
-        DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_FILE_COL_NAME + ","
-            + DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_POS_COL_NAME,
-        mysqlNested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
-
-    // Postgres: the ordering field (_event_lsn) is kept at the root level even when nested fields are
-    // enabled, so it is unchanged in both cases.
-    Map<String, String> pgFlat = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, pgPayload, null, "ts", HoodieTableVersion.NINE, false);
-    Map<String, String> pgNested = HoodieTableConfig.inferMergingConfigsForV9TableCreation(
-        null, pgPayload, null, "ts", HoodieTableVersion.NINE, true);
-    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, pgFlat.get(HoodieTableConfig.ORDERING_FIELDS.key()));
-    assertEquals(DebeziumConstants.FLATTENED_LSN_COL_NAME, pgNested.get(HoodieTableConfig.ORDERING_FIELDS.key()));
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleCdcCrashHarness.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleCdcCrashHarness.scala
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.common.model.debezium.OracleDebeziumAvroPayload
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+import java.util.concurrent.TimeUnit
+
+/**
+ * Subprocess writer for the multi-process crash harness (P1). Run as a real OS process via `java -cp`
+ * so a parent test can SIGKILL it (Process.destroyForcibly). Writes a v9 Oracle FILL_UNCHANGED MOR
+ * table at args(0): a committed base, then a marker file (args(1)) to signal "about to commit the
+ * update", then the update commit. The parent kills it around the marker to hit the commit window.
+ *
+ * args: (0) tablePath  (1) markerFile
+ */
+object OracleCdcCrashWriter {
+  private val cols = Seq("id", "name", "amount", "_changed_columns", "_hoodie_is_deleted", "_event_ordering")
+  private def ord(n: Int): String = "00000000000000000000." + "%020d".format(n)
+
+  def main(args: Array[String]): Unit = {
+    val path = args(0)
+    val marker = args(1)
+    val mode = if (args.length > 2) args(2) else "full" // "full" = base+update; "retry" = update only (append)
+    val spark = SparkSession.builder()
+      .master("local[2]")
+      .appName("oracle-cdc-crash-writer")
+      .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .config("spark.ui.enabled", "false")
+      .getOrCreate()
+    try {
+      def row(id: Int, name: String, amount: Long, changed: String, ordering: String) =
+        spark.createDataFrame(Seq((id, name, amount, changed, false, ordering))).toDF(cols: _*)
+      def writer(df: org.apache.spark.sql.DataFrame) = df.write.format("hudi")
+        .option("hoodie.datasource.write.recordkey.field", "id")
+        .option("hoodie.datasource.write.ordering.fields", "_event_ordering")
+        .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
+        .option("hoodie.table.name", "crash")
+        .option("hoodie.compact.inline", "false")
+      if (mode == "full") {
+        // committed base (alice, amount=100)
+        writer(row(1, "alice", 100L, null, ord(100)))
+          .option("hoodie.datasource.write.operation", "insert")
+          .option("hoodie.write.table.version", "9")
+          .option("hoodie.datasource.write.payload.class", classOf[OracleDebeziumAvroPayload].getName)
+          .mode(SaveMode.Overwrite).save(path)
+        Files.write(Paths.get(marker), "base-committed".getBytes) // signal: base done, update about to start
+      }
+      // the update (name->bob; amount unchanged placeholder must not win). In "retry" this drains it
+      // against a possibly-crashed table (Hudi rolls back any pending inflight first).
+      writer(row(1, "bob", 0L, "name", ord(200)))
+        .option("hoodie.datasource.write.operation", "upsert")
+        .mode(SaveMode.Append).save(path)
+      Files.write(Paths.get(marker), "update-committed".getBytes)
+    } finally {
+      spark.stop()
+    }
+  }
+}
+
+/**
+ * P1 crash harness. The `probe` first validates the risky assumption -- that a real Spark-writing
+ * subprocess launches with a usable classpath in this sandbox. Only once that's green is the
+ * kill variant worth building.
+ */
+class TestOracleCdcCrashHarness extends SparkClientFunctionalTestHarness {
+
+  // Opt-in soak gate. These launch a real Spark subprocess (slow ~15s/launch) and depend on the
+  // parent's `java.class.path` being replayable to a child JVM + on kill timing -- both fragile in a
+  // CI matrix. Skip by default; a nightly/soak lane runs them with -Dhudi.crash.harness=true.
+  private def assumeCrashHarnessEnabled(): Unit =
+    assumeTrue("true".equalsIgnoreCase(System.getProperty("hudi.crash.harness", System.getenv("HUDI_CRASH_HARNESS"))),
+      "opt-in crash/soak harness; enable with -Dhudi.crash.harness=true")
+
+  private def launchWriter(tablePath: String, marker: String, mode: String, logFile: String): Process = {
+    val javaBin = System.getProperty("java.home") + "/bin/java"
+    val cp = System.getProperty("java.class.path")
+    val pb = new ProcessBuilder(javaBin, "-cp", cp,
+      "org.apache.hudi.functional.OracleCdcCrashWriter", tablePath, marker, mode)
+    pb.redirectErrorStream(true)
+    pb.redirectOutput(new File(logFile))
+    pb.start()
+  }
+
+  private def readRow(tablePath: String): Array[org.apache.spark.sql.Row] =
+    spark.read.format("hudi").load(tablePath).select("name", "amount").where("id = 1").collect()
+
+  @Test
+  def probeSubprocessWritesV9OracleTable(): Unit = {
+    assumeCrashHarnessEnabled()
+    val local = basePath.replaceFirst("^file:", "") // basePath is a file: URI; java.io.File needs a plain path
+    val tablePath = s"$local/crash_probe"
+    val marker = s"$local/marker"
+    val log = s"$local/writer.log"
+    val proc = launchWriter(tablePath, marker, "full", log)
+    val finished = proc.waitFor(300, TimeUnit.SECONDS)
+    if (!finished) proc.destroyForcibly()
+    val logTail = if (new File(log).exists) scala.io.Source.fromFile(log).getLines().toList.takeRight(25).mkString("\n") else "(no log)"
+    assertTrue(finished, s"writer subprocess did not finish in 300s. log tail:\n$logTail")
+    assertEquals(0, proc.exitValue(), s"writer subprocess exited non-zero. log tail:\n$logTail")
+    val out = readRow(tablePath)(0)
+    assertEquals("bob", out.getAs[String]("name"), "subprocess update must be committed + readable")
+    assertEquals(100L, out.getAs[Long]("amount"), "unchanged amount preserved by the subprocess FILL_UNCHANGED merge")
+  }
+
+  @Test
+  def crashDuringUpdateLeavesAtomicStateAndRecovers(): Unit = {
+    assumeCrashHarnessEnabled()
+    // P1 real-crash test (INV8): launch the writer as a real OS process, SIGKILL it (destroyForcibly)
+    // right after the base commits, around the update-commit window. After a genuine mid-flight kill
+    // the table must be readable and reflect an ATOMIC state -- either the base (alice) or the fully
+    // committed update (bob), never a torn/half-merged/duplicated row. Then a retry must drain the
+    // update (Hudi rolls back any pending inflight) to the correct final state -- recovery + idempotency.
+    val local = basePath.replaceFirst("^file:", "")
+
+    // Each attempt is an INDEPENDENT sample on a FRESH table dir. Reusing one dir across attempts is
+    // wrong: attempt N's SIGKILL leaves a stale lock/pending-rollback that stalls attempt N+1's writer.
+    val attempts = 2
+    for (attempt <- 1 to attempts) {
+      val tablePath = s"$local/crash_tbl_$attempt"
+      val marker = s"$local/crash_marker_$attempt"
+
+      val p = launchWriter(tablePath, marker, "full", s"$local/full_$attempt.log")
+      // wait until the base is committed (update is now imminent), then kill immediately -> race the update commit
+      val deadline = System.currentTimeMillis() + 180000
+      var baseDone = false
+      while (!baseDone && System.currentTimeMillis() < deadline && p.isAlive) {
+        baseDone = new File(marker).exists() && new String(Files.readAllBytes(Paths.get(marker))).startsWith("base")
+        if (!baseDone) Thread.sleep(50)
+      }
+      val tail = scala.io.Source.fromFile(s"$local/full_$attempt.log").getLines().toList.takeRight(20).mkString("\n")
+      assertTrue(baseDone, s"attempt $attempt: base never committed (writer alive=${p.isAlive}). log tail:\n$tail")
+      p.destroyForcibly() // SIGKILL -- no shutdown hooks, a true crash
+      p.waitFor(60, TimeUnit.SECONDS)
+
+      // INV8: the crashed table is readable and atomic (alice XOR bob), never torn.
+      val rows = readRow(tablePath)
+      assertEquals(1, rows.length, s"attempt $attempt: expected exactly one row (no dup/torn), got ${rows.length}")
+      val name = rows(0).getAs[String]("name")
+      assertTrue(name == "alice" || name == "bob",
+        s"attempt $attempt: crash left a non-atomic state: name=$name (must be committed alice or bob, never a half-merge)")
+      assertEquals(100L, rows(0).getAs[Long]("amount"),
+        s"attempt $attempt: amount must be the committed 100 in either atomic state, never a placeholder leak")
+
+      // recovery: a retry drains the update against THIS crashed table (Hudi rolls back the pending inflight).
+      val retry = launchWriter(tablePath, marker, "retry", s"$local/retry_$attempt.log")
+      assertTrue(retry.waitFor(300, TimeUnit.SECONDS), s"attempt $attempt: retry did not finish")
+      assertEquals(0, retry.exitValue(), s"attempt $attempt: retry writer failed")
+      val fin = readRow(tablePath)(0)
+      assertEquals("bob", fin.getAs[String]("name"), s"attempt $attempt recovery: retry drains the update to the correct final state")
+      assertEquals(100L, fin.getAs[Long]("amount"), s"attempt $attempt recovery: unchanged amount preserved, no duplication/corruption")
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleCdcCrashHarness.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleCdcCrashHarness.scala
@@ -31,12 +31,18 @@ import java.nio.file.{Files, Paths}
 import java.util.concurrent.TimeUnit
 
 /**
- * Subprocess writer for the multi-process crash harness (P1). Run as a real OS process via `java -cp`
- * so a parent test can SIGKILL it (Process.destroyForcibly). Writes a v9 Oracle FILL_UNCHANGED MOR
- * table at args(0): a committed base, then a marker file (args(1)) to signal "about to commit the
- * update", then the update commit. The parent kills it around the marker to hit the commit window.
+ * Subprocess writer for the multi-process crash harness. Run as a real OS process via `java -cp` so a
+ * parent test can SIGKILL it (Process.destroyForcibly) mid-commit. Writes a v9 Oracle FILL_UNCHANGED
+ * MOR table at args(0): a committed base (alice, amount=100), a marker file (args(1)) signalling the
+ * base is done, then the update (name -> bob; amount carries a placeholder that FILL_UNCHANGED must
+ * discard). The base insert + update give two delta commits.
  *
- * args: (0) tablePath  (1) markerFile
+ * args: (0) tablePath  (1) markerFile  (2) mode
+ *   full          base insert + update upsert (no compaction)
+ *   retry         update upsert only (append) -- drains against a possibly-crashed table
+ *   compact       full, but with inline compaction after 2 delta commits (the update triggers it)
+ *   retry-compact retry, with inline compaction on (completes a pending/crashed compaction)
+ * The update always re-uses the same _event_ordering, so a retry re-delivering it is idempotent.
  */
 object OracleCdcCrashWriter {
   private val cols = Seq("id", "name", "amount", "_changed_columns", "_hoodie_is_deleted", "_event_ordering")
@@ -45,7 +51,13 @@ object OracleCdcCrashWriter {
   def main(args: Array[String]): Unit = {
     val path = args(0)
     val marker = args(1)
-    val mode = if (args.length > 2) args(2) else "full" // "full" = base+update; "retry" = update only (append)
+    val mode = if (args.length > 2) args(2) else "full"
+    val compact = mode.contains("compact")
+    val doBase = !mode.startsWith("retry")
+    // "full-big" pads the update with filler rows so the post-inflight data-write phase lasts seconds,
+    // widening the AFTER_INFLIGHT_BEFORE_COMPLETION window enough that a SIGKILL reliably lands inside
+    // it (a 1-row commit completes sub-millisecond after inflight, too fast to catch without a hook).
+    val fillerRows = if (mode == "full-big") 100000 else 0
     val spark = SparkSession.builder()
       .master("local[2]")
       .appName("oracle-cdc-crash-writer")
@@ -55,24 +67,36 @@ object OracleCdcCrashWriter {
     try {
       def row(id: Int, name: String, amount: Long, changed: String, ordering: String) =
         spark.createDataFrame(Seq((id, name, amount, changed, false, ordering))).toDF(cols: _*)
-      def writer(df: org.apache.spark.sql.DataFrame) = df.write.format("hudi")
-        .option("hoodie.datasource.write.recordkey.field", "id")
-        .option("hoodie.datasource.write.ordering.fields", "_event_ordering")
-        .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
-        .option("hoodie.table.name", "crash")
-        .option("hoodie.compact.inline", "false")
-      if (mode == "full") {
-        // committed base (alice, amount=100)
+      def writer(df: org.apache.spark.sql.DataFrame) = {
+        var w = df.write.format("hudi")
+          .option("hoodie.datasource.write.recordkey.field", "id")
+          .option("hoodie.datasource.write.ordering.fields", "_event_ordering")
+          .option("hoodie.datasource.write.table.type", "MERGE_ON_READ")
+          .option("hoodie.table.name", "crash")
+          .option("hoodie.compact.inline", compact.toString)
+        if (compact) {
+          w = w.option("hoodie.compact.inline.max.delta.commits", "2")
+        }
+        w
+      }
+      if (doBase) {
         writer(row(1, "alice", 100L, null, ord(100)))
           .option("hoodie.datasource.write.operation", "insert")
           .option("hoodie.write.table.version", "9")
           .option("hoodie.datasource.write.payload.class", classOf[OracleDebeziumAvroPayload].getName)
           .mode(SaveMode.Overwrite).save(path)
-        Files.write(Paths.get(marker), "base-committed".getBytes) // signal: base done, update about to start
+        Files.write(Paths.get(marker), "base-committed".getBytes) // base done; update about to start
       }
-      // the update (name->bob; amount unchanged placeholder must not win). In "retry" this drains it
-      // against a possibly-crashed table (Hudi rolls back any pending inflight first).
-      writer(row(1, "bob", 0L, "name", ord(200)))
+      val bob = row(1, "bob", 0L, "name", ord(200))
+      val updateDf = if (fillerRows > 0) {
+        val filler = spark.range(2, 2 + fillerRows).selectExpr(
+          "cast(id as int) as id", "'x' as name", "cast(0 as bigint) as amount",
+          "'name' as _changed_columns", "false as _hoodie_is_deleted", s"'${ord(200)}' as _event_ordering")
+        bob.unionByName(filler)
+      } else {
+        bob
+      }
+      writer(updateDf)
         .option("hoodie.datasource.write.operation", "upsert")
         .mode(SaveMode.Append).save(path)
       Files.write(Paths.get(marker), "update-committed".getBytes)
@@ -83,15 +107,21 @@ object OracleCdcCrashWriter {
 }
 
 /**
- * P1 crash harness. The `probe` first validates the risky assumption -- that a real Spark-writing
- * subprocess launches with a usable classpath in this sandbox. Only once that's green is the
- * kill variant worth building.
+ * Multi-process crash harness for the v9 Oracle FILL_UNCHANGED writer/merge (INV8: a crash mid-commit
+ * must never leave a half-applied merge visible). Unlike the single-JVM `revertToInflight` stand-in in
+ * TestOracleDebeziumV9ReadMerge, these launch a REAL Spark subprocess and SIGKILL it, exercising
+ * genuinely torn files, rollback-of-incomplete-instant on restart, and crash-during-recovery.
+ *
+ * P2 additions over the initial P1 kill: (a) the kill is now timed on the delta-commit *inflight*
+ * appearing on the timeline -- the AFTER_INFLIGHT_BEFORE_COMPLETION window -- rather than a coarse
+ * "base committed" marker; (b) a crash-during-inline-compaction nemesis; (c) a double-fault that kills
+ * the recovery writer while it is rolling back the first crash.
+ *
+ * Opt-in soak only (subprocess launches are slow + timing/classpath-fragile in a CI matrix): enable
+ * with -Dhudi.crash.harness=true. The probe validates the subprocess-launch assumption first.
  */
 class TestOracleCdcCrashHarness extends SparkClientFunctionalTestHarness {
 
-  // Opt-in soak gate. These launch a real Spark subprocess (slow ~15s/launch) and depend on the
-  // parent's `java.class.path` being replayable to a child JVM + on kill timing -- both fragile in a
-  // CI matrix. Skip by default; a nightly/soak lane runs them with -Dhudi.crash.harness=true.
   private def assumeCrashHarnessEnabled(): Unit =
     assumeTrue("true".equalsIgnoreCase(System.getProperty("hudi.crash.harness", System.getenv("HUDI_CRASH_HARNESS"))),
       "opt-in crash/soak harness; enable with -Dhudi.crash.harness=true")
@@ -109,6 +139,57 @@ class TestOracleCdcCrashHarness extends SparkClientFunctionalTestHarness {
   private def readRow(tablePath: String): Array[org.apache.spark.sql.Row] =
     spark.read.format("hudi").load(tablePath).select("name", "amount").where("id = 1").collect()
 
+  private def tailOf(log: String): String =
+    if (new File(log).exists) scala.io.Source.fromFile(log).getLines().toList.takeRight(20).mkString("\n") else "(no log)"
+
+  /** true if any file under `<tablePath>/.hoodie` (recursively) contains `substr` in its name. */
+  private def timelineHas(dir: File, substr: String): Boolean = {
+    val kids = dir.listFiles()
+    kids != null && kids.exists(f => if (f.isDirectory) timelineHas(f, substr) else f.getName.contains(substr))
+  }
+
+  /** Poll the timeline until a file whose name contains `substr` appears, the writer dies, or deadline. */
+  private def waitForTimelineFile(tablePath: String, substr: String, deadlineMs: Long, p: Process): Boolean = {
+    val hoodie = new File(tablePath + "/.hoodie")
+    var seen = false
+    while (!seen && System.currentTimeMillis() < deadlineMs && p.isAlive) {
+      seen = timelineHas(hoodie, substr)
+      if (!seen) Thread.sleep(20)
+    }
+    seen || timelineHas(hoodie, substr)
+  }
+
+  private def awaitMarker(marker: String, prefix: String, p: Process, timeoutMs: Long, log: String): Unit = {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    var done = false
+    while (!done && System.currentTimeMillis() < deadline && p.isAlive) {
+      done = new File(marker).exists() && new String(Files.readAllBytes(Paths.get(marker))).startsWith(prefix)
+      if (!done) Thread.sleep(50)
+    }
+    assertTrue(done, s"marker '$prefix' never appeared (writer alive=${p.isAlive}). log tail:\n${tailOf(log)}")
+  }
+
+  /** INV8: after a crash the table is readable and atomic -- one row, a committed name, amount never torn. */
+  private def assertAtomic(tablePath: String, attempt: Int): Unit = {
+    val rows = readRow(tablePath)
+    assertEquals(1, rows.length, s"attempt $attempt: expected exactly one row (no dup/torn), got ${rows.length}")
+    val name = rows(0).getAs[String]("name")
+    assertTrue(name == "alice" || name == "bob",
+      s"attempt $attempt: crash left a non-atomic state: name=$name (must be committed alice or bob, never a half-merge)")
+    assertEquals(100L, rows(0).getAs[Long]("amount"),
+      s"attempt $attempt: amount must be the committed 100 in either atomic state, never a placeholder leak")
+  }
+
+  /** Recovery: a fresh writer drains the pending update to the correct final state (bob, amount preserved). */
+  private def recoverAndAssert(tablePath: String, marker: String, mode: String, attempt: Int, log: String): Unit = {
+    val r = launchWriter(tablePath, marker, mode, log)
+    assertTrue(r.waitFor(300, TimeUnit.SECONDS), s"attempt $attempt: recovery ($mode) did not finish")
+    assertEquals(0, r.exitValue(), s"attempt $attempt: recovery ($mode) failed. log tail:\n${tailOf(log)}")
+    val fin = readRow(tablePath)(0)
+    assertEquals("bob", fin.getAs[String]("name"), s"attempt $attempt recovery: retry must drain the update to bob")
+    assertEquals(100L, fin.getAs[Long]("amount"), s"attempt $attempt recovery: unchanged amount preserved, no corruption")
+  }
+
   @Test
   def probeSubprocessWritesV9OracleTable(): Unit = {
     assumeCrashHarnessEnabled()
@@ -119,60 +200,98 @@ class TestOracleCdcCrashHarness extends SparkClientFunctionalTestHarness {
     val proc = launchWriter(tablePath, marker, "full", log)
     val finished = proc.waitFor(300, TimeUnit.SECONDS)
     if (!finished) proc.destroyForcibly()
-    val logTail = if (new File(log).exists) scala.io.Source.fromFile(log).getLines().toList.takeRight(25).mkString("\n") else "(no log)"
-    assertTrue(finished, s"writer subprocess did not finish in 300s. log tail:\n$logTail")
-    assertEquals(0, proc.exitValue(), s"writer subprocess exited non-zero. log tail:\n$logTail")
+    assertTrue(finished, s"writer subprocess did not finish in 300s. log tail:\n${tailOf(log)}")
+    assertEquals(0, proc.exitValue(), s"writer subprocess exited non-zero. log tail:\n${tailOf(log)}")
     val out = readRow(tablePath)(0)
     assertEquals("bob", out.getAs[String]("name"), "subprocess update must be committed + readable")
     assertEquals(100L, out.getAs[Long]("amount"), "unchanged amount preserved by the subprocess FILL_UNCHANGED merge")
   }
 
   @Test
-  def crashDuringUpdateLeavesAtomicStateAndRecovers(): Unit = {
+  def crashAtUpdateInflightIsAtomicAndRecovers(): Unit = {
     assumeCrashHarnessEnabled()
-    // P1 real-crash test (INV8): launch the writer as a real OS process, SIGKILL it (destroyForcibly)
-    // right after the base commits, around the update-commit window. After a genuine mid-flight kill
-    // the table must be readable and reflect an ATOMIC state -- either the base (alice) or the fully
-    // committed update (bob), never a torn/half-merged/duplicated row. Then a retry must drain the
-    // update (Hudi rolls back any pending inflight) to the correct final state -- recovery + idempotency.
+    // Precise INV8 kill: SIGKILL the writer the instant the update's delta-commit *inflight* lands on
+    // the timeline (data being written, completion marker not yet there -- AFTER_INFLIGHT_BEFORE_COMPLETION).
+    // Independent samples on FRESH dirs: attempt N's kill leaves a stale lock that would stall attempt N+1.
     val local = basePath.replaceFirst("^file:", "")
-
-    // Each attempt is an INDEPENDENT sample on a FRESH table dir. Reusing one dir across attempts is
-    // wrong: attempt N's SIGKILL leaves a stale lock/pending-rollback that stalls attempt N+1's writer.
     val attempts = 2
     for (attempt <- 1 to attempts) {
-      val tablePath = s"$local/crash_tbl_$attempt"
-      val marker = s"$local/crash_marker_$attempt"
-
-      val p = launchWriter(tablePath, marker, "full", s"$local/full_$attempt.log")
-      // wait until the base is committed (update is now imminent), then kill immediately -> race the update commit
-      val deadline = System.currentTimeMillis() + 180000
-      var baseDone = false
-      while (!baseDone && System.currentTimeMillis() < deadline && p.isAlive) {
-        baseDone = new File(marker).exists() && new String(Files.readAllBytes(Paths.get(marker))).startsWith("base")
-        if (!baseDone) Thread.sleep(50)
-      }
-      val tail = scala.io.Source.fromFile(s"$local/full_$attempt.log").getLines().toList.takeRight(20).mkString("\n")
-      assertTrue(baseDone, s"attempt $attempt: base never committed (writer alive=${p.isAlive}). log tail:\n$tail")
+      val tablePath = s"$local/inflight_$attempt"
+      val marker = s"$local/inflight_marker_$attempt"
+      val log = s"$local/inflight_$attempt.log"
+      val p = launchWriter(tablePath, marker, "full", log)
+      awaitMarker(marker, "base", p, 180000, log) // base committed; its inflight is already renamed away
+      waitForTimelineFile(tablePath, ".deltacommit.inflight", System.currentTimeMillis() + 60000, p) // the update's inflight
       p.destroyForcibly() // SIGKILL -- no shutdown hooks, a true crash
       p.waitFor(60, TimeUnit.SECONDS)
-
-      // INV8: the crashed table is readable and atomic (alice XOR bob), never torn.
-      val rows = readRow(tablePath)
-      assertEquals(1, rows.length, s"attempt $attempt: expected exactly one row (no dup/torn), got ${rows.length}")
-      val name = rows(0).getAs[String]("name")
-      assertTrue(name == "alice" || name == "bob",
-        s"attempt $attempt: crash left a non-atomic state: name=$name (must be committed alice or bob, never a half-merge)")
-      assertEquals(100L, rows(0).getAs[Long]("amount"),
-        s"attempt $attempt: amount must be the committed 100 in either atomic state, never a placeholder leak")
-
-      // recovery: a retry drains the update against THIS crashed table (Hudi rolls back the pending inflight).
-      val retry = launchWriter(tablePath, marker, "retry", s"$local/retry_$attempt.log")
-      assertTrue(retry.waitFor(300, TimeUnit.SECONDS), s"attempt $attempt: retry did not finish")
-      assertEquals(0, retry.exitValue(), s"attempt $attempt: retry writer failed")
-      val fin = readRow(tablePath)(0)
-      assertEquals("bob", fin.getAs[String]("name"), s"attempt $attempt recovery: retry drains the update to the correct final state")
-      assertEquals(100L, fin.getAs[Long]("amount"), s"attempt $attempt recovery: unchanged amount preserved, no duplication/corruption")
+      assertAtomic(tablePath, attempt)
+      recoverAndAssert(tablePath, marker, "retry", attempt, s"$local/inflight_retry_$attempt.log")
     }
+  }
+
+  @Test
+  def crashDuringInlineCompactionRecovers(): Unit = {
+    assumeCrashHarnessEnabled()
+    // Nemesis: crash while inline compaction (triggered by the 2nd delta commit) is in flight. The
+    // FILL_UNCHANGED base produced by a half-done compaction must never be visible; recovery must
+    // roll it back / re-run and converge. Assert the nemesis actually armed (a compaction instant was
+    // seen) so a pass can't be silent when compaction never scheduled.
+    val local = basePath.replaceFirst("^file:", "")
+    val attempts = 2
+    var compactionArmed = 0
+    for (attempt <- 1 to attempts) {
+      val tablePath = s"$local/compact_$attempt"
+      val marker = s"$local/compact_marker_$attempt"
+      val log = s"$local/compact_$attempt.log"
+      val p = launchWriter(tablePath, marker, "compact", log)
+      awaitMarker(marker, "base", p, 180000, log)
+      waitForTimelineFile(tablePath, ".compaction.inflight", System.currentTimeMillis() + 60000, p)
+      p.destroyForcibly()
+      p.waitFor(60, TimeUnit.SECONDS)
+      if (timelineHas(new File(tablePath + "/.hoodie"), ".compaction")) {
+        compactionArmed += 1
+      }
+      assertAtomic(tablePath, attempt)
+      recoverAndAssert(tablePath, marker, "retry-compact", attempt, s"$local/compact_retry_$attempt.log")
+    }
+    assertTrue(compactionArmed >= 1,
+      s"compaction nemesis never armed in $attempts attempts (no .compaction instant observed) -- " +
+        "lower hoodie.compact.inline.max.delta.commits or add more updates")
+  }
+
+  @Test
+  def doubleFaultCrashDuringRollbackStillRecovers(): Unit = {
+    assumeCrashHarnessEnabled()
+    // Double fault (unreachable in a single JVM): crash 1 leaves a pending update inflight; the recovery
+    // writer starts rolling that back; crash 2 kills it DURING the rollback; a third writer must still
+    // converge. Assert a rollback was actually observed so the crash-during-recovery path really ran.
+    val local = basePath.replaceFirst("^file:", "")
+    val attempts = 2
+    var rollbackArmed = 0
+    for (attempt <- 1 to attempts) {
+      val tablePath = s"$local/df_$attempt"
+      val marker = s"$local/df_marker_$attempt"
+      val log1 = s"$local/df1_$attempt.log"
+      // "full-big": a large update so the kill reliably lands mid-inflight, leaving a pending inflight
+      // for the recovery writer to roll back (a 1-row update commits too fast to leave one).
+      val p1 = launchWriter(tablePath, marker, "full-big", log1)
+      awaitMarker(marker, "base", p1, 180000, log1)
+      waitForTimelineFile(tablePath, ".deltacommit.inflight", System.currentTimeMillis() + 60000, p1)
+      Thread.sleep(300) // let the executors get into the post-inflight data-write before the kill
+      p1.destroyForcibly()
+      p1.waitFor(60, TimeUnit.SECONDS)
+
+      val p2 = launchWriter(tablePath, marker, "retry", s"$local/df2_$attempt.log")
+      waitForTimelineFile(tablePath, ".rollback", System.currentTimeMillis() + 120000, p2) // rollback of crash 1
+      p2.destroyForcibly() // crash 2: killed during/after the rollback, before committing bob
+      p2.waitFor(60, TimeUnit.SECONDS)
+      if (timelineHas(new File(tablePath + "/.hoodie"), ".rollback")) {
+        rollbackArmed += 1
+      }
+      assertAtomic(tablePath, attempt) // readable + atomic even after a crash during recovery
+      recoverAndAssert(tablePath, marker, "retry", attempt, s"$local/df3_$attempt.log")
+    }
+    assertTrue(rollbackArmed >= 1,
+      s"double-fault never armed in $attempts attempts (no .rollback instant observed) -- crash 1 left no pending inflight")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
@@ -260,4 +260,83 @@ class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
     assertEquals(100L, out.getAs[Long]("amount"),
       "unchanged amount preserved (the _debezium_metadata struct retain field doesn't break the merge)")
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // Property / differential harness: generate random Oracle-CDC event sequences (an insert followed
+  // by updates that change random, often disjoint, column subsets), run each through three merge
+  // paths -- MOR snapshot (log-vs-log deltaMerge), MOR with inline compaction, and COW write-time
+  // merge -- and diff all three against a tiny reference merge model. The reference applies
+  // FILL_UNCHANGED semantics directly: changed columns take the incoming value, unchanged columns
+  // keep the prior value, in _event_ordering order. Any path disagreeing with the reference (or with
+  // each other) is a real merge bug. This would have caught the union bug (a column changed only by
+  // an earlier update dropped by the base merge) and any COW/MOR path divergence by construction.
+  // ---------------------------------------------------------------------------------------------
+  private val propCols = Seq("id", "v1", "v2", "v3", "_changed_columns", "_hoodie_is_deleted", "_event_ordering")
+  private val propDataCols = Seq("v1", "v2", "v3")
+  private val propPlaceholder = -999L // an unchanged column's incoming value; must never win over the prior value
+
+  private def propRow(v1: Long, v2: Long, v3: Long, changed: String, ordering: String): DataFrame =
+    spark.createDataFrame(Seq((1, v1, v2, v3, changed, false, ordering))).toDF(propCols: _*)
+
+  private def propBaseWriter(frame: DataFrame, tableType: String) =
+    frame.write.format("hudi")
+      .option(RECORDKEY_FIELD.key(), "id")
+      .option(ORDERING_FIELDS.key(), "_event_ordering")
+      .option(TABLE_TYPE.key(), tableType)
+      .option(DataSourceWriteOptions.TABLE_NAME.key(), "prop")
+
+  private def writeSequence(path: String, tableType: String, compact: Boolean,
+                            base: Map[String, Long], updates: Seq[(Set[String], Map[String, Long], String)]): Unit = {
+    propBaseWriter(propRow(base("v1"), base("v2"), base("v3"), null, ord(100)), tableType)
+      .option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "9")
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), classOf[OracleDebeziumAvroPayload].getName)
+      .option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false")
+      .mode(SaveMode.Overwrite)
+      .save(path)
+    updates.foreach { case (subset, newVals, ordering) =>
+      def cell(c: String): Long = if (subset.contains(c)) newVals(c) else propPlaceholder
+      var w = propBaseWriter(propRow(cell("v1"), cell("v2"), cell("v3"), subset.toSeq.sorted.mkString(","), ordering), tableType)
+        .option(OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+        .option(HoodieCompactionConfig.INLINE_COMPACT.key(), String.valueOf(compact))
+      if (compact) {
+        w = w.option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1")
+      }
+      w.mode(SaveMode.Append).save(path)
+    }
+  }
+
+  @Test
+  def v9OracleDifferentialRandomSequencesAcrossMergePaths(): Unit = {
+    val rnd = new scala.util.Random(20260719L) // fixed seed -> reproducible
+    val numSeqs = 8
+    for (i <- 0 until numSeqs) {
+      val base = propDataCols.map(c => c -> (1L + rnd.nextInt(1000))).toMap
+      val k = 2 + rnd.nextInt(3) // 2..4 updates
+      var ordN = 100
+      val updates = (0 until k).map { _ =>
+        var subset = propDataCols.filter(_ => rnd.nextBoolean()).toSet
+        if (subset.isEmpty) subset = Set(propDataCols(rnd.nextInt(propDataCols.size)))
+        val newVals = subset.map(c => c -> (2000L + rnd.nextInt(1000))).toMap
+        ordN += 100
+        (subset, newVals, ord(ordN))
+      }
+      // reference model: apply changed columns in ordering order, keep prior otherwise.
+      var expected = base
+      updates.foreach { case (subset, nv, _) =>
+        expected = expected.map { case (c, v) => if (subset.contains(c)) (c, nv(c)) else (c, v) }
+      }
+      val desc = s"seq$i base=$base updates=${updates.map(u => (u._1.toSeq.sorted.mkString("+"), u._2)).mkString("; ")}"
+      Seq(("mor", DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL, false),
+        ("morCompacted", DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL, true),
+        ("cow", DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL, false)).foreach { case (tag, tableType, compact) =>
+        val path = s"$basePath/prop_${i}_$tag"
+        writeSequence(path, tableType, compact, base, updates)
+        val out = spark.read.format("hudi").load(path).select("v1", "v2", "v3").where("id = 1").collect()(0)
+        propDataCols.foreach { c =>
+          assertEquals(expected(c), out.getAs[Long](c), s"[$tag] column $c mismatch vs reference model; $desc")
+        }
+      }
+    }
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
@@ -167,6 +167,42 @@ class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
       s"expected a FILL_UNCHANGED-incompatibility error, got: $flattened")
   }
 
+  @Test
+  def v9OracleSchemaEvolutionAddColumnPreservesUnchanged(): Unit = {
+    // Schema evolution x FILL_UNCHANGED: the base has no `email` column; an evolved update adds it and
+    // changes only email. The pre-existing unchanged columns (name, amount) must still be preserved from
+    // the base (not overwritten by the update's placeholders), and the newly added changed column must
+    // take the incoming value. reconcileChangedColumns iterates the incoming schema and reads unchanged
+    // cols from the (older) base schema, so this exercises a base != incoming schema merge.
+    val schemaOnRead = "hoodie.schema.on.read.enable"
+    baseWriter(row(1, "alice", 100L, null, ord(100)), "oracle_v9_evolve")
+      .option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "9")
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), classOf[OracleDebeziumAvroPayload].getName)
+      .option(schemaOnRead, "true")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    val evolvedCols =
+      Seq("id", "name", "amount", "_changed_columns", "_hoodie_is_deleted", "_event_ordering", "email")
+    val evolved = spark.createDataFrame(Seq((1, "placeholder", 0L, "email", false, ord(200), "new@x")))
+      .toDF(evolvedCols: _*)
+    baseWriter(evolved, "oracle_v9_evolve")
+      .option(OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .option(schemaOnRead, "true")
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    val out = spark.read.format("hudi").load(basePath)
+      .select("id", "name", "amount", "email").where("id = 1").collect()(0)
+    assertEquals("alice", out.getAs[String]("name"),
+      "unchanged name preserved across an add-column schema evolution (not the update's placeholder)")
+    assertEquals(100L, out.getAs[Long]("amount"),
+      "unchanged amount preserved across an add-column schema evolution")
+    assertEquals("new@x", out.getAs[String]("email"),
+      "the newly added column, listed in _changed_columns, takes the incoming value")
+  }
+
   // --- delete: exercises the configured DELETE_KEY (_change_operation_type) / DELETE_MARKER ("d")
   //     reader path (distinct from the update merge). ---
   private val delCols =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
@@ -339,4 +339,53 @@ class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
       }
     }
   }
+
+
+  // --- Fault-injection: ingestion/commit-layer invariants (INV7 duplicate delivery, INV8 crash mid-commit).
+  //     These cover the tier the differential harness intentionally skips. ---
+
+  @Test
+  def v9OracleDuplicateAndStaleRedeliveryIsIdempotent(): Unit = {
+    // INV7: at-least-once delivery can redeliver an event (same _event_ordering). A duplicate, or a
+    // STALE re-delivery of an older event arriving after a newer one, must never change the merged
+    // result -- FILL_UNCHANGED on EVENT_TIME_ORDERING must be idempotent.
+    createV9Table(row(1, "alice", 100L, null, ord(100)), "oracle_v9_inv7")
+    upsert(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_inv7")           // update1: name -> bob
+    upsert(row(1, "placeholder", 200L, "amount", ord(300)), "oracle_v9_inv7") // update2: amount -> 200
+    val pre = readRow(1)
+    assertEquals("bob", pre.getAs[String]("name"))
+    assertEquals(200L, pre.getAs[Long]("amount"))
+
+    // exact duplicate of the latest event, then a stale re-delivery of the older update1.
+    upsert(row(1, "placeholder", 200L, "amount", ord(300)), "oracle_v9_inv7")
+    upsert(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_inv7")
+
+    val post = readRow(1)
+    assertEquals("bob", post.getAs[String]("name"), "duplicate/stale re-delivery must not change name")
+    assertEquals(200L, post.getAs[Long]("amount"),
+      "stale re-delivery of an older (ord=200) event must not revert amount set by the newer (ord=300) event")
+  }
+
+  @Test
+  def v9OracleUncommittedMergeNotVisible(): Unit = {
+    // INV8: a writer crash mid-commit must never leave a half-applied merge visible. Simulate the
+    // worst-case window -- data fully written but the completion marker not -- by reverting the last
+    // completed delta-commit back to inflight via the timeline API, then assert the reader ignores it.
+    // (A real process SIGKILL isn't possible in a single-JVM harness; revertToInflight is the standard
+    // faithful stand-in for the data-on-disk-but-uncommitted window.)
+    createV9Table(row(1, "alice", 100L, null, ord(100)), "oracle_v9_inv8")
+    upsert(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_inv8")     // completed
+    upsert(row(1, "carol", 0L, "name", ord(300)), "oracle_v9_inv8")   // update2: name -> carol (to be "crashed")
+
+    val mc = org.apache.hudi.common.table.HoodieTableMetaClient.builder()
+      .setConf(org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf)
+      .setBasePath(basePath).build()
+    val lastCompleted = mc.getActiveTimeline.getCommitsTimeline.filterCompletedInstants.lastInstant.get
+    mc.getActiveTimeline.revertToInflight(lastCompleted) // crash after data write, before completion
+
+    val out = readRow(1)
+    assertEquals("bob", out.getAs[String]("name"),
+      "an uncommitted (inflight) merge must never be visible on read; the crashed update2 (carol) must be invisible")
+    assertEquals(100L, out.getAs[Long]("amount"), "unchanged amount from the last committed state")
+  }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.DataSourceWriteOptions.{OPERATION, ORDERING_FIELDS, RECORDKEY_FIELD, TABLE_TYPE}
+import org.apache.hudi.common.model.debezium.OracleDebeziumAvroPayload
+import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNull}
+import org.junit.jupiter.api.Test
+
+/**
+ * End-to-end validation that an Oracle Debezium CDC table created on table version 9 merges via the
+ * built-in EVENT_TIME_ORDERING + FILL_UNCHANGED partial-update strategy (driven by the
+ * _changed_columns list) rather than the payload, and that unchanged columns are preserved through a
+ * MOR snapshot read. _event_ordering is the ordering field.
+ */
+class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
+
+  private val cols = Seq("id", "name", "amount", "_changed_columns", "_hoodie_is_deleted", "_event_ordering")
+
+  private def row(id: Int, name: String, amount: Long, changed: String, ordering: String): DataFrame =
+    spark.createDataFrame(Seq((id, name, amount, changed, false, ordering))).toDF(cols: _*)
+
+  /** Create the v9 MOR table with the Oracle payload (which the v9 config inference maps to
+   * EVENT_TIME_ORDERING + FILL_UNCHANGED). */
+  private def createV9Table(frame: DataFrame, table: String): Unit =
+    baseWriter(frame, table)
+      .option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "9")
+      .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), classOf[OracleDebeziumAvroPayload].getName)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+  private def upsert(frame: DataFrame, table: String): Unit =
+    baseWriter(frame, table)
+      .option(OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+  private def baseWriter(frame: DataFrame, table: String) =
+    frame.write.format("hudi")
+      .option(RECORDKEY_FIELD.key(), "id")
+      .option(ORDERING_FIELDS.key(), "_event_ordering")
+      .option(TABLE_TYPE.key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+      .option(DataSourceWriteOptions.TABLE_NAME.key(), table)
+      .option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false")
+
+  private def readRow(id: Int): Row =
+    spark.read.format("hudi").load(basePath).select("id", "name", "amount").where(s"id = $id").collect()(0)
+
+  private def ord(n: Int): String = "00000000000000000000." + "%020d".format(n)
+
+  @Test
+  def v9OracleChangedColumnsPreservesUnchangedColumns(): Unit = {
+    createV9Table(row(1, "alice", 100L, null, ord(100)), "oracle_v9_test")
+    // Only `name` changed; amount carries a zero-value placeholder that must NOT win.
+    upsert(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_test")
+
+    val out = readRow(1)
+    assertEquals("bob", out.getAs[String]("name"), "name is in _changed_columns -> takes the update")
+    assertEquals(100L, out.getAs[Long]("amount"),
+      "amount is NOT in _changed_columns -> preserves the prior value, not the placeholder 0")
+  }
+
+  @Test
+  def v9OracleUnchangedNullableColumnStaysNull(): Unit = {
+    createV9Table(row(1, null, 100L, null, ord(100)), "oracle_v9_test2")
+    // Update changes only amount; name is unchanged (not listed) and was stored null -> stays null.
+    upsert(row(1, "placeholder", 200L, "amount", ord(200)), "oracle_v9_test2")
+
+    val out = readRow(1)
+    assertEquals(200L, out.getAs[Long]("amount"), "amount is in _changed_columns -> takes the update")
+    assertNull(out.getAs[String]("name"),
+      "name is NOT in _changed_columns and was stored null -> stays null (no fallback to placeholder)")
+  }
+
+  @Test
+  def v9OracleDisjointUpdatesUnionChangedColumns(): Unit = {
+    // Two uncompacted log updates change different columns. The reader combines them log-vs-log
+    // (deltaMerge) into one buffered record before merging against the base, so the buffered record's
+    // _changed_columns must be the UNION (name,amount) or the base merge drops the column changed only
+    // by the older update. Discriminating test for the union fix.
+    createV9Table(row(1, "alice", 100L, null, ord(100)), "oracle_v9_test3")
+    upsert(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_test3") // only name changed
+    upsert(row(1, "placeholder", 200L, "amount", ord(300)), "oracle_v9_test3") // only amount changed
+
+    val out = readRow(1)
+    assertEquals("bob", out.getAs[String]("name"),
+      "name was changed only by update1 -> union of changed-columns preserves it through the base merge")
+    assertEquals(200L, out.getAs[Long]("amount"), "amount was changed by update2")
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
@@ -25,14 +25,16 @@ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 
 import org.apache.spark.sql.{DataFrame, Row, SaveMode}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertNull}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNull, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
 
 /**
  * End-to-end validation that an Oracle Debezium CDC table created on table version 9 merges via the
  * built-in EVENT_TIME_ORDERING + FILL_UNCHANGED partial-update strategy (driven by the
- * _changed_columns list) rather than the payload, and that unchanged columns are preserved through a
- * MOR snapshot read. _event_ordering is the ordering field.
+ * _changed_columns list) rather than the payload, and that unchanged columns are preserved. Covers
+ * MOR snapshot read (asserting log files are actually created), MOR inline compaction, COW write-time
+ * merge, deletes, nested metadata, the disjoint-update union, and the guard that rejects incompatible
+ * partial-update (schema-partial) writes against a FILL_UNCHANGED table. _event_ordering is the ordering field.
  */
 class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
 
@@ -41,27 +43,30 @@ class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
   private def row(id: Int, name: String, amount: Long, changed: String, ordering: String): DataFrame =
     spark.createDataFrame(Seq((id, name, amount, changed, false, ordering))).toDF(cols: _*)
 
-  /** Create the v9 MOR table with the Oracle payload (which the v9 config inference maps to
-   * EVENT_TIME_ORDERING + FILL_UNCHANGED). */
-  private def createV9Table(frame: DataFrame, table: String): Unit =
-    baseWriter(frame, table)
+  /** Create the v9 table with the Oracle payload (which the v9 config inference maps to
+   * EVENT_TIME_ORDERING + FILL_UNCHANGED). Defaults to MOR; pass COW to exercise the write-time merge. */
+  private def createV9Table(frame: DataFrame, table: String,
+                            tableType: String = DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL): Unit =
+    baseWriter(frame, table, tableType)
       .option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
       .option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "9")
       .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key(), classOf[OracleDebeziumAvroPayload].getName)
       .mode(SaveMode.Overwrite)
       .save(basePath)
 
-  private def upsert(frame: DataFrame, table: String): Unit =
-    baseWriter(frame, table)
+  private def upsert(frame: DataFrame, table: String,
+                     tableType: String = DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL): Unit =
+    baseWriter(frame, table, tableType)
       .option(OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
       .mode(SaveMode.Append)
       .save(basePath)
 
-  private def baseWriter(frame: DataFrame, table: String) =
+  private def baseWriter(frame: DataFrame, table: String,
+                         tableType: String = DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL) =
     frame.write.format("hudi")
       .option(RECORDKEY_FIELD.key(), "id")
       .option(ORDERING_FIELDS.key(), "_event_ordering")
-      .option(TABLE_TYPE.key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+      .option(TABLE_TYPE.key(), tableType)
       .option(DataSourceWriteOptions.TABLE_NAME.key(), table)
       .option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false")
 
@@ -70,16 +75,44 @@ class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
 
   private def ord(n: Int): String = "00000000000000000000." + "%020d".format(n)
 
+  /** Count MOR delta-commit log files under the (non-partitioned) table base path. Used to prove a
+   * test actually exercised the merge-on-read path rather than passing vacuously on a base-only read. */
+  private def logFileCount(): Int = {
+    val storage = org.apache.hudi.common.table.HoodieTableMetaClient.builder()
+      .setConf(org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf)
+      .setBasePath(basePath).build().getStorage
+    import scala.collection.JavaConverters._
+    storage.listDirectEntries(new org.apache.hudi.storage.StoragePath(basePath)).asScala
+      .count(_.getPath.getName.contains(".log."))
+  }
+
   @Test
   def v9OracleChangedColumnsPreservesUnchangedColumns(): Unit = {
     createV9Table(row(1, "alice", 100L, null, ord(100)), "oracle_v9_test")
     // Only `name` changed; amount carries a zero-value placeholder that must NOT win.
     upsert(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_test")
 
+    // The upsert must land as a log file so this exercises the merge-on-read path (not a base-only read).
+    assertTrue(logFileCount() >= 1, "MOR upsert must create at least one log file")
     val out = readRow(1)
     assertEquals("bob", out.getAs[String]("name"), "name is in _changed_columns -> takes the update")
     assertEquals(100L, out.getAs[Long]("amount"),
       "amount is NOT in _changed_columns -> preserves the prior value, not the placeholder 0")
+  }
+
+  @Test
+  def v9OracleChangedColumnsPreservesUnchangedColumnsCow(): Unit = {
+    // COW applies the partial merge at WRITE time (no log files); verify FILL_UNCHANGED still preserves
+    // the unchanged column when the merge runs on the write path rather than the read path.
+    val cow = DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL
+    createV9Table(row(1, "alice", 100L, null, ord(100)), "oracle_v9_cow", cow)
+    upsert(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_cow", cow)
+
+    assertEquals(0, logFileCount(), "COW must not create log files (merge happens on the write path)")
+    val out = readRow(1)
+    assertEquals("bob", out.getAs[String]("name"), "name is in _changed_columns -> takes the update (COW)")
+    assertEquals(100L, out.getAs[Long]("amount"),
+      "amount is NOT in _changed_columns -> preserves the prior value through the COW write-time merge")
   }
 
   @Test
@@ -104,10 +137,34 @@ class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
     upsert(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_test3") // only name changed
     upsert(row(1, "placeholder", 200L, "amount", ord(300)), "oracle_v9_test3") // only amount changed
 
+    // Two uncompacted log files are required for the log-vs-log deltaMerge this test targets; without
+    // them (e.g. if the 2nd upsert compacted) the union path would never be exercised.
+    assertTrue(logFileCount() >= 2, "the disjoint-update test needs >=2 uncompacted log files")
     val out = readRow(1)
     assertEquals("bob", out.getAs[String]("name"),
       "name was changed only by update1 -> union of changed-columns preserves it through the base merge")
     assertEquals(200L, out.getAs[Long]("amount"), "amount was changed by update2")
+  }
+
+  @Test
+  def v9OraclePartialUpdateWriteRejectedOnFillUnchangedTable(): Unit = {
+    // Guard: a FILL_UNCHANGED table requires full-schema writes. A partial-update write
+    // (WRITE_PARTIAL_UPDATE_SCHEMA, as Spark MERGE INTO with a partial UPDATE SET would emit) writes a
+    // schema-partial IS_PARTIAL log block, which would flip the reader to KEEP_VALUES and silently drop
+    // the changed-columns merge. The write must be rejected up front instead.
+    createV9Table(row(1, "alice", 100L, null, ord(100)), "oracle_v9_guard")
+    val partialSchema =
+      "{\"type\":\"record\",\"name\":\"p\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"}," +
+        "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null}]}"
+    val ex = assertThrows(classOf[Throwable], () =>
+      baseWriter(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_guard")
+        .option(OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+        .option(HoodieWriteConfig.WRITE_PARTIAL_UPDATE_SCHEMA.key(), partialSchema)
+        .mode(SaveMode.Append)
+        .save(basePath))
+    val flattened = Iterator.iterate[Throwable](ex)(_.getCause).takeWhile(_ != null).map(_.getMessage).mkString(" | ")
+    assertTrue(flattened != null && flattened.contains("FILL_UNCHANGED"),
+      s"expected a FILL_UNCHANGED-incompatibility error, got: $flattened")
   }
 
   // --- delete: exercises the configured DELETE_KEY (_change_operation_type) / DELETE_MARKER ("d")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestOracleDebeziumV9ReadMerge.scala
@@ -109,4 +109,62 @@ class TestOracleDebeziumV9ReadMerge extends SparkClientFunctionalTestHarness {
       "name was changed only by update1 -> union of changed-columns preserves it through the base merge")
     assertEquals(200L, out.getAs[Long]("amount"), "amount was changed by update2")
   }
+
+  // --- delete: exercises the configured DELETE_KEY (_change_operation_type) / DELETE_MARKER ("d")
+  //     reader path (distinct from the update merge). ---
+  private val delCols =
+    Seq("id", "name", "amount", "_change_operation_type", "_changed_columns", "_hoodie_is_deleted", "_event_ordering")
+
+  private def delRow(id: Int, name: String, amount: Long, op: String, deleted: Boolean, ordering: String): DataFrame =
+    spark.createDataFrame(Seq((id, name, amount, op, null.asInstanceOf[String], deleted, ordering))).toDF(delCols: _*)
+
+  @Test
+  def v9OracleDeleteRemovesRow(): Unit = {
+    createV9Table(delRow(1, "alice", 100L, "c", false, ord(100)), "oracle_v9_del")
+    // A newer op='d' delete event must drop the row on read.
+    upsert(delRow(1, "alice", 100L, "d", true, ord(200)), "oracle_v9_del")
+
+    val count = spark.read.format("hudi").load(basePath).where("id = 1").count()
+    assertEquals(0L, count, "a newer op='d' delete event removes the row on a v9 MOR read")
+  }
+
+  @Test
+  def v9OracleUnchangedColumnPreservedAfterCompaction(): Unit = {
+    createV9Table(row(1, "alice", 100L, null, ord(100)), "oracle_v9_compact")
+    // Force inline compaction so the log update is merged into the base; the FILL_UNCHANGED merge must
+    // preserve the unchanged column in the compacted base, not only at snapshot-read time.
+    upsertCompacting(row(1, "bob", 0L, "name", ord(200)), "oracle_v9_compact")
+
+    val out = readRow(1)
+    assertEquals("bob", out.getAs[String]("name"), "changed name applied through compaction")
+    assertEquals(100L, out.getAs[Long]("amount"), "unchanged amount preserved in the compacted base")
+  }
+
+  private def upsertCompacting(frame: DataFrame, table: String): Unit =
+    baseWriter(frame, table)
+      .option(OPERATION.key(), DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .option(HoodieCompactionConfig.INLINE_COMPACT.key(), "true")
+      .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1")
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+  // --- nested metadata: scn/commit_scn grouped under a _debezium_metadata struct (a retain field);
+  //     the partial merge must still work with the struct column present. ---
+  private val nestedCols =
+    Seq("id", "name", "amount", "_changed_columns", "_hoodie_is_deleted", "_event_ordering", "_debezium_metadata")
+
+  private def nestedRow(id: Int, name: String, amount: Long, changed: String, ordering: String,
+                        scn: Long, commitScn: Long): DataFrame =
+    spark.createDataFrame(Seq((id, name, amount, changed, false, ordering, (scn, commitScn)))).toDF(nestedCols: _*)
+
+  @Test
+  def v9OracleMergeWorksWithNestedMetadataStruct(): Unit = {
+    createV9Table(nestedRow(1, "alice", 100L, null, ord(100), 100L, 200L), "oracle_v9_nested")
+    upsert(nestedRow(1, "bob", 0L, "name", ord(200), 101L, 201L), "oracle_v9_nested")
+
+    val out = readRow(1)
+    assertEquals("bob", out.getAs[String]("name"), "changed name applied with a nested metadata struct present")
+    assertEquals(100L, out.getAs[Long]("amount"),
+      "unchanged amount preserved (the _debezium_metadata struct retain field doesn't break the merge)")
+  }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DebeziumTransformerConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DebeziumTransformerConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.config;
+
+import org.apache.hudi.common.config.ConfigClassProperty;
+import org.apache.hudi.common.config.ConfigGroups;
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieConfig;
+
+import javax.annotation.concurrent.Immutable;
+
+import static org.apache.hudi.common.util.ConfigUtils.DELTA_STREAMER_CONFIG_PREFIX;
+import static org.apache.hudi.common.util.ConfigUtils.STREAMER_CONFIG_PREFIX;
+
+/**
+ * Configurations controlling the Debezium CDC transformers (e.g.
+ * {@code PostgresDebeziumTransformer}, {@code MysqlDebeziumTransformer}).
+ */
+@Immutable
+@ConfigClassProperty(name = "Debezium Transformer Configs",
+    groupName = ConfigGroups.Names.HUDI_STREAMER,
+    subGroupName = ConfigGroups.SubGroupNames.NONE,
+    description = "Configurations controlling the Debezium CDC transformers that flatten "
+        + "Debezium change-event envelopes into Hudi rows.")
+public class DebeziumTransformerConfig extends HoodieConfig {
+
+  private static final String PREFIX = STREAMER_CONFIG_PREFIX + "transformer.debezium.";
+  private static final String OLD_PREFIX = DELTA_STREAMER_CONFIG_PREFIX + "transformer.debezium.";
+
+  public static final ConfigProperty<Boolean> ENABLE_NESTED_FIELDS = ConfigProperty
+      .key(PREFIX + "nested.fields.enable")
+      .defaultValue(false)
+      .withAlternatives(OLD_PREFIX + "nested.fields.enable")
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("When enabled, the Debezium transformer packs the CDC metadata columns "
+          + "under a single `_debezium_metadata` struct column instead of flattening them to the "
+          + "root level. The change-operation-type column and the log-position column (e.g. the "
+          + "Postgres LSN) are kept at the root level so that payload ordering keeps working. When "
+          + "this property is not set explicitly, the per-database transformer default is used "
+          + "(PostgresDebeziumTransformer defaults to true).");
+
+  public static final ConfigProperty<Boolean> SCHEMA_AS_NULLABLE = ConfigProperty
+      .key(PREFIX + "schema.nullable.enable")
+      .defaultValue(true)
+      .withAlternatives(OLD_PREFIX + "schema.nullable.enable")
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("When enabled, all columns in the transformed Debezium schema are marked "
+          + "as nullable. This keeps the output schema compatible with the nullable columns that "
+          + "Debezium change events produce.");
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DebeziumTransformerConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DebeziumTransformerConfig.java
@@ -55,7 +55,7 @@ public class DebeziumTransformerConfig extends HoodieConfig {
           + "root level. The change-operation-type column and the log-position column (e.g. the "
           + "Postgres LSN) are kept at the root level so that payload ordering keeps working. When "
           + "this property is not set explicitly, the per-database transformer default is used "
-          + "(PostgresDebeziumTransformer defaults to true).");
+          + "(both the Postgres and MySQL transformers default to flat metadata).");
 
   public static final ConfigProperty<Boolean> SCHEMA_AS_NULLABLE = ConfigProperty
       .key(PREFIX + "schema.nullable.enable")

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -66,6 +66,7 @@ import org.apache.hudi.utilities.HiveIncrementalPuller;
 import org.apache.hudi.utilities.IdentitySplitter;
 import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.checkpointing.InitialCheckPointProvider;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionException;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionService;
@@ -158,7 +159,8 @@ public class HoodieStreamer implements Serializable {
     Triple<RecordMergeMode, String, String> mergingConfigs =
         HoodieTableConfig.inferMergingConfigsForWrites(
             cfg.recordMergeMode, cfg.payloadClassName, cfg.recordMergeStrategyId, cfg.sourceOrderingFields,
-            HoodieTableVersion.fromVersionCode(ConfigUtils.getIntWithAltKeys(this.properties, HoodieWriteConfig.WRITE_TABLE_VERSION)));
+            HoodieTableVersion.fromVersionCode(ConfigUtils.getIntWithAltKeys(this.properties, HoodieWriteConfig.WRITE_TABLE_VERSION)),
+            ConfigUtils.getBooleanWithAltKeys(this.properties, DebeziumTransformerConfig.ENABLE_NESTED_FIELDS));
     cfg.recordMergeMode = mergingConfigs.getLeft();
     cfg.recordMergeStrategyId = mergingConfigs.getRight();
     if (cfg.initialCheckpointProvider != null && cfg.checkpoint == null) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -37,6 +37,7 @@ import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.EngineProperty;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -156,11 +157,19 @@ public class HoodieStreamer implements Serializable {
   public HoodieStreamer(Config cfg, JavaSparkContext jssc, FileSystem fs, Configuration conf,
                         Option<TypedProperties> propsOverride, Option<SourceProfileSupplier> sourceProfileSupplier) throws IOException {
     this.properties = combineProperties(cfg, propsOverride, jssc.hadoopConfiguration());
+    // The Hudi Streamer is the only write path that knows both the Debezium payload and whether the
+    // transformer nests the CDC metadata, so it resolves the ordering field here and threads it
+    // through both the write properties and the config that table creation persists.
+    String resolvedDebeziumOrderingFields = DebeziumConstants.resolveOrderingFields(cfg.payloadClassName,
+        ConfigUtils.getBooleanWithAltKeys(this.properties, DebeziumTransformerConfig.ENABLE_NESTED_FIELDS));
+    if (resolvedDebeziumOrderingFields != null) {
+      cfg.sourceOrderingFields = resolvedDebeziumOrderingFields;
+      this.properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), cfg.sourceOrderingFields);
+    }
     Triple<RecordMergeMode, String, String> mergingConfigs =
         HoodieTableConfig.inferMergingConfigsForWrites(
             cfg.recordMergeMode, cfg.payloadClassName, cfg.recordMergeStrategyId, cfg.sourceOrderingFields,
-            HoodieTableVersion.fromVersionCode(ConfigUtils.getIntWithAltKeys(this.properties, HoodieWriteConfig.WRITE_TABLE_VERSION)),
-            ConfigUtils.getBooleanWithAltKeys(this.properties, DebeziumTransformerConfig.ENABLE_NESTED_FIELDS));
+            HoodieTableVersion.fromVersionCode(ConfigUtils.getIntWithAltKeys(this.properties, HoodieWriteConfig.WRITE_TABLE_VERSION)));
     cfg.recordMergeMode = mergingConfigs.getLeft();
     cfg.recordMergeStrategyId = mergingConfigs.getRight();
     if (cfg.initialCheckpointProvider != null && cfg.checkpoint == null) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
@@ -75,7 +75,6 @@ import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABL
  */
 public class AbstractDebeziumTransformer implements Transformer {
 
-  public static final String DEBEZIUM_METADATA_FIELD = DebeziumConstants.DEBEZIUM_METADATA_FIELD;
   private static final String DATA_FIELD = "__data";
 
   private static final List<Column> DEFAULT_ROOT_LEVEL_METADATA_COLUMNS = Arrays.asList(
@@ -155,9 +154,9 @@ public class AbstractDebeziumTransformer implements Transformer {
         nestedMetadataFields.add(new Column(DebeziumConstants.INCOMING_SOURCE_SCHEMA_FIELD).alias(DebeziumConstants.FLATTENED_SCHEMA_NAME));
       }
 
-      rowDataset = rowDataset.withColumn(DEBEZIUM_METADATA_FIELD,
+      rowDataset = rowDataset.withColumn(DebeziumConstants.DEBEZIUM_METADATA_FIELD,
           functions.struct(nestedMetadataFields.toArray(new Column[]{})));
-      allColumns.add(new Column(DEBEZIUM_METADATA_FIELD));
+      allColumns.add(new Column(DebeziumConstants.DEBEZIUM_METADATA_FIELD));
 
       allColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
       if (lsnColumn != null) {
@@ -198,11 +197,12 @@ public class AbstractDebeziumTransformer implements Transformer {
       }
     }
 
-    // Apply correct nullability to the transformed schema
+    // Apply correct nullability to the transformed schema: a column stays non-nullable only if it
+    // was a non-nullable source column; every other column (including Debezium metadata columns) is nullable.
     StructField[] updatedStructFields = Arrays.stream(debeziumDataset.schema().fields())
-        .map(field -> field.nullable() && !nonNullableColumns.contains(field.name())
-          ? new StructField(field.name(), field.dataType(), true, field.metadata())
-          : new StructField(field.name(), field.dataType(), false, field.metadata()))
+        .map(field -> nonNullableColumns.contains(field.name())
+          ? new StructField(field.name(), field.dataType(), false, field.metadata())
+          : new StructField(field.name(), field.dataType(), true, field.metadata()))
         .toArray(StructField[]::new);
 
     return sparkSession.createDataFrame(debeziumDataset.rdd(), new StructType(updatedStructFields));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
+import org.apache.hudi.utilities.transform.Transformer;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_ENABLED;
+import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABLE_CURRUPT_RECORD_COL_NAME;
+
+/**
+ * Base {@link Transformer} that flattens a Debezium change-event envelope into a Hudi row.
+ *
+ * <p>A Debezium change event is a nested record of the form
+ * {@code {op, ts_ms, before:{...}, after:{...}, source:{...}}}. This transformer:
+ * <ul>
+ *   <li>selects the {@code before} image for deletes and the {@code after} image otherwise,
+ *       and explodes it to the row's top level;</li>
+ *   <li>surfaces the common Debezium metadata columns (operation type, processing/origin
+ *       timestamps, shard) along with any database-specific metadata columns supplied by the
+ *       subclass;</li>
+ *   <li>optionally nests the metadata columns under a single {@code _debezium_metadata} struct
+ *       (see {@link DebeziumTransformerConfig#ENABLE_NESTED_FIELDS});</li>
+ *   <li>optionally preserves the error-table corrupt-record column when the error table is
+ *       enabled;</li>
+ *   <li>applies an optional database-specific post-processing step (e.g. ordering/sequence
+ *       columns, LSN defaulting);</li>
+ *   <li>normalizes column nullability (see
+ *       {@link DebeziumTransformerConfig#SCHEMA_AS_NULLABLE}).</li>
+ * </ul>
+ *
+ * <p>The flattened column names are defined in {@link DebeziumConstants}; the matching
+ * {@code DebeziumAvroPayload} implementations rely on these names for merge/ordering semantics.
+ *
+ * <p>Subclasses configure the database-specific behavior purely through the constructor; there is
+ * no abstract method to implement.
+ */
+public class AbstractDebeziumTransformer implements Transformer {
+
+  public static final String DEBEZIUM_METADATA_FIELD = "_debezium_metadata";
+  private static final String DATA_FIELD = "__data";
+
+  private static final List<Column> DEFAULT_ROOT_LEVEL_METADATA_COLUMNS = Arrays.asList(
+      new Column(DebeziumConstants.INCOMING_OP_FIELD).alias(DebeziumConstants.FLATTENED_OP_COL_NAME));
+
+  private static final List<Column> DEFAULT_NESTED_METADATA_COLUMNS = Arrays.asList(
+      new Column(DebeziumConstants.INCOMING_TS_MS_FIELD).alias(DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_NAME_FIELD).alias(DebeziumConstants.FLATTENED_SHARD_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_TS_MS_FIELD).alias(DebeziumConstants.FLATTENED_TS_COL_NAME));
+
+  private final List<Column> typeSpecificMetadataColumns;
+  private final Option<Function<Dataset<Row>, Dataset<Row>>> postProcessingOption;
+  private final boolean nestedFieldsEnabledByDefault;
+
+  protected AbstractDebeziumTransformer(
+      List<Column> typeSpecificMetadataColumns,
+      Option<Function<Dataset<Row>, Dataset<Row>>> postProcessingOption) {
+    this(typeSpecificMetadataColumns, postProcessingOption, false);
+  }
+
+  /**
+   * @param typeSpecificMetadataColumns database-specific metadata columns (already aliased to their
+   *                                    flattened output names).
+   * @param postProcessingOption        optional post-flatten transformation applied to the result.
+   * @param nestedFieldsEnabledByDefault default used for
+   *                                     {@link DebeziumTransformerConfig#ENABLE_NESTED_FIELDS} when
+   *                                     the property is not set explicitly. Lets a subclass (e.g.
+   *                                     Postgres) opt into nested metadata by default.
+   */
+  protected AbstractDebeziumTransformer(
+      List<Column> typeSpecificMetadataColumns,
+      Option<Function<Dataset<Row>, Dataset<Row>>> postProcessingOption,
+      boolean nestedFieldsEnabledByDefault) {
+    this.typeSpecificMetadataColumns = typeSpecificMetadataColumns;
+    this.postProcessingOption = postProcessingOption;
+    this.nestedFieldsEnabledByDefault = nestedFieldsEnabledByDefault;
+  }
+
+  @Override
+  public Dataset<Row> apply(JavaSparkContext javaSparkContext, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties props) {
+    if (rowDataset.columns().length == 0) {
+      return rowDataset;
+    }
+    // Pick selective debezium meta fields: pick the row values from before field for delete record
+    // and row values from after field for insert or update records.
+    rowDataset = rowDataset
+        .withColumn(DATA_FIELD,
+            functions.when(new Column(DebeziumConstants.INCOMING_OP_FIELD).equalTo(DebeziumConstants.DELETE_OP),
+                new Column(DebeziumConstants.INCOMING_BEFORE_FIELD))
+                .otherwise(new Column(DebeziumConstants.INCOMING_AFTER_FIELD)))
+        .drop(DebeziumConstants.INCOMING_AFTER_FIELD, DebeziumConstants.INCOMING_BEFORE_FIELD);
+
+    List<Column> allColumns = new ArrayList<>();
+    boolean enableNestedFields = isNestedFieldsEnabled(props);
+
+    // When nested fields are enabled, only _change_operation_type and root-level metadata columns should be at root level
+    if (enableNestedFields) {
+      Column lsnColumn = null;
+      List<Column> otherMetadata = new ArrayList<>();
+
+      // Extract LSN column to root level, keep other metadata nested
+      for (Column col : typeSpecificMetadataColumns) {
+        String colStr = col.toString();
+        if (colStr.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME)) {
+          lsnColumn = col;
+        } else {
+          otherMetadata.add(col);
+        }
+      }
+
+      List<Column> nestedMetadataFields = new ArrayList<>();
+      nestedMetadataFields.addAll(DEFAULT_NESTED_METADATA_COLUMNS);
+      nestedMetadataFields.addAll(otherMetadata);
+
+      // Only add schema field if it exists in the source struct (not all databases have this field)
+      if (hasSchemaField(rowDataset)) {
+        nestedMetadataFields.add(new Column(DebeziumConstants.INCOMING_SOURCE_SCHEMA_FIELD).alias(DebeziumConstants.FLATTENED_SCHEMA_NAME));
+      }
+
+      rowDataset = rowDataset.withColumn(DEBEZIUM_METADATA_FIELD,
+          functions.struct(nestedMetadataFields.toArray(new Column[]{})));
+      allColumns.add(new Column(DEBEZIUM_METADATA_FIELD));
+
+      allColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
+      if (lsnColumn != null) {
+        // Add LSN column to root level
+        allColumns.add(lsnColumn);
+      }
+    } else {
+      // When nested fields are disabled, all metadata fields are at root level
+      allColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
+      allColumns.addAll(DEFAULT_NESTED_METADATA_COLUMNS);
+      allColumns.addAll(typeSpecificMetadataColumns);
+    }
+
+    allColumns.add(new Column(String.format("%s.*", DATA_FIELD)));
+
+    if (ConfigUtils.getBooleanWithAltKeys(props, ERROR_TABLE_ENABLED)) {
+      if (!Arrays.stream(rowDataset.columns()).collect(Collectors.toList())
+          .contains(ERROR_TABLE_CURRUPT_RECORD_COL_NAME)) {
+        rowDataset = rowDataset.withColumn(ERROR_TABLE_CURRUPT_RECORD_COL_NAME, functions.lit(null));
+      }
+      allColumns.add(new Column(ERROR_TABLE_CURRUPT_RECORD_COL_NAME));
+    }
+
+    Dataset<Row> flattened = rowDataset.select(allColumns.toArray(new Column[]{}));
+    Dataset<Row> debeziumDataset = postProcessingOption.map(postProcessing -> postProcessing.apply(flattened)).orElse(flattened);
+
+    if (ConfigUtils.getBooleanWithAltKeys(props, DebeziumTransformerConfig.SCHEMA_AS_NULLABLE)) {
+      return convertColumnsToNullable(sparkSession, debeziumDataset);
+    }
+
+    Set<String> nonNullableColumns = new HashSet<>();
+    for (StructField field : rowDataset.schema().fields()) {
+      if (field.dataType() instanceof StructType && DATA_FIELD.equals(field.name())) {
+        nonNullableColumns.addAll(Arrays.stream(((StructType) field.dataType()).fields())
+            .filter(dataField -> !dataField.nullable())
+            .map(StructField::name)
+            .collect(Collectors.toSet()));
+      }
+    }
+
+    // Apply correct nullability to the transformed schema
+    StructField[] updatedStructFields = Arrays.stream(debeziumDataset.schema().fields())
+        .map(field -> field.nullable() && !nonNullableColumns.contains(field.name())
+          ? new StructField(field.name(), field.dataType(), true, field.metadata())
+          : new StructField(field.name(), field.dataType(), false, field.metadata()))
+        .toArray(StructField[]::new);
+
+    return sparkSession.createDataFrame(debeziumDataset.rdd(), new StructType(updatedStructFields));
+  }
+
+  /**
+   * Resolves whether to nest the metadata columns. An explicitly set property always wins; when the
+   * property is absent the per-subclass default ({@link #nestedFieldsEnabledByDefault}) is used.
+   */
+  private boolean isNestedFieldsEnabled(TypedProperties props) {
+    return ConfigUtils.getRawValueWithAltKeys(props, DebeziumTransformerConfig.ENABLE_NESTED_FIELDS)
+        .map(value -> Boolean.parseBoolean(value.toString()))
+        .orElse(nestedFieldsEnabledByDefault);
+  }
+
+  /**
+   * Rebuilds the dataset with every column marked nullable.
+   */
+  private static Dataset<Row> convertColumnsToNullable(SparkSession sparkSession, Dataset<Row> dataset) {
+    StructField[] modifiedStructFields = Arrays.stream(dataset.schema().fields())
+        .map(field -> new StructField(field.name(), field.dataType(), true, field.metadata()))
+        .toArray(StructField[]::new);
+    return sparkSession.createDataFrame(dataset.rdd(), new StructType(modifiedStructFields));
+  }
+
+  private static boolean hasSchemaField(Dataset<Row> rowDataset) {
+    return Arrays.stream(rowDataset.schema().fields())
+        .filter(field -> DebeziumConstants.INCOMING_SOURCE_FIELD.equals(field.name()) && field.dataType() instanceof StructType)
+        .findFirst()
+        .map(field -> {
+          StructType sourceType = (StructType) field.dataType();
+          return Arrays.stream(sourceType.fields())
+              .anyMatch(sourceField -> "schema".equals(sourceField.name()));
+        })
+        .orElse(false);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
@@ -75,7 +75,7 @@ import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABL
  */
 public class AbstractDebeziumTransformer implements Transformer {
 
-  public static final String DEBEZIUM_METADATA_FIELD = "_debezium_metadata";
+  public static final String DEBEZIUM_METADATA_FIELD = DebeziumConstants.DEBEZIUM_METADATA_FIELD;
   private static final String DATA_FIELD = "__data";
 
   private static final List<Column> DEFAULT_ROOT_LEVEL_METADATA_COLUMNS = Arrays.asList(

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
@@ -197,12 +197,14 @@ public class AbstractDebeziumTransformer implements Transformer {
       }
     }
 
-    // Apply correct nullability to the transformed schema: a column stays non-nullable only if it
-    // was a non-nullable source column; every other column (including Debezium metadata columns) is nullable.
+    // Apply nullability to the transformed schema: a column stays non-nullable if Spark already
+    // infers it non-nullable, or if it was a non-nullable source data column; every other column
+    // is nullable. This preserves the non-nullability of Debezium metadata columns (e.g.
+    // _change_operation_type) that Spark infers as non-nullable when schema.nullable.enable is off.
     StructField[] updatedStructFields = Arrays.stream(debeziumDataset.schema().fields())
-        .map(field -> nonNullableColumns.contains(field.name())
-          ? new StructField(field.name(), field.dataType(), false, field.metadata())
-          : new StructField(field.name(), field.dataType(), true, field.metadata()))
+        .map(field -> field.nullable() && !nonNullableColumns.contains(field.name())
+          ? new StructField(field.name(), field.dataType(), true, field.metadata())
+          : new StructField(field.name(), field.dataType(), false, field.metadata()))
         .toArray(StructField[]::new);
 
     return sparkSession.createDataFrame(debeziumDataset.rdd(), new StructType(updatedStructFields));

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
@@ -70,12 +70,17 @@ import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABL
  * <p>The flattened column names are defined in {@link DebeziumConstants}; the matching
  * {@code DebeziumAvroPayload} implementations rely on these names for merge/ordering semantics.
  *
+ * <p>The layout and nullability behavior are configured through {@link DebeziumTransformerConfig}.
+ *
  * <p>Subclasses configure the database-specific behavior purely through the constructor; there is
  * no abstract method to implement.
  */
 public class AbstractDebeziumTransformer implements Transformer {
 
   private static final String DATA_FIELD = "__data";
+  // Bare name of the optional {@code schema} field inside the Debezium {@code source} struct
+  // (INCOMING_SOURCE_SCHEMA_FIELD is the fully-qualified {@code source.schema} path).
+  private static final String SOURCE_SCHEMA_FIELD_NAME = "schema";
 
   private static final List<Column> DEFAULT_ROOT_LEVEL_METADATA_COLUMNS = Arrays.asList(
       new Column(DebeziumConstants.INCOMING_OP_FIELD).alias(DebeziumConstants.FLATTENED_OP_COL_NAME));
@@ -99,10 +104,12 @@ public class AbstractDebeziumTransformer implements Transformer {
    * @param typeSpecificMetadataColumns database-specific metadata columns (already aliased to their
    *                                    flattened output names).
    * @param postProcessingOption        optional post-flatten transformation applied to the result.
-   * @param nestedFieldsEnabledByDefault default used for
-   *                                     {@link DebeziumTransformerConfig#ENABLE_NESTED_FIELDS} when
-   *                                     the property is not set explicitly. Lets a subclass (e.g.
-   *                                     Postgres) opt into nested metadata by default.
+   * @param nestedFieldsEnabledByDefault the subclass default for the metadata layout. Resolution
+   *                                     order at runtime: an explicitly set
+   *                                     {@code hoodie.streamer.transformer.debezium.nested.fields.enable}
+   *                                     ({@link DebeziumTransformerConfig#ENABLE_NESTED_FIELDS})
+   *                                     always wins; when the property is absent this default is
+   *                                     used. Lets a subclass opt into nested metadata by default.
    */
   protected AbstractDebeziumTransformer(
       List<Column> typeSpecificMetadataColumns,
@@ -118,77 +125,112 @@ public class AbstractDebeziumTransformer implements Transformer {
     if (rowDataset.columns().length == 0) {
       return rowDataset;
     }
-    // Pick selective debezium meta fields: pick the row values from before field for delete record
-    // and row values from after field for insert or update records.
-    rowDataset = rowDataset
+    Dataset<Row> withDataField = selectBeforeOrAfterImage(rowDataset);
+    List<Column> outputColumns = buildOutputColumns(withDataField, props);
+    Dataset<Row> withErrorCol = applyErrorTablePassthrough(withDataField, outputColumns, props);
+    Dataset<Row> flattened = withErrorCol.select(outputColumns.toArray(new Column[]{}));
+    Dataset<Row> postProcessed = postProcessingOption.map(postProcessing -> postProcessing.apply(flattened)).orElse(flattened);
+    return applyNullabilityRules(sparkSession, withDataField, postProcessed, props);
+  }
+
+  /**
+   * Selects the {@code before} image for deletes and the {@code after} image otherwise into a single
+   * {@code __data} struct column, then drops the original {@code before}/{@code after} columns.
+   */
+  private static Dataset<Row> selectBeforeOrAfterImage(Dataset<Row> rowDataset) {
+    return rowDataset
         .withColumn(DATA_FIELD,
             functions.when(new Column(DebeziumConstants.INCOMING_OP_FIELD).equalTo(DebeziumConstants.DELETE_OP),
                 new Column(DebeziumConstants.INCOMING_BEFORE_FIELD))
                 .otherwise(new Column(DebeziumConstants.INCOMING_AFTER_FIELD)))
         .drop(DebeziumConstants.INCOMING_AFTER_FIELD, DebeziumConstants.INCOMING_BEFORE_FIELD);
+  }
 
-    List<Column> allColumns = new ArrayList<>();
-    boolean enableNestedFields = isNestedFieldsEnabled(props);
-
-    // When nested fields are enabled, only _change_operation_type and root-level metadata columns should be at root level
-    if (enableNestedFields) {
-      Column lsnColumn = null;
-      List<Column> otherMetadata = new ArrayList<>();
-
-      // Extract LSN column to root level, keep other metadata nested
-      for (Column col : typeSpecificMetadataColumns) {
-        String colStr = col.toString();
-        if (colStr.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME)) {
-          lsnColumn = col;
-        } else {
-          otherMetadata.add(col);
-        }
-      }
-
-      List<Column> nestedMetadataFields = new ArrayList<>();
-      nestedMetadataFields.addAll(DEFAULT_NESTED_METADATA_COLUMNS);
-      nestedMetadataFields.addAll(otherMetadata);
-
-      // Only add schema field if it exists in the source struct (not all databases have this field)
-      if (hasSchemaField(rowDataset)) {
-        nestedMetadataFields.add(new Column(DebeziumConstants.INCOMING_SOURCE_SCHEMA_FIELD).alias(DebeziumConstants.FLATTENED_SCHEMA_NAME));
-      }
-
-      rowDataset = rowDataset.withColumn(DebeziumConstants.DEBEZIUM_METADATA_FIELD,
-          functions.struct(nestedMetadataFields.toArray(new Column[]{})));
-      allColumns.add(new Column(DebeziumConstants.DEBEZIUM_METADATA_FIELD));
-
-      allColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
-      if (lsnColumn != null) {
-        // Add LSN column to root level
-        allColumns.add(lsnColumn);
-      }
+  /**
+   * Builds the flattened output column list: the metadata columns (flat at the root or grouped under
+   * the {@code _debezium_metadata} struct, per {@link DebeziumTransformerConfig#ENABLE_NESTED_FIELDS})
+   * followed by the exploded {@code __data} image.
+   */
+  private List<Column> buildOutputColumns(Dataset<Row> withDataField, TypedProperties props) {
+    List<Column> outputColumns = new ArrayList<>();
+    if (isNestedFieldsEnabled(props)) {
+      outputColumns.addAll(buildNestedMetadataColumns(withDataField));
     } else {
-      // When nested fields are disabled, all metadata fields are at root level
-      allColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
-      allColumns.addAll(DEFAULT_NESTED_METADATA_COLUMNS);
-      allColumns.addAll(typeSpecificMetadataColumns);
+      // When nested fields are disabled, all metadata fields are at the root level.
+      outputColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
+      outputColumns.addAll(DEFAULT_NESTED_METADATA_COLUMNS);
+      outputColumns.addAll(typeSpecificMetadataColumns);
     }
+    // Explode the selected before/after image to the row's top level.
+    outputColumns.add(new Column(String.format("%s.*", DATA_FIELD)));
+    return outputColumns;
+  }
 
-    allColumns.add(new Column(String.format("%s.*", DATA_FIELD)));
-
-    if (ConfigUtils.getBooleanWithAltKeys(props, ERROR_TABLE_ENABLED)) {
-      if (!Arrays.stream(rowDataset.columns()).collect(Collectors.toList())
-          .contains(ERROR_TABLE_CURRUPT_RECORD_COL_NAME)) {
-        rowDataset = rowDataset.withColumn(ERROR_TABLE_CURRUPT_RECORD_COL_NAME, functions.lit(null));
+  /**
+   * Assembles the metadata columns for the nested layout: the operation-type column and the
+   * log-position column (e.g. the Postgres LSN) stay at the root level so payload ordering keeps
+   * working, while every other metadata column is grouped under the {@code _debezium_metadata} struct.
+   */
+  private List<Column> buildNestedMetadataColumns(Dataset<Row> withDataField) {
+    Column lsnColumn = null;
+    List<Column> nestedMetadataFields = new ArrayList<>(DEFAULT_NESTED_METADATA_COLUMNS);
+    // Keep the log-position (LSN) column at the root level; nest the rest of the type-specific metadata.
+    for (Column col : typeSpecificMetadataColumns) {
+      if (col.toString().contains(DebeziumConstants.FLATTENED_LSN_COL_NAME)) {
+        lsnColumn = col;
+      } else {
+        nestedMetadataFields.add(col);
       }
-      allColumns.add(new Column(ERROR_TABLE_CURRUPT_RECORD_COL_NAME));
+    }
+    // Only add the schema field if it exists in the source struct (not all databases have this field).
+    if (hasSchemaField(withDataField)) {
+      nestedMetadataFields.add(new Column(DebeziumConstants.INCOMING_SOURCE_SCHEMA_FIELD).alias(DebeziumConstants.FLATTENED_SCHEMA_NAME));
     }
 
-    Dataset<Row> flattened = rowDataset.select(allColumns.toArray(new Column[]{}));
-    Dataset<Row> debeziumDataset = postProcessingOption.map(postProcessing -> postProcessing.apply(flattened)).orElse(flattened);
+    List<Column> outputColumns = new ArrayList<>();
+    outputColumns.add(functions.struct(nestedMetadataFields.toArray(new Column[]{}))
+        .alias(DebeziumConstants.DEBEZIUM_METADATA_FIELD));
+    outputColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
+    if (lsnColumn != null) {
+      outputColumns.add(lsnColumn);
+    }
+    return outputColumns;
+  }
 
+  /**
+   * When the error table is enabled, ensures the corrupt-record column is present (adding a null one
+   * if the input lacks it) and includes it in {@code outputColumns} so it is preserved downstream.
+   */
+  private static Dataset<Row> applyErrorTablePassthrough(Dataset<Row> dataset, List<Column> outputColumns, TypedProperties props) {
+    if (!ConfigUtils.getBooleanWithAltKeys(props, ERROR_TABLE_ENABLED)) {
+      return dataset;
+    }
+    Dataset<Row> withCorruptCol = dataset;
+    if (!Arrays.asList(dataset.columns()).contains(ERROR_TABLE_CURRUPT_RECORD_COL_NAME)) {
+      withCorruptCol = dataset.withColumn(ERROR_TABLE_CURRUPT_RECORD_COL_NAME, functions.lit(null));
+    }
+    outputColumns.add(new Column(ERROR_TABLE_CURRUPT_RECORD_COL_NAME));
+    return withCorruptCol;
+  }
+
+  /**
+   * Normalizes column nullability on the flattened dataset. When
+   * {@link DebeziumTransformerConfig#SCHEMA_AS_NULLABLE} is set every column is marked nullable;
+   * otherwise a column stays non-nullable only if Spark already infers it non-nullable or if it was a
+   * non-nullable source data column. This preserves the non-nullability of Debezium metadata columns
+   * (e.g. {@code _change_operation_type}) that Spark infers as non-nullable.
+   *
+   * @param withDataField the dataset carrying the {@code __data} struct, used to recover which source
+   *                      data columns were non-nullable before flattening.
+   */
+  private Dataset<Row> applyNullabilityRules(SparkSession sparkSession, Dataset<Row> withDataField,
+                                             Dataset<Row> debeziumDataset, TypedProperties props) {
     if (ConfigUtils.getBooleanWithAltKeys(props, DebeziumTransformerConfig.SCHEMA_AS_NULLABLE)) {
       return convertColumnsToNullable(sparkSession, debeziumDataset);
     }
 
     Set<String> nonNullableColumns = new HashSet<>();
-    for (StructField field : rowDataset.schema().fields()) {
+    for (StructField field : withDataField.schema().fields()) {
       if (field.dataType() instanceof StructType && DATA_FIELD.equals(field.name())) {
         nonNullableColumns.addAll(Arrays.stream(((StructType) field.dataType()).fields())
             .filter(dataField -> !dataField.nullable())
@@ -197,10 +239,6 @@ public class AbstractDebeziumTransformer implements Transformer {
       }
     }
 
-    // Apply nullability to the transformed schema: a column stays non-nullable if Spark already
-    // infers it non-nullable, or if it was a non-nullable source data column; every other column
-    // is nullable. This preserves the non-nullability of Debezium metadata columns (e.g.
-    // _change_operation_type) that Spark infers as non-nullable when schema.nullable.enable is off.
     StructField[] updatedStructFields = Arrays.stream(debeziumDataset.schema().fields())
         .map(field -> field.nullable() && !nonNullableColumns.contains(field.name())
           ? new StructField(field.name(), field.dataType(), true, field.metadata())
@@ -230,15 +268,24 @@ public class AbstractDebeziumTransformer implements Transformer {
     return sparkSession.createDataFrame(dataset.rdd(), new StructType(modifiedStructFields));
   }
 
+  /**
+   * Returns whether the source struct carries a {@code schema} field (present for Postgres, absent
+   * for MySQL).
+   */
   private static boolean hasSchemaField(Dataset<Row> rowDataset) {
-    return Arrays.stream(rowDataset.schema().fields())
-        .filter(field -> DebeziumConstants.INCOMING_SOURCE_FIELD.equals(field.name()) && field.dataType() instanceof StructType)
-        .findFirst()
-        .map(field -> {
-          StructType sourceType = (StructType) field.dataType();
-          return Arrays.stream(sourceType.fields())
-              .anyMatch(sourceField -> "schema".equals(sourceField.name()));
-        })
+    return getSourceStruct(rowDataset)
+        .map(source -> Arrays.stream(source.fields()).anyMatch(field -> SOURCE_SCHEMA_FIELD_NAME.equals(field.name())))
         .orElse(false);
+  }
+
+  /**
+   * Locates the Debezium {@code source} struct in the dataset schema, if present.
+   */
+  private static Option<StructType> getSourceStruct(Dataset<Row> rowDataset) {
+    return Option.ofNullable(Arrays.stream(rowDataset.schema().fields())
+        .filter(field -> DebeziumConstants.INCOMING_SOURCE_FIELD.equals(field.name()) && field.dataType() instanceof StructType)
+        .map(field -> (StructType) field.dataType())
+        .findFirst()
+        .orElse(null));
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/MysqlDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/MysqlDebeziumTransformer.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.functions;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * {@link AbstractDebeziumTransformer} for MySQL Debezium change events.
+ *
+ * <p>Surfaces the MySQL binlog coordinates ({@code file}, {@code pos}, {@code row}) as the flattened
+ * {@code _event_bin_file}, {@code _event_pos} and {@code _event_row} columns, and derives the
+ * {@code _event_seq} ordering column as {@code "<binlog-file-suffix>.<pos>"} (e.g. {@code "000001.100"}
+ * for a binlog file {@code "mysql-bin.000001"} at position {@code 100}). {@code _event_seq} is the
+ * precombine/ordering field consumed by {@code MySqlDebeziumAvroPayload}.
+ *
+ * <p>Metadata is flattened to the root level by default; set
+ * {@code hoodie.streamer.transformer.debezium.nested.fields.enable=true} to group it under a
+ * {@code _debezium_metadata} struct instead.
+ */
+public class MysqlDebeziumTransformer extends AbstractDebeziumTransformer {
+
+  private static final List<Column> MYSQL_METADATA = Arrays.asList(
+      new Column(DebeziumConstants.INCOMING_SOURCE_FILE_FIELD).alias(DebeziumConstants.FLATTENED_FILE_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_POS_FIELD).alias(DebeziumConstants.FLATTENED_POS_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_ROW_FIELD).alias(DebeziumConstants.FLATTENED_ROW_COL_NAME));
+
+  public MysqlDebeziumTransformer() {
+    super(MYSQL_METADATA, Option.of(MysqlDebeziumTransformer::applySeqNo));
+  }
+
+  /**
+   * Builds the {@code _event_seq} ordering column from the binlog file and position. The file column
+   * holds a name like {@code "mysql-bin.000001"}; only the numeric suffix after the last dot is used,
+   * yielding a sequence such as {@code "000001.100"}. Handles both the flat and nested metadata
+   * layouts (reading {@code file}/{@code pos} from the {@code _debezium_metadata} struct when nested).
+   *
+   * @param dataset flattened MySQL Debezium dataset.
+   * @return dataset with the {@code _event_seq} column added.
+   */
+  private static Dataset<Row> applySeqNo(Dataset<Row> dataset) {
+    boolean isNested = Arrays.asList(dataset.columns()).contains(DEBEZIUM_METADATA_FIELD);
+
+    Column fileCol = isNested
+        ? dataset.col(DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_FILE_COL_NAME)
+        : dataset.col(DebeziumConstants.FLATTENED_FILE_COL_NAME);
+
+    Column posCol = isNested
+        ? dataset.col(DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_POS_COL_NAME)
+        : dataset.col(DebeziumConstants.FLATTENED_POS_COL_NAME);
+
+    return dataset.withColumn(DebeziumConstants.ADDED_SEQ_COL_NAME, functions.concat(
+        functions.substring_index(fileCol, ".", -1),
+        functions.lit("."),
+        posCol));
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/MysqlDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/MysqlDebeziumTransformer.java
@@ -64,14 +64,14 @@ public class MysqlDebeziumTransformer extends AbstractDebeziumTransformer {
    * @return dataset with the {@code _event_seq} column added.
    */
   private static Dataset<Row> applySeqNo(Dataset<Row> dataset) {
-    boolean isNested = Arrays.asList(dataset.columns()).contains(DEBEZIUM_METADATA_FIELD);
+    boolean isNested = Arrays.asList(dataset.columns()).contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD);
 
     Column fileCol = isNested
-        ? dataset.col(DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_FILE_COL_NAME)
+        ? dataset.col(DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_FILE_COL_NAME)
         : dataset.col(DebeziumConstants.FLATTENED_FILE_COL_NAME);
 
     Column posCol = isNested
-        ? dataset.col(DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_POS_COL_NAME)
+        ? dataset.col(DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_POS_COL_NAME)
         : dataset.col(DebeziumConstants.FLATTENED_POS_COL_NAME);
 
     return dataset.withColumn(DebeziumConstants.ADDED_SEQ_COL_NAME, functions.concat(

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/OracleDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/OracleDebeziumTransformer.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE;
+
+/**
+ * Transformer that flattens an Oracle Debezium CDC envelope into a flat Hudi-ready record with
+ * Oracle-specific metadata and partial-update tracking.
+ *
+ * <p>On top of the shared {@link AbstractDebeziumTransformer} flattening this adds:
+ * <ul>
+ *   <li>Oracle metadata columns {@code _event_scn} / {@code _event_commit_scn} (from
+ *       {@code source.scn} / {@code source.commit_scn}).</li>
+ *   <li>A composite event-time ordering column {@code _event_ordering} = zero-padded
+ *       {@code commit_scn.scn}, used as the ordering field for merging.</li>
+ *   <li>A {@code _changed_columns} field for update events: the comma-separated names of data columns
+ *       whose before/after values differ, excluding columns whose after image is the toasted
+ *       (unavailable) sentinel. It is null for inserts, snapshots and deletes.</li>
+ *   <li>A {@code _hoodie_is_deleted} flag (true for deletes).</li>
+ * </ul>
+ *
+ * <p>Only the supported Debezium operation types are retained: {@code c} (insert), {@code u}
+ * (update), {@code r} (snapshot) and {@code d} (delete); any other operation is dropped.
+ *
+ * <p>The flattened output is consumed either by {@code OracleDebeziumAvroPayload} (payload-based
+ * tables) or, on table version 9, by the built-in {@code EVENT_TIME_ORDERING} +
+ * {@code FILL_UNCHANGED} merge configuration inferred from that payload class.
+ */
+public class OracleDebeziumTransformer extends AbstractDebeziumTransformer {
+
+  // Operation type constants.
+  static final String INSERT_OP = "c";
+  static final String UPDATE_OP = "u";
+  static final String SNAPSHOT_OP = "r";
+
+  private static final List<Column> ORACLE_METADATA = Arrays.asList(
+      new Column(DebeziumConstants.INCOMING_SOURCE_SCN_FIELD).cast(DataTypes.StringType).alias(DebeziumConstants.FLATTENED_SCN_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_COMMIT_SCN_FIELD).cast(DataTypes.StringType).alias(DebeziumConstants.FLATTENED_COMMIT_SCN_COL_NAME));
+
+  public OracleDebeziumTransformer() {
+    super(ORACLE_METADATA, Option.of(OracleDebeziumTransformer::applyOrdering));
+  }
+
+  @Override
+  public Dataset<Row> apply(
+      JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties props) {
+    if (rowDataset.columns().length == 0) {
+      return rowDataset;
+    }
+
+    // Filter to supported operation types only (c, r, u, d).
+    rowDataset = rowDataset.filter(
+        functions.col(DebeziumConstants.INCOMING_OP_FIELD)
+            .isin(INSERT_OP, SNAPSHOT_OP, UPDATE_OP, DebeziumConstants.DELETE_OP));
+
+    StructType afterSchema = (StructType) rowDataset.schema()
+        .apply(DebeziumConstants.INCOMING_AFTER_FIELD).dataType();
+    String[] dataFieldNames = afterSchema.fieldNames();
+
+    // Compute _changed_columns for updates: track field names where before and after values differ,
+    // excluding fields where the after image contains a toasted (unavailable) value.
+    Column toastedLit = functions.lit(DEBEZIUM_TOASTED_VALUE);
+    List<Column> changedColConditions = new ArrayList<>();
+    for (String fieldName : dataFieldNames) {
+      Column afterCol = functions.col(DebeziumConstants.INCOMING_AFTER_FIELD + "." + fieldName);
+      Column beforeCol = functions.col(DebeziumConstants.INCOMING_BEFORE_FIELD + "." + fieldName);
+      // A column is "changed" when before != after (using null-safe comparison).
+      Column isDifferent = afterCol.isNull().and(beforeCol.isNotNull())
+          .or(afterCol.isNotNull().and(beforeCol.isNull()))
+          .or(afterCol.isNotNull().and(beforeCol.isNotNull()).and(afterCol.notEqual(beforeCol)));
+      // Only check for the toasted sentinel on string-typed columns; non-string columns (numeric, etc.)
+      // cannot hold the sentinel value and comparing them against a string literal is type-unsafe.
+      // Use coalesce(..., false) because when afterCol is null, equalTo returns null (Spark's
+      // three-valued logic), which would poison and cause the change to be missed.
+      boolean isStringField = afterSchema.apply(fieldName).dataType() == DataTypes.StringType;
+      Column isChanged = isStringField
+          ? isDifferent.and(functions.not(functions.coalesce(afterCol.equalTo(toastedLit), functions.lit(false))))
+          : isDifferent;
+      changedColConditions.add(
+          functions.when(isChanged, functions.lit(fieldName))
+              .otherwise(functions.lit(null).cast(DataTypes.StringType)));
+    }
+    Column changedColumnsConcat = functions.concat_ws(",",
+        changedColConditions.toArray(new Column[0]));
+    Column changedColsForUpdate = functions.when(changedColumnsConcat.equalTo(""),
+            functions.lit(null).cast(DataTypes.StringType))
+        .otherwise(changedColumnsConcat);
+
+    // Materialize computed values as top-level columns first, so the expression tree is evaluated
+    // once per row rather than duplicated across both struct rebuilds.
+    String tmpChangedCol = "__tmp_changed_columns";
+    String tmpIsDeletedCol = "__tmp_hoodie_is_deleted";
+
+    // _changed_columns is only meaningful for update operations; null for inserts/deletes/snapshots.
+    Column changedCols = functions.when(
+            functions.col(DebeziumConstants.INCOMING_OP_FIELD).equalTo(UPDATE_OP), changedColsForUpdate)
+        .otherwise(functions.lit(null).cast(DataTypes.StringType));
+
+    // _hoodie_is_deleted: true for deletes, false otherwise.
+    Column isDeleted = functions.col(DebeziumConstants.INCOMING_OP_FIELD)
+        .equalTo(DebeziumConstants.DELETE_OP);
+
+    rowDataset = rowDataset
+        .withColumn(tmpChangedCol, changedCols)
+        .withColumn(tmpIsDeletedCol, isDeleted);
+
+    // Reference the materialized columns in struct rebuilds so they are not re-derived.
+    Column changedColsRef = functions.col(tmpChangedCol);
+    Column isDeletedRef = functions.col(tmpIsDeletedCol);
+
+    // Add computed columns to both before and after structs so they survive the flattening in
+    // AbstractDebeziumTransformer.apply() (which selects __data.*).
+    rowDataset = rebuildStructWithExtraFields(rowDataset, DebeziumConstants.INCOMING_AFTER_FIELD,
+        dataFieldNames, changedColsRef, isDeletedRef);
+    rowDataset = rebuildStructWithExtraFields(rowDataset, DebeziumConstants.INCOMING_BEFORE_FIELD,
+        dataFieldNames, changedColsRef, isDeletedRef);
+
+    // Drop temp columns before passing to super — they are now inside the structs.
+    rowDataset = rowDataset.drop(tmpChangedCol, tmpIsDeletedCol);
+
+    return super.apply(jsc, sparkSession, rowDataset, props);
+  }
+
+  private static Dataset<Row> rebuildStructWithExtraFields(Dataset<Row> dataset, String structName,
+                                                           String[] dataFieldNames, Column changedCols, Column isDeleted) {
+    List<Column> fields = new ArrayList<>();
+    for (String fieldName : dataFieldNames) {
+      fields.add(functions.col(structName + "." + fieldName).alias(fieldName));
+    }
+    fields.add(changedCols.alias(DebeziumConstants.CHANGED_COLUMNS_FIELD));
+    fields.add(isDeleted.alias(HoodieRecord.HOODIE_IS_DELETED_FIELD));
+    return dataset.withColumn(structName, functions.struct(fields.toArray(new Column[0])));
+  }
+
+  private static Dataset<Row> applyOrdering(Dataset<Row> dataset) {
+    boolean isNested = Arrays.asList(dataset.columns()).contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD);
+
+    Column commitScnCol = isNested
+        ? dataset.col(DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_COMMIT_SCN_COL_NAME)
+        : dataset.col(DebeziumConstants.FLATTENED_COMMIT_SCN_COL_NAME);
+    Column scnCol = isNested
+        ? dataset.col(DebeziumConstants.DEBEZIUM_METADATA_FIELD + "." + DebeziumConstants.FLATTENED_SCN_COL_NAME)
+        : dataset.col(DebeziumConstants.FLATTENED_SCN_COL_NAME);
+
+    Column paddedCommitScn = functions.lpad(
+        functions.coalesce(commitScnCol, functions.lit("0")), 20, "0");
+    Column paddedScn = functions.lpad(
+        functions.coalesce(scnCol, functions.lit("0")), 20, "0");
+    return dataset.withColumn(DebeziumConstants.FLATTENED_ORDERING_COL_NAME,
+        functions.concat(paddedCommitScn, functions.lit("."), paddedScn));
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/PostgresDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/PostgresDebeziumTransformer.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.spark.sql.functions.expr;
+import static org.apache.spark.sql.functions.when;
+
+/**
+ * {@link AbstractDebeziumTransformer} for Postgres Debezium change events.
+ *
+ * <p>Surfaces the Postgres-specific source metadata ({@code txId}, {@code lsn}, {@code xmin}) as the
+ * flattened {@code _event_tx_id}, {@code _event_lsn} and {@code _event_xmin} columns. The
+ * {@code _event_lsn} column is the ordering field used by {@code PostgresDebeziumAvroPayload}.
+ *
+ * <p>Post-processing defaults a null {@code _event_lsn} to {@code 0} for snapshot records, since the
+ * LSN is not populated for rows produced by Debezium incremental snapshots
+ * (see <a href="https://debezium.io/blog/2021/10/07/incremental-snapshots/">incremental snapshots</a>).
+ *
+ * <p>Nested metadata is enabled by default for Postgres (the {@code _event_lsn} and operation-type
+ * columns stay at the root level so payload ordering keeps working); set
+ * {@code hoodie.streamer.transformer.debezium.nested.fields.enable=false} to flatten all metadata.
+ */
+public class PostgresDebeziumTransformer extends AbstractDebeziumTransformer {
+
+  // Snapshot operation type emitted by Debezium ("read").
+  private static final String SNAPSHOT_OP = "r";
+
+  private static final List<Column> POSTGRES_METADATA = Arrays.asList(
+      new Column(DebeziumConstants.INCOMING_SOURCE_TXID_FIELD).alias(DebeziumConstants.FLATTENED_TX_ID_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_LSN_FIELD).alias(DebeziumConstants.FLATTENED_LSN_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_XMIN_FIELD).alias(DebeziumConstants.FLATTENED_XMIN_COL_NAME));
+
+  public PostgresDebeziumTransformer() {
+    super(POSTGRES_METADATA, Option.of(PostgresDebeziumTransformer::useDefaultValuesForLsnIfNull), true);
+  }
+
+  /**
+   * Defaults a null {@code _event_lsn} to {@code 0} for snapshot records. The LSN is null when a
+   * table is added via a Debezium incremental snapshot; leaving it null would break LSN-based
+   * ordering in the payload.
+   *
+   * @param dataset flattened Postgres Debezium dataset.
+   * @return dataset where null {@code _event_lsn} values on snapshot rows are replaced with 0.
+   */
+  private static Dataset<Row> useDefaultValuesForLsnIfNull(Dataset<Row> dataset) {
+    if (!Arrays.asList(dataset.columns()).contains(DebeziumConstants.FLATTENED_LSN_COL_NAME)) {
+      return dataset;
+    }
+
+    return dataset.withColumn(DebeziumConstants.FLATTENED_LSN_COL_NAME, when(
+        dataset.col(DebeziumConstants.FLATTENED_OP_COL_NAME).equalTo(SNAPSHOT_OP),
+        expr(String.format("coalesce(%s, cast(0 as long))", DebeziumConstants.FLATTENED_LSN_COL_NAME))
+    ).otherwise(dataset.col(DebeziumConstants.FLATTENED_LSN_COL_NAME)));
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/PostgresDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/PostgresDebeziumTransformer.java
@@ -43,14 +43,12 @@ import static org.apache.spark.sql.functions.when;
  * LSN is not populated for rows produced by Debezium incremental snapshots
  * (see <a href="https://debezium.io/blog/2021/10/07/incremental-snapshots/">incremental snapshots</a>).
  *
- * <p>Nested metadata is enabled by default for Postgres (the {@code _event_lsn} and operation-type
- * columns stay at the root level so payload ordering keeps working); set
- * {@code hoodie.streamer.transformer.debezium.nested.fields.enable=false} to flatten all metadata.
+ * <p>Metadata is flattened to the root level by default; set
+ * {@code hoodie.streamer.transformer.debezium.nested.fields.enable=true} to group it under a
+ * {@code _debezium_metadata} struct instead. When nested, the {@code _event_lsn} and operation-type
+ * columns stay at the root level so payload ordering keeps working.
  */
 public class PostgresDebeziumTransformer extends AbstractDebeziumTransformer {
-
-  // Snapshot operation type emitted by Debezium ("read").
-  private static final String SNAPSHOT_OP = "r";
 
   private static final List<Column> POSTGRES_METADATA = Arrays.asList(
       new Column(DebeziumConstants.INCOMING_SOURCE_TXID_FIELD).alias(DebeziumConstants.FLATTENED_TX_ID_COL_NAME),
@@ -58,7 +56,7 @@ public class PostgresDebeziumTransformer extends AbstractDebeziumTransformer {
       new Column(DebeziumConstants.INCOMING_SOURCE_XMIN_FIELD).alias(DebeziumConstants.FLATTENED_XMIN_COL_NAME));
 
   public PostgresDebeziumTransformer() {
-    super(POSTGRES_METADATA, Option.of(PostgresDebeziumTransformer::useDefaultValuesForLsnIfNull), true);
+    super(POSTGRES_METADATA, Option.of(PostgresDebeziumTransformer::useDefaultValuesForLsnIfNull));
   }
 
   /**
@@ -75,7 +73,7 @@ public class PostgresDebeziumTransformer extends AbstractDebeziumTransformer {
     }
 
     return dataset.withColumn(DebeziumConstants.FLATTENED_LSN_COL_NAME, when(
-        dataset.col(DebeziumConstants.FLATTENED_OP_COL_NAME).equalTo(SNAPSHOT_OP),
+        dataset.col(DebeziumConstants.FLATTENED_OP_COL_NAME).equalTo(DebeziumConstants.SNAPSHOT_OP),
         expr(String.format("coalesce(%s, cast(0 as long))", DebeziumConstants.FLATTENED_LSN_COL_NAME))
     ).otherwise(dataset.col(DebeziumConstants.FLATTENED_LSN_COL_NAME)));
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/OracleCdcKafkaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/OracleCdcKafkaStreamer.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.functional;
+
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.model.debezium.OracleDebeziumAvroPayload;
+import org.apache.hudi.utilities.sources.JsonKafkaSource;
+import org.apache.hudi.utilities.streamer.HoodieStreamer;
+import org.apache.hudi.utilities.transform.debezium.OracleDebeziumTransformer;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Subprocess entry point for {@link TestOracleCdcKafkaReplayCrashHarness}: a real HoodieStreamer
+ * ingesting Oracle-Debezium JSON from Kafka into a v9 FILL_UNCHANGED MOR table. Launched via
+ * {@code java -cp} so the parent test can SIGKILL it mid-commit.
+ *
+ * <p>args: (0) tablePath (1) bootstrap (2) topic (3) groupId (4) mode ["once" | "continuous"].
+ */
+public class OracleCdcKafkaStreamer {
+
+  // Avro schema of the incoming Oracle-Debezium JSON envelope (before/after are distinct records).
+  private static final String ENVELOPE_AVSC =
+      "{\"type\":\"record\",\"name\":\"Envelope\",\"namespace\":\"oracle.cdc\",\"fields\":["
+      + "{\"name\":\"op\",\"type\":[\"null\",\"string\"],\"default\":null},"
+      + "{\"name\":\"ts_ms\",\"type\":[\"null\",\"long\"],\"default\":null},"
+      + "{\"name\":\"before\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"BeforeRow\",\"fields\":["
+      + "{\"name\":\"id\",\"type\":[\"null\",\"int\"],\"default\":null},"
+      + "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+      + "{\"name\":\"notes\",\"type\":[\"null\",\"string\"],\"default\":null}]}],\"default\":null},"
+      + "{\"name\":\"after\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"AfterRow\",\"fields\":["
+      + "{\"name\":\"id\",\"type\":[\"null\",\"int\"],\"default\":null},"
+      + "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+      + "{\"name\":\"notes\",\"type\":[\"null\",\"string\"],\"default\":null}]}],\"default\":null},"
+      + "{\"name\":\"source\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Source\",\"fields\":["
+      + "{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},"
+      + "{\"name\":\"ts_ms\",\"type\":[\"null\",\"long\"],\"default\":null},"
+      + "{\"name\":\"txId\",\"type\":[\"null\",\"long\"],\"default\":null},"
+      + "{\"name\":\"scn\",\"type\":[\"null\",\"string\"],\"default\":null},"
+      + "{\"name\":\"commit_scn\",\"type\":[\"null\",\"string\"],\"default\":null}]}],\"default\":null}]}";
+
+  public static void main(String[] args) throws Exception {
+    String tablePath = args[0];
+    String bootstrap = args[1];
+    String topic = args[2];
+    String group = args[3];
+    boolean continuous = args.length > 4 && "continuous".equals(args[4]);
+
+    SparkSession spark = SparkSession.builder()
+        .master("local[2]")
+        .appName("oracle-cdc-kafka-streamer")
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.ui.enabled", "false")
+        .getOrCreate();
+    JavaSparkContext jsc = new JavaSparkContext(spark.sparkContext());
+    try {
+      Path schemaFile = Paths.get(tablePath + "_source.avsc");
+      Files.createDirectories(schemaFile.toAbsolutePath().getParent());
+      Files.write(schemaFile, ENVELOPE_AVSC.getBytes(StandardCharsets.UTF_8));
+
+      HoodieStreamer.Config cfg = new HoodieStreamer.Config();
+      cfg.targetBasePath = tablePath;
+      cfg.targetTableName = "oracle_kafka_crash";
+      cfg.tableType = "MERGE_ON_READ";
+      cfg.sourceClassName = JsonKafkaSource.class.getName();
+      cfg.schemaProviderClassName = TestOracleCdcKafkaReplayCrashHarness.SourceOnlySchemaProvider.class.getName();
+      cfg.transformerClassNames = Collections.singletonList(OracleDebeziumTransformer.class.getName());
+      cfg.sourceOrderingFields = "_event_ordering";
+      cfg.payloadClassName = OracleDebeziumAvroPayload.class.getName();
+      cfg.operation = WriteOperationType.UPSERT;
+      cfg.continuousMode = continuous;
+      cfg.minSyncIntervalSeconds = 1;
+      cfg.configs = new ArrayList<>(Arrays.asList(
+          "hoodie.datasource.write.recordkey.field=id",
+          "hoodie.write.table.version=9",
+          // MOR streamer compaction: once-mode requires inline=true, continuous-mode requires inline=false
+          // (async compaction runs instead). Keep the threshold high so compaction does not fire during the
+          // short probe/crash windows and confound the crash timing.
+          "hoodie.compact.inline=" + (continuous ? "false" : "true"),
+          "hoodie.compact.inline.max.delta.commits=50",
+          "hoodie.embed.timeline.server=false",
+          "hoodie.streamer.source.kafka.topic=" + topic,
+          "bootstrap.servers=" + bootstrap,
+          "auto.offset.reset=earliest",
+          "enable.auto.commit=false",
+          "group.id=" + group,
+          "hoodie.streamer.schemaprovider.source.schema.file=file:" + schemaFile.toAbsolutePath(),
+          // continuous: one event per commit -> many crash boundaries; once: drain the backlog in one pass.
+          "hoodie.streamer.kafka.source.maxEvents=" + (continuous ? "1" : "1000")));
+      new HoodieStreamer(cfg, jsc).sync();
+    } finally {
+      spark.stop();
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestOracleCdcKafkaReplayCrashHarness.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/functional/TestOracleCdcKafkaReplayCrashHarness.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.functional;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
+import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
+import org.apache.hudi.utilities.testutils.KafkaTestUtils;
+
+import org.apache.avro.Schema;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * P2 Kafka-replay crash harness for the v9 Oracle FILL_UNCHANGED ingestion path. Unlike the spark-side
+ * TestOracleCdcCrashHarness (a DataFrame writer), this runs the REAL streamer pipeline end-to-end:
+ * a HoodieStreamer subprocess ingests Oracle-Debezium envelopes from a Kafka topic through the
+ * OracleDebeziumTransformer into a v9 FILL_UNCHANGED MOR table, with source-checkpointed at-least-once
+ * delivery. Crashing (SIGKILL) and restarting the streamer exercises the two properties the single-JVM
+ * tests cannot: (INV8) a crash mid-commit leaves only committed data visible, and (INV7) the source
+ * redelivers uncommitted events on restart and the merge is idempotent (no dup / no loss).
+ *
+ * Fidelity note: events are JSON on the wire (JsonKafkaSource) rather than schema-registry Avro. A
+ * subprocess cannot reach an in-JVM mock schema registry, and the wire format is orthogonal to the
+ * replay/idempotency invariants under test -- the transformer, payload, v9 merge, checkpoint and
+ * crash/restart are all the real production code paths.
+ *
+ * Opt-in soak only: enable with -Dhudi.crash.harness=true. Needs a Docker daemon (testcontainers Kafka,
+ * confluentinc/cp-kafka:7.7.1). The probe validates the whole pipeline before the kill variants run.
+ */
+public class TestOracleCdcKafkaReplayCrashHarness extends SparkClientFunctionalTestHarness {
+
+  /** Oracle Debezium sentinel for an unchanged/unavailable column value (mirrors PostgresDebeziumAvroPayload). */
+  private static final String TOASTED = "__debezium_unavailable_value";
+
+  private void assumeEnabled() {
+    assumeTrue("true".equalsIgnoreCase(System.getProperty("hudi.crash.harness", System.getenv("HUDI_CRASH_HARNESS"))),
+        "opt-in crash/soak harness; enable with -Dhudi.crash.harness=true");
+  }
+
+  /**
+   * Provides the incoming envelope schema as the SOURCE schema (so JSON parses into nested rows) but a
+   * NULL target schema, which makes StreamSync deduce the writer schema from the transformer's flattened
+   * output instead of the (nested) source schema. Instantiated by the streamer via reflection.
+   */
+  public static class SourceOnlySchemaProvider extends FilebasedSchemaProvider {
+    public SourceOnlySchemaProvider(TypedProperties props, JavaSparkContext jssc) {
+      super(props, jssc);
+    }
+
+    @Override
+    public Schema getTargetSchema() {
+      return null;
+    }
+  }
+
+  private static String insertEvent(int id, String name, String notes, long scn) {
+    return String.format("{\"op\":\"c\",\"ts_ms\":%d,\"before\":null,"
+        + "\"after\":{\"id\":%d,\"name\":\"%s\",\"notes\":\"%s\"},"
+        + "\"source\":{\"name\":\"ora\",\"ts_ms\":%d,\"txId\":%d,\"scn\":\"%d\",\"commit_scn\":\"%d\"}}",
+        scn, id, name, notes, scn, scn, scn, scn);
+  }
+
+  private static String updateEvent(int id, String beforeName, String beforeNotes,
+                                    String afterName, String afterNotes, long scn) {
+    return String.format("{\"op\":\"u\",\"ts_ms\":%d,"
+        + "\"before\":{\"id\":%d,\"name\":\"%s\",\"notes\":\"%s\"},"
+        + "\"after\":{\"id\":%d,\"name\":\"%s\",\"notes\":\"%s\"},"
+        + "\"source\":{\"name\":\"ora\",\"ts_ms\":%d,\"txId\":%d,\"scn\":\"%d\",\"commit_scn\":\"%d\"}}",
+        scn, id, beforeName, beforeNotes, id, afterName, afterNotes, scn, scn, scn, scn);
+  }
+
+  private String localBase() {
+    return basePath().replaceFirst("^file:", ""); // basePath is a file: URI; the subprocess + File need a plain path
+  }
+
+  private Process launch(String tablePath, String bootstrap, String topic, String group,
+                         String mode, String log) throws IOException {
+    String javaBin = System.getProperty("java.home") + "/bin/java";
+    String cp = System.getProperty("java.class.path");
+    ProcessBuilder pb = new ProcessBuilder(javaBin, "-cp", cp,
+        OracleCdcKafkaStreamer.class.getName(),
+        tablePath, bootstrap, topic, group, mode);
+    pb.redirectErrorStream(true);
+    pb.redirectOutput(new File(log));
+    return pb.start();
+  }
+
+  private static String tail(String log) {
+    try {
+      List<String> lines = Files.readAllLines(Paths.get(log));
+      return String.join("\n", lines.subList(Math.max(0, lines.size() - 30), lines.size()));
+    } catch (IOException e) {
+      return "(no log: " + e.getMessage() + ")";
+    }
+  }
+
+  private void runOnceToCompletion(String tablePath, String bootstrap, String topic, String group, String log)
+      throws Exception {
+    Process p = launch(tablePath, bootstrap, topic, group, "once", log);
+    boolean done = p.waitFor(300, TimeUnit.SECONDS);
+    if (!done) {
+      p.destroyForcibly();
+    }
+    assertTrue(done, "streamer subprocess did not finish in 300s. log tail:\n" + tail(log));
+    assertEquals(0, p.exitValue(), "streamer subprocess exited non-zero. log tail:\n" + tail(log));
+  }
+
+  private Row readRow(String tablePath) {
+    return spark().read().format("hudi").load(tablePath)
+        .select("name", "notes").where("id = 1").collectAsList().get(0);
+  }
+
+  /** Current name of id=1, or null if the table/row is not yet readable (tolerates mid-write reads). */
+  private String currentName(String tablePath) {
+    try {
+      List<Row> rows = spark().read().format("hudi").load(tablePath)
+          .select("name").where("id = 1").collectAsList();
+      return rows.isEmpty() ? null : rows.get(0).getAs("name");
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /** Poll until id=1 has the target name (or the writer dies / deadline). */
+  private void awaitName(String tablePath, String target, long timeoutMs, Process p) throws InterruptedException {
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    while (System.currentTimeMillis() < deadline && p.isAlive()) {
+      if (target.equals(currentName(tablePath))) {
+        return;
+      }
+      Thread.sleep(300);
+    }
+  }
+
+  @Test
+  public void probeKafkaStreamerPipeline() throws Exception {
+    assumeEnabled();
+    KafkaTestUtils kafka = new KafkaTestUtils();
+    kafka.setup();
+    try {
+      String topic = "oracle_cdc_probe";
+      kafka.createTopic(topic, 1);
+      String tablePath = localBase() + "/kafka_probe";
+      String logDir = System.getProperty("hudi.crash.harness.log", localBase());
+      String bootstrap = kafka.brokerAddress();
+
+      // Commit 1: the base insert (alice, notes=orig-notes).
+      kafka.sendMessages(topic, new String[] {insertEvent(1, "alice", "orig-notes", 100)});
+      runOnceToCompletion(tablePath, bootstrap, topic, "probe-grp", logDir + "/probe1.log");
+
+      // Commit 2: the update (name -> bob; notes carries the toasted sentinel). The streamer resumes
+      // from its committed Kafka checkpoint and reads only this new event, then FILL_UNCHANGED merges it
+      // against the committed base -- notes must stay orig-notes, not the placeholder.
+      kafka.sendMessages(topic, new String[] {updateEvent(1, "alice", "orig-notes", "bob", TOASTED, 200)});
+      runOnceToCompletion(tablePath, bootstrap, topic, "probe-grp", logDir + "/probe2.log");
+
+      Row r = readRow(tablePath);
+      assertEquals("bob", r.getAs("name"), "the update must be applied through the transformer + merge");
+      assertEquals("orig-notes", r.getAs("notes"),
+          "FILL_UNCHANGED must preserve the unchanged (toasted) notes column, not persist the placeholder");
+    } finally {
+      kafka.teardown();
+    }
+  }
+
+  @Test
+  public void crashDuringKafkaIngestionReplaysIdempotently() throws Exception {
+    assumeEnabled();
+    KafkaTestUtils kafka = new KafkaTestUtils();
+    kafka.setup();
+    try {
+      String topic = "oracle_cdc_crash";
+      kafka.createTopic(topic, 1);
+      String tablePath = localBase() + "/kafka_crash";
+      String bootstrap = kafka.brokerAddress();
+      String logDir = System.getProperty("hudi.crash.harness.log", localBase());
+
+      // A monotonic-SCN sequence on id=1. Every update carries the toasted sentinel for notes, so
+      // FILL_UNCHANGED must keep orig-notes at every step; the terminal name is dave (highest SCN).
+      // Because the merge orders by SCN, the outcome is deterministic no matter how many events get
+      // reprocessed on restart -- reprocessing an already-applied SCN is a no-op (idempotent).
+      kafka.sendMessages(topic, new String[] {
+          insertEvent(1, "alice", "orig-notes", 100),
+          updateEvent(1, "alice", "orig-notes", "bob", TOASTED, 200),
+          updateEvent(1, "bob", "orig-notes", "carol", TOASTED, 300),
+          updateEvent(1, "carol", "orig-notes", "dave", TOASTED, 400)
+      });
+
+      // Continuous streamer, one event per commit. Kill it once the base is committed and a couple more
+      // events are flowing -- a real SIGKILL mid-stream, leaving uncommitted events in Kafka to replay.
+      Process p1 = launch(tablePath, bootstrap, topic, "crash-grp", "continuous", logDir + "/crash1.log");
+      awaitName(tablePath, "alice", 180000, p1); // base committed
+      Thread.sleep(1500); // let a couple more per-event commits flow before the crash
+      p1.destroyForcibly();
+      p1.waitFor(60, TimeUnit.SECONDS);
+
+      // INV8: after the crash the table is readable and shows a committed prefix, never torn and never a
+      // placeholder leak. (currentName tolerates a transient mid-write read by retrying via the poll.)
+      String midName = null;
+      for (int i = 0; i < 20 && midName == null; i++) {
+        midName = currentName(tablePath);
+        if (midName == null) {
+          Thread.sleep(200);
+        }
+      }
+      assertTrue(Arrays.asList("alice", "bob", "carol", "dave").contains(midName),
+          "crash left a non-committed / torn name for id=1: " + midName);
+      assertEquals("orig-notes", readRow(tablePath).getAs("notes"),
+          "notes must never be the toasted placeholder, even mid-stream");
+
+      // Restart: resume from the committed Kafka checkpoint, replay the uncommitted tail (at-least-once),
+      // drain to the terminal event.
+      Process p2 = launch(tablePath, bootstrap, topic, "crash-grp", "continuous", logDir + "/crash2.log");
+      awaitName(tablePath, "dave", 240000, p2);
+      p2.destroyForcibly();
+      p2.waitFor(60, TimeUnit.SECONDS);
+
+      // INV7: idempotent replay -- exactly one row for the key (no duplication), terminal state reached
+      // (no loss), and FILL_UNCHANGED preserved across the crash + replay.
+      long count = spark().read().format("hudi").load(tablePath).where("id = 1").count();
+      assertEquals(1L, count, "at-least-once replay must not duplicate the record key");
+      Row fin = readRow(tablePath);
+      assertEquals("dave", fin.getAs("name"), "all events drained in SCN order after the replay (no loss)");
+      assertEquals("orig-notes", fin.getAs("notes"), "FILL_UNCHANGED preserved through the crash + replay");
+    } finally {
+      kafka.teardown();
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/DebeziumTransformerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/DebeziumTransformerTestBase.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.apache.hudi.testutils.HoodieClientTestUtils.getSparkConfForTest;
+
+/**
+ * Lightweight Spark test base for the Debezium transformer tests. Spins up a single local
+ * SparkSession for the test class and parses inline JSON fixtures into {@link Dataset}s that mimic
+ * Debezium change-event envelopes.
+ */
+public abstract class DebeziumTransformerTestBase {
+
+  protected static SparkSession spark;
+  protected static JavaSparkContext jsc;
+
+  @BeforeAll
+  static void setUpSpark() throws IOException {
+    spark = SparkSession.builder()
+        .config(getSparkConfForTest(DebeziumTransformerTestBase.class.getName()))
+        .getOrCreate();
+    jsc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+  }
+
+  @AfterAll
+  static void tearDownSpark() throws IOException {
+    if (spark != null) {
+      spark.close();
+      spark = null;
+      jsc = null;
+    }
+  }
+
+  /**
+   * Parses each argument as a single JSON document into a {@link Dataset}. Passing several
+   * envelopes together lets Spark infer struct types for {@code before}/{@code after} even when an
+   * individual envelope leaves one of them null (inserts have no {@code before}, deletes have no
+   * {@code after}).
+   */
+  protected Dataset<Row> jsonToDataset(String... jsonDocs) {
+    return spark.read().json(jsc.parallelize(Arrays.asList(jsonDocs), 1));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
 
 import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_ENABLED;
 import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABLE_CURRUPT_RECORD_COL_NAME;
-import static org.apache.hudi.utilities.transform.debezium.AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -109,7 +108,7 @@ class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
     assertTrue(columns.contains(DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME));
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_SHARD_NAME));
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_TS_COL_NAME));
-    assertFalse(columns.contains(DEBEZIUM_METADATA_FIELD), "no nested struct when flat");
+    assertFalse(columns.contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD), "no nested struct when flat");
 
     // shard name comes from source.name
     assertEquals("pgdb", result.orderBy("id").collectAsList().get(0).getAs(DebeziumConstants.FLATTENED_SHARD_NAME));
@@ -128,12 +127,12 @@ class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
     Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), props);
     List<String> columns = Arrays.asList(result.columns());
 
-    assertTrue(columns.contains(DEBEZIUM_METADATA_FIELD), "metadata grouped under a struct");
+    assertTrue(columns.contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD), "metadata grouped under a struct");
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op stays at root");
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN stays at root");
     assertFalse(columns.contains(DebeziumConstants.FLATTENED_SHARD_NAME), "shard moved into the nested struct");
 
-    Row metadata = result.first().getAs(DEBEZIUM_METADATA_FIELD);
+    Row metadata = result.first().getAs(DebeziumConstants.DEBEZIUM_METADATA_FIELD);
     List<String> nested = Arrays.asList(metadata.schema().fieldNames());
     assertTrue(nested.contains(DebeziumConstants.FLATTENED_SHARD_NAME));
     assertTrue(nested.contains(DebeziumConstants.FLATTENED_SCHEMA_NAME), "source.schema present -> nested schema col added");
@@ -148,7 +147,7 @@ class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
 
     // property NOT set -> subclass default decides
     Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), new TypedProperties());
-    assertEquals(subclassDefault, Arrays.asList(result.columns()).contains(DEBEZIUM_METADATA_FIELD));
+    assertEquals(subclassDefault, Arrays.asList(result.columns()).contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD));
   }
 
   @Test
@@ -160,7 +159,7 @@ class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
     props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
 
     Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), props);
-    assertFalse(Arrays.asList(result.columns()).contains(DEBEZIUM_METADATA_FIELD));
+    assertFalse(Arrays.asList(result.columns()).contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD));
   }
 
   @Test
@@ -213,6 +212,40 @@ class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
     long id = result.first().<Long>getAs("id");
     assertEquals(1L, id);
     assertEquals("Alice", result.first().getAs("name"));
+  }
+
+  @Test
+  void testSchemaAsNullableFalseMakesMetadataColumnsNullableEvenIfSourceDeclaredNonNullable() {
+    // "op" is declared non-nullable at the envelope level, but it is a Debezium metadata column
+    // (not a __data-derived business column), so it must NOT be treated as a "known non-nullable
+    // source column" -- it should end up nullable in the output regardless of its declared
+    // nullability in the raw envelope schema.
+    StructType rowDataSchema = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.LongType, false, Metadata.empty()),
+        DataTypes.createStructField("name", DataTypes.StringType, true, Metadata.empty())));
+    StructType sourceSchema = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("name", DataTypes.StringType, true, Metadata.empty()),
+        DataTypes.createStructField("ts_ms", DataTypes.LongType, true, Metadata.empty())));
+    StructType envelopeSchema = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("op", DataTypes.StringType, false, Metadata.empty()),
+        DataTypes.createStructField("ts_ms", DataTypes.LongType, true, Metadata.empty()),
+        DataTypes.createStructField("before", rowDataSchema, true, Metadata.empty()),
+        DataTypes.createStructField("after", rowDataSchema, true, Metadata.empty()),
+        DataTypes.createStructField("source", sourceSchema, true, Metadata.empty())));
+
+    Row afterRow = RowFactory.create(1L, "Alice");
+    Row sourceRow = RowFactory.create("pgdb", 1700000000000L);
+    Row envelopeRow = RowFactory.create("c", 1700000000500L, null, afterRow, sourceRow);
+    Dataset<Row> input = spark.createDataFrame(Collections.singletonList(envelopeRow), envelopeSchema);
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.SCHEMA_AS_NULLABLE.key(), "false");
+
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, input, props);
+
+    assertTrue(result.schema().apply(DebeziumConstants.FLATTENED_OP_COL_NAME).nullable(),
+        "op is a Debezium metadata column, not a known non-nullable source column, so it must be nullable");
+    assertFalse(result.schema().apply("id").nullable(), "id remains non-nullable as a known source column");
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.apache.hudi.utilities.transform.debezium.AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the database-agnostic flattening behavior of {@link AbstractDebeziumTransformer}.
+ */
+class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
+
+  // One insert (op=c), one update (op=u), one delete (op=d). before/after differ so the test can
+  // prove which image is selected. The delete carries values only in `before` (after is null).
+  private static final String INSERT_EVENT =
+      "{\"op\":\"c\",\"ts_ms\":1700000000500,"
+          + "\"before\":null,"
+          + "\"after\":{\"id\":1,\"name\":\"Alice\",\"email\":\"alice@x.com\"},"
+          + "\"source\":{\"name\":\"pgdb\",\"ts_ms\":1700000000000,\"schema\":\"public\"}}";
+  private static final String UPDATE_EVENT =
+      "{\"op\":\"u\",\"ts_ms\":1700000001500,"
+          + "\"before\":{\"id\":2,\"name\":\"Bob\",\"email\":\"old@x.com\"},"
+          + "\"after\":{\"id\":2,\"name\":\"Bob\",\"email\":\"new@x.com\"},"
+          + "\"source\":{\"name\":\"pgdb\",\"ts_ms\":1700000001000,\"schema\":\"public\"}}";
+  private static final String DELETE_EVENT =
+      "{\"op\":\"d\",\"ts_ms\":1700000002500,"
+          + "\"before\":{\"id\":3,\"name\":\"Carol\",\"email\":\"carol@x.com\"},"
+          + "\"after\":null,"
+          + "\"source\":{\"name\":\"pgdb\",\"ts_ms\":1700000002000,\"schema\":\"public\"}}";
+
+  @Test
+  void testAfterUsedForInsertUpdate_beforeUsedForDelete() {
+    Dataset<Row> input = jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT);
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, input, new TypedProperties());
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.containsAll(Arrays.asList("id", "name", "email")), "data columns lifted to root");
+    assertFalse(columns.contains(DebeziumConstants.INCOMING_AFTER_FIELD), "after dropped");
+    assertFalse(columns.contains(DebeziumConstants.INCOMING_BEFORE_FIELD), "before dropped");
+
+    List<Row> rows = result.orderBy("id").collectAsList();
+    assertEquals(3, rows.size());
+
+    // insert -> taken from `after`
+    assertEquals("c", rows.get(0).getAs(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertEquals("Alice", rows.get(0).getAs("name"));
+    assertEquals("alice@x.com", rows.get(0).getAs("email"));
+
+    // update -> taken from `after` (the NEW email, not the before/old one)
+    assertEquals("u", rows.get(1).getAs(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertEquals("new@x.com", rows.get(1).getAs("email"));
+
+    // delete -> taken from `before` (after is null, but we keep the key/row)
+    assertEquals("d", rows.get(2).getAs(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertEquals("Carol", rows.get(2).getAs("name"));
+    assertEquals("carol@x.com", rows.get(2).getAs("email"));
+  }
+
+  @Test
+  void testDefaultMetadataColumnsAtRootWhenFlat() {
+    Dataset<Row> input = jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT);
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, input, new TypedProperties());
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertTrue(columns.contains(DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME));
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_SHARD_NAME));
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_TS_COL_NAME));
+    assertFalse(columns.contains(DEBEZIUM_METADATA_FIELD), "no nested struct when flat");
+
+    // shard name comes from source.name
+    assertEquals("pgdb", result.orderBy("id").collectAsList().get(0).getAs(DebeziumConstants.FLATTENED_SHARD_NAME));
+  }
+
+  @Test
+  void testNestedModeGroupsMetadataButKeepsOpAndLsnAtRoot() {
+    // Supply an LSN-named metadata column so the LSN-to-root branch is exercised.
+    Column lsnColumn = new Column(DebeziumConstants.INCOMING_SOURCE_NAME_FIELD).alias(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    TestableDebeziumTransformer transformer =
+        new TestableDebeziumTransformer(Collections.singletonList(lsnColumn), Option.empty(), false);
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "true");
+
+    Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), props);
+    List<String> columns = Arrays.asList(result.columns());
+
+    assertTrue(columns.contains(DEBEZIUM_METADATA_FIELD), "metadata grouped under a struct");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op stays at root");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN stays at root");
+    assertFalse(columns.contains(DebeziumConstants.FLATTENED_SHARD_NAME), "shard moved into the nested struct");
+
+    Row metadata = result.first().getAs(DEBEZIUM_METADATA_FIELD);
+    List<String> nested = Arrays.asList(metadata.schema().fieldNames());
+    assertTrue(nested.contains(DebeziumConstants.FLATTENED_SHARD_NAME));
+    assertTrue(nested.contains(DebeziumConstants.FLATTENED_SCHEMA_NAME), "source.schema present -> nested schema col added");
+    assertFalse(nested.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN is at root, not nested");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testNestedDefaultIsUsedWhenPropertyAbsent(boolean subclassDefault) {
+    TestableDebeziumTransformer transformer =
+        new TestableDebeziumTransformer(Collections.emptyList(), Option.empty(), subclassDefault);
+
+    // property NOT set -> subclass default decides
+    Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), new TypedProperties());
+    assertEquals(subclassDefault, Arrays.asList(result.columns()).contains(DEBEZIUM_METADATA_FIELD));
+  }
+
+  @Test
+  void testExplicitPropertyOverridesSubclassDefault() {
+    // subclass defaults to nested=true, but an explicit false must win
+    TestableDebeziumTransformer transformer =
+        new TestableDebeziumTransformer(Collections.emptyList(), Option.empty(), true);
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), props);
+    assertFalse(Arrays.asList(result.columns()).contains(DEBEZIUM_METADATA_FIELD));
+  }
+
+  @Test
+  void testPostProcessingHookIsApplied() {
+    Function<Dataset<Row>, Dataset<Row>> addColumn =
+        ds -> ds.withColumn("processed", org.apache.spark.sql.functions.lit(true));
+    TestableDebeziumTransformer transformer =
+        new TestableDebeziumTransformer(Collections.emptyList(), Option.of(addColumn), false);
+
+    Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), new TypedProperties());
+    assertTrue(Arrays.asList(result.columns()).contains("processed"));
+    assertTrue(result.collectAsList().stream().allMatch(r -> Boolean.TRUE.equals(r.getAs("processed"))));
+  }
+
+  @Test
+  void testEmptyDatasetIsReturnedUnchanged() {
+    Dataset<Row> empty = spark.emptyDataFrame();
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, empty, new TypedProperties());
+    assertEquals(0, result.columns().length);
+  }
+
+  /** Minimal concrete subclass to exercise the otherwise database-agnostic base. */
+  private static class TestableDebeziumTransformer extends AbstractDebeziumTransformer {
+    TestableDebeziumTransformer() {
+      super(Collections.emptyList(), Option.empty());
+    }
+
+    TestableDebeziumTransformer(List<Column> typeSpecificMetadataColumns,
+                                Option<Function<Dataset<Row>, Dataset<Row>>> postProcessingOption,
+                                boolean nestedFieldsEnabledByDefault) {
+      super(typeSpecificMetadataColumns, postProcessingOption, nestedFieldsEnabledByDefault);
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
@@ -26,6 +26,11 @@ import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -35,9 +40,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_ENABLED;
+import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABLE_CURRUPT_RECORD_COL_NAME;
 import static org.apache.hudi.utilities.transform.debezium.AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -172,6 +180,69 @@ class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
     Dataset<Row> empty = spark.emptyDataFrame();
     Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, empty, new TypedProperties());
     assertEquals(0, result.columns().length);
+  }
+
+  @Test
+  void testSchemaAsNullableFalsePreservesNonNullableSourceFields() {
+    // "id" is declared non-nullable in the source row schema; "name" is nullable.
+    StructType rowDataSchema = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("id", DataTypes.LongType, false, Metadata.empty()),
+        DataTypes.createStructField("name", DataTypes.StringType, true, Metadata.empty())));
+    StructType sourceSchema = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("name", DataTypes.StringType, true, Metadata.empty()),
+        DataTypes.createStructField("ts_ms", DataTypes.LongType, true, Metadata.empty())));
+    StructType envelopeSchema = DataTypes.createStructType(Arrays.asList(
+        DataTypes.createStructField("op", DataTypes.StringType, true, Metadata.empty()),
+        DataTypes.createStructField("ts_ms", DataTypes.LongType, true, Metadata.empty()),
+        DataTypes.createStructField("before", rowDataSchema, true, Metadata.empty()),
+        DataTypes.createStructField("after", rowDataSchema, true, Metadata.empty()),
+        DataTypes.createStructField("source", sourceSchema, true, Metadata.empty())));
+
+    Row afterRow = RowFactory.create(1L, "Alice");
+    Row sourceRow = RowFactory.create("pgdb", 1700000000000L);
+    Row envelopeRow = RowFactory.create("c", 1700000000500L, null, afterRow, sourceRow);
+    Dataset<Row> input = spark.createDataFrame(Collections.singletonList(envelopeRow), envelopeSchema);
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.SCHEMA_AS_NULLABLE.key(), "false");
+
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, input, props);
+
+    assertFalse(result.schema().apply("id").nullable(), "id was non-nullable in the source schema");
+    assertTrue(result.schema().apply("name").nullable(), "name was nullable in the source schema");
+    long id = result.first().<Long>getAs("id");
+    assertEquals(1L, id);
+    assertEquals("Alice", result.first().getAs("name"));
+  }
+
+  @Test
+  void testErrorTableEnabledAddsNullCorruptRecordWhenMissing() {
+    // Include UPDATE_EVENT alongside so Spark's JSON inference sees a non-null `before`
+    // example and types the column as a struct rather than (incorrectly) as a string.
+    TypedProperties props = new TypedProperties();
+    props.setProperty(ERROR_TABLE_ENABLED.key(), "true");
+
+    Dataset<Row> result = new TestableDebeziumTransformer()
+        .apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT), props);
+
+    assertTrue(Arrays.asList(result.columns()).contains(ERROR_TABLE_CURRUPT_RECORD_COL_NAME),
+        "_corrupt_record column added when error table is enabled");
+    Row insertRow = result.where(new Column(DebeziumConstants.FLATTENED_OP_COL_NAME).equalTo("c")).first();
+    assertNull(insertRow.getAs(ERROR_TABLE_CURRUPT_RECORD_COL_NAME), "no corrupt value was present on input");
+  }
+
+  @Test
+  void testErrorTableEnabledPreservesExistingCorruptRecordValue() {
+    Dataset<Row> input = jsonToDataset(INSERT_EVENT, UPDATE_EVENT)
+        .withColumn(ERROR_TABLE_CURRUPT_RECORD_COL_NAME, functions.lit("malformed-row"));
+    TypedProperties props = new TypedProperties();
+    props.setProperty(ERROR_TABLE_ENABLED.key(), "true");
+
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, input, props);
+
+    Row insertRow = result.where(new Column(DebeziumConstants.FLATTENED_OP_COL_NAME).equalTo("c")).first();
+    assertEquals("malformed-row", insertRow.getAs(ERROR_TABLE_CURRUPT_RECORD_COL_NAME),
+        "existing corrupt-record value is preserved, not overwritten");
   }
 
   /** Minimal concrete subclass to exercise the otherwise database-agnostic base. */

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
@@ -215,11 +215,10 @@ class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
   }
 
   @Test
-  void testSchemaAsNullableFalseMakesMetadataColumnsNullableEvenIfSourceDeclaredNonNullable() {
-    // "op" is declared non-nullable at the envelope level, but it is a Debezium metadata column
-    // (not a __data-derived business column), so it must NOT be treated as a "known non-nullable
-    // source column" -- it should end up nullable in the output regardless of its declared
-    // nullability in the raw envelope schema.
+  void testSchemaAsNullableFalsePreservesNonNullableMetadataColumns() {
+    // "op" is declared non-nullable at the envelope level and is selected directly into the
+    // flattened _change_operation_type column, so Spark keeps it non-nullable. The transformer must
+    // preserve that non-nullability when schema.nullable.enable is disabled.
     StructType rowDataSchema = DataTypes.createStructType(Arrays.asList(
         DataTypes.createStructField("id", DataTypes.LongType, false, Metadata.empty()),
         DataTypes.createStructField("name", DataTypes.StringType, true, Metadata.empty())));
@@ -243,8 +242,8 @@ class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
 
     Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, input, props);
 
-    assertTrue(result.schema().apply(DebeziumConstants.FLATTENED_OP_COL_NAME).nullable(),
-        "op is a Debezium metadata column, not a known non-nullable source column, so it must be nullable");
+    assertFalse(result.schema().apply(DebeziumConstants.FLATTENED_OP_COL_NAME).nullable(),
+        "op is selected directly from a non-nullable envelope field, so _change_operation_type stays non-nullable");
     assertFalse(result.schema().apply("id").nullable(), "id remains non-nullable as a known source column");
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestMysqlDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestMysqlDebeziumTransformer.java
@@ -78,7 +78,7 @@ class TestMysqlDebeziumTransformer extends DebeziumTransformerTestBase {
         .apply(jsc, spark, jsonToDataset(mysqlEvent("c", 1, "mysql-bin.000001", 100)), new TypedProperties());
 
     List<String> columns = Arrays.asList(result.columns());
-    assertFalse(columns.contains(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD),
+    assertFalse(columns.contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD),
         "MySQL should be flat by default");
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_FILE_COL_NAME), "_event_bin_file at root");
   }
@@ -92,12 +92,12 @@ class TestMysqlDebeziumTransformer extends DebeziumTransformerTestBase {
         .apply(jsc, spark, jsonToDataset(mysqlEvent("c", 1, "mysql-bin.000001", 100)), props);
 
     List<String> columns = Arrays.asList(result.columns());
-    assertTrue(columns.contains(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD), "metadata nested");
+    assertTrue(columns.contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD), "metadata nested");
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op at root");
     assertTrue(columns.contains(DebeziumConstants.ADDED_SEQ_COL_NAME), "_event_seq at root");
     assertFalse(columns.contains(DebeziumConstants.FLATTENED_FILE_COL_NAME), "binlog file is nested, not root");
 
-    Row metadata = result.first().getAs(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD);
+    Row metadata = result.first().getAs(DebeziumConstants.DEBEZIUM_METADATA_FIELD);
     List<String> nested = Arrays.asList(metadata.schema().fieldNames());
     assertTrue(nested.contains(DebeziumConstants.FLATTENED_FILE_COL_NAME));
     assertTrue(nested.contains(DebeziumConstants.FLATTENED_POS_COL_NAME));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestMysqlDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestMysqlDebeziumTransformer.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the MySQL-specific behavior of {@link MysqlDebeziumTransformer}: the surfaced binlog
+ * metadata columns and the derived {@code _event_seq} ordering column, in both flat and nested
+ * layouts.
+ */
+class TestMysqlDebeziumTransformer extends DebeziumTransformerTestBase {
+
+  // A MySQL source struct carries binlog file/pos/row in addition to name/ts_ms. before is populated
+  // (same shape as after) so Spark infers it as a struct; these tests use inserts (op=c) which take
+  // `after` regardless of before's contents.
+  private static String mysqlEvent(String op, long id, String file, long pos) {
+    String row = "{\"id\":" + id + ",\"title\":\"t" + id + "\"}";
+    return "{\"op\":\"" + op + "\",\"ts_ms\":1700000000500,"
+        + "\"before\":" + row + ","
+        + "\"after\":" + row + ","
+        + "\"source\":{\"name\":\"mysqldb\",\"ts_ms\":1700000000000,"
+        + "\"file\":\"" + file + "\",\"pos\":" + pos + ",\"row\":0}}";
+  }
+
+  @Test
+  void testMysqlMetadataColumnsAndSeqSurfacedFlat() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = new MysqlDebeziumTransformer()
+        .apply(jsc, spark, jsonToDataset(mysqlEvent("c", 1, "mysql-bin.000001", 100)), props);
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_FILE_COL_NAME), "_event_bin_file present");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_POS_COL_NAME), "_event_pos present");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_ROW_COL_NAME), "_event_row present");
+    assertTrue(columns.contains(DebeziumConstants.ADDED_SEQ_COL_NAME), "_event_seq present");
+
+    // _event_seq = "<binlog-suffix>.<pos>" -> "000001.100"
+    String seq = result.first().getAs(DebeziumConstants.ADDED_SEQ_COL_NAME);
+    assertEquals("000001.100", seq);
+  }
+
+  @Test
+  void testFlatByDefault() {
+    // MySQL does not opt into nested metadata, so with no property set the layout is flat.
+    Dataset<Row> result = new MysqlDebeziumTransformer()
+        .apply(jsc, spark, jsonToDataset(mysqlEvent("c", 1, "mysql-bin.000001", 100)), new TypedProperties());
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertFalse(columns.contains(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD),
+        "MySQL should be flat by default");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_FILE_COL_NAME), "_event_bin_file at root");
+  }
+
+  @Test
+  void testNestedModeGroupsMetadataButSeqStaysCorrect() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "true");
+
+    Dataset<Row> result = new MysqlDebeziumTransformer()
+        .apply(jsc, spark, jsonToDataset(mysqlEvent("c", 1, "mysql-bin.000001", 100)), props);
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.contains(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD), "metadata nested");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op at root");
+    assertTrue(columns.contains(DebeziumConstants.ADDED_SEQ_COL_NAME), "_event_seq at root");
+    assertFalse(columns.contains(DebeziumConstants.FLATTENED_FILE_COL_NAME), "binlog file is nested, not root");
+
+    Row metadata = result.first().getAs(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD);
+    List<String> nested = Arrays.asList(metadata.schema().fieldNames());
+    assertTrue(nested.contains(DebeziumConstants.FLATTENED_FILE_COL_NAME));
+    assertTrue(nested.contains(DebeziumConstants.FLATTENED_POS_COL_NAME));
+    assertTrue(nested.contains(DebeziumConstants.FLATTENED_ROW_COL_NAME));
+
+    // _event_seq must still be computed correctly from the nested file/pos
+    String seq = result.first().getAs(DebeziumConstants.ADDED_SEQ_COL_NAME);
+    assertEquals("000001.100", seq);
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestMysqlDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestMysqlDebeziumTransformer.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -50,6 +51,16 @@ class TestMysqlDebeziumTransformer extends DebeziumTransformerTestBase {
         + "\"after\":" + row + ","
         + "\"source\":{\"name\":\"mysqldb\",\"ts_ms\":1700000000000,"
         + "\"file\":\"" + file + "\",\"pos\":" + pos + ",\"row\":0}}";
+  }
+
+  // A MySQL event with no binlog coordinates (file/pos null), e.g. a snapshot row.
+  private static String mysqlEventNullCoords(String op, long id) {
+    String row = "{\"id\":" + id + ",\"title\":\"t" + id + "\"}";
+    return "{\"op\":\"" + op + "\",\"ts_ms\":1700000000500,"
+        + "\"before\":" + row + ","
+        + "\"after\":" + row + ","
+        + "\"source\":{\"name\":\"mysqldb\",\"ts_ms\":1700000000000,"
+        + "\"file\":null,\"pos\":null,\"row\":0}}";
   }
 
   @Test
@@ -106,5 +117,24 @@ class TestMysqlDebeziumTransformer extends DebeziumTransformerTestBase {
     // _event_seq must still be computed correctly from the nested file/pos
     String seq = result.first().getAs(DebeziumConstants.ADDED_SEQ_COL_NAME);
     assertEquals("000001.100", seq);
+  }
+
+  @Test
+  void testSeqIsNullWhenBinlogCoordinatesAreNull() {
+    // With null binlog file/pos (e.g. a snapshot row), _event_seq propagates null rather than a
+    // fabricated value. _event_seq is the payload's ordering field, so surfacing null keeps the
+    // missing-coordinates case explicit instead of silently producing a bogus sequence.
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    // Pair a real-coordinate row with the null-coordinate row so Spark still infers file/pos as
+    // (string, long) rather than a null type.
+    Dataset<Row> result = new MysqlDebeziumTransformer().apply(jsc, spark,
+        jsonToDataset(mysqlEvent("c", 1, "mysql-bin.000001", 100), mysqlEventNullCoords("c", 2)), props);
+
+    assertNull(result.where("id = 2").first().getAs(DebeziumConstants.ADDED_SEQ_COL_NAME),
+        "null binlog coordinates -> null _event_seq");
+    assertEquals("000001.100", result.where("id = 1").first().getAs(DebeziumConstants.ADDED_SEQ_COL_NAME),
+        "real binlog coordinates still produce the sequence");
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestOracleDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestOracleDebeziumTransformer.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload.DEBEZIUM_TOASTED_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@link OracleDebeziumTransformer} flattens the Oracle Debezium envelope, surfaces the
+ * SCN metadata + composite {@code _event_ordering}, computes {@code _changed_columns} for updates
+ * (excluding toasted values), sets {@code _hoodie_is_deleted}, drops unsupported operations, and
+ * honors flat vs nested layouts.
+ */
+class TestOracleDebeziumTransformer extends DebeziumTransformerTestBase {
+
+  /** before/after each carry {id, name, amount}; source carries scn/commit_scn. */
+  private static String oracleEvent(String op, String beforeName, Long beforeAmount,
+                                    String afterName, Long afterAmount, Long scn, Long commitScn) {
+    return "{\"op\":\"" + op + "\",\"ts_ms\":1700000000500,"
+        + "\"before\":" + row(beforeName, beforeAmount) + ","
+        + "\"after\":" + row(afterName, afterAmount) + ","
+        + "\"source\":{\"name\":\"oradb\",\"ts_ms\":1700000000000,"
+        + "\"scn\":" + (scn == null ? "null" : scn) + ",\"commit_scn\":" + (commitScn == null ? "null" : commitScn) + "}}";
+  }
+
+  private static String row(String name, Long amount) {
+    return "{\"id\":1,\"name\":" + (name == null ? "null" : "\"" + name + "\"")
+        + ",\"amount\":" + (amount == null ? "null" : amount) + "}";
+  }
+
+  private Dataset<Row> transform(TypedProperties props, String... events) {
+    return new OracleDebeziumTransformer().apply(jsc, spark, jsonToDataset(events), props);
+  }
+
+  private static TypedProperties flat() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+    return props;
+  }
+
+  @Test
+  void testInsertSurfacesMetadataAndNoChangedColumns() {
+    Row r = transform(flat(), oracleEvent("c", null, null, "alice", 100L, 1700L, 1800L)).first();
+    List<String> cols = Arrays.asList(r.schema().fieldNames());
+    assertTrue(cols.contains(DebeziumConstants.FLATTENED_SCN_COL_NAME));
+    assertTrue(cols.contains(DebeziumConstants.FLATTENED_COMMIT_SCN_COL_NAME));
+    assertTrue(cols.contains(DebeziumConstants.FLATTENED_ORDERING_COL_NAME));
+    assertEquals("alice", r.getAs("name"));
+    assertNull(r.getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD), "insert has no _changed_columns");
+    assertFalse((Boolean) r.getAs(HoodieRecord.HOODIE_IS_DELETED_FIELD));
+    assertEquals("1700", r.getAs(DebeziumConstants.FLATTENED_SCN_COL_NAME));
+    // _event_ordering = zero-padded commit_scn "." zero-padded scn
+    assertEquals(pad(1800L) + "." + pad(1700L), r.getAs(DebeziumConstants.FLATTENED_ORDERING_COL_NAME));
+  }
+
+  @Test
+  void testUpdateComputesChangedColumns() {
+    Row r = transform(flat(), oracleEvent("u", "alice", 100L, "bob", 200L, 1700L, 1800L)).first();
+    String changed = r.getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD);
+    assertTrue(changedSet(changed).contains("name"), "name changed");
+    assertTrue(changedSet(changed).contains("amount"), "amount changed");
+    assertFalse(changedSet(changed).contains("id"), "id unchanged");
+  }
+
+  @Test
+  void testUpdateWithExplicitNullIsChanged() {
+    Row r = transform(flat(), oracleEvent("u", "alice", 100L, null, 100L, 1700L, 1800L)).first();
+    String changed = r.getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD);
+    assertTrue(changedSet(changed).contains("name"), "name -> null is a change");
+    assertFalse(changedSet(changed).contains("amount"), "amount unchanged");
+    assertNull(r.getAs("name"));
+  }
+
+  @Test
+  void testUpdateWithToastedValueExcludedFromChangedColumns() {
+    Row r = transform(flat(),
+        oracleEvent("u", "alice", 100L, DEBEZIUM_TOASTED_VALUE, 200L, 1700L, 1800L)).first();
+    String changed = r.getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD);
+    assertFalse(changedSet(changed).contains("name"), "toasted name excluded");
+    assertTrue(changedSet(changed).contains("amount"), "amount still changed");
+  }
+
+  @Test
+  void testUpdateNoColumnsChangedYieldsNull() {
+    Row r = transform(flat(), oracleEvent("u", "alice", 100L, "alice", 100L, 1700L, 1800L)).first();
+    assertNull(r.getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD), "no diff -> null _changed_columns");
+  }
+
+  @Test
+  void testDeleteSetsHoodieIsDeletedAndNullChangedColumns() {
+    Row r = transform(flat(), oracleEvent("d", "alice", 100L, null, null, 1700L, 1800L)).first();
+    assertTrue((Boolean) r.getAs(HoodieRecord.HOODIE_IS_DELETED_FIELD));
+    assertNull(r.getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD));
+    assertEquals("d", r.getAs(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    // delete surfaces the before image
+    assertEquals("alice", r.getAs("name"));
+  }
+
+  @Test
+  void testSnapshotHasNoChangedColumnsAndNotDeleted() {
+    Row r = transform(flat(), oracleEvent("r", null, null, "alice", 100L, 1700L, 1800L)).first();
+    assertEquals("r", r.getAs(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertNull(r.getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD));
+    assertFalse((Boolean) r.getAs(HoodieRecord.HOODIE_IS_DELETED_FIELD));
+  }
+
+  @Test
+  void testUnsupportedOperationIsDropped() {
+    Dataset<Row> result = transform(flat(),
+        oracleEvent("c", null, null, "alice", 100L, 1700L, 1800L),
+        oracleEvent("t", null, null, null, null, 1900L, 2000L)); // truncate -> dropped
+    assertEquals(1, result.count(), "only the insert survives, truncate dropped");
+  }
+
+  @Test
+  void testOrderingFallsBackToZeroWhenScnNull() {
+    Row r = transform(flat(), oracleEvent("c", null, null, "alice", 100L, null, null)).first();
+    assertEquals(pad(0L) + "." + pad(0L), r.getAs(DebeziumConstants.FLATTENED_ORDERING_COL_NAME));
+  }
+
+  @Test
+  void testMixedBatchFlagsPerRow() {
+    Dataset<Row> result = transform(flat(),
+        oracleEvent("c", null, null, "a", 1L, 1L, 1L),
+        oracleEvent("u", "a", 1L, "b", 1L, 2L, 2L),
+        oracleEvent("d", "b", 1L, null, null, 3L, 3L));
+    Map<String, Row> byOp = new HashMap<>();
+    for (Row r : result.collectAsList()) {
+      byOp.put(r.getAs(DebeziumConstants.FLATTENED_OP_COL_NAME), r);
+    }
+    assertFalse((Boolean) byOp.get("c").getAs(HoodieRecord.HOODIE_IS_DELETED_FIELD));
+    assertNull(byOp.get("c").getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD));
+    assertTrue(changedSet(byOp.get("u").getAs(DebeziumConstants.CHANGED_COLUMNS_FIELD)).contains("name"));
+    assertTrue((Boolean) byOp.get("d").getAs(HoodieRecord.HOODIE_IS_DELETED_FIELD));
+  }
+
+  @Test
+  void testNestedModeKeepsOrderingAndOpAtRoot() {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "true");
+    Row r = transform(props, oracleEvent("u", "alice", 100L, "bob", 100L, 1700L, 1800L)).first();
+    List<String> cols = Arrays.asList(r.schema().fieldNames());
+    assertTrue(cols.contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD), "metadata nested");
+    assertTrue(cols.contains(DebeziumConstants.FLATTENED_ORDERING_COL_NAME), "_event_ordering at root");
+    assertTrue(cols.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op at root");
+    assertTrue(cols.contains(DebeziumConstants.CHANGED_COLUMNS_FIELD), "_changed_columns at root");
+    assertFalse(cols.contains(DebeziumConstants.FLATTENED_SCN_COL_NAME), "scn is nested, not root");
+    // ordering is still computed correctly from the nested scn/commit_scn
+    assertEquals(pad(1800L) + "." + pad(1700L), r.getAs(DebeziumConstants.FLATTENED_ORDERING_COL_NAME));
+  }
+
+  private static String pad(long v) {
+    StringBuilder sb = new StringBuilder(Long.toString(v));
+    while (sb.length() < 20) {
+      sb.insert(0, '0');
+    }
+    return sb.toString();
+  }
+
+  private static java.util.Set<String> changedSet(String csv) {
+    java.util.Set<String> s = new java.util.HashSet<>();
+    if (csv != null && !csv.isEmpty()) {
+      s.addAll(Arrays.asList(csv.split(",")));
+    }
+    return s;
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestPostgresDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestPostgresDebeziumTransformer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the Postgres-specific behavior of {@link PostgresDebeziumTransformer}: the surfaced source
+ * metadata columns, the nested-by-default layout, and the snapshot LSN defaulting.
+ */
+class TestPostgresDebeziumTransformer extends DebeziumTransformerTestBase {
+
+  // A Postgres source struct carries txId/lsn/xmin/schema in addition to name/ts_ms.
+  // before is populated (same shape as after) so Spark infers it as a struct; these tests exercise
+  // inserts/snapshots (op c/r), which take `after` regardless of before's contents.
+  private static String pgEvent(String op, long id, long lsn, boolean nullLsn) {
+    String row = "{\"id\":" + id + ",\"name\":\"row" + id + "\",\"email\":\"e" + id + "@x.com\"}";
+    return "{\"op\":\"" + op + "\",\"ts_ms\":1700000000500,"
+        + "\"before\":" + row + ","
+        + "\"after\":" + row + ","
+        + "\"source\":{\"name\":\"pgdb\",\"ts_ms\":1700000000000,\"schema\":\"public\","
+        + "\"txId\":" + (500 + id) + ",\"lsn\":" + (nullLsn ? "null" : lsn) + ",\"xmin\":" + (9000 + id) + "}}";
+  }
+
+  @Test
+  void testPostgresMetadataColumnsAreSurfaced() {
+    TypedProperties props = new TypedProperties();
+    // force flat so all metadata columns sit at root and are easy to assert
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = new PostgresDebeziumTransformer()
+        .apply(jsc, spark, jsonToDataset(pgEvent("c", 1, 1001, false)), props);
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME), "_event_tx_id present");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "_event_lsn present");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_XMIN_COL_NAME), "_event_xmin present");
+
+    Row row = result.first();
+    long lsn = row.<Long>getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    long txId = row.<Long>getAs(DebeziumConstants.FLATTENED_TX_ID_COL_NAME);
+    assertEquals(1001L, lsn);
+    assertEquals(501L, txId);
+  }
+
+  @Test
+  void testPostgresDefaultsToNestedMetadata() {
+    // No nested property set -> Postgres should nest by default, with op + LSN kept at root.
+    Dataset<Row> result = new PostgresDebeziumTransformer()
+        .apply(jsc, spark, jsonToDataset(pgEvent("c", 1, 1001, false)), new TypedProperties());
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.contains(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD), "nested by default for Postgres");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op at root");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN at root (payload ordering field)");
+    assertFalse(columns.contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME), "tx id is nested, not at root");
+
+    Row metadata = result.first().getAs(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD);
+    assertTrue(Arrays.asList(metadata.schema().fieldNames()).contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME));
+  }
+
+  @Test
+  void testNullLsnDefaultedToZeroForSnapshotRows() {
+    // Snapshot rows (op = r) from incremental snapshots can have a null LSN; it must become 0
+    // so the payload's "higher LSN wins" ordering does not choke on null.
+    Dataset<Row> input = jsonToDataset(
+        pgEvent("r", 1, 0, true),    // snapshot, null lsn -> expect 0
+        pgEvent("r", 2, 2002, false) // snapshot, real lsn -> unchanged
+    );
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = new PostgresDebeziumTransformer().apply(jsc, spark, input, props);
+    List<Row> rows = result.orderBy("id").collectAsList();
+
+    long defaultedLsn = rows.get(0).<Long>getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    long preservedLsn = rows.get(1).<Long>getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    assertEquals(0L, defaultedLsn, "null snapshot LSN defaulted to 0");
+    assertEquals(2002L, preservedLsn, "real LSN preserved");
+  }
+
+  @Test
+  void testNullLsnNotDefaultedForNonSnapshotRows() {
+    // For a real change event (op != r) a null LSN is left as null (only snapshots are defaulted).
+    Dataset<Row> input = jsonToDataset(pgEvent("c", 1, 0, true));
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = new PostgresDebeziumTransformer().apply(jsc, spark, input, props);
+    assertNull(result.first().getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestPostgresDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestPostgresDebeziumTransformer.java
@@ -80,12 +80,12 @@ class TestPostgresDebeziumTransformer extends DebeziumTransformerTestBase {
         .apply(jsc, spark, jsonToDataset(pgEvent("c", 1, 1001, false)), new TypedProperties());
 
     List<String> columns = Arrays.asList(result.columns());
-    assertTrue(columns.contains(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD), "nested by default for Postgres");
+    assertTrue(columns.contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD), "nested by default for Postgres");
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op at root");
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN at root (payload ordering field)");
     assertFalse(columns.contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME), "tx id is nested, not at root");
 
-    Row metadata = result.first().getAs(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD);
+    Row metadata = result.first().getAs(DebeziumConstants.DEBEZIUM_METADATA_FIELD);
     assertTrue(Arrays.asList(metadata.schema().fieldNames()).contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME));
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestPostgresDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestPostgresDebeziumTransformer.java
@@ -74,19 +74,36 @@ class TestPostgresDebeziumTransformer extends DebeziumTransformerTestBase {
   }
 
   @Test
-  void testPostgresDefaultsToNestedMetadata() {
-    // No nested property set -> Postgres should nest by default, with op + LSN kept at root.
+  void testPostgresDefaultsToFlatMetadata() {
+    // No nested property set -> Postgres defaults to flat (consistent with MySQL), so every metadata
+    // column sits at the root and there is no _debezium_metadata struct.
     Dataset<Row> result = new PostgresDebeziumTransformer()
         .apply(jsc, spark, jsonToDataset(pgEvent("c", 1, 1001, false)), new TypedProperties());
 
     List<String> columns = Arrays.asList(result.columns());
-    assertTrue(columns.contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD), "nested by default for Postgres");
+    assertFalse(columns.contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD), "flat by default for Postgres");
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op at root");
     assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN at root (payload ordering field)");
-    assertFalse(columns.contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME), "tx id is nested, not at root");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME), "tx id at root when flat");
+  }
 
-    Row metadata = result.first().getAs(DebeziumConstants.DEBEZIUM_METADATA_FIELD);
-    assertTrue(Arrays.asList(metadata.schema().fieldNames()).contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME));
+  @Test
+  void testNullLsnDefaultedToZeroForSnapshotRowsWhenNested() {
+    // Snapshot LSN defaulting must also hold under the nested layout: the LSN stays at the root level
+    // even when nested, so the "null snapshot LSN -> 0" post-processing still applies.
+    Dataset<Row> input = jsonToDataset(
+        pgEvent("r", 1, 0, true),    // snapshot, null lsn -> expect 0
+        pgEvent("r", 2, 2002, false) // snapshot, real lsn -> unchanged
+    );
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "true");
+
+    Dataset<Row> result = new PostgresDebeziumTransformer().apply(jsc, spark, input, props);
+    assertTrue(Arrays.asList(result.columns()).contains(DebeziumConstants.DEBEZIUM_METADATA_FIELD), "nested layout");
+    List<Row> rows = result.orderBy("id").collectAsList();
+
+    assertEquals(0L, rows.get(0).<Long>getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME), "null snapshot LSN defaulted to 0 (nested)");
+    assertEquals(2002L, rows.get(1).<Long>getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME), "real LSN preserved (nested)");
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Adds an Oracle Debezium CDC transformer and table-version-9 partial-merge support to Hudi, so Oracle CDC tables can merge on the built-in `EVENT_TIME_ORDERING` + partial-update path (driven by the `_changed_columns` list) instead of relying on a custom payload class. Stacked on #19110 (Postgres/MySQL Debezium transformers); the Oracle commits are the top of the stack.

### Summary and Changelog

- `hudi-utilities`: add `OracleDebeziumTransformer` (+ shared `AbstractDebeziumTransformer`) alongside the Postgres/MySQL transformers from #19110; wire the `DebeziumTransformerConfig` nested-fields option.
- `hudi-common`: add `OracleDebeziumAvroPayload`, Oracle constants in `DebeziumConstants`, and a new `PartialUpdateMode.FILL_UNCHANGED` strategy in `PartialUpdateHandler` that preserves unchanged columns using the CDC `_changed_columns` list (unions both records' changed sets across log-vs-log merges).
- `hudi-common`: `HoodieTableConfig` v9 inference maps the Oracle payload to `EVENT_TIME_ORDERING` + `FILL_UNCHANGED` + the changed/retain/delete merge properties.
- `hudi-common`: `FileGroupReaderSchemaHandler` retains the configured changed-columns field as a mandatory merge column so pruning keeps it (without this, unchanged columns fall back to the incoming placeholder on read).
- Tests: unit tests for the payload, config inference, and `FILL_UNCHANGED` handler; an end-to-end `TestOracleDebeziumV9ReadMerge` spark IT (update / null / disjoint-union / delete / inline-compaction / nested-metadata).

No code was copied from external sources; the transformer/payload mirror the existing onehouse-dataplane implementations.

### Impact

New opt-in CDC transformer + a new partial-update mode. No change to existing merge modes or payloads. `FILL_UNCHANGED` only engages for tables configured with the Oracle payload / changed-columns merge property.

### Risk Level

low — additive; gated behind the Oracle payload/config. Verified against current master: `hudi-common` Oracle unit tests (62) green, `TestOracleDebeziumV9ReadMerge` IT 6/6 green, checkstyle/rat/scalastyle clean. (`hudi-utilities` transformer compile relies on CI due to a local-only Confluent dependency resolution issue.)

### Documentation Update

none (internal CDC wiring; no new user-facing website config in this PR).

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable