### PR TITLE
feat(gateway): schema hints -- live schema context for the model

### DIFF
--- a/hudi-agent-gateway/Dockerfile
+++ b/hudi-agent-gateway/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /opt/hudi-agent-gateway
 COPY pyproject.toml README.md ./
 RUN mkdir -p src/hudi_agent_gateway \
     && printf '__version__ = "0.1.0"\n' > src/hudi_agent_gateway/__init__.py \
-    && pip install --no-cache-dir . \
+    && pip install --no-cache-dir ".[spark]" \
     && pip uninstall -y hudi-agent-gateway
 COPY src ./src
 RUN pip install --no-cache-dir --no-deps .

--- a/hudi-agent-gateway/README.md
+++ b/hudi-agent-gateway/README.md
@@ -26,8 +26,9 @@ process hosts three surfaces over the same set of guarded lakehouse tools:
 | MCP server | `/mcp` (streamable HTTP) | external agents (Claude, anything MCP) call the lakehouse tools directly |
 | Chat UI | `/ui/` | first-party ChatGPT-style web UI (zero third-party code) |
 
-The v1 tools query the lakehouse through Trino: `query_lakehouse` (guarded,
-read-only SQL), `list_tables`, `describe_table`. Every model-written query
+The tools query the lakehouse through a pluggable SQL engine -- Trino (the
+default) or a Spark Thrift Server (`GATEWAY_ENGINE=spark`): `query_lakehouse`
+(guarded, read-only SQL), `list_tables`, `describe_table`. Every model-written query
 passes AST-level guardrails (single statement, SELECT-only, row cap injected
 as a real `LIMIT`) and every invocation is logged as structured JSON — the
 seed of the gateway's trace collection.
@@ -67,6 +68,72 @@ Connect an MCP client:
 claude mcp add --transport http hudi-lakehouse http://localhost:8000/mcp/
 ```
 
+## Using Spark instead of Trino (via Apache Kyuubi)
+
+Set `GATEWAY_ENGINE=spark` to serve the same tools through a Spark SQL engine
+over the HiveServer2 Thrift protocol. Spark reads everything Spark can read:
+MOR snapshot queries, and Hudi 1.x tables carrying the unstructured types
+(`BLOB`, `VECTOR`, `VARIANT`) -- e.g. `size(embedding)` over a vector column
+works. Queries are validated and rendered in the Spark SQL dialect;
+`list_tables`/`describe_table` use `SHOW TABLES` / `DESCRIBE TABLE`.
+
+The recommended endpoint is **[Apache Kyuubi](https://kyuubi.apache.org/)**,
+which exposes the same HiveServer2 protocol but adds what a bare Spark Thrift
+Server lacks -- isolated on-demand engines, HA + service discovery, and real
+authn/authz. Because the wire protocol is identical, the gateway connects to
+Kyuubi with **no code change** -- only the host/port differ (Kyuubi defaults to
+10009; a raw Spark Thrift Server uses 10000).
+
+```bash
+# the spark extra brings PyHive (pure-sasl, no C toolchain needed):
+.venv/bin/pip install -e ".[spark,dev]"
+
+# Point Kyuubi's engine at a Spark build with the Hudi bundle on its classpath
+# (SPARK_HOME/conf/spark-defaults.conf), then start Kyuubi:
+#   export SPARK_HOME=/path/to/spark-with-hudi
+#   $KYUUBI_HOME/bin/kyuubi start        # HiveServer2 Thrift on :10009
+
+GATEWAY_ENGINE=spark GATEWAY_SPARK_HOST=localhost GATEWAY_SPARK_PORT=10009 \
+GATEWAY_LLM_PROVIDER=ollama GATEWAY_LLM_MODEL=qwen3:8b \
+  .venv/bin/hudi-agent-gateway serve
+
+curl localhost:8000/ready   # {"checks": {"spark": {"ok": true, ...}, ...}}
+```
+
+Kyuubi operational notes (learned the hard way -- see the PR for detail):
+
+- **Engine share level.** For a single-service gateway, run Kyuubi with
+  `kyuubi.engine.share.level=SERVER` so every connection reuses one engine and
+  one catalog. With the default `USER` level each distinct connecting user
+  gets its *own* engine (extra cold-start) and, with an embedded derby
+  metastore, its *own* tables -- so `GATEWAY_SPARK_USER` must match whoever
+  registered them, or back Kyuubi with a shared Hive Metastore.
+- **First-query cold start.** The engine spins up on the first query and can
+  take minutes with a large Hudi classpath; keep
+  `kyuubi.session.engine.initialize.timeout` generous and give the driver
+  enough memory, or the engine is killed mid-init. The gateway's readiness
+  ping may report `spark` down until the engine is warm.
+
+Any HiveServer2-compatible endpoint works, including a raw
+`start-thriftserver.sh` for a quick local check (lighter, but single shared
+context, no HA) -- set `GATEWAY_SPARK_PORT=10000` for that.
+
+The chat API, UI, MCP server, guardrails, and agent behavior are identical
+across engines -- only the SQL dialect and the endpoint in `/v1/info` change.
+Two engine-specific notes:
+
+- **Connections are pooled.** HiveServer2 sessions are expensive to open, so
+  the client keeps up to `GATEWAY_SPARK_MAX_CONNECTIONS` live sessions,
+  recycles them past idle/lifetime limits, discards any session whose query
+  timed out, and transparently retries once on a fresh connection when a
+  pooled session died underneath a query (server restart, idle kill).
+- **Tool argument shapes follow the engine's namespace model**: `list_tables`
+  takes `database` (not `catalog`/`schema_name`) and `describe_table` accepts
+  `table` or `database.table` -- MCP clients that hardcode tool arguments
+  should read `GET /v1/tools` rather than assume the Trino shapes. The thrift
+  transport is unencrypted; `ldap` sends the password in the SASL exchange,
+  so use it only on trusted networks (TLS support is a tracked follow-up).
+
 ## Deploying on Kubernetes
 
 See `hudi-lakehouse/charts/hudi-agent-gateway` — the product Helm chart —
@@ -86,8 +153,14 @@ Environment variables (prefix `GATEWAY_` except the standard key names):
 | `GATEWAY_OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama endpoint |
 | `GATEWAY_OPENAI_BASE_URL` | — | endpoint for `openai-compatible` (vLLM, Together, …) |
 | `GATEWAY_LLM_TIMEOUT_SECONDS` | `120` | per-model-call timeout |
-| `GATEWAY_TRINO_HOST` / `_PORT` | `hudi-trino.hudi-lakehouse.svc` / `8080` | Trino coordinator |
+| `GATEWAY_ENGINE` | `trino` | lakehouse SQL engine: `trino` \| `spark` |
+| `GATEWAY_TRINO_HOST` / `_PORT` | `hudi-trino.hudi-lakehouse.svc` / `8080` | Trino coordinator (engine=trino) |
 | `GATEWAY_TRINO_CATALOG` / `_SCHEMA` / `_USER` | `hudi` / `default` / `hudi-agent-gateway` | query defaults |
+| `GATEWAY_SPARK_HOST` / `_PORT` | `localhost` / `10000` | Spark Thrift Server (engine=spark) |
+| `GATEWAY_SPARK_DATABASE` / `_USER` | `default` / `hudi-agent-gateway` | query defaults (engine=spark) |
+| `GATEWAY_SPARK_AUTH` / `_PASSWORD` | `none` / — | HiveServer2 auth: `none` \| `nosasl` \| `ldap` (password required for ldap) |
+| `GATEWAY_SPARK_MAX_CONNECTIONS` | `8` | pooled HiveServer2 sessions; also the query concurrency bound |
+| `GATEWAY_SPARK_POOL_MAX_IDLE_SECONDS` / `_MAX_LIFETIME_SECONDS` | `300` / `1800` | pooled sessions are recycled past these limits |
 | `GATEWAY_SQL_ROW_CAP` | `200` | LIMIT enforced on every query |
 | `GATEWAY_SQL_TIMEOUT_SECONDS` | `120` | per-query timeout |
 | `GATEWAY_TOOL_RESULT_MAX_BYTES` | `50000` | tool results truncated beyond this (with notice) |
@@ -111,6 +184,9 @@ readiness probe).
 
 # live integration (against a port-forwarded local-dev stack):
 GATEWAY_IT_TRINO_HOST=localhost GATEWAY_IT_TRINO_PORT=18080 .venv/bin/pytest tests/integration
+
+# live integration against a Spark Thrift Server (needs the spark extra):
+GATEWAY_IT_SPARK_HOST=localhost GATEWAY_IT_SPARK_PORT=10000 .venv/bin/pytest tests/integration/test_live_spark.py
 ```
 
 Adding a tool: write a module under `src/hudi_agent_gateway/tools/` with a

--- a/hudi-agent-gateway/README.md
+++ b/hudi-agent-gateway/README.md
@@ -33,6 +33,26 @@ passes AST-level guardrails (single statement, SELECT-only, row cap injected
 as a real `LIMIT`) and every invocation is logged as structured JSON — the
 seed of the gateway's trace collection.
 
+## Schema hints
+
+Small local models routinely skip `describe_table` and guess column names.
+The gateway counters this with live schema context, auto-derived from the
+engine (never hand-written), controlled by `GATEWAY_SCHEMA_HINTS`:
+
+- **`errors`** -- when a query fails on an unknown column/table, the error
+  hint carries the real names: `Did you mean `beds`? Columns in `listings`:
+  listing_id, address, ...` -- the model corrects itself in one hop.
+- **`prompt`** -- a compact snapshot of tables and columns (TTL-cached,
+  size-capped, Hudi meta columns filtered) is rendered into the system prompt
+  each turn, so the model writes SQL against real names without a discovery
+  hop.
+- **`both`** (default) enables both; `off` restores pure tool-based discovery.
+
+The snapshot comes from one `information_schema` query (Trino) or
+`SHOW TABLES` + `DESCRIBE` (Spark), refreshed every
+`GATEWAY_SCHEMA_CACHE_TTL_SECONDS` and strictly fail-open: an unreachable
+engine only degrades hints, never queries.
+
 ## Quickstart (local process)
 
 ```bash
@@ -163,6 +183,9 @@ Environment variables (prefix `GATEWAY_` except the standard key names):
 | `GATEWAY_SPARK_POOL_MAX_IDLE_SECONDS` / `_MAX_LIFETIME_SECONDS` | `300` / `1800` | pooled sessions are recycled past these limits |
 | `GATEWAY_SQL_ROW_CAP` | `200` | LIMIT enforced on every query |
 | `GATEWAY_SQL_TIMEOUT_SECONDS` | `120` | per-query timeout |
+| `GATEWAY_SCHEMA_HINTS` | `both` | live schema context for the model: `off` \| `errors` (did-you-mean on name errors) \| `prompt` (schema snapshot in the system prompt) \| `both` |
+| `GATEWAY_SCHEMA_CACHE_TTL_SECONDS` | `300` | schema snapshot refresh interval |
+| `GATEWAY_SCHEMA_MAX_TABLES` / `_MAX_COLUMNS` | `20` / `40` | caps on the snapshot size |
 | `GATEWAY_TOOL_RESULT_MAX_BYTES` | `50000` | tool results truncated beyond this (with notice) |
 | `GATEWAY_AGENT_MAX_ITERATIONS` | `25` | agent loop recursion limit |
 | `GATEWAY_SESSION_TTL_SECONDS` / `GATEWAY_MAX_SESSIONS` | `3600` / `1000` | session store bounds |

--- a/hudi-agent-gateway/pyproject.toml
+++ b/hudi-agent-gateway/pyproject.toml
@@ -43,6 +43,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# The Spark Thrift Server backend (GATEWAY_ENGINE=spark). PyHive speaks the
+# HiveServer2 Thrift protocol; the pure-sasl extra avoids a C sasl build.
+spark = [
+  "pyhive[hive_pure_sasl]>=0.7.0",
+]
 dev = [
   "pytest>=8.0",
   "pytest-asyncio>=0.24",

--- a/hudi-agent-gateway/src/hudi_agent_gateway/agent.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/agent.py
@@ -27,18 +27,18 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.prebuilt import create_react_agent
 
 from hudi_agent_gateway.config import GatewaySettings
+from hudi_agent_gateway.tools import get_connector
 from hudi_agent_gateway.tools.registry import ToolRegistry
 
 _SYSTEM_PROMPT = """\
 You are the Apache Hudi lakehouse analyst. You answer questions about data in \
-an Apache Hudi lakehouse by querying it through Trino using your tools. The \
-default catalog is `{catalog}` and the default schema is `{schema}`; tables \
-are Hudi tables registered in the catalog's metastore.
+an Apache Hudi lakehouse by querying it through {engine_name} using your tools. \
+{namespace_line}
 
 Tool strategy:
 - For unfamiliar tables, call `list_tables` and `describe_table` BEFORE writing SQL.
-- `query_lakehouse` accepts exactly ONE read-only SELECT statement (Trino SQL). \
-Qualify names as catalog.schema.table when querying outside the defaults.
+- `query_lakehouse` accepts exactly ONE read-only SELECT statement ({dialect}). \
+{qualify_line}
 - A server-side row cap of {row_cap} rows is enforced. Prefer aggregations, \
 GROUP BY, and explicit LIMIT over raw row dumps.
 - If a result has `truncated: true`, tell the user the result was truncated and \
@@ -54,9 +54,12 @@ Grounding rules:
 
 def build_system_prompt(settings: GatewaySettings) -> str:
     extra = f"\n{settings.system_prompt_extra}" if settings.system_prompt_extra else ""
+    ctx = get_connector(settings.engine).prompt_context(settings)
     return _SYSTEM_PROMPT.format(
-        catalog=settings.trino_catalog,
-        schema=settings.trino_schema,
+        engine_name=ctx.engine_name,
+        dialect=ctx.dialect,
+        namespace_line=ctx.namespace_line,
+        qualify_line=ctx.qualify_line,
         row_cap=settings.sql_row_cap,
         extra=extra,
     )

--- a/hudi-agent-gateway/src/hudi_agent_gateway/agent.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/agent.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from typing import Any, TypeGuard
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, trim_messages
+from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, trim_messages
 from langchain_core.messages.utils import count_tokens_approximately
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.prebuilt import create_react_agent
@@ -33,7 +33,7 @@ from hudi_agent_gateway.tools.registry import ToolRegistry
 _SYSTEM_PROMPT = """\
 You are the Apache Hudi lakehouse analyst. You answer questions about data in \
 an Apache Hudi lakehouse by querying it through {engine_name} using your tools. \
-{namespace_line}
+{namespace_line}{schema_section}
 
 Tool strategy:
 - For unfamiliar tables, call `list_tables` and `describe_table` BEFORE writing SQL.
@@ -52,7 +52,7 @@ Grounding rules:
 {extra}"""
 
 
-def build_system_prompt(settings: GatewaySettings) -> str:
+def build_system_prompt(settings: GatewaySettings, schema_block: str = "") -> str:
     extra = f"\n{settings.system_prompt_extra}" if settings.system_prompt_extra else ""
     ctx = get_connector(settings.engine).prompt_context(settings)
     return _SYSTEM_PROMPT.format(
@@ -60,9 +60,29 @@ def build_system_prompt(settings: GatewaySettings) -> str:
         dialect=ctx.dialect,
         namespace_line=ctx.namespace_line,
         qualify_line=ctx.qualify_line,
+        schema_section=f"\n\n{schema_block}" if schema_block else "",
         row_cap=settings.sql_row_cap,
         extra=extra,
     )
+
+
+def make_prompt(settings: GatewaySettings, schema_cache: Any = None):
+    """The agent prompt: a static string, or -- when the schema cache is on
+    (``GATEWAY_SCHEMA_HINTS=prompt|both``) -- a per-turn callable that renders
+    the current schema snapshot into the system message, so the model writes
+    SQL against real table/column names without a discovery hop."""
+    if schema_cache is None or settings.schema_hints not in ("prompt", "both"):
+        return build_system_prompt(settings)
+
+    def prompt(state: dict[str, Any]) -> list[AnyMessage]:
+        system = SystemMessage(
+            content=build_system_prompt(settings, schema_cache.prompt_block())
+        )
+        # pre_model_hook trims into llm_input_messages; fall back to raw state
+        messages = state.get("llm_input_messages") or state["messages"]
+        return [system, *messages]
+
+    return prompt
 
 
 class AgentCache:
@@ -73,10 +93,11 @@ class AgentCache:
     _MAX_AGENTS = 8
 
     def __init__(self, registry: ToolRegistry, checkpointer: BaseCheckpointSaver,
-                 settings: GatewaySettings) -> None:
+                 settings: GatewaySettings, schema_cache: Any = None) -> None:
         self._registry = registry
         self._checkpointer = checkpointer
         self._settings = settings
+        self._schema_cache = schema_cache
         self._agents: dict[str, Any] = {}
 
     def get(self, model: str | None = None) -> Any:
@@ -91,6 +112,7 @@ class AgentCache:
                 self._registry,
                 self._checkpointer,
                 self._settings,
+                schema_cache=self._schema_cache,
             )
         return self._agents[name]
 
@@ -130,6 +152,7 @@ def build_agent(
     registry: ToolRegistry,
     checkpointer: BaseCheckpointSaver,
     settings: GatewaySettings,
+    schema_cache: Any = None,
 ) -> Any:
     max_messages = settings.max_messages_per_session
 
@@ -149,7 +172,7 @@ def build_agent(
     return create_react_agent(
         model=model,
         tools=registry.langchain_tools(),
-        prompt=build_system_prompt(settings),
+        prompt=make_prompt(settings, schema_cache),
         checkpointer=checkpointer,
         pre_model_hook=trim_llm_input,
     )

--- a/hudi-agent-gateway/src/hudi_agent_gateway/api/meta.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/api/meta.py
@@ -30,6 +30,7 @@ from hudi_agent_gateway.api.models import (
     ReadyResponse,
 )
 from hudi_agent_gateway.llm import list_models
+from hudi_agent_gateway.tools import get_connector
 
 router = APIRouter()
 
@@ -44,13 +45,14 @@ async def health() -> dict[str, str]:
 async def ready(request: Request, response: Response) -> ReadyResponse:
     """Readiness: configuration is valid AND dependencies are reachable."""
     state = request.app.state
+    s = state.settings
+    connector = get_connector(s.engine)
     checks: dict[str, DependencyStatus] = {}
 
-    trino_ok = await state.trino_client.ping()
-    checks["trino"] = DependencyStatus(
-        ok=trino_ok,
-        detail="reachable" if trino_ok else
-        f"cannot reach trino at {state.settings.trino_host}:{state.settings.trino_port}",
+    engine_ok = await state.lakehouse_client.ping()
+    checks[s.engine] = DependencyStatus(
+        ok=engine_ok,
+        detail=connector.readiness_detail(s, state.lakehouse_client, engine_ok),
     )
 
     llm_ok, llm_detail = await state.llm_readiness.check()
@@ -86,14 +88,16 @@ async def models(request: Request) -> ModelsResponse:
 @router.get("/v1/info", response_model=InfoResponse, response_model_by_alias=True)
 async def info(request: Request) -> InfoResponse:
     s = request.app.state.settings
+    ei = get_connector(s.engine).engine_info(s)
     return InfoResponse(
         name="hudi-agent-gateway",
         version=__version__,
+        engine=ei.engine,
         provider=s.llm_provider,
         model=s.llm_model,
-        catalog=s.trino_catalog,
-        schema=s.trino_schema,
-        trino_url=f"http://{s.trino_host}:{s.trino_port}",
-        trino_ui_url=f"http://{s.trino_host}:{s.trino_port}/ui/",
+        catalog=ei.catalog,
+        schema=ei.schema,
+        sql_url=ei.sql_url,
+        web_ui_url=ei.web_ui_url,
         mcp_enabled=s.mcp_enabled,
     )

--- a/hudi-agent-gateway/src/hudi_agent_gateway/api/models.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/api/models.py
@@ -100,13 +100,17 @@ class ReadyResponse(BaseModel):
 class InfoResponse(BaseModel):
     name: str
     version: str
+    engine: str
     provider: str
     model: str
     catalog: str
     schema_: str = Field(alias="schema")
-    # In-cluster/network endpoints, for the UI's connect panel.
-    trino_url: str
-    trino_ui_url: str
+    # In-cluster/network endpoints, for the UI's connect panel. For the trino
+    # engine `sql_url` is the coordinator's HTTP endpoint; for spark it is the
+    # Thrift Server's JDBC URL. `web_ui_url` is None when the engine has no
+    # web UI to link.
+    sql_url: str
+    web_ui_url: str | None = None
     mcp_enabled: bool
 
     model_config = {"populate_by_name": True}

--- a/hudi-agent-gateway/src/hudi_agent_gateway/app.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/app.py
@@ -36,7 +36,7 @@ from hudi_agent_gateway.llm import LLMReadiness
 from hudi_agent_gateway.log import log_event, setup_logging
 from hudi_agent_gateway.mcp_server import build_mcp
 from hudi_agent_gateway.sessions import SessionStore
-from hudi_agent_gateway.tools import build_registry, create_lakehouse_client
+from hudi_agent_gateway.tools import build_registry, build_schema_cache, create_lakehouse_client
 
 logger = logging.getLogger("hudi_agent_gateway.app")
 
@@ -46,7 +46,8 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
     setup_logging(s.log_level)
 
     lakehouse_client = create_lakehouse_client(s)
-    registry = build_registry(s, client=lakehouse_client)
+    schema_cache = build_schema_cache(s, lakehouse_client)
+    registry = build_registry(s, client=lakehouse_client, schema_cache=schema_cache)
     # NOTE: the MCP ASGI sub-app has its own lifespan that MUST run inside the
     # outer app's lifespan, or FastMCP's streamable-HTTP session manager never
     # starts and /mcp requests hang.
@@ -56,11 +57,19 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.settings = s
         app.state.lakehouse_client = lakehouse_client
+        app.state.schema_cache = schema_cache
         app.state.registry = registry
         app.state.llm_readiness = LLMReadiness(s)
         app.state.sessions = SessionStore(s)
-        app.state.agents = AgentCache(registry, app.state.sessions.checkpointer, s)
+        app.state.agents = AgentCache(
+            registry, app.state.sessions.checkpointer, s, schema_cache=schema_cache
+        )
         sweeper = asyncio.create_task(app.state.sessions.sweep_loop())
+        if schema_cache is not None:
+            # Warm the snapshot so the first chat already has schema context;
+            # fail-open, so an unreachable engine only delays hints.
+            prefetch = asyncio.create_task(schema_cache.get())
+            prefetch.add_done_callback(lambda t: t.cancelled() or t.exception())
         log_event(
             logger,
             "gateway_started",

--- a/hudi-agent-gateway/src/hudi_agent_gateway/app.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/app.py
@@ -36,8 +36,7 @@ from hudi_agent_gateway.llm import LLMReadiness
 from hudi_agent_gateway.log import log_event, setup_logging
 from hudi_agent_gateway.mcp_server import build_mcp
 from hudi_agent_gateway.sessions import SessionStore
-from hudi_agent_gateway.tools import build_registry
-from hudi_agent_gateway.tools.trino_client import TrinoClient
+from hudi_agent_gateway.tools import build_registry, create_lakehouse_client
 
 logger = logging.getLogger("hudi_agent_gateway.app")
 
@@ -46,8 +45,8 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
     s = settings or GatewaySettings()
     setup_logging(s.log_level)
 
-    trino_client = TrinoClient(s)
-    registry = build_registry(s, trino_client)
+    lakehouse_client = create_lakehouse_client(s)
+    registry = build_registry(s, client=lakehouse_client)
     # NOTE: the MCP ASGI sub-app has its own lifespan that MUST run inside the
     # outer app's lifespan, or FastMCP's streamable-HTTP session manager never
     # starts and /mcp requests hang.
@@ -56,7 +55,7 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.settings = s
-        app.state.trino_client = trino_client
+        app.state.lakehouse_client = lakehouse_client
         app.state.registry = registry
         app.state.llm_readiness = LLMReadiness(s)
         app.state.sessions = SessionStore(s)
@@ -66,6 +65,7 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
             logger,
             "gateway_started",
             version=__version__,
+            engine=s.engine,
             provider=s.llm_provider,
             model=s.llm_model,
             tools=len(registry),
@@ -79,6 +79,7 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
                 yield
         finally:
             sweeper.cancel()
+            lakehouse_client.close()
 
     app = FastAPI(title="hudi-agent-gateway", version=__version__, lifespan=lifespan)
     app.include_router(meta.router)

--- a/hudi-agent-gateway/src/hudi_agent_gateway/config.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/config.py
@@ -30,6 +30,8 @@ from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 LLMProvider = Literal["anthropic", "openai", "ollama", "openai-compatible"]
+LakehouseEngine = Literal["trino", "spark"]
+SparkAuth = Literal["none", "nosasl", "ldap"]
 
 
 class GatewaySettings(BaseSettings):
@@ -58,12 +60,35 @@ class GatewaySettings(BaseSettings):
     ollama_base_url: str = "http://localhost:11434"
     openai_base_url: str = ""  # required for provider=openai-compatible (vLLM etc.)
 
-    # --- Trino / lakehouse ---
+    # --- lakehouse engine ---
+    # Which SQL engine serves the lakehouse tools. "trino" (default) queries a
+    # Trino coordinator with the Hudi connector; "spark" queries a Spark
+    # Thrift Server (HiveServer2 protocol), which additionally reads MOR
+    # snapshots and Hudi 1.x tables that carry unstructured columns.
+    engine: LakehouseEngine = "trino"
+
+    # --- Trino backend ---
     trino_host: str = "hudi-trino.hudi-lakehouse.svc"
     trino_port: int = 8080
     trino_user: str = "hudi-agent-gateway"
     trino_catalog: str = "hudi"
     trino_schema: str = "default"
+
+    # --- Spark Thrift Server backend ---
+    spark_host: str = "localhost"
+    spark_port: int = 10000
+    spark_user: str = "hudi-agent-gateway"
+    spark_database: str = "default"
+    # HiveServer2 auth mode: "none" (SASL PLAIN, the Spark Thrift default),
+    # "nosasl" (hive.server2.authentication=NOSASL), or "ldap" (user/password).
+    spark_auth: SparkAuth = "none"
+    spark_password: str = ""
+    # Connection pooling: HiveServer2 sessions are expensive to open, so the
+    # client keeps up to `spark_max_connections` live sessions (also the query
+    # concurrency bound) and recycles them past the idle/lifetime limits.
+    spark_max_connections: int = Field(default=8, ge=1, le=64)
+    spark_pool_max_idle_seconds: float = Field(default=300.0, gt=0)
+    spark_pool_max_lifetime_seconds: float = Field(default=1800.0, gt=0)
 
     # --- guardrails / shaping ---
     sql_row_cap: int = 200
@@ -90,4 +115,6 @@ class GatewaySettings(BaseSettings):
             raise ValueError(
                 "GATEWAY_LLM_PROVIDER=openai-compatible requires GATEWAY_OPENAI_BASE_URL"
             )
+        if self.engine == "spark" and self.spark_auth == "ldap" and not self.spark_password:
+            raise ValueError("GATEWAY_SPARK_AUTH=ldap requires GATEWAY_SPARK_PASSWORD")
         return self

--- a/hudi-agent-gateway/src/hudi_agent_gateway/config.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/config.py
@@ -32,6 +32,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 LLMProvider = Literal["anthropic", "openai", "ollama", "openai-compatible"]
 LakehouseEngine = Literal["trino", "spark"]
 SparkAuth = Literal["none", "nosasl", "ldap"]
+SchemaHints = Literal["off", "errors", "prompt", "both"]
 
 
 class GatewaySettings(BaseSettings):
@@ -94,6 +95,17 @@ class GatewaySettings(BaseSettings):
     sql_row_cap: int = 200
     sql_timeout_seconds: float = 120.0
     tool_result_max_bytes: int = 50_000
+
+    # --- schema hints ---
+    # Live schema context for the model, auto-derived from the engine (never
+    # hand-written): "errors" enriches column/table-not-found errors with the
+    # real names ("did you mean `beds`?"), "prompt" injects a compact schema
+    # snapshot into the system prompt so small models stop guessing names,
+    # "both" (default) does both, "off" restores pure tool-based discovery.
+    schema_hints: SchemaHints = "both"
+    schema_cache_ttl_seconds: float = Field(default=300.0, gt=0)
+    schema_max_tables: int = Field(default=20, ge=1, le=200)
+    schema_max_columns: int = Field(default=40, ge=1, le=500)
 
     # --- agent / sessions ---
     agent_max_iterations: int = 25

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/__init__.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/__init__.py
@@ -35,6 +35,7 @@ from hudi_agent_gateway.tools.connector import (
     get_connector,
 )
 from hudi_agent_gateway.tools.registry import ToolRegistry
+from hudi_agent_gateway.tools.schema_cache import SchemaCache
 
 # Built-in connectors. The import registers them (decorator side effect); the
 # re-export makes them part of the package's public surface.
@@ -42,9 +43,11 @@ from hudi_agent_gateway.tools.spark_tools import SparkConnector
 from hudi_agent_gateway.tools.trino_tools import TrinoConnector
 
 __all__ = [
+    "SchemaCache",
     "SparkConnector",
     "TrinoConnector",
     "build_registry",
+    "build_schema_cache",
     "connector_names",
     "create_lakehouse_client",
     "get_connector",
@@ -56,15 +59,39 @@ def create_lakehouse_client(settings: GatewaySettings) -> LakehouseClient:
     return get_connector(settings.engine).create_client(settings)
 
 
+def build_schema_cache(
+    settings: GatewaySettings, client: LakehouseClient
+) -> SchemaCache | None:
+    """The schema cache behind ``GATEWAY_SCHEMA_HINTS``; None when off."""
+    if settings.schema_hints == "off":
+        return None
+    connector = get_connector(settings.engine)
+    return SchemaCache(
+        fetch=lambda: connector.fetch_schema(client, settings),
+        ttl_seconds=settings.schema_cache_ttl_seconds,
+        max_tables=settings.schema_max_tables,
+        max_columns=settings.schema_max_columns,
+    )
+
+
 def build_registry(
-    settings: GatewaySettings, client: LakehouseClient | None = None
+    settings: GatewaySettings,
+    client: LakehouseClient | None = None,
+    schema_cache: SchemaCache | None = None,
 ) -> ToolRegistry:
     """Build the tool registry for the configured engine.
 
     ``client`` is injectable for tests; when omitted a real client is created
-    for the engine. Tool registration is delegated to the engine's connector.
+    for the engine. ``schema_cache`` (optional) lets the tools enrich
+    not-found errors with real names. Tool registration is delegated to the
+    engine's connector.
     """
     connector = get_connector(settings.engine)
     registry = ToolRegistry()
-    connector.register_tools(registry, client or connector.create_client(settings), settings)
+    connector.register_tools(
+        registry,
+        client or connector.create_client(settings),
+        settings,
+        schema_cache=schema_cache,
+    )
     return registry

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/__init__.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/__init__.py
@@ -14,24 +14,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tool assembly: the single place where tool modules get registered.
+"""Tool assembly.
 
-Adding a new tool module = write the module with a ``register(registry, ...)``
-function, then call it here.
+The lakehouse backend is chosen by ``GATEWAY_ENGINE`` and resolved through the
+connector registry (:mod:`hudi_agent_gateway.tools.connector`). Importing a
+connector class runs its ``@register_connector`` decorator, so it becomes
+discoverable via ``get_connector`` / ``build_registry``.
+
+To add an engine: write a connector module (see ``connector.py`` for the
+contract) and add one import line for its class below -- that is the only
+change to shared code.
 """
 
 from __future__ import annotations
 
 from hudi_agent_gateway.config import GatewaySettings
-from hudi_agent_gateway.tools import trino_tools
+from hudi_agent_gateway.tools.connector import (
+    LakehouseClient,
+    connector_names,
+    get_connector,
+)
 from hudi_agent_gateway.tools.registry import ToolRegistry
-from hudi_agent_gateway.tools.trino_client import TrinoClient
+
+# Built-in connectors. The import registers them (decorator side effect); the
+# re-export makes them part of the package's public surface.
+from hudi_agent_gateway.tools.spark_tools import SparkConnector
+from hudi_agent_gateway.tools.trino_tools import TrinoConnector
+
+__all__ = [
+    "SparkConnector",
+    "TrinoConnector",
+    "build_registry",
+    "connector_names",
+    "create_lakehouse_client",
+    "get_connector",
+]
+
+
+def create_lakehouse_client(settings: GatewaySettings) -> LakehouseClient:
+    """Construct the SQL client for the configured ``GATEWAY_ENGINE``."""
+    return get_connector(settings.engine).create_client(settings)
 
 
 def build_registry(
-    settings: GatewaySettings, trino_client: TrinoClient | None = None
+    settings: GatewaySettings, client: LakehouseClient | None = None
 ) -> ToolRegistry:
+    """Build the tool registry for the configured engine.
+
+    ``client`` is injectable for tests; when omitted a real client is created
+    for the engine. Tool registration is delegated to the engine's connector.
+    """
+    connector = get_connector(settings.engine)
     registry = ToolRegistry()
-    client = trino_client or TrinoClient(settings)
-    trino_tools.register(registry, client, settings)
+    connector.register_tools(registry, client or connector.create_client(settings), settings)
     return registry

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/common.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/common.py
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Engine-agnostic pieces shared by the lakehouse tool backends.
+
+Every SQL backend (Trino, Spark Thrift Server, ...) returns the same
+:class:`QueryResult`, shapes results with the same byte/row-cap rules, and
+validates externally supplied identifiers with the same conservative rule.
+Keeping these here means a new engine only supplies a client (execute/ping)
+and the engine-specific SQL for listing and describing tables.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from hudi_agent_gateway.tools.registry import ToolInputError
+
+
+class LakehouseQueryError(Exception):
+    """A query failed on the engine side; message is safe to surface to the model."""
+
+
+class LakehouseTimeoutError(LakehouseQueryError):
+    pass
+
+
+@dataclass
+class QueryResult:
+    columns: list[str]
+    rows: list[list[Any]]
+    row_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.row_count = len(self.rows)
+
+
+def shape_result(result: QueryResult, *, max_bytes: int, sql: str, row_cap: int) -> str:
+    # A result that filled the row cap was almost certainly cut off by it
+    # (LIMIT rewrite + fetchmany), so report it truncated -- the agent warns
+    # the user instead of presenting a capped answer as complete.
+    row_capped = result.row_count >= row_cap
+    payload: dict[str, Any] = {
+        "sql": sql,
+        "columns": result.columns,
+        "rows": result.rows,
+        "row_count": result.row_count,
+        "truncated": row_capped,
+    }
+    if row_capped:
+        payload["notice"] = (
+            f"Result hit the {row_cap}-row cap and may be incomplete. "
+            "Narrow the query (filters, aggregation) for an exact answer."
+        )
+    text = json.dumps(payload, default=str)
+    while len(text.encode()) > max_bytes and payload["rows"]:
+        keep = max(1, len(payload["rows"]) // 2)
+        if keep == len(payload["rows"]):
+            keep -= 1
+        payload["rows"] = payload["rows"][:keep]
+        payload["truncated"] = True
+        payload["notice"] = (
+            f"Result truncated to {len(payload['rows'])} of {result.row_count} fetched rows "
+            "to fit the size limit. Narrow the query (filters, aggregation, fewer columns)."
+        )
+        text = json.dumps(payload, default=str)
+    if len(text.encode()) > max_bytes:
+        # Fail-safe: even zero rows can bust the limit (huge sql text, very
+        # many columns, or a tiny configured cap). Return a bounded payload.
+        text = json.dumps({
+            "sql": sql[:100],
+            "column_count": len(result.columns),
+            "rows": [],
+            "row_count": result.row_count,
+            "truncated": True,
+            "notice": "Result exceeded the size limit; rows and column names omitted. "
+            "Narrow the query or raise the result size limit.",
+        })
+        if len(text.encode()) > max_bytes:
+            text = json.dumps({"error": "result exceeded the size limit", "truncated": True})
+    return text
+
+
+def error_payload(message: str, hint: str = "") -> str:
+    payload = {"error": message}
+    if hint:
+        payload["hint"] = hint
+    return json.dumps(payload)
+
+
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$-]*$")
+
+
+def validate_identifier(value: str, kind: str) -> str:
+    """Reject anything that could escape quoting when interpolated into SQL.
+
+    catalog/schema/table names arrive over HTTP and MCP; only plain
+    identifiers are accepted -- everything else is an input error.
+    """
+    if not IDENTIFIER_RE.match(value):
+        raise ToolInputError(
+            f"invalid {kind} name {value!r}",
+            hint="Names may contain only letters, digits, '_', '$' or '-', "
+            "and must not start with a digit.",
+        )
+    return value
+
+
+def split_table_name(
+    table: str, default_catalog: str, default_schema: str
+) -> tuple[str, str, str]:
+    parts = table.split(".")
+    if len(parts) == 1:
+        return default_catalog, default_schema, parts[0]
+    if len(parts) == 2:
+        return default_catalog, parts[0], parts[1]
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    raise ToolInputError(
+        f"invalid table name {table!r}", hint="Use table, schema.table, or catalog.schema.table."
+    )

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/common.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/common.py
@@ -25,6 +25,7 @@ and the engine-specific SQL for listing and describing tables.
 
 from __future__ import annotations
 
+import difflib
 import json
 import re
 from dataclasses import dataclass, field
@@ -120,6 +121,77 @@ def validate_identifier(value: str, kind: str) -> str:
             "and must not start with a digit.",
         )
     return value
+
+
+# --- schema-aware error hints ------------------------------------------------
+# Engine error fragments identifying "you referenced a name that does not
+# exist". Table markers are checked first: Spark/Trino table errors often also
+# contain the word "column"-adjacent phrasing, but never vice versa.
+_TABLE_NOT_FOUND_MARKERS = (
+    "table_or_view_not_found",
+    "table or view not found",
+    "table_not_found",
+)
+_COLUMN_NOT_FOUND_MARKERS = (
+    "unresolved_column",
+    "column_not_found",
+    "cannot be resolved",
+    "cannot resolve",
+)
+
+# `name`, 'name' or "name" -- how engines quote the offending identifier.
+_QUOTED_IDENTIFIER_RE = re.compile(r"[`'\"]([A-Za-z0-9_$.\-]+)[`'\"]")
+
+_MAX_HINT_CHARS = 700
+
+
+def schema_error_hint(message: str, schema: dict[str, list[tuple[str, str]]]) -> str:
+    """An actionable hint for a not-found query error, built from the cached
+    schema: fuzzy "did you mean" plus the real names, so the model can correct
+    itself in one hop instead of guessing again. Returns "" when the error is
+    not a not-found error or the schema is unknown.
+    """
+    if not schema:
+        return ""
+    lowered = message.lower()
+    is_table_error = any(m in lowered for m in _TABLE_NOT_FOUND_MARKERS) or (
+        "table" in lowered and "does not exist" in lowered  # Trino TABLE_NOT_FOUND
+    )
+    is_column_error = not is_table_error and any(
+        m in lowered for m in _COLUMN_NOT_FOUND_MARKERS
+    )
+    if not (is_table_error or is_column_error):
+        return ""
+
+    match = _QUOTED_IDENTIFIER_RE.search(message)
+    # engines may qualify the name (`db.table` / `t.col`); compare the leaf
+    name = match.group(1).split(".")[-1] if match else ""
+
+    if is_table_error:
+        tables = list(schema)
+        suggestions = difflib.get_close_matches(name, tables, n=1, cutoff=0.5)
+        did_you_mean = f"Did you mean `{suggestions[0]}`? " if suggestions else ""
+        hint = f"{did_you_mean}Available tables: {', '.join(tables)}."
+        return hint[:_MAX_HINT_CHARS]
+
+    # column error: find the closest column anywhere, then show that table's
+    # real column list -- models are far better at copying than guessing.
+    all_columns: dict[str, str] = {}
+    for table, columns in schema.items():
+        for col, _ in columns:
+            all_columns.setdefault(col, table)
+    suggestions = difflib.get_close_matches(name, list(all_columns), n=1, cutoff=0.5)
+    if suggestions:
+        col = suggestions[0]
+        table = all_columns[col]
+        cols = ", ".join(c for c, _ in schema[table])
+        hint = f"Did you mean `{col}`? Columns in `{table}`: {cols}."
+    else:
+        hint = (
+            f"Available tables: {', '.join(schema)}. "
+            "Call describe_table to see their columns."
+        )
+    return hint[:_MAX_HINT_CHARS]
 
 
 def split_table_name(

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/connector.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/connector.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The lakehouse connector abstraction and registry.
+
+A *connector* is everything the gateway needs to talk to one SQL engine
+(Trino, a Spark Thrift Server, ...). It bundles the four engine-specific
+concerns that would otherwise scatter as ``if settings.engine == ...``
+branches across the app, the readiness/info endpoints, and the agent prompt:
+
+1. building the SQL client (``create_client``),
+2. registering the lakehouse tools over that client (``register_tools``),
+3. the agent's prompt framing (``prompt_context`` -- dialect, namespace model),
+4. the operational surfaces (``engine_info`` for ``/v1/info``,
+   ``unreachable_detail`` / ``readiness_detail`` for ``/ready``).
+
+Adding a new engine is therefore a single self-contained module:
+
+    from hudi_agent_gateway.tools.connector import (
+        LakehouseConnector, register_connector, PromptContext, EngineInfo,
+    )
+
+    @register_connector
+    class MyEngineConnector(LakehouseConnector):
+        name = "myengine"          # must match a GatewaySettings.engine value
+        def create_client(self, settings): ...
+        def register_tools(self, registry, client, settings): ...
+        def prompt_context(self, settings): ...
+        def unreachable_detail(self, settings): ...
+        def engine_info(self, settings): ...
+
+...then import the module from ``tools/__init__.py`` so it self-registers.
+Nothing else in the codebase changes.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from hudi_agent_gateway.config import GatewaySettings
+from hudi_agent_gateway.tools.common import QueryResult
+from hudi_agent_gateway.tools.registry import ToolRegistry
+
+
+@runtime_checkable
+class LakehouseClient(Protocol):
+    """The minimal surface every engine client exposes to the tools and app.
+
+    Structural (duck-typed): the Trino and Spark clients satisfy it without
+    inheriting, and tests can substitute a fake with the same three methods.
+    """
+
+    async def execute(self, sql: str, *, timeout: float, max_rows: int) -> QueryResult: ...
+
+    async def ping(self, timeout: float = 5.0) -> bool: ...
+
+    def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class PromptContext:
+    """Engine-specific framing for the agent system prompt."""
+
+    engine_name: str  # e.g. "Trino" / "a Spark Thrift Server"
+    dialect: str  # human label of the SQL dialect, e.g. "Trino SQL"
+    namespace_line: str  # one sentence describing the default catalog/db
+    qualify_line: str  # how to qualify names outside the defaults
+
+
+@dataclass(frozen=True)
+class EngineInfo:
+    """Engine metadata surfaced by ``GET /v1/info`` and the UI connect panel."""
+
+    engine: str
+    catalog: str
+    schema: str
+    sql_url: str
+    web_ui_url: str | None
+
+
+class LakehouseConnector(ABC):
+    """One SQL engine's integration. Stateless -- one instance is registered
+    per engine and reused for the process lifetime."""
+
+    #: engine key; MUST equal one of ``GatewaySettings.engine``'s values.
+    name: str
+
+    @abstractmethod
+    def create_client(self, settings: GatewaySettings) -> LakehouseClient:
+        """Construct the engine client (execute/ping/close)."""
+
+    @abstractmethod
+    def register_tools(
+        self, registry: ToolRegistry, client: LakehouseClient, settings: GatewaySettings
+    ) -> None:
+        """Register query_lakehouse / list_tables / describe_table on ``registry``."""
+
+    @abstractmethod
+    def prompt_context(self, settings: GatewaySettings) -> PromptContext:
+        """Engine framing for the agent system prompt."""
+
+    @abstractmethod
+    def unreachable_detail(self, settings: GatewaySettings) -> str:
+        """Human message for ``/ready`` when the engine is not reachable."""
+
+    @abstractmethod
+    def engine_info(self, settings: GatewaySettings) -> EngineInfo:
+        """Metadata for ``GET /v1/info``."""
+
+    def readiness_detail(
+        self, settings: GatewaySettings, client: LakehouseClient, ok: bool
+    ) -> str:
+        """The ``/ready`` detail string. Default: ``reachable`` when ok, else
+        ``unreachable_detail`` enriched with the client's ``last_error`` if it
+        exposes one. Override for fully custom behavior."""
+        if ok:
+            return "reachable"
+        detail = self.unreachable_detail(settings)
+        last_error = getattr(client, "last_error", "")
+        return f"{detail} ({last_error})" if last_error else detail
+
+
+_REGISTRY: dict[str, LakehouseConnector] = {}
+
+
+def register_connector(cls: type[LakehouseConnector]) -> type[LakehouseConnector]:
+    """Class decorator: instantiate ``cls`` and register it under ``cls.name``."""
+    connector = cls()
+    if connector.name in _REGISTRY:
+        raise ValueError(f"connector {connector.name!r} is already registered")
+    _REGISTRY[connector.name] = connector
+    return cls
+
+
+def get_connector(name: str) -> LakehouseConnector:
+    try:
+        return _REGISTRY[name]
+    except KeyError:
+        raise ValueError(
+            f"unknown lakehouse engine {name!r}; registered engines: {connector_names()}"
+        ) from None
+
+
+def connector_names() -> list[str]:
+    return sorted(_REGISTRY)

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/connector.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/connector.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from hudi_agent_gateway.config import GatewaySettings
 from hudi_agent_gateway.tools.common import QueryResult
@@ -106,9 +106,29 @@ class LakehouseConnector(ABC):
 
     @abstractmethod
     def register_tools(
-        self, registry: ToolRegistry, client: LakehouseClient, settings: GatewaySettings
+        self,
+        registry: ToolRegistry,
+        client: LakehouseClient,
+        settings: GatewaySettings,
+        schema_cache: Any = None,
     ) -> None:
-        """Register query_lakehouse / list_tables / describe_table on ``registry``."""
+        """Register query_lakehouse / list_tables / describe_table on ``registry``.
+
+        ``schema_cache`` (a :class:`~hudi_agent_gateway.tools.schema_cache.
+        SchemaCache`, or None when schema hints are off) lets tools enrich
+        not-found errors with real names.
+        """
+
+    async def fetch_schema(
+        self, client: LakehouseClient, settings: GatewaySettings
+    ) -> dict[str, list[tuple[str, str]]]:
+        """The default namespace's schema: table -> [(column, type), ...].
+
+        Powers the schema cache behind ``GATEWAY_SCHEMA_HINTS``. The default
+        returns nothing, which simply disables schema hints for connectors
+        that do not implement it.
+        """
+        return {}
 
     @abstractmethod
     def prompt_context(self, settings: GatewaySettings) -> PromptContext:

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/guardrails.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/guardrails.py
@@ -16,9 +16,10 @@
 
 """SQL guardrails for model-written queries.
 
-AST-level (sqlglot, Trino dialect) rather than regex: read-only enforcement
-survives comments, CTEs, and string literals; the row cap is injected as a
-real ``LIMIT``. Fail-closed: anything that does not parse is rejected.
+AST-level (sqlglot, per-engine dialect) rather than regex: read-only
+enforcement survives comments, CTEs, and string literals; the row cap is
+injected as a real ``LIMIT``. Fail-closed: anything that does not parse is
+rejected.
 """
 
 from __future__ import annotations
@@ -43,30 +44,38 @@ _FORBIDDEN_NODES: tuple[type[exp.Expression], ...] = (
     exp.Use,
 )
 
-_HINT = "Provide exactly one read-only SELECT statement (Trino SQL)."
+_DIALECT_LABELS = {"trino": "Trino SQL", "spark": "Spark SQL"}
 
 
-def enforce_guardrails(sql: str, row_cap: int) -> str:
+def _hint(dialect: str) -> str:
+    label = _DIALECT_LABELS.get(dialect, f"{dialect} SQL")
+    return f"Provide exactly one read-only SELECT statement ({label})."
+
+
+def enforce_guardrails(sql: str, row_cap: int, dialect: str = "trino") -> str:
     """Validate ``sql`` as a single read-only SELECT and cap its LIMIT.
 
+    ``dialect`` is the sqlglot dialect the SQL is parsed and re-rendered in
+    (``trino`` for the Trino backend, ``spark`` for the Spark Thrift backend).
     Returns the (possibly rewritten) SQL to execute. Raises
     :class:`ToolInputError` on any violation.
     """
+    hint = _hint(dialect)
     try:
-        statements = sqlglot.parse(sql, read="trino")
+        statements = sqlglot.parse(sql, read=dialect)
     except sqlglot.errors.SqlglotError as e:
-        raise ToolInputError(f"could not parse SQL: {e}", hint=_HINT) from e
+        raise ToolInputError(f"could not parse SQL: {e}", hint=hint) from e
 
     statements = [s for s in statements if s is not None]
     if len(statements) != 1:
         raise ToolInputError(
-            f"exactly one statement is allowed, got {len(statements)}", hint=_HINT
+            f"exactly one statement is allowed, got {len(statements)}", hint=hint
         )
     stmt = statements[0]
 
     if not isinstance(stmt, (exp.Select, exp.SetOperation)):
         raise ToolInputError(
-            f"read-only: only SELECT is allowed, got {type(stmt).__name__}", hint=_HINT
+            f"read-only: only SELECT is allowed, got {type(stmt).__name__}", hint=hint
         )
 
     # Defense in depth: no write/DDL/command node anywhere in the tree
@@ -74,10 +83,10 @@ def enforce_guardrails(sql: str, row_cap: int) -> str:
     for node in stmt.walk():
         if isinstance(node, _FORBIDDEN_NODES):
             raise ToolInputError(
-                f"read-only: {type(node).__name__} is not allowed", hint=_HINT
+                f"read-only: {type(node).__name__} is not allowed", hint=hint
             )
 
-    return _cap_limit(stmt, row_cap).sql(dialect="trino")
+    return _cap_limit(stmt, row_cap).sql(dialect=dialect)
 
 
 def _cap_limit(stmt: exp.Query, row_cap: int) -> exp.Query:

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/schema_cache.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/schema_cache.py
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A TTL cache of the lakehouse schema, auto-derived from the engine.
+
+Feeds two model-facing surfaces (``GATEWAY_SCHEMA_HINTS``):
+
+- the system prompt: a compact snapshot of tables and columns, so small
+  models write SQL against real names instead of guessed ones;
+- error hints: when a query fails on an unknown column/table, the tool's
+  error payload carries the actual names ("did you mean `beds`?").
+
+Strictly fail-open: a refresh failure leaves the previous snapshot in place
+(or an empty one) and never breaks the query path -- schema hints degrade,
+queries keep working. Failures are cached for the same TTL so an unreachable
+engine is not hammered on every request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
+from hudi_agent_gateway.log import log_event
+
+logger = logging.getLogger("hudi_agent_gateway.tools.schema")
+
+#: table name -> ordered [(column name, data type), ...]
+Schema = dict[str, list[tuple[str, str]]]
+
+SchemaFetcher = Callable[[], Awaitable[Schema]]
+
+# Hudi meta columns are dropped from hints: they are never what a user
+# question is about, and steering the model toward them wastes attention.
+_META_COLUMN_PREFIX = "_hoodie_"
+
+
+class SchemaCache:
+    """Single-flight, TTL-cached schema snapshot over a fetch callable."""
+
+    def __init__(
+        self,
+        fetch: SchemaFetcher,
+        *,
+        ttl_seconds: float,
+        max_tables: int,
+        max_columns: int,
+    ) -> None:
+        self._fetch = fetch
+        self._ttl = ttl_seconds
+        self._max_tables = max_tables
+        self._max_columns = max_columns
+        self._data: Schema = {}
+        self._fetched_at: float | None = None
+        self._lock = asyncio.Lock()
+
+    def _is_stale(self) -> bool:
+        return self._fetched_at is None or time.monotonic() - self._fetched_at > self._ttl
+
+    async def get(self) -> Schema:
+        """The current schema, refreshing first if the snapshot is stale."""
+        if self._is_stale():
+            async with self._lock:
+                if self._is_stale():  # single-flight: recheck under the lock
+                    try:
+                        data = await self._fetch()
+                        self._data = {
+                            table: [
+                                (col, dtype)
+                                for col, dtype in columns
+                                if not col.startswith(_META_COLUMN_PREFIX)
+                            ]
+                            for table, columns in list(data.items())[: self._max_tables]
+                        }
+                        log_event(logger, "schema_cache_refreshed", tables=len(self._data))
+                    except Exception as e:
+                        # Fail-open: keep the previous snapshot; note the
+                        # failure so the TTL below also debounces retries.
+                        log_event(logger, "schema_cache_refresh_failed", error=str(e)[:200])
+                    self._fetched_at = time.monotonic()
+        return self._data
+
+    def peek(self) -> Schema:
+        """The current snapshot without waiting; kicks a background refresh
+        when stale. Used from sync contexts (the per-turn prompt builder)."""
+        if self._is_stale():
+            with contextlib.suppress(RuntimeError):  # no running loop -> skip
+                task = asyncio.get_running_loop().create_task(self.get())
+                # retrieve the (fail-open) result so the loop never warns
+                task.add_done_callback(lambda t: t.cancelled() or t.exception())
+        return self._data
+
+    def prompt_block(self) -> str:
+        """A compact schema snapshot for the system prompt; "" when unknown."""
+        schema = self.peek()
+        if not schema:
+            return ""
+        lines = []
+        for table, columns in list(schema.items())[: self._max_tables]:
+            shown = columns[: self._max_columns]
+            cols = ", ".join(f"{name} {dtype}" for name, dtype in shown)
+            more = f", ... +{len(columns) - len(shown)} more" if len(columns) > len(shown) else ""
+            lines.append(f"- {table}({cols}{more})")
+        if len(schema) > self._max_tables:
+            lines.append(f"- ... +{len(schema) - self._max_tables} more tables (list_tables)")
+        return (
+            "Current schema (auto-refreshed snapshot; use these exact table and "
+            "column names -- call describe_table only for tables not shown):\n"
+            + "\n".join(lines)
+        )

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/spark_client.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/spark_client.py
@@ -1,0 +1,352 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async wrapper over the Spark Thrift Server (HiveServer2 protocol) via PyHive.
+
+The Spark Thrift Server speaks the HiveServer2 Thrift protocol on port 10000,
+so any Spark cluster that can read Hudi tables (including MOR snapshots and
+the 1.x unstructured types) can serve the gateway without Trino. PyHive is an
+optional dependency: install the gateway with the ``spark`` extra
+(``pip install 'hudi-agent-gateway[spark]'``).
+
+Unlike Trino's stateless HTTP protocol, each HiveServer2 connection is a
+server-side session that is expensive to open (TCP + SASL + OpenSession).
+Connections are therefore pooled and reused across queries:
+
+- bounded LIFO pool (``GATEWAY_SPARK_MAX_CONNECTIONS``, shared with the query
+  worker pool) -- LIFO keeps hot connections hot so idle ones age out;
+- connections are recycled when they exceed the idle or lifetime limits, and
+  discarded (never reused) after a query timeout, since a cancelled session's
+  state is unknown;
+- a query that fails on a *reused* connection with a connection-level error
+  (server restarted, session expired, socket died) is retried exactly once on
+  a fresh connection -- SELECT-only traffic makes this safe;
+- ``close()`` drains the pool on gateway shutdown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import queue
+import re
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any
+
+from hudi_agent_gateway.config import GatewaySettings
+from hudi_agent_gateway.log import log_event
+from hudi_agent_gateway.tools.common import (
+    LakehouseQueryError,
+    LakehouseTimeoutError,
+    QueryResult,
+)
+
+logger = logging.getLogger("hudi_agent_gateway.tools.spark")
+
+class _PyHiveUnavailable(Exception):
+    """Never raised; stands in for pyhive.exc.Error when PyHive is absent so
+    the ``except _PyHiveError`` clause matches nothing instead of everything."""
+
+
+try:  # optional dependency; failure is reported through /ready and tool errors
+    from pyhive import hive as _pyhive
+    from pyhive.exc import Error as _PyHiveError
+
+    _IMPORT_ERROR: Exception | None = None
+except Exception as _e:  # pragma: no cover - depends on the environment
+    _pyhive = None
+    _PyHiveError = _PyHiveUnavailable
+    _IMPORT_ERROR = _e
+
+_MISSING_PYHIVE = (
+    "PyHive is not installed; the Spark Thrift backend requires it. "
+    "Install the gateway with the spark extra: pip install 'hudi-agent-gateway[spark]'"
+)
+
+# PyHive auth values for GATEWAY_SPARK_AUTH. "none" is HiveServer2's default
+# (SASL PLAIN with an arbitrary username), matching an out-of-the-box Spark
+# Thrift Server; "nosasl" matches hive.server2.authentication=NOSASL; "ldap"
+# sends username/password.
+_AUTH_MAP = {"none": "NONE", "nosasl": "NOSASL", "ldap": "LDAP"}
+
+# `tbl.col` where the leading segment is a plain identifier -- HiveServer2's
+# qualified result-column form. Only this exact shape gets its prefix removed.
+_QUALIFIED_COLUMN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\.")
+
+# Message fragments that identify a dead/expired connection (as opposed to a
+# bad query): thrift transport failures and HiveServer2 session expiry after
+# a server restart.
+_CONNECTION_ERROR_MARKERS = (
+    "tsocket read 0 bytes",
+    "ttransportexception",
+    "invalid sessionhandle",
+    "broken pipe",
+    "connection reset",
+    "connection refused",
+    "socket is closed",
+    "eof",
+)
+
+
+class SparkQueryError(LakehouseQueryError):
+    """A query failed on the Spark side; message is safe to surface to the model."""
+
+
+class SparkTimeoutError(SparkQueryError, LakehouseTimeoutError):
+    pass
+
+
+def _is_connection_error(e: Exception) -> bool:
+    if isinstance(e, (OSError, EOFError, ConnectionError)):
+        return True
+    message = str(e).lower()
+    return any(marker in message for marker in _CONNECTION_ERROR_MARKERS)
+
+
+@dataclass
+class _PoolEntry:
+    conn: Any
+    created_at: float = field(default_factory=time.monotonic)
+    last_used_at: float = field(default_factory=time.monotonic)
+
+
+class SparkThriftClient:
+    """Thin async facade over PyHive with a bounded connection pool: each query
+    runs the sync client in a worker thread under a hard timeout, fetches at
+    most ``max_rows`` from the cursor regardless of what the SQL says (defense
+    in depth behind the guardrails), and reuses HiveServer2 sessions across
+    queries. Mirrors :class:`~hudi_agent_gateway.tools.trino_client.TrinoClient`
+    at the surface.
+    """
+
+    def __init__(self, settings: GatewaySettings) -> None:
+        self._settings = settings
+        max_connections = settings.spark_max_connections
+        # Worker pool and connection pool share one bound: a query holds a
+        # worker for its whole runtime and a connection only while executing,
+        # so equal sizes mean the semaphore below is a leak guard, not a queue
+        # (queries queue in the executor, each already under its own timeout).
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_connections, thread_name_prefix="spark-query"
+        )
+        self._pool: queue.LifoQueue[_PoolEntry] = queue.LifoQueue()
+        self._slots = threading.BoundedSemaphore(max_connections)
+        self._closed = False
+        self._ping_cache: tuple[float, bool] | None = None
+        #: last connection/query failure, surfaced in /ready details
+        self.last_error: str = _MISSING_PYHIVE if _pyhive is None else ""
+
+    # ------------------------------------------------------------- pooling
+
+    def _new_connection(self) -> Any:
+        if _pyhive is None:
+            raise SparkQueryError(f"{_MISSING_PYHIVE} (import error: {_IMPORT_ERROR})")
+        s = self._settings
+        kwargs: dict[str, Any] = {
+            "host": s.spark_host,
+            "port": s.spark_port,
+            "username": s.spark_user,
+            "database": s.spark_database,
+            "auth": _AUTH_MAP[s.spark_auth],
+        }
+        if s.spark_auth == "ldap":
+            kwargs["password"] = s.spark_password
+        conn = _pyhive.connect(**kwargs)
+        log_event(logger, "spark_connection_opened", host=s.spark_host, port=s.spark_port)
+        return conn
+
+    def _close_entry(self, entry: _PoolEntry, reason: str) -> None:
+        with contextlib.suppress(Exception):
+            entry.conn.close()
+        log_event(logger, "spark_connection_closed", reason=reason)
+
+    def _acquire(self) -> tuple[_PoolEntry, bool]:
+        """Take a pooled connection (recycling stale ones) or open a new one.
+
+        Returns ``(entry, reused)``. The slot semaphore is a hard upper bound
+        on live connections; it is released by ``_release``/``_discard``.
+        """
+        if self._closed:
+            raise SparkQueryError("client is closed")
+        if not self._slots.acquire(timeout=self._settings.sql_timeout_seconds):
+            raise SparkQueryError(
+                "connection pool exhausted "
+                f"({self._settings.spark_max_connections} connections busy)"
+            )
+        try:
+            now = time.monotonic()
+            while True:
+                try:
+                    entry = self._pool.get_nowait()
+                except queue.Empty:
+                    break
+                if now - entry.created_at > self._settings.spark_pool_max_lifetime_seconds:
+                    self._close_entry(entry, "max_lifetime")
+                    continue
+                if now - entry.last_used_at > self._settings.spark_pool_max_idle_seconds:
+                    self._close_entry(entry, "max_idle")
+                    continue
+                return entry, True
+            return _PoolEntry(conn=self._new_connection()), False
+        except BaseException:
+            self._slots.release()
+            raise
+
+    def _release(self, entry: _PoolEntry) -> None:
+        entry.last_used_at = time.monotonic()
+        if self._closed:
+            self._close_entry(entry, "shutdown")
+        else:
+            self._pool.put(entry)
+        self._slots.release()
+
+    def _discard(self, entry: _PoolEntry, reason: str) -> None:
+        self._close_entry(entry, reason)
+        self._slots.release()
+
+    def close(self) -> None:
+        """Drain the pool and stop the worker pool; called on gateway shutdown."""
+        self._closed = True
+        while True:
+            try:
+                entry = self._pool.get_nowait()
+            except queue.Empty:
+                break
+            self._close_entry(entry, "shutdown")
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+    # ------------------------------------------------------------- queries
+
+    def _run_query(
+        self, conn: Any, sql: str, max_rows: int, holder: dict[str, Any]
+    ) -> QueryResult:
+        cursor = conn.cursor()
+        holder["cursor"] = cursor
+        try:
+            cursor.execute(sql)
+            rows = cursor.fetchmany(max_rows)
+            columns = [d[0] for d in cursor.description or []]
+            # HiveServer2 column names come back qualified (`tbl.col`); strip
+            # the prefix so results look like every other backend. Guarded by
+            # a strict identifier pattern so an alias that merely contains a
+            # dot is left untouched.
+            columns = [
+                _QUALIFIED_COLUMN_RE.sub("", c) for c in columns
+            ]
+            return QueryResult(columns=columns, rows=[list(r) for r in rows])
+        finally:
+            with contextlib.suppress(Exception):
+                cursor.close()
+
+    def _execute_sync(self, sql: str, max_rows: int, holder: dict[str, Any]) -> QueryResult:
+        retried = False
+        while True:
+            entry, reused = self._acquire()
+            try:
+                result = self._run_query(entry.conn, sql, max_rows, holder)
+            except Exception as e:
+                # A cancelled/timed-out or errored session is never reused.
+                self._discard(entry, "error")
+                # Only retry a pooled session that died underneath us (server
+                # restart, idle kill, socket drop); SELECT-only traffic makes
+                # one retry on a fresh connection safe. Never retry once the
+                # caller has abandoned (timed out): the outer wait_for is gone,
+                # so a retry here would run unbounded, pinning a worker+slot.
+                if (
+                    reused
+                    and not retried
+                    and not holder.get("abandoned")
+                    and _is_connection_error(e)
+                ):
+                    retried = True
+                    log_event(logger, "spark_stale_connection_retry", error=str(e)[:200])
+                    continue
+                raise
+            if holder.get("abandoned"):
+                # The caller already timed out and cancelled; session state is
+                # unknown, so drop the connection instead of pooling it.
+                self._discard(entry, "timeout")
+            else:
+                self._release(entry)
+            return result
+
+    async def execute(self, sql: str, *, timeout: float, max_rows: int) -> QueryResult:
+        if self._closed:
+            raise SparkQueryError("client is closed")
+        # `holder` hands the cursor back across the thread boundary so the
+        # timeout path can cancel the query server-side; wait_for alone only
+        # abandons the await while the worker thread stays blocked in Thrift.
+        holder: dict[str, Any] = {}
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(self._executor, self._execute_sync, sql, max_rows, holder)
+        try:
+            result = await asyncio.wait_for(future, timeout=timeout)
+            self.last_error = ""
+            return result
+        except TimeoutError as e:
+            holder["abandoned"] = True
+            cursor = holder.get("cursor")
+            if cursor is not None:
+                # best-effort server-side cancel; the timeout error wins
+                with contextlib.suppress(Exception):
+                    cursor.cancel()
+            self.last_error = f"query exceeded the {timeout:.0f}s timeout"
+            raise SparkTimeoutError(self.last_error) from e
+        except SparkQueryError as e:
+            self.last_error = str(e)
+            raise
+        except _PyHiveError as e:
+            self.last_error = _format_pyhive_error(e)
+            raise SparkQueryError(self.last_error) from e
+        except Exception as e:  # thrift transport errors do not subclass pyhive.exc.Error
+            self.last_error = str(e) or type(e).__name__
+            raise SparkQueryError(self.last_error) from e
+
+    async def ping(self, timeout: float = 5.0, cache_seconds: float = 10.0) -> bool:
+        """Cached reachability check feeding ``/ready``.
+
+        Cached so a 10s readinessProbe period does not run a query on the
+        Spark Thrift Server for every probe.
+        """
+        now = time.monotonic()
+        if self._ping_cache is not None and now - self._ping_cache[0] < cache_seconds:
+            return self._ping_cache[1]
+        try:
+            await self.execute("SELECT 1", timeout=timeout, max_rows=1)
+            ok = True
+        except Exception:
+            ok = False
+        self._ping_cache = (now, ok)
+        return ok
+
+
+def _format_pyhive_error(e: Exception) -> str:
+    """Extract the first meaningful line from a HiveServer2 error.
+
+    Spark Thrift errors arrive as a full ``org.apache.hive.service.cli.
+    HiveSQLException`` rendering with a Java stack trace; only the message
+    line helps the model self-correct.
+    """
+    message = str(e)
+    for marker in ("Error running query: ", "AnalysisException: "):
+        if marker in message:
+            message = message.split(marker, 1)[1]
+            break
+    return message.splitlines()[0][:500] if message else type(e).__name__

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/spark_tools.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/spark_tools.py
@@ -14,12 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Lakehouse tools backed by Trino.
+"""Lakehouse tools backed by a Spark Thrift Server.
 
-Handlers return JSON strings. Expected failures (guardrail rejections, query
-errors, timeouts) are returned as ``{"error": ..., "hint": ...}`` payloads
-rather than raised, so the agent can read the error and self-correct, and MCP
-clients get a useful result instead of a protocol error.
+Same tool surface and error contract as the Trino backend
+(:mod:`hudi_agent_gateway.tools.trino_tools`): handlers return JSON strings,
+and expected failures (guardrail rejections, query errors, timeouts) are
+returned as ``{"error": ..., "hint": ...}`` payloads rather than raised, so
+the agent can read the error and self-correct.
+
+Spark differences, kept behind the shared contract:
+
+- SQL is validated and rendered in the ``spark`` sqlglot dialect.
+- Spark has no ``information_schema``: ``list_tables`` uses ``SHOW TABLES IN``
+  and ``describe_table`` uses ``DESCRIBE TABLE``.
+- Identifiers are quoted with backticks.
 """
 
 from __future__ import annotations
@@ -29,12 +37,7 @@ from typing import Annotated
 from pydantic import Field
 
 from hudi_agent_gateway.config import GatewaySettings
-from hudi_agent_gateway.tools.common import (
-    error_payload,
-    shape_result,
-    split_table_name,
-    validate_identifier,
-)
+from hudi_agent_gateway.tools.common import error_payload, shape_result, validate_identifier
 from hudi_agent_gateway.tools.connector import (
     EngineInfo,
     LakehouseClient,
@@ -44,51 +47,68 @@ from hudi_agent_gateway.tools.connector import (
 )
 from hudi_agent_gateway.tools.guardrails import enforce_guardrails
 from hudi_agent_gateway.tools.registry import ToolInputError, ToolRegistry
-from hudi_agent_gateway.tools.trino_client import (
-    TrinoClient,
-    TrinoQueryError,
-    TrinoTimeoutError,
+from hudi_agent_gateway.tools.spark_client import (
+    SparkQueryError,
+    SparkThriftClient,
+    SparkTimeoutError,
 )
 
-__all__ = ["TrinoConnector", "register", "shape_result"]
+__all__ = ["SparkConnector", "register"]
 
 _QUERY_DESC = (
-    "Run a single read-only SELECT statement (Trino SQL) against the lakehouse "
+    "Run a single read-only SELECT statement (Spark SQL) against the lakehouse "
     "and return the result as JSON. A server-side row cap is enforced; results "
     "may be truncated (indicated by `truncated: true`)."
 )
 _LIST_TABLES_DESC = (
-    "List tables in the lakehouse. Optionally filter by catalog and schema; "
-    "defaults to the gateway's configured catalog and schema."
+    "List tables in the lakehouse. Optionally filter by database; "
+    "defaults to the gateway's configured database."
 )
 _DESCRIBE_DESC = (
-    "Describe a table's columns and types. Accepts `table`, `schema.table`, or "
-    "`catalog.schema.table`."
+    "Describe a table's columns and types. Accepts `table` or `database.table`."
+)
+
+# Spark 4.x error class and the Spark 3.x message form. Deliberately narrow:
+# a generic phrase like "cannot be found" could misclassify unrelated errors.
+_NOT_FOUND_MARKERS = (
+    "TABLE_OR_VIEW_NOT_FOUND",
+    "Table or view not found",
 )
 
 
-def register(registry: ToolRegistry, client: TrinoClient, settings: GatewaySettings) -> None:
+def _split_table_name(table: str, settings: GatewaySettings) -> tuple[str, str]:
+    parts = table.split(".")
+    if len(parts) == 1:
+        return settings.spark_database, parts[0]
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    raise ToolInputError(
+        f"invalid table name {table!r}", hint="Use table or database.table."
+    )
+
+
+def register(registry: ToolRegistry, client: SparkThriftClient, settings: GatewaySettings) -> None:
     @registry.register("query_lakehouse", _QUERY_DESC)
     async def query_lakehouse(
         sql: Annotated[
-            str, Field(description="A single read-only SELECT statement in Trino SQL.")
+            str, Field(description="A single read-only SELECT statement in Spark SQL.")
         ],
     ) -> str:
         try:
-            safe_sql = enforce_guardrails(sql, row_cap=settings.sql_row_cap)
+            safe_sql = enforce_guardrails(sql, row_cap=settings.sql_row_cap, dialect="spark")
             result = await client.execute(
                 safe_sql, timeout=settings.sql_timeout_seconds, max_rows=settings.sql_row_cap
             )
         except ToolInputError as e:
             return error_payload(str(e), e.hint)
-        except TrinoTimeoutError as e:
+        except SparkTimeoutError as e:
             return error_payload(
                 f"query failed: {e}",
                 f"The query hit the gateway's {settings.sql_timeout_seconds:.0f}s limit -- "
                 "narrow it (partition filter, pre-aggregate, fewer columns) or raise "
                 "GATEWAY_SQL_TIMEOUT_SECONDS.",
             )
-        except TrinoQueryError as e:
+        except SparkQueryError as e:
             return error_payload(f"query failed: {e}", "Fix the SQL and try again.")
         return shape_result(
             result,
@@ -99,27 +119,20 @@ def register(registry: ToolRegistry, client: TrinoClient, settings: GatewaySetti
 
     @registry.register("list_tables", _LIST_TABLES_DESC)
     async def list_tables(
-        catalog: Annotated[
-            str, Field(description="Catalog to list from; empty for the default.")
-        ] = "",
-        schema_name: Annotated[
-            str, Field(description="Schema to list from; empty for the default.")
+        database: Annotated[
+            str, Field(description="Database to list from; empty for the default.")
         ] = "",
     ) -> str:
         try:
-            cat = validate_identifier(catalog or settings.trino_catalog, "catalog")
-            sch = validate_identifier(schema_name or settings.trino_schema, "schema")
+            db = validate_identifier(database or settings.spark_database, "database")
         except ToolInputError as e:
             return error_payload(str(e), e.hint)
-        sql = (
-            f'SELECT table_schema, table_name, table_type FROM "{cat}".information_schema.tables '
-            f"WHERE table_schema = '{sch}' ORDER BY table_name"
-        )
+        sql = f"SHOW TABLES IN `{db}`"
         try:
             result = await client.execute(
                 sql, timeout=settings.sql_timeout_seconds, max_rows=settings.sql_row_cap
             )
-        except TrinoQueryError as e:
+        except SparkQueryError as e:
             return error_payload(f"listing tables failed: {e}")
         return shape_result(
             result, max_bytes=settings.tool_result_max_bytes, sql=sql, row_cap=settings.sql_row_cap
@@ -128,30 +141,30 @@ def register(registry: ToolRegistry, client: TrinoClient, settings: GatewaySetti
     @registry.register("describe_table", _DESCRIBE_DESC)
     async def describe_table(
         table: Annotated[
-            str, Field(description="Table name: table, schema.table, or catalog.schema.table.")
+            str, Field(description="Table name: table or database.table.")
         ],
     ) -> str:
         try:
-            cat, sch, tbl = split_table_name(table, settings.trino_catalog, settings.trino_schema)
-            validate_identifier(cat, "catalog")
-            validate_identifier(sch, "schema")
+            db, tbl = _split_table_name(table, settings)
+            validate_identifier(db, "database")
             validate_identifier(tbl, "table")
         except ToolInputError as e:
             return error_payload(str(e), e.hint)
-        sql = (
-            "SELECT column_name, data_type, is_nullable "
-            f'FROM "{cat}".information_schema.columns '
-            f"WHERE table_schema = '{sch}' AND table_name = '{tbl}' ORDER BY ordinal_position"
-        )
+        sql = f"DESCRIBE TABLE `{db}`.`{tbl}`"
         try:
             result = await client.execute(
                 sql, timeout=settings.sql_timeout_seconds, max_rows=settings.sql_row_cap
             )
-        except TrinoQueryError as e:
+        except SparkQueryError as e:
+            if any(marker.lower() in str(e).lower() for marker in _NOT_FOUND_MARKERS):
+                return error_payload(
+                    f"table {db}.{tbl} not found",
+                    "Call list_tables to see available tables.",
+                )
             return error_payload(f"describe failed: {e}")
         if result.row_count == 0:
             return error_payload(
-                f"table {cat}.{sch}.{tbl} not found",
+                f"table {db}.{tbl} not found",
                 "Call list_tables to see available tables.",
             )
         return shape_result(
@@ -160,13 +173,15 @@ def register(registry: ToolRegistry, client: TrinoClient, settings: GatewaySetti
 
 
 @register_connector
-class TrinoConnector(LakehouseConnector):
-    """Trino coordinator with the Hudi connector (the default engine)."""
+class SparkConnector(LakehouseConnector):
+    """Spark SQL over the HiveServer2 Thrift protocol (a Spark Thrift Server,
+    or Apache Kyuubi -- same wire protocol). Reads MOR snapshots and the Hudi
+    1.x unstructured types (BLOB/VECTOR/VARIANT) that Trino cannot serve."""
 
-    name = "trino"
+    name = "spark"
 
-    def create_client(self, settings: GatewaySettings) -> TrinoClient:
-        return TrinoClient(settings)
+    def create_client(self, settings: GatewaySettings) -> SparkThriftClient:
+        return SparkThriftClient(settings)
 
     def register_tools(
         self, registry: ToolRegistry, client: LakehouseClient, settings: GatewaySettings
@@ -175,27 +190,27 @@ class TrinoConnector(LakehouseConnector):
 
     def prompt_context(self, settings: GatewaySettings) -> PromptContext:
         return PromptContext(
-            engine_name="Trino",
-            dialect="Trino SQL",
+            engine_name="a Spark Thrift Server",
+            dialect="Spark SQL",
             namespace_line=(
-                f"The default catalog is `{settings.trino_catalog}` and the default schema "
-                f"is `{settings.trino_schema}`; tables are Hudi tables registered in the "
-                "catalog's metastore."
+                f"The default database is `{settings.spark_database}`; tables are Hudi "
+                "tables registered in the server's metastore."
             ),
             qualify_line=(
-                "Qualify names as catalog.schema.table when querying outside the defaults."
+                "Qualify names as database.table when querying outside the default database."
             ),
         )
 
     def unreachable_detail(self, settings: GatewaySettings) -> str:
-        return f"cannot reach trino at {settings.trino_host}:{settings.trino_port}"
+        return f"cannot reach spark thrift server at {settings.spark_host}:{settings.spark_port}"
 
     def engine_info(self, settings: GatewaySettings) -> EngineInfo:
-        base = f"http://{settings.trino_host}:{settings.trino_port}"
         return EngineInfo(
-            engine="trino",
-            catalog=settings.trino_catalog,
-            schema=settings.trino_schema,
-            sql_url=base,
-            web_ui_url=f"{base}/ui/",
+            engine="spark",
+            catalog="spark_catalog",
+            schema=settings.spark_database,
+            sql_url=(
+                f"jdbc:hive2://{settings.spark_host}:{settings.spark_port}/{settings.spark_database}"
+            ),
+            web_ui_url=None,
         )

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/spark_tools.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/spark_tools.py
@@ -32,12 +32,17 @@ Spark differences, kept behind the shared contract:
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import Field
 
 from hudi_agent_gateway.config import GatewaySettings
-from hudi_agent_gateway.tools.common import error_payload, shape_result, validate_identifier
+from hudi_agent_gateway.tools.common import (
+    error_payload,
+    schema_error_hint,
+    shape_result,
+    validate_identifier,
+)
 from hudi_agent_gateway.tools.connector import (
     EngineInfo,
     LakehouseClient,
@@ -87,7 +92,18 @@ def _split_table_name(table: str, settings: GatewaySettings) -> tuple[str, str]:
     )
 
 
-def register(registry: ToolRegistry, client: SparkThriftClient, settings: GatewaySettings) -> None:
+def register(
+    registry: ToolRegistry,
+    client: SparkThriftClient,
+    settings: GatewaySettings,
+    schema_cache: Any = None,
+) -> None:
+    async def _not_found_hint(message: str) -> str:
+        """Schema-aware hint for name errors (GATEWAY_SCHEMA_HINTS=errors|both)."""
+        if schema_cache is None or settings.schema_hints not in ("errors", "both"):
+            return ""
+        return schema_error_hint(message, await schema_cache.get())
+
     @registry.register("query_lakehouse", _QUERY_DESC)
     async def query_lakehouse(
         sql: Annotated[
@@ -109,7 +125,8 @@ def register(registry: ToolRegistry, client: SparkThriftClient, settings: Gatewa
                 "GATEWAY_SQL_TIMEOUT_SECONDS.",
             )
         except SparkQueryError as e:
-            return error_payload(f"query failed: {e}", "Fix the SQL and try again.")
+            hint = await _not_found_hint(str(e))
+            return error_payload(f"query failed: {e}", hint or "Fix the SQL and try again.")
         return shape_result(
             result,
             max_bytes=settings.tool_result_max_bytes,
@@ -184,9 +201,41 @@ class SparkConnector(LakehouseConnector):
         return SparkThriftClient(settings)
 
     def register_tools(
-        self, registry: ToolRegistry, client: LakehouseClient, settings: GatewaySettings
+        self,
+        registry: ToolRegistry,
+        client: LakehouseClient,
+        settings: GatewaySettings,
+        schema_cache: Any = None,
     ) -> None:
-        register(registry, client, settings)  # type: ignore[arg-type]
+        register(registry, client, settings, schema_cache)  # type: ignore[arg-type]
+
+    async def fetch_schema(
+        self, client: LakehouseClient, settings: GatewaySettings
+    ) -> dict[str, list[tuple[str, str]]]:
+        """SHOW TABLES then one DESCRIBE per table (Spark has no
+        information_schema), bounded by the configured schema caps."""
+        db = settings.spark_database
+        tables = await client.execute(
+            f"SHOW TABLES IN `{db}`",
+            timeout=settings.sql_timeout_seconds,
+            max_rows=settings.schema_max_tables,
+        )
+        schema: dict[str, list[tuple[str, str]]] = {}
+        for row in tables.rows:
+            name = row[1]  # (namespace, tableName, isTemporary)
+            described = await client.execute(
+                f"DESCRIBE TABLE `{db}`.`{name}`",
+                timeout=settings.sql_timeout_seconds,
+                max_rows=settings.schema_max_columns + 10,
+            )
+            columns: list[tuple[str, str]] = []
+            for col_name, col_type, *_ in described.rows:
+                col_name = (col_name or "").strip()
+                if not col_name or col_name.startswith("#"):
+                    break  # blank line / "# Partition Information" section
+                columns.append((col_name, col_type))
+            schema[name] = columns[: settings.schema_max_columns]
+        return schema
 
     def prompt_context(self, settings: GatewaySettings) -> PromptContext:
         return PromptContext(

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/trino_client.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/trino_client.py
@@ -22,30 +22,26 @@ import asyncio
 import contextlib
 import time
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
 from typing import Any
 
 import trino
 
 from hudi_agent_gateway.config import GatewaySettings
+from hudi_agent_gateway.tools.common import (
+    LakehouseQueryError,
+    LakehouseTimeoutError,
+    QueryResult,
+)
+
+__all__ = ["QueryResult", "TrinoClient", "TrinoQueryError", "TrinoTimeoutError"]
 
 
-class TrinoQueryError(Exception):
+class TrinoQueryError(LakehouseQueryError):
     """A query failed on the Trino side; message is safe to surface to the model."""
 
 
-class TrinoTimeoutError(TrinoQueryError):
+class TrinoTimeoutError(TrinoQueryError, LakehouseTimeoutError):
     pass
-
-
-@dataclass
-class QueryResult:
-    columns: list[str]
-    rows: list[list[Any]]
-    row_count: int = field(init=False)
-
-    def __post_init__(self) -> None:
-        self.row_count = len(self.rows)
 
 
 class TrinoClient:
@@ -104,6 +100,11 @@ class TrinoClient:
             raise TrinoQueryError(f"{e.error_name}: {e.message}") from e
         except trino.exceptions.Error as e:
             raise TrinoQueryError(str(e)) from e
+
+    def close(self) -> None:
+        """Stop the worker pool; called on gateway shutdown. Trino's HTTP
+        protocol is stateless, so there are no connections to drain."""
+        self._executor.shutdown(wait=False, cancel_futures=True)
 
     async def ping(self, timeout: float = 5.0, cache_seconds: float = 10.0) -> bool:
         """Cached reachability check feeding ``/ready``.

--- a/hudi-agent-gateway/src/hudi_agent_gateway/tools/trino_tools.py
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/tools/trino_tools.py
@@ -24,13 +24,14 @@ clients get a useful result instead of a protocol error.
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import Field
 
 from hudi_agent_gateway.config import GatewaySettings
 from hudi_agent_gateway.tools.common import (
     error_payload,
+    schema_error_hint,
     shape_result,
     split_table_name,
     validate_identifier,
@@ -67,7 +68,18 @@ _DESCRIBE_DESC = (
 )
 
 
-def register(registry: ToolRegistry, client: TrinoClient, settings: GatewaySettings) -> None:
+def register(
+    registry: ToolRegistry,
+    client: TrinoClient,
+    settings: GatewaySettings,
+    schema_cache: Any = None,
+) -> None:
+    async def _not_found_hint(message: str) -> str:
+        """Schema-aware hint for name errors (GATEWAY_SCHEMA_HINTS=errors|both)."""
+        if schema_cache is None or settings.schema_hints not in ("errors", "both"):
+            return ""
+        return schema_error_hint(message, await schema_cache.get())
+
     @registry.register("query_lakehouse", _QUERY_DESC)
     async def query_lakehouse(
         sql: Annotated[
@@ -89,7 +101,8 @@ def register(registry: ToolRegistry, client: TrinoClient, settings: GatewaySetti
                 "GATEWAY_SQL_TIMEOUT_SECONDS.",
             )
         except TrinoQueryError as e:
-            return error_payload(f"query failed: {e}", "Fix the SQL and try again.")
+            hint = await _not_found_hint(str(e))
+            return error_payload(f"query failed: {e}", hint or "Fix the SQL and try again.")
         return shape_result(
             result,
             max_bytes=settings.tool_result_max_bytes,
@@ -169,9 +182,32 @@ class TrinoConnector(LakehouseConnector):
         return TrinoClient(settings)
 
     def register_tools(
-        self, registry: ToolRegistry, client: LakehouseClient, settings: GatewaySettings
+        self,
+        registry: ToolRegistry,
+        client: LakehouseClient,
+        settings: GatewaySettings,
+        schema_cache: Any = None,
     ) -> None:
-        register(registry, client, settings)  # type: ignore[arg-type]
+        register(registry, client, settings, schema_cache)  # type: ignore[arg-type]
+
+    async def fetch_schema(
+        self, client: LakehouseClient, settings: GatewaySettings
+    ) -> dict[str, list[tuple[str, str]]]:
+        """One information_schema query covering every table in the schema."""
+        sql = (
+            "SELECT table_name, column_name, data_type "
+            f'FROM "{settings.trino_catalog}".information_schema.columns '
+            f"WHERE table_schema = '{settings.trino_schema}' "
+            "ORDER BY table_name, ordinal_position"
+        )
+        max_rows = settings.schema_max_tables * settings.schema_max_columns
+        result = await client.execute(
+            sql, timeout=settings.sql_timeout_seconds, max_rows=max_rows
+        )
+        schema: dict[str, list[tuple[str, str]]] = {}
+        for table, column, dtype in result.rows:
+            schema.setdefault(table, []).append((column, dtype))
+        return schema
 
     def prompt_context(self, settings: GatewaySettings) -> PromptContext:
         return PromptContext(

--- a/hudi-agent-gateway/src/hudi_agent_gateway/ui/app.js
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/ui/app.js
@@ -47,12 +47,20 @@
   }
 
   fetch("../v1/info").then(function (r) { return r.json(); }).then(function (info) {
-    modelInfoEl.textContent = info.provider + " · catalog " + info.catalog;
+    modelInfoEl.textContent = info.provider + " · " +
+      (info.engine === "spark" ? "database " + info.schema : "catalog " + info.catalog);
     var base = window.location.origin;
-    document.getElementById("ep-trino").textContent = info.trino_url;
-    var trinoUi = document.getElementById("ep-trino-ui");
-    trinoUi.textContent = info.trino_ui_url;
-    trinoUi.href = info.trino_ui_url;
+    document.getElementById("ep-sql-label").textContent =
+      info.engine === "spark" ? "Spark SQL (JDBC)" : "Trino SQL";
+    document.getElementById("ep-sql").textContent = info.sql_url;
+    var webUiRow = document.getElementById("ep-web-ui-row");
+    if (info.web_ui_url) {
+      var webUi = document.getElementById("ep-web-ui");
+      webUi.textContent = info.web_ui_url;
+      webUi.href = info.web_ui_url;
+    } else {
+      webUiRow.hidden = true;
+    }
     document.getElementById("ep-chat").textContent = base + "/v1/chat";
     document.getElementById("ep-mcp").textContent = base + "/mcp/";
     document.getElementById("ep-mcp-hint").textContent =

--- a/hudi-agent-gateway/src/hudi_agent_gateway/ui/index.html
+++ b/hudi-agent-gateway/src/hudi_agent_gateway/ui/index.html
@@ -42,19 +42,19 @@ limitations under the License.
   <section id="connect-panel" hidden>
     <div class="endpoint">
       <div>
-        <strong>Trino SQL</strong>
+        <strong id="ep-sql-label">SQL endpoint</strong>
         <small>point any SQL client / BI tool at the lakehouse directly</small>
       </div>
-      <code id="ep-trino">&hellip;</code>
-      <button class="copy" data-copy="ep-trino" title="Copy">&#x2398;</button>
+      <code id="ep-sql">&hellip;</code>
+      <button class="copy" data-copy="ep-sql" title="Copy">&#x2398;</button>
     </div>
-    <div class="endpoint">
+    <div class="endpoint" id="ep-web-ui-row">
       <div>
-        <strong>Trino Web UI</strong>
+        <strong>Engine Web UI</strong>
         <small>query monitoring &amp; cluster overview</small>
       </div>
-      <code><a id="ep-trino-ui" href="#" target="_blank" rel="noopener">&hellip;</a></code>
-      <button class="copy" data-copy="ep-trino-ui" title="Copy">&#x2398;</button>
+      <code><a id="ep-web-ui" href="#" target="_blank" rel="noopener">&hellip;</a></code>
+      <button class="copy" data-copy="ep-web-ui" title="Copy">&#x2398;</button>
     </div>
     <div class="endpoint">
       <div>
@@ -72,8 +72,9 @@ limitations under the License.
       <code id="ep-mcp">&hellip;</code>
       <button class="copy" data-copy="ep-mcp" title="Copy">&#x2398;</button>
     </div>
-    <p class="endpoint-note">Trino is addressed by its in-cluster service name; from outside the
-    cluster, port-forward or expose the service. The inference and MCP URLs are this gateway.</p>
+    <p class="endpoint-note">The SQL engine is addressed by its in-cluster service name; from
+    outside the cluster, port-forward or expose the service. The inference and MCP URLs are this
+    gateway.</p>
   </section>
 
   <main id="messages" aria-live="polite">

--- a/hudi-agent-gateway/tests/conftest.py
+++ b/hudi-agent-gateway/tests/conftest.py
@@ -30,6 +30,7 @@ from langchain_core.messages import AIMessage
 
 from hudi_agent_gateway.config import GatewaySettings
 from hudi_agent_gateway.tools import build_registry
+from hudi_agent_gateway.tools.spark_client import SparkQueryError
 from hudi_agent_gateway.tools.trino_client import QueryResult, TrinoQueryError
 
 
@@ -77,7 +78,57 @@ def fake_trino() -> FakeTrinoClient:
 
 @pytest.fixture()
 def registry(settings: GatewaySettings, fake_trino: FakeTrinoClient):
-    return build_registry(settings, trino_client=fake_trino)  # type: ignore[arg-type]
+    return build_registry(settings, client=fake_trino)  # type: ignore[arg-type]
+
+
+@pytest.fixture()
+def spark_settings(monkeypatch: pytest.MonkeyPatch) -> GatewaySettings:
+    # Isolate from the developer's environment.
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    return GatewaySettings(
+        engine="spark",
+        llm_provider="ollama",
+        spark_host="fake-spark",
+        sql_row_cap=100,
+        tool_result_max_bytes=2000,
+    )
+
+
+class FakeSparkClient:
+    """Records executed SQL; replays canned results or errors (Spark flavor)."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self.result = QueryResult(
+            columns=["city", "trips"],
+            rows=[["chennai", 33], ["san_francisco", 34], ["sao_paulo", 33]],
+        )
+        self.error: Exception | None = None
+        self.last_error: str = ""
+
+    async def execute(self, sql: str, *, timeout: float, max_rows: int) -> QueryResult:
+        self.executed.append(sql)
+        if self.error is not None:
+            self.last_error = str(self.error)
+            raise self.error
+        return self.result
+
+    async def ping(self, timeout: float = 5.0) -> bool:
+        return self.error is None
+
+    def fail_with(self, message: str) -> None:
+        self.error = SparkQueryError(message)
+
+
+@pytest.fixture()
+def fake_spark() -> FakeSparkClient:
+    return FakeSparkClient()
+
+
+@pytest.fixture()
+def spark_registry(spark_settings: GatewaySettings, fake_spark: FakeSparkClient):
+    return build_registry(spark_settings, client=fake_spark)  # type: ignore[arg-type]
 
 
 class ScriptedChatModel(GenericFakeChatModel):

--- a/hudi-agent-gateway/tests/integration/test_live_spark.py
+++ b/hudi-agent-gateway/tests/integration/test_live_spark.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live Spark Thrift Server integration tests, skipped unless the environment
+provides:
+
+- ``GATEWAY_IT_SPARK_HOST`` (e.g. ``localhost`` with a Spark Thrift Server on
+  port 10000 serving a Hudi ``trips`` table like the local-dev example writes)
+  -- enables the tool tests;
+- ``GATEWAY_IT_SPARK_PORT`` to override the port (default 10000).
+
+Requires the ``spark`` extra: ``pip install 'hudi-agent-gateway[spark]'``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from hudi_agent_gateway.config import GatewaySettings
+from hudi_agent_gateway.tools import build_registry
+
+SPARK_HOST = os.environ.get("GATEWAY_IT_SPARK_HOST", "")
+
+pytestmark = pytest.mark.skipif(
+    not SPARK_HOST, reason="set GATEWAY_IT_SPARK_HOST to run live Spark Thrift tests"
+)
+
+
+@pytest.fixture()
+def live_settings() -> GatewaySettings:
+    return GatewaySettings(
+        engine="spark",
+        spark_host=SPARK_HOST,
+        spark_port=int(os.environ.get("GATEWAY_IT_SPARK_PORT", "10000")),
+    )
+
+
+@pytest.fixture()
+def live_registry(live_settings: GatewaySettings):
+    return build_registry(live_settings)
+
+
+async def test_list_tables_live(live_registry) -> None:
+    out = json.loads(await live_registry.get("list_tables").handler())
+    # SHOW TABLES IN returns (namespace, tableName, isTemporary)
+    tables = [row[1] for row in out["rows"]]
+    assert "trips" in tables
+
+
+async def test_describe_table_live(live_registry) -> None:
+    out = json.loads(await live_registry.get("describe_table").handler(table="trips"))
+    columns = [row[0] for row in out["rows"]]
+    assert {"trip_id", "city", "fare"} <= set(columns)
+
+
+async def test_query_lakehouse_live(live_registry) -> None:
+    out = json.loads(
+        await live_registry.get("query_lakehouse").handler(
+            sql="SELECT city, count(*) AS trips FROM trips GROUP BY city ORDER BY city"
+        )
+    )
+    assert out["row_count"] == 3
+    assert sum(row[1] for row in out["rows"]) == 100
+
+
+async def test_guardrails_reject_write_live(live_registry) -> None:
+    out = json.loads(
+        await live_registry.get("query_lakehouse").handler(sql="DROP TABLE trips")
+    )
+    assert "read-only" in out["error"]

--- a/hudi-agent-gateway/tests/test_api_meta.py
+++ b/hudi-agent-gateway/tests/test_api_meta.py
@@ -29,7 +29,7 @@ async def client(settings, fake_trino, monkeypatch):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as c, app.router.lifespan_context(app):
-        app.state.trino_client = fake_trino
+        app.state.lakehouse_client = fake_trino
         yield c, app
 
 
@@ -42,7 +42,7 @@ async def test_health(client) -> None:
 
 async def test_ready_reports_dependency_failures(client) -> None:
     c, app = client
-    app.state.trino_client.fail_with("connection refused")
+    app.state.lakehouse_client.fail_with("connection refused")
 
     class NotReady:
         async def check(self):
@@ -88,6 +88,74 @@ async def test_info(client) -> None:
     assert body["provider"] == "ollama"
     assert body["catalog"] == "hudi"
     assert body["schema"] == "default"
-    assert body["trino_url"] == "http://fake-trino:8080"
-    assert body["trino_ui_url"] == "http://fake-trino:8080/ui/"
+    assert body["engine"] == "trino"
+    assert body["sql_url"] == "http://fake-trino:8080"
+    assert body["web_ui_url"] == "http://fake-trino:8080/ui/"
     assert body["mcp_enabled"] is False  # fixture disables MCP
+
+
+@pytest.fixture()
+async def spark_client_app(spark_settings, fake_spark):
+    import httpx
+
+    app = create_app(spark_settings.model_copy(update={"mcp_enabled": False}))
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c, app.router.lifespan_context(app):
+        app.state.lakehouse_client = fake_spark
+        yield c, app
+
+
+async def test_ready_reports_spark_check(spark_client_app) -> None:
+    c, app = spark_client_app
+
+    class Ready:
+        async def check(self):
+            return True, "reachable"
+
+    app.state.llm_readiness = Ready()
+    resp = await c.get("/ready")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ready"] is True
+    assert body["checks"]["spark"]["ok"] is True
+    assert "trino" not in body["checks"]
+
+
+async def test_ready_spark_failure_carries_last_error(spark_client_app) -> None:
+    c, app = spark_client_app
+    app.state.lakehouse_client.fail_with("TTransportException: Could not connect")
+
+    class Ready:
+        async def check(self):
+            return True, "reachable"
+
+    app.state.llm_readiness = Ready()
+    # prime last_error the way a real failed ping would
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        await app.state.lakehouse_client.execute("SELECT 1", timeout=1, max_rows=1)
+    resp = await c.get("/ready")
+    body = resp.json()
+    assert resp.status_code == 503
+    assert body["checks"]["spark"]["ok"] is False
+    assert "spark thrift server" in body["checks"]["spark"]["detail"]
+    assert "Could not connect" in body["checks"]["spark"]["detail"]
+
+
+async def test_info_spark_engine(spark_client_app) -> None:
+    c, _ = spark_client_app
+    resp = await c.get("/v1/info")
+    body = resp.json()
+    assert body["engine"] == "spark"
+    assert body["schema"] == "default"
+    assert body["sql_url"].startswith("jdbc:hive2://fake-spark:10000")
+    assert body["web_ui_url"] is None
+
+
+async def test_tools_listing_spark(spark_client_app) -> None:
+    c, _ = spark_client_app
+    resp = await c.get("/v1/tools")
+    tools = resp.json()["tools"]
+    assert {t["name"] for t in tools} == {"query_lakehouse", "list_tables", "describe_table"}

--- a/hudi-agent-gateway/tests/test_chat_sse.py
+++ b/hudi-agent-gateway/tests/test_chat_sse.py
@@ -35,7 +35,7 @@ async def client(settings, registry, fake_trino):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as c, app.router.lifespan_context(app):
-        app.state.trino_client = fake_trino
+        app.state.lakehouse_client = fake_trino
         app.state.registry = registry
         app.state.agents = FixedAgents(
             build_agent(

--- a/hudi-agent-gateway/tests/test_config.py
+++ b/hudi-agent-gateway/tests/test_config.py
@@ -74,3 +74,48 @@ def test_prefixed_api_key_alias(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GATEWAY_OPENAI_API_KEY", "sk-test2")
     s = GatewaySettings(llm_provider="openai")
     assert s.openai_api_key == "sk-test2"
+
+
+def test_engine_defaults_to_trino() -> None:
+    assert GatewaySettings().engine == "trino"
+
+
+def test_spark_engine_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GATEWAY_ENGINE", "spark")
+    monkeypatch.setenv("GATEWAY_SPARK_HOST", "sts.example")
+    monkeypatch.setenv("GATEWAY_SPARK_PORT", "10001")
+    monkeypatch.setenv("GATEWAY_SPARK_DATABASE", "lake")
+    s = GatewaySettings()
+    assert s.engine == "spark"
+    assert s.spark_host == "sts.example"
+    assert s.spark_port == 10001
+    assert s.spark_database == "lake"
+    assert s.spark_auth == "none"  # HiveServer2 default
+
+
+def test_spark_defaults() -> None:
+    s = GatewaySettings(engine="spark")
+    assert s.spark_host == "localhost"
+    assert s.spark_port == 10000
+    assert s.spark_database == "default"
+    assert s.spark_user == "hudi-agent-gateway"
+
+
+def test_invalid_engine_rejected() -> None:
+    with pytest.raises(ValidationError):
+        GatewaySettings(engine="duckdb")  # type: ignore[arg-type]
+
+
+def test_spark_ldap_requires_password() -> None:
+    with pytest.raises(ValidationError, match="GATEWAY_SPARK_PASSWORD"):
+        GatewaySettings(engine="spark", spark_auth="ldap")
+
+
+def test_spark_ldap_with_password_ok() -> None:
+    s = GatewaySettings(engine="spark", spark_auth="ldap", spark_password="secret")
+    assert s.spark_auth == "ldap"
+
+
+def test_invalid_spark_auth_rejected() -> None:
+    with pytest.raises(ValidationError):
+        GatewaySettings(engine="spark", spark_auth="kerberos")  # type: ignore[arg-type]

--- a/hudi-agent-gateway/tests/test_connector.py
+++ b/hudi-agent-gateway/tests/test_connector.py
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The connector abstraction: registry wiring and the extensibility contract."""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from hudi_agent_gateway.config import GatewaySettings, LakehouseEngine
+from hudi_agent_gateway.tools import connector_names, get_connector
+from hudi_agent_gateway.tools.common import QueryResult
+from hudi_agent_gateway.tools.connector import (
+    _REGISTRY,
+    EngineInfo,
+    LakehouseClient,
+    LakehouseConnector,
+    PromptContext,
+    register_connector,
+)
+from hudi_agent_gateway.tools.connector import (
+    connector_names as reg_names,
+)
+from hudi_agent_gateway.tools.connector import (
+    get_connector as reg_get,
+)
+
+
+def test_builtin_connectors_registered() -> None:
+    assert set(connector_names()) >= {"trino", "spark"}
+
+
+def test_every_configured_engine_has_a_connector() -> None:
+    """The GATEWAY_ENGINE Literal and the connector registry must not drift."""
+    engines = set(typing.get_args(LakehouseEngine))
+    assert engines == {"trino", "spark"}
+    for engine in engines:
+        assert get_connector(engine).name == engine
+
+
+def test_unknown_engine_raises_with_registered_list() -> None:
+    with pytest.raises(ValueError, match="unknown lakehouse engine 'duckdb'"):
+        get_connector("duckdb")
+
+
+def test_default_engine_resolves_to_trino() -> None:
+    settings = GatewaySettings()
+    assert get_connector(settings.engine).name == "trino"
+
+
+def test_trino_and_spark_expose_the_same_tool_surface(registry, spark_registry) -> None:
+    trino_tools = {t["name"] for t in registry.listing()}
+    spark_tools = {t["name"] for t in spark_registry.listing()}
+    assert trino_tools == spark_tools == {"query_lakehouse", "list_tables", "describe_table"}
+
+
+def test_readiness_detail_default_reachable_and_enriched() -> None:
+    spark = get_connector("spark")
+
+    class _Client:
+        last_error = "TTransportException: Could not connect"
+
+    s = GatewaySettings(engine="spark", spark_host="sts", spark_port=10009)
+    assert spark.readiness_detail(s, _Client(), ok=True) == "reachable"
+    detail = spark.readiness_detail(s, _Client(), ok=False)
+    assert "cannot reach spark thrift server at sts:10009" in detail
+    assert "Could not connect" in detail  # last_error enrichment
+
+
+def test_engine_info_shapes() -> None:
+    ti = get_connector("trino").engine_info(GatewaySettings())
+    assert ti.engine == "trino" and ti.web_ui_url and ti.sql_url.startswith("http://")
+    si = get_connector("spark").engine_info(GatewaySettings(engine="spark", spark_host="h"))
+    assert si.engine == "spark" and si.web_ui_url is None
+    assert si.sql_url.startswith("jdbc:hive2://h:")
+
+
+def test_a_third_party_connector_plugs_in_with_no_core_changes() -> None:
+    """The whole point: a new engine is one self-contained, self-registering
+    class -- no edits to app/meta/agent/config wiring."""
+
+    @register_connector
+    class _DummyConnector(LakehouseConnector):
+        name = "dummy-test-engine"
+
+        def create_client(self, settings: GatewaySettings) -> LakehouseClient:
+            class _C:
+                async def execute(self, sql, *, timeout, max_rows):
+                    return QueryResult(columns=["ok"], rows=[[1]])
+
+                async def ping(self, timeout=5.0):
+                    return True
+
+                def close(self):
+                    pass
+
+            return _C()
+
+        def register_tools(self, registry, client, settings) -> None:
+            registry.register("ping_engine", "dummy tool")(lambda: client.ping())
+
+        def prompt_context(self, settings) -> PromptContext:
+            return PromptContext("Dummy", "Dummy SQL", "one db", "qualify db.table")
+
+        def unreachable_detail(self, settings) -> str:
+            return "cannot reach dummy"
+
+        def engine_info(self, settings) -> EngineInfo:
+            return EngineInfo("dummy-test-engine", "c", "s", "dummy://", None)
+
+    try:
+        assert reg_get("dummy-test-engine").name == "dummy-test-engine"
+        assert "dummy-test-engine" in reg_names()
+        # the connector satisfies the structural client protocol too
+        client = reg_get("dummy-test-engine").create_client(GatewaySettings())
+        assert isinstance(client, LakehouseClient)
+    finally:
+        _REGISTRY.pop("dummy-test-engine", None)
+
+
+def test_duplicate_registration_is_rejected() -> None:
+    with pytest.raises(ValueError, match="already registered"):
+
+        @register_connector
+        class _Dupe(LakehouseConnector):
+            name = "trino"  # collides with the built-in
+
+            def create_client(self, settings):  # pragma: no cover
+                ...
+
+            def register_tools(self, registry, client, settings):  # pragma: no cover
+                ...
+
+            def prompt_context(self, settings):  # pragma: no cover
+                ...
+
+            def unreachable_detail(self, settings):  # pragma: no cover
+                ...
+
+            def engine_info(self, settings):  # pragma: no cover
+                ...

--- a/hudi-agent-gateway/tests/test_guardrails.py
+++ b/hudi-agent-gateway/tests/test_guardrails.py
@@ -102,3 +102,38 @@ def test_string_literal_containing_dml_is_fine() -> None:
 def test_quoted_identifiers_round_trip() -> None:
     out = enforce_guardrails('SELECT "weird col" FROM "my table"', row_cap=CAP)
     assert '"weird col"' in out
+
+
+# --- spark dialect ---
+
+
+def test_spark_dialect_backticks_parse_and_render() -> None:
+    out = enforce_guardrails(
+        "SELECT `city` FROM `default`.`trips`", row_cap=CAP, dialect="spark"
+    )
+    assert "LIMIT" in out
+
+
+def test_spark_dialect_rejects_dml_with_spark_hint() -> None:
+    import pytest
+
+    from hudi_agent_gateway.tools.registry import ToolInputError
+
+    with pytest.raises(ToolInputError) as exc:
+        enforce_guardrails("INSERT INTO t VALUES (1)", row_cap=CAP, dialect="spark")
+    assert "Spark SQL" in exc.value.hint
+
+
+def test_spark_dialect_limit_injected() -> None:
+    out = enforce_guardrails("SELECT a FROM t", row_cap=CAP, dialect="spark")
+    assert f"LIMIT {CAP}" in out
+
+
+def test_default_dialect_is_trino() -> None:
+    import pytest
+
+    from hudi_agent_gateway.tools.registry import ToolInputError
+
+    with pytest.raises(ToolInputError) as exc:
+        enforce_guardrails("DELETE FROM t", row_cap=CAP)
+    assert "Trino SQL" in exc.value.hint

--- a/hudi-agent-gateway/tests/test_mcp.py
+++ b/hudi-agent-gateway/tests/test_mcp.py
@@ -46,7 +46,7 @@ async def test_mounted_mcp_serves_over_http(settings, fake_trino) -> None:
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as c, app.router.lifespan_context(app):
-        app.state.trino_client = fake_trino
+        app.state.lakehouse_client = fake_trino
         resp = await c.post(
             "/mcp/",
             json={

--- a/hudi-agent-gateway/tests/test_schema_hints.py
+++ b/hudi-agent-gateway/tests/test_schema_hints.py
@@ -1,0 +1,329 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Schema hints: the TTL cache, the did-you-mean error hints, and the
+schema-in-prompt rendering (GATEWAY_SCHEMA_HINTS)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from hudi_agent_gateway.agent import build_system_prompt, make_prompt
+from hudi_agent_gateway.config import GatewaySettings
+from hudi_agent_gateway.tools import build_registry, build_schema_cache
+from hudi_agent_gateway.tools.common import schema_error_hint
+from hudi_agent_gateway.tools.schema_cache import SchemaCache
+
+LISTINGS_SCHEMA = {
+    "listings": [
+        ("listing_id", "string"),
+        ("address", "string"),
+        ("neighborhood", "string"),
+        ("price", "double"),
+        ("beds", "int"),
+        ("baths", "int"),
+        ("sqft", "int"),
+        ("status", "string"),
+        ("updated_at", "timestamp"),
+    ],
+    "trips": [("trip_id", "string"), ("city", "string"), ("fare", "double")],
+}
+
+
+def _cache(schema=LISTINGS_SCHEMA, *, ttl=300.0, max_tables=20, max_columns=40, fail=False):
+    calls = {"n": 0}
+
+    async def fetch():
+        calls["n"] += 1
+        if fail:
+            raise ConnectionRefusedError("engine down")
+        return dict(schema)
+
+    cache = SchemaCache(
+        fetch=fetch, ttl_seconds=ttl, max_tables=max_tables, max_columns=max_columns
+    )
+    cache.calls = calls  # type: ignore[attr-defined]
+    return cache
+
+
+# ------------------------------------------------------------ SchemaCache
+
+
+async def test_cache_fetches_once_within_ttl() -> None:
+    cache = _cache()
+    assert await cache.get() == LISTINGS_SCHEMA
+    assert await cache.get() == LISTINGS_SCHEMA
+    assert cache.calls["n"] == 1
+
+
+async def test_cache_refetches_after_ttl() -> None:
+    cache = _cache(ttl=0.0)
+    await cache.get()
+    await asyncio.sleep(0.01)
+    await cache.get()
+    assert cache.calls["n"] == 2
+
+
+async def test_cache_fail_open_and_debounced() -> None:
+    cache = _cache(fail=True)
+    assert await cache.get() == {}  # never raises
+    assert await cache.get() == {}
+    assert cache.calls["n"] == 1  # failure is cached for the TTL too
+
+
+async def test_peek_kicks_background_refresh() -> None:
+    cache = _cache()
+    assert cache.peek() == {}  # nothing yet, refresh scheduled
+    await asyncio.sleep(0.01)
+    assert cache.peek() == LISTINGS_SCHEMA
+
+
+async def test_prompt_block_renders_and_caps() -> None:
+    cache = _cache(max_columns=3)
+    await cache.get()
+    block = cache.prompt_block()
+    assert "listings(listing_id string, address string, neighborhood string, ... +6 more)" in block
+    assert "trips(trip_id string, city string, fare double)" in block
+    assert "exact table and column names" in block
+
+
+async def test_prompt_block_empty_when_unknown() -> None:
+    cache = _cache(fail=True)
+    await cache.get()
+    assert cache.prompt_block() == ""
+
+
+# ------------------------------------------------------ schema_error_hint
+
+
+def test_hint_spark_unresolved_column() -> None:
+    msg = "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column with name `bedrooms` cannot be resolved."
+    hint = schema_error_hint(msg, LISTINGS_SCHEMA)
+    assert "Did you mean `beds`?" in hint
+    assert "Columns in `listings`" in hint and "sqft" in hint
+
+
+def test_hint_trino_column_not_found() -> None:
+    msg = "COLUMN_NOT_FOUND: line 1:8: Column 'bedrooms' cannot be resolved"
+    hint = schema_error_hint(msg, LISTINGS_SCHEMA)
+    assert "Did you mean `beds`?" in hint
+
+
+def test_hint_spark_table_not_found() -> None:
+    msg = "[TABLE_OR_VIEW_NOT_FOUND] The table or view `properties` cannot be found."
+    hint = schema_error_hint(msg, LISTINGS_SCHEMA)
+    assert "Available tables: listings, trips" in hint
+
+
+def test_hint_trino_table_does_not_exist() -> None:
+    msg = "TABLE_NOT_FOUND: line 1:15: Table 'hudi.default.listing' does not exist"
+    hint = schema_error_hint(msg, LISTINGS_SCHEMA)
+    assert "Did you mean `listings`?" in hint
+
+
+def test_hint_qualified_identifier_uses_leaf() -> None:
+    msg = "Column 't.bedroms' cannot be resolved"
+    assert "Did you mean `beds`?" in schema_error_hint(msg, LISTINGS_SCHEMA)
+
+
+def test_hint_no_close_match_lists_tables() -> None:
+    msg = "[UNRESOLVED_COLUMN] A column with name `zzzzz` cannot be resolved."
+    hint = schema_error_hint(msg, LISTINGS_SCHEMA)
+    assert "Available tables: listings, trips" in hint
+    assert "describe_table" in hint
+
+
+def test_hint_ignores_unrelated_errors() -> None:
+    assert schema_error_hint("DIVISION_BY_ZERO: division by zero", LISTINGS_SCHEMA) == ""
+
+
+def test_hint_empty_schema_is_silent() -> None:
+    assert schema_error_hint("Column 'x' cannot be resolved", {}) == ""
+
+
+def test_hint_is_bounded() -> None:
+    huge = {f"table_{i}": [(f"col_{j}", "string") for j in range(50)] for i in range(100)}
+    msg = "[TABLE_OR_VIEW_NOT_FOUND] The table or view `nope` cannot be found."
+    assert len(schema_error_hint(msg, huge)) <= 700
+
+
+# ------------------------------------- end-to-end through the tool handlers
+
+
+async def test_spark_query_error_carries_did_you_mean(spark_settings, fake_spark) -> None:
+    cache = _cache()
+    registry = build_registry(spark_settings, client=fake_spark, schema_cache=cache)
+    fake_spark.fail_with(
+        "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column with name `bedrooms` cannot be resolved."
+    )
+    out = json.loads(
+        await registry.get("query_lakehouse").handler(sql="SELECT bedrooms FROM listings")
+    )
+    assert "Did you mean `beds`?" in out["hint"]
+    assert "listing_id" in out["hint"]  # the real column list is right there
+
+
+async def test_trino_query_error_carries_did_you_mean(settings, fake_trino) -> None:
+    cache = _cache()
+    registry = build_registry(settings, client=fake_trino, schema_cache=cache)
+    fake_trino.fail_with("COLUMN_NOT_FOUND: line 1:8: Column 'bedrooms' cannot be resolved")
+    out = json.loads(
+        await registry.get("query_lakehouse").handler(sql="SELECT bedrooms FROM listings")
+    )
+    assert "Did you mean `beds`?" in out["hint"]
+
+
+async def test_hints_disabled_in_off_and_prompt_modes(spark_settings, fake_spark) -> None:
+    for mode in ("off", "prompt"):
+        cache = _cache()
+        s = spark_settings.model_copy(update={"schema_hints": mode})
+        registry = build_registry(s, client=fake_spark, schema_cache=cache)
+        fake_spark.fail_with("Column `bedrooms` cannot be resolved")
+        out = json.loads(
+            await registry.get("query_lakehouse").handler(sql="SELECT bedrooms FROM listings")
+        )
+        assert out["hint"] == "Fix the SQL and try again."
+        fake_spark.error = None
+
+
+# ----------------------------------------------------- schema in the prompt
+
+
+def test_prompt_includes_schema_block(settings) -> None:
+    prompt = build_system_prompt(settings, "SCHEMA-SNAPSHOT-HERE")
+    assert "SCHEMA-SNAPSHOT-HERE" in prompt
+    assert "Tool strategy:" in prompt  # rest of the prompt intact
+
+
+async def test_make_prompt_renders_current_schema(spark_settings) -> None:
+    cache = _cache()
+    await cache.get()
+    prompt_fn = make_prompt(spark_settings, cache)
+    assert callable(prompt_fn)
+    from langchain_core.messages import HumanMessage
+
+    msgs = prompt_fn({"messages": [HumanMessage(content="hi")]})
+    assert "listings(listing_id string" in msgs[0].content
+    assert msgs[1].content == "hi"
+
+
+def test_make_prompt_static_when_off(spark_settings) -> None:
+    s = spark_settings.model_copy(update={"schema_hints": "errors"})
+    assert isinstance(make_prompt(s, _cache()), str)
+    assert isinstance(make_prompt(spark_settings, None), str)
+
+
+async def test_make_prompt_prefers_trimmed_llm_input(spark_settings) -> None:
+    cache = _cache()
+    await cache.get()
+    prompt_fn = make_prompt(spark_settings, cache)
+    from langchain_core.messages import HumanMessage
+
+    trimmed = [HumanMessage(content="only-this")]
+    msgs = prompt_fn({"messages": [HumanMessage(content="a"), HumanMessage(content="b")],
+                      "llm_input_messages": trimmed})
+    assert [m.content for m in msgs[1:]] == ["only-this"]
+
+
+# ------------------------------------------------------------ build wiring
+
+
+def test_build_schema_cache_none_when_off(settings, fake_trino) -> None:
+    s = settings.model_copy(update={"schema_hints": "off"})
+    assert build_schema_cache(s, fake_trino) is None
+
+
+def test_config_defaults_and_validation() -> None:
+    from pydantic import ValidationError
+
+    s = GatewaySettings()
+    assert s.schema_hints == "both"
+    assert s.schema_cache_ttl_seconds == 300.0
+    with pytest.raises(ValidationError):
+        GatewaySettings(schema_hints="everything")  # type: ignore[arg-type]
+
+
+# ------------------------------------------------------ connector fetchers
+
+
+async def test_trino_fetch_schema_groups_by_table(settings, fake_trino) -> None:
+    from hudi_agent_gateway.tools import get_connector
+    from hudi_agent_gateway.tools.trino_client import QueryResult
+
+    fake_trino.result = QueryResult(
+        columns=["table_name", "column_name", "data_type"],
+        rows=[
+            ["listings", "listing_id", "varchar"],
+            ["listings", "beds", "integer"],
+            ["trips", "city", "varchar"],
+        ],
+    )
+    schema = await get_connector("trino").fetch_schema(fake_trino, settings)
+    assert schema == {
+        "listings": [("listing_id", "varchar"), ("beds", "integer")],
+        "trips": [("city", "varchar")],
+    }
+    assert "information_schema.columns" in fake_trino.executed[0]
+
+
+async def test_spark_fetch_schema_show_then_describe(spark_settings) -> None:
+    from hudi_agent_gateway.tools import get_connector
+    from hudi_agent_gateway.tools.trino_client import QueryResult
+
+    class ScriptedSpark:
+        def __init__(self) -> None:
+            self.executed: list[str] = []
+            self.responses = {
+                "SHOW TABLES IN `default`": QueryResult(
+                    columns=["namespace", "tableName", "isTemporary"],
+                    rows=[["default", "listings", False]],
+                ),
+                "DESCRIBE TABLE `default`.`listings`": QueryResult(
+                    columns=["col_name", "data_type", "comment"],
+                    rows=[
+                        ["listing_id", "string", None],
+                        ["beds", "int", None],
+                        ["", "", ""],  # separator before partition section
+                        ["# Partition Information", "", ""],
+                        ["neighborhood", "string", None],  # partition col repeat
+                    ],
+                ),
+            }
+
+        async def execute(self, sql, *, timeout, max_rows):
+            self.executed.append(sql)
+            return self.responses[sql]
+
+    client = ScriptedSpark()
+    schema = await get_connector("spark").fetch_schema(client, spark_settings)
+    # stops at the separator: partition-section repeats are not duplicated
+    assert schema == {"listings": [("listing_id", "string"), ("beds", "int")]}
+
+
+async def test_hoodie_meta_columns_filtered() -> None:
+    schema = {
+        "listings": [
+            ("_hoodie_commit_time", "string"),
+            ("_hoodie_record_key", "string"),
+            ("listing_id", "string"),
+            ("beds", "int"),
+        ]
+    }
+    cache = _cache(schema)
+    assert await cache.get() == {"listings": [("listing_id", "string"), ("beds", "int")]}

--- a/hudi-agent-gateway/tests/test_spark_client.py
+++ b/hudi-agent-gateway/tests/test_spark_client.py
@@ -1,0 +1,410 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SparkThriftClient behavior that does not need a live server (or PyHive)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from hudi_agent_gateway.config import GatewaySettings
+from hudi_agent_gateway.tools.common import LakehouseQueryError, LakehouseTimeoutError
+from hudi_agent_gateway.tools.spark_client import (
+    SparkQueryError,
+    SparkThriftClient,
+    SparkTimeoutError,
+    _format_pyhive_error,
+)
+from hudi_agent_gateway.tools.trino_client import QueryResult, TrinoQueryError, TrinoTimeoutError
+
+
+@pytest.fixture()
+def spark_client(spark_settings: GatewaySettings) -> SparkThriftClient:
+    return SparkThriftClient(spark_settings)
+
+
+def test_error_hierarchy() -> None:
+    """Both engines' errors share the lakehouse base classes, so engine-generic
+    code can catch one exception family."""
+    assert issubclass(SparkQueryError, LakehouseQueryError)
+    assert issubclass(SparkTimeoutError, LakehouseTimeoutError)
+    assert issubclass(TrinoQueryError, LakehouseQueryError)
+    assert issubclass(TrinoTimeoutError, LakehouseTimeoutError)
+
+
+def test_format_pyhive_error_strips_java_stack() -> None:
+    raw = (
+        "Error running query: org.apache.spark.sql.AnalysisException: "
+        "[TABLE_OR_VIEW_NOT_FOUND] The table or view `ghost` cannot be found.\n"
+        "\tat org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt..."
+    )
+    msg = _format_pyhive_error(Exception(raw))
+    assert "cannot be found" in msg
+    assert "\tat org" not in msg
+    assert "\n" not in msg
+
+
+def test_format_pyhive_error_bounded() -> None:
+    msg = _format_pyhive_error(Exception("x" * 5000))
+    assert len(msg) <= 500
+
+
+async def test_execute_timeout_maps_to_spark_timeout(
+    spark_client: SparkThriftClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def hang(sql: str, max_rows: int, holder: dict) -> QueryResult:
+        time.sleep(2.0)
+        return QueryResult(columns=[], rows=[])
+
+    monkeypatch.setattr(spark_client, "_execute_sync", hang)
+    with pytest.raises(SparkTimeoutError):
+        await spark_client.execute("SELECT 1", timeout=0.1, max_rows=1)
+    assert "timeout" in spark_client.last_error
+
+
+async def test_execute_wraps_unexpected_errors(
+    spark_client: SparkThriftClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(sql: str, max_rows: int, holder: dict) -> QueryResult:
+        raise ConnectionRefusedError("Could not connect to fake-spark:10000")
+
+    monkeypatch.setattr(spark_client, "_execute_sync", boom)
+    with pytest.raises(SparkQueryError, match="Could not connect"):
+        await spark_client.execute("SELECT 1", timeout=5, max_rows=1)
+    assert "Could not connect" in spark_client.last_error
+
+
+async def test_ping_false_when_unreachable_and_cached(
+    spark_client: SparkThriftClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = {"n": 0}
+
+    def boom(sql: str, max_rows: int, holder: dict) -> QueryResult:
+        calls["n"] += 1
+        raise ConnectionRefusedError("refused")
+
+    monkeypatch.setattr(spark_client, "_execute_sync", boom)
+    assert await spark_client.ping(timeout=1) is False
+    assert await spark_client.ping(timeout=1) is False  # served from cache
+    assert calls["n"] == 1
+
+
+async def test_execute_success_clears_last_error(
+    spark_client: SparkThriftClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spark_client.last_error = "previous failure"
+
+    def ok(sql: str, max_rows: int, holder: dict) -> QueryResult:
+        return QueryResult(columns=["one"], rows=[[1]])
+
+    monkeypatch.setattr(spark_client, "_execute_sync", ok)
+    result = await spark_client.execute("SELECT 1", timeout=5, max_rows=1)
+    assert result.rows == [[1]]
+    assert spark_client.last_error == ""
+
+
+async def test_concurrent_executes_do_not_interfere(
+    spark_client: SparkThriftClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def slow_ok(sql: str, max_rows: int, holder: dict) -> QueryResult:
+        time.sleep(0.05)
+        return QueryResult(columns=["sql"], rows=[[sql]])
+
+    monkeypatch.setattr(spark_client, "_execute_sync", slow_ok)
+    results = await asyncio.gather(
+        *(spark_client.execute(f"SELECT {i}", timeout=5, max_rows=1) for i in range(5))
+    )
+    assert sorted(r.rows[0][0] for r in results) == [f"SELECT {i}" for i in range(5)]
+
+
+# ---------------------------------------------------------------- pooling
+
+
+class FakeCursor:
+    def __init__(self, conn: FakeConn) -> None:
+        self._conn = conn
+        self.description = [("one", "int")]
+        self.cancelled = False
+
+    def execute(self, sql: str) -> None:
+        self._conn.executed.append(sql)
+        if self._conn.fail_next is not None:
+            err, self._conn.fail_next = self._conn.fail_next, None
+            raise err
+
+    def fetchmany(self, n: int):
+        return [[1]]
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+    def close(self) -> None:
+        pass
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self.closed = False
+        self.fail_next: Exception | None = None
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture()
+def pooled_client(spark_settings, monkeypatch: pytest.MonkeyPatch) -> SparkThriftClient:
+    client = SparkThriftClient(spark_settings)
+    client.created: list[FakeConn] = []  # type: ignore[attr-defined]
+
+    def new_conn() -> FakeConn:
+        conn = FakeConn()
+        client.created.append(conn)  # type: ignore[attr-defined]
+        return conn
+
+    monkeypatch.setattr(client, "_new_connection", new_conn)
+    return client
+
+
+async def test_pool_reuses_connection_across_queries(pooled_client: SparkThriftClient) -> None:
+    await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)
+    await pooled_client.execute("SELECT 2", timeout=5, max_rows=1)
+    assert len(pooled_client.created) == 1  # second query reused the pooled session
+    assert pooled_client.created[0].executed == ["SELECT 1", "SELECT 2"]
+
+
+async def test_stale_pooled_connection_retries_once_on_fresh(
+    pooled_client: SparkThriftClient,
+) -> None:
+    await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)  # pool a session
+    pooled_client.created[0].fail_next = OSError("TSocket read 0 bytes")
+    result = await pooled_client.execute("SELECT 2", timeout=5, max_rows=1)
+    assert result.rows == [[1]]  # retry on a fresh connection succeeded
+    assert len(pooled_client.created) == 2
+    assert pooled_client.created[0].closed is True  # dead session discarded
+    assert pooled_client.created[1].executed == ["SELECT 2"]
+
+
+async def test_expired_session_handle_triggers_retry(pooled_client: SparkThriftClient) -> None:
+    await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)
+    pooled_client.created[0].fail_next = Exception("Invalid SessionHandle: SessionHandle [x]")
+    result = await pooled_client.execute("SELECT 2", timeout=5, max_rows=1)
+    assert result.rows == [[1]]
+    assert len(pooled_client.created) == 2
+
+
+async def test_fresh_connection_failure_does_not_retry(pooled_client: SparkThriftClient) -> None:
+    """A brand-new connection failing means the server is down; no retry loop."""
+    failing = FakeConn()
+    failing.fail_next = OSError("Connection refused")
+
+    def new_conn() -> FakeConn:
+        pooled_client.created.append(failing)
+        return failing
+
+    pooled_client._new_connection = new_conn  # type: ignore[method-assign]
+    with pytest.raises(SparkQueryError, match="Connection refused"):
+        await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)
+    assert len(pooled_client.created) == 1
+
+
+async def test_query_error_discards_but_does_not_retry(pooled_client: SparkThriftClient) -> None:
+    """A SQL-level error on a reused session is not a connection error: no retry."""
+    await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)
+    pooled_client.created[0].fail_next = Exception("AnalysisException: cannot resolve 'nope'")
+    with pytest.raises(SparkQueryError, match="cannot resolve"):
+        await pooled_client.execute("SELECT nope", timeout=5, max_rows=1)
+    assert len(pooled_client.created) == 1  # no second connection was opened
+
+
+async def test_timeout_discards_connection(
+    pooled_client: SparkThriftClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def hang(sql: str, max_rows: int, holder: dict) -> QueryResult:
+        entry, _ = pooled_client._acquire()
+        holder["cursor"] = entry.conn.cursor()
+        time.sleep(1.0)
+        if holder.get("abandoned"):
+            pooled_client._discard(entry, "timeout")
+        else:
+            pooled_client._release(entry)
+        return QueryResult(columns=[], rows=[])
+
+    monkeypatch.setattr(pooled_client, "_execute_sync", hang)
+    with pytest.raises(SparkTimeoutError):
+        await pooled_client.execute("SELECT slow", timeout=0.05, max_rows=1)
+    await asyncio.sleep(1.2)  # let the worker finish its discard path
+    assert pooled_client.created[0].closed is True
+    assert pooled_client._pool.qsize() == 0  # nothing was returned to the pool
+
+
+async def test_lifetime_recycling(pooled_client: SparkThriftClient) -> None:
+    await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)
+    # age the pooled entry past the lifetime limit
+    entry = pooled_client._pool.queue[0]
+    entry.created_at -= pooled_client._settings.spark_pool_max_lifetime_seconds + 1
+    await pooled_client.execute("SELECT 2", timeout=5, max_rows=1)
+    assert len(pooled_client.created) == 2  # old session recycled, new one opened
+    assert pooled_client.created[0].closed is True
+
+
+async def test_idle_recycling(pooled_client: SparkThriftClient) -> None:
+    await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)
+    entry = pooled_client._pool.queue[0]
+    entry.last_used_at -= pooled_client._settings.spark_pool_max_idle_seconds + 1
+    await pooled_client.execute("SELECT 2", timeout=5, max_rows=1)
+    assert len(pooled_client.created) == 2
+    assert pooled_client.created[0].closed is True
+
+
+async def test_pool_bound_respected_under_concurrency(
+    spark_settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = spark_settings.model_copy(update={"spark_max_connections": 2})
+    client = SparkThriftClient(settings)
+    created: list[FakeConn] = []
+
+    def new_conn() -> FakeConn:
+        conn = FakeConn()
+        created.append(conn)
+        return conn
+
+    monkeypatch.setattr(client, "_new_connection", new_conn)
+
+    real_run = client._run_query
+
+    def slow_run(conn, sql, max_rows, holder):
+        time.sleep(0.05)
+        return real_run(conn, sql, max_rows, holder)
+
+    monkeypatch.setattr(client, "_run_query", slow_run)
+    await asyncio.gather(
+        *(client.execute(f"SELECT {i}", timeout=5, max_rows=1) for i in range(6))
+    )
+    assert len(created) <= 2  # never more live connections than the bound
+
+
+async def test_close_drains_pool_and_rejects_new_queries(
+    pooled_client: SparkThriftClient,
+) -> None:
+    await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)
+    pooled_client.close()
+    assert pooled_client.created[0].closed is True
+    with pytest.raises(SparkQueryError, match="closed"):
+        await pooled_client.execute("SELECT 2", timeout=5, max_rows=1)
+
+
+# ------------------------------------------------------- connection kwargs
+
+
+def test_new_connection_kwargs_none_auth(
+    spark_settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """auth=none maps to PyHive NONE and sends no password."""
+    from hudi_agent_gateway.tools import spark_client as mod
+
+    captured: dict = {}
+
+    class StubPyHive:
+        @staticmethod
+        def connect(**kwargs):
+            captured.update(kwargs)
+            return FakeConn()
+
+    monkeypatch.setattr(mod, "_pyhive", StubPyHive)
+    client = SparkThriftClient(spark_settings)
+    client._new_connection()
+    assert captured == {
+        "host": "fake-spark",
+        "port": 10000,
+        "username": "hudi-agent-gateway",
+        "database": "default",
+        "auth": "NONE",
+    }
+
+
+def test_new_connection_kwargs_ldap_sends_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    from hudi_agent_gateway.tools import spark_client as mod
+
+    captured: dict = {}
+
+    class StubPyHive:
+        @staticmethod
+        def connect(**kwargs):
+            captured.update(kwargs)
+            return FakeConn()
+
+    monkeypatch.setattr(mod, "_pyhive", StubPyHive)
+    settings = GatewaySettings(
+        engine="spark", spark_host="fake-spark", spark_auth="ldap", spark_password="s3cret"
+    )
+    SparkThriftClient(settings)._new_connection()
+    assert captured["auth"] == "LDAP"
+    assert captured["password"] == "s3cret"
+
+
+def test_missing_pyhive_raises_actionable_error(
+    spark_settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hudi_agent_gateway.tools import spark_client as mod
+
+    monkeypatch.setattr(mod, "_pyhive", None)
+    client = SparkThriftClient(spark_settings)
+    with pytest.raises(SparkQueryError, match=r"hudi-agent-gateway\[spark\]"):
+        client._new_connection()
+
+
+def test_qualified_column_names_stripped_but_aliases_kept(
+    pooled_client: SparkThriftClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tbl.col` prefixes are stripped; an alias that merely contains a dot is not."""
+    conn = FakeConn()
+
+    class WideCursor(FakeCursor):
+        def __init__(self, c):
+            super().__init__(c)
+            self.description = [
+                ("trips.city", "string"),
+                ("plain", "int"),
+                ("a b.c", "int"),  # not identifier-dot-shaped: left alone
+            ]
+
+    monkeypatch.setattr(conn, "cursor", lambda: WideCursor(conn))
+    result = pooled_client._run_query(conn, "SELECT ...", 10, {})
+    assert result.columns == ["city", "plain", "a b.c"]
+
+
+async def test_no_retry_after_caller_abandoned(pooled_client: SparkThriftClient) -> None:
+    """A query the caller already abandoned (timed out) must NOT trigger a
+    stale-connection retry -- the outer wait_for is gone, so the retry would
+    run unbounded. The dead session is discarded and the error propagates."""
+    await pooled_client.execute("SELECT 1", timeout=5, max_rows=1)  # warm the pool
+    assert len(pooled_client.created) == 1
+    pooled_client.created[0].fail_next = OSError("TSocket read 0 bytes")  # reused conn dies
+
+    holder = {"abandoned": True}
+    with pytest.raises(OSError, match="TSocket"):
+        pooled_client._execute_sync("SELECT 2", 1, holder)
+
+    # the guard held: no fresh connection was opened for a retry
+    assert len(pooled_client.created) == 1
+    assert pooled_client.created[0].closed is True  # dead session discarded

--- a/hudi-agent-gateway/tests/test_spark_tools.py
+++ b/hudi-agent-gateway/tests/test_spark_tools.py
@@ -1,0 +1,155 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Spark Thrift backend tools: same contract as the Trino backend, Spark SQL shape."""
+
+from __future__ import annotations
+
+import json
+
+from hudi_agent_gateway.tools.registry import ToolRegistry
+from hudi_agent_gateway.tools.trino_client import QueryResult
+
+
+async def _call(registry: ToolRegistry, name: str, **kwargs: object) -> dict:
+    return json.loads(await registry.get(name).handler(**kwargs))
+
+
+async def test_query_lakehouse_shapes_result(spark_registry: ToolRegistry, fake_spark) -> None:
+    out = await _call(spark_registry, "query_lakehouse", sql="SELECT city FROM trips")
+    assert out["columns"] == ["city", "trips"]
+    assert out["row_count"] == 3
+    assert out["truncated"] is False
+    # the guardrail-injected LIMIT reached the client
+    assert "LIMIT 100" in fake_spark.executed[0]
+
+
+async def test_query_lakehouse_accepts_backquoted_identifiers(
+    spark_registry: ToolRegistry, fake_spark
+) -> None:
+    """Spark SQL uses backticks; the guardrails must parse and preserve them."""
+    out = await _call(
+        spark_registry, "query_lakehouse", sql="SELECT `city` FROM `default`.`trips`"
+    )
+    assert "error" not in out
+    assert "`default`.`trips`" in fake_spark.executed[0].replace('"', "`")
+
+
+async def test_query_lakehouse_guardrail_error_returned_not_raised(
+    spark_registry: ToolRegistry,
+) -> None:
+    out = await _call(spark_registry, "query_lakehouse", sql="DROP TABLE trips")
+    assert "error" in out and "read-only" in out["error"]
+    assert "Spark SQL" in out["hint"]
+
+
+async def test_query_lakehouse_spark_error_returned(
+    spark_registry: ToolRegistry, fake_spark
+) -> None:
+    fake_spark.fail_with("AnalysisException: cannot resolve 'nope'")
+    out = await _call(spark_registry, "query_lakehouse", sql="SELECT nope FROM trips")
+    assert out["error"].startswith("query failed")
+
+
+async def test_query_lakehouse_timeout_gets_actionable_hint(
+    spark_registry: ToolRegistry, fake_spark
+) -> None:
+    """Timeouts must NOT get the generic 'fix the SQL' hint -- the SQL is fine."""
+    from hudi_agent_gateway.tools.spark_client import SparkTimeoutError
+
+    fake_spark.error = SparkTimeoutError("query exceeded the 120s timeout")
+    out = await _call(spark_registry, "query_lakehouse", sql="SELECT count(*) FROM trips")
+    assert out["error"].startswith("query failed")
+    assert "GATEWAY_SQL_TIMEOUT_SECONDS" in out["hint"]
+    assert "Fix the SQL" not in out["hint"]
+
+
+async def test_truncation_notice(spark_registry: ToolRegistry, fake_spark) -> None:
+    fake_spark.result = QueryResult(columns=["s"], rows=[["x" * 100] for _ in range(200)])
+    out = await _call(spark_registry, "query_lakehouse", sql="SELECT s FROM big")
+    assert out["truncated"] is True
+    assert "notice" in out
+    assert out["row_count"] == 200  # original fetched count is preserved
+    assert len(out["rows"]) < 200
+
+
+async def test_row_capped_result_reports_truncated(
+    spark_registry: ToolRegistry, fake_spark
+) -> None:
+    """A result that filled the row cap is truncated even when it fits in bytes."""
+    fake_spark.result = QueryResult(columns=["c"], rows=[["v"] for _ in range(100)])
+    out = await _call(spark_registry, "query_lakehouse", sql="SELECT c FROM big")
+    assert out["truncated"] is True
+    assert "row cap" in out["notice"]
+    assert len(out["rows"]) == 100  # the byte-size loop did not fire
+
+
+async def test_list_tables_defaults(spark_registry: ToolRegistry, fake_spark) -> None:
+    await _call(spark_registry, "list_tables")
+    assert fake_spark.executed[0] == "SHOW TABLES IN `default`"
+
+
+async def test_list_tables_explicit(spark_registry: ToolRegistry, fake_spark) -> None:
+    await _call(spark_registry, "list_tables", database="warehouse2")
+    assert fake_spark.executed[0] == "SHOW TABLES IN `warehouse2`"
+
+
+async def test_describe_table_name_forms(spark_registry: ToolRegistry, fake_spark) -> None:
+    await _call(spark_registry, "describe_table", table="trips")
+    assert fake_spark.executed[0] == "DESCRIBE TABLE `default`.`trips`"
+    await _call(spark_registry, "describe_table", table="db2.trips")
+    assert fake_spark.executed[1] == "DESCRIBE TABLE `db2`.`trips`"
+    out = await _call(spark_registry, "describe_table", table="a.b.c")
+    assert "error" in out  # spark tools accept table or database.table only
+
+
+async def test_describe_missing_table_empty_result(
+    spark_registry: ToolRegistry, fake_spark
+) -> None:
+    fake_spark.result = QueryResult(columns=["col_name"], rows=[])
+    out = await _call(spark_registry, "describe_table", table="ghost")
+    assert "not found" in out["error"]
+
+
+async def test_describe_missing_table_server_error_mapped(
+    spark_registry: ToolRegistry, fake_spark
+) -> None:
+    """Spark raises for a missing table; the error maps to the same 'not found' payload."""
+    fake_spark.fail_with(
+        "[TABLE_OR_VIEW_NOT_FOUND] The table or view `ghost` cannot be found."
+    )
+    out = await _call(spark_registry, "describe_table", table="ghost")
+    assert "not found" in out["error"]
+    assert "list_tables" in out["hint"]
+
+
+async def test_identifier_injection_rejected(spark_registry: ToolRegistry, fake_spark) -> None:
+    """Quoted breakouts in database/table params return errors, never reach Spark."""
+    out = await _call(spark_registry, "list_tables", database="x` --")
+    assert "invalid database name" in out["error"]
+    out = await _call(spark_registry, "describe_table", table="a.b`; DROP TABLE t --")
+    assert "invalid table name" in out["error"]
+    assert fake_spark.executed == []  # nothing was ever sent
+
+
+async def test_tool_surface_matches_trino_backend(
+    spark_registry: ToolRegistry, registry: ToolRegistry
+) -> None:
+    """Both engines expose the identical tool names: the agent prompt, MCP
+    clients, and the UI never care which engine is behind the gateway."""
+    spark_names = {t["name"] for t in spark_registry.listing()}
+    trino_names = {t["name"] for t in registry.listing()}
+    assert spark_names == trino_names == {"query_lakehouse", "list_tables", "describe_table"}

--- a/hudi-lakehouse/charts/hudi-agent-gateway/templates/deployment.yaml
+++ b/hudi-lakehouse/charts/hudi-agent-gateway/templates/deployment.yaml
@@ -95,6 +95,8 @@ spec:
               value: {{ .Values.trino.schema | quote }}
             - name: GATEWAY_TRINO_USER
               value: {{ .Values.trino.user | quote }}
+            - name: GATEWAY_SCHEMA_HINTS
+              value: {{ .Values.schemaHints | default "both" | quote }}
             - name: GATEWAY_SQL_ROW_CAP
               value: {{ .Values.guardrails.rowCap | quote }}
             - name: GATEWAY_SQL_TIMEOUT_SECONDS

--- a/hudi-lakehouse/charts/hudi-agent-gateway/templates/deployment.yaml
+++ b/hudi-lakehouse/charts/hudi-agent-gateway/templates/deployment.yaml
@@ -69,6 +69,22 @@ spec:
             - name: GATEWAY_SYSTEM_PROMPT_EXTRA
               value: {{ . | quote }}
             {{- end }}
+            - name: GATEWAY_ENGINE
+              value: {{ .Values.engine | default "trino" | quote }}
+            {{- if eq (.Values.engine | default "trino") "spark" }}
+            - name: GATEWAY_SPARK_HOST
+              value: {{ required "spark.host is required when engine=spark" .Values.spark.host | quote }}
+            - name: GATEWAY_SPARK_PORT
+              value: {{ .Values.spark.port | quote }}
+            - name: GATEWAY_SPARK_DATABASE
+              value: {{ .Values.spark.database | quote }}
+            - name: GATEWAY_SPARK_USER
+              value: {{ .Values.spark.user | quote }}
+            - name: GATEWAY_SPARK_AUTH
+              value: {{ .Values.spark.auth | quote }}
+            - name: GATEWAY_SPARK_MAX_CONNECTIONS
+              value: {{ .Values.spark.maxConnections | quote }}
+            {{- end }}
             - name: GATEWAY_TRINO_HOST
               value: {{ .Values.trino.host | quote }}
             - name: GATEWAY_TRINO_PORT

--- a/hudi-lakehouse/charts/hudi-agent-gateway/values.yaml
+++ b/hudi-lakehouse/charts/hudi-agent-gateway/values.yaml
@@ -75,6 +75,8 @@ spark:
   # Pooled HiveServer2 sessions (also the query concurrency bound).
   maxConnections: 8
 
+# Live schema context for the model: off | errors | prompt | both.
+schemaHints: both
 guardrails:
   rowCap: 200
   queryTimeoutSeconds: 120

--- a/hudi-lakehouse/charts/hudi-agent-gateway/values.yaml
+++ b/hudi-lakehouse/charts/hudi-agent-gateway/values.yaml
@@ -55,12 +55,25 @@ gateway:
     baseUrl: ""
   llmTimeoutSeconds: 120
 
+# Lakehouse SQL engine serving the tools: "trino" (default) or "spark"
+# (a Spark Thrift Server; reads MOR snapshots and Hudi 1.x unstructured types).
+engine: trino
 trino:
   host: hudi-trino.hudi-lakehouse.svc
   port: 8080
   catalog: hudi
   schema: default
   user: hudi-agent-gateway
+spark:
+  host: ""
+  port: 10000
+  database: default
+  user: hudi-agent-gateway
+  # HiveServer2 auth mode: none | nosasl | ldap. For ldap, provide the
+  # password via the existingSecret (key GATEWAY_SPARK_PASSWORD).
+  auth: none
+  # Pooled HiveServer2 sessions (also the query concurrency bound).
+  maxConnections: 8
 
 guardrails:
   rowCap: 200


### PR DESCRIPTION
> **Stacked on #19411** (Spark Thrift Server engine): this branch contains that PR's commit plus one commit of its own. **Review only the last commit** (`feat(gateway): schema hints`); the diff will collapse to it once #19411 merges and this branch is rebased.

### Describe the issue this Pull Request addresses

Part of the agentic-lakehouse umbrella #19256. Small local models routinely skip `describe_table` and guess column names (`bedrooms` for `beds`, invented table names), then fail or hallucinate -- the gateway's tool-based schema discovery depends on exactly the multi-hop planning that small models are worst at. Production text-to-SQL systems converge on a hybrid: compact schema context up front plus execution-error feedback that carries the real names. This PR adds both, auto-derived from the engine (never hand-written), behind one knob.

### Summary and Changelog

`GATEWAY_SCHEMA_HINTS = off | errors | prompt | both` (default `both`); everything degrades gracefully and `off` restores today's pure tool-based discovery.

**`tools/schema_cache.py` -- the snapshot**
- Single-flight TTL cache (default 300s) over a new per-connector `fetch_schema()`: one `information_schema` query on Trino; `SHOW TABLES` + `DESCRIBE TABLE` per table on Spark (stops at the `# Partition Information` section). Size-capped (`GATEWAY_SCHEMA_MAX_TABLES`/`_MAX_COLUMNS`), Hudi `_hoodie_*` meta columns filtered so hints never steer the model toward them.
- Strictly fail-open: a refresh failure keeps the previous snapshot and never breaks the query path; failures are debounced by the same TTL so an unreachable engine is not hammered by probes.

**`errors` mode -- execution-guided self-correction**
- A column/table-not-found error now returns an actionable hint built from the cached schema: fuzzy match on the offending identifier (leaf of qualified names) plus the real names to copy from: `Did you mean `beds`? Columns in `listings`: listing_id, address, price, beds, ...`. Handles Spark (`UNRESOLVED_COLUMN`, `TABLE_OR_VIEW_NOT_FOUND`) and Trino (`COLUMN_NOT_FOUND`, `TABLE_NOT_FOUND`) message shapes; non-name errors keep the existing generic hint; bounded at 700 chars.

**`prompt` mode -- schema in the system prompt**
- A compact snapshot (`listings(listing_id string, address string, ...)`) is rendered into the system prompt per turn via a callable `create_react_agent` prompt, so the model writes SQL against real names without a discovery hop; the message-trimming hook is preserved (`llm_input_messages`-aware). The snapshot is warmed at gateway startup and follows the TTL thereafter, so schema changes propagate without agent rebuilds.

**Plumbing**
- `LakehouseConnector.fetch_schema()` added with a `return {}` default -- third-party connectors are unaffected and simply have hints disabled until they implement it. `build_schema_cache()` + `schema_cache` parameter threaded through `build_registry`/`AgentCache`; helm chart gains `schemaHints`; README section + config rows.

**Tests** -- 28 new offline tests: cache TTL/fail-open/caps/meta-filter/peek-background-refresh, did-you-mean hints for both engines' error shapes (incl. qualified identifiers, no-close-match fallback, bounded output, non-name errors silent), mode gating, end-to-end through both engines' tool handlers, prompt rendering and trimming interplay, and both connector fetchers.

No code copied from other projects.

### Impact

New optional configs (`GATEWAY_SCHEMA_HINTS`, `GATEWAY_SCHEMA_CACHE_TTL_SECONDS`, `GATEWAY_SCHEMA_MAX_TABLES/_MAX_COLUMNS`) documented in the module README; new helm value `schemaHints`. Default `both` changes model-facing behavior only (better hints, a schema block in the system prompt); the tool API and HTTP surfaces are unchanged. Costs one schema fetch per TTL window plus the prompt tokens for the capped snapshot; `GATEWAY_SCHEMA_HINTS=errors` keeps the prompt lean, `off` restores current behavior exactly.

### Risk Level

low -- additive and fail-open by construction (schema fetch failures degrade hints, never queries). 172 offline tests pass; ruff and mypy clean; helm lint clean. Verified live against Apache Kyuubi serving Hudi 1.3 tables with llama3.1: the previously failing question ("active 3-bedroom homes under $800k in Downtown") went from hallucinated column names and a leaked tool-call JSON to correct names (`status`/`beds`/`neighborhood`) on the first tool call, and a forced `bedrooms` query returned the did-you-mean hint carrying the real column list.

### Documentation Update

Module README updated in this PR ("Schema hints" section + config table rows). Website docs tracked with the umbrella #19256.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
