### PR TITLE
[MINOR] Fix invalid Avro FIXED default for proto uint64 in ProtoConversionUtil

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ProtoConversionUtil.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/ProtoConversionUtil.java
@@ -53,6 +53,7 @@ import org.apache.kafka.common.utils.CopyOnWriteMap;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -327,7 +328,13 @@ public class ProtoConversionUtil {
         case SFIXED64:
           return 0;
         case UINT64:
-          return DECIMAL_CONVERSION.toFixed(new BigDecimal(BigInteger.ZERO), fieldSchema.toAvroSchema(), fieldSchema.toAvroSchema().getLogicalType()).bytes();
+          // Avro 1.12 rejects a raw byte[] FIXED default; render the bytes as an ISO-8859-1 String
+          // (1:1 byte-to-char) so the default is textual and passes validateDefault.
+          return new String(
+              DECIMAL_CONVERSION
+                  .toFixed(new BigDecimal(BigInteger.ZERO), fieldSchema.toAvroSchema(), fieldSchema.toAvroSchema().getLogicalType())
+                  .bytes(),
+              StandardCharsets.ISO_8859_1);
         case STRING:
         case BYTES:
           return "";

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestProtoConversionUtil.java
@@ -126,6 +126,24 @@ public class TestProtoConversionUtil {
   }
 
   @Test
+  public void generatedSchemaHasAvroValidFixedDefaults() {
+    // A uint64 field maps to a FIXED "unsigned_long" (size 9); its synthesized default must be a
+    // valid FIXED default, so re-parsing the generated schema with default validation must not throw.
+    for (boolean wrappedPrimitivesAsRecords : new boolean[] {true, false}) {
+      ProtoConversionUtil.SchemaConfig schemaConfig =
+          new ProtoConversionUtil.SchemaConfig(wrappedPrimitivesAsRecords, 2, true);
+      String generatedSchema =
+          ProtoConversionUtil.getSchemaForMessageDescriptor(Sample.getDescriptor(), schemaConfig).toString();
+      Schema reparsed =
+          Assertions.assertDoesNotThrow(
+              () -> new Schema.Parser().setValidateDefaults(true).parse(generatedSchema));
+      Schema unsignedLongSchema = reparsed.getField(PRIMITIVE_UNSIGNED_LONG_FIELD_NAME).schema();
+      Assertions.assertEquals(Schema.Type.FIXED, unsignedLongSchema.getType());
+      Assertions.assertEquals(9, unsignedLongSchema.getFixedSize());
+    }
+  }
+
+  @Test
   public void recursiveSchema_noOverflow() {
     HoodieSchema convertedSchema = new HoodieSchema.Parser().parse(getClass().getClassLoader().getResourceAsStream("schema-provider/proto/parent_schema_recursive_depth_2.avsc"));
     Pair<Parent, GenericRecord> inputAndOutput = createInputOutputForRecursiveSchemaNoOverflow(convertedSchema.toAvroSchema());


### PR DESCRIPTION
### Change Logs

`ProtoConversionUtil` maps a proto `uint64` field to an Avro **FIXED** `unsigned_long` of size 9. When it synthesizes the field default it returned a raw `byte[]`, which Avro renders in the schema JSON as a base64 string (`"AAAAAAAAAAAA"`, 12 chars). Avro 1.11/1.12 tightened `Schema.validateDefault` for FIXED and rejects this because the default length (12) does not equal the fixed size (9):

```
org.apache.avro.AvroTypeException: Invalid default for field <uint64 field>:
  "AAAAAAAAAAAA" not a {"type":"fixed","name":"unsigned_long", ... "size":9, ...}
    at org.apache.avro.Schema.validateDefault(Schema.java)
    at org.apache.avro.Schema$Field.<init>(Schema.java)
    at org.apache.hudi.utilities.sources.helpers.ProtoConversionUtil$AvroSupport.getMessageSchema(...)
```

Any proto schema with a `uint64` field therefore fails schema generation on Avro 1.11+ (e.g. via `ProtoSchemaToAvroSchemaConverter` / a proto schema registry).

Fix: render the fixed bytes as their equivalent ISO-8859-1 String (a 1:1 byte-to-char mapping), so the default is a valid FIXED default of length 9. The default value itself is unchanged. Added a regression test that generates the schema for a proto with a `uint64` field and re-parses it with default validation enabled (the existing tests compare `Schema` objects, and `Schema.equals` ignores field defaults, so the invalid default was not caught).

### Impact

Fixes proto-to-Avro schema generation for any proto containing a `uint64` field when running on Avro 1.11/1.12. No behavior change for existing data (default value unchanged).

### Risk level: low

Localized change to the default synthesized for `uint64` fields, covered by a new regression test.

### Documentation Update

N/A

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
