### PR TITLE
fix(hive-sync): make skip_ro_suffix take precedence over sync_snapshot_with_table_name

### DIFF
--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -211,7 +211,16 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
             syncHoodieTable(snapshotTableName, true, false);
             // sync origin table for MOR
             if (config.getBoolean(META_SYNC_SNAPSHOT_WITH_TABLE_NAME)) {
-              syncHoodieTable(tableName, true, false);
+              if (config.getBoolean(HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE)) {
+                // skip_ro_suffix explicitly claims the bare table name for the RO view;
+                // an implicit sync_snapshot_with_table_name default must not repurpose it as RT.
+                log.warn("{}=true claims the base table name '{}' for the read-optimized view; "
+                        + "ignoring {} for this table (the real-time view remains registered as '{}').",
+                    HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE.key(), tableId(databaseName, tableName),
+                    META_SYNC_SNAPSHOT_WITH_TABLE_NAME.key(), snapshotTableName);
+              } else {
+                syncHoodieTable(tableName, true, false);
+              }
             }
         }
         break;

--- a/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -212,9 +212,7 @@ public class HiveSyncTool extends HoodieSyncTool implements AutoCloseable {
             // sync origin table for MOR
             if (config.getBoolean(META_SYNC_SNAPSHOT_WITH_TABLE_NAME)) {
               if (config.getBoolean(HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE)) {
-                // skip_ro_suffix explicitly claims the bare table name for the RO view;
-                // an implicit sync_snapshot_with_table_name default must not repurpose it as RT.
-                log.warn("{}=true claims the base table name '{}' for the read-optimized view; "
+                log.warn("{}=true claims the bare table name '{}' for the read-optimized view; "
                         + "ignoring {} for this table (the real-time view remains registered as '{}').",
                     HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE.key(), tableId(databaseName, tableName),
                     META_SYNC_SNAPSHOT_WITH_TABLE_NAME.key(), snapshotTableName);

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -1575,10 +1575,7 @@ public class TestHiveSyncTool {
     reInitHiveSyncClient();
     reSyncHiveTable();
 
-    // a second sync round with a new commit: the bare table name's read-optimized sync (which runs
-    // immediately before the origin-table sync within the same doSync() call) advances its own
-    // last-commit-time-synced marker, so the origin-table step is the only one still eligible to run
-    // and flip the format if not guarded
+    // a second sync round with a new commit reproduces the flip; a single round does not
     ZonedDateTime dateTime = ZonedDateTime.now().plusDays(6);
     String commitTime2 = "102";
     String deltaCommitTime2 = "103";

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -99,6 +99,7 @@ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_AUTO_CREATE_DATABAS
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_BATCH_SYNC_PARTITION_NUM;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_CREATE_MANAGED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_IGNORE_EXCEPTIONS;
+import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_AS_DATA_SOURCE_TABLE;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BATCHING_ENABLED;
 import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BATCHING_THREADS;
@@ -119,6 +120,7 @@ import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_DATABASE_NA
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_INCREMENTAL;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_EXTRACTOR_CLASS;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_PARTITION_FIELDS;
+import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_SNAPSHOT_WITH_TABLE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TABLE_NAME;
 import static org.apache.hudi.sync.common.HoodieSyncConfig.META_SYNC_TOUCH_PARTITIONS_ENABLED;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -1555,6 +1557,43 @@ public class TestHiveSyncTool {
                 "Table " + snapshotTableName
                         + " should exist after sync completes");
     }
+  }
+
+  @Test
+  void testSkipRoSuffixTakesPrecedenceOverSnapshotWithTableName() throws Exception {
+    // skip_ro_suffix explicitly claims the bare table name for the RO view; the now-default-true
+    // sync_snapshot_with_table_name must not be allowed to flip it to RT.
+    hiveSyncProps.setProperty(HIVE_SYNC_TABLE_STRATEGY.key(), HoodieSyncTableStrategy.ALL.name());
+    hiveSyncProps.setProperty(HIVE_SKIP_RO_SUFFIX_FOR_READ_OPTIMIZED_TABLE.key(), "true");
+    hiveSyncProps.setProperty(META_SYNC_SNAPSHOT_WITH_TABLE_NAME.key(), "true");
+    hiveSyncProps.setProperty(HIVE_SYNC_AS_DATA_SOURCE_TABLE.key(), "true");
+
+    String instantTime = "100";
+    String deltaCommitTime = "101";
+    HiveTestUtil.createMORTable(instantTime, deltaCommitTime, 5, true, true);
+
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+
+    String snapshotTableName = HiveTestUtil.TABLE_NAME + HiveSyncTool.SUFFIX_SNAPSHOT_TABLE;
+    String roSuffixTableName = HiveTestUtil.TABLE_NAME + HiveSyncTool.SUFFIX_READ_OPTIMIZED_TABLE;
+
+    // the bare table name must stay registered as the read-optimized view
+    StorageDescriptor bareTableSd = hiveClient.getMetastoreStorageDescriptor(HiveTestUtil.TABLE_NAME);
+    assertEquals(HoodieParquetInputFormat.class.getName(), bareTableSd.getInputFormat(),
+        "Bare table name should remain the RO view (skip_ro_suffix=true) despite sync_snapshot_with_table_name=true");
+    assertEquals("true", bareTableSd.getSerdeInfo().getParameters().get(ConfigUtils.IS_QUERY_AS_RO_TABLE),
+        "Bare table name should still be marked as the RO table");
+
+    // the real-time/snapshot view remains available, and only there
+    assertTrue(hiveClient.tableExists(snapshotTableName), "Table " + snapshotTableName + " should exist after sync completes");
+    StorageDescriptor snapshotTableSd = hiveClient.getMetastoreStorageDescriptor(snapshotTableName);
+    assertEquals(HoodieParquetRealtimeInputFormat.class.getName(), snapshotTableSd.getInputFormat(),
+        "Table " + snapshotTableName + " should use the realtime input format");
+
+    // no separate "<t>_ro" table should be created when skip_ro_suffix is set
+    assertFalse(hiveClient.tableExists(roSuffixTableName),
+        "Table " + roSuffixTableName + " should not exist when skip_ro_suffix is set");
   }
 
   @ParameterizedTest

--- a/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-sync/hudi-hive-sync/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -1575,6 +1575,17 @@ public class TestHiveSyncTool {
     reInitHiveSyncClient();
     reSyncHiveTable();
 
+    // a second sync round with a new commit: the bare table name's read-optimized sync (which runs
+    // immediately before the origin-table sync within the same doSync() call) advances its own
+    // last-commit-time-synced marker, so the origin-table step is the only one still eligible to run
+    // and flip the format if not guarded
+    ZonedDateTime dateTime = ZonedDateTime.now().plusDays(6);
+    String commitTime2 = "102";
+    String deltaCommitTime2 = "103";
+    HiveTestUtil.addMORPartitions(1, true, false, true, dateTime, commitTime2, deltaCommitTime2);
+    reInitHiveSyncClient();
+    reSyncHiveTable();
+
     String snapshotTableName = HiveTestUtil.TABLE_NAME + HiveSyncTool.SUFFIX_SNAPSHOT_TABLE;
     String roSuffixTableName = HiveTestUtil.TABLE_NAME + HiveSyncTool.SUFFIX_READ_OPTIMIZED_TABLE;
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Hudi 1.x flipped the default of `hoodie.meta.sync.sync_snapshot_with_table_name` from `false` to `true` ([HUDI-7415]). Under the default `ALL` hive-sync-table-strategy, `HiveSyncTool.doSync()` now syncs the bare table name of a MERGE_ON_READ table twice in the same run when `hoodie.datasource.hive_sync.skip_ro_suffix=true` is also set: once as the read-optimized (RO) table (since `skip_ro_suffix` redirects the RO sync onto the bare name instead of `<table>_ro`), then again as the real-time (RT) table for the "sync origin table" step, with the RT sync silently winning. This makes `skip_ro_suffix` a no-op, leaves no RO view registered anywhere, and breaks read-optimized queries against the bare table name for engines that can't read `HoodieParquetRealtimeInputFormat` (e.g. Presto/Trino).

### Summary and Changelog

Skips the redundant bare-name RT sync in `HiveSyncTool.doSync()` when `skip_ro_suffix` is set, logging a WARN naming the table and stating which config takes precedence. The real-time view remains available at `<table>_rt`; the bare table name stays registered as the RO view.

No code was copied.

### Impact

No public API change. Behavior change only for MERGE_ON_READ tables with both `hoodie.datasource.hive_sync.skip_ro_suffix=true` and `hoodie.meta.sync.sync_snapshot_with_table_name=true`: the bare table name now stays registered as the read-optimized view instead of being flipped to real-time.

### Risk Level

low

Change is scoped to a single conditional in `HiveSyncTool.doSync()`; all other config combinations (including the previous default of `sync_snapshot_with_table_name=false`) are unaffected. Covered by a new regression test that reproduces the pre-fix flip.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
