### PR TITLE
perf(ingest): parallelize SQS receive and delete in the S3 events source

### DIFF
--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -556,6 +556,16 @@
       <artifactId>sqs</artifactId>
       <version>${aws.sdk.version}</version>
     </dependency>
+    <!-- Apache HTTP client is the SDK v2 default sync client and already reaches the runtime classpath
+         transitively via sqs (declared runtime-scope in the awssdk services parent). Declared here as
+         provided purely for compile-time access to ApacheHttpClient.builder().maxConnections(...) in
+         CloudObjectsSelector.createAmazonSqsClient - it does not change the packaged/runtime footprint. -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+      <version>${aws.sdk.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kinesis</artifactId>

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/S3SourceConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/S3SourceConfig.java
@@ -67,7 +67,13 @@ public class S3SourceConfig extends HoodieConfig {
       .defaultValue("20")
       .withAlternatives(OLD_S3_SOURCE_PREFIX + "queue.long.poll.wait")
       .markAdvanced()
-      .withDocumentation("Long poll wait time in seconds, If set as 0 then client will fetch on short poll basis.");
+      .withDocumentation("Long poll wait time in seconds, If set as 0 then client will fetch on short poll basis. "
+          + "This also governs how the source confirms the queue is drained: under long polling SQS sends an empty "
+          + "response only once the wait time expires, so an empty response is strong evidence but always costs a "
+          + "full wait. The source therefore requires however many empty responses fit in one ~20s window (1 empty "
+          + "at 20s, 2 at 10s, 4 at 5s), holding drain confirmation to roughly a single poll window at any setting. "
+          + "Short polling samples only a subset of SQS servers and returns immediately, so its empty responses are "
+          + "weak evidence but nearly free, and a higher fixed count is required instead. AWS caps this at 20s.");
 
   public static final ConfigProperty<String> S3_SOURCE_QUEUE_MAX_MESSAGES_PER_BATCH = ConfigProperty
       .key(S3_SOURCE_PREFIX + "queue.max.messages.per.batch")
@@ -90,4 +96,18 @@ public class S3SourceConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation("Visibility timeout for messages in queue. After we consume the message, queue will move the consumed "
           + "messages to in-flight state, these messages can't be consumed again by source for this timeout period.");
+
+  public static final ConfigProperty<Integer> S3_SOURCE_QUEUE_PROCESSING_PARALLELISM = ConfigProperty
+      .key(S3_SOURCE_PREFIX + "queue.processing.parallelism")
+      .defaultValue(16)
+      .withAlternatives(OLD_S3_SOURCE_PREFIX + "queue.processing.parallelism")
+      .markAdvanced()
+      .withDocumentation("Number of threads used to receive messages from and delete messages against the SQS queue "
+          + "concurrently. ReceiveMessage and DeleteMessageBatch are capped by SQS at 10 messages per call, so draining a "
+          + "large backlog is dominated by serial round-trips; this fans those calls out across a fixed thread pool. The "
+          + "shared SqsClient is thread-safe (AWS SDK for Java 2.x) and its HTTP connection pool must be at least this "
+          + "value so workers never block on connection acquisition; the SDK default (maxConnections=50) already covers "
+          + "any value up to 50, and only a value above 50 makes the source resize the pool, which requires "
+          + "software.amazon.awssdk:apache-client on the runtime classpath. Set to 1 to restore fully sequential "
+          + "behaviour.");
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelector.java
@@ -136,7 +136,14 @@ public class CloudObjectsSelector {
   // including one that returns no messages, which still proves the endpoint and credentials are healthy.
   // Kept small because the AWS SDK has already exhausted its own standard retry strategy (3 attempts
   // with exponential backoff) before the exception ever surfaces here, so this is a second layer.
-  // Independent of parallelism, so tolerance is identical at parallelism=1 and parallelism=16.
+  // NOTE: this counts consecutive *completions*, not serial calls, so the tolerance it delivers is
+  // tighter at high parallelism than at 1 - a throttling episode tends to fail several in-flight calls
+  // at once, and 5 such completions in a row is far likelier than 5 serial calls failing in a row.
+  // Tightest on a queue that is not yielding: there the only calls that could reset the run are 20s
+  // empty polls, and a burst of ~100ms failures lands well ahead of them. The direction is intended - a
+  // fan-out-wide failure is stronger evidence of a systemic problem than one isolated failure - and it
+  // is safe because in-flight calls are drained rather than cancelled, so their healthy responses are
+  // still folded in before the empty-result check in getMessagesToProcess decides whether to throw.
   static final int MAX_CONSECUTIVE_TRANSIENT_FAILURES = 5;
   // ReceiveMessage returns OverLimit "if the maximum number of in flight messages is reached" (~120,000
   // for a standard queue, 20,000 for FIFO). That is backpressure, not an error: received messages stay
@@ -155,7 +162,9 @@ public class CloudObjectsSelector {
   // resetting the empty counter and can hold the loop for hours. Cap the total calls at this multiple of
   // the ideal count (plannedReceiveCalls), which tolerates an average per-call yield as low as
   // 1/RECEIVE_CALL_BUDGET_FACTOR of the maximum before the batch gives up and lets the next ingestion
-  // cycle continue from where it left off.
+  // cycle continue from where it left off. Counted in calls rather than seconds on purpose: the budget
+  // then encodes a claim about queue yield alone and is latency-independent by construction, so slow
+  // round-trips make a batch take longer without making it smaller.
   static final int RECEIVE_CALL_BUDGET_FACTOR = 2;
   // SQS caps DeleteMessageBatch at 10 entries per call (AWS hard limit); a larger batch is rejected
   // outright with TooManyEntriesInBatchRequest.
@@ -263,6 +272,13 @@ public class CloudObjectsSelector {
    * absent (e.g. {@code RedrivePolicy} without a dead-letter queue) go through
    * {@link #attrOrUnknown}.
    *
+   * <p>FIFO-ness is diagnostic only and deliberately does not gate the receive fan-out, which would
+   * otherwise be the obvious thing to check: concurrent receives on a FIFO queue would break the
+   * per-message-group ordering such a queue exists to provide. It is not reachable here. This selector
+   * is driven by S3 event notifications, and S3 cannot publish to a FIFO queue - neither directly nor
+   * through SNS, since a standard SNS topic cannot deliver to a FIFO queue. If this class is ever
+   * repointed at an arbitrary queue, that assumption is what has to be re-checked.
+   *
    * @param queueUrl        the queue url, for correlation
    * @param queueAttributes attributes already fetched for this batch (no extra SQS call is made)
    */
@@ -360,6 +376,15 @@ public class CloudObjectsSelector {
    * #MAX_CONSECUTIVE_TRANSIENT_FAILURES} transient failures occur in a row; or the receive-call budget
    * ({@value #RECEIVE_CALL_BUDGET_FACTOR}x {@code plannedReceiveCalls}) is spent.
    *
+   * <p>Three of those bounds overlap and are deliberately not merged - each answers a different question,
+   * in the unit natural to it. {@code maxMessagePerBatch} bounds how much work to take, in messages.
+   * {@link #emptyReceivesToConfirmDrain} decides whether the queue is empty, using the explicit empty
+   * response SQS returns rather than inferring emptiness from the absence of a signal.
+   * {@code receiveCallBudget} bounds runaway, in calls - deliberately not in seconds, so that slow
+   * round-trips make a batch take longer without making it smaller. A time-based budget would conflate
+   * "the queue is yielding poorly" with "the network is slow right now", which are different problems
+   * with different fixes.
+   *
    * <p>Whenever a <em>stop condition</em> ends dispatch, the calls already in flight are drained and their
    * messages kept - never cancelled. A ReceiveMessage that succeeded server-side has already made its
    * messages invisible, so discarding the response would strand them for the full visibility timeout. For
@@ -376,6 +401,10 @@ public class CloudObjectsSelector {
    * - an empty result would otherwise be indistinguishable from a drained queue to the caller and to
    * on-call. A batch that did get a real answer from SQS (an empty response, or an in-flight-limit
    * rejection) returns normally even if some sibling call failed, since the queue is demonstrably healthy.
+   *
+   * @return the received messages in <em>completion</em> order, not call-issue order. Callers must not
+   *     depend on the ordering: {@code S3EventsMetaSelector} sorts on the S3 event time and derives its
+   *     checkpoint from the maximum, so the source already treats receive order as unordered input.
    */
   protected List<Message> getMessagesToProcess(
       SqsClient sqsClient,
@@ -415,7 +444,7 @@ public class CloudObjectsSelector {
     if (numMessagesToProcess <= 0) {
       log.info("SQS receive summary for queue {}: fetched 0 messages across 0 receive calls, exitReason={}.",
           queueUrl, ReceiveExitReason.NO_MESSAGES);
-      return new ArrayList<>();
+      return Collections.emptyList();
     }
 
     // Bound the total number of receive calls: plannedReceiveCalls is the ideal count (every call
@@ -515,6 +544,18 @@ public class CloudObjectsSelector {
    * still holds messages is expected rather than exceptional, so scattered empties can end a batch before
    * its target is reached. That costs throughput on a non-default setting, not correctness: confirming a
    * drain early only defers the remainder to the next ingestion cycle, it never drops a message.
+   *
+   * <p>Deliberately not scaled by the worker count, even though at the default this returns 1 while
+   * {@code processingParallelism} defaults to 16. Concurrent polls are not independent draws: they
+   * observe the same queue over the same overlapping window, and a long-poll empty reports queue state
+   * ("nothing was visible on any server for the full wait") rather than a per-call sample, so a shared
+   * cause does not compound across workers. The sampling that does produce false empties belongs to
+   * short polling, which queries only a subset of servers - which is why AWS scopes the residual risk to
+   * low wait times, and why {@code longPollWait} is already the right variable to key on. A worker-count
+   * term would also be inert precisely where it is needed: at {@code longPollWait=1} the poll-cost term
+   * already demands 20 empties, while at the default it would raise 1 to 8 in the regime where a single
+   * empty is strongest. It would additionally make the threshold depend on batch size, since the worker
+   * count is {@code min(processingParallelism, plannedReceiveCalls)}.
    */
   static int emptyReceivesToConfirmDrain(int longPollWait) {
     if (longPollWait <= 0) {

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelector.java
@@ -18,14 +18,20 @@
 package org.apache.hudi.utilities.sources.helpers;
 
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.config.DFSPathSelectorConfig;
 import org.apache.hudi.utilities.config.S3SourceConfig;
 
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsClientBuilder;
 import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
@@ -45,8 +51,22 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.util.ConfigUtils.checkRequiredConfigProperties;
@@ -63,6 +83,108 @@ public class CloudObjectsSelector {
   public static final String S3_PREFIX = "s3://";
   public static volatile Logger log = LoggerFactory.getLogger(CloudObjectsSelector.class);
   public static final String SQS_ATTR_APPROX_MESSAGES = "ApproximateNumberOfMessages";
+  // Live queue-depth counters fetched every batch alongside SQS_ATTR_APPROX_MESSAGES. These three
+  // are disjoint: visible (available) + not-visible (in-flight) + delayed = true queue depth.
+  public static final String SQS_ATTR_APPROX_MESSAGES_NOT_VISIBLE = "ApproximateNumberOfMessagesNotVisible";
+  public static final String SQS_ATTR_APPROX_MESSAGES_DELAYED = "ApproximateNumberOfMessagesDelayed";
+  // Static queue-config attributes logged once per selector for diagnostics (not per batch).
+  // NOTE: FIFO-only attributes (FifoQueue, ContentBasedDeduplication, DeduplicationScope,
+  // FifoThroughputLimit) must never be named in a GetQueueAttributes request - SQS rejects the
+  // whole call with InvalidAttributeNameException on a standard queue. FIFO-ness is derived from
+  // the queue-name suffix instead, per the AWS API docs.
+  static final String FIFO_QUEUE_URL_SUFFIX = ".fifo";
+  static final String SQS_ATTR_MESSAGE_RETENTION_PERIOD = "MessageRetentionPeriod";
+  static final String SQS_ATTR_VISIBILITY_TIMEOUT = "VisibilityTimeout";
+  static final String SQS_ATTR_RECEIVE_MESSAGE_WAIT_TIME = "ReceiveMessageWaitTimeSeconds";
+  static final String SQS_ATTR_DELAY_SECONDS = "DelaySeconds";
+  static final String SQS_ATTR_REDRIVE_POLICY = "RedrivePolicy";
+  // Emit a receive-progress DEBUG line every time cumulative fetched messages cross this many, to
+  // keep the loop's logging bounded (~a handful of lines/batch) instead of one line per receive call.
+  private static final int MESSAGE_PROGRESS_LOG_INTERVAL = 25000;
+  // SQS caps ReceiveMessage/DeleteMessageBatch at 10 entries per call (AWS hard limit), so draining a
+  // backlog is dominated by round-trip latency; the receive/delete phases fan calls out across a fixed
+  // pool. Thread names are prefixed so the workers are identifiable in stack dumps.
+  private static final String RECEIVE_THREAD_PREFIX = "sqs-receive-";
+  private static final String DELETE_THREAD_PREFIX = "sqs-delete-";
+  // The shared SqsClient's HTTP connection pool must be at least the worker count or workers block on
+  // connection acquisition (connectionAcquisitionTimeout=10s). This is the AWS SDK v2 default sync
+  // maxConnections: at or below it the default client already has enough connections for every worker
+  // plus headroom for the serial calls, so createAmazonSqsClient leaves the client untouched and only
+  // resizes the pool above this value. See createAmazonSqsClient for why that matters.
+  private static final int SQS_CLIENT_MIN_MAX_CONNECTIONS = 50;
+  // Bound how long we wait for a receive/delete pool to drain on shutdown. On the normal paths every task
+  // has already been joined by the time we shut down, so this only guards against a stuck AWS call on the
+  // paths that abandon the phase without draining (a worker Error, or an interrupt).
+  private static final int POOL_SHUTDOWN_TIMEOUT_SECS = 60;
+  // How many empty ReceiveMessage responses confirm the queue is drained when short polling is in
+  // effect (longPollWait <= 0). A short poll "queries a subset of servers (based on a weighted random
+  // distribution) ... and sends an immediate response, even if no messages are found" (AWS), so a single
+  // empty response proves almost nothing - but it is also nearly free, which is why the count can afford
+  // to be high. See emptyReceivesToConfirmDrain for the long-polling case.
+  static final int MAX_EMPTY_RECEIVES_SHORT_POLL = 5;
+  // Budget, in seconds, for proving the queue is drained. Under long polling an empty response is only
+  // sent once the poll window expires, so an empty response costs a full longPollWait - which makes the
+  // number of empties we can afford a function of longPollWait rather than a fixed count. Sizing the
+  // budget at the AWS maximum long-poll wait (20s) keeps drain confirmation to roughly one poll window
+  // at every setting: 1 empty at longPollWait=20, 2 at 10, 4 at 5, 20 at 1. That is a wall-clock bound
+  // achieved structurally, with no timer and nothing to abort mid-flight.
+  static final int DRAIN_CONFIRMATION_WINDOW_SECS = 20;
+  // A transient ReceiveMessage failure (throttling, a 5xx, a dropped connection) is tolerated rather
+  // than aborting the batch: everything already received is in-flight and would be stranded until the
+  // visibility timeout expires. Only a run of them indicates a systemic problem worth stopping for.
+  // Counted consecutively in completion order on the master thread and reset by any successful call -
+  // including one that returns no messages, which still proves the endpoint and credentials are healthy.
+  // Kept small because the AWS SDK has already exhausted its own standard retry strategy (3 attempts
+  // with exponential backoff) before the exception ever surfaces here, so this is a second layer.
+  // Independent of parallelism, so tolerance is identical at parallelism=1 and parallelism=16.
+  static final int MAX_CONSECUTIVE_TRANSIENT_FAILURES = 5;
+  // ReceiveMessage returns OverLimit "if the maximum number of in flight messages is reached" (~120,000
+  // for a standard queue, 20,000 for FIFO). That is backpressure, not an error: received messages stay
+  // in-flight until onCommit deletes them, so the fix is to stop receiving, hand back what was fetched
+  // and let the delete phase free the quota. Never retried (it would fail identically) and never fatal
+  // (failing the job over normal saturation would take ingestion down).
+  static final String SQS_OVER_LIMIT_ERROR_CODE = "OverLimit";
+  // Only probe queue counters on a drain that fell materially short of what the queue claimed was
+  // available (less than this fraction of it). A drain that lands close to the target is ordinary
+  // eventual consistency in ApproximateNumberOfMessages and does not justify a WARN plus an extra
+  // GetQueueAttributes call on every batch.
+  private static final int DRAIN_SHORTFALL_WARN_DIVISOR = 2;
+  // The receive loop is target-driven (keep fetching until numMessagesToProcess is reached) rather than
+  // fixed-iteration, because SQS routinely returns fewer than maxMessagesPerRequest messages per call
+  // even with a deep backlog. Target-driven alone is unbounded though: a queue with slow ingress keeps
+  // resetting the empty counter and can hold the loop for hours. Cap the total calls at this multiple of
+  // the ideal count (plannedReceiveCalls), which tolerates an average per-call yield as low as
+  // 1/RECEIVE_CALL_BUDGET_FACTOR of the maximum before the batch gives up and lets the next ingestion
+  // cycle continue from where it left off.
+  static final int RECEIVE_CALL_BUDGET_FACTOR = 2;
+  // SQS caps DeleteMessageBatch at 10 entries per call (AWS hard limit); a larger batch is rejected
+  // outright with TooManyEntriesInBatchRequest.
+  static final int SQS_BATCH_MAX_ENTRIES = 10;
+  // DeleteMessageBatch can return partial failures even on an HTTP 200, and a call can also throw
+  // outright (throttling, a dropped connection); both leave the batch undeleted and are retried up to
+  // this many times before the residual failures are logged with their SQS reason. The original code did
+  // not retry at all. Also a constant rather than a config for the same reason.
+  static final int DELETE_MAX_RETRIES = 3;
+  // Retries only ever target transient, server-side failures (SQS InternalError, throttling, a dropped
+  // connection); retrying microseconds later would almost certainly hit the same condition, so each pass
+  // backs off exponentially from this base: 100ms, 200ms, 400ms. Bounded by DELETE_MAX_RETRIES, so the
+  // delete phase adds at most 700ms of sleep on the driver even in the worst case.
+  static final long DELETE_RETRY_BASE_BACKOFF_MS = 100;
+  // How many failed message ids to name in the residual-failure WARN. Enough for on-call to grep the
+  // queue or a DLQ for a concrete message without dumping an unbounded list into the log.
+  private static final int DELETE_FAILURE_SAMPLE_SIZE = 10;
+  // Synthetic reason code for a DeleteMessageBatch call that threw, so a thrown call and an
+  // SQS-reported entry failure can flow through one retry path and one summary. Not an SQS error code.
+  static final String DELETE_CALL_FAILED_CODE = "DeleteMessageBatchCallFailed";
+  // Transient SQS/AWS error codes that the SDK's own throttling predicate does not recognise, so they
+  // would otherwise fall through to the status-code rule and be misjudged. KmsThrottled in particular is
+  // an HTTP 400 on an SSE-KMS encrypted queue and is purely transient, but is absent from
+  // AwsErrorCode.THROTTLING_ERROR_CODES. The rest mirror AwsErrorCode.RETRYABLE_ERROR_CODES.
+  private static final Set<String> EXTRA_TRANSIENT_ERROR_CODES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+      "KmsThrottled", "InternalError", "RequestTimeout", "RequestTimeoutException", "PriorRequestNotComplete")));
+  // Placeholders so the residual-failure WARN never renders a bare "null" for fields SQS may omit.
+  private static final String UNKNOWN_ERROR_CODE = "UNKNOWN";
+  private static final String NO_ERROR_MESSAGE = "<none provided by SQS>";
   static final String SQS_MODEL_MESSAGE = "Message";
   static final String SQS_MODEL_EVENT_RECORDS = "Records";
   static final String SQS_MODEL_EVENT_NAME = "eventName";
@@ -74,9 +196,12 @@ public class CloudObjectsSelector {
   public final int maxMessagePerBatch;
   public final int maxMessagesPerRequest;
   public final int visibilityTimeout;
+  public final int processingParallelism;
   public final TypedProperties props;
   public final String fsName;
   private final String regionName;
+  // Guards the one-time queue-config INFO line so static config is not re-logged every batch.
+  private volatile boolean queueConfigLogged = false;
 
   /**
    * Cloud Objects Selector Class. {@link CloudObjectsSelector}
@@ -92,6 +217,8 @@ public class CloudObjectsSelector {
     this.maxMessagePerBatch = getIntWithAltKeys(props, S3SourceConfig.S3_SOURCE_QUEUE_MAX_MESSAGES_PER_BATCH);
     this.maxMessagesPerRequest = getIntWithAltKeys(props, S3SourceConfig.S3_SOURCE_QUEUE_MAX_MESSAGES_PER_REQUEST);
     this.visibilityTimeout = getIntWithAltKeys(props, S3SourceConfig.S3_SOURCE_QUEUE_VISIBILITY_TIMEOUT);
+    this.processingParallelism =
+        Math.max(1, getIntWithAltKeys(props, S3SourceConfig.S3_SOURCE_QUEUE_PROCESSING_PARALLELISM));
   }
 
   /**
@@ -102,13 +229,64 @@ public class CloudObjectsSelector {
    * @return map of attributes needed
    */
   protected Map<String, String> getSqsQueueAttributes(SqsClient sqsClient, String queueUrl) {
+    // Request ALL rather than an explicit attribute list. FIFO-only attribute names (FifoQueue,
+    // ContentBasedDeduplication, ...) are rejected outright on a standard queue with
+    // InvalidAttributeNameException, which would fail the entire GetQueueAttributes call - and this
+    // call is load-bearing for the receive loop, so that takes ingestion down. ALL returns whatever
+    // applies to this queue type; callers use attrOrUnknown() for anything that may be absent.
     GetQueueAttributesResponse queueAttributesResult = sqsClient.getQueueAttributes(
             GetQueueAttributesRequest.builder()
                     .queueUrl(queueUrl)
-                    .attributeNames(QueueAttributeName.fromValue(SQS_ATTR_APPROX_MESSAGES))
+                    .attributeNames(QueueAttributeName.ALL)
                     .build()
     );
     return queueAttributesResult.attributesAsStrings();
+  }
+
+  /**
+   * Returns the attribute value for {@code key}, or "unknown" when SQS did not return it (for
+   * example a standard queue omits {@code FifoQueue}, or a mock in tests only stubs a subset).
+   */
+  private static String attrOrUnknown(Map<String, String> attributes, String key) {
+    String value = attributes.get(key);
+    return value != null ? value : "unknown";
+  }
+
+  /**
+   * Logs the queue's static configuration exactly once per selector instance. Whether the queue is
+   * FIFO determines which in-flight ceiling applies (standard vs FIFO), and
+   * {@code MessageRetentionPeriod} bounds how long a backlog can sit before messages expire.
+   *
+   * <p>FIFO-ness is derived from the {@code .fifo} queue-name suffix rather than the
+   * {@code FifoQueue} attribute: that attribute exists only on FIFO queues, so naming it in a
+   * GetQueueAttributes request is rejected outright on a standard queue. Attributes that may be
+   * absent (e.g. {@code RedrivePolicy} without a dead-letter queue) go through
+   * {@link #attrOrUnknown}.
+   *
+   * @param queueUrl        the queue url, for correlation
+   * @param queueAttributes attributes already fetched for this batch (no extra SQS call is made)
+   */
+  private void logQueueConfigOnce(String queueUrl, Map<String, String> queueAttributes) {
+    if (queueConfigLogged) {
+      return;
+    }
+    queueConfigLogged = true;
+    // Diagnostics must never be able to fail a batch: this runs inline on the receive path, so any
+    // future change here (parsing an attribute, deriving a new field) stays contained.
+    try {
+      boolean fifoQueue = queueUrl != null && queueUrl.endsWith(FIFO_QUEUE_URL_SUFFIX);
+      log.info("SQS queue config [{}]: fifoQueue={}, messageRetentionPeriod={}s, visibilityTimeout(queue default)={}s, "
+              + "receiveMessageWaitTime(queue default)={}s, delaySeconds={}, redrivePolicy={}",
+          queueUrl,
+          fifoQueue,
+          attrOrUnknown(queueAttributes, SQS_ATTR_MESSAGE_RETENTION_PERIOD),
+          attrOrUnknown(queueAttributes, SQS_ATTR_VISIBILITY_TIMEOUT),
+          attrOrUnknown(queueAttributes, SQS_ATTR_RECEIVE_MESSAGE_WAIT_TIME),
+          attrOrUnknown(queueAttributes, SQS_ATTR_DELAY_SECONDS),
+          attrOrUnknown(queueAttributes, SQS_ATTR_REDRIVE_POLICY));
+    } catch (Exception e) {
+      log.warn("Failed to log SQS queue config for {}; continuing.", queueUrl, e);
+    }
   }
 
   /**
@@ -133,14 +311,71 @@ public class CloudObjectsSelector {
   }
 
   /**
-   * Amazon SQS Client Builder.
+   * Amazon SQS Client Builder. One thread-safe client is shared across the receive/delete worker
+   * pools (AWS SDK for Java 2.x clients are thread-safe and meant to be shared).
+   *
+   * <p>Concurrent ReceiveMessage/DeleteMessageBatch calls must never block on HTTP connection
+   * acquisition, so the connection pool has to be at least {@link #processingParallelism}. The SDK's
+   * default sync pool is already {@value #SQS_CLIENT_MIN_MAX_CONNECTIONS} connections, which covers
+   * every parallelism up to that value with headroom for the serial calls (getQueueAttributes) - so
+   * the pool is only resized when the configured parallelism actually exceeds the default, and the
+   * client is otherwise built exactly as it was before the fan-out was introduced.
+   *
+   * <p>Resizing means naming a concrete HTTP client implementation, which turns
+   * {@code software.amazon.awssdk:apache-client} from "whatever sync implementation the runtime
+   * happens to provide" into a hard requirement of this source. Keeping the default path untouched
+   * confines that requirement to deployments that explicitly opt into a parallelism above
+   * {@value #SQS_CLIENT_MIN_MAX_CONNECTIONS}, rather than imposing it on every S3 source.
    */
   public SqsClient createAmazonSqsClient() {
-    return SqsClient.builder().region(Region.of(regionName)).build();
+    SqsClientBuilder builder = SqsClient.builder().region(Region.of(regionName));
+    if (requiresLargerConnectionPool(processingParallelism)) {
+      builder.httpClientBuilder(ApacheHttpClient.builder().maxConnections(processingParallelism));
+    }
+    return builder.build();
   }
 
   /**
-   * List messages from queue.
+   * Whether the configured parallelism outgrows the SDK's default sync connection pool and therefore
+   * needs {@link #createAmazonSqsClient} to name a concrete HTTP client to resize it.
+   */
+  static boolean requiresLargerConnectionPool(int parallelism) {
+    return parallelism > SQS_CLIENT_MIN_MAX_CONNECTIONS;
+  }
+
+  /**
+   * Receives up to {@code min(approxAvailable, maxMessagePerBatch)} messages from the queue. Calls are
+   * dispatched continuously to a fixed pool of {@link #processingParallelism} workers: the master thread
+   * consumes each completion the moment it arrives and immediately refills the freed slot, so a worker
+   * never waits on a sibling. Each ReceiveMessage returns at most {@code maxMessagesPerRequest} messages
+   * (SQS caps this at 10), so throughput is bound by round-trip latency and concurrency is the only
+   * lever. The shared {@code sqsClient} is thread-safe.
+   *
+   * <p>All counters and every termination decision stay on this master thread, so no termination state
+   * is shared with the workers; {@code busyNanos} remains the only concurrently mutated value.
+   *
+   * <p>The batch stops dispatching on the first of: the target message count is reached; the queue is
+   * confirmed drained (see {@link #emptyReceivesToConfirmDrain}); SQS reports the in-flight ceiling
+   * ({@value #SQS_OVER_LIMIT_ERROR_CODE}); a non-retryable failure occurs; {@value
+   * #MAX_CONSECUTIVE_TRANSIENT_FAILURES} transient failures occur in a row; or the receive-call budget
+   * ({@value #RECEIVE_CALL_BUDGET_FACTOR}x {@code plannedReceiveCalls}) is spent.
+   *
+   * <p>Whenever a <em>stop condition</em> ends dispatch, the calls already in flight are drained and their
+   * messages kept - never cancelled. A ReceiveMessage that succeeded server-side has already made its
+   * messages invisible, so discarding the response would strand them for the full visibility timeout. For
+   * the same reason an individual failure does not abort the batch. Ending early never drops messages:
+   * whatever is not received stays in the queue for the next batch.
+   *
+   * <p>The two paths that abandon the phase outright - a worker {@link Error}, and an interrupt - are the
+   * deliberate exceptions: both discard whatever has been collected, which does leave those messages
+   * in-flight until the visibility timeout expires. That is accepted because in both cases the batch has
+   * no future (a broken JVM or classpath, or a shutdown with nobody left to commit), so returning a
+   * partial result would only feed a checkpoint that is never written. It is a delay, never message loss.
+   *
+   * <p>If nothing at all was fetched and no call even proved the queue reachable, the failure is rethrown
+   * - an empty result would otherwise be indistinguishable from a drained queue to the caller and to
+   * on-call. A batch that did get a real answer from SQS (an empty response, or an in-flight-limit
+   * rejection) returns normally even if some sibling call failed, since the queue is demonstrably healthy.
    */
   protected List<Message> getMessagesToProcess(
       SqsClient sqsClient,
@@ -149,7 +384,6 @@ public class CloudObjectsSelector {
       int visibilityTimeout,
       int maxMessagePerBatch,
       int maxMessagesPerRequest) {
-    List<Message> messagesToProcess = new ArrayList<>();
     ReceiveMessageRequest receiveMessageRequest = ReceiveMessageRequest.builder()
             .queueUrl(queueUrl)
             .waitTimeSeconds(longPollWait)
@@ -158,22 +392,335 @@ public class CloudObjectsSelector {
             .build();
     // Get count for available messages
     Map<String, String> queueAttributesResult = getSqsQueueAttributes(sqsClient, queueUrl);
+    logQueueConfigOnce(queueUrl, queueAttributesResult);
     long approxMessagesAvailable = Long.parseLong(queueAttributesResult.get(SQS_ATTR_APPROX_MESSAGES));
-    log.info("Approximately {} messages available in queue.", approxMessagesAvailable);
     long numMessagesToProcess = Math.min(approxMessagesAvailable, maxMessagePerBatch);
-    for (int i = 0;
-         i < (int) Math.ceil((double) numMessagesToProcess / maxMessagesPerRequest);
-         ++i) {
-      List<Message> messages = sqsClient.receiveMessage(receiveMessageRequest).messages();
-      log.debug("Number of messages: {}", messages.size());
-      messagesToProcess.addAll(messages);
-      if (messages.isEmpty()) {
-        // ApproximateNumberOfMessages value is eventually consistent.
-        // So, we still need to check and break if there are no messages.
-        break;
+    // Integer ceiling division rather than Math.ceil on a double: numMessagesToProcess is a long, and
+    // routing a message count through a 53-bit mantissa to divide it is both lossy above 2^53 and harder
+    // to read than the exact arithmetic. The divisor is floored at 1 so a misconfigured non-positive
+    // maxMessagesPerRequest cannot divide by zero here - SQS rejects such a request on its own.
+    long callSize = Math.max(1, maxMessagesPerRequest);
+    long plannedReceiveCalls = (numMessagesToProcess + callSize - 1) / callSize;
+    int emptiesToConfirmDrain = emptyReceivesToConfirmDrain(longPollWait);
+    log.info("Approximately {} messages available in queue.", approxMessagesAvailable);
+    log.info("SQS receive plan for queue {}: approxAvailable={}, approxInFlight={}, approxDelayed={}, "
+            + "maxMessagePerBatch={}, maxMessagesPerRequest={}, numMessagesToProcess={}, plannedReceiveCalls={}, "
+            + "processingParallelism={}, emptiesToConfirmDrain={}, longPollWait={}s, visibilityTimeout={}s",
+        queueUrl, approxMessagesAvailable,
+        attrOrUnknown(queueAttributesResult, SQS_ATTR_APPROX_MESSAGES_NOT_VISIBLE),
+        attrOrUnknown(queueAttributesResult, SQS_ATTR_APPROX_MESSAGES_DELAYED),
+        maxMessagePerBatch, maxMessagesPerRequest, numMessagesToProcess, plannedReceiveCalls,
+        processingParallelism, emptiesToConfirmDrain, longPollWait, visibilityTimeout);
+
+    if (numMessagesToProcess <= 0) {
+      log.info("SQS receive summary for queue {}: fetched 0 messages across 0 receive calls, exitReason={}.",
+          queueUrl, ReceiveExitReason.NO_MESSAGES);
+      return new ArrayList<>();
+    }
+
+    // Bound the total number of receive calls: plannedReceiveCalls is the ideal count (every call
+    // returning a full maxMessagesPerRequest), and the budget allows for short responses without letting
+    // a trickling queue hold this loop indefinitely. Every call count is a long, since they all derive
+    // from numMessagesToProcess and an int would silently truncate the moment maxMessagePerBatch widened.
+    // The floor keeps the budget from cutting a tiny batch off before either termination heuristic has
+    // had enough calls to reach its threshold.
+    long budgetFloor = Math.max(emptiesToConfirmDrain, MAX_CONSECUTIVE_TRANSIENT_FAILURES);
+    long receiveCallBudget = Math.max(plannedReceiveCalls * RECEIVE_CALL_BUDGET_FACTOR, budgetFloor);
+    // The pool size is the one count that stays an int: it is bounded by processingParallelism, an int
+    // config, and Executors.newFixedThreadPool takes an int.
+    int workers = (int) Math.max(1, Math.min(processingParallelism, plannedReceiveCalls));
+    ReceivePlan plan = new ReceivePlan(numMessagesToProcess, maxMessagesPerRequest, workers,
+        receiveCallBudget, emptiesToConfirmDrain, plannedReceiveCalls);
+
+    long wallStartMs = System.currentTimeMillis();
+    // busyNanos is the only shared state: worker tasks add their SQS-call time concurrently.
+    AtomicLong busyNanos = new AtomicLong();
+    Callable<List<Message>> receiveTask = () -> {
+      long callStartNanos = System.nanoTime();
+      try {
+        return sqsClient.receiveMessage(receiveMessageRequest).messages();
+      } finally {
+        busyNanos.addAndGet(System.nanoTime() - callStartNanos);
+      }
+    };
+
+    ReceiveState state = new ReceiveState();
+    long receiveWallMs;
+    ExecutorService pool = newFixedThreadPool(RECEIVE_THREAD_PREFIX, plan.workers);
+    try {
+      runReceiveLoop(pool, receiveTask, state, plan, queueUrl);
+      // Captured before pool shutdown so the perf line below measures only the fanned-out receive calls.
+      receiveWallMs = System.currentTimeMillis() - wallStartMs;
+    } finally {
+      shutdownThreadPool(pool);
+    }
+
+    if (state.exitReason == null) {
+      state.exitReason = state.callsIssued >= plan.receiveCallBudget && state.messages.size() < plan.numMessagesToProcess
+          ? ReceiveExitReason.CALL_BUDGET_EXHAUSTED : ReceiveExitReason.TARGET_REACHED;
+    }
+    // Probe only on a drain that fell materially short of what the queue claimed: that is the case worth
+    // diagnosing (typically the in-flight ceiling), whereas landing near the target is ordinary
+    // ApproximateNumberOfMessages drift and must not cost a WARN plus an extra API call every batch.
+    // Multiplied rather than divided so a target of 1 still qualifies: integer division would floor the
+    // threshold to 0 and silence the probe exactly when the whole batch came back empty.
+    if (state.exitReason == ReceiveExitReason.DRAINED
+        && (long) DRAIN_SHORTFALL_WARN_DIVISOR * state.messages.size() < plan.numMessagesToProcess) {
+      logReceiveBreakProbe(sqsClient, queueUrl, visibilityTimeout, state.emptyReceives,
+          state.messages.size(), state.callsCompleted, plan.numMessagesToProcess);
+    }
+    logReceiveOutcome(queueUrl, state, plan, receiveWallMs, busyNanos.get());
+
+    if (state.messages.isEmpty()) {
+      // Nothing fetched: an empty return would look indistinguishable from a drained queue to the caller
+      // and to on-call, leaving a stalled pipeline looking healthy.
+      if (state.fatalFailure != null) {
+        throw new HoodieException(String.format(
+            "Non-retryable failure receiving messages from SQS queue %s", queueUrl), state.fatalFailure);
+      }
+      // Only when nothing proved the queue reachable. A call that answered - an empty response, or an
+      // OverLimit that SQS itself returned - is positive evidence that the endpoint, the credentials and
+      // the queue are healthy, which is the very evidence used above to reset the transient-failure run.
+      // Without this guard a genuinely drained queue that also happened to throttle one of its concurrent
+      // polls would take ingestion down, and so would a batch that hit the in-flight ceiling on most calls
+      // and was throttled on one - the outcome the backpressure classification exists to prevent.
+      if (state.failedCalls > 0 && state.healthyResponses == 0) {
+        throw new HoodieException(String.format(
+            "Failed to receive any messages from SQS queue %s: %d of %d ReceiveMessage calls failed and none "
+                + "succeeded", queueUrl, state.failedCalls, state.callsCompleted), state.firstFailure);
       }
     }
-    return messagesToProcess;
+    return state.messages;
+  }
+
+  /**
+   * How many empty ReceiveMessage responses are needed before the queue is treated as drained.
+   *
+   * <p>Under long polling AWS documents that ReceiveMessage "queries all servers for messages, sending a
+   * response once at least one message is available ... An empty response is sent only if the polling
+   * wait time expires". So an empty response is both strong evidence and expensive - it always costs the
+   * full {@code longPollWait}. AWS scopes the residual risk to exactly the cheap case: "In rare cases,
+   * you might receive empty responses even when a queue still contains messages, especially if you
+   * specified a low value for Receive message wait time."
+   *
+   * <p>The count is therefore however many empties fit in {@value #DRAIN_CONFIRMATION_WINDOW_SECS}
+   * seconds, which holds drain confirmation to roughly one poll window at every setting rather than
+   * multiplying it by a fixed count. Short polling ({@code longPollWait <= 0}) samples only a subset of
+   * servers and returns immediately, so its empties are both weak evidence and nearly free, and it keeps
+   * the higher fixed count.
+   *
+   * <p>Empties are always counted as a batch total rather than consecutively, in both modes: consecutive
+   * counting is what lets a queue with slow ingress reset the counter indefinitely and hold the phase for
+   * the whole call budget. The trade is on the short-poll path, where an empty response on a queue that
+   * still holds messages is expected rather than exceptional, so scattered empties can end a batch before
+   * its target is reached. That costs throughput on a non-default setting, not correctness: confirming a
+   * drain early only defers the remainder to the next ingestion cycle, it never drops a message.
+   */
+  static int emptyReceivesToConfirmDrain(int longPollWait) {
+    if (longPollWait <= 0) {
+      return MAX_EMPTY_RECEIVES_SHORT_POLL;
+    }
+    return Math.max(1, DRAIN_CONFIRMATION_WINDOW_SECS / longPollWait);
+  }
+
+  /**
+   * Drives the receive phase: prime the pool, then consume one completion at a time and refill the freed
+   * slot immediately. {@link CompletionService#take()} blocks on <em>any</em> completion, never on all of
+   * them, which is what removes the wave barrier - a worker that returns in 40ms starts its next call
+   * without waiting for a sibling that is long-polling for 20s.
+   *
+   * <p>The loop runs until nothing is outstanding. Once a stop condition is set, no further calls are
+   * dispatched but the calls already in flight are still drained and their messages kept: cancelling them
+   * would discard responses for calls that already succeeded server-side and strand those messages for
+   * the full visibility timeout.
+   */
+  private void runReceiveLoop(ExecutorService pool, Callable<List<Message>> receiveTask,
+                              ReceiveState state, ReceivePlan plan, String queueUrl) {
+    CompletionService<List<Message>> completionService = new ExecutorCompletionService<>(pool);
+    try {
+      dispatchReceiveCalls(completionService, receiveTask, state, plan);
+      while (state.outstanding > 0) {
+        Future<List<Message>> completed = completionService.take();
+        state.outstanding--;
+        state.callsCompleted++;
+        foldReceiveResult(completed, state, plan, queueUrl);
+        dispatchReceiveCalls(completionService, receiveTask, state, plan);
+      }
+    } catch (InterruptedException e) {
+      // Only take() on this master thread throws this, i.e. the driver thread was interrupted, which in
+      // practice only happens while the ingestion service is being torn down. This path discards the
+      // messages already collected, and since their receipt handles go with them they stay in-flight
+      // until the visibility timeout expires before another batch can see them. That is accepted because
+      // the batch is being abandoned anyway - there is nobody left to commit it, so returning a partial
+      // result would only push the same messages into a checkpoint that will never be written. It is a
+      // delay, never message loss.
+      Thread.currentThread().interrupt();
+      throw new HoodieException("Interrupted while receiving messages from SQS queue " + queueUrl, e);
+    }
+  }
+
+  /**
+   * Fills every free worker slot with a new ReceiveMessage call, subject to {@link #canDispatchMore}.
+   * Called once to prime the pool and again after each completion, so the pool stays saturated while
+   * work remains.
+   */
+  private static void dispatchReceiveCalls(CompletionService<List<Message>> completionService,
+                                           Callable<List<Message>> receiveTask,
+                                           ReceiveState state, ReceivePlan plan) {
+    while (state.outstanding < plan.workers && canDispatchMore(state, plan)) {
+      completionService.submit(receiveTask);
+      state.outstanding++;
+      state.callsIssued++;
+    }
+  }
+
+  /**
+   * Whether another ReceiveMessage call is worth dispatching. The in-flight term optimistically credits
+   * every outstanding call with a full {@code maxMessagesPerRequest}, so a call is never dispatched that
+   * the messages already in flight would make redundant. That bounds the residual overshoot of
+   * {@code maxMessagePerBatch} to {@code maxMessagesPerRequest - 1}.
+   */
+  static boolean canDispatchMore(ReceiveState state, ReceivePlan plan) {
+    return !state.stopped()
+        && state.callsIssued < plan.receiveCallBudget
+        && state.messages.size() + (long) state.outstanding * plan.maxMessagesPerRequest < plan.numMessagesToProcess;
+  }
+
+  /**
+   * Folds one completed ReceiveMessage call into the loop state on the master thread: merge its messages,
+   * or classify and account for its failure.
+   */
+  private void foldReceiveResult(Future<List<Message>> completed, ReceiveState state,
+                                 ReceivePlan plan, String queueUrl) throws InterruptedException {
+    List<Message> messages;
+    try {
+      messages = completed.get();
+    } catch (ExecutionException e) {
+      // An Error (OutOfMemoryError, a LinkageError from a missing SDK class) says nothing about the
+      // health of the queue and is not something to absorb: the JVM or the classpath is broken, and
+      // counting it as one more tolerated failure could return a "successful" partial batch after a
+      // fatal condition. Propagate it unchanged - the caller's finally block still shuts the pool down.
+      if (e.getCause() instanceof Error) {
+        throw (Error) e.getCause();
+      }
+      handleReceiveFailure(e.getCause(), state, queueUrl);
+      return;
+    }
+    // Any successful call - including an empty one - proves the endpoint and credentials are healthy.
+    state.consecutiveTransientFailures = 0;
+    state.healthyResponses++;
+    if (messages.isEmpty()) {
+      // Empties are a batch total that never resets. Resetting on a stray message is what let a
+      // slow-ingress queue hold the phase for its entire call budget, and a total is what bounds the
+      // drain-confirmation cost to one poll window.
+      if (++state.emptyReceives >= plan.emptiesToConfirmDrain) {
+        state.stop(ReceiveExitReason.DRAINED);
+      }
+      return;
+    }
+    long before = state.messages.size();
+    state.messages.addAll(messages);
+    maybeLogReceiveProgress(queueUrl, before, state.messages.size(), state.callsCompleted);
+  }
+
+  /**
+   * Applies the classification in {@link #classifySqsFailure} to one failed call. Backpressure and
+   * non-retryable failures stop dispatch at once; transient ones are tolerated until
+   * {@value #MAX_CONSECUTIVE_TRANSIENT_FAILURES} occur in a row.
+   */
+  private void handleReceiveFailure(Throwable cause, ReceiveState state, String queueUrl) {
+    switch (classifySqsFailure(cause)) {
+      case BACKPRESSURE:
+        // Deliberately not counted as a failed call: it is normal saturation, and counting it would make
+        // an OverLimit-only batch throw below as though the queue were broken. It does count as a healthy
+        // response - SQS answered, so the endpoint and credentials demonstrably work.
+        state.healthyResponses++;
+        state.stop(ReceiveExitReason.IN_FLIGHT_LIMIT);
+        log.warn("SQS reported the in-flight message limit ({}) for queue {} after fetching {} messages; ending the "
+                + "receive phase. Received messages stay in-flight until onCommit deletes them, which frees the quota, "
+                + "so the remaining backlog is picked up by the next ingestion cycle.",
+            SQS_OVER_LIMIT_ERROR_CODE, queueUrl, state.messages.size(), cause);
+        break;
+      case FATAL:
+        state.recordFailure(cause);
+        // First one wins, matching stop() and recordFailure(): when several concurrent calls fail fatally
+        // in the same drain, the exception thrown must carry the same cause the summary reports.
+        if (state.fatalFailure == null) {
+          state.fatalFailure = cause;
+        }
+        state.stop(ReceiveExitReason.FATAL_ERROR);
+        log.error("Non-retryable SQS ReceiveMessage failure for queue {} after fetching {} messages; ending the receive "
+                + "phase immediately rather than retrying a condition no retry can fix. Check the queue url, its "
+                + "region, and the credentials/permissions of this job.",
+            queueUrl, state.messages.size(), cause);
+        break;
+      default:
+        state.recordFailure(cause);
+        if (++state.consecutiveTransientFailures >= MAX_CONSECUTIVE_TRANSIENT_FAILURES) {
+          state.stop(ReceiveExitReason.CONSECUTIVE_FAILURES);
+        }
+        break;
+    }
+  }
+
+  /**
+   * Emits the receive phase's summary, any condition-specific warnings, and the parallelism perf line.
+   */
+  private void logReceiveOutcome(String queueUrl, ReceiveState state, ReceivePlan plan, long wallMs, long busyNanos) {
+    log.info("SQS receive summary for queue {}: fetched {} messages across {} receive calls "
+            + "({} failed), exitReason={}.",
+        queueUrl, state.messages.size(), state.callsCompleted, state.failedCalls, state.exitReason);
+    if (state.failedCalls > 0) {
+      log.warn("{} of {} SQS ReceiveMessage calls failed for queue {}; continued with the {} messages that "
+              + "were received. Undelivered messages stay in the queue and are picked up by the next batch.",
+          state.failedCalls, state.callsCompleted, queueUrl, state.messages.size(), state.firstFailure);
+    }
+    if (state.exitReason == ReceiveExitReason.CALL_BUDGET_EXHAUSTED) {
+      log.warn("SQS receive call budget exhausted for queue {}: {} calls yielded {} of {} targeted messages "
+              + "(plannedReceiveCalls={}, budgetFactor={}). The queue is returning short responses; the "
+              + "remaining backlog is left for the next ingestion cycle.",
+          queueUrl, state.callsCompleted, state.messages.size(), plan.numMessagesToProcess, plan.plannedReceiveCalls,
+          RECEIVE_CALL_BUDGET_FACTOR);
+    }
+    logParallelPerf("receive", queueUrl, plan.workers, state.callsCompleted, wallMs, busyNanos);
+  }
+
+  /**
+   * Emits a bounded receive-progress DEBUG line only when the cumulative fetched count crosses a
+   * {@link #MESSAGE_PROGRESS_LOG_INTERVAL} boundary, so logging stays at a handful of lines per batch
+   * regardless of parallelism.
+   */
+  private void maybeLogReceiveProgress(String queueUrl, long before, long after, long receiveCalls) {
+    if (before / MESSAGE_PROGRESS_LOG_INTERVAL != after / MESSAGE_PROGRESS_LOG_INTERVAL) {
+      log.debug("SQS receive progress for queue {}: {} messages fetched across {} receive calls.",
+          queueUrl, after, receiveCalls);
+    }
+  }
+
+  /**
+   * Probes queue counters when the batch ends on empty responses, to diagnose early termination
+   * while a backlog remains: received messages stay in-flight until onCommit deletes them, so an SQS
+   * in-flight ceiling can cap the batch far below approxAvailable. Purely diagnostic - never lets the
+   * probe fail the batch.
+   */
+  private void logReceiveBreakProbe(SqsClient sqsClient, String queueUrl, int visibilityTimeout, long emptyReceives,
+                                    long fetched, long receiveCalls, long numMessagesToProcess) {
+    Map<String, String> attributesAtBreak = Collections.emptyMap();
+    try {
+      attributesAtBreak = getSqsQueueAttributes(sqsClient, queueUrl);
+    } catch (Exception e) {
+      log.warn("Failed to probe SQS queue attributes at receive-loop break for queue {}; "
+          + "continuing without in-flight counters.", queueUrl, e);
+    }
+    log.warn("SQS ReceiveMessage returned {} empty responses for queue {} after fetching {} messages "
+            + "across {} receive calls (numMessagesToProcess={}); ending batch early. approxAvailable(now)={}, "
+            + "approxInFlight(now)={}, approxDelayed(now)={}, visibilityTimeout={}s. Received messages remain "
+            + "in-flight until onCommit delete, so an in-flight ceiling can cap the batch below the backlog.",
+        emptyReceives, queueUrl, fetched, receiveCalls, numMessagesToProcess,
+        attrOrUnknown(attributesAtBreak, SQS_ATTR_APPROX_MESSAGES),
+        attrOrUnknown(attributesAtBreak, SQS_ATTR_APPROX_MESSAGES_NOT_VISIBLE),
+        attrOrUnknown(attributesAtBreak, SQS_ATTR_APPROX_MESSAGES_DELAYED),
+        visibilityTimeout);
   }
 
   /**
@@ -197,48 +744,446 @@ public class CloudObjectsSelector {
   }
 
   /**
-   * Delete batch of messages from queue.
+   * Deletes one batch (at most {@value #SQS_BATCH_MAX_ENTRIES} entries, the SQS API cap) of messages
+   * and returns the trackers SQS reported as failed, so the caller can retry them. DeleteMessageBatch
+   * can return partial failures even on an HTTP 200, and undeleted messages stay in-flight and are
+   * redelivered once the visibility timeout expires, so failures must be surfaced rather than only
+   * counted.
+   *
+   * <p>A synthetic per-entry id (the batch-local index) is used instead of the message id: the id
+   * only has to be unique within the batch, and under at-least-once delivery the same message id can
+   * appear twice, which would otherwise collide and make SQS reject the whole batch.
    */
-  protected void deleteBatchOfMessages(SqsClient sqs, String queueUrl, List<MessageTracker> messagesToBeDeleted) {
+  protected List<FailedDelete> deleteBatchOfMessages(SqsClient sqs, String queueUrl, List<MessageTracker> messagesToBeDeleted) {
     if (messagesToBeDeleted.isEmpty()) {
-      return;
+      return Collections.emptyList();
     }
-    DeleteMessageBatchRequest.Builder builder = DeleteMessageBatchRequest.builder().queueUrl(queueUrl);
-    List<DeleteMessageBatchRequestEntry> deleteEntries = new ArrayList<>();
-
-    for (MessageTracker message : messagesToBeDeleted) {
+    ValidationUtils.checkArgument(messagesToBeDeleted.size() <= SQS_BATCH_MAX_ENTRIES,
+        "DeleteMessageBatch accepts at most " + SQS_BATCH_MAX_ENTRIES + " entries per call, got "
+            + messagesToBeDeleted.size());
+    List<DeleteMessageBatchRequestEntry> deleteEntries = new ArrayList<>(messagesToBeDeleted.size());
+    for (int i = 0; i < messagesToBeDeleted.size(); i++) {
       deleteEntries.add(
           DeleteMessageBatchRequestEntry.builder()
-                  .id(message.messageId)
-                  .receiptHandle(message.receiptHandle)
+                  .id(String.valueOf(i))
+                  .receiptHandle(messagesToBeDeleted.get(i).receiptHandle)
                   .build());
     }
-    builder.entries(deleteEntries);
-    DeleteMessageBatchResponse deleteResponse = sqs.deleteMessageBatch(builder.build());
-    List<String> deleteFailures =
-        deleteResponse.failed().stream()
-            .map(BatchResultErrorEntry::id)
-            .collect(Collectors.toList());
-    if (!deleteFailures.isEmpty()) {
-      log.warn(
-          "Failed to delete {} messages out of {} from queue.", deleteFailures.size(), deleteEntries.size());
-    } else {
+    DeleteMessageBatchResponse deleteResponse = sqs.deleteMessageBatch(
+        DeleteMessageBatchRequest.builder().queueUrl(queueUrl).entries(deleteEntries).build());
+    if (deleteResponse.failed().isEmpty()) {
       log.debug("Successfully deleted {} messages from queue.", deleteEntries.size());
+      return Collections.emptyList();
+    }
+    // Keep the SQS-provided reason (code + senderFault) with each failed tracker so the caller can log
+    // why deletion failed once at the end rather than per batch.
+    List<FailedDelete> failed = new ArrayList<>(deleteResponse.failed().size());
+    for (BatchResultErrorEntry error : deleteResponse.failed()) {
+      MessageTracker tracker = trackerForEntryId(messagesToBeDeleted, error.id());
+      if (tracker == null) {
+        // SQS echoed an entry id that was never sent (ids are batch-local indices assigned just above, so
+        // this is a protocol violation rather than something that happens in practice). The failure cannot
+        // be attributed to a message: there is no receipt handle to retry with, and it cannot be added to
+        // the residual set either, since that set is counted against processedMessages to derive the
+        // deleted total and a phantom entry would corrupt it. So it is reported here and nowhere else -
+        // meaning the summary's deleted count is an upper bound whenever this WARN fires. The affected
+        // message stays in-flight and is redelivered after the visibility timeout regardless.
+        log.warn("SQS reported a delete failure for unknown entry id \"{}\" on queue {} (code={}); it cannot be "
+            + "mapped back to a message, so that message's deletion status is unknown and the deleted count "
+            + "below may over-count by one.",
+            error.id(), queueUrl, error.code());
+        continue;
+      }
+      failed.add(FailedDelete.reported(tracker, error));
+    }
+    // Per-batch detail at DEBUG only; residual failures are summarized once at WARN in
+    // deleteProcessedMessages so a transient blip across many batches does not flood the logs.
+    log.debug("Failed to delete {} messages out of {} from queue {}.", failed.size(), deleteEntries.size(), queueUrl);
+    return failed;
+  }
+
+  /**
+   * Resolves an entry id assigned by {@link #deleteBatchOfMessages} back to its message. The id is the
+   * batch-local index, so no lookup map is needed. Returns {@code null} when SQS echoes an id that was
+   * never sent (non-numeric or out of range), which the caller reports rather than ignores.
+   */
+  private static MessageTracker trackerForEntryId(List<MessageTracker> batch, String entryId) {
+    try {
+      int index = Integer.parseInt(entryId);
+      return index >= 0 && index < batch.size() ? batch.get(index) : null;
+    } catch (NumberFormatException e) {
+      return null;
     }
   }
 
   /**
    * Delete Queue Messages after hudi commit. This method will be invoked by source.onCommit.
+   * Deletes run concurrently across a fixed pool of up to {@link #processingParallelism} threads;
+   * batches that fail - whether SQS reported the entry as failed on an HTTP 200 or the call threw
+   * outright - are collected across all batches and retried up to {@value #DELETE_MAX_RETRIES} times
+   * with exponential backoff, since undeleted messages stay in-flight, consume the in-flight quota, and
+   * are redelivered once the visibility timeout expires. Any residual failures after the retries are
+   * logged with their reason (see {@link #logDeleteFailures}).
+   *
+   * <p>A failed delete is deliberately not fatal. This runs from {@code Source.onCommit}, which
+   * StreamSync calls <em>after</em> the Hudi commit has already landed, and HoodieStreamer turns any
+   * exception out of the sync round into a job shutdown - so aborting here on one throttled call would
+   * take ingestion down over a condition SQS itself recovers from by redelivering. The one exception is
+   * a systemic failure: if calls were throwing and not a single message could be deleted, that is a
+   * queue/credential/network problem rather than stale individual entries, and it is surfaced.
    */
   public void deleteProcessedMessages(SqsClient sqs, String queueUrl, List<MessageTracker> processedMessages) {
-    if (!processedMessages.isEmpty()) {
-      // create batch for deletion, SES DeleteMessageBatchRequest only accept max 10 entries
-      List<List<MessageTracker>> deleteBatches = createListPartitions(processedMessages, 10);
-      for (List<MessageTracker> deleteBatch : deleteBatches) {
-        deleteBatchOfMessages(sqs, queueUrl, deleteBatch);
-      }
-      log.info("Deleted {} processed messages from queue.", processedMessages.size());
+    if (processedMessages.isEmpty()) {
+      return;
     }
+    long startMs = System.currentTimeMillis();
+    // create batch for deletion, DeleteMessageBatchRequest only accepts max SQS_BATCH_MAX_ENTRIES entries
+    List<List<MessageTracker>> deleteBatches = createListPartitions(processedMessages, SQS_BATCH_MAX_ENTRIES);
+    int totalBatches = deleteBatches.size();
+    int workers = Math.max(1, Math.min(processingParallelism, totalBatches));
+    AtomicLong busyNanos = new AtomicLong();
+    ExecutorService pool = newFixedThreadPool(DELETE_THREAD_PREFIX, workers);
+    // Failures SQS attributes to this caller (senderFault=true, e.g. ReceiptHandleIsInvalid once the
+    // visibility timeout has expired) cannot succeed on a retry, so they are set aside by the pass that
+    // reported them instead of consuming the retry budget - and are still reported at the end.
+    List<FailedDelete> permanentFailures = new ArrayList<>();
+    DeleteStats stats = new DeleteStats();
+    int retries = 0;
+    try {
+      DeletePass pass = deleteBatchesConcurrently(pool, sqs, queueUrl, deleteBatches, busyNanos);
+      stats.add(pass);
+      List<FailedDelete> retryable = splitOffPermanentFailures(pass, permanentFailures);
+      while (!retryable.isEmpty() && retries < DELETE_MAX_RETRIES) {
+        retries++;
+        long backoffMs = sleepBeforeDeleteRetry(queueUrl, retryable.size(), retries);
+        List<MessageTracker> retryTrackers =
+            retryable.stream().map(failedDelete -> failedDelete.message).collect(Collectors.toList());
+        pass = deleteBatchesConcurrently(pool, sqs, queueUrl,
+            createListPartitions(retryTrackers, SQS_BATCH_MAX_ENTRIES), busyNanos);
+        stats.add(pass);
+        retryable = splitOffPermanentFailures(pass, permanentFailures);
+        log.debug("Delete retry {} for queue {} (backoff {} ms) left {} messages still failing.",
+            retries, queueUrl, backoffMs, retryable.size());
+      }
+      List<FailedDelete> residual = new ArrayList<>(permanentFailures);
+      residual.addAll(retryable);
+      long wallMs = System.currentTimeMillis() - startMs;
+      int deleted = processedMessages.size() - residual.size();
+      log.info("Deleted {} of {} processed messages from queue {} across {} delete batches and {} SQS calls "
+              + "({} calls failed, {} retry passes) in {} ms ({} messages failed to delete).",
+          deleted, processedMessages.size(), queueUrl, totalBatches, stats.calls, stats.failedCalls,
+          retries, wallMs, residual.size());
+      if (stats.failedCalls > 0) {
+        // The residual WARN below groups by reason but carries no stack trace; log the first cause once
+        // here so the SDK-level reason (throttling, connection acquisition timeout, ...) is recoverable.
+        log.warn("{} of {} SQS DeleteMessageBatch calls failed for queue {}; their batches were retried and "
+                + "{} messages remain undeleted. Undeleted messages are redelivered after the visibility "
+                + "timeout, so ingestion may see them again rather than losing them.",
+            stats.failedCalls, stats.calls, queueUrl, residual.size(), stats.firstThrown);
+      }
+      if (stats.fatalThrown != null) {
+        // A non-retryable failure that struck only part of the phase (a session token expiring mid-run,
+        // say) leaves deleted > 0, so the systemic throw below stays silent by design. Without this it
+        // would be reported only as an indistinguishable residual-failure WARN, so name the condition
+        // explicitly: no retry can clear it, and it will recur on every commit until an operator acts.
+        log.error("Non-retryable SQS DeleteMessageBatch failure for queue {}; stopped dispatching further "
+                + "delete batches ({} batches skipped) and did not retry, since no retry can succeed. {} of {} "
+                + "messages remain undeleted and will be redelivered after the visibility timeout. Check the "
+                + "queue url, its region, and the credentials/permissions of this job.",
+            queueUrl, stats.skippedBatches, residual.size(), processedMessages.size(), stats.fatalThrown);
+      }
+      if (!residual.isEmpty()) {
+        logDeleteFailures(queueUrl, residual, retries);
+      }
+      logParallelPerf("delete", queueUrl, workers, stats.calls, wallMs, busyNanos.get());
+      // Nothing at all could be deleted and calls were throwing: systemic (bad credentials, queue gone,
+      // network down) rather than individual stale entries, and the caller is about to clear its tracked
+      // messages as if they had been handled, so surface it. A purely senderFault residue is deliberately
+      // not fatal - every receipt handle being stale is a real queue state that no retry or job failure
+      // can fix, and the messages are redelivered regardless.
+      //
+      // NOTE: this deliberately does not fire when every entry failed server-side on an HTTP 200
+      // (senderFault=false, e.g. InternalError) with no call ever throwing. That is an equally total
+      // failure to delete, but SQS reports genuinely broken plumbing - bad credentials, a deleted queue -
+      // by throwing, so firstThrown is the sharper signal, and escalating a persistent per-entry
+      // condition into a job shutdown would trade at-least-once redelivery for an ingestion outage.
+      // Making that case visible belongs to the residual-failure metric tracked as follow-up, not here.
+      // The extra answeredCalls() guard: a DeleteMessageBatch that returned HTTP 200 proves the queue is
+      // reachable and the credentials work, even if it reported every entry as failed. Without it, the
+      // deliberately-non-fatal all-senderFault case above (every receipt handle stale after a long commit)
+      // turns into a job shutdown as soon as one unrelated call is also throttled - and fanning out makes
+      // such a throttle more likely, not less.
+      if (deleted == 0 && stats.firstThrown != null && stats.answeredCalls() == 0) {
+        throw new HoodieException("Failed to delete any of the " + processedMessages.size()
+            + " processed messages from SQS queue " + queueUrl + " (" + stats.failedCalls + " of "
+            + stats.calls + " DeleteMessageBatch calls threw, " + residual.size()
+            + " messages still undeleted after " + retries + " retries)", stats.firstThrown);
+      }
+    } finally {
+      shutdownThreadPool(pool);
+    }
+  }
+
+  /**
+   * Deletes the given batches concurrently on {@code pool} and returns the outcome of the pass: every
+   * message that was not deleted, plus the call stats. Each batch's SQS call time is accumulated into
+   * {@code busyNanos} so the caller can log the serialized-equivalent time and prove the deletes
+   * actually overlapped.
+   */
+  private DeletePass deleteBatchesConcurrently(ExecutorService pool, SqsClient sqs, String queueUrl,
+                                               List<List<MessageTracker>> deleteBatches, AtomicLong busyNanos) {
+    int workers = Math.max(1, Math.min(processingParallelism, deleteBatches.size()));
+    CompletionService<BatchOutcome> completionService = new ExecutorCompletionService<>(pool);
+    Iterator<List<MessageTracker>> pending = deleteBatches.iterator();
+    DeletePass pass = new DeletePass();
+    int outstanding = 0;
+    try {
+      // Dispatch incrementally rather than queueing every batch up front. The pool stays saturated either
+      // way, but holding the untried batches back is what makes fail-fast possible: on a non-retryable
+      // failure the remaining batches are simply never submitted. With a deleted queue or revoked
+      // credentials that is the difference between ceil(M/10) doomed calls and roughly one per worker.
+      outstanding += dispatchDeleteBatches(completionService, pending, sqs, queueUrl, busyNanos,
+          workers - outstanding);
+      while (outstanding > 0) {
+        Future<BatchOutcome> completed = completionService.take();
+        outstanding--;
+        pass.calls++;
+        BatchOutcome outcome = outcomeOf(completed);
+        if (outcome.thrown == null) {
+          pass.failures.addAll(outcome.failures);
+        } else {
+          // A thrown call leaves its whole batch undeleted, exactly like an SQS-reported entry failure, so
+          // it goes through the same path. Aborting the pass outright would discard the failures already
+          // collected from the other batches, skip the retries entirely, and propagate out of onCommit
+          // into a job shutdown (see deleteProcessedMessages). Fanning out makes a transient throttle or
+          // connection-acquisition timeout more likely, not less, so it must be survivable.
+          pass.failedCalls++;
+          if (pass.firstThrown == null) {
+            pass.firstThrown = outcome.thrown;
+          }
+          if (classifySqsFailure(outcome.thrown) == SqsFailureKind.FATAL) {
+            // Nothing that follows can succeed, so stop handing out work. The batches already in flight
+            // still drain below - their messages are recorded as failures either way, and cancelling them
+            // would only lose the outcome of calls that may well have succeeded.
+            if (pass.fatalThrown == null) {
+              pass.fatalThrown = outcome.thrown;
+            }
+          }
+          for (MessageTracker message : outcome.batch) {
+            pass.failures.add(FailedDelete.thrown(message, outcome.thrown));
+          }
+        }
+        if (pass.fatalThrown == null) {
+          outstanding += dispatchDeleteBatches(completionService, pending, sqs, queueUrl, busyNanos,
+              workers - outstanding);
+        }
+      }
+      if (pass.fatalThrown != null) {
+        // Everything never dispatched is undeleted too, and must be accounted for or the summary would
+        // report those messages as deleted. They are recorded against the fatal cause, which
+        // FailedDelete.thrown classifies as permanent, so they are reported rather than retried.
+        while (pending.hasNext()) {
+          for (MessageTracker message : pending.next()) {
+            pass.failures.add(FailedDelete.thrown(message, pass.fatalThrown));
+          }
+          pass.skippedBatches++;
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new HoodieException("Interrupted while deleting messages from SQS queue " + queueUrl, e);
+    }
+    return pass;
+  }
+
+  /**
+   * Submits up to {@code slots} more delete batches, returning how many were actually dispatched.
+   */
+  private int dispatchDeleteBatches(CompletionService<BatchOutcome> completionService,
+                                    Iterator<List<MessageTracker>> pending, SqsClient sqs, String queueUrl,
+                                    AtomicLong busyNanos, int slots) {
+    int dispatched = 0;
+    while (dispatched < slots && pending.hasNext()) {
+      List<MessageTracker> deleteBatch = pending.next();
+      completionService.submit(() -> {
+        long callStartNanos = System.nanoTime();
+        try {
+          return new BatchOutcome(deleteBatch, deleteBatchOfMessages(sqs, queueUrl, deleteBatch), null);
+        } catch (Exception e) {
+          // Returned rather than thrown so the outcome carries its own batch: a CompletionService future
+          // cannot be mapped back to its task. An Error is deliberately not caught here and still
+          // surfaces through ExecutionException - see outcomeOf.
+          return new BatchOutcome(deleteBatch, Collections.emptyList(), e);
+        } finally {
+          busyNanos.addAndGet(System.nanoTime() - callStartNanos);
+        }
+      });
+      dispatched++;
+    }
+    return dispatched;
+  }
+
+  /**
+   * Unwraps a completed delete task. Only an {@link Error} can surface as an {@link ExecutionException}
+   * here, since the task itself converts every {@code Exception} into a {@link BatchOutcome}. An Error
+   * (OutOfMemoryError, a LinkageError from a missing SDK class) is not a delete failure and must not be
+   * funnelled into the retry path: the JVM or the classpath is broken, and retrying the batch would only
+   * hide a fatal condition behind a residual-failure log line. Propagate it, mirroring the receive loop.
+   */
+  private static BatchOutcome outcomeOf(Future<BatchOutcome> completed) throws InterruptedException {
+    try {
+      return completed.get();
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof Error) {
+        throw (Error) e.getCause();
+      }
+      throw new HoodieException("Unexpected failure completing an SQS delete batch", e.getCause());
+    }
+  }
+
+  /**
+   * Moves the pass's permanent failures - the ones no retry can make succeed - into
+   * {@code permanentSink} and returns the ones worth retrying. See {@link FailedDelete#permanent}.
+   */
+  private static List<FailedDelete> splitOffPermanentFailures(DeletePass pass, List<FailedDelete> permanentSink) {
+    List<FailedDelete> retryable = new ArrayList<>();
+    for (FailedDelete failedDelete : pass.failures) {
+      if (failedDelete.permanent) {
+        permanentSink.add(failedDelete);
+      } else {
+        retryable.add(failedDelete);
+      }
+    }
+    return retryable;
+  }
+
+  /**
+   * Classifies a failed SQS call. Shared by the receive and delete phases, because SQS reports the same
+   * conditions the same way on both.
+   *
+   * <p>SQS status codes do not track severity - {@code RequestThrottled} and {@code OverLimit} are HTTP
+   * 400, {@code ThrottlingException} is HTTP 403, while {@code MalformedQueryString} is HTTP 404 - so the
+   * error code decides and the status code is only the fallback for codes we do not recognise.
+   *
+   * <p>{@code AwsServiceException.isThrottlingException()} matches on error code rather than status, but
+   * its set omits {@code KmsThrottled}; {@link #EXTRA_TRANSIENT_ERROR_CODES} covers that gap. The
+   * fallback degrades safely in both directions: an unrecognised 5xx is transient, an unrecognised 4xx is
+   * non-retryable, and an exception carrying no usable status at all is treated as transient rather than
+   * failing the operation outright.
+   */
+  static SqsFailureKind classifySqsFailure(Throwable cause) {
+    if (cause instanceof AwsServiceException) {
+      AwsServiceException serviceException = (AwsServiceException) cause;
+      String errorCode = serviceException.awsErrorDetails() != null
+          ? serviceException.awsErrorDetails().errorCode() : null;
+      if (SQS_OVER_LIMIT_ERROR_CODE.equals(errorCode)) {
+        return SqsFailureKind.BACKPRESSURE;
+      }
+      if (serviceException.isThrottlingException() || EXTRA_TRANSIENT_ERROR_CODES.contains(errorCode)) {
+        return SqsFailureKind.TRANSIENT;
+      }
+      int statusCode = serviceException.statusCode();
+      if (statusCode >= 500) {
+        return SqsFailureKind.TRANSIENT;
+      }
+      return statusCode >= 400 ? SqsFailureKind.FATAL : SqsFailureKind.TRANSIENT;
+    }
+    // SdkClientException and friends are transport-level (connection reset, socket timeout, connection
+    // acquisition timeout) and therefore transient by nature.
+    return cause instanceof SdkException ? SqsFailureKind.TRANSIENT : SqsFailureKind.FATAL;
+  }
+
+  /**
+   * Logs the upcoming retry and sleeps for its exponential backoff, returning the backoff applied. The
+   * first retry logs at INFO - one transient partial failure is routine and self-healing - and later
+   * attempts at WARN, since a failure that survives a retry is worth an operator's attention.
+   *
+   * @return the backoff in millis that was slept
+   */
+  private static long sleepBeforeDeleteRetry(String queueUrl, int failedCount, int attempt) {
+    long backoffMs = DELETE_RETRY_BASE_BACKOFF_MS << (attempt - 1);
+    if (attempt == 1) {
+      log.info("Retrying delete of {} failed SQS messages (attempt {}/{}) for queue {} after {} ms backoff.",
+          failedCount, attempt, DELETE_MAX_RETRIES, queueUrl, backoffMs);
+    } else {
+      log.warn("Retrying delete of {} failed SQS messages (attempt {}/{}) for queue {} after {} ms backoff.",
+          failedCount, attempt, DELETE_MAX_RETRIES, queueUrl, backoffMs);
+    }
+    try {
+      Thread.sleep(backoffMs);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new HoodieException("Interrupted while backing off before an SQS delete retry for queue " + queueUrl, e);
+    }
+    return backoffMs;
+  }
+
+  /**
+   * Logs why the residual messages could not be deleted after all retries, grouped by reason (SQS error
+   * code + senderFault, or {@value #DELETE_CALL_FAILED_CODE} for a call that threw) and with a sample of
+   * the affected message ids. Undeleted messages stay in-flight until the visibility timeout expires and
+   * are then redelivered, so the reason - a transient server error vs. a permanent client fault such as
+   * an expired receipt handle (senderFault=true) - is what on-call needs to decide whether to act, and
+   * the message ids are what makes the queue or DLQ greppable.
+   */
+  private void logDeleteFailures(String queueUrl, List<FailedDelete> failed, int retries) {
+    Map<String, Long> failuresByReason = failed.stream()
+        .collect(Collectors.groupingBy(FailedDelete::reason, Collectors.counting()));
+    List<String> sampleMessageIds = failed.stream()
+        .limit(DELETE_FAILURE_SAMPLE_SIZE)
+        .map(failedDelete -> failedDelete.message.messageId)
+        .collect(Collectors.toList());
+    log.warn("Failed to delete {} SQS messages from queue {} after {} retries; failures by reason: {}; "
+            + "sample messageIds (up to {} of {}): {}; sample error: \"{}\". Undeleted messages remain "
+            + "in-flight until the visibility timeout expires and are then redelivered - and redrive to the "
+            + "DLQ once maxReceiveCount is reached, if a redrive policy is configured on the queue.",
+        failed.size(), queueUrl, retries, failuresByReason, DELETE_FAILURE_SAMPLE_SIZE, failed.size(),
+        sampleMessageIds, failed.get(0).errorMessage);
+  }
+
+  /**
+   * Creates a fixed-size pool of daemon threads named with {@code namePrefix} for identifiability in
+   * stack dumps. Daemon threads so a leaked pool can never block JVM shutdown.
+   */
+  private static ExecutorService newFixedThreadPool(String namePrefix, int size) {
+    AtomicInteger threadIndex = new AtomicInteger();
+    return Executors.newFixedThreadPool(size, runnable -> {
+      Thread thread = new Thread(runnable, namePrefix + threadIndex.getAndIncrement());
+      thread.setDaemon(true);
+      return thread;
+    });
+  }
+
+  /**
+   * Shuts a receive/delete pool down. On the normal paths every task has already been joined by the time
+   * this runs, so it returns promptly; the timeout only guards against a stuck AWS call on the paths that
+   * abandon the phase with work still outstanding (a worker {@link Error}, or an interrupt). Restores the
+   * interrupt flag on interruption per the standard contract.
+   */
+  private static void shutdownThreadPool(ExecutorService pool) {
+    pool.shutdown();
+    try {
+      if (!pool.awaitTermination(POOL_SHUTDOWN_TIMEOUT_SECS, TimeUnit.SECONDS)) {
+        pool.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      pool.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Logs whether a fanned-out phase actually ran concurrently. {@code serialEquivMs} is the summed
+   * wall time of every individual SQS call; {@code speedup = serialEquivMs / wallMs}. A speedup near
+   * 1 means the calls ran serialized (a regression); a speedup near {@code parallelism} means they
+   * overlapped as intended.
+   */
+  private void logParallelPerf(String phase, String queueUrl, int parallelism, long calls, long wallMs, long busyNanos) {
+    long serialEquivMs = busyNanos / 1_000_000L;
+    double speedup = wallMs > 0 ? (double) serialEquivMs / wallMs : 1.0;
+    log.info("SQS {} perf for queue {}: parallelism={}, calls={}, wallMs={}, serialEquivMs={}, speedup={}x.",
+        phase, queueUrl, parallelism, calls, wallMs, serialEquivMs,
+        String.format(Locale.ROOT, "%.1f", speedup));
   }
 
   /**
@@ -306,5 +1251,215 @@ public class CloudObjectsSelector {
       this.messageId = message.messageId();
       this.receiptHandle = message.receiptHandle();
     }
+  }
+
+  /**
+   * A message that could not be deleted, paired with the reason. Covers both ways a delete fails: SQS
+   * reported the entry as failed on an otherwise successful DeleteMessageBatch, or the call threw and
+   * the whole batch is undeleted. Normalising both into one type lets a single retry path and a single
+   * summary handle them - see {@link #deleteProcessedMessages} and {@link #logDeleteFailures}.
+   *
+   * <p>{@link #permanent} is the retry decision. For an entry SQS reported, it is {@code senderFault}:
+   * SQS sets that when the fault is the caller's (an expired receipt handle, say), which no retry can
+   * fix. For a call that threw, it is whether {@link #classifySqsFailure} judged the cause non-retryable
+   * - a deleted queue or revoked credentials is not made retryable by the fact that it surfaced as a
+   * thrown call rather than a per-entry error, and retrying it would burn the entire retry budget on
+   * calls that cannot succeed.
+   */
+  static final class FailedDelete {
+    private final MessageTracker message;
+    private final String code;
+    private final boolean senderFault;
+    private final boolean permanent;
+    private final String errorMessage;
+
+    private FailedDelete(MessageTracker message, String code, boolean senderFault, boolean permanent,
+                         String errorMessage) {
+      this.message = message;
+      this.code = code;
+      this.senderFault = senderFault;
+      this.permanent = permanent;
+      this.errorMessage = errorMessage;
+    }
+
+    /** SQS reported this entry as failed on an otherwise successful DeleteMessageBatch call. */
+    static FailedDelete reported(MessageTracker message, BatchResultErrorEntry error) {
+      boolean senderFault = Boolean.TRUE.equals(error.senderFault());
+      return new FailedDelete(message,
+          error.code() != null ? error.code() : UNKNOWN_ERROR_CODE,
+          senderFault, senderFault,
+          error.message() != null ? error.message() : NO_ERROR_MESSAGE);
+    }
+
+    /** The DeleteMessageBatch call threw, so SQS never reported per-entry status for this message. */
+    static FailedDelete thrown(MessageTracker message, Throwable cause) {
+      return new FailedDelete(message, DELETE_CALL_FAILED_CODE, false,
+          classifySqsFailure(cause) == SqsFailureKind.FATAL,
+          cause != null ? cause.toString() : NO_ERROR_MESSAGE);
+    }
+
+    /** Grouping key for the residual-failure summary. */
+    String reason() {
+      return code + " (senderFault=" + senderFault + ")";
+    }
+  }
+
+  /**
+   * Why the receive phase stopped dispatching, reported in the summary line for on-call.
+   */
+  enum ReceiveExitReason {
+    /** The queue reported no available messages, so no receive call was made at all. */
+    NO_MESSAGES,
+    /** {@code numMessagesToProcess} was reached. */
+    TARGET_REACHED,
+    /** Enough empty responses accumulated to confirm the queue is drained. */
+    DRAINED,
+    /** SQS reported {@value #SQS_OVER_LIMIT_ERROR_CODE}: the in-flight quota is exhausted. */
+    IN_FLIGHT_LIMIT,
+    /** A non-retryable failure occurred. */
+    FATAL_ERROR,
+    /** {@value #MAX_CONSECUTIVE_TRANSIENT_FAILURES} transient failures occurred in a row. */
+    CONSECUTIVE_FAILURES,
+    /** The receive-call budget was spent while the queue kept returning short responses. */
+    CALL_BUDGET_EXHAUSTED
+  }
+
+  /**
+   * The immutable plan for one receive phase: what to fetch and the limits that bound the attempt.
+   * Separated from {@link ReceiveState} so the loop's inputs cannot be confused with its running totals.
+   */
+  static final class ReceivePlan {
+    private final long numMessagesToProcess;
+    private final int maxMessagesPerRequest;
+    private final int workers;
+    private final long receiveCallBudget;
+    private final int emptiesToConfirmDrain;
+    private final long plannedReceiveCalls;
+
+    ReceivePlan(long numMessagesToProcess, int maxMessagesPerRequest, int workers, long receiveCallBudget,
+                int emptiesToConfirmDrain, long plannedReceiveCalls) {
+      this.numMessagesToProcess = numMessagesToProcess;
+      this.maxMessagesPerRequest = maxMessagesPerRequest;
+      this.workers = workers;
+      this.receiveCallBudget = receiveCallBudget;
+      this.emptiesToConfirmDrain = emptiesToConfirmDrain;
+      this.plannedReceiveCalls = plannedReceiveCalls;
+    }
+  }
+
+  /**
+   * Running state of one receive phase. Every field is touched only by the master thread, so all of it is
+   * plain non-atomic state - the workers never see it.
+   */
+  static final class ReceiveState {
+    private final List<Message> messages = new ArrayList<>();
+    /** Calls submitted to the pool but not yet folded back in. */
+    private int outstanding;
+    private long callsIssued;
+    private long callsCompleted;
+    /** Excludes {@link SqsFailureKind#BACKPRESSURE}, which is saturation rather than a failure. */
+    private long failedCalls;
+    /**
+     * Calls that proved the queue reachable: any successful response, plus an OverLimit, which SQS itself
+     * returned and which therefore also demonstrates working credentials and a live queue. Used to decide
+     * whether an empty result with some failures is a broken pipeline or a healthy one that got unlucky.
+     */
+    private long healthyResponses;
+    private long emptyReceives;
+    private int consecutiveTransientFailures;
+    private ReceiveExitReason exitReason;
+    private Throwable firstFailure;
+    private Throwable fatalFailure;
+
+    boolean stopped() {
+      return exitReason != null;
+    }
+
+    /** Records the first stop condition to fire; later ones cannot mask why dispatch actually ended. */
+    void stop(ReceiveExitReason reason) {
+      if (exitReason == null) {
+        exitReason = reason;
+      }
+    }
+
+    void recordFailure(Throwable cause) {
+      failedCalls++;
+      if (firstFailure == null) {
+        firstFailure = cause;
+      }
+    }
+  }
+
+  /**
+   * Outcome of one concurrent pass of delete batches: every message the pass failed to delete, and the
+   * call stats needed for the perf line and for telling a systemic failure from individual bad entries.
+   */
+  private static final class DeletePass {
+    private final List<FailedDelete> failures = new ArrayList<>();
+    private int calls;
+    private int failedCalls;
+    /** Batches never dispatched because a non-retryable failure stopped the pass. */
+    private int skippedBatches;
+    private Throwable firstThrown;
+    /** Set when a call failed non-retryably, which stops this pass dispatching any more batches. */
+    private Throwable fatalThrown;
+  }
+
+  /** Running totals across all delete passes (initial + retries), for the summary and perf lines. */
+  private static final class DeleteStats {
+    private int calls;
+    private int failedCalls;
+    private int skippedBatches;
+    private Throwable firstThrown;
+    private Throwable fatalThrown;
+
+    void add(DeletePass pass) {
+      calls += pass.calls;
+      failedCalls += pass.failedCalls;
+      skippedBatches += pass.skippedBatches;
+      if (firstThrown == null) {
+        firstThrown = pass.firstThrown;
+      }
+      if (fatalThrown == null) {
+        fatalThrown = pass.fatalThrown;
+      }
+    }
+
+    /**
+     * Calls that got an answer from SQS. A DeleteMessageBatch that returned HTTP 200 proves the endpoint
+     * resolved, the credentials authenticated and the queue exists, even when it reported every entry as
+     * failed - which is exactly the evidence needed to tell a broken pipeline from a stale-handle batch.
+     */
+    int answeredCalls() {
+      return calls - failedCalls;
+    }
+  }
+
+  /**
+   * Outcome of one DeleteMessageBatch task, carrying its own batch because a {@link CompletionService}
+   * future cannot be mapped back to the task that produced it.
+   */
+  private static final class BatchOutcome {
+    private final List<MessageTracker> batch;
+    private final List<FailedDelete> failures;
+    private final Throwable thrown;
+
+    BatchOutcome(List<MessageTracker> batch, List<FailedDelete> failures, Throwable thrown) {
+      this.batch = batch;
+      this.failures = failures;
+      this.thrown = thrown;
+    }
+  }
+
+  /**
+   * How a failed SQS call should be handled. See {@link #classifySqsFailure}.
+   */
+  enum SqsFailureKind {
+    /** Retrying may succeed: throttling, a 5xx, a dropped connection. */
+    TRANSIENT,
+    /** A queue-level ceiling was hit. Stop issuing calls, but this is saturation, not a failure. */
+    BACKPRESSURE,
+    /** No retry can succeed: queue gone, bad credentials, malformed request. */
+    FATAL
   }
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelector.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/CloudObjectsSelector.java
@@ -177,7 +177,11 @@ public class CloudObjectsSelector {
   // Retries only ever target transient, server-side failures (SQS InternalError, throttling, a dropped
   // connection); retrying microseconds later would almost certainly hit the same condition, so each pass
   // backs off exponentially from this base: 100ms, 200ms, 400ms. Bounded by DELETE_MAX_RETRIES, so the
-  // delete phase adds at most 700ms of sleep on the driver even in the worst case.
+  // retries add at most 700ms of *sleep* on the driver even in the worst case. That is the sleep alone,
+  // not a bound on the phase: the dominant term is up to DELETE_MAX_RETRIES + 1 passes of ceil(M/10)
+  // concurrent calls, which at a large maxMessagePerBatch is the part that can approach a short
+  // visibilityTimeout - at which point retries start failing on stale handles and the remaining budget
+  // is spent on entries that have already moved to the permanent bucket.
   static final long DELETE_RETRY_BASE_BACKOFF_MS = 100;
   // How many failed message ids to name in the residual-failure WARN. Enough for on-call to grep the
   // queue or a DLQ for a concrete message without dumping an unbounded list into the log.
@@ -891,7 +895,7 @@ public class CloudObjectsSelector {
     DeleteStats stats = new DeleteStats();
     int retries = 0;
     try {
-      DeletePass pass = deleteBatchesConcurrently(pool, sqs, queueUrl, deleteBatches, busyNanos);
+      DeletePass pass = deleteBatchesConcurrently(pool, sqs, queueUrl, deleteBatches, workers, busyNanos);
       stats.add(pass);
       List<FailedDelete> retryable = splitOffPermanentFailures(pass, permanentFailures);
       while (!retryable.isEmpty() && retries < DELETE_MAX_RETRIES) {
@@ -900,7 +904,7 @@ public class CloudObjectsSelector {
         List<MessageTracker> retryTrackers =
             retryable.stream().map(failedDelete -> failedDelete.message).collect(Collectors.toList());
         pass = deleteBatchesConcurrently(pool, sqs, queueUrl,
-            createListPartitions(retryTrackers, SQS_BATCH_MAX_ENTRIES), busyNanos);
+            createListPartitions(retryTrackers, SQS_BATCH_MAX_ENTRIES), workers, busyNanos);
         stats.add(pass);
         retryable = splitOffPermanentFailures(pass, permanentFailures);
         log.debug("Delete retry {} for queue {} (backoff {} ms) left {} messages still failing.",
@@ -970,10 +974,16 @@ public class CloudObjectsSelector {
    * message that was not deleted, plus the call stats. Each batch's SQS call time is accumulated into
    * {@code busyNanos} so the caller can log the serialized-equivalent time and prove the deletes
    * actually overlapped.
+   *
+   * @param workers the pool's size, passed in rather than re-derived from {@code deleteBatches}. A retry
+   *     pass carries fewer batches than the first one, so deriving it here would produce a second,
+   *     smaller value under the same name as the caller's - and the caller's is the one that sized the
+   *     pool and is reported as {@code parallelism} on the perf line. Over-dispatch is not a concern:
+   *     {@code pending} is exhausted once every batch is submitted, whatever the slot count says.
    */
   private DeletePass deleteBatchesConcurrently(ExecutorService pool, SqsClient sqs, String queueUrl,
-                                               List<List<MessageTracker>> deleteBatches, AtomicLong busyNanos) {
-    int workers = Math.max(1, Math.min(processingParallelism, deleteBatches.size()));
+                                               List<List<MessageTracker>> deleteBatches, int workers,
+                                               AtomicLong busyNanos) {
     CompletionService<BatchOutcome> completionService = new ExecutorCompletionService<>(pool);
     Iterator<List<MessageTracker>> pending = deleteBatches.iterator();
     DeletePass pass = new DeletePass();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelector.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/helpers/TestCloudObjectsSelector.java
@@ -21,6 +21,7 @@ package org.apache.hudi.utilities.sources.helpers;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.testutils.HoodieSparkClientTestHarness;
 import org.apache.hudi.utilities.testutils.CloudObjectTestUtils;
 
@@ -28,20 +29,47 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse;
 import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SqsException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
+import static org.apache.hudi.utilities.config.S3SourceConfig.S3_SOURCE_QUEUE_PROCESSING_PARALLELISM;
 import static org.apache.hudi.utilities.config.S3SourceConfig.S3_SOURCE_QUEUE_REGION;
 import static org.apache.hudi.utilities.config.S3SourceConfig.S3_SOURCE_QUEUE_URL;
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.S3_FILE_PATH;
@@ -49,10 +77,19 @@ import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.S3_
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.S3_MODEL_EVENT_TIME;
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.S3_PREFIX;
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.SQS_ATTR_APPROX_MESSAGES;
+import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.SQS_ATTR_MESSAGE_RETENTION_PERIOD;
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.SQS_MODEL_EVENT_RECORDS;
 import static org.apache.hudi.utilities.sources.helpers.CloudObjectsSelector.SQS_MODEL_MESSAGE;
 import static org.apache.hudi.utilities.testutils.CloudObjectTestUtils.deleteMessagesInQueue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestCloudObjectsSelector extends HoodieSparkClientTestHarness {
 
@@ -211,14 +248,14 @@ public class TestCloudObjectsSelector extends HoodieSparkClientTestHarness {
     List<CloudObjectsSelector.MessageTracker> testSingleList = new ArrayList<>();
     testSingleList.add(
         new CloudObjectsSelector.MessageTracker(Message.builder()
-            .attributesWithStrings(createAttributeMap("MessageId", "1"))
-            .attributesWithStrings(createAttributeMap("ReceiptHandle", "1"))
-            .build()));
+                    .attributesWithStrings(createAttributeMap("MessageId", "1"))
+                    .attributesWithStrings(createAttributeMap("ReceiptHandle", "1"))
+                    .build()));
     testSingleList.add(
         new CloudObjectsSelector.MessageTracker(Message.builder()
-            .attributesWithStrings(createAttributeMap("MessageId", "2"))
-            .attributesWithStrings(createAttributeMap("ReceiptHandle", "1"))
-            .build()));
+                    .attributesWithStrings(createAttributeMap("MessageId", "2"))
+                    .attributesWithStrings(createAttributeMap("ReceiptHandle", "1"))
+                    .build()));
 
     deleteMessagesInQueue(sqs);
 
@@ -226,10 +263,1363 @@ public class TestCloudObjectsSelector extends HoodieSparkClientTestHarness {
     selector.deleteProcessedMessages(sqs, sqsUrl, testSingleList);
   }
 
+  @Test
+  public void testEmptyReceivesToConfirmDrainScalesWithPollCost() {
+    // Under long polling AWS sends an empty response "only if the polling wait time expires", so an
+    // empty costs a full longPollWait. The number of empties required is therefore whatever fits in one
+    // drain-confirmation window, which holds the cost of proving "drained" to ~one poll window at every
+    // setting instead of multiplying it by a fixed count.
+    assertEquals(1, CloudObjectsSelector.emptyReceivesToConfirmDrain(20));
+    assertEquals(2, CloudObjectsSelector.emptyReceivesToConfirmDrain(10));
+    assertEquals(4, CloudObjectsSelector.emptyReceivesToConfirmDrain(5));
+    assertEquals(20, CloudObjectsSelector.emptyReceivesToConfirmDrain(1));
+    // A wait longer than the window still needs one empty, never zero.
+    assertEquals(1, CloudObjectsSelector.emptyReceivesToConfirmDrain(60));
+    // Short polling samples only a subset of servers and returns immediately: weak evidence, but nearly
+    // free, so it keeps the higher fixed count.
+    assertEquals(CloudObjectsSelector.MAX_EMPTY_RECEIVES_SHORT_POLL,
+        CloudObjectsSelector.emptyReceivesToConfirmDrain(0));
+    assertEquals(CloudObjectsSelector.MAX_EMPTY_RECEIVES_SHORT_POLL,
+        CloudObjectsSelector.emptyReceivesToConfirmDrain(-1));
+  }
+
+  @Test
+  public void testReceiveStopsOnFirstEmptyLongPoll() {
+    // Backlog reports 100 messages available but ReceiveMessage returns empty (e.g. the rest are already
+    // in-flight). At the maximum long-poll wait a single empty response means SQS queried every server
+    // and waited the full 20s, so it ends the batch immediately. The previous behaviour spent five
+    // sequential 20-second long polls (~100s) to reach the same conclusion.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class)))
+        .thenReturn(ReceiveMessageResponse.builder().build());
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 100, 10);
+
+    assertEquals(0, messages.size());
+    verify(sqs, times(1)).receiveMessage(any(ReceiveMessageRequest.class));
+    // One attributes call at loop start + one in-flight probe, since the drain fell materially short of
+    // the 100 messages the queue claimed were available.
+    verify(sqs, times(2)).getQueueAttributes(any(GetQueueAttributesRequest.class));
+  }
+
+  @Test
+  public void testShortPollStillRequiresMultipleEmpties() {
+    // longPollWait=0 is short polling: SQS "samples a subset of its servers" and answers immediately, so
+    // a single empty response is genuinely weak evidence - and cheap to repeat. The higher fixed count
+    // must still apply there.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class)))
+        .thenReturn(ReceiveMessageResponse.builder().build());
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 0, 30, 100, 10);
+
+    assertEquals(0, messages.size());
+    verify(sqs, times(CloudObjectsSelector.MAX_EMPTY_RECEIVES_SHORT_POLL))
+        .receiveMessage(any(ReceiveMessageRequest.class));
+  }
+
+  @Test
+  public void testReceiveDoesNotTruncateOnSpuriousEmptyWhenPollWaitIsLow() {
+    // AWS scopes the false-empty risk to low wait times, and the drain count grows to match: at
+    // longPollWait=5 four empties are required, so one spurious empty must not truncate the batch and the
+    // messages arriving after it must survive.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    ReceiveMessageResponse empty = ReceiveMessageResponse.builder().build();
+    ReceiveMessageResponse twoMessages = ReceiveMessageResponse.builder()
+        .messages(sqsMessage("m1", "r1"), sqsMessage("m2", "r2")).build();
+    // empty, 2 msgs, then empty forever (Mockito repeats the last stub).
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class)))
+        .thenReturn(empty, twoMessages, empty);
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 5, 30, 100, 10);
+
+    // Both real messages survive the spurious leading empty; validate the actual ids, not just the count.
+    assertEquals(2, messages.size());
+    List<String> ids = messages.stream().map(Message::messageId).sorted().collect(Collectors.toList());
+    assertEquals("m1", ids.get(0));
+    assertEquals("m2", ids.get(1));
+    // 4 empties are required in total, and one of the 5 calls returned messages.
+    verify(sqs, times(5)).receiveMessage(any(ReceiveMessageRequest.class));
+  }
+
+  @Test
+  public void testTricklingQueueTerminatesOnAccumulatedEmpties() {
+    // A queue with slow ingress: 4 empty polls then 1 message, repeating. Counting empties consecutively
+    // let every 5th call reset the counter, so the phase ran the entire call budget - 80 calls, 64 of them
+    // full-length empty long polls (~21 minutes of wall time at longPollWait=20). Counting them as a batch
+    // total makes the run terminate on the accumulated empties instead.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "5000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      int call = calls.incrementAndGet();
+      if (call % 5 == 0) {
+        return ReceiveMessageResponse.builder().messages(sqsMessage("m" + call, "r" + call)).build();
+      }
+      return ReceiveMessageResponse.builder().build();
+    });
+
+    // maxMessagePerBatch=200, maxMessagesPerRequest=10 -> plannedReceiveCalls=20, budget=20*4=80.
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 5, 30, 200, 10);
+
+    // longPollWait=5 -> 4 empties confirm the drain, which the first four calls supply.
+    assertEquals(4, calls.get(), "must terminate on accumulated empties, not the call budget");
+    assertEquals(0, messages.size());
+    assertTrue(calls.get() < 20 * CloudObjectsSelector.RECEIVE_CALL_BUDGET_FACTOR,
+        "must stop far short of the call budget, was " + calls.get());
+  }
+
+  @Test
+  public void testParallelReceiveFetchesEveryMessageExactlyOnce() {
+    // Real concurrency: 8 workers drain a shared backlog of 250 messages (10 per receive call). Every
+    // message must be fetched exactly once - no loss, no duplication - and merged into the result.
+    int totalMessages = 250;
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "8");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, String.valueOf(totalMessages));
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    ConcurrentLinkedQueue<Message> backlog = new ConcurrentLinkedQueue<>();
+    for (int i = 0; i < totalMessages; i++) {
+      backlog.add(sqsMessage("m" + i, "r" + i));
+    }
+    // Thread-safe stub: each receive pops up to 10 messages; empty response once drained.
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      List<Message> batch = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        Message polled = backlog.poll();
+        if (polled == null) {
+          break;
+        }
+        batch.add(polled);
+      }
+      return ReceiveMessageResponse.builder().messages(batch).build();
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 1000, 10);
+
+    assertEquals(totalMessages, messages.size());
+    List<String> distinctIds =
+        messages.stream().map(Message::messageId).distinct().collect(Collectors.toList());
+    assertEquals(totalMessages, distinctIds.size());
+    assertTrue(backlog.isEmpty());
+  }
+
+  @Test
+  public void testSlowCallDoesNotStallSiblingWorkers() {
+    // The point of the redesign: a worker that finishes proceeds to its next call immediately instead of
+    // waiting for the slowest call in a wave. One straggler is held until its siblings have completed
+    // eight further calls between them. Under the previous wave-based invokeAll the siblings could issue
+    // at most (workers - 1) more calls before the wave barrier blocked them behind the straggler, so this
+    // test would deadlock until the latch timed out.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "4");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "1000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    CountDownLatch stragglerMayReturn = new CountDownLatch(1);
+    AtomicInteger calls = new AtomicInteger();
+    AtomicInteger siblingCalls = new AtomicInteger();
+    AtomicBoolean siblingsProgressed = new AtomicBoolean();
+    AtomicInteger messageId = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() == 1) {
+        siblingsProgressed.set(stragglerMayReturn.await(30, TimeUnit.SECONDS));
+        return ReceiveMessageResponse.builder().build();
+      }
+      if (siblingCalls.incrementAndGet() >= 8) {
+        stragglerMayReturn.countDown();
+      }
+      List<Message> batch = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        int id = messageId.incrementAndGet();
+        batch.add(sqsMessage("m" + id, "r" + id));
+      }
+      return ReceiveMessageResponse.builder().messages(batch).build();
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 150, 10);
+
+    assertTrue(siblingsProgressed.get(),
+        "siblings were blocked behind the straggler - the receive phase is not dispatching continuously");
+    assertTrue(siblingCalls.get() >= 8, "expected at least 8 sibling calls, was " + siblingCalls.get());
+    // Every message the siblings returned is kept, including the ones that landed while the straggler ran.
+    assertEquals(10 * siblingCalls.get(), messages.size());
+    assertEquals(messages.size(), messages.stream().map(Message::messageId).distinct().count());
+  }
+
+  @Test
+  public void testReceiveOvershootIsBoundedByInFlightAccounting() {
+    // 16 workers are configured but only 11 calls are needed for the 105-message target. Admission credits
+    // every in-flight call with a full maxMessagesPerRequest, so no redundant call is ever dispatched and
+    // the overshoot stays under maxMessagesPerRequest rather than a whole wave (16*10-1 = 159 messages
+    // beyond the operator's configured cap).
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "16");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "1000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    ConcurrentLinkedQueue<Message> backlog = new ConcurrentLinkedQueue<>();
+    for (int i = 0; i < 1000; i++) {
+      backlog.add(sqsMessage("m" + i, "r" + i));
+    }
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      List<Message> batch = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        Message polled = backlog.poll();
+        if (polled == null) {
+          break;
+        }
+        batch.add(polled);
+      }
+      return ReceiveMessageResponse.builder().messages(batch).build();
+    });
+
+    int maxMessagePerBatch = 105;
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, maxMessagePerBatch, 10);
+
+    // ceil(105/10) = 11 calls, each returning 10 -> exactly 110.
+    assertEquals(110, messages.size());
+    assertTrue(messages.size() <= maxMessagePerBatch + 9,
+        "overshoot must be bounded by maxMessagesPerRequest-1, was " + (messages.size() - maxMessagePerBatch));
+    verify(sqs, times(11)).receiveMessage(any(ReceiveMessageRequest.class));
+  }
+
+  @Test
+  public void testReceiveToleratesIndividualTransientFailure() {
+    // One ReceiveMessage call fails with a throttle. The messages fetched by the sibling calls are already
+    // in-flight, so the batch must keep them and carry on rather than abort - aborting would strand them
+    // until the visibility timeout expires.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "4");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "40");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    ConcurrentLinkedQueue<Message> backlog = new ConcurrentLinkedQueue<>();
+    for (int i = 0; i < 40; i++) {
+      backlog.add(sqsMessage("m" + i, "r" + i));
+    }
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() == 2) {
+        throw sqsError("RequestThrottled", 400, "Rate exceeded");
+      }
+      List<Message> batch = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        Message polled = backlog.poll();
+        if (polled == null) {
+          break;
+        }
+        batch.add(polled);
+      }
+      return ReceiveMessageResponse.builder().messages(batch).build();
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 40, 10);
+
+    assertEquals(40, messages.size());
+    assertEquals(40, messages.stream().map(Message::messageId).distinct().count());
+    assertTrue(backlog.isEmpty());
+  }
+
+  @Test
+  public void testReceiveStopsAfterConsecutiveTransientFailures() {
+    // A systemic failure with nothing fetched must surface as an exception - returning an empty batch
+    // would be indistinguishable from a drained queue - and must stop well short of the call budget.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "2");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      calls.incrementAndGet();
+      throw sqsError("InternalFailure", 500, "We encountered an internal error");
+    });
+
+    HoodieException thrown = assertThrows(HoodieException.class,
+        () -> selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 100, 10));
+    assertTrue(thrown.getCause() instanceof SqsException, "the SQS cause must be preserved");
+    // 2 primed, then one replacement per completion until the 5th consecutive failure stops dispatch,
+    // leaving the last outstanding call to drain: 2 + 4 = 6 calls, against a budget of 4 x 10 = 40.
+    assertEquals(2 + CloudObjectsSelector.MAX_CONSECUTIVE_TRANSIENT_FAILURES - 1, calls.get());
+    assertTrue(calls.get() < 40, "must stop well short of the call budget, was " + calls.get());
+  }
+
+  @Test
+  public void testReceiveStopsImmediatelyOnNonRetryableFailure() {
+    // A deleted queue cannot be fixed by retrying. Previously it burned the full transient tolerance
+    // (5 round-trips); it must now stop at the first one, with only the already-dispatched siblings
+    // draining behind it.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "2");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      calls.incrementAndGet();
+      throw sqsError("QueueDoesNotExist", 400, "The specified queue does not exist");
+    });
+
+    HoodieException thrown = assertThrows(HoodieException.class,
+        () -> selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 100, 10));
+    assertTrue(thrown.getCause() instanceof SqsException, "the SQS cause must be preserved");
+    // Only the two primed calls run: the first fatal completion stops dispatch outright.
+    assertEquals(2, calls.get(), "a non-retryable failure must not consume the transient tolerance");
+  }
+
+  @Test
+  public void testNonRetryableFailureAfterMessagesFetchedReturnsThem() {
+    // Credentials revoked mid-batch. The messages already fetched are in-flight and would be stranded for
+    // the whole visibility timeout if discarded, and the condition resurfaces on the next batch's first
+    // call anyway - so the phase returns them rather than throwing.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() == 1) {
+        List<Message> batch = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+          batch.add(sqsMessage("m" + i, "r" + i));
+        }
+        return ReceiveMessageResponse.builder().messages(batch).build();
+      }
+      throw sqsError("AccessDeniedException", 400, "Access to the resource is denied");
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 100, 10);
+
+    assertEquals(10, messages.size(), "already-fetched messages must not be discarded");
+    assertEquals(2, calls.get());
+  }
+
+  @Test
+  public void testOverLimitEndsBatchCleanlyAndKeepsMessages() {
+    // OverLimit is the in-flight ceiling (~120,000 standard / 20,000 FIFO), i.e. backpressure rather than
+    // an error: the received messages stay in-flight until onCommit deletes them, which is exactly what
+    // frees the quota. Stop receiving, hand back what was fetched, and never fail the job over it.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "1000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() == 1) {
+        List<Message> batch = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+          batch.add(sqsMessage("m" + i, "r" + i));
+        }
+        return ReceiveMessageResponse.builder().messages(batch).build();
+      }
+      throw sqsError(CloudObjectsSelector.SQS_OVER_LIMIT_ERROR_CODE, 400,
+          "Number of in flight messages exceeded");
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 1000, 10);
+
+    assertEquals(10, messages.size());
+    assertEquals(2, calls.get(), "OverLimit must stop dispatch at once, not consume the retry tolerance");
+  }
+
+  @Test
+  public void testOverLimitWithNothingFetchedDoesNotThrow() {
+    // The in-flight quota can already be exhausted before this batch fetches anything - a previous batch's
+    // messages are still awaiting their commit. That is a real, self-clearing queue state, so it must
+    // return empty rather than throw: failing the job would trade normal saturation for an outage.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "1000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      calls.incrementAndGet();
+      throw sqsError(CloudObjectsSelector.SQS_OVER_LIMIT_ERROR_CODE, 400,
+          "Number of in flight messages exceeded");
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 1000, 10);
+
+    assertTrue(messages.isEmpty());
+    assertEquals(1, calls.get());
+  }
+
+  @Test
+  public void testInFlightCallsAreDrainedAndTheirMessagesKept() {
+    // When a stop condition fires there are still calls in flight. They must be allowed to return and
+    // their messages kept: a ReceiveMessage that already succeeded server-side has made those messages
+    // invisible, so discarding the response would strand them for the whole visibility timeout.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "4");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "1000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    AtomicInteger messageId = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      // The first call returns empty at once and, at longPollWait=20, that alone confirms the drain and
+      // stops dispatch. The three siblings primed alongside it are slower and land afterwards.
+      if (calls.incrementAndGet() == 1) {
+        return ReceiveMessageResponse.builder().build();
+      }
+      Thread.sleep(250);
+      List<Message> batch = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        int id = messageId.incrementAndGet();
+        batch.add(sqsMessage("m" + id, "r" + id));
+      }
+      return ReceiveMessageResponse.builder().messages(batch).build();
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 1000, 10);
+
+    assertEquals(4, calls.get(), "the primed calls must all be drained, never cancelled");
+    assertEquals(30, messages.size(), "messages from in-flight calls must be kept after the stop decision");
+    assertEquals(30, messages.stream().map(Message::messageId).distinct().count());
+  }
+
+  @Test
+  public void testEmptyResultThrowsOnlyWhenNothingProvedTheQueueReachable() {
+    // The boundary for turning an empty result into a job failure. Failures interleaved with empty
+    // responses (call 1 throttled, call 2 empty) must NOT throw: the successful empty response is a real
+    // answer from SQS, so the endpoint, the credentials and the queue are all demonstrably fine and the
+    // empty result means drained, not broken. Only a batch where nothing answered at all is a stalled
+    // pipeline masquerading as a drained queue - covered by
+    // testReceiveStopsAfterConsecutiveTransientFailures and testReceiveStopsImmediatelyOnNonRetryableFailure.
+    // Sequential so the alternation is deterministic; concurrently the call count would depend on
+    // completion order.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() % 2 == 1) {
+        throw sqsError("RequestThrottled", 400, "Rate exceeded");
+      }
+      return ReceiveMessageResponse.builder().build();
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 100, 10);
+
+    assertTrue(messages.isEmpty());
+    // The throttle, then the empty that confirms the drain at longPollWait=20.
+    assertEquals(2, calls.get());
+  }
+
+  @Test
+  public void testDrainedQueueWithOneThrottledCallDoesNotThrow() {
+    // A drained queue whose concurrent polls also got one throttle must NOT fail the job. 15 empty
+    // responses are positive proof the endpoint, credentials and queue are healthy - the same evidence the
+    // loop uses to reset the transient-failure run - so an empty result here is a drained queue, not a
+    // broken one. Throwing would turn the steady state of a caught-up pipeline into a HoodieStreamer
+    // shutdown every time SQS throttled one of 16 concurrent ReceiveMessage calls.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "16");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "1000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() == 1) {
+        throw sqsError("RequestThrottled", 400, "Rate exceeded");
+      }
+      return ReceiveMessageResponse.builder().build();
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 1000, 10);
+
+    assertTrue(messages.isEmpty());
+    assertTrue(calls.get() >= 2, "the drain must still have been observed, was " + calls.get());
+  }
+
+  @Test
+  public void testInFlightLimitWithOneThrottledCallDoesNotThrow() {
+    // The in-flight ceiling and throttling co-occur, since both are symptoms of a saturated queue. A batch
+    // where most concurrent calls returned OverLimit and one was throttled fetches nothing - but OverLimit
+    // is an answer from SQS, so the queue is demonstrably reachable and this is backpressure, not a
+    // failure. Failing the job here is exactly what the backpressure classification exists to prevent.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "8");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "1000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() == 1) {
+        throw sqsError("RequestThrottled", 400, "Rate exceeded");
+      }
+      throw sqsError(CloudObjectsSelector.SQS_OVER_LIMIT_ERROR_CODE, 400,
+          "Number of in flight messages exceeded");
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 1000, 10);
+
+    assertTrue(messages.isEmpty());
+  }
+
+  @Test
+  public void testShortPollEmptiesAccumulateAndCanEndABatchBeforeItsTarget() {
+    // Empties are a batch total in both polling modes - counting them consecutively is what let a
+    // slow-ingress queue reset the counter indefinitely and hold the phase for its whole call budget.
+    // The trade lands here. Short polling "samples a subset of its servers", so an empty response on a
+    // queue that still holds messages is expected rather than exceptional, and scattered empties therefore
+    // accumulate until the batch ends short of its target. That is throughput on a non-default setting,
+    // not correctness: the remainder is simply left for the next ingestion cycle, never dropped. This test
+    // pins that deliberate behaviour so a future change to the counting cannot alter it silently.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    AtomicInteger messageId = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() % 2 == 1) {
+        return ReceiveMessageResponse.builder().build();
+      }
+      List<Message> batch = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        int id = messageId.incrementAndGet();
+        batch.add(sqsMessage("m" + id, "r" + id));
+      }
+      return ReceiveMessageResponse.builder().messages(batch).build();
+    });
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 0, 30, 100, 10);
+
+    // Every other call is empty, so the 5th empty lands on call 9 having yielded 4 batches of 10. The
+    // batch ends there rather than running on to its 100-message target.
+    int expectedCalls = 2 * CloudObjectsSelector.MAX_EMPTY_RECEIVES_SHORT_POLL - 1;
+    assertEquals(expectedCalls, calls.get());
+    assertEquals(10 * (CloudObjectsSelector.MAX_EMPTY_RECEIVES_SHORT_POLL - 1), messages.size());
+    assertEquals(messages.size(), messages.stream().map(Message::messageId).distinct().count(),
+        "whatever was fetched before the drain must still be returned intact");
+    assertTrue(messages.size() < 100, "the accumulated empties end the batch before its target");
+  }
+
+  @Test
+  public void testProcessingParallelismIsClampedToAtLeastOne() {
+    // A misconfigured non-positive parallelism must degrade to sequential rather than blowing up in
+    // Executors.newFixedThreadPool, which rejects a size of 0.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "0");
+    assertEquals(1, new CloudObjectsSelector(props).processingParallelism);
+
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "-4");
+    assertEquals(1, new CloudObjectsSelector(props).processingParallelism);
+  }
+
+  @Test
+  public void testErrorFromReceiveWorkerIsNotToleratedAsACallFailure() {
+    // An Error on a worker (OutOfMemoryError here) is not an SQS failure: absorbing it into failedCalls
+    // would keep dispatching and could even return a "successful" partial batch after a fatal condition.
+    // It must propagate unchanged, and dispatch must stop at the calls already in flight.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "2");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "1000");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build());
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(invocation -> {
+      calls.incrementAndGet();
+      throw new OutOfMemoryError("Java heap space");
+    });
+
+    OutOfMemoryError thrown = assertThrows(OutOfMemoryError.class,
+        () -> selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 1000, 10));
+    assertEquals("Java heap space", thrown.getMessage(), "the Error must propagate unwrapped");
+    // Both primed calls ran; the first Error folded in aborts the loop before any replacement is issued.
+    assertEquals(2, calls.get());
+  }
+
+  @Test
+  public void testConnectionPoolIsOnlyResizedAboveTheSdkDefault() {
+    // Naming ApacheHttpClient to resize the pool makes software.amazon.awssdk:apache-client a hard
+    // runtime requirement of this source, so it must only happen when the parallelism actually outgrows
+    // the SDK's default pool of 50. The default parallelism (16) must leave the client untouched.
+    assertFalse(CloudObjectsSelector.requiresLargerConnectionPool(
+        S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.defaultValue()));
+    assertFalse(CloudObjectsSelector.requiresLargerConnectionPool(1));
+    assertFalse(CloudObjectsSelector.requiresLargerConnectionPool(50));
+    assertTrue(CloudObjectsSelector.requiresLargerConnectionPool(51));
+  }
+
+  @Test
+  public void testParallelDeleteRemovesEveryMessageExactlyOnce() throws Exception {
+    // Real concurrency: 8 workers delete 250 messages in batches of SQS_BATCH_MAX_ENTRIES. Every receipt
+    // handle must be deleted exactly once - no loss, no duplication - and the calls must genuinely
+    // overlap, otherwise the fan-out has silently regressed to serial. Overlap is proven rather than
+    // inferred: each call blocks until WORKERS of them are in flight simultaneously.
+    int totalMessages = 250;
+    int workers = 8;
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), String.valueOf(workers));
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    ConcurrentLinkedQueue<String> deletedHandles = new ConcurrentLinkedQueue<>();
+    Set<String> threadNames = ConcurrentHashMap.newKeySet();
+    AtomicInteger deleteCalls = new AtomicInteger();
+    AtomicBoolean neverOverlapped = new AtomicBoolean();
+    CountDownLatch allWorkersInFlight = new CountDownLatch(workers);
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      threadNames.add(Thread.currentThread().getName());
+      deleteCalls.incrementAndGet();
+      allWorkersInFlight.countDown();
+      // Blocks until `workers` calls are in flight at once, so overlap is proven rather than inferred.
+      // A serial regression cannot satisfy the latch: record that and release everyone, so the test
+      // fails on the assertion below in seconds instead of timing out once per remaining batch.
+      if (!allWorkersInFlight.await(10, TimeUnit.SECONDS)) {
+        neverOverlapped.set(true);
+        while (allWorkersInFlight.getCount() > 0) {
+          allWorkersInFlight.countDown();
+        }
+      }
+      DeleteMessageBatchRequest request = invocation.getArgument(0);
+      request.entries().forEach(entry -> deletedHandles.add(entry.receiptHandle()));
+      return DeleteMessageBatchResponse.builder().build();
+    });
+
+    selector.deleteProcessedMessages(sqs, sqsUrl, trackers(totalMessages));
+
+    assertFalse(neverOverlapped.get(),
+        "delete calls never ran " + workers + "-way concurrently; the fan-out has regressed to serial");
+    // Validate the actual handles deleted, not just the count: exactly r0..r249, each once.
+    assertEquals(totalMessages, deletedHandles.size());
+    assertEquals(expectedHandles(totalMessages), new HashSet<>(deletedHandles));
+    assertEquals(totalMessages / CloudObjectsSelector.SQS_BATCH_MAX_ENTRIES, deleteCalls.get());
+    assertEquals(workers, threadNames.size(), "expected one call per worker thread: " + threadNames);
+    assertTrue(threadNames.stream().allMatch(name -> name.startsWith("sqs-delete-")),
+        "delete calls must run on the named delete pool, got: " + threadNames);
+  }
+
+  @Test
+  public void testDeleteAggregatesFailuresAcrossConcurrentBatches() {
+    // Partial failures from several concurrent batches must be merged into a single retry pass rather
+    // than retried per batch: 5 batches each fail one entry, and the 5 survivors re-partition into one
+    // batch of 5.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "5");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Set<String> attempted = ConcurrentHashMap.newKeySet();
+    ConcurrentLinkedQueue<String> deletedHandles = new ConcurrentLinkedQueue<>();
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      deleteCalls.incrementAndGet();
+      DeleteMessageBatchRequest request = invocation.getArgument(0);
+      List<BatchResultErrorEntry> failures = new ArrayList<>();
+      for (DeleteMessageBatchRequestEntry entry : request.entries()) {
+        // Fail the first entry of every batch, but only on its first attempt, so the retry succeeds.
+        if (attempted.add(entry.receiptHandle()) && "0".equals(entry.id())) {
+          failures.add(errorEntry(entry.id(), "InternalError", false));
+        } else {
+          deletedHandles.add(entry.receiptHandle());
+        }
+      }
+      return DeleteMessageBatchResponse.builder().failed(failures).build();
+    });
+
+    String infoLogs = captureLogs("info", () -> selector.deleteProcessedMessages(sqs, sqsUrl, trackers(50)));
+
+    // 5 first-pass batches + 1 retry batch holding all 5 failed entries.
+    assertEquals(6, deleteCalls.get());
+    ArgumentCaptor<DeleteMessageBatchRequest> captor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
+    verify(sqs, times(6)).deleteMessageBatch(captor.capture());
+    DeleteMessageBatchRequest retry = captor.getAllValues().get(5);
+    assertEquals(new HashSet<>(Arrays.asList("r0", "r10", "r20", "r30", "r40")),
+        retry.entries().stream().map(DeleteMessageBatchRequestEntry::receiptHandle).collect(Collectors.toSet()));
+    assertEquals(expectedHandles(50), new HashSet<>(deletedHandles));
+    assertTrue(infoLogs.contains("Deleted 50 of 50"), "delete summary should report a full delete: " + infoLogs);
+  }
+
+  @Test
+  public void testDeleteToleratesThrownCallAndRetriesItsBatch() {
+    // A DeleteMessageBatch that throws leaves its whole batch undeleted, exactly like an SQS-reported
+    // entry failure, so it must feed the same retry path. Aborting instead would discard the other
+    // batches' results and propagate out of onCommit - which StreamSync calls after the Hudi commit has
+    // already landed, so HoodieStreamer would shut the job down over a transient throttle.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "3");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    Set<String> alreadyThrown = ConcurrentHashMap.newKeySet();
+    ConcurrentLinkedQueue<String> deletedHandles = new ConcurrentLinkedQueue<>();
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      deleteCalls.incrementAndGet();
+      DeleteMessageBatchRequest request = invocation.getArgument(0);
+      boolean isFirstBatch = request.entries().stream()
+          .anyMatch(entry -> "r0".equals(entry.receiptHandle()));
+      if (isFirstBatch && alreadyThrown.add("first-attempt")) {
+        throw SqsException.builder().message("Rate exceeded").build();
+      }
+      request.entries().forEach(entry -> deletedHandles.add(entry.receiptHandle()));
+      return DeleteMessageBatchResponse.builder().build();
+    });
+
+    String warnings = captureLogs("warn", () -> selector.deleteProcessedMessages(sqs, sqsUrl, trackers(25)));
+
+    // 3 first-pass batches (one threw) + 1 retry batch for the 10 messages it stranded.
+    assertEquals(4, deleteCalls.get());
+    assertEquals(expectedHandles(25), new HashSet<>(deletedHandles));
+    assertTrue(warnings.contains("DeleteMessageBatch calls failed"),
+        "a thrown call must be reported with its cause: " + warnings);
+  }
+
+  @Test
+  public void testDeleteThrowsOnlyWhenNoMessageCouldBeDeleted() {
+    // Systemic failure - every call throws on every pass, nothing is deleted. Unlike a partial failure
+    // this must surface, because the caller is about to clear its tracked messages as if they had been
+    // handled.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "2");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      deleteCalls.incrementAndGet();
+      throw SqsException.builder().message("queue does not exist").build();
+    });
+
+    HoodieException thrown = assertThrows(HoodieException.class,
+        () -> selector.deleteProcessedMessages(sqs, sqsUrl, trackers(15)));
+
+    assertTrue(thrown.getMessage().contains("Failed to delete any of the 15"), thrown.getMessage());
+    assertTrue(thrown.getCause() instanceof SqsException, "the SQS cause must be preserved");
+    // 2 batches x (1 initial pass + DELETE_MAX_RETRIES retry passes).
+    assertEquals(2 * (1 + CloudObjectsSelector.DELETE_MAX_RETRIES), deleteCalls.get());
+  }
+
+  @Test
+  public void testDeleteDoesNotRetrySenderFaultFailuresAndDoesNotThrow() {
+    // senderFault=true means SQS blames the caller - a receipt handle that expired with the visibility
+    // timeout, say - so no retry can succeed and the retry budget must not be spent on it. It is also
+    // not fatal even when nothing at all was deleted: the messages are redelivered regardless, so
+    // failing the job would change nothing.
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      deleteCalls.incrementAndGet();
+      return DeleteMessageBatchResponse.builder()
+          .failed(errorEntry("0", "ReceiptHandleIsInvalid", true))
+          .build();
+    });
+
+    String warnings = captureLogs("warn",
+        () -> selector.deleteProcessedMessages(sqs, sqsUrl, Collections.singletonList(tracker("m0", "r0"))));
+
+    assertEquals(1, deleteCalls.get(), "a senderFault failure must not be retried");
+    // The residual WARN is what on-call reads: it must name the reason and identify the message.
+    assertTrue(warnings.contains("ReceiptHandleIsInvalid (senderFault=true)"), warnings);
+    assertTrue(warnings.contains("m0"), "the failed messageId must be sampled into the WARN: " + warnings);
+    assertTrue(warnings.contains("after 0 retries"), warnings);
+  }
+
+  @Test
+  public void testDeleteRetriesOnlyTheTransientFailureInAMixedBatch() {
+    // One batch, one permanent (senderFault=true) and one transient failure. Only the transient entry
+    // may be retried; the permanent one is set aside and reported.
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      if (deleteCalls.getAndIncrement() == 0) {
+        return DeleteMessageBatchResponse.builder()
+            .failed(errorEntry("0", "ReceiptHandleIsInvalid", true), errorEntry("1", "InternalError", false))
+            .build();
+      }
+      return DeleteMessageBatchResponse.builder().build();
+    });
+
+    List<CloudObjectsSelector.MessageTracker> processed =
+        Arrays.asList(tracker("m0", "r0"), tracker("m1", "r1"));
+    String logs = captureLogs("info", () -> selector.deleteProcessedMessages(sqs, sqsUrl, processed));
+
+    assertEquals(2, deleteCalls.get());
+    ArgumentCaptor<DeleteMessageBatchRequest> captor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
+    verify(sqs, times(2)).deleteMessageBatch(captor.capture());
+    // Negative verification: the permanent failure (r0) must NOT appear in the retry.
+    DeleteMessageBatchRequest retry = captor.getAllValues().get(1);
+    assertEquals(1, retry.entries().size());
+    assertEquals("r1", retry.entries().get(0).receiptHandle());
+    assertTrue(logs.contains("Deleted 1 of 2"), logs);
+  }
+
+  @Test
+  public void testDeleteReportsEntryIdsItCannotMapBackToAMessage() {
+    // Defensive: SQS should only echo ids we sent. If it echoes an unknown one we cannot tell which
+    // message failed, so it must be logged loudly rather than dropped silently. Covers both unmappable
+    // shapes - out of range and non-numeric.
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      deleteCalls.incrementAndGet();
+      return DeleteMessageBatchResponse.builder()
+          .failed(errorEntry("99", "InternalError", false), errorEntry("-1", "InternalError", false),
+              errorEntry("not-a-number", "InternalError", false))
+          .build();
+    });
+
+    String warnings = captureLogs("warn",
+        () -> selector.deleteProcessedMessages(sqs, sqsUrl, Collections.singletonList(tracker("m0", "r0"))));
+
+    // Nothing mappable failed, so there is nothing to retry - but every id must be reported.
+    assertEquals(1, deleteCalls.get());
+    assertTrue(warnings.contains("unknown entry id \"99\""), warnings);
+    assertTrue(warnings.contains("unknown entry id \"-1\""), warnings);
+    assertTrue(warnings.contains("unknown entry id \"not-a-number\""), warnings);
+  }
+
+  @Test
+  public void testDeleteNormalizesMissingSqsErrorFields() {
+    // code, message and senderFault are all optional on BatchResultErrorEntry. A missing senderFault must
+    // read as "not the caller's fault" (so the entry is still retried), and the residual WARN must never
+    // render a bare "null" at the reason an operator is trying to read.
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      deleteCalls.incrementAndGet();
+      return DeleteMessageBatchResponse.builder()
+          .failed(BatchResultErrorEntry.builder().id("0").build())
+          .build();
+    });
+
+    String warnings = captureLogs("warn",
+        () -> selector.deleteProcessedMessages(sqs, sqsUrl, Collections.singletonList(tracker("m0", "r0"))));
+
+    // senderFault absent => treated as transient => retried the full budget.
+    assertEquals(1 + CloudObjectsSelector.DELETE_MAX_RETRIES, deleteCalls.get());
+    assertTrue(warnings.contains("UNKNOWN (senderFault=false)"), warnings);
+    assertTrue(warnings.contains("<none provided by SQS>"), warnings);
+  }
+
+  @Test
+  public void testDeleteAssignsDistinctEntryIdsForDuplicateMessageIds() {
+    // Under at-least-once delivery the same messageId can appear twice in one batch. Entry ids must stay
+    // distinct or SQS rejects the whole request with BatchEntryIdsNotDistinct.
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
+        .thenReturn(DeleteMessageBatchResponse.builder().build());
+
+    selector.deleteProcessedMessages(sqs, sqsUrl,
+        Arrays.asList(tracker("duplicate-id", "r0"), tracker("duplicate-id", "r1")));
+
+    ArgumentCaptor<DeleteMessageBatchRequest> captor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
+    verify(sqs, times(1)).deleteMessageBatch(captor.capture());
+    List<DeleteMessageBatchRequestEntry> entries = captor.getValue().entries();
+    assertEquals(2, entries.size());
+    assertEquals(2, entries.stream().map(DeleteMessageBatchRequestEntry::id).distinct().count(),
+        "duplicate messageIds must not produce duplicate entry ids");
+    assertEquals(new HashSet<>(Arrays.asList("r0", "r1")),
+        entries.stream().map(DeleteMessageBatchRequestEntry::receiptHandle).collect(Collectors.toSet()));
+  }
+
+  @Test
+  public void testDeleteBatchRejectsMoreEntriesThanTheSqsCap() {
+    // deleteBatchOfMessages is protected and documents a 10-entry cap; SQS rejects a larger batch
+    // wholesale with TooManyEntriesInBatchRequest, so fail fast at the boundary instead.
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    assertThrows(IllegalArgumentException.class, () -> selector.deleteBatchOfMessages(sqs, sqsUrl,
+        trackers(CloudObjectsSelector.SQS_BATCH_MAX_ENTRIES + 1)));
+    assertTrue(selector.deleteBatchOfMessages(sqs, sqsUrl, Collections.emptyList()).isEmpty());
+    verify(sqs, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+  }
+
+  @Test
+  public void testClassifySqsFailureUsesErrorCodeNotStatus() {
+    // SQS status codes do not track severity: RequestThrottled and OverLimit are HTTP 400,
+    // ThrottlingException is HTTP 403, MalformedQueryString is HTTP 404. A status-only rule would call a
+    // throttle fatal and the in-flight ceiling fatal, so the error code has to decide.
+    assertEquals(CloudObjectsSelector.SqsFailureKind.BACKPRESSURE,
+        CloudObjectsSelector.classifySqsFailure(sqsError("OverLimit", 400, "in flight limit")));
+    assertEquals(CloudObjectsSelector.SqsFailureKind.TRANSIENT,
+        CloudObjectsSelector.classifySqsFailure(sqsError("RequestThrottled", 400, "throttled")));
+    assertEquals(CloudObjectsSelector.SqsFailureKind.TRANSIENT,
+        CloudObjectsSelector.classifySqsFailure(sqsError("ThrottlingException", 403, "throttled")));
+    // KmsThrottled is an HTTP 400 that the SDK's own throttling code set does not recognise, so it would
+    // fall through to the status rule and be misjudged fatal without the explicit transient set.
+    assertEquals(CloudObjectsSelector.SqsFailureKind.TRANSIENT,
+        CloudObjectsSelector.classifySqsFailure(sqsError("KmsThrottled", 400, "kms throttled")));
+    assertEquals(CloudObjectsSelector.SqsFailureKind.TRANSIENT,
+        CloudObjectsSelector.classifySqsFailure(sqsError("InternalFailure", 500, "internal error")));
+    assertEquals(CloudObjectsSelector.SqsFailureKind.FATAL,
+        CloudObjectsSelector.classifySqsFailure(sqsError("QueueDoesNotExist", 400, "no such queue")));
+    assertEquals(CloudObjectsSelector.SqsFailureKind.FATAL,
+        CloudObjectsSelector.classifySqsFailure(sqsError("MalformedQueryString", 404, "malformed")));
+    assertEquals(CloudObjectsSelector.SqsFailureKind.FATAL,
+        CloudObjectsSelector.classifySqsFailure(sqsError("InvalidClientTokenId", 403, "bad key id")));
+    // Transport-level failures are transient by nature.
+    assertEquals(CloudObjectsSelector.SqsFailureKind.TRANSIENT,
+        CloudObjectsSelector.classifySqsFailure(SdkClientException.create("Connection reset")));
+    // No usable status at all: tolerate rather than fail outright.
+    assertEquals(CloudObjectsSelector.SqsFailureKind.TRANSIENT,
+        CloudObjectsSelector.classifySqsFailure(SqsException.builder().message("no details").build()));
+    assertEquals(CloudObjectsSelector.SqsFailureKind.FATAL,
+        CloudObjectsSelector.classifySqsFailure(new IllegalStateException("boom")));
+  }
+
+  @Test
+  public void testDeleteDoesNotRetryANonRetryableThrownCall() {
+    // A thrown call was previously recorded as senderFault=false, i.e. always retryable - so a deleted
+    // queue or revoked credentials was retried across every batch for all DELETE_MAX_RETRIES passes.
+    // Nothing about a fatal condition becomes retryable just because it surfaced as a thrown call rather
+    // than a per-entry error, and this runs from onCommit AFTER the Hudi commit has already landed, so
+    // the wasted calls are pure post-commit driver time.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "4");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    int totalMessages = 200;
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      calls.incrementAndGet();
+      throw sqsError("QueueDoesNotExist", 400, "The specified queue does not exist");
+    });
+
+    // Nothing could be deleted and no call ever answered, so this is systemic and still surfaces.
+    assertThrows(HoodieException.class,
+        () -> selector.deleteProcessedMessages(sqs, sqsUrl, trackers(totalMessages)));
+
+    // 20 batches x (1 + 3 retry passes) = 80 calls before. Dispatch now stops as soon as the first fatal
+    // completion is folded in, so only the calls already in flight run and no retry pass is attempted.
+    assertTrue(calls.get() <= 4,
+        "a non-retryable failure must stop dispatch instead of retrying every batch, was " + calls.get());
+  }
+
+  @Test
+  public void testDeleteDoesNotThrowWhenStaleHandlesCoincideWithOneThrottle() {
+    // A commit that outruns the visibility timeout leaves every receipt handle stale, so every entry fails
+    // with senderFault=true - a real queue state the code deliberately treats as non-fatal. If one
+    // unrelated call is also throttled (fanning out makes that MORE likely), deleted==0 and firstThrown is
+    // set, and the systemic guard used to fire: one transient throttle turned a documented-benign
+    // condition into a HoodieStreamer shutdown. A call that returned HTTP 200 proves the queue is
+    // reachable, so it must not throw.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "2");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      DeleteMessageBatchRequest request = invocation.getArgument(0);
+      if (calls.incrementAndGet() == 1) {
+        throw sqsError("RequestThrottled", 400, "Rate exceeded");
+      }
+      // Every other call answers with HTTP 200 but reports each entry as a permanent sender fault.
+      List<BatchResultErrorEntry> failed = request.entries().stream()
+          .map(entry -> errorEntry(entry.id(), "ReceiptHandleIsInvalid", true))
+          .collect(Collectors.toList());
+      return DeleteMessageBatchResponse.builder().failed(failed).build();
+    });
+
+    // Must not throw: nothing here is fixable by failing the job, and the messages are redelivered anyway.
+    selector.deleteProcessedMessages(sqs, sqsUrl, trackers(30));
+  }
+
+  @Test
+  public void testDeleteStillThrowsWhenNoCallEverAnswered() {
+    // The complement of the guard above: when every call threw, nothing proved the queue reachable, the
+    // caller is about to clear its tracked messages as if they had been handled, and that must surface.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "2");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
+        .thenThrow(sqsError("InternalFailure", 500, "We encountered an internal error"));
+
+    HoodieException thrown = assertThrows(HoodieException.class,
+        () -> selector.deleteProcessedMessages(sqs, sqsUrl, trackers(20)));
+    assertTrue(thrown.getMessage().contains("Failed to delete any of the"));
+  }
+
+  @Test
+  public void testPartialNonRetryableDeleteFailureIsReportedAtError() {
+    // The silent variant: a session token expiring mid-phase leaves deleted > 0, so the systemic throw
+    // stays quiet by design. Without an explicit signal it would look like an ordinary residual-failure
+    // WARN, yet no retry can clear it and it recurs on every commit until an operator acts.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "1");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    AtomicInteger calls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      if (calls.incrementAndGet() <= 2) {
+        return DeleteMessageBatchResponse.builder().build();
+      }
+      throw sqsError("ExpiredToken", 403, "The security token included in the request is expired");
+    });
+
+    String errors = captureLogs("error", () -> selector.deleteProcessedMessages(sqs, sqsUrl, trackers(100)));
+
+    assertTrue(errors.contains("Non-retryable SQS DeleteMessageBatch failure"),
+        "a partial fatal must be named explicitly, logs were: " + errors);
+    assertTrue(errors.contains("did not retry"), "the ERROR must state that retrying was skipped");
+  }
+
+  @Test
+  public void testDeleteOfNoProcessedMessagesMakesNoSqsCall() {
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    selector.deleteProcessedMessages(sqs, sqsUrl, Collections.emptyList());
+
+    verify(sqs, never()).deleteMessageBatch(any(DeleteMessageBatchRequest.class));
+  }
+
+  @Test
+  public void testDeleteSurfacesInterruptionWhileWaitingOnBatches() throws Exception {
+    // Interrupting the driver thread mid-delete must restore the interrupt flag and surface a
+    // HoodieException rather than silently reporting a successful delete.
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    CountDownLatch callInFlight = new CountDownLatch(1);
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      callInFlight.countDown();
+      // Held until the delete pool is shut down, guaranteeing the master thread is still in invokeAll.
+      Thread.sleep(30_000);
+      return DeleteMessageBatchResponse.builder().build();
+    });
+
+    Thread driver = Thread.currentThread();
+    Thread interrupter = new Thread(() -> {
+      try {
+        assertTrue(callInFlight.await(30, TimeUnit.SECONDS));
+        driver.interrupt();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    interrupter.start();
+    try {
+      HoodieException thrown = assertThrows(HoodieException.class, () -> selector.deleteProcessedMessages(
+          sqs, sqsUrl, Collections.singletonList(tracker("m0", "r0"))));
+      assertTrue(thrown.getMessage().contains("Interrupted while deleting messages"), thrown.getMessage());
+      assertTrue(Thread.currentThread().isInterrupted(), "the interrupt flag must be restored");
+    } finally {
+      // Clear the flag so it cannot leak into the next test.
+      Thread.interrupted();
+      interrupter.join();
+    }
+  }
+
+  @Test
+  public void testErrorFromDeleteWorkerIsNotFunnelledIntoRetries() {
+    // An Error on a delete worker is not a delete failure: funnelling it into the retry path would replay
+    // the batch DELETE_MAX_RETRIES times and then reduce a fatal condition to a residual-failure log line.
+    // It must propagate unwrapped, on the first pass.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "2");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      deleteCalls.incrementAndGet();
+      throw new OutOfMemoryError("Java heap space");
+    });
+
+    OutOfMemoryError thrown = assertThrows(OutOfMemoryError.class,
+        () -> selector.deleteProcessedMessages(sqs, sqsUrl, trackers(2)));
+    assertEquals("Java heap space", thrown.getMessage(), "the Error must propagate unwrapped");
+    // Both messages fit one batch, so exactly one call ran and no retry pass followed it.
+    assertEquals(1, deleteCalls.get());
+  }
+
+  @Test
+  public void testDeleteRetriesPartialFailureThenSucceeds() {
+    // DeleteMessageBatch can return a partial failure on an HTTP 200. The failed entry must be
+    // collected and retried; after the retry succeeds there must be zero residual failures.
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "4");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    List<CloudObjectsSelector.MessageTracker> processed = new ArrayList<>();
+    processed.add(tracker("m0", "r0"));
+    processed.add(tracker("m1", "r1"));
+
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      DeleteMessageBatchRequest request = invocation.getArgument(0);
+      // First call: fail whichever entry carries receiptHandle r0. Later calls: succeed.
+      if (deleteCalls.getAndIncrement() == 0) {
+        String failedEntryId = request.entries().stream()
+            .filter(entry -> entry.receiptHandle().equals("r0"))
+            .map(entry -> entry.id())
+            .findFirst().orElseThrow(() -> new AssertionError("r0 not present in first batch"));
+        return DeleteMessageBatchResponse.builder()
+            .failed(BatchResultErrorEntry.builder().id(failedEntryId).senderFault(false).code("500").build())
+            .build();
+      }
+      return DeleteMessageBatchResponse.builder().build();
+    });
+
+    selector.deleteProcessedMessages(sqs, sqsUrl, processed);
+
+    // 1 initial batch call + 1 retry call for the single failed entry.
+    assertEquals(2, deleteCalls.get());
+    ArgumentCaptor<DeleteMessageBatchRequest> captor = ArgumentCaptor.forClass(DeleteMessageBatchRequest.class);
+    verify(sqs, times(2)).deleteMessageBatch(captor.capture());
+    // The retry must target exactly the originally-failed message (receiptHandle r0), nothing else.
+    DeleteMessageBatchRequest retry = captor.getAllValues().get(1);
+    assertEquals(1, retry.entries().size());
+    assertEquals("r0", retry.entries().get(0).receiptHandle());
+  }
+
+  @Test
+  public void testDeleteExhaustsRetriesAndReportsResidualFailure() {
+    // When an entry keeps failing, deletion must stop after DELETE_MAX_RETRIES passes without throwing,
+    // leaving the residual failure to be logged (and eventually redriven by SQS).
+    props.setProperty(S3_SOURCE_QUEUE_PROCESSING_PARALLELISM.key(), "4");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    List<CloudObjectsSelector.MessageTracker> processed = new ArrayList<>();
+    processed.add(tracker("m0", "r0"));
+
+    AtomicInteger deleteCalls = new AtomicInteger();
+    when(sqs.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(invocation -> {
+      deleteCalls.incrementAndGet();
+      DeleteMessageBatchRequest request = invocation.getArgument(0);
+      return DeleteMessageBatchResponse.builder()
+          .failed(BatchResultErrorEntry.builder()
+              .id(request.entries().get(0).id()).senderFault(false).code("500").build())
+          .build();
+    });
+
+    selector.deleteProcessedMessages(sqs, sqsUrl, processed);
+
+    // 1 initial pass + DELETE_MAX_RETRIES retry passes; no exception despite the persistent failure.
+    assertEquals(1 + CloudObjectsSelector.DELETE_MAX_RETRIES, deleteCalls.get());
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {CloudObjectsSelector.class})
+  public void testSqsQueueAttributesRequestsAllOnly(Class<?> clazz) {
+    CloudObjectsSelector selector =
+        (CloudObjectsSelector) ReflectionUtils.loadClass(clazz.getName(), props);
+    CloudObjectTestUtils.setMessagesInQueue(sqs, null);
+
+    selector.getSqsQueueAttributes(sqs, sqsUrl);
+
+    ArgumentCaptor<GetQueueAttributesRequest> captor =
+        ArgumentCaptor.forClass(GetQueueAttributesRequest.class);
+    verify(sqs).getQueueAttributes(captor.capture());
+    // Must request ALL only. Naming FIFO-only attributes (e.g. FifoQueue) or dead-letter-queue-only
+    // attributes (e.g. RedrivePolicy) makes SQS reject the entire GetQueueAttributes call with
+    // InvalidAttributeNameException, which takes ingestion down since the receive loop depends on
+    // this call. Assert the serialized wire value too, not just the enum constant.
+    assertEquals(Collections.singletonList(QueueAttributeName.ALL), captor.getValue().attributeNames());
+    assertEquals(Collections.singletonList("All"), captor.getValue().attributeNamesAsStrings());
+  }
+
+  @Test
+  public void testProbeFailureAtBreakDoesNotFailBatch() {
+    CloudObjectsSelector selector = new CloudObjectsSelector(props);
+
+    // The in-flight probe at the receive-loop break is purely diagnostic. Even if SQS rejects it,
+    // the batch must still complete - diagnostics must never sit on the load-bearing path.
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put(SQS_ATTR_APPROX_MESSAGES, "100");
+    when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+        .thenReturn(GetQueueAttributesResponse.builder().attributesWithStrings(attributes).build())
+        .thenThrow(SqsException.builder().message("InvalidAttributeName").build());
+    when(sqs.receiveMessage(any(ReceiveMessageRequest.class)))
+        .thenReturn(ReceiveMessageResponse.builder().build());
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, sqsUrl, 20, 30, 100, 10);
+
+    assertEquals(0, messages.size());
+    // One attributes call at loop start + the failed probe at the break, both consumed.
+    verify(sqs, times(2)).getQueueAttributes(any(GetQueueAttributesRequest.class));
+  }
+
+  @Test
+  public void testQueueConfigLoggingFailureDoesNotFailBatch() {
+    // A .fifo url exercises the suffix-based FIFO derivation, and the attribute map blows up
+    // mid-log to prove the once-per-selector config logging can never fail the receive path.
+    String fifoQueueUrl = "test-queue.fifo";
+    Map<String, String> explodingAttributes = new HashMap<String, String>() {
+      @Override
+      public String get(Object key) {
+        if (SQS_ATTR_MESSAGE_RETENTION_PERIOD.equals(key)) {
+          throw new IllegalStateException("attribute lookup failed");
+        }
+        return super.get(key);
+      }
+    };
+    explodingAttributes.put(SQS_ATTR_APPROX_MESSAGES, "0");
+    CloudObjectsSelector selector = new CloudObjectsSelector(props) {
+      @Override
+      protected Map<String, String> getSqsQueueAttributes(SqsClient sqsClient, String queueUrl) {
+        return explodingAttributes;
+      }
+    };
+
+    List<Message> messages = selector.getMessagesToProcess(sqs, fifoQueueUrl, 20, 30, 100, 10);
+
+    assertEquals(0, messages.size());
+    // Backlog is empty, so the receive loop never runs; the failed log must not have thrown.
+    verify(sqs, never()).receiveMessage(any(ReceiveMessageRequest.class));
+  }
+
   public Map<String, String> createAttributeMap(String key, String value) {
     Map<String, String> attribute = new HashMap<>();
     attribute.put(key, value);
     return attribute;
+  }
+
+  /**
+   * Builds an SQS service exception carrying both an error code and an HTTP status, which is what the
+   * failure classification reads. The two are supplied independently because SQS pairs them in ways a
+   * status-only rule gets wrong (RequestThrottled and OverLimit are both HTTP 400).
+   */
+  private static SqsException sqsError(String errorCode, int statusCode, String message) {
+    return (SqsException) SqsException.builder()
+        .awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).errorMessage(message).build())
+        .statusCode(statusCode)
+        .message(message)
+        .build();
+  }
+
+  private static Message sqsMessage(String messageId, String receiptHandle) {
+    return Message.builder().messageId(messageId).receiptHandle(receiptHandle).body("{}").build();
+  }
+
+  private static CloudObjectsSelector.MessageTracker tracker(String messageId, String receiptHandle) {
+    return new CloudObjectsSelector.MessageTracker(sqsMessage(messageId, receiptHandle));
+  }
+
+  /** {@code count} trackers with ids m0..m(count-1) and receipt handles r0..r(count-1). */
+  private static List<CloudObjectsSelector.MessageTracker> trackers(int count) {
+    List<CloudObjectsSelector.MessageTracker> trackers = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      trackers.add(tracker("m" + i, "r" + i));
+    }
+    return trackers;
+  }
+
+  /** The receipt handles {@link #trackers(int)} produces, for asserting on the full deleted set. */
+  private static Set<String> expectedHandles(int count) {
+    Set<String> handles = new HashSet<>();
+    for (int i = 0; i < count; i++) {
+      handles.add("r" + i);
+    }
+    return handles;
+  }
+
+  private static BatchResultErrorEntry errorEntry(String id, String code, boolean senderFault) {
+    return BatchResultErrorEntry.builder().id(id).code(code).senderFault(senderFault)
+        .message(code + " for entry " + id).build();
+  }
+
+  /**
+   * Runs {@code body} with {@link CloudObjectsSelector#log} swapped for a mock and returns everything it
+   * logged at {@code level} - format string and arguments flattened - so a test can assert on what
+   * on-call would actually see. The real logger is always restored.
+   */
+  private static String captureLogs(String level, Runnable body) {
+    Logger capturingLogger = Mockito.mock(Logger.class);
+    Logger original = CloudObjectsSelector.log;
+    CloudObjectsSelector.log = capturingLogger;
+    try {
+      body.run();
+    } finally {
+      CloudObjectsSelector.log = original;
+    }
+    return Mockito.mockingDetails(capturingLogger).getInvocations().stream()
+        .filter(invocation -> level.equals(invocation.getMethod().getName()))
+        .map(invocation -> renderLogEvent(invocation.getArguments()))
+        .collect(Collectors.joining("\n"));
+  }
+
+  /**
+   * Substitutes a captured slf4j event's arguments into its {@code {}} placeholders, so assertions can
+   * be written against the line an operator reads rather than against the unformatted template.
+   */
+  private static String renderLogEvent(Object[] arguments) {
+    if (arguments.length == 0) {
+      return "";
+    }
+    StringBuilder rendered = new StringBuilder(String.valueOf(arguments[0]));
+    int searchFrom = 0;
+    for (int i = 1; i < arguments.length; i++) {
+      String value = String.valueOf(arguments[i]);
+      int placeholder = rendered.indexOf("{}", searchFrom);
+      if (placeholder < 0) {
+        // A trailing Throwable (or a surplus argument) is appended by slf4j, not substituted.
+        rendered.append(" | ").append(value);
+      } else {
+        rendered.replace(placeholder, placeholder + 2, value);
+        searchFrom = placeholder + value.length();
+      }
+    }
+    return rendered.toString();
   }
 
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`S3EventsSource` drains its SQS queue serially, 10 messages at a time, for both receive and delete. `ReceiveMessage` and `DeleteMessageBatch` are capped by SQS at 10 entries per call, so draining a backlog is dominated by round-trip latency and concurrency is the only available lever. On a deep backlog these two serial phases dominate the ingestion cycle.

Three correctness problems in the existing loops compound this:

1. **Any `ReceiveMessage` failure aborts the whole batch.** A throttle, a 5xx or a dropped connection propagates straight out of the loop, discarding every message already fetched — and since those messages were made invisible server-side, they are stranded until the visibility timeout expires. The same applies to `OverLimit`, which is normal in-flight saturation rather than an error, so reaching the in-flight ceiling fails the job.
2. The receive loop ends the entire batch on the **first empty response**, with no allowance for the case AWS documents as unreliable — *"in rare cases, you might receive empty responses even when a queue still contains messages, especially if you specified a low value for the `WaitTimeSeconds` parameter."* Note this is only a real exposure at low `WaitTimeSeconds`; at the default of 20 an empty response is strong evidence and one is still sufficient (see the drain-detection bullet below).
3. `DeleteMessageBatch` partial failures are counted but never retried, and undeleted messages stay in flight, consume the in-flight quota, and are redelivered once the visibility timeout expires.

### Summary and Changelog

Users draining a large SQS backlog through `S3EventsSource` get a substantially shorter fetch/commit cycle, since the receive and delete round-trips now overlap instead of running one at a time. Behaviour is unchanged at `parallelism=1`.

Changes:

- **Both phases fan out across a shared bounded thread pool.** Calls are dispatched through an `ExecutorCompletionService`: the coordinating thread consumes each completion as it arrives and immediately refills the freed slot. `invokeAll` over a batch of calls in a loop was rejected as it is a barrier — a wave costs `max(latency)` rather than `avg(latency)`, and no worker starts its next call until the slowest sibling returns. All counters and termination state stay on the coordinating thread; nothing is shared with the workers beyond a timing accumulator.
- **Admission control** credits each in-flight call with a full `maxMessagesPerRequest`, so a call is never dispatched that messages already in flight would make redundant. Overshoot of `maxMessagePerBatch` is bounded to `maxMessagesPerRequest - 1`.
- **Drain detection scaled to poll cost.** Under long polling, *"an empty response is sent only if the polling wait time expires"*, so an empty costs a full `WaitTimeSeconds` while a non-empty one returns as soon as a message is available. The batch now requires however many empty responses fit in one ~20s window — 1 at `WaitTimeSeconds=20`, 2 at 10, 4 at 5, 20 at 1 — which bounds drain confirmation to roughly a single poll window at any setting, with no timer. Short polling samples only a subset of servers, so its empty responses are weak evidence but nearly free, and keep a higher fixed count (5). Empty responses are counted as a batch total rather than consecutively, since resetting on a stray message lets a queue with slow ingress hold the phase for its entire call budget.
- **Failure classification by SQS error code**, with the HTTP status used only as a fallback for unrecognised codes (unknown 5xx transient, unknown 4xx not). SQS status codes do not track severity: `RequestThrottled` and `OverLimit` are both HTTP 400, `ThrottlingException` is 403, `MalformedQueryString` is 404. `AwsErrorCode.THROTTLING_ERROR_CODES` omits `KmsThrottled`, which is covered explicitly.
- **`OverLimit` treated as backpressure**, not an error: it stops dispatch and returns what was fetched, since the received messages become deletable once the batch commits, which is what frees the in-flight quota. Non-retryable failures stop at the first occurrence rather than consuming the retry budget.
- **In-flight calls are drained, never cancelled.** A `ReceiveMessage` that succeeded server-side has already made those messages invisible, so discarding the response would strand them for the full visibility timeout. Correspondingly, an empty result only surfaces as an error when nothing at all proved the queue reachable — a successful response, or an `OverLimit` returned by SQS itself, is evidence the endpoint, credentials and queue are healthy.
- **Delete partial failures aggregated and retried** with exponential backoff. `senderFault` entries are set aside rather than retried, as no retry can fix them. A synthetic per-entry id (the batch-local index) replaces the message id, so duplicate message ids within a batch under at-least-once delivery cannot collide and cause SQS to reject the whole batch; the id doubles as the reverse lookup, so no map is needed.
- **Observability**: a receive plan line, a one-time queue-config line, a drain break probe that reports live queue counters when a batch ends short, and a perf line reporting summed call time against wall time so it is visible whether the calls actually overlapped.

Deletes remain in `Source.onCommit`. Deleting inside the receive loop would lift the in-flight ceiling but would break the coupling between message deletion and the commit that consumed those messages.

No code was copied from another project.

### Impact

- **Performance**: receive and delete round-trips overlap, so cycle time on a deep backlog is bound by round-trip latency divided by parallelism rather than multiplied by call count.
- **New config**: `hoodie.streamer.s3.source.queue.processing.parallelism`, default 16. Setting it to 1 restores the previous fully sequential behaviour.
- **Behaviour change — drain detection.** How many empty responses end a batch is now a function of `WaitTimeSeconds` rather than always being one. At the **default `WaitTimeSeconds=20` (also the AWS maximum) it remains one**, so the default path behaves as before; below that the count rises (2 at 10, 4 at 5, 20 at 1) and a batch can fetch *more* messages than before against a queue that returns a spurious empty. Short polling keeps a fixed count of 5.
- **Behaviour change — failures no longer discard the batch.** A transient `ReceiveMessage` failure is tolerated rather than aborting: only 5 consecutive failed completions stop the phase, and everything already fetched is returned. `OverLimit` returns cleanly as backpressure instead of failing the job. A non-retryable failure still stops immediately, but keeps what was fetched.
- No public API changes, no storage-format changes, no breaking changes.
- The shared `SqsClient` is thread-safe and remains a single instance. Its HTTP connection pool must be at least the worker count or workers block on connection acquisition; the SDK's default sync pool (`maxConnections=50`) already covers any value up to 50, so only a larger value causes the source to resize the pool — which is why `software.amazon.awssdk:apache-client` is declared `provided` rather than made a hard runtime requirement.

### Risk Level

**Medium.** The change makes a previously single-threaded ingestion path concurrent and alters when a receive batch terminates.

Mitigations and verification:

- `TestCloudObjectsSelector` 50/50, plus `TestS3EventsMetaSelector` and `TestS3EventsSource`; full `mvn clean install` clean.
- Concurrency is covered with real threads, not mocks of concurrency: 250 messages drained across 8 workers asserting every message is fetched exactly once — no loss, no duplication.
- Two tests are regression detectors rather than plain assertions: one holds a single call until its siblings have completed several further calls between them, so a return to wave-based dispatch fails the test rather than passing quietly; another pins the deliberate short-poll trade-off so a change to empty-response counting cannot alter it silently.
- Each failure class is covered end to end — transient tolerated, non-retryable failing fast, `OverLimit` returning cleanly with and without fetched messages — plus the classifier itself as a unit table, and `Error` propagation.
- Four behavioural guards were verified by mutation rather than line coverage: reverting each one causes its test to fail rather than pass silently.
- `parallelism=1` is retained as an escape hatch to the previous sequential behaviour.

### Documentation Update

The new config `hoodie.streamer.s3.source.queue.processing.parallelism` carries a full `withDocumentation` description covering the SQS 10-per-call cap, the connection-pool requirement, and the `parallelism=1` escape hatch.

`hoodie.streamer.s3.source.queue.long.poll.wait` has its description extended, since it now also governs how many empty responses confirm a drain.

No website changes are needed — both are existing/advanced source configs surfaced through the generated config docs.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

