### PR TITLE
fix(ci): retry the jacoco download when Maven Central returns 429

### DIFF
--- a/scripts/jacoco/download_jacoco.sh
+++ b/scripts/jacoco/download_jacoco.sh
@@ -17,6 +17,26 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-wget https://repo1.maven.org/maven2/org/jacoco/jacoco/0.8.12/jacoco-0.8.12.zip
-unzip jacoco-0.8.12.zip -d jacoco-lib
+set -euo pipefail
+
+JACOCO_VERSION=0.8.12
+JACOCO_ZIP="jacoco-${JACOCO_VERSION}.zip"
+JACOCO_URL="https://repo1.maven.org/maven2/org/jacoco/jacoco/${JACOCO_VERSION}/${JACOCO_ZIP}"
+
+# Maven Central answers 429 (Too Many Requests) when the shared CI egress IP is rate limited, and
+# wget treats every 4xx as fatal. Without a retry a single 429 fails a job whose build and tests
+# have already passed, so back off long enough to outlast the rate-limit window before giving up.
+for backoff in 15 30 60 0; do
+  if wget --tries=1 -O "$JACOCO_ZIP" "$JACOCO_URL"; then
+    break
+  fi
+  if [ "$backoff" -eq 0 ]; then
+    echo "Unable to download $JACOCO_URL" >&2
+    exit 1
+  fi
+  echo "Download failed, retrying in ${backoff}s"
+  sleep "$backoff"
+done
+
+unzip "$JACOCO_ZIP" -d jacoco-lib
 ls -l jacoco-lib/lib/jacococli.jar


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`scripts/jacoco/download_jacoco.sh` downloads the JaCoCo CLI with a bare `wget` and no retry. Maven Central answers HTTP 429 (Too Many Requests) when the shared CI egress IP is rate limited, and `wget` treats every 4xx as fatal, so a single 429 fails the job.

Seen on https://github.com/apache/hudi/pull/19426, job https://github.com/apache/hudi/actions/runs/30583128545/job/91008100450: all 550 tests passed and Maven reported `BUILD SUCCESS`, and only then did the `Generate merged coverage report` step die.

```
HTTP request sent, awaiting response... 429 Too Many Requests
2026-07-30 22:31:00 ERROR 429: Too Many Requests.
unzip:  cannot find or open jacoco-0.8.12.zip, ...
ls: cannot access 'jacoco-lib/lib/jacococli.jar': No such file or directory
##[error]Process completed with exit code 2.
```

The script also has no `set -e`, so the failed `wget` did not stop it and the reported failure came from the trailing `ls`, not from the 429. It runs at the end of 17 jobs in `.github/workflows/bot.yml` and 11 in `azure-pipelines-20230430.yml`, so one unlucky request discards up to an hour of green work and trips matrix fail-fast on sibling jobs.

### Summary and Changelog

- Added `set -euo pipefail` so a failed download aborts at the point of failure with the real error.
- Wrapped the download in a retry loop with a 15s / 30s / 60s backoff; on exhaustion it prints `Unable to download <url>` to stderr and exits 1.
- Extracted `JACOCO_VERSION` so the version appears once instead of three times.

The backoff is explicit rather than `wget --waitretry`, which ramps linearly from one second and so retries too fast to clear a rate-limit window.

No code was copied.

### Impact

CI only. No production code and no user-facing behavior changes. A transient 429 or 5xx no longer fails an otherwise green job; a persistent one still does, now with an accurate error message.

### Risk Level

low

Confined to a CI helper script, and `bash -n` passes. Verified against real Maven Central (exit 0, `jacococli.jar` extracted) and against a local server returning 429s: two transient 429s recover in 16s, and a permanent 429 exits 1 after 105s, matching the intended 15 + 30 + 60 schedule, with no misleading unzip/ls errors. The previous bare `wget` exits 8 immediately on the same input. `scripts/jacoco/merge_jacoco_exec_files.sh` already got retries in #12921, so this was the last unguarded step in the coverage chain.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
