### PR TITLE
test(common): add LSM file group read path coverage

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestBufferedRecordMergerFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestBufferedRecordMergerFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.engine.RecordContext;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.table.PartialUpdateMode;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestBufferedRecordMergerFactory {
+
+  @Test
+  void testSelectsMergerForEveryConfiguredMode() {
+    HoodieReaderContext<String> context = mock(HoodieReaderContext.class);
+    when(context.getRecordContext()).thenReturn(mock(RecordContext.class));
+    HoodieSchema schema = HoodieSchema.create(HoodieSchemaType.STRING);
+    TypedProperties props = new TypedProperties();
+    Option<HoodieRecordMerger> recordMerger = Option.of(mock(HoodieRecordMerger.class));
+
+    assertMerger("CommitTimeRecordMerger", context, RecordMergeMode.COMMIT_TIME_ORDERING, false,
+        recordMerger, schema, Option.empty(), props, Option.empty());
+    assertMerger("CommitTimePartialRecordMerger", context, RecordMergeMode.COMMIT_TIME_ORDERING, false,
+        recordMerger, schema, Option.empty(), props, Option.of(PartialUpdateMode.IGNORE_DEFAULTS));
+    assertMerger("EventTimeRecordMerger", context, RecordMergeMode.EVENT_TIME_ORDERING, false,
+        recordMerger, schema, Option.empty(), props, Option.empty());
+    assertMerger("EventTimePartialRecordMerger", context, RecordMergeMode.EVENT_TIME_ORDERING, false,
+        recordMerger, schema, Option.empty(), props, Option.of(PartialUpdateMode.FILL_UNAVAILABLE));
+    assertMerger("PartialUpdateBufferedRecordMerger", context, RecordMergeMode.EVENT_TIME_ORDERING, true,
+        recordMerger, schema, Option.empty(), props, Option.empty());
+    assertMerger("CustomRecordMerger", context, RecordMergeMode.CUSTOM, false,
+        recordMerger, schema, Option.empty(), props, Option.empty());
+    assertMerger("CustomPayloadRecordMerger", context, RecordMergeMode.CUSTOM, false,
+        recordMerger, schema, Option.of(Pair.of("table.Payload", "incoming.Payload")), props, Option.empty());
+    assertMerger("ExpressionPayloadRecordMerger", context, RecordMergeMode.CUSTOM, false,
+        recordMerger, schema, Option.of(Pair.of("table.Payload", "org.apache.spark.sql.hudi.command.payload.ExpressionPayload")), props, Option.empty());
+
+    assertEquals("CustomPayloadRecordMerger", BufferedRecordMergerFactory.create(
+        context, RecordMergeMode.CUSTOM, false, recordMerger, Option.of("payload.Class"), schema, props, Option.empty())
+        .getClass().getSimpleName());
+  }
+
+  private static void assertMerger(String expected,
+                                   HoodieReaderContext<String> context,
+                                   RecordMergeMode mode,
+                                   boolean partialMerging,
+                                   Option<HoodieRecordMerger> recordMerger,
+                                   HoodieSchema schema,
+                                   Option<Pair<String, String>> payloadClasses,
+                                   TypedProperties props,
+                                   Option<PartialUpdateMode> partialUpdateMode) {
+    assertEquals(expected, BufferedRecordMergerFactory.create(
+        context, mode, partialMerging, recordMerger, schema, payloadClasses, props, partialUpdateMode)
+        .getClass().getSimpleName());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestIncrementalQueryAnalyzer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestIncrementalQueryAnalyzer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.InstantRange;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestIncrementalQueryAnalyzer {
+
+  @Test
+  void testQueryContextRangeEdges() {
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    HoodieInstant active = mock(HoodieInstant.class);
+    when(active.getCompletionTime()).thenReturn("20240102000000");
+    IncrementalQueryAnalyzer.QueryContext earliestToLatest = IncrementalQueryAnalyzer.QueryContext.create(
+        null, null, Arrays.asList("001", "002"), Collections.emptyList(), Collections.singletonList(active), timeline, null);
+
+    assertFalse(earliestToLatest.isEmpty());
+    assertEquals("002", earliestToLatest.getLastInstant());
+    assertTrue(earliestToLatest.isConsumingFromEarliest());
+    assertTrue(earliestToLatest.isConsumingToLatest());
+    assertTrue(earliestToLatest.getInstantRange().isEmpty());
+    assertEquals("20240102000000", earliestToLatest.getMaxCompletionTime());
+    assertEquals(Collections.singletonList(active), earliestToLatest.getInstants());
+
+    IncrementalQueryAnalyzer.QueryContext boundedEarliest = IncrementalQueryAnalyzer.QueryContext.create(
+        null, "002", Arrays.asList("001", "002"), Collections.emptyList(), Collections.emptyList(), timeline, null);
+    HoodieInstant latestActive = mock(HoodieInstant.class);
+    when(latestActive.getCompletionTime()).thenReturn("20240103000000");
+    when(timeline.getInstantsAsStream()).thenReturn(Stream.of(latestActive));
+    InstantRange boundedRange = boundedEarliest.getInstantRange().get();
+    assertTrue(boundedEarliest.isConsumingFromEarliest());
+    assertFalse(boundedEarliest.isConsumingToLatest());
+    assertTrue(boundedRange.isInRange("001"));
+    assertTrue(boundedRange.isInRange("002"));
+    assertEquals("20240103000000", boundedEarliest.getMaxCompletionTime());
+    assertNull(boundedEarliest.getArchivedTimeline());
+
+    IncrementalQueryAnalyzer.QueryContext exact = IncrementalQueryAnalyzer.QueryContext.create(
+        "001", "002", Arrays.asList("001", "002"), Collections.emptyList(), Collections.emptyList(), timeline, null);
+    assertFalse(exact.isConsumingFromEarliest());
+    assertTrue(exact.getInstantRange().get().isInRange("001"));
+    assertFalse(exact.getInstantRange().get().isInRange("003"));
+    assertThrows(IllegalStateException.class, IncrementalQueryAnalyzer.QueryContext.EMPTY::getLastInstant);
+  }
+
+  @Test
+  void testBuilderRequiresMetaClientAndRangeType() {
+    assertThrows(NullPointerException.class, () -> IncrementalQueryAnalyzer.builder()
+        .rangeType(InstantRange.RangeType.CLOSED_CLOSED)
+        .build());
+    assertThrows(NullPointerException.class, () -> IncrementalQueryAnalyzer.builder()
+        .metaClient(mock(HoodieTableMetaClient.class))
+        .build());
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestPositionBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestPositionBasedFileGroupRecordBuffer.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read.buffer;
+
+import org.apache.hudi.common.avro.HoodieAvroReaderContext;
+import org.apache.hudi.common.config.HoodieMemoryConfig;
+import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.schema.internal.InternalSchema;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.log.block.HoodieDataBlock;
+import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
+import org.apache.hudi.common.table.log.block.HoodieLogBlock;
+import org.apache.hudi.common.table.read.BufferedRecords;
+import org.apache.hudi.common.table.read.DeleteContext;
+import org.apache.hudi.common.table.read.FileGroupReaderSchemaHandler;
+import org.apache.hudi.common.table.read.UpdateProcessor;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieKeyException;
+import org.apache.hudi.storage.StorageConfiguration;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestPositionBasedFileGroupRecordBuffer {
+
+  private static final HoodieSchema SCHEMA = HoodieSchema.createRecord("record", null, null, Arrays.asList(
+      HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.STRING)),
+      HoodieSchemaField.of("ts", HoodieSchema.create(HoodieSchemaType.LONG))));
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void testPositionHeaderValidationAndKeyFiltering() throws Exception {
+    HoodieLogBlock block = mock(HoodieLogBlock.class);
+    when(block.getBaseFileInstantTimeOfPositions()).thenReturn(null, "002", "001", "001");
+    when(block.getRecordPositionList()).thenReturn(Collections.emptyList(), Arrays.asList(2L, 4L));
+
+    assertNull(PositionBasedFileGroupRecordBuffer.extractRecordPositions(block, "001"));
+    assertNull(PositionBasedFileGroupRecordBuffer.extractRecordPositions(block, "001"));
+    assertNull(PositionBasedFileGroupRecordBuffer.extractRecordPositions(block, "001"));
+    assertEquals(Arrays.asList(2L, 4L), PositionBasedFileGroupRecordBuffer.extractRecordPositions(block, "001"));
+
+    PositionBasedFileGroupRecordBuffer<IndexedRecord> buffer = createBuffer();
+    IndexedRecord a = record("alpha", 1);
+    assertFalse(buffer.shouldSkip(a, true, Collections.emptySet(), SCHEMA));
+    assertFalse(buffer.shouldSkip(a, true, Collections.singleton("alpha"), SCHEMA));
+    assertTrue(buffer.shouldSkip(a, true, Collections.singleton("beta"), SCHEMA));
+    assertFalse(buffer.shouldSkip(a, false, Collections.singleton("al"), SCHEMA));
+    assertTrue(buffer.shouldSkip(a, false, Collections.singleton("be"), SCHEMA));
+    assertThrows(HoodieKeyException.class, () -> buffer.shouldSkip(record("", 1), true,
+        new HashSet<>(Collections.singletonList("alpha")), SCHEMA));
+    assertEquals(HoodieFileGroupRecordBuffer.BufferType.POSITION_BASED_MERGE, buffer.getBufferType());
+    buffer.close();
+  }
+
+  @Test
+  void testBlockCardinalityGuardsAndContainsLogRecord() throws Exception {
+    PositionBasedFileGroupRecordBuffer<IndexedRecord> buffer = createBuffer();
+    HoodieDataBlock dataBlock = mock(HoodieDataBlock.class);
+    when(dataBlock.getBaseFileInstantTimeOfPositions()).thenReturn("001");
+    when(dataBlock.getRecordPositionList()).thenReturn(Collections.singletonList(0L));
+    when(dataBlock.containsPartialUpdates()).thenReturn(false);
+    when(dataBlock.getSchema()).thenReturn(SCHEMA);
+    when(dataBlock.getEngineRecordIterator(buffer.readerContext)).thenReturn(ClosableIterator.wrap(Collections.emptyIterator()));
+    assertThrows(HoodieException.class, () -> buffer.processDataBlock(dataBlock, Option.empty()));
+
+    HoodieDeleteBlock deleteBlock = mock(HoodieDeleteBlock.class);
+    when(deleteBlock.getBaseFileInstantTimeOfPositions()).thenReturn("001");
+    when(deleteBlock.getRecordPositionList()).thenReturn(Collections.singletonList(0L));
+    when(deleteBlock.getRecordsToDelete(buffer.readerContext)).thenReturn(Collections.emptyList());
+    assertThrows(HoodieException.class, () -> buffer.processDeleteBlock(deleteBlock));
+
+    IndexedRecord alpha = record("alpha", 1);
+    buffer.processNextDataRecord(BufferedRecords.fromEngineRecord(
+        alpha, SCHEMA, buffer.readerContext.getRecordContext(), Collections.emptyList(), false), 0L);
+    assertTrue(buffer.containsLogRecord("alpha"));
+    assertFalse(buffer.containsLogRecord("missing"));
+
+    buffer.readerContext.setShouldMergeUseRecordPosition(false);
+    HoodieDataBlock emptyBlock = mock(HoodieDataBlock.class);
+    when(emptyBlock.getEngineRecordIterator(buffer.readerContext)).thenReturn(ClosableIterator.wrap(Collections.emptyIterator()));
+    when(emptyBlock.getSchema()).thenReturn(SCHEMA);
+    buffer.processDataBlock(emptyBlock, Option.empty());
+    assertEquals(HoodieFileGroupRecordBuffer.BufferType.KEY_BASED_MERGE, buffer.getBufferType());
+    buffer.close();
+  }
+
+  private PositionBasedFileGroupRecordBuffer<IndexedRecord> createBuffer() {
+    HoodieTableConfig tableConfig = new HoodieTableConfig();
+    tableConfig.setValue(HoodieTableConfig.RECORDKEY_FIELDS, "id");
+    tableConfig.setValue(HoodieTableConfig.RECORD_MERGE_MODE, RecordMergeMode.COMMIT_TIME_ORDERING.name());
+    tableConfig.setValue(HoodieTableConfig.BASE_FILE_FORMAT, HoodieFileFormat.PARQUET.name());
+    tableConfig.setValue(HoodieTableConfig.POPULATE_META_FIELDS, "false");
+    HoodieReaderContext<IndexedRecord> context = new HoodieAvroReaderContext(
+        mock(StorageConfiguration.class), tableConfig, Option.empty(), Option.empty());
+    context.initRecordMerger(new TypedProperties());
+    context.setShouldMergeUseRecordPosition(true);
+    FileGroupReaderSchemaHandler<IndexedRecord> schemaHandler = mock(FileGroupReaderSchemaHandler.class);
+    when(schemaHandler.getRequiredSchema()).thenReturn(SCHEMA);
+    when(schemaHandler.getSchemaForUpdates()).thenReturn(SCHEMA);
+    when(schemaHandler.getInternalSchema()).thenReturn(InternalSchema.getEmptyInternalSchema());
+    when(schemaHandler.getDeleteContext()).thenReturn(new DeleteContext(new TypedProperties(), SCHEMA));
+    context.setSchemaHandler(schemaHandler);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key(), tempDir.toString());
+    return new PositionBasedFileGroupRecordBuffer<>(context, metaClient, RecordMergeMode.COMMIT_TIME_ORDERING,
+        Option.empty(), "001", props, Collections.emptyList(), mock(UpdateProcessor.class));
+  }
+
+  private static IndexedRecord record(String key, long ts) {
+    GenericData.Record record = new GenericData.Record(SCHEMA.toAvroSchema());
+    record.put("id", key);
+    record.put("ts", ts);
+    return record;
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/lsm/TestHoodieLsmFileGroupReader.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/lsm/TestHoodieLsmFileGroupReader.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.table.read.lsm;
+
+import org.apache.hudi.common.avro.HoodieAvroReaderContext;
+import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodieOperation;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.read.BufferedRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestHoodieLsmFileGroupReader {
+
+  private static final HoodieSchema SCHEMA = HoodieSchema.createRecord("lsm_record", null, null, Arrays.asList(
+      HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.STRING)),
+      HoodieSchemaField.of("value", HoodieSchema.create(HoodieSchemaType.STRING)),
+      HoodieSchemaField.of("ts", HoodieSchema.create(HoodieSchemaType.LONG))));
+
+  private HoodieTableMetaClient metaClient;
+  private TypedProperties props;
+  private StorageConfiguration<?> storageConfiguration;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    HoodieTableConfig tableConfig = new HoodieTableConfig();
+    tableConfig.setValue(HoodieTableConfig.RECORDKEY_FIELDS, "id");
+    tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
+    tableConfig.setValue(HoodieTableConfig.RECORD_MERGE_MODE, RecordMergeMode.EVENT_TIME_ORDERING.name());
+    tableConfig.setValue(HoodieTableConfig.BASE_FILE_FORMAT, HoodieFileFormat.PARQUET.name());
+    tableConfig.setValue(HoodieTableConfig.LOG_FILE_FORMAT, HoodieFileFormat.PARQUET.name());
+    tableConfig.setValue(HoodieTableConfig.POPULATE_META_FIELDS, "false");
+    storageConfiguration = mock(StorageConfiguration.class);
+    HoodieStorage storage = mock(HoodieStorage.class);
+    when(storage.newInstance(any(StoragePath.class), any(StorageConfiguration.class))).thenReturn(storage);
+    metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(metaClient.getBasePath()).thenReturn(new StoragePath("/tmp/lsm-reader-test"));
+    when(metaClient.getStorage()).thenReturn(storage);
+    doReturn(storageConfiguration).when(metaClient).getStorageConf();
+    props = new TypedProperties();
+  }
+
+  @Test
+  void testAllIteratorModesMergeSortedRecordsAndHandleDeletes() throws IOException {
+    List<HoodieRecord> records = Arrays.asList(
+        record("a", "old", 1),
+        record("a", "new", 2),
+        record("b", "kept", 1),
+        delete("c", 3));
+
+    try (HoodieLsmFileGroupReader<IndexedRecord> reader = reader(records, false);
+         ClosableIterator<IndexedRecord> iterator = reader.getClosableIterator()) {
+      List<String> values = new ArrayList<>();
+      iterator.forEachRemaining(record -> values.add(record.get(0) + ":" + record.get(1)));
+      assertEquals(Arrays.asList("a:new", "b:kept"), values);
+      assertFalse(iterator.hasNext());
+    }
+
+    try (HoodieLsmFileGroupReader<IndexedRecord> reader = reader(records, false);
+         ClosableIterator<HoodieRecord<IndexedRecord>> iterator = reader.getClosableHoodieRecordIterator()) {
+      assertEquals(Arrays.asList("a", "b"), drainKeys(iterator));
+    }
+
+    try (HoodieLsmFileGroupReader<IndexedRecord> reader = reader(records, false);
+         ClosableIterator<String> iterator = reader.getClosableKeyIterator()) {
+      assertEquals(Arrays.asList("a", "b"), drain(iterator));
+    }
+
+    try (HoodieLsmFileGroupReader<IndexedRecord> reader = reader(records, true);
+         ClosableIterator<BufferedRecord<IndexedRecord>> iterator = reader.getClosableBufferedRecordIterator()) {
+      assertEquals("a", iterator.next().getRecordKey());
+      assertEquals("b", iterator.next().getRecordKey());
+      assertThrows(UnsupportedOperationException.class, iterator::hasNext);
+    }
+  }
+
+  @Test
+  void testLogOnlyIteratorAndRepeatedOpenClosePreviousIterator() throws IOException {
+    HoodieLsmFileGroupReader<IndexedRecord> reader = reader(Arrays.asList(record("a", "one", 1), record("b", "two", 2)), false);
+    ClosableIterator<BufferedRecord<IndexedRecord>> first = reader.getLogRecordsOnly();
+    assertTrue(first.hasNext());
+
+    try (ClosableIterator<String> replacement = reader.getClosableKeyIterator()) {
+      assertEquals(Collections.emptyList(), drain(replacement));
+    }
+    first.close();
+    reader.close();
+  }
+
+  @Test
+  void testBuilderDefaultsAndRequiredArguments() {
+    HoodieReaderContext<IndexedRecord> context = context();
+    assertThrows(IllegalArgumentException.class, () -> HoodieLsmFileGroupReader.<IndexedRecord>builder()
+        .withHoodieTableMetaClient(metaClient)
+        .withLatestCommitTime("001")
+        .withDataSchema(SCHEMA)
+        .withRequestedSchema(SCHEMA)
+        .withProps(props)
+        .withPartitionPath("")
+        .build());
+
+    assertThrows(IllegalArgumentException.class, () -> HoodieLsmFileGroupReader.<IndexedRecord>builder()
+        .withReaderContext(context)
+        .withHoodieTableMetaClient(metaClient)
+        .withLatestCommitTime("001")
+        .withDataSchema(SCHEMA)
+        .withRequestedSchema(SCHEMA)
+        .withProps(props)
+        .withPartitionPath("")
+        .withStart(1L)
+        .withLogFiles(Collections.singletonList(mock(HoodieLogFile.class)).stream())
+        .build());
+  }
+
+  private HoodieLsmFileGroupReader<IndexedRecord> reader(List<HoodieRecord> records, boolean emitDeletes) {
+    return HoodieLsmFileGroupReader.<IndexedRecord>builder()
+        .withReaderContext(context())
+        .withHoodieTableMetaClient(metaClient)
+        .withLatestCommitTime("001")
+        .withDataSchema(SCHEMA)
+        .withRequestedSchema(SCHEMA)
+        .withProps(props)
+        .withRecordIterator(records.iterator())
+        .withPartitionPath("")
+        .withEmitDelete(emitDeletes)
+        .build();
+  }
+
+  private HoodieReaderContext<IndexedRecord> context() {
+    return new HoodieAvroReaderContext(storageConfiguration, metaClient.getTableConfig(), Option.empty(), Option.empty());
+  }
+
+  private static HoodieRecord record(String key, String value, long ts) {
+    GenericData.Record record = new GenericData.Record(SCHEMA.toAvroSchema());
+    record.put("id", key);
+    record.put("value", value);
+    record.put("ts", ts);
+    return new HoodieAvroIndexedRecord(new HoodieKey(key, ""), record, ts);
+  }
+
+  private static HoodieRecord delete(String key, long ts) {
+    return new HoodieEmptyRecord<>(new HoodieKey(key, ""), HoodieOperation.DELETE, ts, HoodieRecord.HoodieRecordType.AVRO);
+  }
+
+  private static <T> List<T> drain(ClosableIterator<T> iterator) {
+    List<T> values = new ArrayList<>();
+    iterator.forEachRemaining(values::add);
+    return values;
+  }
+
+  private static List<String> drainKeys(ClosableIterator<HoodieRecord<IndexedRecord>> iterator) {
+    List<String> keys = new ArrayList<>();
+    iterator.forEachRemaining(record -> keys.add(record.getRecordKey()));
+    return keys;
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/lsm/TestLsmFileGroupRecordIterator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/lsm/TestLsmFileGroupRecordIterator.java
@@ -19,21 +19,45 @@
 
 package org.apache.hudi.common.table.read.lsm;
 
+import org.apache.hudi.common.avro.HoodieAvroReaderContext;
+import org.apache.hudi.common.config.HoodieMemoryConfig;
+import org.apache.hudi.common.config.HoodieReaderConfig;
+import org.apache.hudi.common.config.RecordMergeMode;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.RecordContext;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.schema.HoodieSchemas;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.read.BufferedRecords;
+import org.apache.hudi.common.table.read.DeleteContext;
+import org.apache.hudi.common.table.read.FileGroupReaderSchemaHandler;
+import org.apache.hudi.common.table.read.HoodieReadStats;
+import org.apache.hudi.common.table.read.InputSplit;
+import org.apache.hudi.common.table.read.ReaderParameters;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,12 +68,20 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class TestLsmFileGroupRecordIterator {
+
+  @TempDir
+  Path tempDir;
 
   @Test
   void testDeleteLogSchemaUsesRecordKeyAndOrderingFields() {
@@ -119,6 +151,95 @@ class TestLsmFileGroupRecordIterator {
     assertEquals(new HashSet<>(Arrays.asList(2, 3)), directReadersWithoutBase);
   }
 
+  @Test
+  void testSortedRunFixturesMergeAcrossBaseAndSpilledLogs() throws IOException {
+    HoodieTableConfig tableConfig = new HoodieTableConfig();
+    tableConfig.setValue(HoodieTableConfig.RECORDKEY_FIELDS, "id");
+    tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
+    tableConfig.setValue(HoodieTableConfig.RECORD_MERGE_MODE, RecordMergeMode.EVENT_TIME_ORDERING.name());
+    tableConfig.setValue(HoodieTableConfig.BASE_FILE_FORMAT, HoodieFileFormat.PARQUET.name());
+    tableConfig.setValue(HoodieTableConfig.POPULATE_META_FIELDS, "false");
+    StorageConfiguration<?> storageConfiguration = mock(StorageConfiguration.class);
+    HoodieAvroReaderContext context = org.mockito.Mockito.spy(
+        new HoodieAvroReaderContext(storageConfiguration, tableConfig, Option.empty(), Option.empty()));
+    TypedProperties props = new TypedProperties();
+    props.setProperty(HoodieReaderConfig.LSM_SORT_MERGE_SPILL_THRESHOLD.key(), "1");
+    props.setProperty(HoodieMemoryConfig.SPILLABLE_MAP_BASE_PATH.key(), tempDir.toString());
+    context.initRecordMerger(props);
+
+    FileGroupReaderSchemaHandler<IndexedRecord> schemaHandler = mock(FileGroupReaderSchemaHandler.class);
+    when(schemaHandler.getRequiredSchema()).thenReturn(tableSchema());
+    when(schemaHandler.getRequestedSchema()).thenReturn(tableSchema());
+    when(schemaHandler.getTableSchema()).thenReturn(tableSchema());
+    when(schemaHandler.getDeleteContext()).thenReturn(new DeleteContext(props, tableSchema()));
+    when(schemaHandler.getRequiredSchemaForFileAndRenamedColumns(any(StoragePath.class)))
+        .thenReturn(Pair.of(tableSchema(), Collections.emptyMap()));
+    context.setSchemaHandler(schemaHandler);
+    context.setTablePath("/tmp/lsm-fixture");
+
+    doAnswer(invocation -> {
+      StoragePathInfo pathInfo = invocation.getArgument(0);
+      String name = pathInfo.getPath().getName();
+      if (name.endsWith("deletes.parquet")) {
+        HoodieSchema deleteSchema = invocation.getArgument(3);
+        return ClosableIterator.wrap(Collections.singletonList(deleteRecord(deleteSchema, "b", 2L)).iterator());
+      }
+      List<IndexedRecord> records;
+      if (name.endsWith(".parquet") && !name.contains(".log.")) {
+        records = Arrays.asList(indexedRecord("a", "base-a", 1), indexedRecord("c", "base-c", 5));
+      } else if (name.contains("_002_")) {
+        records = Arrays.asList(indexedRecord("a", "log2-a", 3), indexedRecord("c", "stale-c", 2));
+      } else {
+        records = Arrays.asList(indexedRecord("a", "log1-a", 2), indexedRecord("b", "log1-b", 1));
+      }
+      return ClosableIterator.wrap(records.iterator());
+    }).when(context).getFileRecordIterator(any(StoragePathInfo.class), anyLong(), anyLong(),
+        any(HoodieSchema.class), any(HoodieSchema.class), any(HoodieStorage.class));
+
+    HoodieBaseFile baseFile = new HoodieBaseFile(pathInfo("/tmp/file1_1-0-1_001.parquet", 100));
+    List<HoodieLogFile> logs = Arrays.asList(
+        new HoodieLogFile(pathInfo("/tmp/file1_1-0-1_001_1.log.parquet", 50)),
+        new HoodieLogFile(pathInfo("/tmp/file1_1-0-1_002_1.log.parquet", 60)),
+        new HoodieLogFile(pathInfo("/tmp/file1_1-0-1_003_1.deletes.parquet", 10)));
+    InputSplit split = InputSplit.builder()
+        .baseFileOption(Option.of(baseFile))
+        .logFileStream(logs.stream())
+        .partitionPath("")
+        .start(0)
+        .length(Long.MAX_VALUE)
+        .build();
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    ReaderParameters parameters = ReaderParameters.builder().emitDeletes(false).build();
+
+    List<String> actual = new ArrayList<>();
+    try (LsmFileGroupRecordIterator<IndexedRecord> iterator = new LsmFileGroupRecordIterator<>(
+        context, mock(HoodieStorage.class), split, Collections.singletonList("ts"), metaClient,
+        props, parameters, new HoodieReadStats(), Option.empty())) {
+      assertTrue(iterator.hasNext());
+      assertTrue(iterator.hasNext());
+      while (iterator.hasNext()) {
+        BufferedRecord<IndexedRecord> record = iterator.next();
+        actual.add(record.getRecordKey() + ":" + record.getRecord().get(1));
+      }
+      assertFalse(iterator.hasNext());
+      assertThrows(java.util.NoSuchElementException.class, iterator::next);
+    }
+
+    assertEquals(Arrays.asList("a:log2-a", "c:base-c"), actual);
+
+    List<String> logOnly = new ArrayList<>();
+    try (LsmFileGroupRecordIterator<IndexedRecord> iterator = new LsmFileGroupRecordIterator<>(
+        context, mock(HoodieStorage.class), split, Collections.singletonList("ts"), metaClient,
+        props, parameters, new HoodieReadStats(), Option.empty(), false)) {
+      while (iterator.hasNext()) {
+        BufferedRecord<IndexedRecord> record = iterator.next();
+        logOnly.add(record.getRecordKey() + ":" + record.getRecord().get(1));
+      }
+    }
+    assertEquals(Arrays.asList("a:log2-a", "c:stale-c"), logOnly);
+  }
+
   private static LsmFileGroupRecordIterator.SortedRunReader<String> sortedRunReader(int mergeOrder,
                                                                                     BufferedRecord<String>... records) {
     LsmFileGroupRecordIterator.SortedRunReader<String> reader = new LsmFileGroupRecordIterator.SortedRunReader<>(
@@ -134,7 +255,27 @@ class TestLsmFileGroupRecordIterator {
   private static HoodieSchema tableSchema() {
     return HoodieSchema.createRecord("test_record", null, null, Arrays.asList(
         HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.STRING)),
+        HoodieSchemaField.of("value", HoodieSchema.create(HoodieSchemaType.STRING)),
         HoodieSchemaField.of("ts", HoodieSchema.create(HoodieSchemaType.LONG))));
+  }
+
+  private static IndexedRecord indexedRecord(String key, String value, long ts) {
+    GenericData.Record record = new GenericData.Record(tableSchema().toAvroSchema());
+    record.put("id", key);
+    record.put("value", value);
+    record.put("ts", ts);
+    return record;
+  }
+
+  private static IndexedRecord deleteRecord(HoodieSchema schema, String key, long ts) {
+    GenericData.Record record = new GenericData.Record(schema.toAvroSchema());
+    record.put(HoodieRecord.RECORD_KEY_METADATA_FIELD, key);
+    record.put("ts", ts);
+    return record;
+  }
+
+  private static StoragePathInfo pathInfo(String path, long size) {
+    return new StoragePathInfo(new StoragePath(path), size, false, (short) 1, 1024, 0);
   }
 
   private static List<String> drain(LsmFileGroupRecordIterator.LoserTree<String> loserTree) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/lsm/TestSpillableLsmRecordIterator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/lsm/TestSpillableLsmRecordIterator.java
@@ -78,6 +78,42 @@ class TestSpillableLsmRecordIterator {
     assertSame(closeFailure, exception.getCause().getSuppressed()[0]);
   }
 
+  @Test
+  void testEmptySpillAndIdempotentClose() throws IOException {
+    SpillableLsmRecordIterator<String> iterator = new SpillableLsmRecordIterator<>(
+        ClosableIterator.wrap(java.util.Collections.emptyIterator()), new DefaultSerializer<>(), null, tempDir.toString());
+
+    assertFalse(iterator.hasNext());
+    assertThrows(java.util.NoSuchElementException.class, iterator::next);
+    iterator.close();
+    iterator.close();
+    assertEquals(0, spillFileCount());
+  }
+
+  @Test
+  void testMissingSpillFileIsReportedAsReadFailure() throws IOException {
+    SpillableLsmRecordIterator<String> iterator = new SpillableLsmRecordIterator<>(
+        ClosableIterator.wrap(java.util.Collections.singletonList(
+            new BufferedRecord<String>("key", 1, null, null, null)).iterator()),
+        new DefaultSerializer<>(), null, tempDir.toString());
+    Path spillFile;
+    try (Stream<Path> paths = Files.list(tempDir)) {
+      spillFile = paths.findFirst().get();
+    }
+    Files.delete(spillFile);
+
+    assertThrows(HoodieIOException.class, iterator::hasNext);
+    iterator.close();
+  }
+
+  @Test
+  void testSuccessfulSpillPropagatesSourceCloseFailure() {
+    RuntimeException closeFailure = new RuntimeException("source close failed");
+
+    assertSame(closeFailure, assertThrows(RuntimeException.class, () -> new SpillableLsmRecordIterator<>(
+        closeFailingIterator(closeFailure), new DefaultSerializer<>(), null, tempDir.toString())));
+  }
+
   private long spillFileCount() throws IOException {
     try (Stream<Path> paths = Files.list(tempDir)) {
       return paths.count();


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The LSM file-group read path in `hudi-common` had limited coverage around sorted-run merging, delete handling, reader lifecycle and output modes, and disk spilling. Several adjacent read-path branches also lacked focused edge-case coverage.

### Summary and Changelog

This PR adds focused unit coverage for the LSM file-group reader and iterator stack.

- Builds an in-memory LSM fixture with a base run, multiple sorted L0 runs, and a native delete run.
- Verifies event-time merging, deterministic key ordering, delete suppression, and log-only reads.
- Forces L0 runs through `SpillableLsmRecordIterator` with a direct-reader threshold of one.
- Covers all public `HoodieLsmFileGroupReader` iterator modes and reader replacement/close behavior.
- Adds position-based cardinality, key-filtering, and fallback edge cases.
- Covers buffered merger selection and incremental query range boundaries.

| Class | Before | After |
| --- | ---: | ---: |
| `LsmFileGroupRecordIterator` | 39% | 93.7% |
| `HoodieLsmFileGroupReader` | 0% | 93.5% |
| `PositionBasedFileGroupRecordBuffer` | 74% | >=85% merged |
| `SpillableLsmRecordIterator` | 73% | 85.9% |
| `BufferedRecordMergerFactory` | 90% | >=90% |
| `IncrementalQueryAnalyzer` | 90% | >=90% |

The exact merged percentages for classes covered by tests in multiple modules will be confirmed by Codecov CI.

### Impact

No public API or runtime behavior changes. This PR only adds tests and improves regression coverage for the common read path.

### Risk Level

Low. The changes are test-only and the targeted suite passes with zero Checkstyle violations.

Validation:

```
mvn -pl hudi-common -Punit-tests -DskipITs -Drat.skip=true -Dtest=TestHoodieLsmFileGroupReader,TestLsmFileGroupRecordIterator,TestSpillableLsmRecordIterator,TestBufferedRecordMergerFactory,TestIncrementalQueryAnalyzer,TestPositionBasedFileGroupRecordBuffer test
```

17 tests passed with no failures.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
