### PR TITLE
feat(common): query LAYOUT_VERSION_1 timelines in CompletionTimeQueryView by using instant time as completion time

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CompletionTimeQueryViewV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CompletionTimeQueryViewV1.java
@@ -32,14 +32,19 @@ import lombok.Getter;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.START_COMMIT_EARLIEST;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN;
+import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
 
 public class CompletionTimeQueryViewV1 implements CompletionTimeQueryView, Serializable {
 
@@ -188,14 +193,20 @@ public class CompletionTimeQueryViewV1 implements CompletionTimeQueryView, Seria
   }
 
   /**
-   * Queries the instant start time with given completion time range.
+   * Queries the instant times within the given range.
    *
-   * @param timeline            The timeline.
-   * @param rangeStart              The query range start completion time.
-   * @param rangeEnd                The query range end completion time.
+   * <p>A LAYOUT_VERSION_1 timeline (table versions 5 ~ 7) does not persist a separate completion
+   * time; an instant's completion time is, backward-compatibly, its instant (request) time. The
+   * range bounds are therefore matched against the requested time, and the archived timeline is
+   * never consulted (it is intentionally not loaded for V1). This is the "completion time = instant
+   * time" specialization of the same range logic implemented in {@code CompletionTimeQueryViewV2}.
+   *
+   * @param timeline            The timeline (already filtered as per user configs by the caller).
+   * @param rangeStart              The query range start requested time.
+   * @param rangeEnd                The query range end requested time.
    * @param rangeType               The range type.
-   * @param earliestInstantTimeFunc The function to generate the earliest start time boundary
-   *                                with the minimum completion time.
+   * @param earliestInstantTimeFunc Unused for V1: it only serves the V2 archive lazy-load boundary,
+   *                                and V1 does not load the archive.
    *
    * @return The sorted instant time list.
    */
@@ -205,7 +216,39 @@ public class CompletionTimeQueryViewV1 implements CompletionTimeQueryView, Seria
       Option<String> rangeEnd,
       InstantRange.RangeType rangeType,
       Function<String, String> earliestInstantTimeFunc) {
-    throw new RuntimeException("Incremental query view for timeline version 1 not yet implemented");
+    final boolean startFromEarliest = START_COMMIT_EARLIEST.equalsIgnoreCase(rangeStart.orElse(null));
+    HoodieTimeline completedTimeline = timeline.filterCompletedInstants();
+
+    if (rangeStart.isEmpty() && rangeEnd.isPresent()) {
+      // (_, end]: returns the last instant whose requested time is at or before 'end'.
+      return completedTimeline.getInstantsAsStream()
+          .filter(instant -> InstantComparison.compareTimestamps(instant.requestedTime(), LESSER_THAN_OR_EQUALS, rangeEnd.get()))
+          .max(Comparator.comparing(HoodieInstant::requestedTime))
+          .map(instant -> Collections.singletonList(instant.requestedTime()))
+          .orElse(Collections.emptyList());
+    }
+
+    if (startFromEarliest) {
+      // ['earliest', _): clear the start so it degenerates to consuming from the earliest instant.
+      rangeStart = Option.empty();
+    }
+
+    if (rangeStart.isEmpty() && rangeEnd.isEmpty()) {
+      // (_, _): read the latest snapshot.
+      return completedTimeline.lastInstant().map(instant -> Collections.singletonList(instant.requestedTime())).orElse(Collections.emptyList());
+    }
+
+    final InstantRange instantRange = InstantRange.builder()
+        .rangeType(rangeType)
+        .startInstant(rangeStart.orElse(null))
+        .endInstant(rangeEnd.orElse(null))
+        .nullableBoundary(true)
+        .build();
+    return completedTimeline.getInstantsAsStream()
+        .map(HoodieInstant::requestedTime)
+        .filter(instantRange::isInRange)
+        .sorted()
+        .collect(Collectors.toList());
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CompletionTimeQueryViewV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/CompletionTimeQueryViewV1.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.read.IncrementalQueryAnalyzer.START_COMMIT_EARLIEST;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN_OR_EQUALS;
@@ -197,16 +198,16 @@ public class CompletionTimeQueryViewV1 implements CompletionTimeQueryView, Seria
    *
    * <p>A LAYOUT_VERSION_1 timeline (table versions 5 ~ 7) does not persist a separate completion
    * time; an instant's completion time is, backward-compatibly, its instant (request) time. The
-   * range bounds are therefore matched against the requested time, and the archived timeline is
-   * never consulted (it is intentionally not loaded for V1). This is the "completion time = instant
-   * time" specialization of the same range logic implemented in {@code CompletionTimeQueryViewV2}.
+   * range bounds are therefore matched against the requested time. Archived instants are loaded on
+   * demand when the requested range can overlap with the archived timeline. This is the "completion
+   * time = instant time" specialization of the same range logic implemented in
+   * {@code CompletionTimeQueryViewV2}.
    *
    * @param timeline            The timeline (already filtered as per user configs by the caller).
    * @param rangeStart              The query range start requested time.
    * @param rangeEnd                The query range end requested time.
    * @param rangeType               The range type.
-   * @param earliestInstantTimeFunc Unused for V1: it only serves the V2 archive lazy-load boundary,
-   *                                and V1 does not load the archive.
+   * @param earliestInstantTimeFunc Unused for V1 and retained for API compatibility with V2.
    *
    * @return The sorted instant time list.
    */
@@ -217,38 +218,56 @@ public class CompletionTimeQueryViewV1 implements CompletionTimeQueryView, Seria
       InstantRange.RangeType rangeType,
       Function<String, String> earliestInstantTimeFunc) {
     final boolean startFromEarliest = START_COMMIT_EARLIEST.equalsIgnoreCase(rangeStart.orElse(null));
-    HoodieTimeline completedTimeline = timeline.filterCompletedInstants();
+    final Option<String> effectiveStart = startFromEarliest ? Option.empty() : rangeStart;
+    final HoodieTimeline completedTimeline = timeline.filterCompletedInstants();
 
     if (rangeStart.isEmpty() && rangeEnd.isPresent()) {
       // (_, end]: returns the last instant whose requested time is at or before 'end'.
-      return completedTimeline.getInstantsAsStream()
+      Option<String> latestActiveInstant = Option.fromJavaOptional(completedTimeline.getInstantsAsStream()
           .filter(instant -> InstantComparison.compareTimestamps(instant.requestedTime(), LESSER_THAN_OR_EQUALS, rangeEnd.get()))
           .max(Comparator.comparing(HoodieInstant::requestedTime))
-          .map(instant -> Collections.singletonList(instant.requestedTime()))
-          .orElse(Collections.emptyList());
+          .map(HoodieInstant::requestedTime));
+      if (latestActiveInstant.isPresent()) {
+        return Collections.singletonList(latestActiveInstant.get());
+      }
+      // The archived timeline is not filtered by user configs yet, so return all candidates and
+      // let IncrementalQueryAnalyzer select the last eligible instant after applying those filters.
+      return getArchivedInstantTimes(Option.empty())
+          .filter(instant -> InstantComparison.compareTimestamps(instant, LESSER_THAN_OR_EQUALS, rangeEnd.get()))
+          .sorted()
+          .collect(Collectors.toList());
     }
 
-    if (startFromEarliest) {
-      // ['earliest', _): clear the start so it degenerates to consuming from the earliest instant.
-      rangeStart = Option.empty();
-    }
-
-    if (rangeStart.isEmpty() && rangeEnd.isEmpty()) {
+    if (effectiveStart.isEmpty() && rangeEnd.isEmpty()) {
       // (_, _): read the latest snapshot.
       return completedTimeline.lastInstant().map(instant -> Collections.singletonList(instant.requestedTime())).orElse(Collections.emptyList());
     }
 
     final InstantRange instantRange = InstantRange.builder()
         .rangeType(rangeType)
-        .startInstant(rangeStart.orElse(null))
+        .startInstant(effectiveStart.orElse(null))
         .endInstant(rangeEnd.orElse(null))
         .nullableBoundary(true)
         .build();
-    return completedTimeline.getInstantsAsStream()
-        .map(HoodieInstant::requestedTime)
+    Stream<String> candidateInstants = completedTimeline.getInstantsAsStream().map(HoodieInstant::requestedTime);
+    final boolean needsArchivedInstants = startFromEarliest
+        || (effectiveStart.isPresent() && isArchived(effectiveStart.get()));
+    if (needsArchivedInstants) {
+      candidateInstants = Stream.concat(getArchivedInstantTimes(effectiveStart), candidateInstants);
+    }
+    return candidateInstants
         .filter(instantRange::isInRange)
+        .distinct()
         .sorted()
         .collect(Collectors.toList());
+  }
+
+  private Stream<String> getArchivedInstantTimes(Option<String> startInstant) {
+    return metaClient.getArchivedTimeline(startInstant.orElse(""), false)
+        .getCommitsTimeline()
+        .filterCompletedInstants()
+        .getInstantsAsStream()
+        .map(HoodieInstant::requestedTime);
   }
 
   // -------------------------------------------------------------------------
@@ -265,7 +284,7 @@ public class CompletionTimeQueryViewV1 implements CompletionTimeQueryView, Seria
     this.metaClient.getActiveTimeline()
         .filterCompletedInstants().getInstantsAsStream()
         .forEach(instant -> setCompletionTime(instant.requestedTime(), instant.getCompletionTime()));
-    // Do not load archive timeline.
+    // The archived timeline is loaded on demand by range queries that can overlap with it.
   }
 
   private void setCompletionTime(String beginInstantTime, String completionTime) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCompletionTimeQueryViewV1.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCompletionTimeQueryViewV1.java
@@ -21,6 +21,7 @@ package org.apache.hudi.common.table.timeline.versioning.v1;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieArchivedTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
@@ -33,7 +34,11 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -46,9 +51,8 @@ import static org.mockito.Mockito.when;
  * first read includes the start commit, etc.), the same behavior as the V2 view keyed on completion
  * time.
  *
- * <p>The timeline is mocked rather than materialized on disk: {@code getInstantTimes} consumes only
- * the supplied {@link HoodieTimeline}, and {@code hudi-common} test scope has no hadoop storage
- * implementation to build a real table from.
+ * <p>The active and archived timelines are mocked rather than materialized on disk because the
+ * {@code hudi-common} test scope has no hadoop storage implementation to build a real table from.
  */
 public class TestCompletionTimeQueryViewV1 {
 
@@ -61,25 +65,26 @@ public class TestCompletionTimeQueryViewV1 {
   private static final String T5 = "20240101010005000";
 
   private CompletionTimeQueryViewV1 view;
+  private HoodieTableMetaClient metaClient;
   private HoodieTimeline timeline;
 
   @BeforeEach
   void setUp() {
-    List<HoodieInstant> instants = Arrays.asList(
-        completedCommit(T1), completedCommit(T2), completedCommit(T3), completedCommit(T4), completedCommit(T5));
+    List<HoodieInstant> archivedInstants = Arrays.asList(completedCommit(T1), completedCommit(T2));
+    List<HoodieInstant> activeInstants = Arrays.asList(completedCommit(T3), completedCommit(T4), completedCommit(T5));
 
-    // A timeline whose filterCompletedInstants() returns itself and replays a fresh stream each call.
-    timeline = mock(HoodieTimeline.class);
-    when(timeline.filterCompletedInstants()).thenReturn(timeline);
-    when(timeline.getInstantsAsStream()).thenAnswer(invocation -> instants.stream());
-    when(timeline.lastInstant()).thenAnswer(invocation -> Option.of(instants.get(instants.size() - 1)));
+    timeline = completedTimelineMock(activeInstants);
+    HoodieTimeline archivedCommitsTimeline = completedTimelineMock(archivedInstants);
+    HoodieArchivedTimeline archivedTimeline = mock(HoodieArchivedTimeline.class);
+    when(archivedTimeline.getCommitsTimeline()).thenReturn(archivedCommitsTimeline);
 
     // Minimal meta client wiring so the V1 view can be constructed (load()/cursor/firstNonSavepoint).
     // Build the active timeline mock fully before stubbing getActiveTimeline(), otherwise Mockito
     // sees nested stubbing (a when() started inside another when()'s argument) and fails.
-    HoodieActiveTimeline activeTimeline = activeTimelineMock(instants);
-    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieActiveTimeline activeTimeline = activeTimelineMock(activeInstants);
+    metaClient = mock(HoodieTableMetaClient.class);
     when(metaClient.getActiveTimeline()).thenReturn(activeTimeline);
+    when(metaClient.getArchivedTimeline(anyString(), eq(false))).thenReturn(archivedTimeline);
     view = new CompletionTimeQueryViewV1(metaClient);
   }
 
@@ -88,6 +93,15 @@ public class TestCompletionTimeQueryViewV1 {
     return new HoodieInstant(
         HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, instantTime, instantTime,
         InstantComparatorV1.REQUESTED_TIME_BASED_COMPARATOR);
+  }
+
+  private static HoodieTimeline completedTimelineMock(List<HoodieInstant> instants) {
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+    when(completedTimeline.filterCompletedInstants()).thenReturn(completedTimeline);
+    when(completedTimeline.getInstantsAsStream()).thenAnswer(invocation -> instants.stream());
+    when(completedTimeline.lastInstant()).thenAnswer(invocation -> Option.fromJavaOptional(
+        instants.stream().max(HoodieInstant::compareTo)));
+    return completedTimeline;
   }
 
   /**
@@ -110,7 +124,7 @@ public class TestCompletionTimeQueryViewV1 {
 
   @Test
   void testClosedClosedRange() {
-    // [T2, T4]: first-time consume with explicit start/end commit, both bounds inclusive.
+    // [T2, T4]: first-time consume with an archived start and an active end, both bounds inclusive.
     assertEquals(Arrays.asList(T2, T3, T4), query(Option.of(T2), Option.of(T4), InstantRange.RangeType.CLOSED_CLOSED));
 
     // [T3, _): from the start commit to the latest, open end.
@@ -122,7 +136,7 @@ public class TestCompletionTimeQueryViewV1 {
 
   @Test
   void testOpenClosedResumeRange() {
-    // (T2, T4]: streaming resume from issued offset T2, the start point must be excluded.
+    // (T2, T4]: streaming resume from archived offset T2, the start point must be excluded.
     assertEquals(Arrays.asList(T3, T4), query(Option.of(T2), Option.of(T4), InstantRange.RangeType.OPEN_CLOSED));
 
     // (T4, _]: resume from T4 with open end, only T5 is new.
@@ -134,7 +148,7 @@ public class TestCompletionTimeQueryViewV1 {
 
   @Test
   void testEarliestStart() {
-    // ['earliest', T3]: 'earliest' degenerates to consuming from the first instant.
+    // ['earliest', T3]: archived instants must be included when consuming from the beginning.
     assertEquals(Arrays.asList(T1, T2, T3),
         query(Option.of("earliest"), Option.of(T3), InstantRange.RangeType.CLOSED_CLOSED));
   }
@@ -149,8 +163,24 @@ public class TestCompletionTimeQueryViewV1 {
   }
 
   @Test
+  void testEndOnlyFallsBackToArchivedCandidates() {
+    // The analyzer applies user-config filters to the archived timeline and then selects the last
+    // eligible instant, so the view must return all archived candidates at or before the end.
+    assertEquals(Arrays.asList(T1, T2),
+        query(Option.empty(), Option.of(T2), InstantRange.RangeType.CLOSED_CLOSED));
+  }
+
+  @Test
+  void testActiveRangeDoesNotLoadArchivedTimeline() {
+    assertEquals(Arrays.asList(T3, T4),
+        query(Option.of(T3), Option.of(T4), InstantRange.RangeType.CLOSED_CLOSED));
+    verify(metaClient, never()).getArchivedTimeline(anyString(), eq(false));
+  }
+
+  @Test
   void testNoBoundsReadsLatestSnapshot() {
     // (_, _): no range at all, reads the latest snapshot instant.
     assertEquals(Collections.singletonList(T5), query(Option.empty(), Option.empty(), InstantRange.RangeType.CLOSED_CLOSED));
+    verify(metaClient, never()).getArchivedTimeline(anyString(), eq(false));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCompletionTimeQueryViewV1.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/versioning/v1/TestCompletionTimeQueryViewV1.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.table.timeline.versioning.v1;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.InstantRange;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.util.Option;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link CompletionTimeQueryViewV1#getInstantTimes}.
+ *
+ * <p>A LAYOUT_VERSION_1 timeline (table versions 5 ~ 7) does not persist a separate completion
+ * time; an instant's completion time is, backward-compatibly, its instant (request) time. The range
+ * query therefore filters by requested time. These tests assert the candidate instant selection
+ * matches the streaming/incremental read semantics (resume excludes the last issued offset, the
+ * first read includes the start commit, etc.), the same behavior as the V2 view keyed on completion
+ * time.
+ *
+ * <p>The timeline is mocked rather than materialized on disk: {@code getInstantTimes} consumes only
+ * the supplied {@link HoodieTimeline}, and {@code hudi-common} test scope has no hadoop storage
+ * implementation to build a real table from.
+ */
+public class TestCompletionTimeQueryViewV1 {
+
+  // Use datetime-format instant times so they are not short-circuited by the length < 10 branch in
+  // getCompletionTime, and behave like real V5 ~ V7 instants.
+  private static final String T1 = "20240101010001000";
+  private static final String T2 = "20240101010002000";
+  private static final String T3 = "20240101010003000";
+  private static final String T4 = "20240101010004000";
+  private static final String T5 = "20240101010005000";
+
+  private CompletionTimeQueryViewV1 view;
+  private HoodieTimeline timeline;
+
+  @BeforeEach
+  void setUp() {
+    List<HoodieInstant> instants = Arrays.asList(
+        completedCommit(T1), completedCommit(T2), completedCommit(T3), completedCommit(T4), completedCommit(T5));
+
+    // A timeline whose filterCompletedInstants() returns itself and replays a fresh stream each call.
+    timeline = mock(HoodieTimeline.class);
+    when(timeline.filterCompletedInstants()).thenReturn(timeline);
+    when(timeline.getInstantsAsStream()).thenAnswer(invocation -> instants.stream());
+    when(timeline.lastInstant()).thenAnswer(invocation -> Option.of(instants.get(instants.size() - 1)));
+
+    // Minimal meta client wiring so the V1 view can be constructed (load()/cursor/firstNonSavepoint).
+    // Build the active timeline mock fully before stubbing getActiveTimeline(), otherwise Mockito
+    // sees nested stubbing (a when() started inside another when()'s argument) and fails.
+    HoodieActiveTimeline activeTimeline = activeTimelineMock(instants);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getActiveTimeline()).thenReturn(activeTimeline);
+    view = new CompletionTimeQueryViewV1(metaClient);
+  }
+
+  private static HoodieInstant completedCommit(String instantTime) {
+    // V1 instants are ordered/compared by requested(instant) time; completion time mirrors it.
+    return new HoodieInstant(
+        HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, instantTime, instantTime,
+        InstantComparatorV1.REQUESTED_TIME_BASED_COMPARATOR);
+  }
+
+  /**
+   * Builds a mock active timeline used only for constructing the view (load(), cursor and
+   * firstNonSavepointCommit). It is independent of the timeline passed to getInstantTimes.
+   */
+  private static HoodieActiveTimeline activeTimelineMock(List<HoodieInstant> instants) {
+    HoodieActiveTimeline active = mock(HoodieActiveTimeline.class);
+    when(active.filterCompletedInstants()).thenReturn(active);
+    when(active.getWriteTimeline()).thenReturn(active);
+    when(active.getInstantsAsStream()).thenAnswer(invocation -> instants.stream());
+    when(active.firstInstant()).thenAnswer(invocation -> Option.of(instants.get(0)));
+    when(active.getFirstNonSavepointCommit()).thenAnswer(invocation -> Option.of(instants.get(0)));
+    return active;
+  }
+
+  private List<String> query(Option<String> start, Option<String> end, InstantRange.RangeType rangeType) {
+    return view.getInstantTimes(timeline, start, end, rangeType);
+  }
+
+  @Test
+  void testClosedClosedRange() {
+    // [T2, T4]: first-time consume with explicit start/end commit, both bounds inclusive.
+    assertEquals(Arrays.asList(T2, T3, T4), query(Option.of(T2), Option.of(T4), InstantRange.RangeType.CLOSED_CLOSED));
+
+    // [T3, _): from the start commit to the latest, open end.
+    assertEquals(Arrays.asList(T3, T4, T5), query(Option.of(T3), Option.empty(), InstantRange.RangeType.CLOSED_CLOSED));
+
+    // [T1, T5]: the full range, also verifies the result is sorted ascending.
+    assertEquals(Arrays.asList(T1, T2, T3, T4, T5), query(Option.of(T1), Option.of(T5), InstantRange.RangeType.CLOSED_CLOSED));
+  }
+
+  @Test
+  void testOpenClosedResumeRange() {
+    // (T2, T4]: streaming resume from issued offset T2, the start point must be excluded.
+    assertEquals(Arrays.asList(T3, T4), query(Option.of(T2), Option.of(T4), InstantRange.RangeType.OPEN_CLOSED));
+
+    // (T4, _]: resume from T4 with open end, only T5 is new.
+    assertEquals(Collections.singletonList(T5), query(Option.of(T4), Option.empty(), InstantRange.RangeType.OPEN_CLOSED));
+
+    // (T5, _]: resume from the latest issued offset T5, nothing new, must not re-read T5.
+    assertEquals(Collections.emptyList(), query(Option.of(T5), Option.empty(), InstantRange.RangeType.OPEN_CLOSED));
+  }
+
+  @Test
+  void testEarliestStart() {
+    // ['earliest', T3]: 'earliest' degenerates to consuming from the first instant.
+    assertEquals(Arrays.asList(T1, T2, T3),
+        query(Option.of("earliest"), Option.of(T3), InstantRange.RangeType.CLOSED_CLOSED));
+  }
+
+  @Test
+  void testEndOnlyReturnsLastAtOrBeforeEnd() {
+    // (_, T3]: no start commit, returns the single latest instant at or before T3.
+    assertEquals(Collections.singletonList(T3), query(Option.empty(), Option.of(T3), InstantRange.RangeType.CLOSED_CLOSED));
+
+    // (_, T5]: end at the latest, returns T5.
+    assertEquals(Collections.singletonList(T5), query(Option.empty(), Option.of(T5), InstantRange.RangeType.CLOSED_CLOSED));
+  }
+
+  @Test
+  void testNoBoundsReadsLatestSnapshot() {
+    // (_, _): no range at all, reads the latest snapshot instant.
+    assertEquals(Collections.singletonList(T5), query(Option.empty(), Option.empty(), InstantRange.RangeType.CLOSED_CLOSED));
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The 1.x incremental read stack (`IncrementalQueryAnalyzer` → `CompletionTimeQueryView.getInstantTimes`) resolves the query range by completion time. For a `LAYOUT_VERSION_1` timeline (table versions 5–7, releases 0.12–0.16), `CompletionTimeQueryViewV1.getInstantTimes` currently throws:

```
RuntimeException("Incremental query view for timeline version 1 not yet implemented")
```

As a result, any incremental (and streaming) read against these older tables via the 1.x reader fails outright.

The key observation — as raised in review — is that this is **not** a "missing completion time" problem: for a `LAYOUT_VERSION_1` timeline, an instant's completion time *is* its instant (request) time, and the semantics are backward compatible. This is already how the V1 view behaves elsewhere (`load()` maps `requestedTime → completionTime`, and `getCompletionTime` returns the begin time for archived instants). This PR applies that same equivalence to the range query, so V1 falls out as the "completion time = instant time" special case of the existing V2 range logic rather than a separate implementation.

### Summary and Changelog

Implements `CompletionTimeQueryViewV1.getInstantTimes(...)` by mirroring the branch structure already used in `CompletionTimeQueryViewV2`, driven by requested (instant) time instead of a persisted completion time:

- `(_, end]` — returns the single latest instant whose requested time is `<= end`.
- `['earliest', _)` — clears the start bound so it degenerates to consuming from the earliest instant.
- `(_, _)` — returns the latest snapshot instant.
- otherwise — filters instants through a shared `InstantRange` (honoring the `OPEN_CLOSED` / `CLOSED_CLOSED` bounds and nullable boundaries), sorted ascending.

Notes:

- The candidate instants are taken from the `HoodieTimeline` passed in by the caller (already filtered per user configs such as `skipCompaction` / `skipClustering`), consistent with the V2 code path.
- The archived timeline is intentionally **not** consulted for V1 (it is not loaded), which is the only V1-specific boundary; the range/resume semantics are the same logic as V2, not a fork. The `earliestInstantTimeFunc` parameter is unused for V1 (it only serves V2's archive lazy-load boundary).

Tests: adds `TestCompletionTimeQueryViewV1` covering closed/closed first read, open/closed streaming resume (excluding the last issued offset), `earliest` start, end-only, and no-bounds latest-snapshot cases.

No code was copied verbatim; the implementation follows the shape of `CompletionTimeQueryViewV2#getInstantTimes`.

### Impact

- Enables incremental and streaming reads on table versions 5–7 (`LAYOUT_VERSION_1`) through the 1.x reader; these previously threw.
- No behavior change for table version ≥ 8 (the V2 view is untouched).
- No public API change: only the previously-throwing package-private `getInstantTimes` body is implemented.

### Risk Level

Medium. This changes read semantics for older tables from "throws" to "returns instants". Mitigated by:

- New unit tests exercising the range and streaming-resume boundaries (`OPEN_CLOSED` must exclude the issued offset, `CLOSED_CLOSED` first read includes the start commit, `earliest` / end-only / no-bounds).
- Verified by compiling `hudi-common` and running `TestCompletionTimeQueryViewV1` locally — 5/5 tests pass.

### Documentation Update

None. No new config, and no user-facing option changes; this makes an existing documented feature (incremental/streaming query) work on `LAYOUT_VERSION_1` tables.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable