### PR TITLE
fix(client): fix NPE in schema conflict resolution on commits with null writer schema

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/ConcurrentSchemaEvolutionTableSchemaGetter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/ConcurrentSchemaEvolutionTableSchemaGetter.java
@@ -25,7 +25,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.TimelineLayout;
+import org.apache.hudi.common.table.timeline.InstantComparator;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.common.util.Option;
@@ -60,6 +60,8 @@ class ConcurrentSchemaEvolutionTableSchemaGetter {
 
   private final Lazy<ConcurrentHashMap<HoodieInstant, HoodieSchema>> tableSchemaCache;
 
+  private final InstantComparator instantComparator;
+
   private Option<HoodieInstant> latestCommitWithValidSchema = Option.empty();
 
   @VisibleForTesting
@@ -69,8 +71,16 @@ class ConcurrentSchemaEvolutionTableSchemaGetter {
 
   public ConcurrentSchemaEvolutionTableSchemaGetter(HoodieTableMetaClient metaClient) {
     this.metaClient = metaClient;
+    this.instantComparator = metaClient.getTimelineLayout().getInstantComparator();
     // Unbounded sized map. Should replace with some caching library.
     this.tableSchemaCache = Lazy.lazily(ConcurrentHashMap::new);
+  }
+
+  /**
+   * Returns the timestamp ordering the instant in the schema evolution timeline.
+   */
+  String getOrderingTime(HoodieInstant instant) {
+    return instantComparator.getOrderingTime(instant);
   }
 
   /**
@@ -160,9 +170,11 @@ class ConcurrentSchemaEvolutionTableSchemaGetter {
     // the timeline finding a completed instant containing a valid schema.
     ConcurrentHashMap<HoodieInstant, HoodieSchema> tableSchemaAtInstant = new ConcurrentHashMap<>();
     Option<HoodieInstant> instantWithTableSchema = Option.fromJavaOptional(reversedTimelineStream
-        // If a completion time is specified, find the first eligible instant in the schema evolution timeline.
-        // Should switch to completion time based.
-        .filter(s -> instant.isEmpty() || compareTimestamps(s.getCompletionTime(), LESSER_THAN_OR_EQUALS, instant.get().getCompletionTime()))
+        // Find the first eligible instant whose ordering time is no later than the target instant's;
+        // a target instant without an ordering time (not completed yet, on table version 8 and above)
+        // does not bound the lookup.
+        .filter(s -> instant.isEmpty() || StringUtils.isNullOrEmpty(getOrderingTime(instant.get()))
+            || compareTimestamps(getOrderingTime(s), LESSER_THAN_OR_EQUALS, getOrderingTime(instant.get())))
         // Make sure the commit metadata has a valid schema inside. Same caching the result for expensive operation.
         .filter(s -> {
           try {
@@ -193,6 +205,8 @@ class ConcurrentSchemaEvolutionTableSchemaGetter {
 
   /**
    * Get timeline in REVERSE order that only contains completed instants which POTENTIALLY evolve the table schema.
+   * The stream follows the timeline layout's instant ordering, newest first (completion time for
+   * layout v2, requested time for v1).
    * For types of instants that are included and not reflecting table schema at their instant completion time please refer
    * comments inside the code.
    */
@@ -214,9 +228,7 @@ class ConcurrentSchemaEvolutionTableSchemaGetter {
     }
 
     // We only care committed instant when it comes to table schema.
-    TimelineLayout timelineLayout = metaClient.getTimelineLayout();
-    // Table schema getter is completion time based ordering.
-    Comparator<HoodieInstant> reversedComparator = timelineLayout.getInstantComparator().completionTimeOrderedComparator().reversed();
+    Comparator<HoodieInstant> reversedComparator = instantComparator.orderingComparator().reversed();
 
     // The timeline still contains DELTA_COMMIT_ACTION/COMMIT_ACTION which might not contain a valid schema
     // field in their commit metadata.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleSchemaConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/SimpleSchemaConflictResolutionStrategy.java
@@ -30,8 +30,6 @@ import org.apache.hudi.table.HoodieTable;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.stream.Stream;
-
 import static org.apache.hudi.client.transaction.SchemaConflictResolutionStrategy.throwConcurrentSchemaEvolutionException;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMPACTION_ACTION;
 import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
@@ -77,7 +75,7 @@ public class SimpleSchemaConflictResolutionStrategy implements SchemaConflictRes
     // schema and writer schema.
     HoodieInstant lastCompletedInstantAtTxnStart = lastCompletedTxnOwnerInstant.isPresent()
         ? getInstantInTimelineImmediatelyPriorToTimestamp(
-        lastCompletedTxnOwnerInstant.get().getCompletionTime(), schemaResolver.computeSchemaEvolutionTimelineInReverseOrder()).orElse(null)
+        schemaResolver.getOrderingTime(lastCompletedTxnOwnerInstant.get()), schemaResolver).orElse(null)
         : null;
     // If lastCompletedInstantAtTxnValidation is null there are 2 possibilities:
     // - No committed txn at validation starts
@@ -157,9 +155,9 @@ public class SimpleSchemaConflictResolutionStrategy implements SchemaConflictRes
   }
 
   private Option<HoodieInstant> getInstantInTimelineImmediatelyPriorToTimestamp(
-      String timestamp, Stream<HoodieInstant> reverseOrderTimeline) {
-    return Option.fromJavaOptional(reverseOrderTimeline
-        .filter(s -> compareTimestamps(s.getCompletionTime(), LESSER_THAN_OR_EQUALS, timestamp))
+      String timestamp, ConcurrentSchemaEvolutionTableSchemaGetter schemaResolver) {
+    return Option.fromJavaOptional(schemaResolver.computeSchemaEvolutionTimelineInReverseOrder()
+        .filter(s -> compareTimestamps(schemaResolver.getOrderingTime(s), LESSER_THAN_OR_EQUALS, timestamp))
         .findFirst());
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConcurrentSchemaEvolutionTableSchemaGetter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConcurrentSchemaEvolutionTableSchemaGetter.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.table.timeline.versioning.clean.CleanPlanV2MigrationHandler;
 import org.apache.hudi.common.testutils.HoodieCommonTestHarness;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
@@ -52,6 +53,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -70,6 +76,7 @@ import static org.apache.hudi.common.testutils.FileCreateUtils.createRequestedDe
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.apache.hudi.common.util.CommitUtils.buildMetadata;
+import static org.apache.hudi.config.HoodieWriteConfig.WRITE_TABLE_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -403,6 +410,76 @@ public class TestConcurrentSchemaEvolutionTableSchemaGetter extends HoodieCommon
         includeMetadataFields, Option.of(instant)).get());
   }
 
+  @Test
+  void testTableVersionEightAndAboveOrdersByCompletionTime() throws Exception {
+    metaClient = HoodieTestUtils.getMetaClientBuilder(HoodieTableType.COPY_ON_WRITE, new Properties(), "")
+        .initTable(getDefaultStorageConf(), basePath);
+    // The ordering is driven by the timeline layout version.
+    assertEquals(TimelineLayoutVersion.VERSION_2, metaClient.getTimelineLayoutVersion().getVersion());
+    testTable = HoodieTestTable.of(metaClient);
+
+    // Completion order inverts requested order: requested 001 completes last (at 100) with
+    // schema 2, requested 009 completes first (at 050) with schema 1.
+    testTable.addCommit("001", Option.of("100"), Option.of(buildMetadata(
+        Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UNKNOWN,
+        SCHEMA_WITHOUT_METADATA_STR2, COMMIT_ACTION)));
+    testTable.addCommit("009", Option.of("050"), Option.of(buildMetadata(
+        Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UNKNOWN,
+        SCHEMA_WITHOUT_METADATA_STR, COMMIT_ACTION)));
+
+    ConcurrentSchemaEvolutionTableSchemaGetter resolver = new ConcurrentSchemaEvolutionTableSchemaGetter(metaClient);
+    // The latest table schema follows completion time: schema 2 of requested 001, completed 100.
+    assertEquals(SCHEMA_WITHOUT_METADATA2.toString(),
+        resolver.getTableSchemaIfPresent(false, Option.empty()).get().toString());
+    // A target completed at 075 only sees the commit completed at 050 (requested 009, schema 1).
+    assertEquals(SCHEMA_WITHOUT_METADATA.toString(),
+        resolver.getTableSchemaIfPresent(false,
+            Option.of(metaClient.getInstantGenerator().createNewInstant(
+                HoodieInstant.State.COMPLETED, COMMIT_ACTION, "005", "075"))).get().toString());
+  }
+
+  @Test
+  void testTableVersionSixOrdersByRequestedTime() throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty(WRITE_TABLE_VERSION.key(), "6");
+    metaClient = HoodieTestUtils.getMetaClientBuilder(HoodieTableType.COPY_ON_WRITE, properties, "")
+        .initTable(getDefaultStorageConf(), basePath);
+    // The ordering is driven by the timeline layout version.
+    assertEquals(TimelineLayoutVersion.VERSION_1, metaClient.getTimelineLayoutVersion().getVersion());
+    testTable = HoodieTestTable.of(metaClient);
+
+    // Same layout as the table-version-8 test: requested 001 carries schema 2, requested 009
+    // carries schema 1. The completion times below are ignored by the table-version-6
+    // (timeline layout v1) instant file naming.
+    testTable.addCommit("001", Option.of("100"), Option.of(buildMetadata(
+        Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UNKNOWN,
+        SCHEMA_WITHOUT_METADATA_STR2, COMMIT_ACTION)));
+    testTable.addCommit("009", Option.of("050"), Option.of(buildMetadata(
+        Collections.emptyList(), Collections.emptyMap(), Option.empty(), WriteOperationType.UNKNOWN,
+        SCHEMA_WITHOUT_METADATA_STR, COMMIT_ACTION)));
+    // Invert the file modification times so that the mtime-derived completion order disagrees
+    // with the requested order, mirroring the table-version-8 fixture above.
+    Path timelinePath = Paths.get(metaClient.getTimelinePath().makeQualified(new URI("file:///")).toUri());
+    Files.setLastModifiedTime(timelinePath.resolve("001.commit"), FileTime.fromMillis(2_000_000_000_000L));
+    Files.setLastModifiedTime(timelinePath.resolve("009.commit"), FileTime.fromMillis(1_000_000_000_000L));
+    metaClient.reloadActiveTimeline();
+
+    ConcurrentSchemaEvolutionTableSchemaGetter resolver = new ConcurrentSchemaEvolutionTableSchemaGetter(metaClient);
+    // The latest table schema follows requested time (schema 1 of requested 009), not the
+    // mtime-derived completion order which would pick schema 2 of requested 001.
+    assertEquals(SCHEMA_WITHOUT_METADATA.toString(),
+        resolver.getTableSchemaIfPresent(false, Option.empty()).get().toString());
+    // An inflight target bounds the lookup by its requested time.
+    assertEquals(SCHEMA_WITHOUT_METADATA2.toString(),
+        resolver.getTableSchemaIfPresent(false,
+            Option.of(metaClient.getInstantGenerator().createNewInstant(
+                HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "005"))).get().toString());
+    assertEquals(SCHEMA_WITHOUT_METADATA.toString(),
+        resolver.getTableSchemaIfPresent(false,
+            Option.of(metaClient.getInstantGenerator().createNewInstant(
+                HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "999"))).get().toString());
+  }
+
   private static Stream<Arguments> partitionColumnSchemaTestParams() {
     return Stream.of(
         Arguments.of(false, SCHEMA_WITHOUT_METADATA),    // Schema with metadata fields, don't include metadata
@@ -527,6 +604,18 @@ public class TestConcurrentSchemaEvolutionTableSchemaGetter extends HoodieCommon
         Option.of(metaClient.getInstantGenerator().createNewInstant(HoodieInstant.State.COMPLETED, COMMIT_ACTION, timestamp2, incTimestampStrByOne(timestamp2))));
     assertTrue(schema2Option.isPresent());
     assertEquals(schema2.toString(), schema2Option.get().toString());
+
+    // A target instant without a completion time (e.g., an inflight instant at pre-commit time)
+    // does not bound the lookup; the latest table schema is returned.
+    String inflightTimestamp = padWithLeadingZeros(Integer.toString(startCommitTime), REQUEST_TIME_LENGTH);
+    Option<HoodieSchema> schemaAtInstantWithoutCompletionTime = resolver.getTableSchemaIfPresent(
+        false,
+        Option.of(metaClient.getInstantGenerator().createNewInstant(
+            HoodieInstant.State.INFLIGHT,
+            tableType.equals(HoodieTableType.COPY_ON_WRITE) ? COMMIT_ACTION : DELTA_COMMIT_ACTION,
+            inflightTimestamp)));
+    assertTrue(schemaAtInstantWithoutCompletionTime.isPresent());
+    assertEquals(schema2.toString(), schemaAtInstantWithoutCompletionTime.get().toString());
 
     // Now follow with more disqualified instants and try to get table schema with their request time, we should back track to instant 2.
     int endCommitTime = createExhaustiveDisqualifiedInstants(startCommitTime, tableType);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConcurrentSchemaEvolutionTableSchemaGetter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestConcurrentSchemaEvolutionTableSchemaGetter.java
@@ -61,7 +61,9 @@ import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.HoodieTableConfig.PARTITION_FIELDS;
@@ -463,6 +465,12 @@ public class TestConcurrentSchemaEvolutionTableSchemaGetter extends HoodieCommon
     Files.setLastModifiedTime(timelinePath.resolve("001.commit"), FileTime.fromMillis(2_000_000_000_000L));
     Files.setLastModifiedTime(timelinePath.resolve("009.commit"), FileTime.fromMillis(1_000_000_000_000L));
     metaClient.reloadActiveTimeline();
+
+    // The mtime inversion must stick, otherwise the assertions below also hold under completion-time
+    // ordering and the test would pass against unfixed code.
+    Map<String, String> completionTimeByRequestedTime = metaClient.getActiveTimeline().getInstantsAsStream()
+        .collect(Collectors.toMap(HoodieInstant::requestedTime, HoodieInstant::getCompletionTime));
+    assertTrue(completionTimeByRequestedTime.get("001").compareTo(completionTimeByRequestedTime.get("009")) > 0);
 
     ConcurrentSchemaEvolutionTableSchemaGetter resolver = new ConcurrentSchemaEvolutionTableSchemaGetter(metaClient);
     // The latest table schema follows requested time (schema 1 of requested 009), not the

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleSchemaConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleSchemaConflictResolutionStrategy.java
@@ -60,6 +60,7 @@ import static org.apache.hudi.common.testutils.HoodieCommonTestHarness.incTimest
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.apache.hudi.common.util.CommitUtils.buildMetadata;
 import static org.apache.hudi.config.HoodieWriteConfig.ENABLE_SCHEMA_CONFLICT_RESOLUTION;
+import static org.apache.hudi.config.HoodieWriteConfig.WRITE_TABLE_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -93,7 +94,14 @@ public class TestSimpleSchemaConflictResolutionStrategy {
 
   private void setupInstants(String tableSchemaAtTxnStart, String tableSchemaAtTxnValidation,
                              String writerSchemaOfTxn, Boolean enableResolution, boolean setupLegacyClustering) throws Exception {
-    metaClient = HoodieTestUtils.getMetaClientBuilder(HoodieTableType.COPY_ON_WRITE, new Properties(), "")
+    setupInstants(tableSchemaAtTxnStart, tableSchemaAtTxnValidation, writerSchemaOfTxn,
+        enableResolution, setupLegacyClustering, new Properties());
+  }
+
+  private void setupInstants(String tableSchemaAtTxnStart, String tableSchemaAtTxnValidation,
+                             String writerSchemaOfTxn, Boolean enableResolution, boolean setupLegacyClustering,
+                             Properties tableProperties) throws Exception {
+    metaClient = HoodieTestUtils.getMetaClientBuilder(HoodieTableType.COPY_ON_WRITE, tableProperties, "")
         .setTableCreateSchema(SCHEMA1)
         .initTable(getDefaultStorageConf(), basePath.toString());
     dummyInstantGenerator = HoodieTestTable.of(metaClient);
@@ -154,6 +162,66 @@ public class TestSimpleSchemaConflictResolutionStrategy {
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).get();
     assertEquals(HoodieSchema.parse(SCHEMA1), result);
+  }
+
+  @Test
+  void testNullTypeWriterSchemaCurrTxnInstantWithoutCompletionTime() throws Exception {
+    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false);
+    // At pre-commit time the curr txn owner instant is inflight and has no completion time;
+    // on table version 8 and above the resolution falls back to the latest table schema.
+    Option<HoodieInstant> currTxnOwnerInstant = Option.of(
+        metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "0040"));
+    HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
+        table, config, lastCompletedTxnOwnerInstant, currTxnOwnerInstant).get();
+    assertEquals(HoodieSchema.parse(SCHEMA2), result);
+  }
+
+  @Test
+  void testNullTypeWriterSchemaTableVersionSixBoundedByRequestedTime() throws Exception {
+    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false, tableVersionSixProperties());
+    // Table version 6 orders the schema evolution timeline by requested time: a curr txn owner
+    // instant requested between the two commits adopts the table schema of the earlier commit.
+    Option<HoodieInstant> currTxnOwnerInstant = Option.of(
+        metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "0015"));
+    HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
+        table, config, lastCompletedTxnOwnerInstant, currTxnOwnerInstant).get();
+    assertEquals(HoodieSchema.parse(SCHEMA1), result);
+  }
+
+  @Test
+  void testNullTypeWriterSchemaTableVersionSixAfterAllCommits() throws Exception {
+    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false, tableVersionSixProperties());
+    Option<HoodieInstant> currTxnOwnerInstant = Option.of(
+        metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "0040"));
+    HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
+        table, config, lastCompletedTxnOwnerInstant, currTxnOwnerInstant).get();
+    assertEquals(HoodieSchema.parse(SCHEMA2), result);
+  }
+
+  @Test
+  void testNullTypeWriterSchemaTableVersionSixBeforeAllCommits() throws Exception {
+    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false, tableVersionSixProperties());
+    // No commit is requested at or before the curr txn owner instant, so the lookup falls back
+    // to the table create schema.
+    Option<HoodieInstant> currTxnOwnerInstant = Option.of(
+        metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "0005"));
+    HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
+        table, config, lastCompletedTxnOwnerInstant, currTxnOwnerInstant).get();
+    assertEquals(HoodieSchema.parse(SCHEMA1), result);
+  }
+
+  @Test
+  void testNoConflictBackwardsCompatible1TableVersionSix() throws Exception {
+    setupInstants(SCHEMA1, SCHEMA2, SCHEMA1, true, false, tableVersionSixProperties());
+    HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
+        table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).get();
+    assertEquals(HoodieSchema.parse(SCHEMA2), result);
+  }
+
+  private static Properties tableVersionSixProperties() {
+    Properties properties = new Properties();
+    properties.setProperty(WRITE_TABLE_VERSION.key(), "6");
+    return properties;
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleSchemaConflictResolutionStrategy.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/TestSimpleSchemaConflictResolutionStrategy.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.testutils.HoodieTestTable;
@@ -45,12 +46,17 @@ import org.apache.hudi.table.TestBaseHoodieTable;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.CLUSTERING_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
@@ -93,16 +99,25 @@ public class TestSimpleSchemaConflictResolutionStrategy {
   private static final String NULL_SCHEMA = "{\"type\":\"null\"}";
 
   private void setupInstants(String tableSchemaAtTxnStart, String tableSchemaAtTxnValidation,
-                             String writerSchemaOfTxn, Boolean enableResolution, boolean setupLegacyClustering) throws Exception {
-    setupInstants(tableSchemaAtTxnStart, tableSchemaAtTxnValidation, writerSchemaOfTxn,
-        enableResolution, setupLegacyClustering, new Properties());
+                             String writerSchemaOfTxn, boolean enableResolution, boolean setupLegacyClustering) throws Exception {
+    setupInstants(SCHEMA1, tableSchemaAtTxnStart, tableSchemaAtTxnValidation, writerSchemaOfTxn,
+        enableResolution, setupLegacyClustering, HoodieTableVersion.current().versionCode());
   }
 
   private void setupInstants(String tableSchemaAtTxnStart, String tableSchemaAtTxnValidation,
-                             String writerSchemaOfTxn, Boolean enableResolution, boolean setupLegacyClustering,
-                             Properties tableProperties) throws Exception {
+                             String writerSchemaOfTxn, boolean enableResolution, boolean setupLegacyClustering,
+                             int writeTableVersion) throws Exception {
+    setupInstants(SCHEMA1, tableSchemaAtTxnStart, tableSchemaAtTxnValidation, writerSchemaOfTxn,
+        enableResolution, setupLegacyClustering, writeTableVersion);
+  }
+
+  private void setupInstants(String tableCreateSchema, String tableSchemaAtTxnStart, String tableSchemaAtTxnValidation,
+                             String writerSchemaOfTxn, boolean enableResolution, boolean setupLegacyClustering,
+                             int writeTableVersion) throws Exception {
+    Properties tableProperties = new Properties();
+    tableProperties.setProperty(WRITE_TABLE_VERSION.key(), String.valueOf(writeTableVersion));
     metaClient = HoodieTestUtils.getMetaClientBuilder(HoodieTableType.COPY_ON_WRITE, tableProperties, "")
-        .setTableCreateSchema(SCHEMA1)
+        .setTableCreateSchema(tableCreateSchema)
         .initTable(getDefaultStorageConf(), basePath.toString());
     dummyInstantGenerator = HoodieTestTable.of(metaClient);
 
@@ -141,24 +156,30 @@ public class TestSimpleSchemaConflictResolutionStrategy {
     strategy = new SimpleSchemaConflictResolutionStrategy();
   }
 
-  @Test
-  void testNoConflictFirstCommit() throws Exception {
-    setupInstants(null, null, SCHEMA1, true, false);
+  // The schema evolution timeline ordering follows the table version (requested time for table
+  // version 6, completion time for 8 and above), so the RFC-82 resolution cases run on both. The
+  // fixture's requested and completion orders agree, so the outcomes are the same on both versions.
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testNoConflictFirstCommit(int writeTableVersion) throws Exception {
+    setupInstants(null, null, SCHEMA1, true, false, writeTableVersion);
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, Option.empty(), nonTableCompactionInstant).get();
     assertEquals(HoodieSchema.parse(SCHEMA1), result);
   }
 
-  @Test
-  void testNullWriterSchema() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA1, "", true, false);
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testNullWriterSchema(int writeTableVersion) throws Exception {
+    setupInstants(SCHEMA1, SCHEMA1, "", true, false, writeTableVersion);
     assertFalse(strategy.resolveConcurrentSchemaEvolution(
         table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).isPresent());
   }
 
-  @Test
-  void testNullTypeWriterSchema() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA1, NULL_SCHEMA, true, false);
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testNullTypeWriterSchema(int writeTableVersion) throws Exception {
+    setupInstants(SCHEMA1, SCHEMA1, NULL_SCHEMA, true, false, writeTableVersion);
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).get();
     assertEquals(HoodieSchema.parse(SCHEMA1), result);
@@ -166,7 +187,7 @@ public class TestSimpleSchemaConflictResolutionStrategy {
 
   @Test
   void testNullTypeWriterSchemaCurrTxnInstantWithoutCompletionTime() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false);
+    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false, 8);
     // At pre-commit time the curr txn owner instant is inflight and has no completion time;
     // on table version 8 and above the resolution falls back to the latest table schema.
     Option<HoodieInstant> currTxnOwnerInstant = Option.of(
@@ -176,96 +197,78 @@ public class TestSimpleSchemaConflictResolutionStrategy {
     assertEquals(HoodieSchema.parse(SCHEMA2), result);
   }
 
-  @Test
-  void testNullTypeWriterSchemaTableVersionSixBoundedByRequestedTime() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false, tableVersionSixProperties());
-    // Table version 6 orders the schema evolution timeline by requested time: a curr txn owner
-    // instant requested between the two commits adopts the table schema of the earlier commit.
+  @ParameterizedTest
+  @MethodSource("tableVersionSixNullSchemaCases")
+  void testNullTypeWriterSchemaTableVersionSix(String currTxnInstantTime, String expectedSchema) throws Exception {
+    // Table version 6 orders the schema evolution timeline by requested time, so the curr txn owner
+    // instant's requested time bounds the null-writer-schema lookup. A create schema (SCHEMA3)
+    // distinct from the commit schemas makes the before-all-commits fallback observable.
+    setupInstants(SCHEMA3, SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false, 6);
     Option<HoodieInstant> currTxnOwnerInstant = Option.of(
-        metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "0015"));
+        metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, COMMIT_ACTION, currTxnInstantTime));
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, lastCompletedTxnOwnerInstant, currTxnOwnerInstant).get();
-    assertEquals(HoodieSchema.parse(SCHEMA1), result);
+    assertEquals(HoodieSchema.parse(expectedSchema), result);
   }
 
-  @Test
-  void testNullTypeWriterSchemaTableVersionSixAfterAllCommits() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false, tableVersionSixProperties());
-    Option<HoodieInstant> currTxnOwnerInstant = Option.of(
-        metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "0040"));
-    HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
-        table, config, lastCompletedTxnOwnerInstant, currTxnOwnerInstant).get();
-    assertEquals(HoodieSchema.parse(SCHEMA2), result);
+  private static Stream<Arguments> tableVersionSixNullSchemaCases() {
+    return Stream.of(
+        // curr txn requested between the two commits: adopt the earlier commit's schema
+        Arguments.of("0015", SCHEMA1),
+        // curr txn requested after all commits: adopt the latest commit's schema
+        Arguments.of("0040", SCHEMA2),
+        // curr txn requested before all commits: fall back to the table create schema
+        Arguments.of("0005", SCHEMA3));
   }
 
-  @Test
-  void testNullTypeWriterSchemaTableVersionSixBeforeAllCommits() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA2, NULL_SCHEMA, true, false, tableVersionSixProperties());
-    // No commit is requested at or before the curr txn owner instant, so the lookup falls back
-    // to the table create schema.
-    Option<HoodieInstant> currTxnOwnerInstant = Option.of(
-        metaClient.createNewInstant(HoodieInstant.State.INFLIGHT, COMMIT_ACTION, "0005"));
-    HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
-        table, config, lastCompletedTxnOwnerInstant, currTxnOwnerInstant).get();
-    assertEquals(HoodieSchema.parse(SCHEMA1), result);
-  }
-
-  @Test
-  void testNoConflictBackwardsCompatible1TableVersionSix() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA2, SCHEMA1, true, false, tableVersionSixProperties());
-    HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
-        table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).get();
-    assertEquals(HoodieSchema.parse(SCHEMA2), result);
-  }
-
-  private static Properties tableVersionSixProperties() {
-    Properties properties = new Properties();
-    properties.setProperty(WRITE_TABLE_VERSION.key(), "6");
-    return properties;
-  }
-
-  @Test
-  void testConflictSecondCommitDifferentSchema() throws Exception {
-    setupInstants(null, SCHEMA1, SCHEMA2, true, false);
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testConflictSecondCommitDifferentSchema(int writeTableVersion) throws Exception {
+    setupInstants(null, SCHEMA1, SCHEMA2, true, false, writeTableVersion);
     assertThrows(HoodieSchemaEvolutionConflictException.class,
         () -> strategy.resolveConcurrentSchemaEvolution(table, config, Option.empty(), nonTableCompactionInstant));
   }
 
-  @Test
-  void testConflictSecondCommitSameSchema() throws Exception {
-    setupInstants(null, SCHEMA1, SCHEMA1, true, false);
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testConflictSecondCommitSameSchema(int writeTableVersion) throws Exception {
+    setupInstants(null, SCHEMA1, SCHEMA1, true, false, writeTableVersion);
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, Option.empty(), nonTableCompactionInstant).get();
     assertEquals(HoodieSchema.parse(SCHEMA1), result);
   }
 
-  @Test
-  void testNoConflictSameSchema() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA1, SCHEMA1, true, false);
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testNoConflictSameSchema(int writeTableVersion) throws Exception {
+    setupInstants(SCHEMA1, SCHEMA1, SCHEMA1, true, false, writeTableVersion);
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).get();
     assertEquals(HoodieSchema.parse(SCHEMA1), result);
   }
 
-  @Test
-  void testNoConflictBackwardsCompatible1() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA2, SCHEMA1, true, false);
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testNoConflictBackwardsCompatible1(int writeTableVersion) throws Exception {
+    setupInstants(SCHEMA1, SCHEMA2, SCHEMA1, true, false, writeTableVersion);
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).get();
     assertEquals(HoodieSchema.parse(SCHEMA2), result);
   }
 
-  @Test
-  void testNoConflictBackwardsCompatible2() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA1, SCHEMA2, true, false);
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testNoConflictBackwardsCompatible2(int writeTableVersion) throws Exception {
+    setupInstants(SCHEMA1, SCHEMA1, SCHEMA2, true, false, writeTableVersion);
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).get();
     assertEquals(HoodieSchema.parse(SCHEMA2), result);
   }
 
-  @Test
-  void testNoConflictConcurrentEvolutionSameSchema() throws Exception {
-    setupInstants(SCHEMA1, SCHEMA2, SCHEMA2, true, false);
+  @ParameterizedTest
+  @ValueSource(ints = {6, 8})
+  void testNoConflictConcurrentEvolutionSameSchema(int writeTableVersion) throws Exception {
+    setupInstants(SCHEMA1, SCHEMA2, SCHEMA2, true, false, writeTableVersion);
     HoodieSchema result = strategy.resolveConcurrentSchemaEvolution(
         table, config, lastCompletedTxnOwnerInstant, nonTableCompactionInstant).get();
     assertEquals(HoodieSchema.parse(SCHEMA2), result);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/InstantComparator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/InstantComparator.java
@@ -37,4 +37,16 @@ public interface InstantComparator extends Serializable {
    * @return {@link Comparator<HoodieInstant>} that orders primarily based on completion time and secondary ordering based on {@link #requestedTimeOrderedComparator()}.
    */
   Comparator<HoodieInstant> completionTimeOrderedComparator();
+
+  /**
+   * Returns the comparator implementing the instant ordering of this timeline version:
+   * completion-time based for v2, requested-time based for v1.
+   */
+  Comparator<HoodieInstant> orderingComparator();
+
+  /**
+   * Returns the timestamp ordering the given instant in this timeline version: completion time
+   * for v2 (null if the instant is not completed yet), requested time for v1.
+   */
+  String getOrderingTime(HoodieInstant instant);
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/InstantComparator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/InstantComparator.java
@@ -41,6 +41,10 @@ public interface InstantComparator extends Serializable {
   /**
    * Returns the comparator implementing the instant ordering of this timeline version:
    * completion-time based for v2, requested-time based for v1.
+   *
+   * <p>Implementations must keep this consistent with {@link #getOrderingTime(HoodieInstant)},
+   * which returns the primary timestamp this comparator orders by: a timeline walk that sorts by
+   * this comparator and then bounds instants by {@code getOrderingTime} relies on the two agreeing.
    */
   Comparator<HoodieInstant> orderingComparator();
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/InstantComparatorV1.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v1/InstantComparatorV1.java
@@ -74,4 +74,14 @@ public class InstantComparatorV1 implements Serializable, InstantComparator {
   public Comparator<HoodieInstant> completionTimeOrderedComparator() {
     return COMPLETION_TIME_BASED_COMPARATOR;
   }
+
+  @Override
+  public Comparator<HoodieInstant> orderingComparator() {
+    return REQUESTED_TIME_BASED_COMPARATOR;
+  }
+
+  @Override
+  public String getOrderingTime(HoodieInstant instant) {
+    return instant.requestedTime();
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/InstantComparatorV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/InstantComparatorV2.java
@@ -76,6 +76,10 @@ public class InstantComparatorV2 implements Serializable, InstantComparator {
     return COMPLETION_TIME_BASED_COMPARATOR;
   }
 
+  // On tables upgraded from version 6, completion times of instants before the upgrade boundary are
+  // backfilled from the meta file modification time and are not guaranteed durable ordering keys.
+  // This is safe: the upgrade runs a full compaction with no concurrent writers, so those pre-upgrade
+  // completion times no longer affect concurrency or file-slicing decisions.
   @Override
   public String getOrderingTime(HoodieInstant instant) {
     return instant.getCompletionTime();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/InstantComparatorV2.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/versioning/v2/InstantComparatorV2.java
@@ -70,4 +70,14 @@ public class InstantComparatorV2 implements Serializable, InstantComparator {
   public Comparator<HoodieInstant> completionTimeOrderedComparator() {
     return COMPLETION_TIME_BASED_COMPARATOR;
   }
+
+  @Override
+  public Comparator<HoodieInstant> orderingComparator() {
+    return COMPLETION_TIME_BASED_COMPARATOR;
+  }
+
+  @Override
+  public String getOrderingTime(HoodieInstant instant) {
+    return instant.getCompletionTime();
+  }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestInstantComparators.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestInstantComparators.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.common.table.timeline;
 
 import org.apache.hudi.common.table.timeline.versioning.common.InstantComparators;
+import org.apache.hudi.common.table.timeline.versioning.v1.InstantComparatorV1;
 import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TestInstantComparators {
   @Test
@@ -44,6 +46,39 @@ class TestInstantComparators {
     List<HoodieInstant> instants = Arrays.asList(instant5, instant3, instant1, instant4, instant2);
     instants.sort(comparator);
     assertEquals(Arrays.asList(instant1, instant3, instant2, instant4, instant5), instants);
+  }
+
+  @Test
+  void testOrderingComparatorPerTimelineVersion() {
+    // Completion order (001 completes at 005, 002 completes at 003) inverts requested order.
+    HoodieInstant instant1 = createCompletedHoodieInstant("001", "005");
+    HoodieInstant instant2 = createCompletedHoodieInstant("002", "003");
+
+    // Timeline layout v1 orders by requested time.
+    List<HoodieInstant> instants = Arrays.asList(instant2, instant1);
+    instants.sort(new InstantComparatorV1().orderingComparator());
+    assertEquals(Arrays.asList(instant1, instant2), instants);
+
+    // Timeline layout v2 orders by completion time.
+    instants = Arrays.asList(instant1, instant2);
+    instants.sort(new InstantComparatorV2().orderingComparator());
+    assertEquals(Arrays.asList(instant2, instant1), instants);
+  }
+
+  @Test
+  void testGetOrderingTimePerTimelineVersion() {
+    HoodieInstant completed = createCompletedHoodieInstant("001", "005");
+    HoodieInstant inflight = createInflightHoodieInstant("002");
+
+    // Timeline layout v1 orders by requested time.
+    InstantComparator comparatorV1 = new InstantComparatorV1();
+    assertEquals("001", comparatorV1.getOrderingTime(completed));
+    assertEquals("002", comparatorV1.getOrderingTime(inflight));
+
+    // Timeline layout v2 orders by completion time, which an inflight instant does not have yet.
+    InstantComparator comparatorV2 = new InstantComparatorV2();
+    assertEquals("005", comparatorV2.getOrderingTime(completed));
+    assertNull(comparatorV2.getOrderingTime(inflight));
   }
 
   private static HoodieInstant createCompletedHoodieInstant(String requestedTime, String completionTime) {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

When schema conflict resolution is enabled and a writer commits a batch whose writer schema is the Avro null schema (for example, an ingestion round that writes no data), `SimpleSchemaConflictResolutionStrategy.resolveConcurrentSchemaEvolution` resolves the table schema at the current transaction's owner instant. At pre-commit time that instant is inflight and has no completion time, so the completion-time filter in `ConcurrentSchemaEvolutionTableSchemaGetter.getLastCommitMetadataWithValidSchemaFromTimeline` calls `String.compareTo(null)`, and the commit fails:

```
Caused by: org.apache.hudi.exception.HoodieException: Unable to get table schema
	at org.apache.hudi.client.transaction.SimpleSchemaConflictResolutionStrategy.getTableSchemaAtInstant(SimpleSchemaConflictResolutionStrategy.java:173)
	at org.apache.hudi.client.transaction.SimpleSchemaConflictResolutionStrategy.resolveConcurrentSchemaEvolution(SimpleSchemaConflictResolutionStrategy.java:74)
	...
Caused by: java.lang.NullPointerException
	at java.lang.String.compareTo(String.java:1155)
	at org.apache.hudi.common.table.timeline.InstantComparison.lambda$static$3(InstantComparison.java:34)
	at org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps(InstantComparison.java:38)
	at org.apache.hudi.client.transaction.ConcurrentSchemaEvolutionTableSchemaGetter.lambda$getLastCommitMetadataWithValidSchemaFromTimeline$3(ConcurrentSchemaEvolutionTableSchemaGetter.java:175)
```

The defect is twofold, and Hudi 1.x writes both table versions:

- On table version 6, ordering the schema evolution timeline by completion time is wrong to begin with: version 6 does not record completion time on disk (the in-memory value is synthesized from the meta file modification time), and 0.x writers concurrently writing the same table order the timeline by requested time. Requested-time ordering restores 0.x parity and also removes the NPE on this version, since every instant carries a requested time.
- On table version 8 and above, completion-time ordering is correct, but the same NPE fires for an empty-batch commit: the current transaction's owner instant is not completed yet and has no completion time.

A transaction with a null writer schema does not evolve the schema, so the resolution should adopt the current table schema.

### Summary and Changelog

- The per-timeline-version instant ordering is exposed as a first-class API on `InstantComparator`: `orderingComparator()` / `getOrderingTime(instant)` (requested-time based in v1, completion-time based in v2), so version handling lives in the timeline layer rather than in callers.
- `ConcurrentSchemaEvolutionTableSchemaGetter`: sorts and bounds the schema evolution timeline with that ordering (completion time for table version 8 and above, requested time for earlier versions, matching 0.x). A target instant without an ordering time (not completed yet, on table version 8 and above) does not bound the lookup instead of throwing NPE.
- `SimpleSchemaConflictResolutionStrategy`: the null-writer-schema path adopts the table schema as of the current transaction's owner instant. On table version 6 the lookup is bounded by the instant's requested time (matching 0.x behavior); on table version 8 and above the inflight instant carries no completion time, so the latest table schema is resolved. The prior-instant lookup for the transaction start snapshot also uses the version-appropriate ordering time.
- Tests: `TestSimpleSchemaConflictResolutionStrategy` gains the inflight-instant NPE regression plus table-version-6 cases proving requested-time bounding; `TestConcurrentSchemaEvolutionTableSchemaGetter` gains latest-schema ordering regressions with the same two-commit layout on both versions (the earlier-requested commit completes last), so table version 8 and above must return the completion-time winner and table version 6 must return the requested-time winner even when the synthesized completion order disagrees; `TestInstantComparators` covers the new `InstantComparator` ordering APIs directly.

### Impact

Fixes commit failures on multi-writer tables for ingestion rounds that write no data, on table version 6 and table version 8 and above alike. No public API or user-facing behavior change otherwise.

### Risk Level

low

The new regression tests fail with the production NPE signature before the fix and pass after; the table-version-6 ordering tests fail without the version-aware ordering and pass with it; both full test classes pass.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
