### PR TITLE
fix(reader): derive pre-v9 CDC delete markers from the effective payload class

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieWriteHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieWriteHandle.java
@@ -81,6 +81,7 @@ class TestHoodieWriteHandle {
     MockitoAnnotations.initMocks(this);
     when(mockHoodieTable.getMetaClient()).thenReturn(mockMetaClient);
     when(mockMetaClient.getTableConfig()).thenReturn(mockTableConfig);
+    when(mockTableConfig.getPayloadClassIfPresent()).thenReturn(Option.empty());
     when(mockWriteConfig.getRecordMerger()).thenReturn(mockRecordMerger);
 
     // Set up a basic schema for the write config

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -1408,13 +1408,23 @@ public class HoodieTableConfig extends HoodieConfig {
   }
 
   public Map<String, String> getTableMergeProperties() {
+    return getTableMergeProperties(getPayloadClass());
+  }
+
+  /**
+   * Same as {@link #getTableMergeProperties()} but resolves the pre-v9 delete markers from the given
+   * effective payload class rather than the one persisted in this table config. Callers on the write
+   * path pass the write-config payload class ({@code hoodie.datasource.write.payload.class}), which
+   * for a pre-v9 table may be the only place the payload class is set.
+   */
+  public Map<String, String> getTableMergeProperties(String payloadClass) {
     Map<String, String> configs = ConfigUtils.extractWithPrefix(this.props, RECORD_MERGE_PROPERTY_PREFIX);
     if (getTableVersion().lesserThan(HoodieTableVersion.NINE)) {
       // Convert legacy payload properties do delete key and delete marker properties
-      if (getPayloadClass().equals(AWSDmsAvroPayload.class.getName())) {
+      if (payloadClass.equals(AWSDmsAvroPayload.class.getName())) {
         configs.put(DELETE_KEY, OP_FIELD);
         configs.put(DELETE_MARKER, DELETE_OPERATION_VALUE);
-      } else if (getPayloadClass().equals(MySqlDebeziumAvroPayload.class.getName()) || getPayloadClass().equals(PostgresDebeziumAvroPayload.class.getName())) {
+      } else if (payloadClass.equals(MySqlDebeziumAvroPayload.class.getName()) || payloadClass.equals(PostgresDebeziumAvroPayload.class.getName())) {
         configs.put(DELETE_KEY, DebeziumConstants.FLATTENED_OP_COL_NAME);
         configs.put(DELETE_MARKER, DebeziumConstants.DELETE_OP);
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -1407,15 +1407,11 @@ public class HoodieTableConfig extends HoodieConfig {
     return Option.empty();
   }
 
-  public Map<String, String> getTableMergeProperties() {
-    return getTableMergeProperties(getPayloadClass());
-  }
-
   /**
-   * Same as {@link #getTableMergeProperties()} but resolves the pre-v9 delete markers from the given
-   * effective payload class rather than the one persisted in this table config. Callers on the write
-   * path pass the write-config payload class ({@code hoodie.datasource.write.payload.class}), which
-   * for a pre-v9 table may be the only place the payload class is set.
+   * Returns the record-merge properties for this table, deriving the pre-v9 delete markers from the
+   * given effective payload class rather than the one persisted in this table config. Callers on the
+   * write path pass the write-config payload class ({@code hoodie.datasource.write.payload.class}),
+   * which for a pre-v9 table may be the only place the payload class is set.
    */
   public Map<String, String> getTableMergeProperties(String payloadClass) {
     Map<String, String> configs = ConfigUtils.extractWithPrefix(this.props, RECORD_MERGE_PROPERTY_PREFIX);

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -151,12 +151,12 @@ public class ConfigUtils {
    * Ensures that the prefixed merge properties are populated for mergers.
    */
   public static TypedProperties getMergeProps(TypedProperties props, HoodieTableConfig tableConfig) {
-    // Resolve the effective payload class from the reader/write props first -- it may be set only
-    // there (e.g. hoodie.datasource.write.payload.class for a pre-v9 table that never persisted the
-    // payload class into its table config), falling back to the table config. This ensures the
-    // pre-v9 delete-marker derivation in getTableMergeProperties fires for such tables.
-    String payloadClass = HoodieRecordPayload.getPayloadClassNameIfPresent(props)
-        .orElseGet(tableConfig::getPayloadClass);
+    // Prefer the payload class persisted in the table config, falling back to the reader/write props
+    // (e.g. hoodie.datasource.write.payload.class) when the table never persisted it. This keeps the
+    // persisted payload authoritative (no query-side shadowing) while pre-v9 delete markers still derive.
+    String payloadClass = tableConfig.getPayloadClassIfPresent()
+        .orElseGet(() -> HoodieRecordPayload.getPayloadClassNameIfPresent(props)
+            .orElseGet(tableConfig::getPayloadClass));
     Map<String, String> mergeProps = tableConfig.getTableMergeProperties(payloadClass);
     if (mergeProps.isEmpty()) {
       return props;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
@@ -151,7 +151,13 @@ public class ConfigUtils {
    * Ensures that the prefixed merge properties are populated for mergers.
    */
   public static TypedProperties getMergeProps(TypedProperties props, HoodieTableConfig tableConfig) {
-    Map<String, String> mergeProps = tableConfig.getTableMergeProperties();
+    // Resolve the effective payload class from the reader/write props first -- it may be set only
+    // there (e.g. hoodie.datasource.write.payload.class for a pre-v9 table that never persisted the
+    // payload class into its table config), falling back to the table config. This ensures the
+    // pre-v9 delete-marker derivation in getTableMergeProperties fires for such tables.
+    String payloadClass = HoodieRecordPayload.getPayloadClassNameIfPresent(props)
+        .orElseGet(tableConfig::getPayloadClass);
+    Map<String, String> mergeProps = tableConfig.getTableMergeProperties(payloadClass);
     if (mergeProps.isEmpty()) {
       return props;
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestConfigUtils.java
@@ -24,8 +24,13 @@ import org.apache.hudi.common.config.HoodieCommonConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.AWSDmsAvroPayload;
 import org.apache.hudi.common.model.HoodiePayloadProps;
+import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap.DiskMapType;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
 
@@ -41,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY;
+import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
 import static org.apache.hudi.common.table.HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -477,5 +484,79 @@ public class TestConfigUtils {
     assertEquals("false", fileGroupReaderProps.getProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_ENABLED.key()));
     assertEquals("200000", fileGroupReaderProps.getProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_SIZE.key()));
     assertEquals("7", fileGroupReaderProps.getProperty(HoodieReaderConfig.HFILE_BLOCK_CACHE_TTL_MINUTES.key()));
+  }
+
+  @Test
+  void testGetMergePropsPrefersPersistedTableConfigPayloadClass() {
+    // A payload override in the write props must not shadow the class persisted in the table config:
+    // the persisted Debezium payload wins, so the pre-v9 delete markers are derived from it.
+    HoodieTableConfig tableConfig = preV9TableConfig(PostgresDebeziumAvroPayload.class.getName());
+    TypedProperties props = new TypedProperties();
+    props.put("hoodie.datasource.write.payload.class", OverwriteWithLatestAvroPayload.class.getName());
+
+    TypedProperties merged = ConfigUtils.getMergeProps(props, tableConfig);
+
+    assertEquals(DebeziumConstants.FLATTENED_OP_COL_NAME, merged.getString(DELETE_KEY));
+    assertEquals(DebeziumConstants.DELETE_OP, merged.getString(DELETE_MARKER));
+  }
+
+  @Test
+  void testGetMergePropsFallsBackToWritePropsPayloadClass() {
+    // Pre-v9 table that never persisted a payload class: resolve it from the write props so the
+    // delete-marker derivation still fires.
+    HoodieTableConfig tableConfig = preV9TableConfig(null);
+    TypedProperties props = new TypedProperties();
+    props.put("hoodie.datasource.write.payload.class", PostgresDebeziumAvroPayload.class.getName());
+
+    TypedProperties merged = ConfigUtils.getMergeProps(props, tableConfig);
+
+    assertEquals(DebeziumConstants.FLATTENED_OP_COL_NAME, merged.getString(DELETE_KEY));
+    assertEquals(DebeziumConstants.DELETE_OP, merged.getString(DELETE_MARKER));
+  }
+
+  @Test
+  void testGetMergePropsDerivesAwsDmsDeleteMarkers() {
+    HoodieTableConfig tableConfig = preV9TableConfig(AWSDmsAvroPayload.class.getName());
+
+    TypedProperties merged = ConfigUtils.getMergeProps(new TypedProperties(), tableConfig);
+
+    assertEquals(AWSDmsAvroPayload.OP_FIELD, merged.getString(DELETE_KEY));
+    assertEquals(AWSDmsAvroPayload.DELETE_OPERATION_VALUE, merged.getString(DELETE_MARKER));
+  }
+
+  @Test
+  void testGetMergePropsDerivesNoDeleteMarkersForVersionNine() {
+    // Version 9+ tables carry the merge configs directly, so the legacy delete markers are not
+    // derived even for a CDC payload.
+    HoodieTableConfig tableConfig = new HoodieTableConfig();
+    tableConfig.getProps().put(HoodieTableConfig.VERSION.key(), String.valueOf(HoodieTableVersion.NINE.versionCode()));
+    tableConfig.getProps().put(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), PostgresDebeziumAvroPayload.class.getName());
+
+    TypedProperties merged = ConfigUtils.getMergeProps(new TypedProperties(), tableConfig);
+
+    assertFalse(merged.containsKey(DELETE_KEY));
+    assertFalse(merged.containsKey(DELETE_MARKER));
+  }
+
+  @Test
+  void testGetMergePropsDerivesNoDeleteMarkersForNonCdcPayload() {
+    // Pre-v9 table with a non-CDC payload and no override: no delete markers, props returned as-is.
+    HoodieTableConfig tableConfig = preV9TableConfig(OverwriteWithLatestAvroPayload.class.getName());
+    TypedProperties props = new TypedProperties();
+    props.put("normal.key", "val");
+
+    TypedProperties merged = ConfigUtils.getMergeProps(props, tableConfig);
+
+    assertFalse(merged.containsKey(DELETE_KEY));
+    assertEquals("val", merged.getString("normal.key"));
+  }
+
+  private static HoodieTableConfig preV9TableConfig(String payloadClass) {
+    HoodieTableConfig tableConfig = new HoodieTableConfig();
+    tableConfig.getProps().put(HoodieTableConfig.VERSION.key(), String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
+    if (payloadClass != null) {
+      tableConfig.getProps().put(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), payloadClass);
+    }
+    return tableConfig;
   }
 }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
@@ -397,7 +397,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
   void testTableMergeProperties() throws IOException {
     // for out of the box, there are no merge properties
     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath);
-    assertTrue(config.getTableMergeProperties().isEmpty());
+    assertTrue(config.getTableMergeProperties(config.getPayloadClass()).isEmpty());
 
     // delete and re-create w/ merge properties
     storage.deleteFile(cfgPath);
@@ -416,7 +416,7 @@ class TestHoodieTableConfig extends HoodieCommonTestHarness {
     Map<String, String> expectedProps = new HashMap<>();
     expectedProps.put("key1","value1");
     expectedProps.put("key2","value2");
-    assertEquals(expectedProps, config.getTableMergeProperties());
+    assertEquals(expectedProps, config.getTableMergeProperties(config.getPayloadClass()));
   }
 
   private static Stream<Arguments> testInferMergingConfigsForPreV9Table() {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -504,32 +504,26 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
   }
 
   /**
-   * End-to-end reproduction for a Copy-on-Write, pre-v9 Postgres-Debezium table whose payload class
-   * is supplied ONLY via the write config (hoodie.datasource.write.payload.class) and is NOT
-   * persisted in the table properties. A Debezium delete (_change_operation_type='d') for a key that
-   * is absent from the base file it gets merged into goes down the FileGroupReader write path's
-   * previousRecord==null branch. Before the fix the reader cannot derive the Debezium delete markers
-   * (getTableMergeProperties resolves the payload class from the table config, which does not have
-   * it), so the delete is classified isDelete=false, routed into
-   * PayloadUpdateProcessor.handleNonDeletes, and .get()s the empty Option -> NoSuchElementException.
+   * COW pre-v9 Postgres-Debezium table whose payload class is set only via the write config
+   * (hoodie.datasource.write.payload.class), not the table properties. A Debezium delete
+   * (_change_operation_type='d') for a key absent from the base file must be classified as a delete
+   * and become a no-op, rather than failing when the reader derives the delete markers.
    *
-   * The parameter is the "similar test case": stripPayloadClass=false keeps the payload class in the
-   * table properties (delete detected, always works) and acts as the control; stripPayloadClass=true
-   * reproduces the incident (broken before the fix, correct after).
+   * stripPayloadClass=true removes the payload class from the table properties (the failing case
+   * before the fix); stripPayloadClass=false keeps it and acts as the control.
    */
   @ParameterizedTest
   @ValueSource(strings = Array("true", "false"))
   def testDebeziumDeleteForAbsentKeyWithPayloadClassNotInTableConfig(stripPayloadClassStr: String): Unit = {
-    val stripPayloadClass = stripPayloadClassStr.equals("true")
+    val stripPayloadClass = stripPayloadClassStr.toBoolean
     val payloadClazz = classOf[PostgresDebeziumAvroPayload].getName
-    // Payload class is only a write option, never a table property (mirrors gw-agent provisioning).
+    // Payload class supplied only as a write option, not as a table property.
     val opts: Map[String, String] = Map(
       HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> payloadClazz,
       HoodieMetadataConfig.ENABLE.key() -> "false")
-    // Single-bucket index so every record (including the new delete key) hashes to the one existing
-    // file group and is merged against its base file -- deterministically forcing the FileGroupReader
-    // write path's previousRecord==null branch rather than a fresh insert file group.
-    val serviceOpts: Map[String, String] = Map(
+    // Single-bucket index so the delete key hashes to the existing file group and is merged against
+    // its base file, rather than creating a fresh insert file group.
+    val indexOpts: Map[String, String] = Map(
       "hoodie.index.type" -> "BUCKET",
       "hoodie.index.bucket.engine" -> "SIMPLE",
       "hoodie.bucket.index.num.buckets" -> "1",
@@ -550,7 +544,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       .option(DataSourceWriteOptions.TABLE_NAME.key(), "test_table")
       .option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
       .option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8")
-      .options(serviceOpts)
+      .options(indexOpts)
       .options(opts)
       .mode(SaveMode.Overwrite)
       .save(basePath)
@@ -559,8 +553,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     assertEquals(8, metaClient.getTableConfig.getTableVersion.versionCode())
 
     if (stripPayloadClass) {
-      // Simulate the incident: strip any persisted payload-class keys so the table config no longer
-      // resolves to the Debezium payload (it lives only in the write config).
+      // Remove any persisted payload-class keys so the payload class lives only in the write config.
       val payloadKeys = metaClient.getTableConfig.getProps.asScala.keys
         .filter(k => k.toString.contains("payload.class")).map(_.toString).toSet
       HoodieTableConfig.delete(metaClient.getStorage, metaClient.getMetaPath, payloadKeys.asJava)
@@ -571,10 +564,10 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
     // 2. Upsert a Debezium delete ('d') for a key ABSENT from the base file (lsn 99).
     val deleteData = Seq(
       (12, 99L, "rider-Z", "driver-Z", 20.10, "D", "12.1", 12, 1, "d"))
-    performUpsert(deleteData, columns, serviceOpts, opts, basePath,
+    performUpsert(deleteData, columns, indexOpts, opts, basePath,
       tableVersion = Some("8"), orderingFields = Some("_event_lsn"))
 
-    // 3. No NoSuchElementException; base rows intact and the absent-key delete is a no-op.
+    // 3. Base rows intact and the absent-key delete is a no-op.
     val df = spark.read.format("hudi").load(basePath)
     assertEquals(3, df.count())
     assertEquals(0, df.filter("_event_lsn = 99").count())

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
@@ -35,7 +35,7 @@ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
 import org.apache.spark.sql.SaveMode
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.{Arguments, MethodSource}
+import org.junit.jupiter.params.provider.{Arguments, MethodSource, ValueSource}
 import org.scalatest.Assertions.assertThrows
 
 import scala.jdk.CollectionConverters._
@@ -501,6 +501,83 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
       .withProps(props)
       .withPath(basePath())
       .build()
+  }
+
+  /**
+   * End-to-end reproduction for a Copy-on-Write, pre-v9 Postgres-Debezium table whose payload class
+   * is supplied ONLY via the write config (hoodie.datasource.write.payload.class) and is NOT
+   * persisted in the table properties. A Debezium delete (_change_operation_type='d') for a key that
+   * is absent from the base file it gets merged into goes down the FileGroupReader write path's
+   * previousRecord==null branch. Before the fix the reader cannot derive the Debezium delete markers
+   * (getTableMergeProperties resolves the payload class from the table config, which does not have
+   * it), so the delete is classified isDelete=false, routed into
+   * PayloadUpdateProcessor.handleNonDeletes, and .get()s the empty Option -> NoSuchElementException.
+   *
+   * The parameter is the "similar test case": stripPayloadClass=false keeps the payload class in the
+   * table properties (delete detected, always works) and acts as the control; stripPayloadClass=true
+   * reproduces the incident (broken before the fix, correct after).
+   */
+  @ParameterizedTest
+  @ValueSource(strings = Array("true", "false"))
+  def testDebeziumDeleteForAbsentKeyWithPayloadClassNotInTableConfig(stripPayloadClassStr: String): Unit = {
+    val stripPayloadClass = stripPayloadClassStr.equals("true")
+    val payloadClazz = classOf[PostgresDebeziumAvroPayload].getName
+    // Payload class is only a write option, never a table property (mirrors gw-agent provisioning).
+    val opts: Map[String, String] = Map(
+      HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> payloadClazz,
+      HoodieMetadataConfig.ENABLE.key() -> "false")
+    // Single-bucket index so every record (including the new delete key) hashes to the one existing
+    // file group and is merged against its base file -- deterministically forcing the FileGroupReader
+    // write path's previousRecord==null branch rather than a fresh insert file group.
+    val serviceOpts: Map[String, String] = Map(
+      "hoodie.index.type" -> "BUCKET",
+      "hoodie.index.bucket.engine" -> "SIMPLE",
+      "hoodie.bucket.index.num.buckets" -> "1",
+      "hoodie.bucket.index.hash.field" -> "_event_lsn")
+
+    val columns = Seq("ts", "_event_lsn", "rider", "driver", "fare", "Op", "_event_seq",
+      DebeziumConstants.FLATTENED_FILE_COL_NAME, DebeziumConstants.FLATTENED_POS_COL_NAME, DebeziumConstants.FLATTENED_OP_COL_NAME)
+
+    // 1. Insert base rows (lsn 1,2,3) into a COW table at table version 8.
+    val data = Seq(
+      (10, 1L, "rider-A", "driver-A", 19.10, "i", "10.1", 10, 1, "i"),
+      (10, 2L, "rider-B", "driver-B", 27.70, "i", "10.1", 10, 1, "i"),
+      (10, 3L, "rider-C", "driver-C", 33.90, "i", "10.1", 10, 1, "i"))
+    spark.createDataFrame(data).toDF(columns: _*).write.format("hudi")
+      .option(RECORDKEY_FIELD.key(), "_event_lsn")
+      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "_event_lsn")
+      .option(TABLE_TYPE.key(), HoodieTableType.COPY_ON_WRITE.name())
+      .option(DataSourceWriteOptions.TABLE_NAME.key(), "test_table")
+      .option(OPERATION.key(), DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option(HoodieWriteConfig.WRITE_TABLE_VERSION.key(), "8")
+      .options(serviceOpts)
+      .options(opts)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    var metaClient = HoodieTableMetaClient.builder().setBasePath(basePath).setConf(storageConf()).build()
+    assertEquals(8, metaClient.getTableConfig.getTableVersion.versionCode())
+
+    if (stripPayloadClass) {
+      // Simulate the incident: strip any persisted payload-class keys so the table config no longer
+      // resolves to the Debezium payload (it lives only in the write config).
+      val payloadKeys = metaClient.getTableConfig.getProps.asScala.keys
+        .filter(k => k.toString.contains("payload.class")).map(_.toString).toSet
+      HoodieTableConfig.delete(metaClient.getStorage, metaClient.getMetaPath, payloadKeys.asJava)
+      metaClient = HoodieTableMetaClient.builder().setBasePath(basePath).setConf(storageConf()).build()
+      assertFalse(metaClient.getTableConfig.getPayloadClassIfPresent.isPresent)
+    }
+
+    // 2. Upsert a Debezium delete ('d') for a key ABSENT from the base file (lsn 99).
+    val deleteData = Seq(
+      (12, 99L, "rider-Z", "driver-Z", 20.10, "D", "12.1", 12, 1, "d"))
+    performUpsert(deleteData, columns, serviceOpts, opts, basePath,
+      tableVersion = Some("8"), orderingFields = Some("_event_lsn"))
+
+    // 3. No NoSuchElementException; base rows intact and the absent-key delete is a no-op.
+    val df = spark.read.format("hudi").load(basePath)
+    assertEquals(3, df.count())
+    assertEquals(0, df.filter("_event_lsn = 99").count())
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

For a table below table version 9 whose payload class is supplied **only via the write config** (`hoodie.datasource.write.payload.class`) and is **not persisted in the table properties**, `HoodieTableConfig.getTableMergeProperties()` resolved the payload class from the table config alone, so it never derived the Debezium/DMS delete markers (`hoodie.payload.delete.field` / `hoodie.payload.delete.marker`) for the pre-v9 path.

As a result the FileGroupReader write path could not classify a payload-level delete (for example a Postgres/MySQL Debezium `_change_operation_type='d'` record) for a key absent from the base file it is merged into. The record took the `previousRecord == null` branch of `PayloadUpdateProcessor.handleNonDeletes`, which calls `rewriteRecordWithNewSchema` and `.get()`s the `Option` the payload deliberately emptied for a delete:

```
org.apache.hudi.exception.HoodieUpsertException: Error upserting bucketType UPDATE for partition :0
Caused by: java.util.NoSuchElementException: No value present in Option
  at org.apache.hudi.common.util.Option.get(Option.java:93)
  at org.apache.hudi.common.model.HoodieAvroRecord.rewriteRecordWithNewSchema(HoodieAvroRecord.java:178)
  at org.apache.hudi.common.table.read.UpdateProcessor$PayloadUpdateProcessor.handleNonDeletes(UpdateProcessor.java:146)
  at org.apache.hudi.io.FileGroupReaderBasedMergeHandle.doMerge(FileGroupReaderBasedMergeHandle.java:294)
```

### Summary and Changelog

- `ConfigUtils.getMergeProps(props, tableConfig)` now resolves the effective payload class from the **table config first**, falling back to the reader/write `props` (for example `hoodie.datasource.write.payload.class`) when the table never persisted a payload class. This keeps the persisted payload authoritative so a query-side override cannot shadow it, while still deriving the pre-v9 delete markers for a table whose payload class lives only in the write config.
- The resolved class is passed into a new `HoodieTableConfig.getTableMergeProperties(String payloadClass)` overload. The now-unused no-arg `getTableMergeProperties()` is removed and its test callers migrated to the overload.
- Adds an end-to-end reproduction in `TestPayloadDeprecationFlow` (payload-class-absent, which reproduces the crash, versus payload-class-present as the control).

Behavior is unchanged for tables that carry the payload class in the table config, and for table version >= 9 (the pre-v9 derivation block does not run).

### Impact

Fixes an upsert failure (`NoSuchElementException: No value present in Option`) for Debezium/AWS-DMS CDC tables on the FileGroupReader write path when the payload class is set only in the write config and the table has not been upgraded to version 9. No config or storage-format change.

### Risk Level

low

Localized to the pre-v9 merge-property derivation. Covered by a new end-to-end test plus existing `TestPayloadDeprecationFlow` and `TestHoodieTableConfig` coverage.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
