### PR TITLE
docs(hudi-notebooks): note S3A works with any S3-compatible object store

### DIFF
--- a/hudi-notebooks/README.md
+++ b/hudi-notebooks/README.md
@@ -93,18 +93,20 @@ provider's endpoint and credentials:
   <name>fs.s3a.endpoint</name>
   <!-- Amazon S3: https://s3.<region>.amazonaws.com
        any other provider: its S3 endpoint URL -->
-  <value>https://<s3-endpoint></value>
+  <value>https://your-s3-endpoint.example.com</value>
 </property>
 <property>
   <name>fs.s3a.access.key</name>
-  <value><access-key></value>
+  <value>ACCESS_KEY</value>
 </property>
 <property>
   <name>fs.s3a.secret.key</name>
-  <value><secret-key></value>
+  <value>SECRET_KEY</value>
 </property>
 <property>
   <name>fs.s3a.path.style.access</name>
+  <!-- MinIO and most other providers need path-style addressing;
+       leave this out for Amazon S3 -->
   <value>true</value>
 </property>
 ```

--- a/hudi-notebooks/README.md
+++ b/hudi-notebooks/README.md
@@ -79,6 +79,40 @@ This project provides a ready-to-use Docker Compose environment for running Apac
 - Spark, Hive, and Hudi configs are in `conf/` and automatically copied into containers.
 - S3 access keys and endpoints are set for MinIO and referenced in Spark/Hive configs.
 
+### Using another S3-compatible object store
+
+Hudi reads and writes through the Hadoop S3A connector, so the same `fs.s3a.*`
+settings work against any S3-compatible object store: Amazon S3, or a compatible
+provider such as Backblaze B2, Cloudflare R2, or MinIO. This demo points
+`fs.s3a.endpoint` at the bundled MinIO service; to target a different store,
+edit `conf/hadoop/core-site.xml` (and the matching Spark/Hive configs) with that
+provider's endpoint and credentials:
+
+```xml
+<property>
+  <name>fs.s3a.endpoint</name>
+  <!-- Amazon S3: https://s3.<region>.amazonaws.com
+       any other provider: its S3 endpoint URL -->
+  <value>https://<s3-endpoint></value>
+</property>
+<property>
+  <name>fs.s3a.access.key</name>
+  <value><access-key></value>
+</property>
+<property>
+  <name>fs.s3a.secret.key</name>
+  <value><secret-key></value>
+</property>
+<property>
+  <name>fs.s3a.path.style.access</name>
+  <value>true</value>
+</property>
+```
+
+For Amazon S3 the region-default endpoint is used when `fs.s3a.endpoint` is
+omitted; most other S3-compatible providers need an explicit endpoint and
+`fs.s3a.path.style.access=true`.
+
 ## 📒 Example: Using JupyterLab
 
 1. Open [http://localhost:8888](http://localhost:8888) in your browser.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

The `hudi-notebooks` Docker Compose environment ships MinIO as its object store, and the README only documents that setup. Nothing states that the storage layer is the Hadoop S3A connector, so it is not obvious that the same environment can point at Amazon S3 or any other S3-compatible store by changing configuration, or which settings need to change.

### Summary and Changelog

Docs-only addition to `hudi-notebooks/README.md`, as a new "Using another S3-compatible object store" subsection under Configuration:

- state that reads and writes go through the Hadoop S3A connector, so the same `fs.s3a.*` settings apply to Amazon S3 or a compatible provider (Backblaze B2, Cloudflare R2, MinIO)
- point to `conf/hadoop/core-site.xml` and the matching Spark/Hive configs as the files to edit, with a placeholder `fs.s3a.endpoint` / access key / secret key / `path.style.access` snippet
- note that Amazon S3 uses the region-default endpoint when `fs.s3a.endpoint` is omitted, while most other providers need an explicit endpoint and `fs.s3a.path.style.access=true`

### Impact

None. Documentation only, no code, config, or behavior changes. The bundled demo still defaults to MinIO.

### Risk Level

none

### Documentation Update

This PR is itself the documentation update; only `hudi-notebooks/README.md` changes. No website update is needed since no new feature or configuration is introduced.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (not applicable; documentation-only change)
