### PR TITLE
feat(spark): upgrade Spark 4.2 dependency to GA 4.2.0

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -107,14 +107,14 @@ github:
           - validate-bundles (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark3.5, spark3.5.1)
           - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.0, spark4.0.0)
           - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.1, spark4.1.1)
-          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.2, spark4.2.0)
+          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.2, spark4.2.0-preview4)
           - validate-bundles-java11 (scala-2.12, flink2.0, 1.11.4, 1.14.4, spark3.5, spark3.5.1)
           - validate-bundles-java11 (scala-2.12, flink2.1, 1.11.4, 1.15.2, spark3.5, spark3.5.1)
           - docker-java17-test (scala-2.12, flink2.1, spark3.5, spark3.5.0)
           - docker-java17-test (scala-2.13, flink2.1, spark3.5, spark3.5.0)
           - docker-java17-test (scala-2.13, flink2.1, spark4.0, spark4.0.0)
           - docker-java17-test (scala-2.13, flink2.1, spark4.1, spark4.1.1)
-          - docker-java17-test (scala-2.13, flink1.20, spark4.2, spark4.2.0)
+          - docker-java17-test (scala-2.13, flink1.20, spark4.2, spark4.2.0-preview4)
           - integration-tests (spark3.5, flink2.1, spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz)
   collaborators:
     - ad1happy2go

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -107,14 +107,14 @@ github:
           - validate-bundles (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark3.5, spark3.5.1)
           - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.0, spark4.0.0)
           - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.1, spark4.1.1)
-          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.2, spark4.2.0-preview4)
+          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.2, spark4.2.0)
           - validate-bundles-java11 (scala-2.12, flink2.0, 1.11.4, 1.14.4, spark3.5, spark3.5.1)
           - validate-bundles-java11 (scala-2.12, flink2.1, 1.11.4, 1.15.2, spark3.5, spark3.5.1)
           - docker-java17-test (scala-2.12, flink2.1, spark3.5, spark3.5.0)
           - docker-java17-test (scala-2.13, flink2.1, spark3.5, spark3.5.0)
           - docker-java17-test (scala-2.13, flink2.1, spark4.0, spark4.0.0)
           - docker-java17-test (scala-2.13, flink2.1, spark4.1, spark4.1.1)
-          - docker-java17-test (scala-2.13, flink1.20, spark4.2, spark4.2.0-preview4)
+          - docker-java17-test (scala-2.13, flink1.20, spark4.2, spark4.2.0)
           - integration-tests (spark3.5, flink2.1, spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz)
   collaborators:
     - ad1happy2go

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1176,7 +1176,7 @@ jobs:
           - scalaProfile: 'scala-2.13'
             flinkProfile: 'flink1.20'
             sparkProfile: 'spark4.2'
-            sparkRuntime: 'spark4.2.0-preview4'
+            sparkRuntime: 'spark4.2.0'
 
     steps:
       - if: needs.changes.outputs.relevant == 'true'
@@ -1304,7 +1304,7 @@ jobs:
             flinkAvroVersion: '1.11.4'
             flinkParquetVersion: '1.13.1'
             sparkProfile: 'spark4.2'
-            sparkRuntime: 'spark4.2.0-preview4'
+            sparkRuntime: 'spark4.2.0'
     steps:
       - if: needs.changes.outputs.relevant == 'true'
         uses: actions/checkout@v5

--- a/.github/workflows/release_candidate_validation.yml
+++ b/.github/workflows/release_candidate_validation.yml
@@ -82,6 +82,10 @@ jobs:
             flinkProfile: 'flink1.20'
             sparkProfile: 'spark4.1'
             sparkRuntime: 'spark4.1.1'
+          - scalaProfile: 'scala-2.13'
+            flinkProfile: 'flink1.20'
+            sparkProfile: 'spark4.2'
+            sparkRuntime: 'spark4.2.0'
     steps:
       - uses: actions/checkout@v5
       - name: Set up JDK 17

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark4Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark4Analysis.scala
@@ -18,9 +18,10 @@
 package org.apache.spark.sql.hudi.analysis
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.analysis.{ResolveInsertionBase, TableOutputResolver}
+import org.apache.spark.sql.catalyst.analysis.ResolveInsertionBase
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.plans.logical.InsertIntoStatement
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, LogicalPlan}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.PreprocessTableInsertion
@@ -54,6 +55,17 @@ import org.apache.spark.sql.util.PartitioningUtils.normalizePartitionSpec
  * case-class shapes of [[InsertIntoStatement]].
  */
 abstract class HoodieSpark4ResolveColumnsForInsertInto extends ResolveInsertionBase {
+
+  /**
+   * Resolves the query output against the table schema, filling any user-omitted column with its
+   * default value. Spark 4.2 GA replaced the boolean `supportColDefaultValue` flag of
+   * `TableOutputResolver.resolveOutputColumns` with a `defaultValueFillMode` enum, so the call
+   * itself lives in the per-version subclasses.
+   */
+  protected def resolveOutputColumns(tblName: String,
+                                     expectedColumns: Seq[Attribute],
+                                     query: LogicalPlan,
+                                     byName: Boolean): LogicalPlan
 
   protected def preprocess(insert: InsertIntoStatement,
                            catalogTable: Option[CatalogTable]): InsertIntoStatement = {
@@ -100,13 +112,11 @@ abstract class HoodieSpark4ResolveColumnsForInsertInto extends ResolveInsertionB
       insert.query
     }
     val newQuery = try {
-      TableOutputResolver.resolveOutputColumns(
+      resolveOutputColumns(
         tblName,
         expectedColumns,
         query,
-        byName = hasColumnList || insert.byName,
-        conf,
-        supportColDefaultValue = true)
+        byName = hasColumnList || insert.byName)
     } catch {
       case e: AnalysisException if staticPartCols.nonEmpty &&
         (e.getErrorClass == "INSERT_COLUMN_ARITY_MISMATCH.NOT_ENOUGH_DATA_COLUMNS" ||

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark40Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark40Analysis.scala
@@ -21,7 +21,9 @@ import org.apache.hudi.{DefaultSource, EmptyRelation, HoodieBaseRelation}
 import org.apache.hudi.SparkAdapterSupport.sparkAdapter
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.TableOutputResolver
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
@@ -101,4 +103,11 @@ case class HoodieSpark40ResolveColumnsForInsertInto() extends HoodieSpark4Resolv
       case _ => plan
     }
   }
+
+  override protected def resolveOutputColumns(tblName: String,
+                                              expectedColumns: Seq[Attribute],
+                                              query: LogicalPlan,
+                                              byName: Boolean): LogicalPlan =
+    TableOutputResolver.resolveOutputColumns(
+      tblName, expectedColumns, query, byName, conf, supportColDefaultValue = true)
 }

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark41Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark41Analysis.scala
@@ -21,7 +21,9 @@ import org.apache.hudi.{DefaultSource, EmptyRelation, HoodieBaseRelation}
 import org.apache.hudi.SparkAdapterSupport.sparkAdapter
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.TableOutputResolver
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
@@ -101,4 +103,11 @@ case class HoodieSpark41ResolveColumnsForInsertInto() extends HoodieSpark4Resolv
       case _ => plan
     }
   }
+
+  override protected def resolveOutputColumns(tblName: String,
+                                              expectedColumns: Seq[Attribute],
+                                              query: LogicalPlan,
+                                              byName: Boolean): LogicalPlan =
+    TableOutputResolver.resolveOutputColumns(
+      tblName, expectedColumns, query, byName, conf, supportColDefaultValue = true)
 }

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/hudi/Spark42HoodiePartitionValues.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/hudi/Spark42HoodiePartitionValues.scala
@@ -20,7 +20,7 @@
 package org.apache.hudi
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.unsafe.types.{GeographyVal, GeometryVal}
+import org.apache.spark.unsafe.types.BinaryView
 
 case class Spark42HoodiePartitionValues(override val values: InternalRow)
   extends Spark4HoodiePartitionValues(values) {
@@ -29,11 +29,7 @@ case class Spark42HoodiePartitionValues(override val values: InternalRow)
     Spark42HoodiePartitionValues(values.copy())
   }
 
-  override def getGeography(ordinal: Int): GeographyVal = {
-    values.getGeography(ordinal)
-  }
-
-  override def getGeometry(ordinal: Int): GeometryVal = {
-    values.getGeometry(ordinal)
+  override def getBinaryView(ordinal: Int): BinaryView = {
+    values.getBinaryView(ordinal)
   }
 }

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/hudi/client/model/Spark42HoodieInternalRow.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/hudi/client/model/Spark42HoodieInternalRow.scala
@@ -19,7 +19,7 @@
 package org.apache.hudi.client.model
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.unsafe.types.{GeographyVal, GeometryVal, UTF8String}
+import org.apache.spark.unsafe.types.{BinaryView, UTF8String}
 
 class Spark42HoodieInternalRow(
     metaFields: Array[UTF8String],
@@ -27,14 +27,9 @@ class Spark42HoodieInternalRow(
     sourceContainsMetaFields: Boolean)
   extends Spark4HoodieInternalRow(metaFields, sourceRow, sourceContainsMetaFields) {
 
-  override def getGeography(ordinal: Int): GeographyVal = {
-    ruleOutMetaFieldsAccess(ordinal, classOf[GeographyVal])
-    sourceRow.getGeography(rebaseOrdinal(ordinal))
-  }
-
-  override def getGeometry(ordinal: Int): GeometryVal = {
-    ruleOutMetaFieldsAccess(ordinal, classOf[GeometryVal])
-    sourceRow.getGeometry(rebaseOrdinal(ordinal))
+  override def getBinaryView(ordinal: Int): BinaryView = {
+    ruleOutMetaFieldsAccess(ordinal, classOf[BinaryView])
+    sourceRow.getBinaryView(rebaseOrdinal(ordinal))
   }
 
   override protected def newInternalRow(metaFields: Array[UTF8String],

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark42Analysis.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/hudi/analysis/HoodieSpark42Analysis.scala
@@ -21,7 +21,9 @@ import org.apache.hudi.{DefaultSource, EmptyRelation, HoodieBaseRelation}
 import org.apache.hudi.SparkAdapterSupport.sparkAdapter
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.TableOutputResolver
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
@@ -101,4 +103,12 @@ case class HoodieSpark42ResolveColumnsForInsertInto() extends HoodieSpark4Resolv
       case _ => plan
     }
   }
+
+  override protected def resolveOutputColumns(tblName: String,
+                                              expectedColumns: Seq[Attribute],
+                                              query: LogicalPlan,
+                                              byName: Boolean): LogicalPlan =
+    TableOutputResolver.resolveOutputColumns(
+      tblName, expectedColumns, query, byName, conf,
+      defaultValueFillMode = TableOutputResolver.DefaultValueFillMode.FILL)
 }

--- a/packaging/bundle-validation/base/build_flink1200hive313spark420scala213.sh
+++ b/packaging/bundle-validation/base/build_flink1200hive313spark420scala213.sh
@@ -20,10 +20,10 @@
 docker build \
  --build-arg HIVE_VERSION=3.1.3 \
  --build-arg FLINK_VERSION=1.20.1 \
- --build-arg SPARK_VERSION=4.2.0-preview4 \
+ --build-arg SPARK_VERSION=4.2.0 \
  --build-arg SPARK_HADOOP_VERSION=3 \
- --build-arg HADOOP_VERSION=3.4.3 \
+ --build-arg HADOOP_VERSION=3.5.0 \
  --build-arg SCALA_VERSION=2.13 \
  --build-arg DERBY_VERSION=10.16.1.1 \
- -t hudi-ci-bundle-validation-base:flink1200hive313spark420previewscala213 .
-docker image tag hudi-ci-bundle-validation-base:flink1200hive313spark420previewscala213 apachehudi/hudi-ci-bundle-validation-base:flink1200hive313spark420previewscala213
+ -t hudi-ci-bundle-validation-base:flink1200hive313spark420scala213 .
+docker image tag hudi-ci-bundle-validation-base:flink1200hive313spark420scala213 apachehudi/hudi-ci-bundle-validation-base:flink1200hive313spark420scala213

--- a/packaging/bundle-validation/ci_run.sh
+++ b/packaging/bundle-validation/ci_run.sh
@@ -147,16 +147,16 @@ elif [[ ${SPARK_RUNTIME} == 'spark4.1.1' && ${SCALA_PROFILE} == 'scala-2.13' ]];
   CONFLUENT_VERSION=5.5.12
   KAFKA_CONNECT_HDFS_VERSION=10.1.13
   IMAGE_TAG=flink1200hive313spark411scala213
-elif [[ ${SPARK_RUNTIME} == 'spark4.2.0-preview4' && ${SCALA_PROFILE} == 'scala-2.13' ]]; then
-  HADOOP_VERSION=3.4.3
+elif [[ ${SPARK_RUNTIME} == 'spark4.2.0' && ${SCALA_PROFILE} == 'scala-2.13' ]]; then
+  HADOOP_VERSION=3.5.0
   HIVE_VERSION=3.1.3
   DERBY_VERSION=10.14.1.0
   FLINK_VERSION=1.20.1
-  SPARK_VERSION=4.2.0-preview4
+  SPARK_VERSION=4.2.0
   SPARK_HADOOP_VERSION=3
   CONFLUENT_VERSION=5.5.12
   KAFKA_CONNECT_HDFS_VERSION=10.1.13
-  IMAGE_TAG=flink1200hive313spark420previewscala213
+  IMAGE_TAG=flink1200hive313spark420scala213
 fi
 
 # Copy bundle jars to temp dir for mounting

--- a/packaging/bundle-validation/run_docker_java17.sh
+++ b/packaging/bundle-validation/run_docker_java17.sh
@@ -103,16 +103,16 @@ elif [[ ${SPARK_RUNTIME} == 'spark4.1.1' && ${SCALA_PROFILE} == 'scala-2.13' ]];
   CONFLUENT_VERSION=5.5.12
   KAFKA_CONNECT_HDFS_VERSION=10.1.13
   IMAGE_TAG=flink1200hive313spark411scala213
-elif [[ ${SPARK_RUNTIME} == 'spark4.2.0-preview4' && ${SCALA_PROFILE} == 'scala-2.13' ]]; then
-  HADOOP_VERSION=3.4.3
+elif [[ ${SPARK_RUNTIME} == 'spark4.2.0' && ${SCALA_PROFILE} == 'scala-2.13' ]]; then
+  HADOOP_VERSION=3.5.0
   HIVE_VERSION=3.1.3
   DERBY_VERSION=10.14.1.0
   FLINK_VERSION=1.20.1
-  SPARK_VERSION=4.2.0-preview4
+  SPARK_VERSION=4.2.0
   SPARK_HADOOP_VERSION=3
   CONFLUENT_VERSION=5.5.12
   KAFKA_CONNECT_HDFS_VERSION=10.1.13
-  IMAGE_TAG=flink1200hive313spark420previewscala213
+  IMAGE_TAG=flink1200hive313spark420scala213
 fi
 
 # build docker image

--- a/packaging/bundle-validation/validate.sh
+++ b/packaging/bundle-validation/validate.sh
@@ -80,7 +80,7 @@ use_default_java_runtime () {
 test_spark_hadoop_mr_bundles () {
     echo "::warning::validate.sh setting up hive metastore for spark & hadoop-mr bundles validation"
 
-    if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0" ]; then
+    if [[ "$SPARK_VERSION" == 4.* ]]; then
         change_java_runtime_version
     fi
     $DERBY_HOME/bin/startNetworkServer -h 0.0.0.0 &
@@ -112,7 +112,7 @@ test_spark_hadoop_mr_bundles () {
     numRecordsHiveQL=$(cat $hiveqlresultsdir/*.csv | wc -l)
     if [ "$numRecordsHiveQL" -ne 10 ]; then
         echo "::error::validate.sh HiveQL validation failed."
-        if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0" ]; then
+        if [[ "$SPARK_VERSION" == 4.* ]]; then
             echo "::error::validate.sh Debug info for Spark4 validation failure:"
             $HIVE_HOME/bin/beeline --hiveconf hive.input.format=org.apache.hudi.hadoop.HoodieParquetInputFormat \
                       -u jdbc:hive2://localhost:10000/default --showHeader=true --outputformat=csv2 \
@@ -259,7 +259,7 @@ test_metaserver_bundle () {
     java -jar $JARS_DIR/metaserver.jar &
     local METASEVER_PID=$!
 
-    if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0" ]; then
+    if [[ "$SPARK_VERSION" == 4.* ]]; then
             change_java_runtime_version
     fi
     echo "::warning::validate.sh Start hive server"

--- a/packaging/bundle-validation/validate.sh
+++ b/packaging/bundle-validation/validate.sh
@@ -80,7 +80,7 @@ use_default_java_runtime () {
 test_spark_hadoop_mr_bundles () {
     echo "::warning::validate.sh setting up hive metastore for spark & hadoop-mr bundles validation"
 
-    if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0-preview4" ]; then
+    if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0" ]; then
         change_java_runtime_version
     fi
     $DERBY_HOME/bin/startNetworkServer -h 0.0.0.0 &
@@ -112,7 +112,7 @@ test_spark_hadoop_mr_bundles () {
     numRecordsHiveQL=$(cat $hiveqlresultsdir/*.csv | wc -l)
     if [ "$numRecordsHiveQL" -ne 10 ]; then
         echo "::error::validate.sh HiveQL validation failed."
-        if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0-preview4" ]; then
+        if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0" ]; then
             echo "::error::validate.sh Debug info for Spark4 validation failure:"
             $HIVE_HOME/bin/beeline --hiveconf hive.input.format=org.apache.hudi.hadoop.HoodieParquetInputFormat \
                       -u jdbc:hive2://localhost:10000/default --showHeader=true --outputformat=csv2 \
@@ -259,7 +259,7 @@ test_metaserver_bundle () {
     java -jar $JARS_DIR/metaserver.jar &
     local METASEVER_PID=$!
 
-    if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0-preview4" ]; then
+    if [ "$SPARK_VERSION" = "4.0.0" ] || [ "$SPARK_VERSION" = "4.1.1" ] || [ "$SPARK_VERSION" = "4.2.0" ]; then
             change_java_runtime_version
     fi
     echo "::warning::validate.sh Start hive server"

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <spark35.version>3.5.5</spark35.version>
     <spark40.version>4.0.2</spark40.version>
     <spark41.version>4.1.1</spark41.version>
-    <spark42.version>4.2.0-preview4</spark42.version>
+    <spark42.version>4.2.0</spark42.version>
     <hudi.spark.module>hudi-spark3.5.x</hudi.spark.module>
     <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
     <avro.version>1.11.4</avro.version>
@@ -3002,7 +3002,7 @@
         <!-- This glob has to include hudi-spark4-common -->
         <hudi.spark.common.module>hudi-spark4-common</hudi.spark.common.module>
         <scalatest.version>${scalatest.spark4.version}</scalatest.version>
-        <hadoop.version>3.4.3</hadoop.version>
+        <hadoop.version>3.5.0</hadoop.version>
         <kafka.version>3.9.2</kafka.version>
         <hive.storage.version>2.8.1</hive.storage.version>
         <!-- TODO: Enable lance tests on Spark 4.2 -->
@@ -3031,7 +3031,7 @@
              both provide the same net.jpountz.lz4 package so we must use the Spark-provided one
              to avoid classpath conflicts (the newer version adds LZ4BlockInputStream.newBuilder()) -->
         <lz4.groupId>at.yawk.lz4</lz4.groupId>
-        <lz4.version>1.10.4</lz4.version>
+        <lz4.version>1.11.0</lz4.version>
         <skip.hudi-spark2.unit.tests>true</skip.hudi-spark2.unit.tests>
         <skipITs>true</skipITs>
       </properties>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19364

Depends on #19367 (the `.asf.yaml` required-check rename), which must merge first.

Apache Spark 4.2.0 has been officially released (GA). Hudi's `spark4.2` profile currently builds against `4.2.0-preview4` (added in #18621). This PR upgrades the Spark 4.2 dependency to the GA release.

### Summary and Changelog

- `pom.xml` `spark4.2` profile: `spark42.version` `4.2.0-preview4` to `4.2.0`; `hadoop.version` `3.4.3` to `3.5.0`; `lz4.version` (`at.yawk.lz4:lz4-java`) `1.10.4` to `1.11.0`. The hadoop and lz4 bumps match the versions Spark 4.2.0 GA ships, verified by diffing Spark's parent POM (all other transitive versions, Scala/Parquet/ORC/Avro/Jackson/Kafka/Log4j/slf4j/antlr, are unchanged between preview4 and GA).
- Adapted `hudi-spark4-common` and `hudi-spark4.2.x` to source-breaking Catalyst API changes Spark made between preview4 and GA:
  - `TableOutputResolver.resolveOutputColumns` swapped its boolean `supportColDefaultValue` flag for a `defaultValueFillMode` enum. Moved the call into a per-version `resolveOutputColumns` seam on the shared base; 4.0/4.1 pass `supportColDefaultValue = true`, 4.2 passes `defaultValueFillMode = FILL` (the exact equivalent, since the old `true` mapped internally to `FILL`).
  - Spark unified the geospatial physical representation ([SPARK-57058](https://issues.apache.org/jira/browse/SPARK-57058)): the `GeographyVal`/`GeometryVal` byte-wrapper types and the `SpecializedGetters.getGeography`/`getGeometry` accessors were replaced by a single general-purpose `BinaryView`, read via `getBinaryView(int): BinaryView`, for zero-copy reads (mirroring `UTF8String`). GEOMETRY and GEOGRAPHY stay distinct logical types but share one physical layout, so they collapse onto `BinaryView`; the user-facing DataTypes are unchanged, only the physical layer moved. Accordingly, dropped the `getGeography`/`getGeometry` overrides from the Spark 4.2 `InternalRow` and partition-values wrappers and implemented `getBinaryView` instead (the partition-mapping subclasses inherit it).
- CI bundle-validation base image renamed `flink1200hive313spark420previewscala213` to `flink1200hive313spark420scala213`, rebuilt with `SPARK_VERSION=4.2.0` and `HADOOP_VERSION=3.5.0`. The new base image must be published to `apachehudi/hudi-ci-bundle-validation-base` (see #18548 for the process) before the Spark 4.2 CI jobs can go green.
- Spark 4.2 runtime string `spark4.2.0-preview4` to `spark4.2.0` across `ci_run.sh`, `run_docker_java17.sh`, `validate.sh`, and `.github/workflows/bot.yml`. The matching `.asf.yaml` required-status-check rename is split into #19367 and must land first, since `.asf.yaml` `required_status_checks` only take effect from master, so the renamed jobs here cannot satisfy the required checks until master requires the new `spark4.2.0` names.

### Impact

Hudi's Spark 4.2 support now targets the GA release instead of a preview. Behavior on Spark 3.x, 4.0, and 4.1 is unchanged.

### Risk Level

medium. The dependency and CI wiring changes are confined to the version-gated `spark4.2` profile, but the Catalyst source-compatibility changes touch shared `hudi-spark4-common` plus the 4.0/4.1/4.2 adapter modules. They are behavior-preserving: the 4.0/4.1 path relocates an identical call, and the 4.2 `FILL` mapping is the exact equivalent of the old `supportColDefaultValue = true`. Verified locally under JDK 17: `hudi-spark4-common` and the full Spark 4.0, 4.1, and 4.2 datasource plus Spark bundle builds all compile clean; Spark 4.2.0, `hadoop-client-api` 3.5.0, and `lz4-java` 1.11.0 resolve from Maven Central. Full unit tests and bundle/docker validation run in the Spark 4.2 CI matrix (once the base image is published).

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable


