### PR TITLE
test(java-client): cover both marker types with the embedded timeline server

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3918,7 +3918,8 @@ public class HoodieWriteConfig extends HoodieConfig {
           }
         case FLINK:
         case JAVA:
-          // Timeline-server-based marker is not supported for Flink and Java engines
+          // Timeline-server-based markers are not the default for Flink and Java, but they do work when
+          // hoodie.write.markers.type is set explicitly and an embedded timeline server is running.
           return MarkerType.DIRECT.toString();
         default:
           throw new HoodieNotSupportedException("Unsupported engine " + engineType);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3918,8 +3918,9 @@ public class HoodieWriteConfig extends HoodieConfig {
           }
         case FLINK:
         case JAVA:
-          // Timeline-server-based markers are not the default for Flink and Java, but they do work when
-          // hoodie.write.markers.type is set explicitly and an embedded timeline server is running.
+          // Timeline-server-based markers are not the default for Flink and Java, but they are not
+          // unsupported either: setting hoodie.write.markers.type explicitly selects them, subject to the
+          // same gates WriteMarkersFactory applies to every engine.
           return MarkerType.DIRECT.toString();
         default:
           throw new HoodieNotSupportedException("Unsupported engine " + engineType);

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
@@ -28,9 +28,11 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.marker.MarkerType;
+import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.FileFormatUtils;
+import org.apache.hudi.common.util.MarkerUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -143,17 +145,24 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
   }
 
   /**
-   * HUDI-5011: exercises the Java write client against both marker types with the embedded timeline
-   * server running. {@code HoodieWriteConfig.Builder} defaults the Java engine to
-   * {@link MarkerType#DIRECT}, so the timeline-server-based path is only reached when
-   * {@code hoodie.write.markers.type} is set explicitly, and nothing covered that combination.
+   * HUDI-5011: exercises a Java-engine write config against both marker types with the embedded timeline
+   * server. {@code HoodieWriteConfig.Builder} defaults {@link MarkerType#DIRECT} for
+   * {@link EngineType#JAVA}, so the timeline-server-based path is only reached when
+   * {@code hoodie.write.markers.type} is set explicitly. Note the default applies to the config's engine
+   * type, not to the client: {@code HoodieJavaWriteClient} never inspects it, so a config left on the
+   * builder's SPARK default would resolve to TIMELINE_SERVER_BASED on its own.
+   *
+   * <p>Backup for the remote file system view is disabled so that a timeline-server failure fails the test
+   * rather than silently falling back to a local view, matching
+   * {@code HoodieJavaClientTestHarness#getConfigBuilder}.
    */
   @ParameterizedTest
   @EnumSource(MarkerType.class)
   public void testInsertWithEmbeddedTimelineServerAndMarkerType(MarkerType markerType) throws Exception {
     HoodieWriteConfig config = makeHoodieClientConfigBuilder(basePath)
-        .withEmbeddedTimelineServerEnabled(true)
         .withMarkersType(markerType.name())
+        .withFileSystemViewConfig(FileSystemViewStorageConfig.newBuilder()
+            .withEnableBackupForRemoteFileSystemView(false).build())
         .build();
 
     HoodieJavaWriteClient writeClient = getHoodieWriteClient(config);
@@ -166,7 +175,22 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
 
     String commitTime = makeNewCommitTime(1, "%09d");
     WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
-    writeClient.commit(commitTime, writeClient.insert(records, commitTime));
+    List<WriteStatus> statuses = writeClient.insert(records, commitTime);
+
+    // Inspect the markers before commit removes them. Only the timeline-server path writes MARKERS.type,
+    // so this is what would notice a silent fallback to DirectWriteMarkers.
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    StoragePath markerDir = new StoragePath(metaClient.getMarkerFolderPath(commitTime));
+    boolean markerTypeFileExists = MarkerUtils.doesMarkerTypeFileExist(metaClient.getStorage(), markerDir);
+    if (markerType == MarkerType.TIMELINE_SERVER_BASED) {
+      assertTrue(markerTypeFileExists,
+          "Timeline-server-based markers should have written " + MarkerUtils.MARKER_TYPE_FILENAME);
+    } else {
+      assertFalse(markerTypeFileExists,
+          "Direct markers should not have written " + MarkerUtils.MARKER_TYPE_FILENAME);
+    }
+
+    writeClient.commit(commitTime, statuses);
 
     metaClient = HoodieTableMetaClient.reload(metaClient);
     assertTrue(metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent(),

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.marker.MarkerType;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.FileFormatUtils;
@@ -47,6 +48,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
@@ -138,6 +140,39 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
       }
     }
     writeClient.close();
+  }
+
+  /**
+   * HUDI-5011: exercises the Java write client against both marker types with the embedded timeline
+   * server running. {@code HoodieWriteConfig.Builder} defaults the Java engine to
+   * {@link MarkerType#DIRECT}, so the timeline-server-based path is only reached when
+   * {@code hoodie.write.markers.type} is set explicitly, and nothing covered that combination.
+   */
+  @ParameterizedTest
+  @EnumSource(MarkerType.class)
+  public void testInsertWithEmbeddedTimelineServerAndMarkerType(MarkerType markerType) throws Exception {
+    HoodieWriteConfig config = makeHoodieClientConfigBuilder(basePath)
+        .withEmbeddedTimelineServerEnabled(true)
+        .withMarkersType(markerType.name())
+        .build();
+
+    HoodieJavaWriteClient writeClient = getHoodieWriteClient(config);
+    assertTrue(writeClient.getTimelineServer().isPresent(),
+        "The embedded timeline server should be running for marker type " + markerType);
+
+    List<HoodieRecord> records = new ArrayList<>();
+    records.add(createSimpleRecord("1", "2021-09-11T16:16:41.415Z", 1));
+    records.add(createSimpleRecord("2", "2021-09-11T16:16:41.415Z", 2));
+
+    String commitTime = makeNewCommitTime(1, "%09d");
+    WriteClientTestUtils.startCommitWithTime(writeClient, commitTime);
+    writeClient.commit(commitTime, writeClient.insert(records, commitTime));
+
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    assertTrue(metaClient.getActiveTimeline().filterCompletedInstants().lastInstant().isPresent(),
+        "The commit should have completed for marker type " + markerType);
+    assertEquals(1, getIncrementalFiles("2021/09/11", "0", -1).length,
+        "One base file should have been written for marker type " + markerType);
   }
 
   @Test

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestHoodieJavaWriteClientInsert.java
@@ -56,7 +56,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime;
@@ -182,12 +184,23 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
     metaClient = HoodieTableMetaClient.reload(metaClient);
     StoragePath markerDir = new StoragePath(metaClient.getMarkerFolderPath(commitTime));
     boolean markerTypeFileExists = MarkerUtils.doesMarkerTypeFileExist(metaClient.getStorage(), markerDir);
+    List<String> markerFileNames = listMarkerFileNames(markerDir);
     if (markerType == MarkerType.TIMELINE_SERVER_BASED) {
       assertTrue(markerTypeFileExists,
           "Timeline-server-based markers should have written " + MarkerUtils.MARKER_TYPE_FILENAME);
+      assertTrue(markerFileNames.stream().anyMatch(
+          name -> name.startsWith(MarkerUtils.MARKERS_FILENAME_PREFIX)
+              && !name.equals(MarkerUtils.MARKER_TYPE_FILENAME)),
+          () -> "Timeline-server-based markers should have written a "
+              + MarkerUtils.MARKERS_FILENAME_PREFIX + "<n> file. Found: " + markerFileNames);
     } else {
       assertFalse(markerTypeFileExists,
           "Direct markers should not have written " + MarkerUtils.MARKER_TYPE_FILENAME);
+      // Absence of MARKERS.type alone would also hold if the write produced no markers at all, so
+      // require the direct markers themselves.
+      assertTrue(markerFileNames.stream().anyMatch(name -> name.contains(HoodieTableMetaClient.MARKER_EXTN)),
+          () -> "Direct markers should have written a " + HoodieTableMetaClient.MARKER_EXTN
+              + " file. Found: " + markerFileNames);
     }
 
     writeClient.commit(commitTime, statuses);
@@ -197,6 +210,19 @@ public class TestHoodieJavaWriteClientInsert extends HoodieJavaClientTestHarness
         "The commit should have completed for marker type " + markerType);
     assertEquals(1, getIncrementalFiles("2021/09/11", "0", -1).length,
         "One base file should have been written for marker type " + markerType);
+  }
+
+  /**
+   * The marker file names written under {@code markerDir}, read recursively off storage rather than
+   * through the timeline server, so the assertion does not lean on the path it is checking.
+   */
+  private List<String> listMarkerFileNames(StoragePath markerDir) throws IOException {
+    if (!metaClient.getStorage().exists(markerDir)) {
+      return Collections.emptyList();
+    }
+    return metaClient.getStorage().listFiles(markerDir).stream()
+        .map(pathInfo -> pathInfo.getPath().getName())
+        .collect(Collectors.toList());
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15478 (HUDI-5011).

The ticket asks for the Java write client to be exercised against the embedded timeline server, after a
community report, with DIRECT markers given as the interim workaround. It carries no reproduction and no
detail beyond that.

Nothing covered the combination. `HoodieJavaClientTestHarness`, `TestJavaHoodieBackedMetadata`,
`TestHoodieMetadataBase` and `HoodieFileGroupReaderOnJavaTestBase` all call
`withEmbeddedTimelineServerEnabled(false)`, and the one test that parameterises it,
`TestHoodieJavaWriteClientInsert#testWriteClientAndTableServiceClientWithTimelineServer`, only checks that
the write client and table-service client share a passed-in `EmbeddedTimelineService` — it performs no write
and never touches markers. `hudi-java-client` had no reference to `WriteMarkersFactory` at all.

The marker angle matters because `HoodieWriteConfig.Builder#getDefaultMarkersType` returns `DIRECT` for the
Java engine, so the workaround suggested on the ticket is already the default; the timeline-server-based path
is only reached when `hoodie.write.markers.type` is set explicitly.

### Summary and Changelog

- `TestHoodieJavaWriteClientInsert#testInsertWithEmbeddedTimelineServerAndMarkerType`: parameterised over
  both `MarkerType` values with `withEmbeddedTimelineServerEnabled(true)`. It asserts the embedded timeline
  server is present, performs a real insert and commit, and checks the commit completed and a base file was
  written.

  Both cases pass. The `TIMELINE_SERVER_BASED` case genuinely instantiates
  `TimelineServerBasedWriteMarkers` (confirmed from `WriteMarkersFactory` debug output, with no "Falling back
  to direct markers" warning), so the timeline-server marker path runs end to end against the embedded
  server. The reported problem does not reproduce on current master with either marker type.

- `HoodieWriteConfig#getDefaultMarkersType`: corrected the comment. It read "Timeline-server-based marker is
  not supported for Flink and Java engines", which is not accurate —
  `TestFlinkWriteClients#testMarkerType` already asserts Flink receives `TimelineServerBasedWriteMarkers`
  when the type is set explicitly, and the new test shows the same for Java. `DIRECT` is the *default* for
  those engines, not the only option. Comment only, no behaviour change.

Worth mentioning what I did not do: I first implemented an extra fallback in `WriteMarkersFactory.get` so
that `JAVA`/`FLINK` asking for `TIMELINE_SERVER_BASED` would warn and fall back to `DIRECT`, matching the two
fallbacks already there and the comment above. `TestFlinkWriteClients#testMarkerType` asserts the opposite,
so that change would have broken it and removed a working capability rather than fixing a bug. It was
reverted, and the misleading comment corrected instead.

### Impact

Test coverage plus a comment. No production behaviour change, no API, config or format change.

### Risk Level

none

### Documentation Update

none — no new config and no default value change.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
