### PR TITLE
fix(metadata-table): follow-ups for the zero-size file skip (#18611)

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -579,9 +579,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    *
    * @param initializationTime  Files which have a timestamp after this are neglected
    * @param pendingDataInstants Pending instants on data set
-   * @param skipZeroSizeFiles   Whether zero-size data files should be skipped during listing. This should only be
-   *                            enabled on the initialize path; other callers (e.g. restore) must pass false so that
-   *                            files already tracked in the metadata table are not spuriously deleted.
+   * @param skipZeroSizeFiles   Whether zero-size data files should be skipped during listing, per
+   *                            hoodie.metadata.skip.zero.size.files.on.initialize. Both the initialize path and the
+   *                            restore-sync relisting pass the config so zero-size files are treated consistently;
+   *                            otherwise restore would re-add to the metadata table the files skipped at initialization.
    * @return List consisting of {@code DirectoryInfo} for each partition found.
    */
   private List<DirectoryInfo> listAllPartitionsFromFilesystem(String initializationTime, Set<String> pendingDataInstants, boolean skipZeroSizeFiles) {
@@ -635,8 +636,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       }
     }
 
-    final long zeroSizeCount = totalZeroSizeFiles;
-    metrics.ifPresent(m -> m.incrementMetric("skipped_zero_size_files_on_initialize", zeroSizeCount));
+    if (totalZeroSizeFiles > 0) {
+      final long zeroSizeCount = totalZeroSizeFiles;
+      metrics.ifPresent(m -> m.incrementMetric(HoodieMetadataMetrics.SKIPPED_ZERO_SIZE_FILES_ON_INITIALIZE_STR, zeroSizeCount));
+    }
     return partitionsToBootstrap;
   }
 
@@ -1181,7 +1184,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
     // Restore requires the existing pipelines to be shutdown. So we can safely scan the dataset to find the current
     // list of files in the filesystem.
-    List<DirectoryInfo> dirInfoList = listAllPartitionsFromFilesystem(instantTime, Collections.emptySet(), false);
+    List<DirectoryInfo> dirInfoList = listAllPartitionsFromFilesystem(instantTime, Collections.emptySet(),
+        dataWriteConfig.getMetadataConfig().shouldSkipZeroSizeFilesOnInitialize());
     Map<String, DirectoryInfo> dirInfoMap = dirInfoList.stream().collect(Collectors.toMap(DirectoryInfo::getRelativePath, Function.identity()));
     dirInfoList.clear();
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -199,9 +199,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".skip.zero.size.files.on.initialize")
       .defaultValue(false)
       .markAdvanced()
-      .sinceVersion("1.2.0")
+      .sinceVersion("1.3.0")
       .withDocumentation("When enabled, zero-size data files encountered while listing the data table during "
-          + "metadata table initialization are skipped instead of being recorded in the metadata table.");
+          + "metadata table initialization and restore sync are skipped instead of being recorded in the metadata "
+          + "table. Skipped files remain on storage and are not tracked by the metadata table or the cleaner; "
+          + "remove them manually. The metadata validator will report them as inconsistencies.");
 
   public static final ConfigProperty<Integer> FILE_LISTING_PARALLELISM_VALUE = ConfigProperty
       .key("hoodie.file.listing.parallelism")

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -67,6 +67,7 @@ public class HoodieMetadataMetrics implements Serializable {
   public static final String INITIALIZE_STR = "initialize";
   public static final String REBOOTSTRAP_STR = "rebootstrap_count";
   public static final String BOOTSTRAP_ERR_STR = "bootstrap_error";
+  public static final String SKIPPED_ZERO_SIZE_FILES_ON_INITIALIZE_STR = "skipped_zero_size_files_on_initialize";
 
   // Stats names
   public static final String STAT_TOTAL_BASE_FILE_SIZE = "totalBaseFileSizeInBytes";

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/model/DirectoryInfo.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/model/DirectoryInfo.java
@@ -100,11 +100,15 @@ public class DirectoryInfo implements Serializable {
           if (pathInfo.getLength() > 0 || !skipZeroSizeFiles) {
             filenameToSizeMap.put(pathInfo.getPath().getName(), pathInfo.getLength());
           } else {
-            log.warn("Skipping zero-size data file during MDT bootstrap: {}", pathInfo.getPath());
+            log.debug("Skipping zero-size data file: {}", pathInfo.getPath());
             zeroSizeFileCount++;
           }
         }
       }
+    }
+    if (zeroSizeFileCount > 0) {
+      log.warn("Skipped {} zero-size data files while listing partition {}; they remain on storage and are not tracked in the metadata table",
+          zeroSizeFileCount, relativePath);
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestRecordLevelIndex.scala
@@ -811,6 +811,108 @@ class TestRecordLevelIndex extends RecordLevelIndexTestBase with SparkDatasetMix
     }
   }
 
+  /**
+   * Tests that when a zero-size base file is skipped during MDT bootstrap, a subsequent upsert
+   * still succeeds and produces consistent data. Because the skipped file group is absent from MDT,
+   * the upsert treats those records as new inserts and writes them to a new file group. The test
+   * verifies the final record count and that every RLI entry points to a real, readable file.
+   */
+  @Test
+  def testUpsertAfterSkippingZeroSizeFileOnInitialize(): Unit = {
+    // Use a single-partition data generator so all inserts land in one parquet file.
+    val singlePartitionDataGen = HoodieTestDataGenerator.createTestGeneratorFirstPartition()
+    val singlePartition = HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH
+    val insertedRecords = 10
+    val inserts = singlePartitionDataGen.generateInserts("001", insertedRecords)
+    val insertDf = toDataset(spark, inserts)
+
+    val baseOptions = Map(
+      HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+      DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.COPY_ON_WRITE.name(),
+      RECORDKEY_FIELD.key -> "_row_key",
+      PARTITIONPATH_FIELD.key -> "partition_path",
+      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+      HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "false",
+      HoodieMetadataConfig.RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "false",
+      HoodieCompactionConfig.INLINE_COMPACT.key() -> "false")
+
+    insertDf.write.format("hudi")
+      .options(baseOptions)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+    assertEquals(insertedRecords, spark.read.format("hudi").load(basePath).count())
+
+    // Confirm there is exactly one parquet base file in the single partition.
+    val partitionPath = new StoragePath(basePath, singlePartition)
+    val baseFilesBeforeCorruption = storage.listDirectEntries(partitionPath).asScala
+      .filter(_.getPath.getName.endsWith(".parquet"))
+      .toSeq
+    assertEquals(1, baseFilesBeforeCorruption.size, "Expected exactly one parquet file in the single partition")
+    val zeroSizeFileId = FSUtils.getFileId(baseFilesBeforeCorruption.head.getPath.getName)
+
+    // Replace the only base file with an empty (zero-size) file.
+    replaceOneBaseFileWithEmpty(Seq(singlePartition))
+
+    // Delete MDT to force a full rebootstrap.
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    HoodieTableMetadataUtil.deleteMetadataTable(metaClient, context, false)
+    assertFalse(storage.exists(new StoragePath(HoodieTableMetadata.getMetadataTableBasePath(basePath))),
+      "Metadata table should be absent before rebootstrap")
+
+    // The upsert triggers MDT rebootstrap (since MDT was deleted). Skip config is set so
+    // the zero-size file is skipped during bootstrap. Because RLI has no entries for these
+    // records (they were in the skipped file), the upsert treats them as new inserts.
+    // Use global RLI so that the MDT bootstraps at least minFileGroupCount (10) file groups
+    // for record_index even when all data files were skipped as zero-size.
+    metaClient.reloadActiveTimeline()
+    val latestSchema = new TableSchemaResolver(metaClient).getTableSchemaFromLatestCommit(false).get().toString
+    val optionsWithSkip = baseOptions ++ Map(
+      HoodieMetadataConfig.GLOBAL_RECORD_LEVEL_INDEX_ENABLE_PROP.key() -> "true",
+      HoodieIndexConfig.INDEX_TYPE.key() -> "GLOBAL_RECORD_LEVEL_INDEX",
+      HoodieMetadataConfig.SKIP_ZERO_SIZE_FILES_ON_INITIALIZE.key() -> "true",
+      HoodieWriteConfig.AVRO_SCHEMA_STRING.key() -> latestSchema)
+
+    // Reuse the same 10 records for the upsert. Since RLI has no entries for these record keys
+    // (the original file was zero-size and skipped during bootstrap), the upsert treats them as
+    // new inserts and writes them to a brand-new file group — NOT the zero-size one.
+    val upsertDf = toDataset(spark, inserts)
+    // Upsert should succeed — any exception here fails the test.
+    upsertDf.write.format("hudi")
+      .options(optionsWithSkip)
+      .option(DataSourceWriteOptions.OPERATION.key(), UPSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    // Data consistency check: all 10 records must be readable in the new file group.
+    // (The zero-size base file contributes 0 readable records; the new file group has 10.)
+    val readDf = spark.read.format("hudi").load(basePath)
+    assertEquals(insertedRecords, readDf.count(),
+      "All records should be readable after upsert into a new file group")
+
+    // RLI consistency check: every live record must be indexed at the location where it actually lives.
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    val writeConfig = getWriteConfig(optionsWithSkip)
+    val postUpsertMetadata = metadataWriter(writeConfig).getTableMetadata.asInstanceOf[HoodieBackedTableMetadata]
+
+    // MDT files partition must not track the zero-size file group.
+    val allMdtFiles = getFilesInAllPartitions(postUpsertMetadata)
+    assertFalse(allMdtFiles.exists(_.getPath.getName.contains(zeroSizeFileId)),
+      s"MDT should not contain the zero-size file group $zeroSizeFileId after bootstrap with skip enabled")
+
+    // Global RLI: look up all record keys without a partition hint.
+    val recordKeys = inserts.asScala.map(_.getRecordKey).asJava.stream().collect(Collectors.toList())
+    val postUpsertLocations = readRecordIndex(postUpsertMetadata, recordKeys, HOption.empty())
+    assertEquals(insertedRecords, postUpsertLocations.size,
+      "All upserted records should have an RLI entry after upsert")
+    val df = readDf.collect()
+    validateDFWithLocations(df, postUpsertLocations, singlePartition)
+
+    // The zero-size file group must not have been selected as the write target — its file ID
+    // should not appear in any of the post-upsert RLI locations.
+    assertFalse(postUpsertLocations.values.exists(_.getFileId == zeroSizeFileId),
+      "The zero-size file group should not have been picked as a write target during upsert")
+  }
+
   private def replaceOneBaseFileWithEmpty(partitionPaths: Seq[String]): String = {
     val candidateBaseFile = partitionPaths.view.flatMap { partition =>
       storage.listDirectEntries(new StoragePath(basePath, partition)).asScala


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Follow-up to #18611, which added the opt-in config `hoodie.metadata.skip.zero.size.files.on.initialize` (skip zero-size data files while listing the data table during MDT initialization). #19243 was a duplicate submission of the same branch and collected review comments that apply to the merged code; it is now closed. This PR addresses those comments and carries over the E2E test from #19243 that never merged (cherry-picked with authorship preserved, thanks @lokeshj1703 @nada-attia).

### Summary and Changelog

- Honor the config in the restore-sync relisting. Previously `update(HoodieRestoreMetadata, ...)` passed `skipZeroSizeFiles=false` unconditionally, so a restore would diff the filesystem against MDT, see the files skipped at initialization as FS-only, and re-add them via `partitionFilesToAdd` -- re-introducing the failure the config exists to avoid (e.g. the column-stats restore build reading a zero-size parquet footer). With the config enabled, restore now skips them too, and zero-size files already tracked in MDT are removed by the restore sync, converging MDT to the configured semantics.
- Document the operational trade-off in the config description: skipped files remain on storage and are not tracked by the metadata table or the cleaner; they must be removed manually, and the metadata validator will report them as inconsistencies.
- Correct the config `sinceVersion` to 1.3.0 (it first ships in 1.3.0, not 1.2.0).
- Move the metric name into `HoodieMetadataMetrics.SKIPPED_ZERO_SIZE_FILES_ON_INITIALIZE_STR` alongside the other metric-name constants, and only emit it when files were actually skipped (previously an unconditional 0 was emitted on every listing, including restore).
- Reduce log noise: one aggregated WARN per partition with the skipped count; individual file paths moved to DEBUG.
- Add a Scala E2E test (`TestRecordLevelIndex.testUpsertAfterSkippingZeroSizeFileOnInitialize`): after a zero-size base file is skipped during MDT bootstrap with global RLI, an upsert of the affected records succeeds, routes them to a new file group (never the zero-size one), and leaves RLI consistent with the data.

### Impact

None by default. With the config enabled, restore-sync now treats zero-size files the same way initialization does instead of re-adding them to MDT. The `skipped_zero_size_files_on_initialize` metric is now only emitted when non-zero.

### Risk Level

low. All behavior changes are gated behind the default-off config; the metric/logging changes are observability-only.

### Documentation Update

None beyond the updated config description (the website config reference is generated from it).

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
