### PR TITLE
fix(ci): stop docker-java17-test from sealing a near-empty Maven cache

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1193,7 +1193,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           architecture: x64
-          cache: maven
+          # No `cache: maven` on purpose. This job runs no Maven on the host: run_docker_java17.sh
+          # builds inside the container and never mounts $HOME/.m2. Caching here seals a near-empty
+          # repo under the key all jobs share, which every later job then discards and re-downloads.
       - name: UT/FT - Docker Test - OpenJDK 17
         env:
           FLINK_PROFILE: ${{ matrix.flinkProfile }}
@@ -1203,7 +1205,6 @@ jobs:
         # Only support Spark 3.4 for now
         if: ${{ env.SPARK_PROFILE >= 'spark3.4' && needs.changes.outputs.relevant == 'true' }}
         run: |
-          HUDI_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           ./packaging/bundle-validation/run_docker_java17.sh
 
   validate-bundles:


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

`docker-java17-test` declares `cache: maven`, but `run_docker_java17.sh` builds inside a container and never mounts `$HOME/.m2`, so the host repo `actions/setup-java` snapshots is near-empty. All jobs share one cache key and the first to finish wins the write, so when this job misses on restore it seals that near-empty repo for the rest of the PR.

Measured on run 30610414199: [job 91092305450](https://github.com/apache/hudi/actions/runs/30610414199/job/91092305450) logged `maven cache is not found`, then `Cache saved with the key: setup-java-Linux-x64-maven-233646b0...`. The resulting entry is 8,940,929 bytes against 1,213,136,182 bytes on `refs/heads/master`. On #19408 an identical entry was restored by a later job in the same run (`Cache Size: ~9 MB (8939585 B)`), which then re-downloaded ~1 GB from Maven Central.

That burst is what gets a runner's shared egress IP rate limited. Originating failure: [job 91092304952](https://github.com/apache/hudi/actions/runs/30610414199/job/91092304952), `Build Project` dead before any test ran on `scala-maven-plugin:pom:3.4.6 ... status code: 403, reason phrase: Forbidden (403)`. Same defect #19244 fixed for `validate-source`.

### Summary and Changelog

- Drop `cache: maven` from `docker-java17-test`, with a comment mirroring the existing one on `validate-source`.
- Delete the dead `HUDI_VERSION=$(mvn help:evaluate ...)` in that job: `run_docker_java17.sh` is called with no arguments and never reads it (unlike `ci_run.sh`, where it is `$2`). The job is then left with no host-side Maven at all.

Audited: this is the only live job with that shape. `test-common-and-other-modules` also builds in Docker but mounts `-v "$HOME/.m2:/root/.m2"`; every other `cache: maven` job in `bot.yml` runs a real host build; the same-shaped jobs in `maven_artifact_validation.yml` and `release_candidate_validation.yml` all carry `if: false`.

### Impact

CI only. Jobs that previously restored ~9 MB and re-downloaded from Maven Central will restore ~1 GB instead.

### Risk Level

low

Confined to one job whose real work runs inside a container with its own local repository. `cache-read-only: true` would be more surgical, but it exists only on `actions/setup-java`'s `main`, not the released `v5` tag pinned here.

Verifiable on this PR's run: the job still passes, its post step no longer prints `Cache saved with the key: setup-java-...`, and the entry under this PR's ref is ~1 GB rather than ~9 MB.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
