### PR TITLE
fix(bundle): relocate the AWS SDK bundled into hudi-utilities-bundle

### DIFF
--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -153,6 +153,11 @@
                   <include>com.101tec:zkclient</include>
                   <include>org.apache.kafka:kafka-clients</include>
 
+                  <!-- AWS SDK for JsonKinesisSource; relocated below, matching hudi-aws-bundle. -->
+                  <include>software.amazon.awssdk:*</include>
+                  <!-- KPL de-aggregation: extracts user records from Kinesis Producer Library aggregated records -->
+                  <include>com.amazonaws:amazon-kinesis-deaggregator</include>
+
                   <include>org.apache.hive:hive-common</include>
                   <include>org.apache.hive:hive-service</include>
                   <include>org.apache.hive:hive-service-rpc</include>
@@ -234,6 +239,10 @@
                 <relocation>
                   <pattern>org.apache.httpcomponents.</pattern>
                   <shadedPattern>org.apache.hudi.aws.org.apache.httpcomponents.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>software.amazon.awssdk.</pattern>
+                  <shadedPattern>org.apache.hudi.software.amazon.awssdk.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.uber.m3.</pattern>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -153,8 +153,40 @@
                   <include>com.101tec:zkclient</include>
                   <include>org.apache.kafka:kafka-clients</include>
 
-                  <!-- AWS SDK for JsonKinesisSource; relocated below, matching hudi-aws-bundle. -->
-                  <include>software.amazon.awssdk:*</include>
+                  <!-- AWS SDK v2 core, shared by the kinesis and sts clients below; relocated further down. -->
+                  <include>software.amazon.awssdk:annotations</include>
+                  <include>software.amazon.awssdk:utils</include>
+                  <include>software.amazon.awssdk:sdk-core</include>
+                  <include>software.amazon.awssdk:aws-core</include>
+                  <include>software.amazon.awssdk:auth</include>
+                  <include>software.amazon.awssdk:http-client-spi</include>
+                  <include>software.amazon.awssdk:regions</include>
+                  <include>software.amazon.awssdk:metrics-spi</include>
+                  <include>software.amazon.awssdk:json-utils</include>
+                  <include>software.amazon.awssdk:endpoints-spi</include>
+                  <include>software.amazon.awssdk:retries</include>
+                  <include>software.amazon.awssdk:retries-spi</include>
+                  <include>software.amazon.awssdk:checksums</include>
+                  <include>software.amazon.awssdk:checksums-spi</include>
+                  <include>software.amazon.awssdk:identity-spi</include>
+                  <include>software.amazon.awssdk:http-auth</include>
+                  <include>software.amazon.awssdk:http-auth-spi</include>
+                  <include>software.amazon.awssdk:http-auth-aws</include>
+                  <include>software.amazon.awssdk:http-auth-aws-eventstream</include>
+                  <include>software.amazon.awssdk:protocol-core</include>
+                  <include>software.amazon.awssdk:apache-client</include>
+                  <include>software.amazon.awssdk:netty-nio-client</include>
+                  <include>org.reactivestreams:reactive-streams</include>
+                  <!-- Kinesis client for JsonKinesisSource -->
+                  <include>software.amazon.awssdk:kinesis</include>
+                  <include>software.amazon.awssdk:aws-cbor-protocol</include>
+                  <include>software.amazon.awssdk:aws-json-protocol</include>
+                  <include>software.amazon.awssdk:third-party-jackson-dataformat-cbor</include>
+                  <include>software.amazon.awssdk:third-party-jackson-core</include>
+                  <!-- STS: assume-role credentials for cross-account Kinesis reads (KinesisOffsetGen). -->
+                  <include>software.amazon.awssdk:sts</include>
+                  <include>software.amazon.awssdk:aws-query-protocol</include>
+                  <include>software.amazon.awssdk:profiles</include>
                   <!-- KPL de-aggregation: extracts user records from Kinesis Producer Library aggregated records -->
                   <include>com.amazonaws:amazon-kinesis-deaggregator</include>
 


### PR DESCRIPTION
### Change Logs

**Summary.** `hudi-utilities-bundle` doesn't shade the AWS SDK that `JsonKinesisSource` needs, so the published bundle jar can't actually run `JsonKinesisSource` on its own.

`hudi-utilities` depends on `software.amazon.awssdk:kinesis` and `com.amazonaws:amazon-kinesis-deaggregator` for `JsonKinesisSource`/`KinesisOffsetGen`/`KinesisDeaggregator`, but `packaging/hudi-utilities-bundle/pom.xml`'s shade includes never picked either up. Neither artifact ends up in the shaded jar, so a deployment running only `hudi-utilities-bundle` hits `NoClassDefFoundError` on any `software.amazon.awssdk.services.kinesis.*` class the moment `JsonKinesisSource` is used.

`hudi-aws-bundle` already relocates its AWS SDK dependencies the same way this PR relocates `hudi-utilities-bundle`'s: moving the `software.amazon.awssdk` package prefix to `org.apache.hudi.software.amazon.awssdk`, avoiding a classpath collision with whatever SDK version a consuming application has pinned on its own classpath.

**Include list is scoped to kinesis/sts, not a wildcard.** `kinesis`/`sts` aren't self-contained — they're thin client artifacts that depend on a shared set of AWS SDK v2 core libraries to actually load: `KinesisClient` implements `AwsClient`, which lives in the separate `aws-core` artifact; both need `sdk-core` for request handling, `auth` for signing, `regions`, `http-client-spi` plus `apache-client`/`netty-nio-client` for transport, and so on down the chain. None of that is optional — omit any of it and the class fails to load at runtime.

`hudi-utilities` also depends on `hudi-aws` (for Glue sync, the DynamoDB lock provider, and CloudWatch metrics elsewhere in `hudi-utilities`), which transitively resolves `s3`, `dynamodb`, `glue`, `cloudwatch`, and their protocol/support artifacts. A `software.amazon.awssdk:*` wildcard include would sweep those into this bundle too, even though `JsonKinesisSource` never touches them and `hudi-aws`'s own classes aren't part of this bundle — so they'd just be dead weight (measured at ~17.7MB on the built jar).

Instead, the include list enumerates exactly the `kinesis`+`sts` transitive closure, traced with `mvn dependency:tree -Dverbose` against `hudi-utilities`: the shared AWS SDK v2 core (`sdk-core`, `aws-core`, `auth`, `regions`, `http-client-spi`, `apache-client`, `netty-nio-client`, `checksums`, `retries`, and their `-spi` siblings), `kinesis`'s own protocol dependencies (`aws-cbor-protocol`, `third-party-jackson-dataformat-cbor` and `-core`), `sts`'s (`aws-query-protocol`, `profiles`), and `org.reactivestreams:reactive-streams`, which `sdk-core` needs and isn't in the `software.amazon.awssdk` group (so a group-scoped wildcard wouldn't have covered it either).

### Impact

`hudi-utilities-bundle` now carries the `kinesis`/`sts` dependency closure `JsonKinesisSource` needs, relocated under `org.apache.hudi.software.amazon.awssdk.**`. No behavior change for anything not using `JsonKinesisSource`.

### Risk level

**Low.** Additive to the bundle's shaded contents; no existing classes move or change behavior.

The one thing worth double-checking on the built artifact is AWS SDK v2's `ServiceLoader`-based HTTP client discovery, since `KinesisOffsetGen.createKinesisClient` builds a `KinesisClient` without an explicit `.httpClient(...)`. Verified locally that the relocated jar carries the rewritten service file, `META-INF/services/org.apache.hudi.software.amazon.awssdk.http.SdkHttpService`, containing `org.apache.hudi.software.amazon.awssdk.http.apache.ApacheSdkHttpService`.

### Documentation Update

None. No configs, public API, or user-facing behavior change.

### Contributor's checklist

- [x] Read through contributor's guide
- [x] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable — packaging-only change, no unit-test surface.
- [x] `mvn -pl packaging/hudi-utilities-bundle -am package -DskipTests -Dscala-2.12 -Dspark3.5 -Dflink1.20` succeeds locally. Verified the resulting jar: zero classes remain at the original `software/amazon/awssdk/**` paths; the relocated `SdkHttpService` services file is present; `s3`/`dynamodb`/`glue`/`cloudwatch`/`sqs`/`arns`/`aws-xml-protocol`/`crt-core` are all absent; and `JsonKinesisSource`'s own bytecode resolves to the relocated `KinesisClient`.
- [ ] CI passed
