### PR TITLE
chore(utilities): add SQS backlog / in-flight visibility to S3 events source

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsSource.java
@@ -113,7 +113,7 @@ public class S3EventsSource extends RowSource implements Closeable {
 
   @Override
   public void onCommit(String lastCkptStr) {
-    LOG.info("S3EventsSource.onCommit: deleting {} processed messages from queue, checkpoint={}.",
+    LOG.info("Deleting {} processed messages from SQS queue, checkpoint={}.",
         processedMessages.size(), lastCkptStr);
     pathSelector.deleteProcessedMessages(sqs, pathSelector.queueUrl, processedMessages);
     processedMessages.clear();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/S3EventsSource.java
@@ -35,6 +35,8 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 import java.io.Closeable;
@@ -51,6 +53,8 @@ import static org.apache.hudi.utilities.config.CloudSourceConfig.META_EVENTS_PER
  * {@link S3EventsHoodieIncrSource} to apply changes to the hudi table corresponding to user data.
  */
 public class S3EventsSource extends RowSource implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3EventsSource.class);
 
   private final S3EventsMetaSelector pathSelector;
   private final SchemaProvider schemaProvider;
@@ -109,6 +113,8 @@ public class S3EventsSource extends RowSource implements Closeable {
 
   @Override
   public void onCommit(String lastCkptStr) {
+    LOG.info("S3EventsSource.onCommit: deleting {} processed messages from queue, checkpoint={}.",
+        processedMessages.size(), lastCkptStr);
     pathSelector.deleteProcessedMessages(sqs, pathSelector.queueUrl, processedMessages);
     processedMessages.clear();
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The SQS-backed S3 events ingestion path gives no signal about message cleanup. When `S3EventsSource.onCommit` runs, it deletes the processed messages from the queue and clears its tracker, but nothing is logged, so there is no way to tell from the logs how many messages were reclaimed at a given checkpoint or whether cleanup ran at all.

### Summary and Changelog

Operators get a per-commit log line showing how many SQS messages were deleted and at which checkpoint, making the ingestion path's queue cleanup observable. This is the first increment of a broader observability change (receive-loop plan/summary and in-flight queue counters) that will follow.

- `S3EventsSource`: added an SLF4J logger.
- `S3EventsSource.onCommit`: log the processed-message count and the checkpoint before deleting the messages from the queue.

No existing code paths were modified and no code was copied.

### Impact

Logging only. No public API, config, or behavior change. One additional INFO line per commit on the S3 events source path.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
