### PR TITLE
fix(build): make submodule builds find the checkstyle import-control file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,14 @@
 target/
 metastore_db/
 .metals/
-# Keep ignoring locally generated .mvn content (e.g. the maven wrapper), but track
-# .mvn/extensions.xml: the directory must exist for maven.multiModuleProjectDirectory to
-# resolve to the repo root when a build runs from inside a submodule (HUDI-6111).
-.mvn/*
-!.mvn/extensions.xml
+# Keep ignoring .mvn directories anywhere in the tree (maven wrapper, IDE output, and
+# nested ones such as hudi-trino/.mvn), while tracking the repo-root .mvn/extensions.xml:
+# that directory must exist for maven.multiModuleProjectDirectory to resolve to the repo
+# root when a build runs from inside a submodule (HUDI-6111).
+.mvn/
+!/.mvn/
+/.mvn/*
+!/.mvn/extensions.xml
 *.bloop/
 *.vscode/
 *.metals/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,11 @@
 target/
 metastore_db/
 .metals/
-.mvn/
+# Keep ignoring locally generated .mvn content (e.g. the maven wrapper), but track
+# .mvn/extensions.xml: the directory must exist for maven.multiModuleProjectDirectory to
+# resolve to the repo root when a build runs from inside a submodule (HUDI-6111).
+.mvn/*
+!.mvn/extensions.xml
 *.bloop/
 *.vscode/
 *.metals/

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,13 @@
 target/
 metastore_db/
 .metals/
-# Keep ignoring .mvn directories anywhere in the tree (maven wrapper, IDE output, and
-# nested ones such as hudi-trino/.mvn), while tracking the repo-root .mvn/extensions.xml:
-# that directory must exist for maven.multiModuleProjectDirectory to resolve to the repo
-# root when a build runs from inside a submodule (HUDI-6111).
+# Track the repo-root .mvn/extensions.xml: that directory must exist for
+# maven.multiModuleProjectDirectory to resolve to the repo root when a build runs from inside a
+# submodule (HUDI-6111).
+# Keep the un-anchored `.mvn/` entry. A pattern containing a slash is anchored to this file's
+# directory, so narrowing it to `.mvn/*` would stop matching nested .mvn directories -- and
+# apache-rat reads .gitignore, so that un-hides hudi-trino/.mvn/modernizer/*.xml, which are tracked
+# without ASF headers, and validate-source fails.
 .mvn/
 !/.mvn/
 /.mvn/*

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file intentionally declares no build extensions.
+
+  Its purpose is the presence of the `.mvn` directory itself: Maven walks up from
+  the working directory looking for `.mvn` to decide `maven.multiModuleProjectDirectory`.
+  Without it, that property resolves to whatever directory Maven was invoked from, so
+  running a build inside a submodule (for example `cd hudi-cli && mvn checkstyle:check`)
+  made the checkstyle `propertyExpansion` in the root pom point `basedir` at the submodule
+  and checkstyle failed with "Unable to find: <module>/style/import-control.xml".
+  See HUDI-6111.
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+</extensions>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15909 (HUDI-6111).

Building a single module from inside its own directory fails on checkstyle. Reproduced on current
master, unchanged from the 2023 report:

```
cd hudi-cli && mvn checkstyle:check

[ERROR] Failed during checkstyle configuration: cannot initialize module TreeWalker
  - cannot initialize module ImportControl - illegal value
  '<repo>/hudi-cli/style/import-control.xml' for property 'file':
  Unable to find: <repo>/hudi-cli/style/import-control.xml
```

`style/checkstyle.xml` locates that file via `${basedir}/style/import-control.xml`, and the root pom
supplies the property as `basedir=${maven.multiModuleProjectDirectory}`. Maven derives that property by
walking up from the working directory looking for a `.mvn` directory; with none in the repo it falls back
to the directory Maven was invoked from. From the root that is the repo root, so root builds work; from
inside a submodule it becomes the submodule, and checkstyle looks for `style/import-control.xml` there.

### Summary and Changelog

- Add `.mvn/extensions.xml` declaring **no** extensions. The file's purpose is that the `.mvn` directory
  exists, which is the hook Maven uses to resolve `maven.multiModuleProjectDirectory` to the repo root
  from any working directory. It carries an ASF header and a comment explaining why an otherwise-empty
  file is tracked.
- `.gitignore`: four lines, keeping the un-anchored `.mvn/` entry and re-including only the repo-root file:

  ```
  .mvn/
  !/.mvn/
  /.mvn/*
  !/.mvn/extensions.xml
  ```

  Two constraints shape this. Git cannot re-include a file whose parent directory is excluded by a `dir/`
  pattern, so the directory has to be re-included (`!/.mvn/`) before its contents can be filtered. And the
  un-anchored `.mvn/` has to stay: a pattern containing a slash is anchored to the `.gitignore`'s directory,
  so narrowing it to `.mvn/*` stops matching nested `.mvn` directories — and **apache-rat reads
  `.gitignore`**, so that un-hides `hudi-trino/.mvn/modernizer/*.xml`, which are tracked without ASF headers.
  My first revision did exactly that and failed `validate-source` with "Too many files with unapproved
  license: 2". Locally generated `.mvn` content such as the maven wrapper stays ignored.

Verified, before and after, from three places: repo root (`-pl hudi-common`, unchanged — still passes),
`cd hudi-cli` (was failing, now passes), and `cd hudi-client/hudi-client-common` (was failing, now
passes). Also confirmed the rule is actually enforced afterwards rather than merely initialising:
temporarily adding `import scala.Option;` to `HoodieWriteConfig.java` and running checkstyle from inside
`hudi-client-common` reports `ImportControl: Disallowed import - scala.Option.` and fails the build.
`apache-rat:check` passes with the new file (`Unapproved: 0`).

Two alternatives were tried and rejected:

- `${config_loc}/import-control.xml`, the idiomatic checkstyle form — fails with `Property ${config_loc}
  has not been set`, because the pom's explicit `propertyExpansion` replaces the plugin's default
  properties.
- `basedir=${main.basedir}`, reusing the repo's own property — no new files, but `main.basedir` defaults
  to `${project.basedir}` and is only overridden in 72 of 82 poms. The 10 that don't override it include
  the largest source modules, among them `hudi-client-common`, which is the only module `ImportControl`
  applies to. Fixing it that way needs 10 more pom edits with per-module parent-depth reasoning.

I am aware `.mvn/` was ignored on purpose; if you would rather not track anything under `.mvn`, the
alternative above is workable and I am happy to switch.

### Impact

No effect on a build run from the repo root, which is how CI builds — `maven.multiModuleProjectDirectory`
already resolved to the repo root there. The change makes module-scoped builds started from inside a
submodule behave the same as root builds. No production code, API, config, or format change.

### Risk Level

low — build configuration only. Verified that root builds are unchanged, that submodule builds now pass,
that checkstyle still fails on a real violation, and that rat and the `.gitignore` narrowing behave as
intended.

### Documentation Update

none — no new config and no user-facing behavior change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
