### PR TITLE
fix(metrics): explain how to enable the CloudWatch reporter when hudi-aws is absent

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.config.metrics.HoodieMetricsConfig;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metrics.custom.CustomizableMetricsReporter;
 import org.apache.hudi.metrics.datadog.DatadogMetricsReporter;
@@ -40,7 +41,8 @@ import java.util.Properties;
 @Slf4j
 public class MetricsReporterFactory {
 
-  private static final String CLOUDWATCH_REPORTER_CLASS =
+  @VisibleForTesting
+  static final String CLOUDWATCH_REPORTER_CLASS =
       "org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter";
 
   public static Option<MetricsReporter> createReporter(HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
@@ -104,9 +106,8 @@ public class MetricsReporterFactory {
 
   /**
    * The CloudWatch reporter ships in the optional {@code hudi-aws} module and so is loaded reflectively.
-   * Not every engine bundle shades that module (notably {@code hudi-spark-bundle} does not), in which
-   * case class loading fails with a message that names neither the missing class nor a remedy. Translate
-   * that into an actionable error.
+   * Not every engine bundle shades that module, in which case class loading fails without pointing at a
+   * remedy. Translate that into an actionable error.
    */
   private static MetricsReporter createCloudWatchReporter(HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
     try {
@@ -116,9 +117,9 @@ public class MetricsReporterFactory {
       if (e.getCause() instanceof ClassNotFoundException) {
         throw new HoodieException(String.format(
             "Cannot report metrics to CloudWatch: %s was not found on the classpath. It ships in the "
-                + "optional hudi-aws module, which is not included in every engine bundle (for example "
-                + "hudi-spark-bundle does not bundle it). Add the hudi-aws-bundle jar matching your Hudi "
-                + "version to the classpath, or set %s to a different reporter type.",
+                + "optional hudi-aws module, which not every engine bundle includes. Add the "
+                + "hudi-aws-bundle jar matching your Hudi version to the classpath, or set %s to a "
+                + "different reporter type.",
             CLOUDWATCH_REPORTER_CLASS, HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
       }
       throw e;

--- a/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
@@ -40,6 +40,9 @@ import java.util.Properties;
 @Slf4j
 public class MetricsReporterFactory {
 
+  private static final String CLOUDWATCH_REPORTER_CLASS =
+      "org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter";
+
   public static Option<MetricsReporter> createReporter(HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
     String reporterClassName = metricsConfig.getMetricReporterClassName();
 
@@ -84,8 +87,7 @@ public class MetricsReporterFactory {
         reporter = new ConsoleMetricsReporter(registry);
         break;
       case CLOUDWATCH:
-        reporter = (MetricsReporter) ReflectionUtils.loadClass("org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter",
-            new Class[]{HoodieMetricsConfig.class, MetricRegistry.class}, metricsConfig, registry);
+        reporter = createCloudWatchReporter(metricsConfig, registry);
         break;
       case M3:
         reporter = new M3MetricsReporter(metricsConfig, registry);
@@ -98,5 +100,28 @@ public class MetricsReporterFactory {
         break;
     }
     return Option.ofNullable(reporter);
+  }
+
+  /**
+   * The CloudWatch reporter ships in the optional {@code hudi-aws} module and so is loaded reflectively.
+   * Not every engine bundle shades that module (notably {@code hudi-spark-bundle} does not), in which
+   * case class loading fails with a message that names neither the missing class nor a remedy. Translate
+   * that into an actionable error.
+   */
+  private static MetricsReporter createCloudWatchReporter(HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
+    try {
+      return (MetricsReporter) ReflectionUtils.loadClass(CLOUDWATCH_REPORTER_CLASS,
+          new Class[] {HoodieMetricsConfig.class, MetricRegistry.class}, metricsConfig, registry);
+    } catch (HoodieException e) {
+      if (e.getCause() instanceof ClassNotFoundException) {
+        throw new HoodieException(String.format(
+            "Cannot report metrics to CloudWatch: %s was not found on the classpath. It ships in the "
+                + "optional hudi-aws module, which is not included in every engine bundle (for example "
+                + "hudi-spark-bundle does not bundle it). Add the hudi-aws-bundle jar matching your Hudi "
+                + "version to the classpath, or set %s to a different reporter type.",
+            CLOUDWATCH_REPORTER_CLASS, HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
+      }
+      throw e;
+    }
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
@@ -82,7 +82,7 @@ class TestMetricsReporterFactory {
     try (MockedStatic<ReflectionUtils> mockedStatic = Mockito.mockStatic(ReflectionUtils.class)) {
       mockedStatic.when(() ->
           ReflectionUtils.loadClass(
-              eq("org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter"),
+              eq(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS),
               any(Class[].class),
               eq(metricsConfig),
               eq(registry)
@@ -108,12 +108,52 @@ class TestMetricsReporterFactory {
         () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
 
     String message = exception.getMessage();
-    assertTrue(message.contains("org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter"),
+    assertTrue(message.contains(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS),
         () -> "The failure should name the missing reporter class, but was: " + message);
     assertTrue(message.contains("hudi-aws-bundle"),
         () -> "The failure should name the bundle that provides the reporter, but was: " + message);
     assertTrue(message.contains(HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()),
         () -> "The failure should name the config to change, but was: " + message);
+  }
+
+  /**
+   * The classpath-based test above exercises the real failure but passes for any resolution failure.
+   * This pins the mapping itself: a ClassNotFoundException cause is what triggers the rewrite.
+   */
+  @Test
+  void metricsReporterFactoryRewritesClassNotFoundIntoAnActionableMessage() {
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.CLOUDWATCH);
+    try (MockedStatic<ReflectionUtils> mockedStatic = Mockito.mockStatic(ReflectionUtils.class)) {
+      mockedStatic.when(() -> ReflectionUtils.loadClass(
+          eq(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS), any(Class[].class), eq(metricsConfig), eq(registry)))
+          .thenThrow(new HoodieException("Unable to load class " + MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS,
+              new ClassNotFoundException(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS)));
+
+      HoodieException exception = assertThrows(HoodieException.class,
+          () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
+      assertTrue(exception.getMessage().contains("hudi-aws-bundle"),
+          () -> "Expected the remedy to be named, but was: " + exception.getMessage());
+    }
+  }
+
+  /**
+   * The other direction, and the branch most likely to regress: a failure that is not a missing class must
+   * pass through untouched, so an unrelated instantiation error is never rewritten into "add hudi-aws-bundle".
+   */
+  @Test
+  void metricsReporterFactoryLeavesNonClassNotFoundFailuresUntouched() {
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.CLOUDWATCH);
+    try (MockedStatic<ReflectionUtils> mockedStatic = Mockito.mockStatic(ReflectionUtils.class)) {
+      mockedStatic.when(() -> ReflectionUtils.loadClass(
+          eq(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS), any(Class[].class), eq(metricsConfig), eq(registry)))
+          .thenThrow(new HoodieException("Unable to instantiate class " + MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS,
+              new NoSuchMethodException("<init>")));
+
+      HoodieException exception = assertThrows(HoodieException.class,
+          () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
+      assertEquals("Unable to instantiate class " + MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS,
+          exception.getMessage(), "A non-ClassNotFound failure must not be rewritten");
+    }
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
@@ -96,9 +96,9 @@ class TestMetricsReporterFactory {
 
   /**
    * {@code hudi-aws} is deliberately absent from this module's test classpath, which is exactly the
-   * situation a user hits with {@code hudi-spark-bundle}: that bundle does not shade {@code hudi-aws},
-   * so the reflectively loaded CloudWatch reporter cannot be found. The failure must name the missing
-   * class and how to fix it, not just report that some class could not be loaded.
+   * situation a user hits on an engine bundle that does not shade that module: the reflectively loaded
+   * CloudWatch reporter cannot be found. The failure must name the missing class and how to fix it,
+   * not just report that some class could not be loaded.
    */
   @Test
   void metricsReporterFactoryShouldExplainHowToEnableCloudWatchWhenHudiAwsIsMissing() {

--- a/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
@@ -94,6 +94,28 @@ class TestMetricsReporterFactory {
     }
   }
 
+  /**
+   * {@code hudi-aws} is deliberately absent from this module's test classpath, which is exactly the
+   * situation a user hits with {@code hudi-spark-bundle}: that bundle does not shade {@code hudi-aws},
+   * so the reflectively loaded CloudWatch reporter cannot be found. The failure must name the missing
+   * class and how to fix it, not just report that some class could not be loaded.
+   */
+  @Test
+  void metricsReporterFactoryShouldExplainHowToEnableCloudWatchWhenHudiAwsIsMissing() {
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.CLOUDWATCH);
+
+    HoodieException exception = assertThrows(HoodieException.class,
+        () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
+
+    String message = exception.getMessage();
+    assertTrue(message.contains("org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter"),
+        () -> "The failure should name the missing reporter class, but was: " + message);
+    assertTrue(message.contains("hudi-aws-bundle"),
+        () -> "The failure should name the bundle that provides the reporter, but was: " + message);
+    assertTrue(message.contains(HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()),
+        () -> "The failure should name the config to change, but was: " + message);
+  }
+
   @Test
   void metricsReporterFactoryShouldReturnUserDefinedReporter() {
     when(metricsConfig.getMetricReporterClassName()).thenReturn(DummyMetricsReporter.class.getName());

--- a/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
+++ b/hudi-io/src/main/java/org/apache/hudi/common/util/ReflectionUtils.java
@@ -50,7 +50,7 @@ public class ReflectionUtils {
       try {
         return Class.forName(c);
       } catch (ClassNotFoundException e) {
-        throw new HoodieException("Unable to load class", e);
+        throw new HoodieException("Unable to load class " + c, e);
       }
     });
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15293 (HUDI-4452).

The CloudWatch metrics reporter lives in the optional `hudi-aws` module and is loaded reflectively by
`MetricsReporterFactory`. `packaging/hudi-spark-bundle/pom.xml` does not shade `hudi-aws` (unlike
`hudi-flink-bundle` and `hudi-kafka-connect-bundle`, which do), so a Spark user who sets
`hoodie.metrics.reporter.type=CLOUDWATCH` with only the Spark bundle on the classpath gets:

```
org.apache.hudi.exception.HoodieException: Unable to load class
  Caused by: java.lang.ClassNotFoundException: org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter
```

The message names neither the missing class nor anything the user can do about it.

### Summary and Changelog

Turns that failure into an actionable one instead of changing the bundle's dependencies.

- `MetricsReporterFactory`: extracted the reporter class name to a constant and moved the reflective
  load into a small private helper. When the load fails with a `ClassNotFoundException` cause, rethrow a
  `HoodieException` naming the missing class, the `hudi-aws` module, the `hudi-aws-bundle` jar to add,
  and `hoodie.metrics.reporter.type` as the alternative. Every other failure is rethrown unchanged.
- `TestMetricsReporterFactory`: new test asserting the message names the class, the bundle, and the
  config key. It works because `hudi-aws` is not on `hudi-common`'s test classpath, which is the same
  condition the user hits (the pre-existing CloudWatch test has to `mockStatic` `ReflectionUtils` for
  exactly that reason).

**On the approach:** the issue title asks for `hudi-aws` to be added to `hudi-spark-bundle`. #6183 did
that and was closed unmerged; the review there asked for the opposite direction — "Ideally, we need a
way to completely decouple the two. Just because one class we need to pull in this dependency" — and
conditioned merging on `hudi-aws` being in `provided` scope, which would not put the class on a user's
classpath anyway. Shading an AWS SDK into the general-purpose Spark bundle for one optional reporter
seemed like the wrong trade, so this PR fixes the user-visible defect (an unactionable error) and leaves
the bundle contents alone. Happy to switch approaches if the preference is otherwise.

`MetricsReporterFactory` is the only place the class is loaded, so there is no second path to update.

### Impact

No API, config, or format change, and no change in which reporters work. Only the failure message for
`CLOUDWATCH` when `hudi-aws` is missing; the exception type stays `HoodieException`.

Known limitation, deliberately not addressed: if `hudi-aws` is present but the AWS SDK is not, the JVM
raises `NoClassDefFoundError`, which this does not intercept — catching `Error` in a metrics factory
would be worse than the message it would improve.

### Risk Level

none

### Documentation Update

none — no new config and no default value change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
