### PR TITLE
fix(build): publish dependency-reduced POMs for shaded bundles

### DIFF
--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -117,7 +117,7 @@
                                     <shadedPattern>org.apache.hudi.aws.org.apache.httpcomponents.</shadedPattern>
                                 </relocation>
                             </relocations>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -118,6 +118,9 @@
                                 </relocation>
                             </relocations>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <!-- Keep dependencies that are not absorbed into the shaded jar, so the reduced POM still
+                                 declares what consumers need at runtime. -->
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -133,6 +133,9 @@
                 </relocation>
               </relocations>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Keep dependencies that are not absorbed into the shaded jar, so the reduced POM still
+                   declares what consumers need at runtime. -->
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-azure-bundle/pom.xml
+++ b/packaging/hudi-azure-bundle/pom.xml
@@ -132,7 +132,7 @@
                   <shadedPattern>org.apache.hudi.org.reactivestreams.</shadedPattern>
                 </relocation>
               </relocations>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-datahub-sync-bundle/pom.xml
+++ b/packaging/hudi-datahub-sync-bundle/pom.xml
@@ -92,6 +92,9 @@
                 </relocation>
               </relocations>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Keep dependencies that are not absorbed into the shaded jar, so the reduced POM still
+                   declares what consumers need at runtime. -->
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-datahub-sync-bundle/pom.xml
+++ b/packaging/hudi-datahub-sync-bundle/pom.xml
@@ -91,7 +91,7 @@
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
                 </relocation>
               </relocations>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-gcp-bundle/pom.xml
+++ b/packaging/hudi-gcp-bundle/pom.xml
@@ -115,7 +115,7 @@
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
                 </relocation>
               </relocations>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-gcp-bundle/pom.xml
+++ b/packaging/hudi-gcp-bundle/pom.xml
@@ -116,6 +116,9 @@
                 </relocation>
               </relocations>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Keep dependencies that are not absorbed into the shaded jar, so the reduced POM still
+                   declares what consumers need at runtime. -->
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-hadoop-mr-bundle/pom.xml
+++ b/packaging/hudi-hadoop-mr-bundle/pom.xml
@@ -136,7 +136,7 @@
                   <shadedPattern>org.apache.hudi.com.fasterxml.jackson.</shadedPattern>
                 </relocation>
               </relocations>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-hadoop-mr-bundle/pom.xml
+++ b/packaging/hudi-hadoop-mr-bundle/pom.xml
@@ -137,6 +137,9 @@
                 </relocation>
               </relocations>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Keep dependencies that are not absorbed into the shaded jar, so the reduced POM still
+                   declares what consumers need at runtime. -->
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -123,7 +123,7 @@
                   <shadedPattern>org.apache.hudi.org.objenesis.</shadedPattern>
                 </relocation>
               </relocations>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -124,6 +124,9 @@
                 </relocation>
               </relocations>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Keep dependencies that are not absorbed into the shaded jar, so the reduced POM still
+                   declares what consumers need at runtime. -->
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -141,7 +141,7 @@
                   <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
                 </relocation>
               </relocations>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -142,6 +142,9 @@
                 </relocation>
               </relocations>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Keep dependencies that are not absorbed into the shaded jar, so the reduced POM still
+                   declares what consumers need at runtime. -->
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>
@@ -191,6 +194,19 @@
     <dependency>
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-hadoop-mr-bundle</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- Both are shaded in by the artifactSet above. Declared directly rather than relying on
+         hudi-hadoop-mr-bundle to supply them transitively, so this bundle's shade inputs do not depend
+         on another bundle's published dependency list. -->
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-hadoop-mr</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-hadoop-common</artifactId>
       <version>${project.version}</version>
     </dependency>
 


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #16407 (HUDI-7455).

Seven bundles set `<createDependencyReducedPom>false</createDependencyReducedPom>`, so the POM published
to Maven Central still declares the artifacts that were shaded into the jar. Consumers inherit those
artifacts as transitive dependencies even though the classes are already inside the bundle.

What suggests this was unintended rather than deliberate: each of those bundles *also* sets
`<dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>`
in the same `<configuration>` block, `dependency-reduced-pom.xml` is already in `.gitignore`, and
`hudi-timeline-server-bundle` already sets the flag to `true` — as do the nine bundles that don't override
shade's default.

### Summary and Changelog

- `createDependencyReducedPom=true` on the seven bundles that had it disabled: `hudi-aws-bundle`,
  `hudi-hadoop-mr-bundle`, `hudi-datahub-sync-bundle`, `hudi-presto-bundle`, `hudi-azure-bundle`,
  `hudi-hive-sync-bundle`, `hudi-gcp-bundle`.

- `promoteTransitiveDependencies=true` on the same seven. The flag defaults to false, which makes shade drop
  the removed dependency *and* everything reaching the project only through it — including artifacts that are
  not in the shaded jar. With it enabled the reduced POM keeps the runtime contract minus what was absorbed.
  `hudi-hadoop-mr-bundle`'s reduced POM goes from 0 dependencies to 79, restoring `orc-core`, `rocksdbjni`,
  `jetty-server`/`jetty-servlet`, dropwizard metrics, `simpleclient`, `tally-core`, `lz4-java`, `disruptor`
  and `jaxb-api` among others. The other six land between 73 and 191.

- `hudi-presto-bundle` now declares `hudi-hadoop-mr` and `hudi-hadoop-common` directly. It shades both, but
  reached them only transitively through `hudi-hadoop-mr-bundle`. Once that bundle's POM was reduced, the two
  includes matched nothing and shade silently wrote a smaller jar: **109 `org/apache/hudi/hadoop/**` entries
  dropped to 0, losing `HoodieParquetInputFormat`**, which is the reason the bundle exists. Declaring them
  directly restores 109 and stops this bundle's shade inputs depending on another bundle's published
  dependency list.

### Verification

The only meaningful check here is install-then-resolve-from-repository, because an in-reactor build never
sees the reduced POM: shade mutates `project.getOriginalModel()` and calls `setFile(reducedPom)`, while
Maven's `ReactorReader` serves the effective model, which shade does not touch. `mvn package -pl
packaging/<bundle>` with a stale un-reduced POM in `~/.m2` also passes, which invalidated my first attempt at
verifying this.

```
mvn install -pl packaging/hudi-hadoop-mr-bundle -DskipTests     # publishes the reduced POM
mvn package -pl packaging/hudi-presto-bundle -DskipTests        # no -am, resolves from the repository
unzip -l packaging/hudi-presto-bundle/target/hudi-presto-bundle-*.jar | grep -c org/apache/hudi/hadoop/
```

| state | presto `org/apache/hudi/hadoop/**` entries |
| --- | --- |
| before this PR | 109 |
| reduced POM, presto not declaring its shade inputs | 0 |
| this PR | 109 |

All seven bundles build and emit a reduced POM. `apache-rat:check` passes.

### Open question: consistency with the nine already-reduced bundles

Worth deciding before this merges. Nine other bundles already publish a reduced POM — `hudi-spark-bundle`,
`hudi-utilities-bundle`, `hudi-utilities-slim-bundle`, `hudi-flink-bundle`, `hudi-cli-bundle`,
`hudi-kafka-connect-bundle`, `hudi-integ-test-bundle`, `hudi-metaserver-server-bundle` (shade's default) and
`hudi-timeline-server-bundle` (explicitly `true`) — and **none of them sets
`promoteTransitiveDependencies`**. `hudi-spark3.5-bundle`'s published POM has carried 8 dependencies from
0.15.0 through to current master, so dropping non-bundled transitives is the shipped behaviour of those nine.

With promotion enabled the seven bundles here publish 73–191 dependencies instead, which is safer for
consumers but different from house style. So the choice is really: promotion everywhere, or promotion nowhere.

I have kept promotion on these seven because it preserves the runtime contract, which was the concern raised
in review, and because it is the conservative direction for a consumer. Happy to go either way:

- drop `promoteTransitiveDependencies` here, matching the nine, and document the transitive drop instead; or
- keep it and add it to the other nine as a follow-up, so all sixteen behave the same.

Deliberately not expanding to those nine in this PR — that would change published metadata for nine more
artifacts, including the Spark and Flink bundles, and each needs its own verification.

### Impact

This changes the **published POM** of seven artifacts. A downstream build that currently resolves something
transitively through an artifact that is now absorbed into the bundle will need to declare it directly. That
is the intended correction — a shaded bundle should not advertise dependencies it has already absorbed — but
it is visible to consumers and worth a release note. Happy to stage it per bundle if smaller steps are
preferred.

With `promoteTransitiveDependencies=true`, dependencies that are *not* absorbed are still declared, so the
change is limited to the absorbed set rather than to everything that arrived through it.

Note on what is unchanged: Hadoop and Hive artifacts such as `hadoop-common`, `hadoop-hdfs`, `hive-jdbc` and
`hive-metastore` are `provided` in the root pom's `dependencyManagement`, so they are not transitive and were
never advertised by these bundles. Consumers were already expected to supply them, before and after this PR.

No change to jar contents beyond the presto fix restoring what it used to contain, and no Hudi API, config or
table format change.

### Risk Level

medium — it alters published dependency metadata for seven released artifacts. Verified that all seven build,
that each emits a reduced POM, which dependencies are removed versus retained, and that the presto bundle's
contents are byte-for-byte restored under the install-then-resolve recipe that exposed the regression.

### Documentation Update

none in the docs tree, but worth a release-note line for the affected bundles, since consumers may need to
declare dependencies they previously received transitively.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
