### PR TITLE
fix(flink): make hudi-flink-bundle built with flink-bundle-shade-hive usable for Hive sync

### DIFF
--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -745,15 +745,18 @@
                       <shadedPattern>${flink.bundle.shade.prefix}jodd.</shadedPattern>
                     </relocation>
                   </relocations>
-                  <!-- Strip hive-exec's stale embedded Avro (no LogicalType) and ORC so the
-                       relocated org.apache.avro.* / org.apache.orc.* namespaces are populated
-                       only by the declared modern avro / orc-core artifacts. -->
+                  <!-- Strip hive-exec's stale embedded Avro / ORC / Parquet so the declared
+                       modern avro, orc-core and parquet-* artifacts are the only source for
+                       those namespaces (relocated for avro/orc/parquet.format, canonical for
+                       parquet core). Without this we rely on shade's artifact ordering to make
+                       the modern copy win; stripping makes it explicit and version-safe. -->
                   <filters combine.children="append">
                     <filter>
                       <artifact>org.apache.hive:hive-exec</artifact>
                       <excludes>
                         <exclude>org/apache/avro/**</exclude>
                         <exclude>org/apache/orc/**</exclude>
+                        <exclude>org/apache/parquet/**</exclude>
                       </excludes>
                     </filter>
                   </filters>
@@ -878,15 +881,18 @@
                       <shadedPattern>${flink.bundle.shade.prefix}jodd.</shadedPattern>
                     </relocation>
                   </relocations>
-                  <!-- Strip hive-exec's stale embedded Avro (no LogicalType) and ORC so the
-                       relocated org.apache.avro.* / org.apache.orc.* namespaces are populated
-                       only by the declared modern avro / orc-core artifacts. -->
+                  <!-- Strip hive-exec's stale embedded Avro / ORC / Parquet so the declared
+                       modern avro, orc-core and parquet-* artifacts are the only source for
+                       those namespaces (relocated for avro/orc/parquet.format, canonical for
+                       parquet core). Without this we rely on shade's artifact ordering to make
+                       the modern copy win; stripping makes it explicit and version-safe. -->
                   <filters combine.children="append">
                     <filter>
                       <artifact>org.apache.hive:hive-exec</artifact>
                       <excludes>
                         <exclude>org/apache/avro/**</exclude>
                         <exclude>org/apache/orc/**</exclude>
+                        <exclude>org/apache/parquet/**</exclude>
                       </excludes>
                     </filter>
                   </filters>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -661,12 +661,12 @@
               <execution>
                 <configuration>
                   <artifactSet>
-                    <!-- hive-exec needs the ANTLR runtime for Hive DDL parsing
-                         (Driver.compile) but does not embed it. -->
+                    <!-- hive-exec parses Hive DDL (Driver.compile) with the ANTLR 3 runtime
+                         and ST4, which it depends on transitively but does not embed. These
+                         are pulled into the bundle here. (Hive 2.x/3.x use ANTLR 3, not 4.) -->
                     <includes combine.children="append">
                       <include>org.antlr:antlr-runtime</include>
                       <include>org.antlr:ST4</include>
-                      <include>org.antlr:antlr4-runtime</include>
                     </includes>
                   </artifactSet>
                   <!-- hive-exec is a fat jar that embeds these deps un-relocated; under Flink
@@ -705,17 +705,6 @@
                       <pattern>io.airlift.compress.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}io.airlift.compress.</shadedPattern>
                     </relocation>
-                    <!-- Relocate parquet-format-structures embedded in hive-exec, but keep
-                         org.apache.parquet.format.converter.** (provided by parquet-hadoop) at
-                         its original name: it is used with the un-relocated
-                         ParquetFileReader.readFooter, so relocating it causes a NoSuchMethodError. -->
-                    <relocation>
-                      <pattern>org.apache.parquet.format.</pattern>
-                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.parquet.format.</shadedPattern>
-                      <excludes>
-                        <exclude>org.apache.parquet.format.converter.**</exclude>
-                      </excludes>
-                    </relocation>
                     <relocation>
                       <pattern>org.codehaus.jackson.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}org.codehaus.jackson.</shadedPattern>
@@ -745,11 +734,9 @@
                       <shadedPattern>${flink.bundle.shade.prefix}jodd.</shadedPattern>
                     </relocation>
                   </relocations>
-                  <!-- Strip hive-exec's stale embedded Avro / ORC / Parquet so the declared
-                       modern avro, orc-core and parquet-* artifacts are the only source for
-                       those namespaces (relocated for avro/orc/parquet.format, canonical for
-                       parquet core). Without this we rely on shade's artifact ordering to make
-                       the modern copy win; stripping makes it explicit and version-safe. -->
+                  <!-- Drop hive-exec's stale embedded copies so only the declared modern
+                       artifacts populate these namespaces; otherwise shade would pick the
+                       winner by artifact order. -->
                   <filters combine.children="append">
                     <filter>
                       <artifact>org.apache.hive:hive-exec</artifact>
@@ -757,6 +744,8 @@
                         <exclude>org/apache/avro/**</exclude>
                         <exclude>org/apache/orc/**</exclude>
                         <exclude>org/apache/parquet/**</exclude>
+                        <exclude>com/google/protobuf/**</exclude>
+                        <exclude>io/airlift/compress/**</exclude>
                       </excludes>
                     </filter>
                   </filters>
@@ -797,12 +786,12 @@
               <execution>
                 <configuration>
                   <artifactSet>
-                    <!-- hive-exec needs the ANTLR runtime for Hive DDL parsing
-                         (Driver.compile) but does not embed it. -->
+                    <!-- hive-exec parses Hive DDL (Driver.compile) with the ANTLR 3 runtime
+                         and ST4, which it depends on transitively but does not embed. These
+                         are pulled into the bundle here. (Hive 2.x/3.x use ANTLR 3, not 4.) -->
                     <includes combine.children="append">
                       <include>org.antlr:antlr-runtime</include>
                       <include>org.antlr:ST4</include>
-                      <include>org.antlr:antlr4-runtime</include>
                     </includes>
                   </artifactSet>
                   <!-- hive-exec is a fat jar that embeds these deps un-relocated; under Flink
@@ -841,17 +830,6 @@
                       <pattern>io.airlift.compress.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}io.airlift.compress.</shadedPattern>
                     </relocation>
-                    <!-- Relocate parquet-format-structures embedded in hive-exec, but keep
-                         org.apache.parquet.format.converter.** (provided by parquet-hadoop) at
-                         its original name: it is used with the un-relocated
-                         ParquetFileReader.readFooter, so relocating it causes a NoSuchMethodError. -->
-                    <relocation>
-                      <pattern>org.apache.parquet.format.</pattern>
-                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.parquet.format.</shadedPattern>
-                      <excludes>
-                        <exclude>org.apache.parquet.format.converter.**</exclude>
-                      </excludes>
-                    </relocation>
                     <relocation>
                       <pattern>org.codehaus.jackson.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}org.codehaus.jackson.</shadedPattern>
@@ -881,11 +859,9 @@
                       <shadedPattern>${flink.bundle.shade.prefix}jodd.</shadedPattern>
                     </relocation>
                   </relocations>
-                  <!-- Strip hive-exec's stale embedded Avro / ORC / Parquet so the declared
-                       modern avro, orc-core and parquet-* artifacts are the only source for
-                       those namespaces (relocated for avro/orc/parquet.format, canonical for
-                       parquet core). Without this we rely on shade's artifact ordering to make
-                       the modern copy win; stripping makes it explicit and version-safe. -->
+                  <!-- Drop hive-exec's stale embedded copies so only the declared modern
+                       artifacts populate these namespaces; otherwise shade would pick the
+                       winner by artifact order. -->
                   <filters combine.children="append">
                     <filter>
                       <artifact>org.apache.hive:hive-exec</artifact>
@@ -893,6 +869,8 @@
                         <exclude>org/apache/avro/**</exclude>
                         <exclude>org/apache/orc/**</exclude>
                         <exclude>org/apache/parquet/**</exclude>
+                        <exclude>com/google/protobuf/**</exclude>
+                        <exclude>io/airlift/compress/**</exclude>
                       </excludes>
                     </filter>
                   </filters>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -677,6 +677,14 @@
                       <pattern>com.google.common.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}com.google.common.</shadedPattern>
                     </relocation>
+                    <!-- hudi-io ships protobuf pre-shaded at org.apache.hudi.com.google.protobuf.
+                         hive-exec's classes were compiled against com.google.protobuf; this relocation
+                         rewrites those references onto hudi-io's shaded copy. The filter below strips
+                         hive-exec's stale embedded protobuf so nothing collides at the original names. -->
+                    <relocation>
+                      <pattern>com.google.protobuf.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}com.google.protobuf.</shadedPattern>
+                    </relocation>
                     <relocation>
                       <pattern>org.apache.commons.lang3.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang3.</shadedPattern>
@@ -789,6 +797,14 @@
                     <relocation>
                       <pattern>com.google.common.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}com.google.common.</shadedPattern>
+                    </relocation>
+                    <!-- hudi-io ships protobuf pre-shaded at org.apache.hudi.com.google.protobuf.
+                         hive-exec's classes were compiled against com.google.protobuf; this relocation
+                         rewrites those references onto hudi-io's shaded copy. The filter below strips
+                         hive-exec's stale embedded protobuf so nothing collides at the original names. -->
+                    <relocation>
+                      <pattern>com.google.protobuf.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}com.google.protobuf.</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>org.apache.commons.lang3.</pattern>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -97,11 +97,6 @@
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>org.antlr:stringtemplate</include>
-                  <!-- ANTLR runtime needed by Hive DDL parsing (Driver.compile); hive-exec
-                       does not embed it. Only bundled when a shade-hive profile is active. -->
-                  <include>org.antlr:antlr-runtime</include>
-                  <include>org.antlr:ST4</include>
-                  <include>org.antlr:antlr4-runtime</include>
                   <!-- Parquet -->
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>org.apache.parquet:parquet-hadoop</include>
@@ -233,88 +228,6 @@
                   <pattern>com.uber.m3.</pattern>
                   <shadedPattern>org.apache.hudi.com.uber.m3.</shadedPattern>
                 </relocation>
-
-                <!-- hive-exec is a fat jar that embeds these deps un-relocated; under Flink
-                     child-first classloading they shadow the versions Hudi/Flink need. No-op
-                     for the default bundle (classes only present when a shade-hive profile
-                     pulls hive-exec into compile scope). -->
-                <relocation>
-                  <pattern>com.google.common.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}com.google.common.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.google.protobuf.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}com.google.protobuf.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.commons.lang3.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang3.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.commons.lang.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.thrift.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.thrift.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.orc.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.orc.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.json.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.json.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>io.airlift.compress.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}io.airlift.compress.</shadedPattern>
-                </relocation>
-                <!-- Relocate parquet-format-structures embedded in hive-exec, but keep
-                     org.apache.parquet.format.converter.** (provided by parquet-hadoop) at its
-                     original name: it is used with the un-relocated ParquetFileReader.readFooter,
-                     so relocating it causes a NoSuchMethodError. -->
-                <relocation>
-                  <pattern>org.apache.parquet.format.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.parquet.format.</shadedPattern>
-                  <excludes>
-                    <exclude>org.apache.parquet.format.converter.**</exclude>
-                  </excludes>
-                </relocation>
-                <relocation>
-                  <pattern>org.codehaus.jackson.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.codehaus.jackson.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.facebook.fb303.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}com.facebook.fb303.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.iq80.snappy.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.iq80.snappy.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>au.com.bytecode.opencsv.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}au.com.bytecode.opencsv.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>javaewah.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}javaewah.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>javolution.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}javolution.</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>jodd.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}jodd.</shadedPattern>
-                </relocation>
-                <!-- DataNucleus (JDO impl behind HMS); its META-INF/services entries are
-                     rewritten by the ServicesResourceTransformer above. -->
-                <relocation>
-                  <pattern>org.datanucleus.</pattern>
-                  <shadedPattern>${flink.bundle.shade.prefix}org.datanucleus.</shadedPattern>
-                </relocation>
               </relocations>
               <filters>
                 <filter>
@@ -325,15 +238,6 @@
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>META-INF/services/javax.*</exclude>
                     <exclude>**/*.proto</exclude>
-                  </excludes>
-                </filter>
-                <!-- hive-exec embeds a stale Avro 1.7.7 (no LogicalType); strip it so the
-                     relocated org.apache.avro.* namespace is populated only by the modern
-                     Avro artifact bundled here. -->
-                <filter>
-                  <artifact>org.apache.hive:hive-exec</artifact>
-                  <excludes>
-                    <exclude>org/apache/avro/**</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -747,6 +651,118 @@
           <scope>${flink.bundle.hive.scope}</scope>
         </dependency>
       </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>${maven-shade-plugin.version}</version>
+            <executions>
+              <execution>
+                <configuration>
+                  <artifactSet>
+                    <!-- hive-exec needs the ANTLR runtime for Hive DDL parsing
+                         (Driver.compile) but does not embed it. -->
+                    <includes combine.children="append">
+                      <include>org.antlr:antlr-runtime</include>
+                      <include>org.antlr:ST4</include>
+                      <include>org.antlr:antlr4-runtime</include>
+                    </includes>
+                  </artifactSet>
+                  <!-- hive-exec is a fat jar that embeds these deps un-relocated; under Flink
+                       child-first classloading they would shadow the versions Hudi/Flink need.
+                       Scoped to this profile so the default (no-Hive) bundle's ABI is unchanged. -->
+                  <relocations combine.children="append">
+                    <relocation>
+                      <pattern>com.google.common.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}com.google.common.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.protobuf.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}com.google.protobuf.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.commons.lang3.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang3.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.commons.lang.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.thrift.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.thrift.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.orc.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.orc.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.json.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.json.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>io.airlift.compress.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}io.airlift.compress.</shadedPattern>
+                    </relocation>
+                    <!-- Relocate parquet-format-structures embedded in hive-exec, but keep
+                         org.apache.parquet.format.converter.** (provided by parquet-hadoop) at
+                         its original name: it is used with the un-relocated
+                         ParquetFileReader.readFooter, so relocating it causes a NoSuchMethodError. -->
+                    <relocation>
+                      <pattern>org.apache.parquet.format.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.parquet.format.</shadedPattern>
+                      <excludes>
+                        <exclude>org.apache.parquet.format.converter.**</exclude>
+                      </excludes>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.codehaus.jackson.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.codehaus.jackson.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.facebook.fb303.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}com.facebook.fb303.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.iq80.snappy.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.iq80.snappy.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>au.com.bytecode.opencsv.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}au.com.bytecode.opencsv.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>javaewah.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}javaewah.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>javolution.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}javolution.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>jodd.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}jodd.</shadedPattern>
+                    </relocation>
+                  </relocations>
+                  <!-- Strip hive-exec's stale embedded Avro (no LogicalType) and ORC so the
+                       relocated org.apache.avro.* / org.apache.orc.* namespaces are populated
+                       only by the declared modern avro / orc-core artifacts. -->
+                  <filters combine.children="append">
+                    <filter>
+                      <artifact>org.apache.hive:hive-exec</artifact>
+                      <excludes>
+                        <exclude>org/apache/avro/**</exclude>
+                        <exclude>org/apache/orc/**</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>flink-bundle-shade-hive3</id>
@@ -768,6 +784,118 @@
           <scope>${flink.bundle.hive.scope}</scope>
         </dependency>
       </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>${maven-shade-plugin.version}</version>
+            <executions>
+              <execution>
+                <configuration>
+                  <artifactSet>
+                    <!-- hive-exec needs the ANTLR runtime for Hive DDL parsing
+                         (Driver.compile) but does not embed it. -->
+                    <includes combine.children="append">
+                      <include>org.antlr:antlr-runtime</include>
+                      <include>org.antlr:ST4</include>
+                      <include>org.antlr:antlr4-runtime</include>
+                    </includes>
+                  </artifactSet>
+                  <!-- hive-exec is a fat jar that embeds these deps un-relocated; under Flink
+                       child-first classloading they would shadow the versions Hudi/Flink need.
+                       Scoped to this profile so the default (no-Hive) bundle's ABI is unchanged. -->
+                  <relocations combine.children="append">
+                    <relocation>
+                      <pattern>com.google.common.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}com.google.common.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.protobuf.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}com.google.protobuf.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.commons.lang3.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang3.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.commons.lang.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.thrift.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.thrift.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.orc.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.orc.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.json.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.json.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>io.airlift.compress.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}io.airlift.compress.</shadedPattern>
+                    </relocation>
+                    <!-- Relocate parquet-format-structures embedded in hive-exec, but keep
+                         org.apache.parquet.format.converter.** (provided by parquet-hadoop) at
+                         its original name: it is used with the un-relocated
+                         ParquetFileReader.readFooter, so relocating it causes a NoSuchMethodError. -->
+                    <relocation>
+                      <pattern>org.apache.parquet.format.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.apache.parquet.format.</shadedPattern>
+                      <excludes>
+                        <exclude>org.apache.parquet.format.converter.**</exclude>
+                      </excludes>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.codehaus.jackson.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.codehaus.jackson.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.facebook.fb303.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}com.facebook.fb303.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.iq80.snappy.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}org.iq80.snappy.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>au.com.bytecode.opencsv.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}au.com.bytecode.opencsv.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>javaewah.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}javaewah.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>javolution.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}javolution.</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>jodd.</pattern>
+                      <shadedPattern>${flink.bundle.shade.prefix}jodd.</shadedPattern>
+                    </relocation>
+                  </relocations>
+                  <!-- Strip hive-exec's stale embedded Avro (no LogicalType) and ORC so the
+                       relocated org.apache.avro.* / org.apache.orc.* namespaces are populated
+                       only by the declared modern avro / orc-core artifacts. -->
+                  <filters combine.children="append">
+                    <filter>
+                      <artifact>org.apache.hive:hive-exec</artifact>
+                      <excludes>
+                        <exclude>org/apache/avro/**</exclude>
+                        <exclude>org/apache/orc/**</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>hudi-platform-service</id>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -678,10 +678,6 @@
                       <shadedPattern>${flink.bundle.shade.prefix}com.google.common.</shadedPattern>
                     </relocation>
                     <relocation>
-                      <pattern>com.google.protobuf.</pattern>
-                      <shadedPattern>${flink.bundle.shade.prefix}com.google.protobuf.</shadedPattern>
-                    </relocation>
-                    <relocation>
                       <pattern>org.apache.commons.lang3.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang3.</shadedPattern>
                     </relocation>
@@ -702,20 +698,12 @@
                       <shadedPattern>${flink.bundle.shade.prefix}org.json.</shadedPattern>
                     </relocation>
                     <relocation>
-                      <pattern>io.airlift.compress.</pattern>
-                      <shadedPattern>${flink.bundle.shade.prefix}io.airlift.compress.</shadedPattern>
-                    </relocation>
-                    <relocation>
                       <pattern>org.codehaus.jackson.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}org.codehaus.jackson.</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>com.facebook.fb303.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}com.facebook.fb303.</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.iq80.snappy.</pattern>
-                      <shadedPattern>${flink.bundle.shade.prefix}org.iq80.snappy.</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>au.com.bytecode.opencsv.</pattern>
@@ -803,10 +791,6 @@
                       <shadedPattern>${flink.bundle.shade.prefix}com.google.common.</shadedPattern>
                     </relocation>
                     <relocation>
-                      <pattern>com.google.protobuf.</pattern>
-                      <shadedPattern>${flink.bundle.shade.prefix}com.google.protobuf.</shadedPattern>
-                    </relocation>
-                    <relocation>
                       <pattern>org.apache.commons.lang3.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang3.</shadedPattern>
                     </relocation>
@@ -827,20 +811,12 @@
                       <shadedPattern>${flink.bundle.shade.prefix}org.json.</shadedPattern>
                     </relocation>
                     <relocation>
-                      <pattern>io.airlift.compress.</pattern>
-                      <shadedPattern>${flink.bundle.shade.prefix}io.airlift.compress.</shadedPattern>
-                    </relocation>
-                    <relocation>
                       <pattern>org.codehaus.jackson.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}org.codehaus.jackson.</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>com.facebook.fb303.</pattern>
                       <shadedPattern>${flink.bundle.shade.prefix}com.facebook.fb303.</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.iq80.snappy.</pattern>
-                      <shadedPattern>${flink.bundle.shade.prefix}org.iq80.snappy.</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>au.com.bytecode.opencsv.</pattern>

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -97,6 +97,11 @@
                   <include>org.jetbrains.kotlin:*</include>
                   <include>org.rocksdb:rocksdbjni</include>
                   <include>org.antlr:stringtemplate</include>
+                  <!-- ANTLR runtime needed by Hive DDL parsing (Driver.compile); hive-exec
+                       does not embed it. Only bundled when a shade-hive profile is active. -->
+                  <include>org.antlr:antlr-runtime</include>
+                  <include>org.antlr:ST4</include>
+                  <include>org.antlr:antlr4-runtime</include>
                   <!-- Parquet -->
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>org.apache.parquet:parquet-hadoop</include>
@@ -228,6 +233,88 @@
                   <pattern>com.uber.m3.</pattern>
                   <shadedPattern>org.apache.hudi.com.uber.m3.</shadedPattern>
                 </relocation>
+
+                <!-- hive-exec is a fat jar that embeds these deps un-relocated; under Flink
+                     child-first classloading they shadow the versions Hudi/Flink need. No-op
+                     for the default bundle (classes only present when a shade-hive profile
+                     pulls hive-exec into compile scope). -->
+                <relocation>
+                  <pattern>com.google.common.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}com.google.common.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.protobuf.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}com.google.protobuf.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.lang3.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang3.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.lang.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.commons.lang.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.thrift.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.thrift.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.orc.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.orc.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.json.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.json.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.airlift.compress.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}io.airlift.compress.</shadedPattern>
+                </relocation>
+                <!-- Relocate parquet-format-structures embedded in hive-exec, but keep
+                     org.apache.parquet.format.converter.** (provided by parquet-hadoop) at its
+                     original name: it is used with the un-relocated ParquetFileReader.readFooter,
+                     so relocating it causes a NoSuchMethodError. -->
+                <relocation>
+                  <pattern>org.apache.parquet.format.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.apache.parquet.format.</shadedPattern>
+                  <excludes>
+                    <exclude>org.apache.parquet.format.converter.**</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus.jackson.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.codehaus.jackson.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.facebook.fb303.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}com.facebook.fb303.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.iq80.snappy.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.iq80.snappy.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>au.com.bytecode.opencsv.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}au.com.bytecode.opencsv.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javaewah.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}javaewah.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javolution.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}javolution.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>jodd.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}jodd.</shadedPattern>
+                </relocation>
+                <!-- DataNucleus (JDO impl behind HMS); its META-INF/services entries are
+                     rewritten by the ServicesResourceTransformer above. -->
+                <relocation>
+                  <pattern>org.datanucleus.</pattern>
+                  <shadedPattern>${flink.bundle.shade.prefix}org.datanucleus.</shadedPattern>
+                </relocation>
               </relocations>
               <filters>
                 <filter>
@@ -238,6 +325,15 @@
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>META-INF/services/javax.*</exclude>
                     <exclude>**/*.proto</exclude>
+                  </excludes>
+                </filter>
+                <!-- hive-exec embeds a stale Avro 1.7.7 (no LogicalType); strip it so the
+                     relocated org.apache.avro.* namespace is populated only by the modern
+                     Avro artifact bundled here. -->
+                <filter>
+                  <artifact>org.apache.hive:hive-exec</artifact>
+                  <excludes>
+                    <exclude>org/apache/avro/**</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The flink-bundle-shade-hive* profiles bundle hive-exec, but the resulting bundle fails at runtime as soon as HiveSyncTool talks to HMS. This PR fixes the shade config in packaging/hudi-flink-bundle/pom.xml. All changes are scoped to the flink-bundle-shade-hive* profiles, so the default (no-Hive) bundle's ABI is unchanged.

- Bundle the ANTLR 3 runtime (org.antlr:antlr-runtime) and org.antlr:ST4 that hive-exec needs for Hive DDL parsing (Driver.compile) but depends on transitively without embedding. (Hive 2.x/3.x use ANTLR 3, not 4.)
- Relocate the transitive deps hive-exec embeds un-relocated so they don't shadow the versions Hudi/Flink rely on under Flink child-first classloading: Guava, Commons Lang (2.x and 3.x), Thrift, ORC, JSON, codehaus Jackson, fb303, OpenCSV, JavaEWAH, Javolution, and Jodd.
- Strip hive-exec's stale embedded copies of Avro (1.7.7), ORC, Parquet, protobuf (2.5.0), and Airlift. This ensures each of those namespaces is populated only by the modern declared artifact instead of shade picking a winner by artifact order. Parquet and Airlift stay at their canonical locations, and protobuf is already supplied pre-relocated by hudi-io (3.25.5), so once the stale hive-exec copies are stripped, no separate relocation of those three is needed.

Fixes: #19319

### Summary and Changelog

Built `hudi-flink1.18-bundle` with `-Pflink-bundle-shade-hive2` and verified the relocation/exclusion are working as expected

### Impact

Increase hudi-flink-bundle size

### Risk Level

Low. Have done Uber internal verifications to make sure things work.

### Documentation Update

N/A

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
