### PR TITLE
refactor(reader): seal the shared merge path in KeyBasedFileGroupRecordBuffer

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/KeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/KeyBasedFileGroupRecordBuffer.java
@@ -101,8 +101,13 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
   /**
    * Merges the incoming record with whatever is already buffered under {@code recordKey} and stores the
    * result. Subclasses choose the identifier a record is buffered under (a record key here, a record
-   * position in {@link PositionBasedFileGroupRecordBuffer}), but must not alter the merge-then-store
-   * behavior itself, hence this method is final.
+   * position in {@link PositionBasedFileGroupRecordBuffer}), but cannot replace this merge-then-store
+   * step itself, hence the {@code final}.
+   *
+   * <p>This is not the only way {@code records} is mutated. The map is {@code protected}, and
+   * {@link PositionBasedFileGroupRecordBuffer} writes to it directly where merging would be wrong: when
+   * re-keying already-merged entries in its key-based fallback, and when overwriting delete markers under
+   * commit-time ordering.
    */
   @Override
   public final void processNextDataRecord(BufferedRecord<T> record, Serializable recordKey) throws IOException {
@@ -146,8 +151,9 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
   }
 
   /**
-   * Whether partial merging has been switched on for this buffer. The flag is owned by the base buffer
-   * and toggled while processing data blocks, so subclasses must not shadow it; hence this is final.
+   * Whether partial merging has been switched on for this buffer. Subclasses cannot replace this accessor,
+   * hence the {@code final}; they may still set the underlying {@code enablePartialMerging} flag while
+   * processing a data block, as {@link PositionBasedFileGroupRecordBuffer} does.
    */
   public final boolean isPartialMergingEnabled() {
     return enablePartialMerging;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/KeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/buffer/KeyBasedFileGroupRecordBuffer.java
@@ -98,8 +98,14 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
     }
   }
 
+  /**
+   * Merges the incoming record with whatever is already buffered under {@code recordKey} and stores the
+   * result. Subclasses choose the identifier a record is buffered under (a record key here, a record
+   * position in {@link PositionBasedFileGroupRecordBuffer}), but must not alter the merge-then-store
+   * behavior itself, hence this method is final.
+   */
   @Override
-  public void processNextDataRecord(BufferedRecord<T> record, Serializable recordKey) throws IOException {
+  public final void processNextDataRecord(BufferedRecord<T> record, Serializable recordKey) throws IOException {
     BufferedRecord<T> existingRecord = records.get(recordKey);
     totalLogRecords++;
     bufferedRecordMerger.deltaMerge(record, existingRecord).ifPresent(bufferedRecord ->
@@ -139,7 +145,11 @@ public class KeyBasedFileGroupRecordBuffer<T> extends FileGroupRecordBuffer<T> {
     return hasNextLogRecord();
   }
 
-  public boolean isPartialMergingEnabled() {
+  /**
+   * Whether partial merging has been switched on for this buffer. The flag is owned by the base buffer
+   * and toggled while processing data blocks, so subclasses must not shadow it; hence this is final.
+   */
+  public final boolean isPartialMergingEnabled() {
     return enablePartialMerging;
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.table.log.block.HoodieDataBlock;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
+import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.read.FileGroupReaderSchemaHandler;
 import org.apache.hudi.common.table.read.HoodieReadStats;
 import org.apache.hudi.common.util.Option;
@@ -42,6 +43,9 @@ import org.apache.avro.generic.IndexedRecord;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +54,7 @@ import java.util.stream.Stream;
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_KEY;
 import static org.apache.hudi.common.model.DefaultHoodieRecordPayload.DELETE_MARKER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,6 +78,27 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
   private final IndexedRecord testRecord6 = createTestRecord("6", 1, 5L);
   private final IndexedRecord testRecord6DeleteByCustomMarker = createTestRecord("6", 3, 2L);
   private final IndexedRecord testRecord7 = createTestRecord("7", 1, 5L);
+
+  /**
+   * Every buffer in this hierarchy must funnel records into the buffer through the same
+   * merge-then-put path and expose the same partial-merge state, so these methods are sealed with
+   * {@code final} and subclasses such as {@code PositionBasedFileGroupRecordBuffer} and
+   * {@code SortedKeyBasedFileGroupRecordBuffer} cannot replace that behavior. The methods that a
+   * subclass legitimately specializes (block processing, base-record advancement, buffer type) are
+   * deliberately left open. This test fails if a {@code final} modifier is dropped.
+   */
+  @Test
+  void keyMergeBehaviorIsSealedAgainstSubclasses() throws NoSuchMethodException {
+    assertMethodIsFinal(KeyBasedFileGroupRecordBuffer.class
+        .getDeclaredMethod("processNextDataRecord", BufferedRecord.class, Serializable.class));
+    assertMethodIsFinal(KeyBasedFileGroupRecordBuffer.class.getDeclaredMethod("isPartialMergingEnabled"));
+  }
+
+  private static void assertMethodIsFinal(Method method) {
+    assertTrue(Modifier.isFinal(method.getModifiers()),
+        () -> String.format("%s#%s must remain final so subclasses cannot override the key-based merge behavior",
+            method.getDeclaringClass().getSimpleName(), method.getName()));
+  }
 
   @Test
   void readWithEventTimeOrdering() throws IOException {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
@@ -80,15 +80,20 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
   private final IndexedRecord testRecord7 = createTestRecord("7", 1, 5L);
 
   /**
-   * Every buffer in this hierarchy must funnel records into the buffer through the same
-   * merge-then-put path and expose the same partial-merge state, so these methods are sealed with
-   * {@code final} and subclasses such as {@code PositionBasedFileGroupRecordBuffer} and
-   * {@code SortedKeyBasedFileGroupRecordBuffer} cannot replace that behavior. The methods that a
-   * subclass legitimately specializes (block processing, base-record advancement, buffer type) are
-   * deliberately left open. This test fails if a {@code final} modifier is dropped.
+   * Asserts that {@code processNextDataRecord} and {@code isPartialMergingEnabled} keep their
+   * {@code final} modifier, so a subclass cannot substitute its own implementation of either.
+   *
+   * <p>That is the entire guarantee, and it is deliberately narrow. It does <em>not</em> mean all buffer
+   * mutations go through {@code processNextDataRecord}: {@code records} and {@code enablePartialMerging}
+   * are {@code protected}, and {@code PositionBasedFileGroupRecordBuffer} legitimately writes to
+   * {@code records} directly when it re-keys entries in its key-based fallback and when it overwrites
+   * delete markers under commit-time ordering, as well as overriding block processing. Those paths must
+   * not merge, so routing them through this method would be wrong.
+   *
+   * <p>The modifier itself is compiler-enforced; this test exists only to catch it being dropped.
    */
   @Test
-  void keyMergeBehaviorIsSealedAgainstSubclasses() throws NoSuchMethodException {
+  void sealedMethodsCannotBeOverridden() throws NoSuchMethodException {
     assertMethodIsFinal(KeyBasedFileGroupRecordBuffer.class
         .getDeclaredMethod("processNextDataRecord", BufferedRecord.class, Serializable.class));
     assertMethodIsFinal(KeyBasedFileGroupRecordBuffer.class.getDeclaredMethod("isPartialMergingEnabled"));
@@ -96,7 +101,7 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
 
   private static void assertMethodIsFinal(Method method) {
     assertTrue(Modifier.isFinal(method.getModifiers()),
-        () -> String.format("%s#%s must remain final so subclasses cannot override the key-based merge behavior",
+        () -> String.format("%s#%s must remain final so subclasses cannot override it",
             method.getDeclaringClass().getSimpleName(), method.getName()));
   }
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16920 (HUDI-9200).

`KeyBasedFileGroupRecordBuffer` is subclassed by `PositionBasedFileGroupRecordBuffer` and
`SortedKeyBasedFileGroupRecordBuffer`. Both legitimately specialize how log blocks are consumed and
how the base-file iterator is advanced, but the step that actually mutates the buffer — merge the
incoming record against what is already buffered, then store the result — must behave identically for
every buffer in the hierarchy. Today nothing expresses that, so a subclass can silently replace it.

### Summary and Changelog

Marks the two methods that no subclass overrides as `final`, so the shared merge path cannot be
replaced by a subclass, and documents why:

- `KeyBasedFileGroupRecordBuffer#processNextDataRecord` → `final`. Subclasses still choose the
  identifier a record is buffered under (a record key here, a record position in
  `PositionBasedFileGroupRecordBuffer`), which is the parameter, not the behavior.
- `KeyBasedFileGroupRecordBuffer#isPartialMergingEnabled` → `final`. The `enablePartialMerging` flag is
  owned and toggled by the base buffer while processing data blocks.
- Adds `TestKeyBasedFileGroupRecordBuffer#keyMergeBehaviorIsSealedAgainstSubclasses`, which asserts
  both modifiers via reflection. `final` is compiler-enforced, but nothing otherwise stops the keyword
  from being dropped later; the test was confirmed to fail for each method independently before the
  change.

The remaining methods (`getBufferType`, `processDataBlock`, `processDeleteBlock`, `containsLogRecord`,
`hasNextBaseRecord`, `doHasNext`) are **deliberately left open** — each is overridden by
`PositionBasedFileGroupRecordBuffer` and/or `SortedKeyBasedFileGroupRecordBuffer` today.

Note on scope: the ticket is phrased as preventing `PositionBasedFileGroupRecordBuffer` from overriding
key functions, and `PositionBased` does not override either method sealed here. If the intent was
instead to refactor `PositionBased` so it stops overriding the block-processing methods (each of which
currently opens with a `if (!getShouldMergeUseRecordPosition()) { super.…; return; }` fallback) and then
seal those, that is a larger design change and I'm happy to defer to the ticket's assignee on it. This
PR is the behavior-preserving subset.

### Impact

None for users. `final` is enforced at compile time and these are internal reader classes — nothing in
`org.apache.hudi.common.table.read.buffer` is annotated `@PublicAPIClass`. No public API, config, or
on-disk format change. Making a public method `final` is binary-compatible; it would only affect an
out-of-tree subclass that overrides these methods, and no in-tree subclass, test, or mock does.

No performance claim is made: these call sites are already monomorphic and devirtualized by the JIT.

### Risk Level

none

### Documentation Update

none — no new config, no default value change, no user-facing behavior change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
