### PR TITLE
fix(flink): rethrow StreamWriteOperatorCoordinator start() failures

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -254,8 +254,12 @@ public class StreamWriteOperatorCoordinator
       }
       restoreEvents(Long.MAX_VALUE);
     } catch (Throwable throwable) {
-      log.error("Failed to start operator coordinator.", throwable);
-      context.failJob(throwable);
+      // Rethrow instead of context.failJob(): failJob triggers an in-graph global failover that
+      // keeps this same coordinator instance alive without calling start() again, leaving the
+      // half-initialized null fields (executor, writeClient, metaClient ...) to be reused and NPE
+      // later. Rethrowing surfaces the failure as a JobMaster start failure so the partially
+      // initialized instance is discarded rather than kept serving.
+      throw new HoodieException("Failed to start operator coordinator.", throwable);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/StreamWriteOperatorCoordinator.java
@@ -253,13 +253,13 @@ public class StreamWriteOperatorCoordinator
         initClientIds(conf);
       }
       restoreEvents(Long.MAX_VALUE);
-    } catch (Throwable throwable) {
+    } catch (Exception exception) {
       // Rethrow instead of context.failJob(): failJob triggers an in-graph global failover that
       // keeps this same coordinator instance alive without calling start() again, leaving the
       // half-initialized null fields (executor, writeClient, metaClient ...) to be reused and NPE
       // later. Rethrowing surfaces the failure as a JobMaster start failure so the partially
       // initialized instance is discarded rather than kept serving.
-      throw new HoodieException("Failed to start operator coordinator.", throwable);
+      throw new HoodieException("Failed to start operator coordinator.", exception);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteCopyOnWrite.java
@@ -745,7 +745,7 @@ public class TestWriteCopyOnWrite extends TestWriteBase {
 
   protected void validateNonBlockingConcurrencyControlConditions() {
     assertThrows(
-        IllegalArgumentException.class,
+        HoodieException.class,
         () -> preparePipeline(conf),
         "Non-blocking concurrency control requires the MOR table with simple bucket index");
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`StreamWriteOperatorCoordinator.start()` initializes several fields that are required by later coordinator operations, such as `metaClient`, `writeClient`, `executor`, and related coordinator state.

Previously, if startup failed, the coordinator called `context.failJob(throwable)`. This can trigger an in-graph global failover while keeping the same coordinator instance alive. In that path, Flink may restore the job without invoking `start()` again on the same coordinator instance. If the original startup failed before all fields were initialized, the restored coordinator can continue running with null fields and later fail with `NullPointerException`.

### Summary and Changelog

This PR updates `StreamWriteOperatorCoordinator.start()` to rethrow startup failures as a `HoodieException`.

Changes:
- Replace `context.failJob(throwable)` in the `start()` failure path with `throw new HoodieException(...)`.

### Impact

None

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable