### PR TITLE
docs(contribute): link developer setup to the actual build instructions

### DIFF
--- a/website/contribute/developer-setup.md
+++ b/website/contribute/developer-setup.md
@@ -118,7 +118,7 @@ Watch this [quick video](https://www.youtube.com/watch?v=N2eDfU_rQ_U) for a code
 
 IntelliJ is the recommended IDE for developing Hudi. To contribute, you would need to do the following
 
-- Fork the Hudi code on Github & then clone your own fork locally. Once cloned, we recommend building as per instructions on [spark quickstart](/docs/quick-start-guide) or [flink quickstart](/docs/flink-quick-start-guide).
+- Fork the Hudi code on Github & then clone your own fork locally. Once cloned, build Hudi by following [Building Apache Hudi from source](https://github.com/apache/hudi#building-apache-hudi-from-source) in the README, which also covers building against a specific [Spark version](https://github.com/apache/hudi#build-with-different-spark-versions) or [Flink version](https://github.com/apache/hudi#build-with-different-flink-versions).
 
 - In IntelliJ, select `File` > `New` > `Project from Existing Sources...` and select the `pom.xml` file under your local Hudi source folder.
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15632 (HUDI-5396).

`contribute/developer-setup` tells a new contributor to build Hudi "as per instructions on
[spark quickstart] or [flink quickstart]". Neither page is a build guide:

- `docs/flink-quick-start-guide` has **no** build instructions for Hudi. Its only build-related link is
  to instructions for building the Flink *bundle* jar.
- `docs/quick-start-guide` mentions building only in one aside at the very bottom of a ~1250-line page,
  and that aside itself links out to the README.

So the page sends contributors to a dead end at the first step of setup.

### Summary and Changelog

Points the IntelliJ setup step directly at the canonical build instructions in the README, including the
per-engine variants:

- `Building Apache Hudi from source` (`README.md#building-apache-hudi-from-source`)
- `Build with different Spark versions`
- `Build with different Flink versions`

One line changed in `website/contribute/developer-setup.md`. Linking the website to that README section
is already the established pattern — `docs/quick-start-guide` links to the same anchor.

### Impact

Documentation only. No code, config, or behavior change.

### Risk Level

none

### Documentation Update

This PR *is* the documentation update: `website/contribute/developer-setup.md`.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
