### PR TITLE
fix(common): load single archived instant details

### DIFF
--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
@@ -112,6 +112,25 @@ public class TestArchivedTimelineV2 extends HoodieCommonTestHarness {
   }
 
   @Test
+  void testLoadCompletedDetailsForSingleInstant() {
+    String instantTime = "10000001";
+    byte[] commitMetadata = {1, 2, 3};
+    HoodieInstant completed = INSTANT_GENERATOR.createNewInstant(
+        HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, instantTime, "10000002");
+    createTimelineWriter().write(
+        Collections.singletonList(new DummyActiveAction(completed, commitMetadata)),
+        Option.empty(), Option.empty());
+
+    HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline();
+    HoodieInstant archivedInstant = archivedTimeline.firstInstant().get();
+    assertFalse(archivedTimeline.getInstantDetails(archivedInstant).isPresent());
+
+    archivedTimeline.loadCompletedInstantDetailsInMemory(instantTime, instantTime);
+
+    assertArrayEquals(commitMetadata, archivedTimeline.getInstantDetails(archivedInstant).get());
+  }
+
+  @Test
   void getInstantReaderReferencesSelf() {
     HoodieArchivedTimeline timeline = TIMELINE_FACTORY.createArchivedTimeline(metaClient);
     assertSame(timeline, timeline.getInstantReader());

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/common/table/timeline/TestArchivedTimelineV2.java
@@ -26,8 +26,10 @@ import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.engine.LocalTaskContextSupplier;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -46,6 +49,8 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.convertMetadataTo
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
@@ -78,6 +83,35 @@ public class TestArchivedTimelineV2 extends HoodieCommonTestHarness {
   }
 
   @Test
+  void testLoadCompactionDetailsForSingleInstant() {
+    String instantTime = "10000001";
+    byte[] compactionPlan = {1, 2, 3};
+    HoodieInstant completed = INSTANT_GENERATOR.createNewInstant(
+        HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, instantTime, "10000002");
+    ActiveAction activeAction = new DummyActiveAction(completed, new byte[0]) {
+      @Override
+      public String getPendingAction() {
+        return HoodieTimeline.COMPACTION_ACTION;
+      }
+
+      @Override
+      public Option<byte[]> getCompactionPlan(HoodieTableMetaClient metaClient) {
+        return Option.of(compactionPlan);
+      }
+    };
+    createTimelineWriter().write(
+        Collections.singletonList(activeAction), Option.empty(), Option.empty());
+
+    HoodieArchivedTimeline archivedTimeline = metaClient.getArchivedTimeline();
+    HoodieInstant archivedInstant = archivedTimeline.firstInstant().get();
+    assertFalse(archivedTimeline.getInstantDetails(archivedInstant).isPresent());
+
+    archivedTimeline.loadCompactionDetailsInMemory(instantTime);
+
+    assertArrayEquals(compactionPlan, archivedTimeline.getInstantDetails(archivedInstant).get());
+  }
+
+  @Test
   void getInstantReaderReferencesSelf() {
     HoodieArchivedTimeline timeline = TIMELINE_FACTORY.createArchivedTimeline(metaClient);
     assertSame(timeline, timeline.getInstantReader());
@@ -88,12 +122,8 @@ public class TestArchivedTimelineV2 extends HoodieCommonTestHarness {
 
   private void writeArchivedTimeline(int batchSize, long startTs) throws Exception {
     HoodieTestTable testTable = HoodieTestTable.of(this.metaClient);
-    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath(this.metaClient.getBasePath())
-        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
-        .withMarkersType("DIRECT")
-        .build();
+    LSMTimelineWriter writer = createTimelineWriter();
     HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
-    LSMTimelineWriter writer = LSMTimelineWriter.getInstance(writeConfig, new LocalTaskContextSupplier(), metaClient);
     List<ActiveAction> instantBuffer = new ArrayList<>();
     for (int i = 1; i <= 50; i++) {
       long instantTimeTs = startTs + i;
@@ -105,10 +135,18 @@ public class TestArchivedTimelineV2 extends HoodieCommonTestHarness {
       instantBuffer.add(new DummyActiveAction(instant, serializedMetadata));
       if (i % batchSize == 0) {
         // archive 10 instants each time
-        writer.write(instantBuffer, org.apache.hudi.common.util.Option.empty(), org.apache.hudi.common.util.Option.empty());
+        writer.write(instantBuffer, Option.empty(), Option.empty());
         writer.compactAndClean(engineContext);
         instantBuffer.clear();
       }
     }
+  }
+
+  private LSMTimelineWriter createTimelineWriter() {
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath(this.metaClient.getBasePath())
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
+        .withMarkersType("DIRECT")
+        .build();
+    return LSMTimelineWriter.getInstance(writeConfig, new LocalTaskContextSupplier(), metaClient);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
@@ -164,7 +164,7 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
 
   @Override
   public void loadCompletedInstantDetailsInMemory(String startTs, String endTs) {
-    List<HoodieInstant> loadedInstants = loadInstants(new HoodieArchivedTimeline.TimeRangeFilter(startTs, endTs), HoodieArchivedTimeline.LoadMode.METADATA);
+    List<HoodieInstant> loadedInstants = loadInstants(new HoodieArchivedTimeline.ClosedClosedTimeRangeFilter(startTs, endTs), HoodieArchivedTimeline.LoadMode.METADATA);
     appendLoadedInstants(loadedInstants);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/ArchivedTimelineV2.java
@@ -147,7 +147,7 @@ public class ArchivedTimelineV2 extends BaseTimelineV2 implements HoodieArchived
 
   public void loadCompactionDetailsInMemory(String startTs, String endTs) {
     // load compactionPlan
-    List<HoodieInstant> loadedInstants = loadInstants(new HoodieArchivedTimeline.TimeRangeFilter(startTs, endTs), HoodieArchivedTimeline.LoadMode.PLAN,
+    List<HoodieInstant> loadedInstants = loadInstants(new HoodieArchivedTimeline.ClosedClosedTimeRangeFilter(startTs, endTs), HoodieArchivedTimeline.LoadMode.PLAN,
         record -> record.get(ACTION_ARCHIVED_META_FIELD).toString().equals(COMMIT_ACTION)
             && record.get(PLAN_ARCHIVED_META_FIELD) != null
     );


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`ArchivedTimelineV2.loadCompactionDetailsInMemory(String)` delegates to the range overload with identical start and end instants. The range overload previously used `TimeRangeFilter`, whose interval is `(startTs, endTs]`. For a single-instant request, this produced the empty interval `(t, t]`, so the matching archived compaction plan was not loaded. The completed-instant detail loader used the same open-start filter and therefore had the same endpoint inconsistency.

Timeline V1 already treats compaction and completed-detail ranges as closed on both ends. Timeline V2 should provide the same behavior.

### Summary and Changelog

This PR makes archived detail lookup work for a single requested instant in timeline V2.

- Use `ClosedClosedTimeRangeFilter` for V2 compaction-detail loading.
- Use `ClosedClosedTimeRangeFilter` for V2 completed-instant detail loading.
- Preserve inclusive behavior for both endpoints of multi-instant compaction ranges.
- Add end-to-end regression tests that archive compaction and completed-instant details and load them through exact-instant ranges.

### Impact

This is a bug fix with no public API, storage-format, configuration, or performance changes. Timeline V2 callers can now retrieve archived compaction and completed-instant details when the requested range contains a single exact instant.

### Risk Level

Low. The change is limited to the endpoint semantics of the V2 detail filters and aligns them with timeline V1. Regression tests cover the previously failing single-instant paths, and the full `TestArchivedTimelineV2` suite passes.

Validation:

```text
mvn -pl hudi-client/hudi-client-common -am \
  -DskipITs \
  -Dtest=TestArchivedTimelineV2 \
  -Dsurefire.failIfNoSpecifiedTests=false test

Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

### Documentation Update

None. This corrects existing behavior without changing a public API, configuration, or documented user workflow.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
