### PR TITLE
fix(hive-sync): close proxied IMetaStoreClient in HoodieHiveSyncClient.close() to prevent HMS connection leak

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HoodieHiveSyncClient.java
@@ -598,6 +598,18 @@ public class HoodieHiveSyncClient extends HoodieSyncClient {
     try {
       ddlExecutor.close();
       if (client != null) {
+        // Close the proxied IMetaStoreClient directly before Hive.closeCurrent().
+        // When RetryingMetaStoreClient rebuilds the underlying client on a transient
+        // TException, the fresh MSC is reachable only through this proxy, while the
+        // thread-local Hive singleton still references the older instance. So
+        // Hive.closeCurrent() alone closes the stale MSC and orphans the retry-created
+        // one, leaking a connection per sync cycle. client.close() releases the live
+        // MSC by identity; Hive.closeCurrent() remains a fallback for the singleton path.
+        try {
+          client.close();
+        } catch (Exception e) {
+          log.warn("Failed to close IMetaStoreClient directly; Hive.closeCurrent() will run anyway", e);
+        }
         Hive.closeCurrent();
         client = null;
       }

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHoodieHiveSyncClientClose.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHoodieHiveSyncClientClose.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive;
+
+import org.apache.hudi.hive.ddl.DDLExecutor;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link HoodieHiveSyncClient#close()} connection cleanup.
+ *
+ * <p>Regression coverage for the metastore connection leak: when
+ * {@code RetryingMetaStoreClient} rebuilds the underlying client on a transient
+ * error, {@code Hive.closeCurrent()} alone closes the stale singleton-bound
+ * client and orphans the retry-created one. {@code close()} must therefore
+ * release the client held on the proxy field directly.
+ */
+class TestHoodieHiveSyncClientClose {
+
+  @Test
+  void closeReleasesProxiedMetastoreClientDirectly() throws Exception {
+    HoodieHiveSyncClient syncClient = mock(HoodieHiveSyncClient.class, CALLS_REAL_METHODS);
+    IMetaStoreClient metaStoreClient = mock(IMetaStoreClient.class);
+    DDLExecutor ddlExecutor = mock(DDLExecutor.class);
+    setField(syncClient, "client", metaStoreClient);
+    setField(syncClient, "ddlExecutor", ddlExecutor);
+
+    syncClient.close();
+
+    verify(metaStoreClient).close();
+    verify(ddlExecutor).close();
+  }
+
+  @Test
+  void closeSwallowsProxyCloseFailure() throws Exception {
+    HoodieHiveSyncClient syncClient = mock(HoodieHiveSyncClient.class, CALLS_REAL_METHODS);
+    IMetaStoreClient metaStoreClient = mock(IMetaStoreClient.class);
+    DDLExecutor ddlExecutor = mock(DDLExecutor.class);
+    doThrow(new RuntimeException("transient close failure")).when(metaStoreClient).close();
+    setField(syncClient, "client", metaStoreClient);
+    setField(syncClient, "ddlExecutor", ddlExecutor);
+
+    // A transient failure closing the proxied client must not propagate.
+    assertDoesNotThrow(syncClient::close);
+    verify(metaStoreClient).close();
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = HoodieHiveSyncClient.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

HoodieHiveSyncClient.close() leaks one Hive Metastore connection per sync cycle. When RetryingMetaStoreClient rebuilds the underlying IMetaStoreClient after a transient TException, the fresh client is reachable only via the proxy on the client field, while the thread-local Hive singleton still points at the older instance. close() only called Hive.closeCurrent(), which closes the stale client and orphans the live one, so long-running jobs that sync every commit (Flink streaming, DeltaStreamer continuous mode) grow HMS connections until exhaustion.

Fixes: #19321

### Summary and Changelog

Metastore connections are now released reliably on close(), so HMS open-connection count stays bounded across sync cycles instead of climbing over time.

Changes:

- HoodieHiveSyncClient.close(): close the proxied IMetaStoreClient directly (client.close()) before falling back to Hive.closeCurrent(). This closes whichever underlying client is currently live including one rebuilt by RetryingMetaStoreClient, while Hive.closeCurrent() remains as belt-and-suspenders for the singleton path. The direct close is wrapped in its own try/catch so a transient close failure doesn't skip the fallback.

- Added TestHoodieHiveSyncClientClose with two unit tests: one asserting close() releases the proxied client and the DDL executor, and one asserting a failure from client.close() is swallowed rather than propagated.

### Impact

Fixed the HMS connection leak issue

### Risk Level

Low. We've verified it fixed the connection leak issue in Uber internal testings

### Documentation Update

N/A

### Contributor's checklist

- [X] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [X] Enough context is provided in the sections above
- [X] Adequate tests were added if applicable
