### PR TITLE
feat(release): add a JDK 25 staging path for org.apache.hudi:hudi-trino

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -87,8 +87,11 @@ jobs:
       #
       # Stage the copy outside the workspace. `mvn apache-rat:check` in the RAT check step scans
       # the filesystem from the repository root, so a copy of the tree left inside the workspace
-      # gets scanned too, and every root-anchored exclude in the root pom (such as
-      # `hudi-trino-plugin/**`) silently stops applying to it.
+      # gets scanned too, and every root-anchored exclude in the root pom (such as `.github/**`)
+      # silently stops applying to it.
+      #
+      # hudi-trino needs no RAT exclude: its files carry AL headers that RAT accepts, and its
+      # Trino-style license checks are handled by airlift.
       - name: Create source release directory
         run: ./scripts/release/create_source_directory.sh "${{ runner.temp }}/hudi-tmp-repo"
       - name: Check Binary Files

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -90,8 +90,10 @@ jobs:
       # gets scanned too, and every root-anchored exclude in the root pom (such as `.github/**`)
       # silently stops applying to it.
       #
-      # hudi-trino needs no RAT exclude: its files carry AL headers that RAT accepts, and its
-      # Trino-style license checks are handled by airlift.
+      # hudi-trino needs no RAT exclude: its files carry AL headers that RAT's default matchers
+      # accept. The Trino-style header check (airbase's license-maven-plugin) runs only in the
+      # upstream trinodb/trino build; nothing in this repo runs it since RFC-105 dropped the
+      # trino-root parent.
       - name: Create source release directory
         run: ./scripts/release/create_source_directory.sh "${{ runner.temp }}/hudi-tmp-repo"
       - name: Check Binary Files

--- a/.github/workflows/hudi_trino_ci.yml
+++ b/.github/workflows/hudi_trino_ci.yml
@@ -142,6 +142,12 @@ jobs:
       - name: Build connector (JDK 25)
         if: needs.changes.outputs.trino == 'true'
         run: mvn $MVN_ARGS -Phudi-trino -pl hudi-trino install -Dmaven.test.skip=true
+      # The release deploy (-DdeployArtifacts=true) runs javadoc:jar with doclint=none,
+      # and the module pom keeps failOnError=true. Reproduce that exact configuration here
+      # so a javadoc break fails the PR instead of surfacing during the staging deploy.
+      - name: Javadoc check (JDK 25)
+        if: needs.changes.outputs.trino == 'true'
+        run: mvn $MVN_ARGS -Phudi-trino -pl hudi-trino javadoc:jar -Ddoclint=none
       - name: Test connector (JDK 25)
         if: needs.changes.outputs.trino == 'true'
         run: mvn $MVN_ARGS -Phudi-trino,hudi-trino-tests -pl hudi-trino test

--- a/hudi-trino/pom.xml
+++ b/hudi-trino/pom.xml
@@ -602,6 +602,8 @@
                     <!-- The parent release profile pins javadoc source to 11, which rejects records
                          (a Java 16 feature); follow hudi.trino.java.version instead. -->
                     <source>${hudi.trino.java.version}</source>
+                    <!-- The release profile also sets failOnError=false; this module's javadoc is clean, keep breaks loud. -->
+                    <failOnError>true</failOnError>
                 </configuration>
             </plugin>
             <plugin>

--- a/hudi-trino/pom.xml
+++ b/hudi-trino/pom.xml
@@ -597,6 +597,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- The parent release profile pins javadoc source to 11; records need 25. -->
+                    <source>${hudi.trino.java.version}</source>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
                     <execution>

--- a/hudi-trino/pom.xml
+++ b/hudi-trino/pom.xml
@@ -599,7 +599,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- The parent release profile pins javadoc source to 11; records need 25. -->
+                    <!-- The parent release profile pins javadoc source to 11, which rejects records
+                         (a Java 16 feature); follow hudi.trino.java.version instead. -->
                     <source>${hudi.trino.java.version}</source>
                 </configuration>
             </plugin>

--- a/release/release_guide.md
+++ b/release/release_guide.md
@@ -408,8 +408,8 @@ Set up a few environment variables to simplify Maven commands that follow. This 
    1. This will deploy jar artifacts to the Apache Nexus Repository, which is the staging area for deploying jars to Maven Central.
    2. Review all staged artifacts (https://repository.apache.org/). They should contain all relevant parts for each module, including pom.xml, jar, test jar, source, test source, javadoc, etc. Carefully review any new artifacts.
    3. git checkout ${RELEASE_BRANCH}
-   4. Given that certain bundle jars are built by Java 17 (Spark 4 bundle), multiple
-      scripts need to be run. Run each from the repository root directory (the one containing `packaging/`).
+   4. Given that certain artifacts require newer JDKs (Java 17 for the Spark 4 bundles, Java 25 for hudi-trino),
+      multiple scripts need to be run. Run each from the repository root directory (the one containing `packaging/`).
        1. For most modules with Java 11 build, run `export JAVA_HOME=$(/usr/libexec/java_home -v 11)` and
           `./scripts/release/deploy_staging_jars.sh 2>&1 | tee -a "/tmp/${RELEASE_VERSION}-${RC_NUM}.deploy1.log"`
            1. when prompted for the passphrase, if you have multiple gpg keys in your keyring, make sure that you enter
@@ -425,23 +425,29 @@ Set up a few environment variables to simplify Maven commands that follow. This 
               module. See [checklist](#checklist-to-proceed-to-the-next-step).
        2. Continue with Java 17 build for Spark 4 bundle, run `export JAVA_HOME=$(/usr/libexec/java_home -v 17)` and
           `./scripts/release/deploy_staging_jars_java17.sh 2>&1 | tee -a "/tmp/${RELEASE_VERSION}-${RC_NUM}.deploy2.log"`
-   5. Note that the artifacts from Java 17 build are uploaded to a separate staging repo. Use the
-      `copy_staging_repo.sh` script to copy all artifacts from the Java 17 staging repo into the Java 11 staging repo
+       3. Continue with Java 25 build for the hudi-trino connector, run `export JAVA_HOME=$(/usr/libexec/java_home -v 25)`
+          and `./scripts/release/deploy_staging_jars_java25.sh 2>&1 | tee -a "/tmp/${RELEASE_VERSION}-${RC_NUM}.deploy3.log"`.
+          This step must run after the Java 11 step in 9.4.1, which installs the upstream Hudi modules that hudi-trino
+          resolves from the local m2 (the script does not pass `-am` because Lombok cannot run on JDK 25).
+   5. Note that each of the Java 17 and Java 25 builds uploads its artifacts to its own separate staging repo. Use the
+      `copy_staging_repo.sh` script once per extra staging repo to copy all artifacts into the Java 11 staging repo
       so that all artifacts stay in the same repo.
-      1. Identify both staging repo IDs from [Apache Nexus Staging Repositories](https://repository.apache.org/#stagingRepositories)
-         (e.g., `orgapachehudi-1177` for Java 17, `orgapachehudi-1176` for Java 11). Make sure both repos are still in
-         the "open" state (not closed).
+      1. Identify all staging repo IDs from [Apache Nexus Staging Repositories](https://repository.apache.org/#stagingRepositories)
+         (e.g., `orgapachehudi-1177` for Java 17, `orgapachehudi-1178` for Java 25, `orgapachehudi-1176` for Java 11).
+         Make sure all repos are still in the "open" state (not closed).
       2. First do a dry-run to verify the list of artifacts to be copied:
          ```shell
          ./scripts/release/copy_staging_repo.sh --dry-run <java17-repo-id> <java11-repo-id>
+         ./scripts/release/copy_staging_repo.sh --dry-run <java25-repo-id> <java11-repo-id>
          ```
-      3. Then run the actual copy:
+      3. Then run the actual copies:
          ```shell
          ./scripts/release/copy_staging_repo.sh <java17-repo-id> <java11-repo-id> 2>&1 | tee -a "/tmp/${RELEASE_VERSION}-${RC_NUM}.copy_staging.log"
+         ./scripts/release/copy_staging_repo.sh <java25-repo-id> <java11-repo-id> 2>&1 | tee -a "/tmp/${RELEASE_VERSION}-${RC_NUM}.copy_staging.log"
          ```
       4. The script reads Nexus credentials from `~/.m2/settings.xml` (server id `apache.releases.https`), downloads
-         every artifact from the source repo, and re-uploads them to the target repo. After it finishes, drop the
-         Java 17 staging repo on Apache Nexus.
+         every artifact from the source repo, and re-uploads them to the target repo. After it finishes, drop both the
+         Java 17 and the Java 25 staging repos on Apache Nexus.
    6. Review all staged artifacts by logging into Apache Nexus and clicking on "Staging Repositories" link on left pane.
       Then find a "open" entry for apachehudi
    7. Ensure it contains all 2 (2.12 and 2.13) artifacts, mainly hudi-spark-bundle-2.12/2.13,

--- a/scripts/release/deploy_staging_jars_java25.sh
+++ b/scripts/release/deploy_staging_jars_java25.sh
@@ -86,12 +86,8 @@ fi
 COMMON_OPTIONS="-DdeployArtifacts=true -Dmaven.test.skip=true -DretryFailedDeploymentCount=10"
 for v in "${ALL_VERSION_OPTS[@]}"
 do
-  echo "Cleaning everything before any deployment"
-  $MVN clean $COMMON_OPTIONS ${v}
-  echo "Building with options ${v}"
-  $MVN install $COMMON_OPTIONS ${v}
-
-  echo "Deploying to repository.apache.org with version options ${v%-am}"
-  # remove `-am` option to only deploy intended modules
-  $MVN deploy $COMMON_OPTIONS ${v%-am}
+  echo "Deploying to repository.apache.org with options ${v}"
+  # Single pass: unlike deploy_staging_jars.sh there is no -am here, so a separate
+  # install pass would rebuild exactly what deploy builds.
+  $MVN clean deploy $COMMON_OPTIONS ${v}
 done

--- a/scripts/release/deploy_staging_jars_java25.sh
+++ b/scripts/release/deploy_staging_jars_java25.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+MVN=${MVN:-mvn}
+# fail immediately
+set -o errexit
+set -o nounset
+
+CURR_DIR=$(pwd)
+if [ ! -d "$CURR_DIR/packaging" ] ; then
+  echo "You have to call the script from the repository root dir that contains 'packaging/'"
+  exit 1
+fi
+
+# Validate Java version (hudi-trino requires Java 25)
+EXPECTED_JAVA_VERSION=25
+JAVA_VERSION_OUTPUT=$("${JAVA_HOME:+$JAVA_HOME/bin/}java" -version 2>&1)
+JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION_OUTPUT" | awk -F[\".] '/version/ {print ($2 == "1" ? $3 : $2); exit}')
+if [ "$JAVA_MAJOR_VERSION" != "$EXPECTED_JAVA_VERSION" ]; then
+  echo "Error: Java $EXPECTED_JAVA_VERSION is required for this script, but found:"
+  echo "$JAVA_VERSION_OUTPUT"
+  echo "Set JAVA_HOME to a Java $EXPECTED_JAVA_VERSION installation and retry."
+  exit 1
+fi
+
+if [ "$#" -gt "1" ]; then
+  echo "Only accept 0 or 1 argument. Use -h to see examples."
+  exit 1
+fi
+
+declare -a ALL_VERSION_OPTS=(
+# org.apache.hudi:hudi-trino (RFC-105), a plain library jar compiled with JDK 25.
+# No -am: Lombok cannot run on JDK 25, so upstream Hudi modules (hudi-common,
+# hudi-hive-sync, hudi-io:shaded, hudi-sync-common) must already be in the local m2
+# from a prior deploy_staging_jars.sh (JDK 11) run.
+"-Phudi-trino -pl hudi-trino"
+)
+printf -v joined "'%s'\n" "${ALL_VERSION_OPTS[@]}"
+
+if [ "${1:-}" == "-h" ]; then
+  echo "
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+<version option>  One of the version options below
+${joined}
+-h, --help
+"
+  exit 0
+fi
+
+VERSION_OPT=${1:-}
+valid_version_opt=false
+for v in "${ALL_VERSION_OPTS[@]}"; do
+    [[ $VERSION_OPT == "$v" ]] && valid_version_opt=true
+done
+
+if [ "$valid_version_opt" = true ]; then
+  # run deploy for only specified version option
+  ALL_VERSION_OPTS=("$VERSION_OPT")
+elif [ "$#" == "1" ]; then
+  echo "Version option $VERSION_OPT is invalid. Use -h to see examples."
+  exit 1
+fi
+
+COMMON_OPTIONS="-DdeployArtifacts=true -DskipTests -DretryFailedDeploymentCount=10"
+for v in "${ALL_VERSION_OPTS[@]}"
+do
+  echo "Cleaning everything before any deployment"
+  $MVN clean $COMMON_OPTIONS ${v}
+  echo "Building with options ${v}"
+  $MVN install $COMMON_OPTIONS ${v}
+
+  echo "Deploying to repository.apache.org with version options ${v%-am}"
+  # remove `-am` option to only deploy intended modules
+  $MVN deploy $COMMON_OPTIONS ${v%-am}
+done

--- a/scripts/release/deploy_staging_jars_java25.sh
+++ b/scripts/release/deploy_staging_jars_java25.sh
@@ -82,7 +82,8 @@ elif [ "$#" == "1" ]; then
   exit 1
 fi
 
-COMMON_OPTIONS="-DdeployArtifacts=true -DskipTests -DretryFailedDeploymentCount=10"
+# -Dmaven.test.skip=true, not -DskipTests: test-compile needs hudi-trino-tests profile deps that are absent here.
+COMMON_OPTIONS="-DdeployArtifacts=true -Dmaven.test.skip=true -DretryFailedDeploymentCount=10"
 for v in "${ALL_VERSION_OPTS[@]}"
 do
   echo "Cleaning everything before any deployment"

--- a/scripts/release/validate_source_copyright.sh
+++ b/scripts/release/validate_source_copyright.sh
@@ -47,8 +47,9 @@ echo -e "\t\tNotice file exists ? [OK]\n"
 ### Licensing Check
 echo "Performing custom Licensing Check "
 # ---
-# Exclude the 'hudi-trino' directory. Its license checks are handled by airlift:
-# https://github.com/airlift/airbase/blob/823101482dbc60600d7862f0f5c93aded6190996/airbase/pom.xml#L1239
+# Exclude the 'hudi-trino' directory: its files carry the short AL header (Trino convention),
+# which the ASF wording this grep matches does not cover. RAT still checks the module via its
+# default AL matchers. Drop this prune once apache/hudi#19412 converts the module to ASF headers.
 # ---
 numfilesWithNoLicense=$(find . -path './hudi-trino' -prune -o -type f -iname '*' | grep -v './hudi-trino' | grep -v NOTICE | grep -v LICENSE | grep -v '.jpg' | grep -v '.json' | grep -v '.zip' | grep -v '.hfile' | grep -v '.data' | grep -v '.commit' | grep -v emptyFile | grep -v DISCLAIMER | grep -v '.sqltemplate' | grep -v KEYS | grep -v '.mailmap' | grep -v 'banner.txt' | grep -v '.txt' | grep -v "fixtures" | xargs grep -L "Licensed to the Apache Software Foundation (ASF)")
 # Check if the variable holding the list of files is non-empty

--- a/scripts/release/validate_staged_bundles.sh
+++ b/scripts/release/validate_staged_bundles.sh
@@ -83,12 +83,14 @@ declare -a extensions=("-javadoc.jar" "-javadoc.jar.asc" "-javadoc.jar.md5" "-ja
 "-sources.jar.asc" "-sources.jar.md5" "-sources.jar.sha1" ".jar" ".jar.asc" ".jar.md5" ".jar.sha1" ".pom" ".pom.asc"
 ".pom.md5" ".pom.sha1")
 
+# hudi-trino is a plain library jar, not a bundle, but it is staged and validated like the bundles.
 declare -a bundles=("hudi-aws-bundle" "hudi-azure-bundle" "hudi-cli-bundle_2.12" "hudi-cli-bundle_2.13" "hudi-datahub-sync-bundle"
 "hudi-flink1.18-bundle" "hudi-flink1.19-bundle" "hudi-flink1.20-bundle"
 "hudi-flink2.0-bundle" "hudi-flink2.1-bundle" "hudi-gcp-bundle" "hudi-hadoop-mr-bundle" "hudi-hive-sync-bundle" "hudi-integ-test-bundle"
 "hudi-kafka-connect-bundle" "hudi-metaserver-server-bundle" "hudi-presto-bundle"
 "hudi-spark3.3-bundle_2.12" "hudi-spark3.4-bundle_2.12" "hudi-spark3.5-bundle_2.12"
 "hudi-spark3.5-bundle_2.13" "hudi-spark4.0-bundle_2.13" "hudi-spark4.1-bundle_2.13" "hudi-spark4.2-bundle_2.13" "hudi-timeline-server-bundle"
+"hudi-trino"
 "hudi-utilities-bundle_2.12" "hudi-utilities-bundle_2.13"
 "hudi-utilities-slim-bundle_2.12" "hudi-utilities-slim-bundle_2.13")
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19346. Part of RFC-105 (#18780), raised in review of #18837: no release path built or staged `org.apache.hudi:hudi-trino`. The existing staging scripts abort unless JAVA_HOME is JDK 11 (`deploy_staging_jars.sh`) or JDK 17 (`deploy_staging_jars_java17.sh`), neither passes `-Phudi-trino`, and the legacy `hudi-trino-bundle` was dropped in #18837, while the module itself enforces JDK 25. The Trino-side shim depends on this artifact, so it must be staged with the first 1.3.0 RC.

### Summary and Changelog

Adds a JDK 25 staging path so `org.apache.hudi:hudi-trino` is deployed alongside the other release artifacts.

- `scripts/release/deploy_staging_jars_java25.sh` (new): mirrors the java17 script but runs a single pass, `mvn deploy -Phudi-trino -pl hudi-trino`, deliberately without `-am`. Lombok cannot run on JDK 25, so the upstream Hudi modules (`hudi-common`, `hudi-hive-sync`, `hudi-io:shaded`, `hudi-sync-common`) resolve from the local m2 populated by the prior `deploy_staging_jars.sh` (JDK 11) run.
- `hudi-trino/pom.xml`: overrides the release profile's javadoc source level (pinned to 11 by the root pom) to `${hudi.trino.java.version}`. At source 11, javadoc errors on records and unnamed variables, and `failOnError=false` turns that into a silently broken `-javadoc.jar` in the staging repo.
- `scripts/release/validate_staged_bundles.sh`: now checks `org.apache.hudi:hudi-trino` across all 16 jar/sources/javadoc/pom + signature/checksum extensions.
- `release/release_guide.md`: documents the JDK 25 deploy step (deploy3 log) and the extra `copy_staging_repo.sh` pass for the JDK 25 staging repo.
- The source release tarball needs no change: `create_source_directory.sh` rsyncs the full git clone, so `hudi-trino/` ships regardless of the profile. A stale `bot.yml` comment citing the removed `hudi-trino-plugin` RAT exclude is reworded.

### Impact

Release tooling and docs only; no runtime code change. Starting with 1.3.0, `org.apache.hudi:hudi-trino` is staged and validated like the other release artifacts.

### Risk Level

low. Verified locally: upstream modules installed under JDK 17, then a clean `mvn install -Phudi-trino -pl hudi-trino -DdeployArtifacts=true -Dgpg.skip` under JDK 25 produces the main, sources, and javadoc jars with record classes documented; without the pom override, javadoc fails with `records are not supported in -source 11` and the build still exits 0 with a broken javadoc jar. GPG signing (maven-gpg-plugin 1.4 under a JDK 25 Maven) will be exercised in the first real staging run.

### Documentation Update

`release/release_guide.md` is updated in this PR; no website change needed.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
