### PR TITLE
test(spark): enhance blob/vector SQL DDL coverage of the extended parser

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExtendedParserTestHelpers.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExtendedParserTestHelpers.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hudi.common
+
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable
+import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, Transform}
+import org.scalatest.Assertions
+
+/**
+ * Shared helpers for the extended-parser coverage tests (e.g. TestCreateTable, TestBlobDataType),
+ * which route a full CREATE TABLE through the extended AST builder and pull partition transforms and
+ * their arguments out of the resulting [[CreateTable]] plan. Kept in one place so the transform
+ * inspection stays consistent across the per-type test suites that share it.
+ */
+trait ExtendedParserTestHelpers extends Assertions {
+
+  protected def transformByName(plan: CreateTable, name: String): Transform =
+    plan.partitioning.find(_.name == name)
+      .getOrElse(fail(s"No partition transform named $name in ${plan.partitioning.mkString(", ")}"))
+
+  protected def transformFieldRefs(t: Transform): Seq[Seq[String]] =
+    t.arguments().collect { case r: FieldReference => r.fieldNames().toSeq }.toSeq
+
+  protected def firstLiteralArg(t: Transform): LiteralValue[_] =
+    t.arguments().collectFirst { case l: LiteralValue[_] => l }
+      .getOrElse(fail(s"No literal argument in transform ${t.name}"))
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExtendedParserTestHelpers.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExtendedParserTestHelpers.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hudi.common
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.CreateTable
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, Transform}
 import org.scalatest.Assertions
@@ -24,10 +25,16 @@ import org.scalatest.Assertions
 /**
  * Shared helpers for the extended-parser coverage tests (e.g. TestCreateTable, TestBlobDataType),
  * which route a full CREATE TABLE through the extended AST builder and pull partition transforms and
- * their arguments out of the resulting [[CreateTable]] plan. Kept in one place so the transform
- * inspection stays consistent across the per-type test suites that share it.
+ * their arguments out of the resulting [[CreateTable]] plan. Kept in one place so the parse entry
+ * point and the transform inspection stay consistent across the per-type test suites that share it.
  */
 trait ExtendedParserTestHelpers extends Assertions {
+
+  /** Satisfied by HoodieSparkSqlTestBase's `protected lazy val spark`. */
+  protected def spark: SparkSession
+
+  protected def parseCreateTable(sql: String): CreateTable =
+    spark.sessionState.sqlParser.parsePlan(sql).asInstanceOf[CreateTable]
 
   protected def transformByName(plan: CreateTable, name: String): Transform =
     plan.partitioning.find(_.name == name)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -2368,7 +2368,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
       s"""
          |CREATE TABLE vec_parse_tbl (
          |  id BIGINT,
-         |  ts TIMESTAMP,
+         |  ts DATE,
          |  region STRING,
          |  name STRING,
          |  embedding VECTOR(8)
@@ -2392,11 +2392,12 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
 
   test("test create VECTOR table with typed transform-argument literals parses (parser coverage)") {
     // Each transform carries a differently-typed constant argument to exercise the literal
-    // visitors: string, integer, long, exponent/double, the typed timestamp constructor, and both
-    // interval forms (multi-units and unit-to-unit). A bare true/false/null in this position is
-    // parsed as a column reference (qualifiedName takes precedence over a constant in the grammar
-    // under the default non-ANSI config), so the boolean and null literal visitors are not
-    // reachable from a CREATE TABLE statement.
+    // visitors: string, integer, long, exponent/double, the typed date constructor, and both
+    // interval forms (multi-units and unit-to-unit). A typed timestamp constructor is not used
+    // because the Spark 4.x extended parser rejects a bare TIMESTAMP token. A bare true/false/null
+    // in this position is parsed as a column reference (qualifiedName takes precedence over a
+    // constant in the grammar under the default non-ANSI config), so the boolean and null literal
+    // visitors are not reachable from a CREATE TABLE statement.
     val plan = parseCreateTable(
       s"""
          |CREATE TABLE vec_lit_tbl (
@@ -2408,7 +2409,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
          |  int_t(4, id),
          |  long_t(9000000000L, id),
          |  exp_t(1E3, id),
-         |  ts_t(TIMESTAMP '2020-01-01 00:00:00', id),
+         |  date_t(DATE '2020-01-01', id),
          |  mu_ivl_t(INTERVAL '1' DAY, id),
          |  uu_ivl_t(INTERVAL '1-2' YEAR TO MONTH, id)
          |)
@@ -2419,7 +2420,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
     assertEquals(IntegerType, firstLiteralArg(transformByName(plan, "int_t")).dataType)
     assertEquals(LongType, firstLiteralArg(transformByName(plan, "long_t")).dataType)
     assertEquals(DoubleType, firstLiteralArg(transformByName(plan, "exp_t")).dataType)
-    assertEquals(TimestampType, firstLiteralArg(transformByName(plan, "ts_t")).dataType)
+    assertEquals(DateType, firstLiteralArg(transformByName(plan, "date_t")).dataType)
     assertEquals(
       DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY),
       firstLiteralArg(transformByName(plan, "mu_ivl_t")).dataType)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -37,18 +37,17 @@ import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, HoodieCatalogTable}
 import org.apache.spark.sql.catalyst.plans.logical.CreateTable
-import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, Transform}
 import org.apache.spark.sql.functions.{col, concat, expr, lit}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
 import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand
-import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.common.{ExtendedParserTestHelpers, HoodieSparkSqlTestBase}
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.{disableComplexKeygenValidation, getLastCommitMetadata}
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNull, assertTrue}
 
 import scala.collection.JavaConverters._
 
-class TestCreateTable extends HoodieSparkSqlTestBase {
+class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelpers {
 
   test("Test Create Managed Hoodie Table") {
     val databaseName = "hudi_database"
@@ -2351,17 +2350,6 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
 
   private def parseCreateTable(sql: String): CreateTable =
     spark.sessionState.sqlParser.parsePlan(sql).asInstanceOf[CreateTable]
-
-  private def transformByName(plan: CreateTable, name: String): Transform =
-    plan.partitioning.find(_.name == name)
-      .getOrElse(sys.error(s"No partition transform named $name in ${plan.partitioning.mkString(", ")}"))
-
-  private def transformFieldRefs(t: Transform): Seq[Seq[String]] =
-    t.arguments().collect { case r: FieldReference => r.fieldNames().toSeq }.toSeq
-
-  private def firstLiteralArg(t: Transform): LiteralValue[_] =
-    t.arguments().collectFirst { case l: LiteralValue[_] => l }
-      .getOrElse(sys.error(s"No literal argument in transform ${t.name}"))
 
   test("test create VECTOR table with partition transforms parses (parser coverage)") {
     val plan = parseCreateTable(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -36,7 +36,6 @@ import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, HoodieCatalogTable}
-import org.apache.spark.sql.catalyst.plans.logical.CreateTable
 import org.apache.spark.sql.functions.{col, concat, expr, lit}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
 import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand
@@ -2344,78 +2343,12 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
   // The following cases are parser-coverage only: a VECTOR column routes the whole CREATE TABLE
   // through the extended AST builder, so its clause visitors run. parsePlan is purely syntactic
   // (no catalog, no execution), matching how TestIndexSyntax exercises the index statements, which
-  // lets us cover clauses that are not supported at execution time (transform partitioning,
-  // CLUSTERED BY, typed literal arguments). The VECTOR column type proves the statement routed
-  // here because the stock Spark parser rejects the VECTOR type name.
-
-  private def parseCreateTable(sql: String): CreateTable =
-    spark.sessionState.sqlParser.parsePlan(sql).asInstanceOf[CreateTable]
-
-  test("test create VECTOR table with partition transforms parses (parser coverage)") {
-    val plan = parseCreateTable(
-      s"""
-         |CREATE TABLE vec_parse_tbl (
-         |  id BIGINT,
-         |  ts DATE,
-         |  region STRING,
-         |  name STRING,
-         |  embedding VECTOR(8)
-         |) USING hudi
-         |PARTITIONED BY (region, bucket(4, id), years(ts), truncate(10, name))
-         """.stripMargin)
-
-    assertEquals(ArrayType(FloatType, containsNull = false), plan.tableSchema("embedding").dataType)
-
-    assertEquals(Seq(Seq("region")), transformFieldRefs(transformByName(plan, "identity")))
-    val bucket = transformByName(plan, "bucket")
-    assertEquals(IntegerType, firstLiteralArg(bucket).dataType)
-    assertEquals("4", firstLiteralArg(bucket).value.toString)
-    assertEquals(Seq(Seq("id")), transformFieldRefs(bucket))
-    assertEquals(Seq(Seq("ts")), transformFieldRefs(transformByName(plan, "years")))
-    val truncate = transformByName(plan, "truncate")
-    assertEquals(IntegerType, firstLiteralArg(truncate).dataType)
-    assertEquals("10", firstLiteralArg(truncate).value.toString)
-    assertEquals(Seq(Seq("name")), transformFieldRefs(truncate))
-  }
-
-  test("test create VECTOR table with typed transform-argument literals parses (parser coverage)") {
-    // Each transform carries a differently-typed constant argument to exercise the literal
-    // visitors: string, integer, long, exponent/double, the typed date constructor, and both
-    // interval forms (multi-units and unit-to-unit). A typed timestamp constructor is not used
-    // because the Spark 4.x extended parser rejects a bare TIMESTAMP token. A bare true/false/null
-    // in this position is parsed as a column reference (qualifiedName takes precedence over a
-    // constant in the grammar under the default non-ANSI config), so the boolean and null literal
-    // visitors are not reachable from a CREATE TABLE statement.
-    val plan = parseCreateTable(
-      s"""
-         |CREATE TABLE vec_lit_tbl (
-         |  id BIGINT,
-         |  embedding VECTOR(4)
-         |) USING hudi
-         |PARTITIONED BY (
-         |  str_t('x', id),
-         |  int_t(4, id),
-         |  long_t(9000000000L, id),
-         |  exp_t(1E3, id),
-         |  date_t(DATE '2020-01-01', id),
-         |  mu_ivl_t(INTERVAL '1' DAY, id),
-         |  uu_ivl_t(INTERVAL '1-2' YEAR TO MONTH, id)
-         |)
-         """.stripMargin)
-
-    assertEquals(StringType, firstLiteralArg(transformByName(plan, "str_t")).dataType)
-    assertEquals("x", firstLiteralArg(transformByName(plan, "str_t")).value.toString)
-    assertEquals(IntegerType, firstLiteralArg(transformByName(plan, "int_t")).dataType)
-    assertEquals(LongType, firstLiteralArg(transformByName(plan, "long_t")).dataType)
-    assertEquals(DoubleType, firstLiteralArg(transformByName(plan, "exp_t")).dataType)
-    assertEquals(DateType, firstLiteralArg(transformByName(plan, "date_t")).dataType)
-    assertEquals(
-      DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY),
-      firstLiteralArg(transformByName(plan, "mu_ivl_t")).dataType)
-    assertEquals(
-      YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH),
-      firstLiteralArg(transformByName(plan, "uu_ivl_t")).dataType)
-  }
+  // lets us cover clauses that are not supported at execution time (CLUSTERED BY bucket specs).
+  // Transform-partitioning and typed-literal coverage lives in TestBlobDataType only: the clause
+  // visitors are type-agnostic (the builder branches on blob-vs-vector solely in
+  // visitPrimitiveDataType), so a second per-type copy would exercise no new production line. The
+  // VECTOR column type proves the statement routed here because the stock Spark parser rejects the
+  // VECTOR type name.
 
   test("test create VECTOR table with CLUSTERED BY bucket spec parses (parser coverage)") {
     val plan = parseCreateTable(
@@ -2425,11 +2358,12 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
     assertEquals("4", firstLiteralArg(bucket).value.toString)
     assertEquals(Seq(Seq("id")), transformFieldRefs(bucket))
 
-    // SORTED BY ... ASC is accepted by the bucket-spec visitor.
+    // SORTED BY ... ASC is accepted by the bucket-spec visitor and yields a sorted_bucket
+    // transform; a plain bucket transform here would mean the SORTED BY clause was dropped.
     val sortedPlan = parseCreateTable(
       "CREATE TABLE vec_sbucket_tbl (id BIGINT, ts BIGINT, embedding VECTOR(4)) USING hudi " +
         "CLUSTERED BY (id, ts) SORTED BY (id ASC) INTO 8 BUCKETS")
-    assertTrue(sortedPlan.partitioning.exists(_.name.toLowerCase.contains("bucket")))
+    assertEquals("sorted_bucket", sortedPlan.partitioning.head.name)
 
     // SORTED BY ... DESC is rejected by the bucket-spec visitor.
     checkExceptionContain(
@@ -2440,7 +2374,10 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
 
   test("test create VECTOR table with LOCATION/COMMENT/OPTIONS/TBLPROPERTIES parses (parser coverage)") {
     // String, integer and boolean property values exercise all branches of the property visitors;
-    // COMMENT and LOCATION exercise their clause visitors.
+    // COMMENT and LOCATION exercise their clause visitors. The clause results are asserted on
+    // tableSpec (location/comment/properties are stable across Spark 3.3 through 4.2; the parsed
+    // options map is not exposed on the 3.5+ TableSpecBase, so OPTIONS is only asserted through
+    // the path-folding case below).
     val plan = parseCreateTable(
       s"""
          |CREATE TABLE vec_clause_tbl (
@@ -2453,12 +2390,17 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
          |TBLPROPERTIES ('prop_str' = 'v', 'prop_int' = 2, 'prop_bool' = false)
          """.stripMargin)
     assertEquals(ArrayType(FloatType, containsNull = false), plan.tableSchema("embedding").dataType)
+    assertEquals(Some("a vector table"), plan.tableSpec.comment)
+    assertEquals(Some("/tmp/vec_clause_tbl"), plan.tableSpec.location)
+    assertEquals("v", plan.tableSpec.properties("prop_str"))
+    assertEquals("2", plan.tableSpec.properties("prop_int"))
+    assertEquals("false", plan.tableSpec.properties("prop_bool"))
 
     // A 'path' option with no LOCATION is folded into the table location by the option cleaner.
     val pathPlan = parseCreateTable(
       "CREATE TABLE vec_path_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
         "OPTIONS ('path' = '/tmp/vec_path_tbl')")
-    assertEquals(ArrayType(FloatType, containsNull = false), pathPlan.tableSchema("embedding").dataType)
+    assertEquals(Some("/tmp/vec_path_tbl"), pathPlan.tableSpec.location)
 
     // A 'path' option colliding with LOCATION is rejected by the option cleaner.
     checkExceptionContain(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -36,6 +36,8 @@ import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, HoodieCatalogTable}
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable
+import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, Transform}
 import org.apache.spark.sql.functions.{col, concat, expr, lit}
 import org.apache.spark.sql.hudi.HoodieSqlCommonUtils
 import org.apache.spark.sql.hudi.command.CreateHoodieTableCommand
@@ -2337,6 +2339,150 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
       val embeddingField = schema.find(_.name == "embedding").get
       assertTrue(embeddingField.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD))
       assertEquals(ArrayType(FloatType, containsNull = false), embeddingField.dataType)
+    }
+  }
+
+  // The following cases are parser-coverage only: a VECTOR column routes the whole CREATE TABLE
+  // through the extended AST builder, so its clause visitors run. parsePlan is purely syntactic
+  // (no catalog, no execution), matching how TestIndexSyntax exercises the index statements, which
+  // lets us cover clauses that are not supported at execution time (transform partitioning,
+  // CLUSTERED BY, typed literal arguments). The VECTOR column type proves the statement routed
+  // here because the stock Spark parser rejects the VECTOR type name.
+
+  private def parseCreateTable(sql: String): CreateTable =
+    spark.sessionState.sqlParser.parsePlan(sql).asInstanceOf[CreateTable]
+
+  private def transformByName(plan: CreateTable, name: String): Transform =
+    plan.partitioning.find(_.name == name)
+      .getOrElse(sys.error(s"No partition transform named $name in ${plan.partitioning.mkString(", ")}"))
+
+  private def transformFieldRefs(t: Transform): Seq[Seq[String]] =
+    t.arguments().collect { case r: FieldReference => r.fieldNames().toSeq }.toSeq
+
+  private def firstLiteralArg(t: Transform): LiteralValue[_] =
+    t.arguments().collectFirst { case l: LiteralValue[_] => l }
+      .getOrElse(sys.error(s"No literal argument in transform ${t.name}"))
+
+  test("test create VECTOR table with partition transforms parses (parser coverage)") {
+    val plan = parseCreateTable(
+      s"""
+         |CREATE TABLE vec_parse_tbl (
+         |  id BIGINT,
+         |  ts TIMESTAMP,
+         |  region STRING,
+         |  name STRING,
+         |  embedding VECTOR(8)
+         |) USING hudi
+         |PARTITIONED BY (region, bucket(4, id), years(ts), truncate(10, name))
+         """.stripMargin)
+
+    assertEquals(ArrayType(FloatType, containsNull = false), plan.tableSchema("embedding").dataType)
+
+    assertEquals(Seq(Seq("region")), transformFieldRefs(transformByName(plan, "identity")))
+    val bucket = transformByName(plan, "bucket")
+    assertEquals(IntegerType, firstLiteralArg(bucket).dataType)
+    assertEquals("4", firstLiteralArg(bucket).value.toString)
+    assertEquals(Seq(Seq("id")), transformFieldRefs(bucket))
+    assertEquals(Seq(Seq("ts")), transformFieldRefs(transformByName(plan, "years")))
+    val truncate = transformByName(plan, "truncate")
+    assertEquals(IntegerType, firstLiteralArg(truncate).dataType)
+    assertEquals("10", firstLiteralArg(truncate).value.toString)
+    assertEquals(Seq(Seq("name")), transformFieldRefs(truncate))
+  }
+
+  test("test create VECTOR table with typed transform-argument literals parses (parser coverage)") {
+    // Each transform carries a differently-typed constant argument to exercise the literal
+    // visitors: string, integer, long, exponent/double, the typed timestamp constructor, and both
+    // interval forms (multi-units and unit-to-unit). A bare true/false/null in this position is
+    // parsed as a column reference (qualifiedName takes precedence over a constant in the grammar
+    // under the default non-ANSI config), so the boolean and null literal visitors are not
+    // reachable from a CREATE TABLE statement.
+    val plan = parseCreateTable(
+      s"""
+         |CREATE TABLE vec_lit_tbl (
+         |  id BIGINT,
+         |  embedding VECTOR(4)
+         |) USING hudi
+         |PARTITIONED BY (
+         |  str_t('x', id),
+         |  int_t(4, id),
+         |  long_t(9000000000L, id),
+         |  exp_t(1E3, id),
+         |  ts_t(TIMESTAMP '2020-01-01 00:00:00', id),
+         |  mu_ivl_t(INTERVAL '1' DAY, id),
+         |  uu_ivl_t(INTERVAL '1-2' YEAR TO MONTH, id)
+         |)
+         """.stripMargin)
+
+    assertEquals(StringType, firstLiteralArg(transformByName(plan, "str_t")).dataType)
+    assertEquals("x", firstLiteralArg(transformByName(plan, "str_t")).value.toString)
+    assertEquals(IntegerType, firstLiteralArg(transformByName(plan, "int_t")).dataType)
+    assertEquals(LongType, firstLiteralArg(transformByName(plan, "long_t")).dataType)
+    assertEquals(DoubleType, firstLiteralArg(transformByName(plan, "exp_t")).dataType)
+    assertEquals(TimestampType, firstLiteralArg(transformByName(plan, "ts_t")).dataType)
+    assertEquals(
+      DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY),
+      firstLiteralArg(transformByName(plan, "mu_ivl_t")).dataType)
+    assertEquals(
+      YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH),
+      firstLiteralArg(transformByName(plan, "uu_ivl_t")).dataType)
+  }
+
+  test("test create VECTOR table with CLUSTERED BY bucket spec parses (parser coverage)") {
+    val plan = parseCreateTable(
+      "CREATE TABLE vec_bucket_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
+        "CLUSTERED BY (id) INTO 4 BUCKETS")
+    val bucket = transformByName(plan, "bucket")
+    assertEquals("4", firstLiteralArg(bucket).value.toString)
+    assertEquals(Seq(Seq("id")), transformFieldRefs(bucket))
+
+    // SORTED BY ... ASC is accepted by the bucket-spec visitor.
+    val sortedPlan = parseCreateTable(
+      "CREATE TABLE vec_sbucket_tbl (id BIGINT, ts BIGINT, embedding VECTOR(4)) USING hudi " +
+        "CLUSTERED BY (id, ts) SORTED BY (id ASC) INTO 8 BUCKETS")
+    assertTrue(sortedPlan.partitioning.exists(_.name.toLowerCase.contains("bucket")))
+
+    // SORTED BY ... DESC is rejected by the bucket-spec visitor.
+    checkExceptionContain(
+      "CREATE TABLE vec_bad_bucket_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
+        "CLUSTERED BY (id) SORTED BY (id DESC) INTO 4 BUCKETS")(
+      "Column ordering must be ASC")
+  }
+
+  test("test create VECTOR table with LOCATION/COMMENT/OPTIONS/TBLPROPERTIES parses (parser coverage)") {
+    // String, integer and boolean property values exercise all branches of the property visitors;
+    // COMMENT and LOCATION exercise their clause visitors.
+    val plan = parseCreateTable(
+      s"""
+         |CREATE TABLE vec_clause_tbl (
+         |  id BIGINT,
+         |  embedding VECTOR(4)
+         |) USING hudi
+         |COMMENT 'a vector table'
+         |LOCATION '/tmp/vec_clause_tbl'
+         |OPTIONS ('opt_str' = 'v', 'opt_int' = 1, 'opt_bool' = true)
+         |TBLPROPERTIES ('prop_str' = 'v', 'prop_int' = 2, 'prop_bool' = false)
+         """.stripMargin)
+    assertEquals(ArrayType(FloatType, containsNull = false), plan.tableSchema("embedding").dataType)
+
+    // A 'path' option with no LOCATION is folded into the table location by the option cleaner.
+    val pathPlan = parseCreateTable(
+      "CREATE TABLE vec_path_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
+        "OPTIONS ('path' = '/tmp/vec_path_tbl')")
+    assertEquals(ArrayType(FloatType, containsNull = false), pathPlan.tableSchema("embedding").dataType)
+
+    // A 'path' option colliding with LOCATION is rejected by the option cleaner.
+    checkExceptionContain(
+      "CREATE TABLE vec_dup_path_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
+        "OPTIONS ('path' = '/tmp/a') LOCATION '/tmp/b'")(
+      "Duplicated table paths")
+
+    // Each reserved table property (provider, location, owner) is rejected by the property cleaner.
+    Seq("provider", "location", "owner").foreach { reserved =>
+      checkExceptionContain(
+        s"CREATE TABLE vec_reserved_$reserved (id BIGINT, embedding VECTOR(4)) USING hudi " +
+          s"TBLPROPERTIES ('$reserved' = 'x')")(
+        "reserved table property")
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -319,7 +319,6 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
          |  c_float FLOAT,
          |  c_double DOUBLE,
          |  c_date DATE,
-         |  c_ts TIMESTAMP,
          |  c_str STRING,
          |  c_char CHAR(5),
          |  c_varchar VARCHAR(10),
@@ -341,7 +340,6 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
     assertResult(FloatType)(schema("c_float").dataType)
     assertResult(DoubleType)(schema("c_double").dataType)
     assertResult(DateType)(schema("c_date").dataType)
-    assertResult(TimestampType)(schema("c_ts").dataType)
     assertResult(StringType)(schema("c_str").dataType)
     // CHAR/VARCHAR may be preserved or replaced with STRING depending on the Spark version.
     assert(Seq[DataType](CharType(5), StringType).contains(schema("c_char").dataType))
@@ -421,7 +419,7 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
       s"""
          |CREATE TABLE blob_tf_tbl (
          |  id BIGINT,
-         |  ts TIMESTAMP,
+         |  ts DATE,
          |  region STRING,
          |  data BLOB
          |) USING hudi
@@ -450,11 +448,12 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
 
   test("Test parse CREATE TABLE with BLOB column and typed transform-argument literals") {
     // Constant transform arguments exercise the literal visitors: string, integer, big-integer and
-    // exponent numerics (the private numeric-literal helper), the typed timestamp constructor, and
-    // both interval forms (multi-unit and unit-to-unit). Note: a bare true/false/null in this
-    // position is parsed as a column reference (qualifiedName takes precedence over a constant in
-    // the grammar under the default non-ANSI config), so the boolean and null literal visitors are
-    // not reachable from a CREATE TABLE statement and are intentionally not asserted here.
+    // exponent numerics (the private numeric-literal helper), the typed date constructor, and both
+    // interval forms (multi-unit and unit-to-unit). A typed timestamp constructor is not used
+    // because the Spark 4.x extended parser rejects a bare TIMESTAMP token. Note: a bare
+    // true/false/null in this position is parsed as a column reference (qualifiedName takes
+    // precedence over a constant in the grammar under the default non-ANSI config), so the boolean
+    // and null literal visitors are not reachable from a CREATE TABLE statement.
     val plan = parse(
       s"""
          |CREATE TABLE blob_lit_tbl (
@@ -466,7 +465,7 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
          |  int_t(7, id),
          |  long_t(9000000000L, id),
          |  exp_t(1E3, id),
-         |  ts_t(TIMESTAMP '2020-01-01 00:00:00', id),
+         |  date_t(DATE '2020-01-01', id),
          |  mu_ivl_t(INTERVAL '1' DAY, id),
          |  uu_ivl_t(INTERVAL '1-2' YEAR TO MONTH, id)
          |)
@@ -476,7 +475,7 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
     assertResult(IntegerType)(firstLiteralArg(transformByName(plan, "int_t")).dataType)
     assertResult(LongType)(firstLiteralArg(transformByName(plan, "long_t")).dataType)
     assertResult(DoubleType)(firstLiteralArg(transformByName(plan, "exp_t")).dataType)
-    assertResult(TimestampType)(firstLiteralArg(transformByName(plan, "ts_t")).dataType)
+    assertResult(DateType)(firstLiteralArg(transformByName(plan, "date_t")).dataType)
     assertResult(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY))(
       firstLiteralArg(transformByName(plan, "mu_ivl_t")).dataType)
     assertResult(YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH))(
@@ -494,7 +493,7 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
       "Expected a column reference")
     // A single-field transform given more than one argument.
     checkExceptionContain(
-      "CREATE TABLE blob_e3 (id BIGINT, ts TIMESTAMP, data BLOB) USING hudi " +
+      "CREATE TABLE blob_e3 (id BIGINT, ts DATE, data BLOB) USING hudi " +
         "PARTITIONED BY (years(id, ts))")(
       "Too many arguments")
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -24,7 +24,7 @@ import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
 import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
-import org.apache.spark.sql.catalyst.plans.logical.CreateTable
+import org.apache.spark.sql.catalyst.plans.logical.FormatClasses
 import org.apache.spark.sql.hudi.common.{ExtendedParserTestHelpers, HoodieSparkSqlTestBase}
 import org.apache.spark.sql.types._
 
@@ -291,12 +291,9 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
   // time (transform partitioning, STORED AS / ROW FORMAT, interval columns). The BLOB column type
   // itself proves routing because the stock Spark parser rejects the BLOB type name.
 
-  private def parse(sql: String): CreateTable =
-    spark.sessionState.sqlParser.parsePlan(sql).asInstanceOf[CreateTable]
-
   test("Test parse CREATE TABLE with BLOB column and primitive data types") {
     // Exercises the primitive-data-type match arms plus NOT NULL and column COMMENT.
-    val plan = parse(
+    val plan = parseCreateTable(
       s"""
          |CREATE TABLE blob_prim_tbl (
          |  c_bool BOOLEAN,
@@ -342,14 +339,14 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
   }
 
   test("Test parse CREATE TABLE with BLOB column and complex data types") {
-    // Exercises the ARRAY / MAP / STRUCT arms and BLOB-in-struct metadata handling.
-    val plan = parse(
+    // Exercises the ARRAY / MAP / STRUCT arms. BLOB-in-struct metadata handling is already
+    // covered by "test BLOB in nested struct".
+    val plan = parseCreateTable(
       s"""
          |CREATE TABLE blob_complex_tbl (
          |  c_arr ARRAY<INT>,
          |  c_map MAP<STRING, INT>,
          |  c_struct STRUCT<a: INT, b: STRING>,
-         |  c_nested_blob STRUCT<x: BLOB>,
          |  data BLOB
          |) USING hudi
        """.stripMargin)
@@ -359,15 +356,11 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     val inner = schema("c_struct").dataType.asInstanceOf[StructType]
     assertResult(IntegerType)(inner("a").dataType)
     assertResult(StringType)(inner("b").dataType)
-    // A BLOB nested inside a struct still carries the BLOB type descriptor.
-    val nested = schema("c_nested_blob").dataType.asInstanceOf[StructType]("x")
-    assertResult(BlobType())(nested.dataType)
-    assertResult(HoodieSchemaType.BLOB.name())(
-      nested.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+    assertResult(BlobType())(schema("data").dataType)
   }
 
   test("Test parse CREATE TABLE with BLOB column and interval data types") {
-    val plan = parse(
+    val plan = parseCreateTable(
       s"""
          |CREATE TABLE blob_ivl_tbl (
          |  i_year INTERVAL YEAR,
@@ -395,15 +388,10 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     checkExceptionContain(
       "CREATE TABLE blob_bad_dt (id BIGINT, bad INTERVAL SECOND TO HOUR, data BLOB) USING hudi")(
       "are not supported")
-
-    // An unknown primitive type name is rejected.
-    checkExceptionContain(
-      "CREATE TABLE blob_bad_type (id BIGINT, weird sometype, data BLOB) USING hudi")(
-      "is not supported")
   }
 
   test("Test parse CREATE TABLE with BLOB column and partition transforms") {
-    val plan = parse(
+    val plan = parseCreateTable(
       s"""
          |CREATE TABLE blob_tf_tbl (
          |  id BIGINT,
@@ -425,7 +413,7 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // bucket(numBuckets, col) with int, long and short number-of-buckets literals exercises the
     // three numeric arms of the bucket handling.
     Seq("4", "4L", "4S").foreach { numLiteral =>
-      val bp = parse(
+      val bp = parseCreateTable(
         s"CREATE TABLE blob_bkt_tbl (id BIGINT, data BLOB) USING hudi " +
           s"PARTITIONED BY (bucket($numLiteral, id))")
       val bkt = transformByName(bp, "bucket")
@@ -434,15 +422,44 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     }
   }
 
+  test("Test parse CREATE TABLE with BLOB column and partition columns") {
+    // The partition-COLUMN arm is the only partitioning branch that changes the emitted schema:
+    // the parsed partition columns are appended to the table columns and each becomes an
+    // identity transform.
+    val plan = parseCreateTable(
+      "CREATE TABLE blob_pcol_tbl (id BIGINT, data BLOB) USING hudi PARTITIONED BY (p STRING)")
+    assertResult(StringType)(plan.tableSchema("p").dataType)
+    assertResult(BlobType())(plan.tableSchema("data").dataType)
+    assertResult(Seq(Seq("p")))(transformFieldRefs(transformByName(plan, "identity")))
+
+    // Mixing partition columns and transform expressions is rejected.
+    checkExceptionContain(
+      "CREATE TABLE blob_mix_tbl (id BIGINT, data BLOB) USING hudi " +
+        "PARTITIONED BY (p STRING, bucket(4, id))")(
+      "Cannot mix partition expressions and partition columns")
+
+    // SKEWED BY and CREATE TEMPORARY TABLE are rejected by the clause and header visitors.
+    checkExceptionContain(
+      "CREATE TABLE blob_skew_tbl (id BIGINT, data BLOB) USING hudi SKEWED BY (id) ON (1, 2)")(
+      "CREATE TABLE ... SKEWED BY")
+    checkExceptionContain(
+      "CREATE TEMPORARY TABLE blob_tmp_tbl (id BIGINT, data BLOB) USING hudi")(
+      "use CREATE TEMPORARY VIEW instead")
+  }
+
   test("Test parse CREATE TABLE with BLOB column and typed transform-argument literals") {
     // Constant transform arguments exercise the literal visitors: string, integer, big-integer and
     // exponent numerics (the private numeric-literal helper), the typed date constructor, and both
-    // interval forms (multi-unit and unit-to-unit). A typed timestamp constructor is not used
-    // because the Spark 4.x extended parser rejects a bare TIMESTAMP token. Note: a bare
-    // true/false/null in this position is parsed as a column reference (qualifiedName takes
-    // precedence over a constant in the grammar under the default non-ANSI config), so the boolean
-    // and null literal visitors are not reachable from a CREATE TABLE statement.
-    val plan = parse(
+    // interval forms (multi-unit and unit-to-unit). A typed TIMESTAMP constructor is skipped due
+    // to #19449: the extended parser enables ANSI reserved-keyword enforcement whenever
+    // spark.sql.ansi.enabled is set (the Spark 4.x default) instead of following Spark's
+    // spark.sql.ansi.enforceReservedKeywords, which makes a bare TIMESTAMP token unparseable
+    // there (a bug, not a Spark 4 constraint). A bare true/false in this position parses as a
+    // column reference in BOTH keyword modes (TRUE/FALSE are ansiNonReserved, so qualifiedName
+    // wins), leaving visitBooleanLiteral unreachable (#19451); null is a column reference only
+    // under the default non-ANSI keyword mode and a null literal under ANSI, so visitNullLiteral
+    // is mode-dependent and both are left unasserted here.
+    val plan = parseCreateTable(
       s"""
          |CREATE TABLE blob_lit_tbl (
          |  id BIGINT,
@@ -471,10 +488,14 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
   }
 
   test("Test parse CREATE TABLE with BLOB column and invalid partition transforms") {
-    // Non-numeric number of buckets.
-    checkExceptionContain(
-      "CREATE TABLE blob_e1 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")(
-      "Invalid number of buckets")
+    // Non-numeric number of buckets. The builders' raw `new ParseException(message, ctx)` sites
+    // surface on Spark 3.4+ as SparkException [INTERNAL_ERROR] wrapping the message text
+    // (#19450), so this case asserts the message via a plain intercept.
+    // TODO(#19450): tighten to intercept[ParseException] once the builders throw it cleanly.
+    val e = intercept[Exception] {
+      spark.sql("CREATE TABLE blob_e1 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")
+    }
+    assert(e.getMessage.contains("Invalid number of buckets"))
     // A non-column-reference where a column is required.
     checkExceptionContain(
       "CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")(
@@ -487,35 +508,37 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
   }
 
   test("Test parse CREATE TABLE with BLOB column and file-format / row-format clauses") {
+    // Each positive case asserts the SerdeInfo the clause visitors produced (portable across
+    // Spark 3.3 through 4.2 via tableSpec.serde); asserting only the BLOB column type would pass
+    // even if the file/row-format visitors dropped their clause.
     // Generic STORED AS format.
-    assertResult(BlobType())(
-      parse("CREATE TABLE blob_ff1 (id BIGINT, data BLOB) STORED AS PARQUET")
-        .tableSchema("data").dataType)
+    val ff1 = parseCreateTable("CREATE TABLE blob_ff1 (id BIGINT, data BLOB) STORED AS PARQUET")
+    assertResult(BlobType())(ff1.tableSchema("data").dataType)
+    assertResult(Some("PARQUET"))(ff1.tableSpec.serde.get.storedAs)
     // STORED AS INPUTFORMAT ... OUTPUTFORMAT ... (the table-file-format arm).
-    assertResult(BlobType())(
-      parse("CREATE TABLE blob_ff2 (id BIGINT, data BLOB) " +
-        "STORED AS INPUTFORMAT 'com.example.InFmt' OUTPUTFORMAT 'com.example.OutFmt'")
-        .tableSchema("data").dataType)
+    val ff2 = parseCreateTable("CREATE TABLE blob_ff2 (id BIGINT, data BLOB) " +
+      "STORED AS INPUTFORMAT 'com.example.InFmt' OUTPUTFORMAT 'com.example.OutFmt'")
+    assertResult(Some(FormatClasses("com.example.InFmt", "com.example.OutFmt")))(
+      ff2.tableSpec.serde.get.formatClasses)
     // ROW FORMAT SERDE on its own.
-    assertResult(BlobType())(
-      parse("CREATE TABLE blob_ff3 (id BIGINT, data BLOB) " +
-        "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'")
-        .tableSchema("data").dataType)
+    val ff3 = parseCreateTable("CREATE TABLE blob_ff3 (id BIGINT, data BLOB) " +
+      "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'")
+    assertResult(Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))(
+      ff3.tableSpec.serde.get.serde)
     // ROW FORMAT DELIMITED on its own.
-    assertResult(BlobType())(
-      parse("CREATE TABLE blob_ff4 (id BIGINT, data BLOB) " +
-        "ROW FORMAT DELIMITED FIELDS TERMINATED BY ','")
-        .tableSchema("data").dataType)
-    // Compatible ROW FORMAT SERDE + STORED AS SEQUENCEFILE.
-    assertResult(BlobType())(
-      parse("CREATE TABLE blob_ff5 (id BIGINT, data BLOB) " +
-        "ROW FORMAT SERDE 'com.example.Serde' STORED AS SEQUENCEFILE")
-        .tableSchema("data").dataType)
+    val ff4 = parseCreateTable("CREATE TABLE blob_ff4 (id BIGINT, data BLOB) " +
+      "ROW FORMAT DELIMITED FIELDS TERMINATED BY ','")
+    assertResult(",")(ff4.tableSpec.serde.get.serdeProperties("field.delim"))
+    // Compatible ROW FORMAT SERDE + STORED AS SEQUENCEFILE merges both into one SerdeInfo.
+    val ff5 = parseCreateTable("CREATE TABLE blob_ff5 (id BIGINT, data BLOB) " +
+      "ROW FORMAT SERDE 'com.example.Serde' STORED AS SEQUENCEFILE")
+    assertResult(Some("SEQUENCEFILE"))(ff5.tableSpec.serde.get.storedAs)
+    assertResult(Some("com.example.Serde"))(ff5.tableSpec.serde.get.serde)
     // Compatible ROW FORMAT DELIMITED + STORED AS TEXTFILE.
-    assertResult(BlobType())(
-      parse("CREATE TABLE blob_ff6 (id BIGINT, data BLOB) " +
-        "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE")
-        .tableSchema("data").dataType)
+    val ff6 = parseCreateTable("CREATE TABLE blob_ff6 (id BIGINT, data BLOB) " +
+      "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE")
+    assertResult(Some("TEXTFILE"))(ff6.tableSpec.serde.get.storedAs)
+    assertResult(",")(ff6.tableSpec.serde.get.serdeProperties("field.delim"))
 
     // ROW FORMAT DELIMITED with a non-text file format is rejected.
     checkExceptionContain(
@@ -527,10 +550,12 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
       "CREATE TABLE blob_ferr2 (id BIGINT, data BLOB) " +
         "ROW FORMAT SERDE 'com.example.Serde' STORED AS PARQUET")(
       "incompatible with format")
-    // STORED BY (a storage handler) is not allowed.
+    // STORED BY (a storage handler) is not allowed. The full "Operation not allowed" prefix is
+    // asserted because ParseException.getMessage echoes the SQL text, so a bare "STORED BY"
+    // expectation would match any failure of this statement.
     checkExceptionContain(
       "CREATE TABLE blob_ferr3 (id BIGINT, data BLOB) STORED BY 'com.example.Handler'")(
-      "STORED BY")
+      "Operation not allowed: STORED BY")
     // A USING provider combined with a serde clause is not allowed.
     checkExceptionContain(
       "CREATE TABLE blob_ferr4 (id BIGINT, data BLOB) USING hudi STORED AS PARQUET")(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -24,7 +24,10 @@ import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
 import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable
+import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, Transform}
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.types._
 
 import java.io.File
 
@@ -281,5 +284,269 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
       assert(metaClient.getActiveTimeline.getCleanerTimeline.countInstants() > 0,
         "Expected at least one .clean instant on the timeline after compaction")
     })
+  }
+
+  // The following cases are parser-coverage only: a BLOB column routes the whole CREATE TABLE
+  // through the extended AST builder, so its clause visitors run. parsePlan is purely syntactic
+  // (no catalog, no execution), which lets us exercise clauses Hudi does not support at execution
+  // time (transform partitioning, STORED AS / ROW FORMAT, interval columns). The BLOB column type
+  // itself proves routing because the stock Spark parser rejects the BLOB type name.
+
+  private def parse(sql: String): CreateTable =
+    spark.sessionState.sqlParser.parsePlan(sql).asInstanceOf[CreateTable]
+
+  private def transformByName(plan: CreateTable, name: String): Transform =
+    plan.partitioning.find(_.name == name)
+      .getOrElse(fail(s"No partition transform named $name in ${plan.partitioning.mkString(", ")}"))
+
+  private def transformFieldRefs(t: Transform): Seq[Seq[String]] =
+    t.arguments().collect { case r: FieldReference => r.fieldNames().toSeq }.toSeq
+
+  private def firstLiteralArg(t: Transform): LiteralValue[_] =
+    t.arguments().collectFirst { case l: LiteralValue[_] => l }
+      .getOrElse(fail(s"No literal argument in transform ${t.name}"))
+
+  test("Test parse CREATE TABLE with BLOB column and primitive data types") {
+    // Exercises the primitive-data-type match arms plus NOT NULL and column COMMENT.
+    val plan = parse(
+      s"""
+         |CREATE TABLE blob_prim_tbl (
+         |  c_bool BOOLEAN,
+         |  c_tiny TINYINT,
+         |  c_small SMALLINT,
+         |  c_int INT,
+         |  c_big BIGINT,
+         |  c_float FLOAT,
+         |  c_double DOUBLE,
+         |  c_date DATE,
+         |  c_ts TIMESTAMP,
+         |  c_str STRING,
+         |  c_char CHAR(5),
+         |  c_varchar VARCHAR(10),
+         |  c_bin BINARY,
+         |  c_dec DECIMAL,
+         |  c_dec1 DECIMAL(12),
+         |  c_dec2 DECIMAL(12, 3),
+         |  c_notnull INT NOT NULL,
+         |  c_comment INT COMMENT 'a comment',
+         |  data BLOB
+         |) USING hudi
+       """.stripMargin)
+    val schema = plan.tableSchema
+    assertResult(BooleanType)(schema("c_bool").dataType)
+    assertResult(ByteType)(schema("c_tiny").dataType)
+    assertResult(ShortType)(schema("c_small").dataType)
+    assertResult(IntegerType)(schema("c_int").dataType)
+    assertResult(LongType)(schema("c_big").dataType)
+    assertResult(FloatType)(schema("c_float").dataType)
+    assertResult(DoubleType)(schema("c_double").dataType)
+    assertResult(DateType)(schema("c_date").dataType)
+    assertResult(TimestampType)(schema("c_ts").dataType)
+    assertResult(StringType)(schema("c_str").dataType)
+    // CHAR/VARCHAR may be preserved or replaced with STRING depending on the Spark version.
+    assert(Seq[DataType](CharType(5), StringType).contains(schema("c_char").dataType))
+    assert(Seq[DataType](VarcharType(10), StringType).contains(schema("c_varchar").dataType))
+    assertResult(BinaryType)(schema("c_bin").dataType)
+    assertResult(DecimalType(10, 0))(schema("c_dec").dataType)
+    assertResult(DecimalType(12, 0))(schema("c_dec1").dataType)
+    assertResult(DecimalType(12, 3))(schema("c_dec2").dataType)
+    assertResult(BlobType())(schema("data").dataType)
+    assert(!schema("c_notnull").nullable)
+    assertResult("a comment")(schema("c_comment").metadata.getString("comment"))
+  }
+
+  test("Test parse CREATE TABLE with BLOB column and complex data types") {
+    // Exercises the ARRAY / MAP / STRUCT arms and BLOB-in-struct metadata handling.
+    val plan = parse(
+      s"""
+         |CREATE TABLE blob_complex_tbl (
+         |  c_arr ARRAY<INT>,
+         |  c_map MAP<STRING, INT>,
+         |  c_struct STRUCT<a: INT, b: STRING>,
+         |  c_nested_blob STRUCT<x: BLOB>,
+         |  data BLOB
+         |) USING hudi
+       """.stripMargin)
+    val schema = plan.tableSchema
+    assertResult(ArrayType(IntegerType))(schema("c_arr").dataType)
+    assertResult(MapType(StringType, IntegerType))(schema("c_map").dataType)
+    val inner = schema("c_struct").dataType.asInstanceOf[StructType]
+    assertResult(IntegerType)(inner("a").dataType)
+    assertResult(StringType)(inner("b").dataType)
+    // A BLOB nested inside a struct still carries the BLOB type descriptor.
+    val nested = schema("c_nested_blob").dataType.asInstanceOf[StructType]("x")
+    assertResult(BlobType())(nested.dataType)
+    assertResult(HoodieSchemaType.BLOB.name())(
+      nested.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD))
+  }
+
+  test("Test parse CREATE TABLE with BLOB column and interval data types") {
+    val plan = parse(
+      s"""
+         |CREATE TABLE blob_ivl_tbl (
+         |  i_year INTERVAL YEAR,
+         |  i_ym INTERVAL YEAR TO MONTH,
+         |  i_day INTERVAL DAY,
+         |  i_ds INTERVAL DAY TO SECOND,
+         |  data BLOB
+         |) USING hudi
+       """.stripMargin)
+    val schema = plan.tableSchema
+    assertResult(YearMonthIntervalType(YearMonthIntervalType.YEAR))(schema("i_year").dataType)
+    assertResult(YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH))(
+      schema("i_ym").dataType)
+    assertResult(DayTimeIntervalType(DayTimeIntervalType.DAY))(schema("i_day").dataType)
+    assertResult(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.SECOND))(
+      schema("i_ds").dataType)
+    assertResult(BlobType())(schema("data").dataType)
+
+    // Endpoints where the end field does not follow the start are rejected by both interval
+    // data-type visitors. The grammar only allows YEAR/MONTH -> MONTH and DAY/HOUR/MINUTE/SECOND
+    // -> HOUR/MINUTE/SECOND, so these stay grammatical yet still hit the builder's end <= start guard.
+    checkExceptionContain(
+      "CREATE TABLE blob_bad_ym (id BIGINT, bad INTERVAL MONTH TO MONTH, data BLOB) USING hudi")(
+      "are not supported")
+    checkExceptionContain(
+      "CREATE TABLE blob_bad_dt (id BIGINT, bad INTERVAL SECOND TO HOUR, data BLOB) USING hudi")(
+      "are not supported")
+
+    // An unknown primitive type name is rejected.
+    checkExceptionContain(
+      "CREATE TABLE blob_bad_type (id BIGINT, weird sometype, data BLOB) USING hudi")(
+      "is not supported")
+  }
+
+  test("Test parse CREATE TABLE with BLOB column and partition transforms") {
+    val plan = parse(
+      s"""
+         |CREATE TABLE blob_tf_tbl (
+         |  id BIGINT,
+         |  ts TIMESTAMP,
+         |  region STRING,
+         |  data BLOB
+         |) USING hudi
+         |PARTITIONED BY (region, years(ts), months(ts), days(ts), hours(ts), myfunc(id))
+       """.stripMargin)
+    assertResult(BlobType())(plan.tableSchema("data").dataType)
+    assertResult(Seq(Seq("region")))(transformFieldRefs(transformByName(plan, "identity")))
+    assertResult(Seq(Seq("ts")))(transformFieldRefs(transformByName(plan, "years")))
+    assertResult(Seq(Seq("ts")))(transformFieldRefs(transformByName(plan, "months")))
+    assertResult(Seq(Seq("ts")))(transformFieldRefs(transformByName(plan, "days")))
+    assertResult(Seq(Seq("ts")))(transformFieldRefs(transformByName(plan, "hours")))
+    // an arbitrary function transform falls through to the generic apply-transform arm
+    assertResult(Seq(Seq("id")))(transformFieldRefs(transformByName(plan, "myfunc")))
+
+    // bucket(numBuckets, col) with int, long and short number-of-buckets literals exercises the
+    // three numeric arms of the bucket handling.
+    Seq("4", "4L", "4S").foreach { numLiteral =>
+      val bp = parse(
+        s"CREATE TABLE blob_bkt_tbl (id BIGINT, data BLOB) USING hudi " +
+          s"PARTITIONED BY (bucket($numLiteral, id))")
+      val bkt = transformByName(bp, "bucket")
+      assertResult("4")(firstLiteralArg(bkt).value.toString)
+      assertResult(Seq(Seq("id")))(transformFieldRefs(bkt))
+    }
+  }
+
+  test("Test parse CREATE TABLE with BLOB column and typed transform-argument literals") {
+    // Constant transform arguments exercise the literal visitors: string, integer, big-integer and
+    // exponent numerics (the private numeric-literal helper), the typed timestamp constructor, and
+    // both interval forms (multi-unit and unit-to-unit). Note: a bare true/false/null in this
+    // position is parsed as a column reference (qualifiedName takes precedence over a constant in
+    // the grammar under the default non-ANSI config), so the boolean and null literal visitors are
+    // not reachable from a CREATE TABLE statement and are intentionally not asserted here.
+    val plan = parse(
+      s"""
+         |CREATE TABLE blob_lit_tbl (
+         |  id BIGINT,
+         |  data BLOB
+         |) USING hudi
+         |PARTITIONED BY (
+         |  str_t('x', id),
+         |  int_t(7, id),
+         |  long_t(9000000000L, id),
+         |  exp_t(1E3, id),
+         |  ts_t(TIMESTAMP '2020-01-01 00:00:00', id),
+         |  mu_ivl_t(INTERVAL '1' DAY, id),
+         |  uu_ivl_t(INTERVAL '1-2' YEAR TO MONTH, id)
+         |)
+       """.stripMargin)
+    assertResult(StringType)(firstLiteralArg(transformByName(plan, "str_t")).dataType)
+    assertResult("x")(firstLiteralArg(transformByName(plan, "str_t")).value.toString)
+    assertResult(IntegerType)(firstLiteralArg(transformByName(plan, "int_t")).dataType)
+    assertResult(LongType)(firstLiteralArg(transformByName(plan, "long_t")).dataType)
+    assertResult(DoubleType)(firstLiteralArg(transformByName(plan, "exp_t")).dataType)
+    assertResult(TimestampType)(firstLiteralArg(transformByName(plan, "ts_t")).dataType)
+    assertResult(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY))(
+      firstLiteralArg(transformByName(plan, "mu_ivl_t")).dataType)
+    assertResult(YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH))(
+      firstLiteralArg(transformByName(plan, "uu_ivl_t")).dataType)
+  }
+
+  test("Test parse CREATE TABLE with BLOB column and invalid partition transforms") {
+    // Non-numeric number of buckets.
+    checkExceptionContain(
+      "CREATE TABLE blob_e1 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")(
+      "Invalid number of buckets")
+    // A non-column-reference where a column is required.
+    checkExceptionContain(
+      "CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")(
+      "Expected a column reference")
+    // A single-field transform given more than one argument.
+    checkExceptionContain(
+      "CREATE TABLE blob_e3 (id BIGINT, ts TIMESTAMP, data BLOB) USING hudi " +
+        "PARTITIONED BY (years(id, ts))")(
+      "Too many arguments")
+  }
+
+  test("Test parse CREATE TABLE with BLOB column and file-format / row-format clauses") {
+    // Generic STORED AS format.
+    assertResult(BlobType())(
+      parse("CREATE TABLE blob_ff1 (id BIGINT, data BLOB) STORED AS PARQUET")
+        .tableSchema("data").dataType)
+    // STORED AS INPUTFORMAT ... OUTPUTFORMAT ... (the table-file-format arm).
+    assertResult(BlobType())(
+      parse("CREATE TABLE blob_ff2 (id BIGINT, data BLOB) " +
+        "STORED AS INPUTFORMAT 'com.example.InFmt' OUTPUTFORMAT 'com.example.OutFmt'")
+        .tableSchema("data").dataType)
+    // ROW FORMAT SERDE on its own.
+    assertResult(BlobType())(
+      parse("CREATE TABLE blob_ff3 (id BIGINT, data BLOB) " +
+        "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'")
+        .tableSchema("data").dataType)
+    // ROW FORMAT DELIMITED on its own.
+    assertResult(BlobType())(
+      parse("CREATE TABLE blob_ff4 (id BIGINT, data BLOB) " +
+        "ROW FORMAT DELIMITED FIELDS TERMINATED BY ','")
+        .tableSchema("data").dataType)
+    // Compatible ROW FORMAT SERDE + STORED AS SEQUENCEFILE.
+    assertResult(BlobType())(
+      parse("CREATE TABLE blob_ff5 (id BIGINT, data BLOB) " +
+        "ROW FORMAT SERDE 'com.example.Serde' STORED AS SEQUENCEFILE")
+        .tableSchema("data").dataType)
+    // Compatible ROW FORMAT DELIMITED + STORED AS TEXTFILE.
+    assertResult(BlobType())(
+      parse("CREATE TABLE blob_ff6 (id BIGINT, data BLOB) " +
+        "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE")
+        .tableSchema("data").dataType)
+
+    // ROW FORMAT DELIMITED with a non-text file format is rejected.
+    checkExceptionContain(
+      "CREATE TABLE blob_ferr1 (id BIGINT, data BLOB) " +
+        "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS PARQUET")(
+      "only compatible with 'textfile'")
+    // ROW FORMAT SERDE with a format that also specifies a serde is rejected.
+    checkExceptionContain(
+      "CREATE TABLE blob_ferr2 (id BIGINT, data BLOB) " +
+        "ROW FORMAT SERDE 'com.example.Serde' STORED AS PARQUET")(
+      "incompatible with format")
+    // STORED BY (a storage handler) is not allowed.
+    checkExceptionContain(
+      "CREATE TABLE blob_ferr3 (id BIGINT, data BLOB) STORED BY 'com.example.Handler'")(
+      "STORED BY")
+    // A USING provider combined with a serde clause is not allowed.
+    checkExceptionContain(
+      "CREATE TABLE blob_ferr4 (id BIGINT, data BLOB) USING hudi STORED AS PARQUET")(
+      "CREATE TABLE ... USING")
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -25,13 +25,12 @@ import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
 import org.apache.spark.sql.catalyst.plans.logical.CreateTable
-import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, Transform}
-import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.common.{ExtendedParserTestHelpers, HoodieSparkSqlTestBase}
 import org.apache.spark.sql.types._
 
 import java.io.File
 
-class TestBlobDataType extends HoodieSparkSqlTestBase {
+class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHelpers {
 
   private val referenceStructType =
     "struct<external_path:string, offset:bigint, length:bigint, managed:boolean>"
@@ -294,17 +293,6 @@ class TestBlobDataType extends HoodieSparkSqlTestBase {
 
   private def parse(sql: String): CreateTable =
     spark.sessionState.sqlParser.parsePlan(sql).asInstanceOf[CreateTable]
-
-  private def transformByName(plan: CreateTable, name: String): Transform =
-    plan.partitioning.find(_.name == name)
-      .getOrElse(fail(s"No partition transform named $name in ${plan.partitioning.mkString(", ")}"))
-
-  private def transformFieldRefs(t: Transform): Seq[Seq[String]] =
-    t.arguments().collect { case r: FieldReference => r.fieldNames().toSeq }.toSeq
-
-  private def firstLiteralArg(t: Transform): LiteralValue[_] =
-    t.arguments().collectFirst { case l: LiteralValue[_] => l }
-      .getOrElse(fail(s"No literal argument in transform ${t.name}"))
 
   test("Test parse CREATE TABLE with BLOB column and primitive data types") {
     // Exercises the primitive-data-type match arms plus NOT NULL and column COMMENT.

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestIndexSyntax.scala
@@ -102,7 +102,6 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
         assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
         assertResult("idx_default")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
         assertResult("")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
-        assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
 
         // DROP INDEX without IF EXISTS
         logicalPlan = sqlParser.parsePlan(s"drop index idx_price on $tableName")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestIndexSyntax.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestIndexSyntax.scala
@@ -95,6 +95,26 @@ class TestIndexSyntax extends HoodieSparkSqlTestBase {
         resolvedLogicalPlan = analyzer.execute(logicalPlan)
         assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[RefreshIndexCommand].table, databaseName, tableName)
         assertResult("idx_name")(resolvedLogicalPlan.asInstanceOf[RefreshIndexCommand].indexName)
+
+        // CREATE INDEX without a USING clause: the index type defaults to empty
+        logicalPlan = sqlParser.parsePlan(s"create index idx_default on $tableName (name)")
+        resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].table, databaseName, tableName)
+        assertResult("idx_default")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexName)
+        assertResult("")(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].indexType)
+        assertResult(false)(resolvedLogicalPlan.asInstanceOf[CreateIndexCommand].ignoreIfExists)
+
+        // DROP INDEX without IF EXISTS
+        logicalPlan = sqlParser.parsePlan(s"drop index idx_price on $tableName")
+        resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[DropIndexCommand].table, databaseName, tableName)
+        assertResult("idx_price")(resolvedLogicalPlan.asInstanceOf[DropIndexCommand].indexName)
+        assertResult(false)(resolvedLogicalPlan.asInstanceOf[DropIndexCommand].ignoreIfNotExists)
+
+        // SHOW INDEXES with the IN keyword and an unqualified table identifier
+        logicalPlan = sqlParser.parsePlan(s"show indexes in $tableName")
+        resolvedLogicalPlan = analyzer.execute(logicalPlan)
+        assertTableIdentifier(resolvedLogicalPlan.asInstanceOf[ShowIndexesCommand].table, databaseName, tableName)
       }
     }
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The six per-version extended SQL AST builders (`HoodieSpark{3.3,3.4,3.5,4.0,4.1,4.2}ExtendedSqlAstBuilder.scala`) were only about a quarter line-covered. The extended parser is reached only when a statement contains a Hudi-specific ` blob` or ` vector` token (`isHoodieCommand`), and such a statement is then parsed entirely by this builder. After the recent prune of the forked parser to Hudi-only statements (#19132), the remaining CREATE TABLE clause visitors (partition transforms, literal arguments, bucket spec, file and row format, interval and other data types, table properties and options) are all reachable and required, but were largely unexercised because the existing tests used a bare `blob`/`vector` column with no other clauses.

### Summary and Changelog

Enhances the existing blob/vector SQL DDL and index syntax test suites to exercise the extended AST builder's CREATE TABLE clause visitors. This is a test-only, parser-coverage change. The reachable paths are exercised here; the residual dead code the coverage work identified (unused helpers, visitBooleanLiteral, grammar-unreachable branches) is tracked for deletion in #19451 rather than tested.

New cases route through the extended builder by keeping a BLOB or VECTOR column in every statement, and assert the parsed logical plan (`CreateTable.tableSchema` and `CreateTable.partitioning`, both stable across Spark 3.3 through 4.2) via `spark.sessionState.sqlParser.parsePlan`, or assert the exact parse error for the negative cases. Parse-level assertions exercise the builder without needing table creation, so they also cover clauses Hudi does not support at execution time (transform partitioning, STORED AS / ROW FORMAT, interval columns).

Suites enhanced (no new suite added):
- `TestBlobDataType`: primitive, complex and interval data-type arms; partition transforms (identity, years/months/days/hours, generic apply, and bucket with int/long/short counts); partition COLUMNS (`PARTITIONED BY (p STRING)`, the one arm that changes the emitted schema) with the mixed-partitioning, SKEWED BY and CREATE TEMPORARY TABLE rejections; typed transform-argument literals (string, integer, long, exponent/double, date constructor, multi-unit and unit-to-unit intervals); their error twins (invalid bucket count, non-column reference, too many arguments, reversed interval endpoints); and file-format / row-format clauses asserting the produced `tableSpec.serde` (STORED AS generic and INPUTFORMAT/OUTPUTFORMAT, ROW FORMAT SERDE / DELIMITED, the merged combinations, plus the incompatible-combination, STORED BY, and USING-with-serde errors).
- `TestCreateTable` (vector): CLUSTERED BY bucket spec (plain, SORTED BY ASC yielding a `sorted_bucket` transform, and the SORTED BY DESC rejection); and LOCATION / COMMENT / OPTIONS / TBLPROPERTIES asserting the parsed `tableSpec` fields (comment, location, properties, and the path-option-into-location folding), plus the path-collision and reserved-property (provider/location/owner) errors. Transform and literal coverage lives only in `TestBlobDataType`: the clause visitors are type-agnostic, so per-type copies would exercise no new production line.
- `TestIndexSyntax`: pins the parsed plan fields in the existing fixture-backed test: CREATE INDEX without USING (default empty index type), DROP INDEX without IF EXISTS (`ignoreIfNotExists=false`), and the SHOW INDEXES ... IN keyword variant. These branches already executed elsewhere; the delta is the direct plan-field assertions.

Findings from writing these tests:
- A bare `TIMESTAMP`-typed column, and a `TIMESTAMP '...'` typed literal, fail to parse for a blob/vector CREATE TABLE on Spark 4.x. Root cause is #19449: the six extended parsers key ANSI reserved-keyword enforcement off `spark.sql.ansi.enabled` (the Spark 4.x default) instead of Spark's `spark.sql.ansi.enforceReservedKeywords` (default false), so the fork rejects SQL stock Spark accepts. The tests use `DATE` until that lands.
- A bare `true`/`false` in a transform-argument position is parsed as a column reference in BOTH keyword modes (TRUE/FALSE are `ansiNonReserved`, so `qualifiedName` wins), leaving `visitBooleanLiteral` unreachable; it is tracked for deletion in #19451. `null` is a column reference only under the default non-ANSI keyword mode and parses as a null literal under ANSI keyword mode (the Spark 4.x profiles today), so `visitNullLiteral` is mode-dependent and left unasserted.
- The grammar mandates at least one transform argument, so `getSingleFieldReference`'s empty-arguments branch ("Not enough arguments for transform") is unreachable from SQL; it is tracked for deletion in #19451 together with the other dead remnants. Separately, the builders' raw `new ParseException(message, ctx)` sites surface as `[INTERNAL_ERROR]` on Spark 3.4+ (#19450); the negative tests assert message text and carry a TODO to tighten to a clean ParseException once that is fixed.

### Impact

None. Test-only change; no production code or public API is modified.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable

