### PR TITLE
chore: upload Flink integration-test coverage

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1087,7 +1087,18 @@ jobs:
         if: ${{ endsWith(env.FLINK_PROFILE, '2.1') && needs.changes.outputs.relevant == 'true' }}
         run: |
           mvn clean install -T 2 -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-flink-datasource/hudi-flink -am -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION" -DskipTests=true $MVN_ARGS
-          mvn verify -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION" $FLINK_IT_FILTER1 -pl hudi-flink-datasource/hudi-flink $MVN_ARGS
+          mvn verify -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION" $FLINK_IT_FILTER1 -pl hudi-flink-datasource/hudi-flink $MVN_ARGS -Djacoco.skip=false
+      - name: Generate merged coverage report
+        if: always() && endsWith(matrix.flinkProfile, '2.1') && needs.changes.outputs.relevant == 'true'
+        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
+      - name: Upload coverage to Codecov
+        if: always() && endsWith(matrix.flinkProfile, '2.1') && needs.changes.outputs.relevant == 'true'
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          files: ./jacoco-report.xml
+          disable_search: true
+          flags: flink-integration-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-flink-2:
     runs-on: ubuntu-latest
@@ -1127,7 +1138,18 @@ jobs:
         if: ${{ endsWith(env.FLINK_PROFILE, '2.1') && needs.changes.outputs.relevant == 'true' }}
         run: |
           mvn clean install -T 2 -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -pl hudi-flink-datasource/hudi-flink -am -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION" -DskipTests=true $MVN_ARGS
-          mvn verify -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION" $FLINK_IT_FILTER2 -pl hudi-flink-datasource/hudi-flink $MVN_ARGS
+          mvn verify -Pintegration-tests -D"$SCALA_PROFILE" -D"$FLINK_PROFILE" -Davro.version="$FLINK_AVRO_VERSION" -Dparquet.version="$FLINK_PARQUET_VERSION" $FLINK_IT_FILTER2 -pl hudi-flink-datasource/hudi-flink $MVN_ARGS -Djacoco.skip=false
+      - name: Generate merged coverage report
+        if: always() && endsWith(matrix.flinkProfile, '2.1') && needs.changes.outputs.relevant == 'true'
+        run: ./scripts/jacoco/generate_merged_coverage_report.sh $GITHUB_WORKSPACE
+      - name: Upload coverage to Codecov
+        if: always() && endsWith(matrix.flinkProfile, '2.1') && needs.changes.outputs.relevant == 'true'
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          files: ./jacoco-report.xml
+          disable_search: true
+          flags: flink-integration-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   docker-java17-test:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -2409,10 +2409,11 @@
               </execution>
             </executions>
           </plugin>
-          <!-- Attach the JaCoCo agent so the integration-test (failsafe) and integ-test unit
-               (surefire) runs emit coverage. The agent argument is appended to the argLine
-               property, which both plugins pick up. destFile matches the jacoco-agent path
-               that scripts/jacoco/generate_merged_coverage_report.sh globs for. -->
+          <!-- Attach the JaCoCo agent so integration-tests profile runs, including Flink
+               datasource jobs, emit coverage from both integration-test (failsafe) and
+               integ-test unit (surefire) executions. The agent argument is appended to the
+               argLine property, which both plugins pick up. destFile matches the jacoco-agent
+               path that scripts/jacoco/generate_merged_coverage_report.sh globs for. -->
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The Flink integration-test jobs inherit `-Djacoco.skip` from `MVN_ARGS`, so they currently run without the JaCoCo agent and produce no execution data. Flink job drivers and end-to-end pipeline paths exercised only by integration tests therefore remain uncovered in Codecov.

### Summary and Changelog

- Enable the existing integration-test JaCoCo agent for both Flink IT partitions.
- Generate the standard merged coverage report after each Flink IT job.
- Upload both reports to Codecov under the `flink-integration-tests` flag.
- Clarify that the shared integration-tests JaCoCo configuration covers Flink datasource jobs.

### Impact

No public API or user-facing behavior changes. CI performs coverage report generation and upload after the existing Flink 2.1 integration tests; test selection is unchanged.

### Risk Level

low: the additional work is isolated to CI coverage collection. A local Flink integration-test run produced valid JaCoCo execution data and a coverage XML report.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable