### PR TITLE
fix(hive-sync): set HMS table createTime in seconds instead of milliseconds

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/ddl/HMSDDLExecutor.java
@@ -122,7 +122,9 @@ public class HMSDDLExecutor implements DDLExecutor {
       newTb.setDbName(databaseName);
       newTb.setTableName(tableName);
       newTb.setOwner(UserGroupInformation.getCurrentUser().getShortUserName());
-      newTb.setCreateTime((int) System.currentTimeMillis());
+      // Hive stores createTime as seconds since the epoch in an i32 field; passing raw
+      // milliseconds both uses the wrong unit and overflows the int cast.
+      newTb.setCreateTime((int) (System.currentTimeMillis() / 1000));
       StorageDescriptor storageDescriptor = new StorageDescriptor();
       storageDescriptor.setCols(fieldSchema);
       storageDescriptor.setInputFormat(inputFormatClass);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHMSDDLExecutorCreateTable.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHMSDDLExecutorCreateTable.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hive.ddl;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.hive.HiveSyncConfig;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Properties;
+
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_BASE_PATH;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NAME;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class TestHMSDDLExecutorCreateTable {
+
+  @Test
+  void createTableSetsCreateTimeInSeconds() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(META_SYNC_DATABASE_NAME.key(), "testdb");
+    props.setProperty(META_SYNC_BASE_PATH.key(), "/tmp/test_table");
+    HiveSyncConfig config = new HiveSyncConfig(props, new Configuration());
+
+    IMetaStoreClient client = mock(IMetaStoreClient.class);
+    HMSDDLExecutor executor = new HMSDDLExecutor(config, client);
+
+    HoodieSchema schema = HoodieSchema.createRecord("test_record", null, null,
+        Collections.singletonList(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT))));
+
+    long beforeSec = System.currentTimeMillis() / 1000;
+    executor.createTable("test_table", schema, "input.Format", "output.Format", "serde.Class",
+        new HashMap<>(), new HashMap<>());
+    long afterSec = System.currentTimeMillis() / 1000;
+
+    ArgumentCaptor<Table> captor = ArgumentCaptor.forClass(Table.class);
+    verify(client).createTable(captor.capture());
+    int createTime = captor.getValue().getCreateTime();
+
+    // createTime must be epoch seconds within the call window. Passing raw milliseconds instead
+    // would overflow the int cast into a garbage/negative value far outside this range.
+    assertTrue(createTime >= beforeSec && createTime <= afterSec,
+        "createTime should be epoch seconds within [" + beforeSec + ", " + afterSec + "] but was " + createTime);
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHMSDDLExecutorCreateTable.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/ddl/TestHMSDDLExecutorCreateTable.java
@@ -63,8 +63,7 @@ class TestHMSDDLExecutorCreateTable {
     verify(client).createTable(captor.capture());
     int createTime = captor.getValue().getCreateTime();
 
-    // createTime must be epoch seconds within the call window. Passing raw milliseconds instead
-    // would overflow the int cast into a garbage/negative value far outside this range.
+    // createTime must be epoch seconds within the call window.
     assertTrue(createTime >= beforeSec && createTime <= afterSec,
         "createTime should be epoch seconds within [" + beforeSec + ", " + afterSec + "] but was " + createTime);
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When syncing a table in HMS mode, `HMSDDLExecutor.createTable` sets the Hive `createTime` with `newTb.setCreateTime((int) System.currentTimeMillis())`. Hive stores `createTime` as seconds since the epoch in an `i32` field, but this passes raw milliseconds: the value is 1000x too large and, being ~1.7e12, overflows the `int` cast into a garbage (often negative or far-past) value. The rest of the codebase already does this correctly, for example `HoodieHiveCatalog` uses `(int) (System.currentTimeMillis() / 1000)`.

### Summary and Changelog

Divides the millisecond timestamp by 1000 before the `int` cast so the Hive metastore records the table's creation time as epoch seconds, matching Hive's contract and the existing `HoodieHiveCatalog` usage.

- `HMSDDLExecutor.createTable` now calls `setCreateTime((int) (System.currentTimeMillis() / 1000))`.
- Adds unit test `TestHMSDDLExecutorCreateTable` that captures the `Table` passed to `createTable` (with a mocked `IMetaStoreClient`) and asserts `createTime` is epoch seconds within the call window; this assertion fails against the previous milliseconds value.

### Impact

Tables created via HMS-mode Hive sync now record a correct `createTime` (visible in `DESCRIBE FORMATTED` and used by tools that read table age). No public API or configuration change.

### Risk Level

low

One-line change plus a unit test; the behavior is verified against the corrected value and matches the existing `HoodieHiveCatalog` convention.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
