### PR TITLE
test(spark): add HiveSyncProcedure coverage

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHiveSyncProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHiveSyncProcedure.scala
@@ -18,11 +18,12 @@
 package org.apache.spark.sql.hudi.procedure
 
 import org.apache.hudi.common.testutils.HoodieTestUtils
+import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.hive.{HiveSyncConfig, HiveSyncConfigHolder}
 import org.apache.hudi.sync.common.HoodieSyncConfig
 
 import org.apache.hadoop.hive.conf.HiveConf
-import org.junit.jupiter.api.Assertions.{assertNotNull, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 
 class TestHiveSyncProcedure extends HoodieSparkProcedureTestBase {
 
@@ -54,44 +55,58 @@ class TestHiveSyncProcedure extends HoodieSparkProcedureTestBase {
   }
 
   test("Test call hive_sync procedure surfaces a sync failure as HoodieException") {
-    // The procedure constructs a HiveConf; Hive 2.3.7 is compiled with Java 1.8 and its class
-    // loader throws when the Hive APIs are exercised on Java 17, so the test is skipped there.
-    if (HoodieTestUtils.getJavaVersion < 17) {
-      withTempDir { tmp =>
-        val tableName = generateTableName
-        val basePath = s"${tmp.getCanonicalPath}/$tableName"
-        createHudiTable(tableName, basePath)
+    // The procedure constructs a HiveConf; Hive 2.3.7 is compiled with Java 1.8 and its class loader
+    // throws when the Hive APIs are exercised on Java 17. Cancel (report as skipped, not passed) there.
+    assume(HoodieTestUtils.getJavaVersion < 17)
+    withTempDir { tmp =>
+      val tableName = generateTableName
+      val basePath = s"${tmp.getCanonicalPath}/$tableName"
+      createHudiTable(tableName, basePath)
 
-        try {
-          // Every optional argument is supplied so each argument branch of the procedure runs. The
-          // unresolvable partition_extractor_class makes the HiveSyncTool constructor throw while
-          // loading the extractor (in the HoodieSyncClient constructor, before any metastore
-          // connection is attempted).
-          var thrown: Throwable = null
-          try {
-            spark.sql(
-              s"call hive_sync(table => '$tableName', metastore_uri => 'thrift://localhost:9083'," +
-                s" username => 'hive', password => 'hive', use_jdbc => 'false', mode => 'hms'," +
-                s" partition_fields => 'name', strategy => 'ALL', sync_incremental => 'false'," +
-                s" partition_extractor_class => 'org.apache.hudi.hive.MissingPartitionExtractor')")
-          } catch {
-            case e: Throwable => thrown = e
-          }
-          assertNotNull(thrown, "hive_sync should fail when the partition extractor cannot be loaded")
-
-          // The procedure must wrap the failure as HoodieException("hive sync failed"), and the
-          // cause must be the unresolvable extractor supplied as an argument. Asserting both pins
-          // the wrapping contract and that the argument is applied and fails before the metastore.
-          val chain = Iterator.iterate(thrown)(_.getCause).takeWhile(_ != null)
-            .flatMap(t => Option(t.getMessage)).mkString(" | ")
-          assertTrue(chain.contains("hive sync failed"),
-            s"expected the procedure to wrap the failure as HoodieException, but got: $chain")
-          assertTrue(chain.contains("org.apache.hudi.hive.MissingPartitionExtractor"),
-            s"expected the failure to originate from loading the supplied extractor, but got: $chain")
-        } finally {
-          spark.sparkContext.hadoopConfiguration.unset(HiveConf.ConfVars.METASTOREURIS.varname)
-          sessionSyncConfKeys.foreach(spark.sessionState.conf.unsetConf)
+      try {
+        // Every optional argument is supplied so each argument branch of the procedure runs. The
+        // unresolvable partition_extractor_class makes the HiveSyncTool constructor throw while
+        // loading the extractor (in the HoodieSyncClient constructor, before any metastore
+        // connection is attempted).
+        val thrown = intercept[Throwable] {
+          spark.sql(
+            s"call hive_sync(table => '$tableName', metastore_uri => 'thrift://localhost:9083'," +
+              s" username => 'hive', password => 'hive', use_jdbc => 'false', mode => 'hms'," +
+              s" partition_fields => 'name', strategy => 'ALL', sync_incremental => 'false'," +
+              s" partition_extractor_class => 'org.apache.hudi.hive.MissingPartitionExtractor')")
         }
+
+        // The procedure must wrap the failure as HoodieException("hive sync failed"), and the cause
+        // must be the unresolvable extractor supplied as an argument. Asserting the exception type,
+        // the wrapping message, and the cause together pins the wrapping contract and that the
+        // supplied extractor is applied and fails before the metastore.
+        val causes = Iterator.iterate(thrown)(_.getCause).takeWhile(_ != null).toList
+        assertTrue(causes.exists(_.isInstanceOf[HoodieException]),
+          "expected a HoodieException in the cause chain, but got: " +
+            causes.map(_.getClass.getName).mkString(" -> "))
+        val chain = causes.flatMap(t => Option(t.getMessage)).mkString(" | ")
+        assertTrue(chain.contains("hive sync failed"),
+          s"expected the procedure to wrap the failure as HoodieException, but got: $chain")
+        assertTrue(chain.contains("org.apache.hudi.hive.MissingPartitionExtractor"),
+          s"expected the failure to originate from loading the supplied extractor, but got: $chain")
+
+        // Each supplied optional argument must be applied to the session/hadoop conf before the sync
+        // is attempted; asserting the written values catches dropping any of the setConfString calls.
+        val sqlConf = spark.sessionState.conf
+        assertEquals("hive", sqlConf.getConfString(HiveSyncConfig.HIVE_USER.key))
+        assertEquals("hive", sqlConf.getConfString(HiveSyncConfig.HIVE_PASS.key))
+        assertEquals("false", sqlConf.getConfString(HiveSyncConfig.HIVE_USE_JDBC.key))
+        assertEquals("hms", sqlConf.getConfString(HiveSyncConfigHolder.HIVE_SYNC_MODE.key))
+        assertEquals("name", sqlConf.getConfString(HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key))
+        assertEquals("org.apache.hudi.hive.MissingPartitionExtractor",
+          sqlConf.getConfString(HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key))
+        assertEquals("ALL", sqlConf.getConfString(HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY.key))
+        assertEquals("false", sqlConf.getConfString(HoodieSyncConfig.META_SYNC_INCREMENTAL.key))
+        assertEquals("thrift://localhost:9083",
+          spark.sparkContext.hadoopConfiguration.get(HiveConf.ConfVars.METASTOREURIS.varname))
+      } finally {
+        spark.sparkContext.hadoopConfiguration.unset(HiveConf.ConfVars.METASTOREURIS.varname)
+        sessionSyncConfKeys.foreach(spark.sessionState.conf.unsetConf)
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHiveSyncProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestHiveSyncProcedure.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.procedure
+
+import org.apache.hudi.common.testutils.HoodieTestUtils
+import org.apache.hudi.hive.{HiveSyncConfig, HiveSyncConfigHolder}
+import org.apache.hudi.sync.common.HoodieSyncConfig
+
+import org.apache.hadoop.hive.conf.HiveConf
+import org.junit.jupiter.api.Assertions.{assertNotNull, assertTrue}
+
+class TestHiveSyncProcedure extends HoodieSparkProcedureTestBase {
+
+  // Session-conf keys the procedure writes from its optional arguments; reset after the call so
+  // they do not leak into sibling tests sharing the session.
+  private val sessionSyncConfKeys = Seq(
+    HiveSyncConfig.HIVE_USER.key, HiveSyncConfig.HIVE_PASS.key, HiveSyncConfig.HIVE_USE_JDBC.key,
+    HiveSyncConfigHolder.HIVE_SYNC_MODE.key, HoodieSyncConfig.META_SYNC_PARTITION_FIELDS.key,
+    HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS.key,
+    HiveSyncConfigHolder.HIVE_SYNC_TABLE_STRATEGY.key, HoodieSyncConfig.META_SYNC_INCREMENTAL.key)
+
+  private def createHudiTable(tableName: String, basePath: String): Unit = {
+    spark.sql(
+      s"""
+         |create table $tableName (
+         |  id int,
+         |  name string,
+         |  price double,
+         |  ts long
+         |) using hudi
+         | options (
+         |  primaryKey = 'id',
+         |  type = 'cow',
+         |  preCombineField = 'ts'
+         | )
+         | location '$basePath'
+       """.stripMargin)
+    spark.sql(s"insert into $tableName values(1, 'a1', 10.0, 1000)")
+  }
+
+  test("Test call hive_sync procedure surfaces a sync failure as HoodieException") {
+    // The procedure constructs a HiveConf; Hive 2.3.7 is compiled with Java 1.8 and its class
+    // loader throws when the Hive APIs are exercised on Java 17, so the test is skipped there.
+    if (HoodieTestUtils.getJavaVersion < 17) {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        val basePath = s"${tmp.getCanonicalPath}/$tableName"
+        createHudiTable(tableName, basePath)
+
+        try {
+          // Every optional argument is supplied so each argument branch of the procedure runs. The
+          // unresolvable partition_extractor_class makes the HiveSyncTool constructor throw while
+          // loading the extractor (in the HoodieSyncClient constructor, before any metastore
+          // connection is attempted).
+          var thrown: Throwable = null
+          try {
+            spark.sql(
+              s"call hive_sync(table => '$tableName', metastore_uri => 'thrift://localhost:9083'," +
+                s" username => 'hive', password => 'hive', use_jdbc => 'false', mode => 'hms'," +
+                s" partition_fields => 'name', strategy => 'ALL', sync_incremental => 'false'," +
+                s" partition_extractor_class => 'org.apache.hudi.hive.MissingPartitionExtractor')")
+          } catch {
+            case e: Throwable => thrown = e
+          }
+          assertNotNull(thrown, "hive_sync should fail when the partition extractor cannot be loaded")
+
+          // The procedure must wrap the failure as HoodieException("hive sync failed"), and the
+          // cause must be the unresolvable extractor supplied as an argument. Asserting both pins
+          // the wrapping contract and that the argument is applied and fails before the metastore.
+          val chain = Iterator.iterate(thrown)(_.getCause).takeWhile(_ != null)
+            .flatMap(t => Option(t.getMessage)).mkString(" | ")
+          assertTrue(chain.contains("hive sync failed"),
+            s"expected the procedure to wrap the failure as HoodieException, but got: $chain")
+          assertTrue(chain.contains("org.apache.hudi.hive.MissingPartitionExtractor"),
+            s"expected the failure to originate from loading the supplied extractor, but got: $chain")
+        } finally {
+          spark.sparkContext.hadoopConfiguration.unset(HiveConf.ConfVars.METASTOREURIS.varname)
+          sessionSyncConfKeys.foreach(spark.sessionState.conf.unsetConf)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`HiveSyncProcedure` (the `call hive_sync(...)` stored procedure) had almost no coverage on its `call` method: only the class and parameter setup were exercised (around 40% of the file), while the entire body that reads the arguments, applies them to the session and Hadoop configs, builds the `HiveSyncConfig`, runs the sync, and wraps failures was uncovered.

### Summary and Changelog

Adds `TestHiveSyncProcedure`, which invokes `call hive_sync(...)` with every optional argument supplied so each argument-handling and configuration-setup branch runs. It passes an unresolvable `partition_extractor_class`, which makes the `HiveSyncTool` constructor fail while loading the extractor in the `HoodieSyncClient` constructor (before any metastore connection is attempted).

The test pins three things about that failure. It walks the exception cause chain and asserts a `HoodieException` instance is present (not just a message match), that the chain carries the `hive sync failed` wrapper message, and that it originates from loading the supplied extractor. It then asserts every value the procedure writes to the session conf (user, password, JDBC flag, sync mode, partition fields, extractor class, strategy, incremental) and `METASTOREURIS` on the Hadoop conf before the finally block clears them, so deleting any of the `setConfString` calls is caught.

This covers argument extraction, all nine optional argument branches, the config assembly (`buildHiveSyncConfig`), the `HiveSyncTool` construction, and the catch/finally path. The successful-sync tail (`syncHoodieTable()` returning and the `hive sync success.` row) is not covered here: it needs a live metastore, and the embedded metastore harness (`HiveTestUtil`) cannot start on the `hudi-spark` test classpath under the JDK 11 CI because of a Thrift version conflict (`HiveTestService`'s server socket and the metastore client both reference Thrift APIs that clash with the Thrift bundled through Spark/Hive on this module). On Java 17 the test cancels through `assume` (the Hive 2.3.7 classes fail to load there), so it reports as skipped rather than passed, matching the Java-17 constraint on the other Hive sync tests in this module.

### Impact

None. Test-only change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
