### PR TITLE
fix(hive-sync): drop the unreachable HMS lock timeout-recovery path

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/transaction/lock/HiveMetastoreBasedLockProvider.java
@@ -215,29 +215,15 @@ public class HiveMetastoreBasedLockProvider implements LockProvider<LockResponse
 
   private void acquireLockInternal(long time, TimeUnit unit, LockComponent lockComponent)
       throws InterruptedException, ExecutionException, TimeoutException, TException {
-    LockRequest lockRequest = null;
     lockLostRemotely = false;
     try {
       // TODO : FIX:Using the parameterized constructor throws MethodNotFound
       final LockRequestBuilder builder = new LockRequestBuilder();
-      lockRequest = builder.addLockComponent(lockComponent).setUser(System.getProperty("user.name")).build();
+      final LockRequest lockRequest = builder.addLockComponent(lockComponent).setUser(System.getProperty("user.name")).build();
       lockRequest.setUserIsSet(true);
-      final LockRequest lockRequestFinal = lockRequest;
-      this.lock = executor.submit(() -> hiveClient.lock(lockRequestFinal))
+      this.lock = executor.submit(() -> hiveClient.lock(lockRequest))
           .get(time, unit);
       scheduleHeartbeat();
-    } catch (InterruptedException | TimeoutException e) {
-      if (this.lock == null || this.lock.getState() != LockState.ACQUIRED) {
-        LockResponse lockResponse = this.hiveClient.checkLock(lockRequest.getTxnid());
-        if (lockResponse.getState() == LockState.ACQUIRED) {
-          this.lock = lockResponse;
-          // The lock was granted server-side even though the client timed out waiting on the
-          // future; it still needs a heartbeat, otherwise a long-running commit lets HMS expire it.
-          scheduleHeartbeat();
-        } else {
-          throw e;
-        }
-      }
     } finally {
       // it is better to release WAITING lock, otherwise hive lock will hang forever
       // Snapshot the lock: the heartbeat thread clears it as soon as the metastore reports it gone.

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/transaction/lock/TestHiveMetastoreBasedLockProviderAcquireTimeout.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/transaction/lock/TestHiveMetastoreBasedLockProviderAcquireTimeout.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hive.transaction.lock;
+
+import org.apache.hudi.exception.HoodieLockException;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for what {@link HiveMetastoreBasedLockProvider} reports when the metastore does not
+ * answer a lock request in time, with a mocked {@link IMetaStoreClient} and no live metastore or
+ * ZooKeeper.
+ */
+class TestHiveMetastoreBasedLockProviderAcquireTimeout extends HiveMetastoreBasedLockProviderTestBase {
+
+  private static final long LOCK_ID = 42L;
+  private static final long ACQUIRE_TIMEOUT_MS = 200L;
+
+  @Test
+  void acquireTimeoutIsReportedAsATimeout() throws Exception {
+    IMetaStoreClient client = mock(IMetaStoreClient.class);
+    CountDownLatch metastoreAnswers = new CountDownLatch(1);
+    when(client.lock(any())).thenAnswer(invocation -> {
+      metastoreAnswers.await();
+      return acquiredLock(LOCK_ID);
+    });
+
+    HiveMetastoreBasedLockProvider provider = new HiveMetastoreBasedLockProvider(lockConfiguration, client);
+    try {
+      HoodieLockException thrown = assertThrows(HoodieLockException.class,
+          () -> provider.tryLock(ACQUIRE_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+      // The metastore never answered, and that is what the writer has to be told. Looking the lock
+      // up afterwards cannot help: the request that timed out never returned a lock id.
+      assertInstanceOf(TimeoutException.class, thrown.getCause());
+      verify(client, never()).checkLock(anyLong());
+      assertNull(provider.getLock());
+    } finally {
+      metastoreAnswers.countDown();
+      provider.close();
+    }
+  }
+}

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/transaction/lock/TestHiveMetastoreBasedLockProviderAcquireTimeout.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/transaction/lock/TestHiveMetastoreBasedLockProviderAcquireTimeout.java
@@ -22,6 +22,7 @@ package org.apache.hudi.hive.transaction.lock;
 import org.apache.hudi.exception.HoodieLockException;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.NoSuchLockException;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -31,6 +32,7 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -52,10 +54,16 @@ class TestHiveMetastoreBasedLockProviderAcquireTimeout extends HiveMetastoreBase
   void acquireTimeoutIsReportedAsATimeout() throws Exception {
     IMetaStoreClient client = mock(IMetaStoreClient.class);
     CountDownLatch metastoreAnswers = new CountDownLatch(1);
+    CountDownLatch lockReturned = new CountDownLatch(1);
     when(client.lock(any())).thenAnswer(invocation -> {
       metastoreAnswers.await();
+      lockReturned.countDown();
       return acquiredLock(LOCK_ID);
     });
+    // What a real metastore answers for the txn id 0 that the timed-out request carried. Never
+    // reached now, it is here so that restoring the removed lookup fails this test on the cause of
+    // the exception rather than on a bare NPE from an unstubbed call.
+    when(client.checkLock(anyLong())).thenThrow(new NoSuchLockException("No such lock 0"));
 
     HiveMetastoreBasedLockProvider provider = new HiveMetastoreBasedLockProvider(lockConfiguration, client);
     try {
@@ -71,5 +79,12 @@ class TestHiveMetastoreBasedLockProviderAcquireTimeout extends HiveMetastoreBase
       metastoreAnswers.countDown();
       provider.close();
     }
+
+    // A lock granted after the client gave up is abandoned, not released: the timed-out get() never
+    // assigned it, so neither the acquire path nor close() knows of a lock to unlock or heartbeat.
+    // It stays held at the metastore until hive.txn.timeout reaps it.
+    assertTrue(lockReturned.await(30, TimeUnit.SECONDS));
+    verify(client, never()).unlock(anyLong());
+    verify(client, never()).heartbeat(anyLong(), anyLong());
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19345, point 1. Point 2 of that issue is addressed by #19370.

### Summary and Changelog

An acquire that times out now reports the timeout instead of a misleading `NoSuchLockException`.

- Removed the `catch (InterruptedException | TimeoutException e)` block from `HiveMetastoreBasedLockProvider.acquireLockInternal`. Both exceptions are already declared by the method, so they propagate and `tryLock` wraps the actual `TimeoutException`.
- Collapsed the hoisted `lockRequest` local and its `lockRequestFinal` copy into one final local, since they only existed to feed `checkLock` after the `try` block.
- Added `TestHiveMetastoreBasedLockProviderAcquireTimeout` on top of the shared `HiveMetastoreBasedLockProviderTestBase`: with a mocked `IMetaStoreClient` whose `lock()` never answers, the acquire must fail with `HoodieLockException` caused by `TimeoutException` and must not call `checkLock`. Without this change that test fails with a bare `NullPointerException`.

### Impact

`HoodieLockException` on an acquire timeout is now caused by `TimeoutException` rather than `NoSuchLockException`. No API or configuration change.

### Risk Level

low

The removed code could not execute against a real metastore, so no working behaviour is taken away.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
