### PR TITLE
test(spark): Fix flaky TestSparkFilterHelper by giving it its own SparkSession

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestSparkFilterHelper.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestSparkFilterHelper.scala
@@ -28,11 +28,21 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.junit.jupiter.api.{Assertions, Test}
+import org.junit.jupiter.api.{AfterEach, Assertions, BeforeEach, Test}
 
 import scala.collection.JavaConverters._
 
 class TestSparkFilterHelper extends HoodieSparkClientTestHarness with SparkAdapterSupport  {
+
+  @BeforeEach
+  def setUp(): Unit = {
+    initSparkContexts()
+  }
+
+  @AfterEach
+  def tearDown(): Unit = {
+    cleanupSparkContexts()
+  }
 
   @Test
   def testConvertInExpression(): Unit = {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`org.apache.hudi.TestSparkFilterHelper.testConvertInExpression` is intermittently flaky, failing with `IllegalStateException: LiveListenerBus is stopped` (wrapped in `Error while instantiating 'SessionStateBuilder'`). It last surfaced across the spark3.3/3.4/3.5 `test-spark-java-tests-part1` jobs on an unrelated Flink-only PR (https://github.com/apache/hudi/pull/19354, CI run https://github.com/apache/hudi/actions/runs/29977957778). The test calls `functions.expr(...)`, which needs an active `SparkSession`, but `TestSparkFilterHelper` extends `HoodieSparkClientTestHarness` directly and never wires `initSparkContexts()` (that wiring lives in `HoodieClientTestBase`), so it relied on a leaked active session from a prior test in the same Surefire fork and failed whenever that session's context was already stopped.

### Summary and Changelog

Add `@BeforeEach`/`@AfterEach` that call the inherited `initSparkContexts()`/`cleanupSparkContexts()` so the test owns a fresh `SparkSession`, matching `HoodieClientTestBase` and the sibling `TestHoodieDataSourceHelper`. Test-only; no production code or assertions change. No code was copied.

### Impact

None. Test-only change confined to `TestSparkFilterHelper`.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
