### PR TITLE
chore(ci): update .asf.yaml required checks for Spark 4.2.0 GA

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -107,14 +107,14 @@ github:
           - validate-bundles (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark3.5, spark3.5.1)
           - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.0, spark4.0.0)
           - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.1, spark4.1.1)
-          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.2, spark4.2.0-preview4)
+          - validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.2, spark4.2.0)
           - validate-bundles-java11 (scala-2.12, flink2.0, 1.11.4, 1.14.4, spark3.5, spark3.5.1)
           - validate-bundles-java11 (scala-2.12, flink2.1, 1.11.4, 1.15.2, spark3.5, spark3.5.1)
           - docker-java17-test (scala-2.12, flink2.1, spark3.5, spark3.5.0)
           - docker-java17-test (scala-2.13, flink2.1, spark3.5, spark3.5.0)
           - docker-java17-test (scala-2.13, flink2.1, spark4.0, spark4.0.0)
           - docker-java17-test (scala-2.13, flink2.1, spark4.1, spark4.1.1)
-          - docker-java17-test (scala-2.13, flink1.20, spark4.2, spark4.2.0-preview4)
+          - docker-java17-test (scala-2.13, flink1.20, spark4.2, spark4.2.0)
           - integration-tests (spark3.5, flink2.1, spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz)
   collaborators:
     - ad1happy2go


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

issue: #19364

Split out of #19365 (Spark 4.2.0 GA dependency upgrade). `.asf.yaml` `required_status_checks` only take effect once merged to master, so the Spark 4.2 job rename in #19365 (`spark4.2.0-preview4` to `spark4.2.0`) cannot pass while master still requires the old check names. This PR updates those required-check names first so #19365 can go green once it lands.

### Summary and Changelog

Rename the two Spark 4.2 required status checks from `spark4.2.0-preview4` to `spark4.2.0`:
- `validate-bundle-spark4 (scala-2.13, flink1.20, 1.11.4, 1.13.1, spark4.2, spark4.2.0)`
- `docker-java17-test (scala-2.13, flink1.20, spark4.2, spark4.2.0)`

### Impact

No build impact. After this merges, master requires the `spark4.2.0` check names; the matrix job rename that actually produces those checks lands in #19365.

### Risk Level

low. `.asf.yaml`-only change to two required-status-check names.

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
