### PR TITLE
fix(utilities): guard Source.releaseResources() against transient RDD unpersist failures

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/Source.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.table.checkpoint.StreamerCheckpointV2;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Either;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.utilities.callback.SourceCommitCallback;
 import org.apache.hudi.utilities.schema.SchemaProvider;
 import org.apache.hudi.utilities.streamer.DefaultStreamContext;
@@ -172,6 +173,17 @@ public abstract class Source<T> implements SourceCommitCallback, Serializable {
 
   @Override
   public void releaseResources() {
+    // Cleanup runs after the write/commit; a transient Spark failure while unpersisting
+    // must not fail an already-successful round.
+    try {
+      unpersistCachedSourceRdd();
+    } catch (Exception e) {
+      log.warn("Failed to unpersist cached source RDD during releaseResources; ignoring", e);
+    }
+  }
+
+  @VisibleForTesting
+  protected void unpersistCachedSourceRdd() {
     if (cachedSourceRdd != null && cachedSourceRdd.isLeft()) {
       cachedSourceRdd.asLeft().unpersist();
     } else if (cachedSourceRdd != null && cachedSourceRdd.isRight()) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestSource.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link Source#releaseResources()}.
+ *
+ * <p>releaseResources() is invoked from StreamSync.syncOnce()'s finally block, after the
+ * write/commit has already completed. A transient Spark failure while unpersisting the
+ * cached source RDD (e.g. a NullPointerException from BlockManagerMaster.removeRdd when
+ * the SparkContext is mid-teardown/stopping) must not fail an otherwise-successful
+ * ingestion round.
+ */
+public class TestSource {
+
+  /**
+   * Minimal concrete {@link Source} whose unpersist step always fails, so the
+   * swallow-on-failure behaviour of releaseResources() can be exercised without a
+   * live SparkContext.
+   */
+  private static class MockSourceWithUnpersistenceFailure extends Source<String> {
+    private int unpersistCalls = 0;
+
+    MockSourceWithUnpersistenceFailure(TypedProperties props) {
+      super(props, null, null, null);
+    }
+
+    @Override
+    protected InputBatch<String> fetchNewData(Option<String> lastCkptStr, long sourceLimit) {
+      // Not exercised by these tests; releaseResources() is tested directly.
+      return null;
+    }
+
+    @Override
+    protected void unpersistCachedSourceRdd() {
+      unpersistCalls++;
+      throw new NullPointerException("simulated BlockManagerMaster.removeRdd NPE");
+    }
+  }
+
+  @Test
+  public void releaseResourcesSwallowsTransientUnpersistFailure() {
+    MockSourceWithUnpersistenceFailure source =
+        new MockSourceWithUnpersistenceFailure(new TypedProperties());
+    assertDoesNotThrow(source::releaseResources,
+        "A transient unpersist failure in cleanup must not propagate out of releaseResources()");
+    assertEquals(1, source.unpersistCalls, "unpersist should have been attempted exactly once");
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Source.releaseResources() is invoked from StreamSync.syncOnce()'s finally block, after the write/commit for the round has already completed. It unpersists the cached source RDD via JavaRDD/Dataset.unpersist() -> SparkContext.unpersistRDD -> BlockManagerMaster.removeRdd.

When the SparkContext is momentarily mid-teardown / stopping, BlockManagerMaster.removeRdd dereferences a null driverEndpoint and throws a NullPointerException. Because this happens inside the finally, it masks an otherwise-successful round and fails the ingestion attempt (in multi-table delta streamer this surfaces as a per-table "Failed to run job" and a spurious failure notification), even though no data was lost.

### Summary and Changelog

Make the post-write cleanup best-effort:
- Wrap the unpersist in try/catch(Exception) and log at WARN (using the existing @Slf4j logger).
- Extract the unpersist into a protected unpersistCachedSourceRdd() method (@VisibleForTesting) so the behavior is unit-testable.
- Add TestSource with two cases: (1) a transient unpersist failure does not propagate out of releaseResources(), (2) unpersist is still invoked on the happy path.

The write/commit has already completed before this cleanup runs, so swallowing a cleanup-only failure is safe. No code copied.

### Impact

Prevents a transient Spark cleanup NPE from failing an otherwise-successful ingestion round. No behavior change on the happy path; no public API change.

### Risk Level

low

Confined to a best-effort cleanup path; happy-path behavior is unchanged and covered by a new unit test.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable