### PR TITLE
chore(spark): prune dead code in the six extended SQL AST builders

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -454,11 +454,10 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // to #19449: the extended parser enables ANSI reserved-keyword enforcement whenever
     // spark.sql.ansi.enabled is set (the Spark 4.x default) instead of following Spark's
     // spark.sql.ansi.enforceReservedKeywords, which makes a bare TIMESTAMP token unparseable
-    // there (a bug, not a Spark 4 constraint). A bare true/false in this position parses as a
-    // column reference in BOTH keyword modes (TRUE/FALSE are ansiNonReserved, so qualifiedName
-    // wins), leaving visitBooleanLiteral unreachable (#19451); null is a column reference only
-    // under the default non-ANSI keyword mode and a null literal under ANSI, so visitNullLiteral
-    // is mode-dependent and both are left unasserted here.
+    // there (a bug, not a Spark 4 constraint). Boolean and null literals are keyword-mode
+    // dependent: only TRUE is ansiNonReserved, so a bare true always parses as a column
+    // reference, while false and null are column references under the default non-ANSI keyword
+    // mode but typed literals under ANSI mode (the boolean case is asserted below).
     val plan = parseCreateTable(
       s"""
          |CREATE TABLE blob_lit_tbl (
@@ -485,6 +484,18 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
       firstLiteralArg(transformByName(plan, "mu_ivl_t")).dataType)
     assertResult(YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH))(
       firstLiteralArg(transformByName(plan, "uu_ivl_t")).dataType)
+
+    // Under ANSI keyword mode a bare false must survive visitBooleanLiteral as a typed literal,
+    // while a bare true stays a column reference (TRUE is ansiNonReserved, FALSE is not).
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      val ansiPlan = parseCreateTable(
+        "CREATE TABLE blob_bool_tbl (id BIGINT, data BLOB) USING hudi " +
+          "PARTITIONED BY (bool_t(false, id), true_t(true, id))")
+      assertResult(BooleanType)(firstLiteralArg(transformByName(ansiPlan, "bool_t")).dataType)
+      assertResult(false)(firstLiteralArg(transformByName(ansiPlan, "bool_t")).value)
+      assertResult(Seq(Seq("true"), Seq("id")))(
+        transformFieldRefs(transformByName(ansiPlan, "true_t")))
+    }
   }
 
   test("Test parse CREATE TABLE with BLOB column and invalid partition transforms") {
@@ -539,6 +550,14 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
       "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE")
     assertResult(Some("TEXTFILE"))(ff6.tableSpec.serde.get.storedAs)
     assertResult(",")(ff6.tableSpec.serde.get.serdeProperties("field.delim"))
+    // Any ROW FORMAT combined with STORED AS INPUTFORMAT/OUTPUTFORMAT is accepted (the
+    // table-file-format arm of validateRowFormatFileFormat).
+    val ff7 = parseCreateTable("CREATE TABLE blob_ff7 (id BIGINT, data BLOB) " +
+      "ROW FORMAT SERDE 'com.example.Serde' " +
+      "STORED AS INPUTFORMAT 'com.example.InFmt' OUTPUTFORMAT 'com.example.OutFmt'")
+    assertResult(Some("com.example.Serde"))(ff7.tableSpec.serde.get.serde)
+    assertResult(Some(FormatClasses("com.example.InFmt", "com.example.OutFmt")))(
+      ff7.tableSpec.serde.get.formatClasses)
 
     // ROW FORMAT DELIMITED with a non-text file format is rejected.
     checkExceptionContain(
@@ -556,6 +575,13 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     checkExceptionContain(
       "CREATE TABLE blob_ferr3 (id BIGINT, data BLOB) STORED BY 'com.example.Handler'")(
       "Operation not allowed: STORED BY")
+    // ROW FORMAT combined with STORED BY leaves no file format for the row format to pair with;
+    // validateRowFormatFileFormat's catch-all arm rejects the combination before the STORED BY
+    // error can fire.
+    checkExceptionContain(
+      "CREATE TABLE blob_ferr5 (id BIGINT, data BLOB) " +
+        "ROW FORMAT SERDE 'com.example.Serde' STORED BY 'com.example.Handler'")(
+      "Unexpected combination of")
     // A USING provider combined with a serde clause is not allowed.
     checkExceptionContain(
       "CREATE TABLE blob_ferr4 (id BIGINT, data BLOB) USING hudi STORED AS PARQUET")(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -457,7 +457,7 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // there (a bug, not a Spark 4 constraint). Boolean and null literals are keyword-mode
     // dependent: only TRUE is ansiNonReserved, so a bare true always parses as a column
     // reference, while false and null are column references under the default non-ANSI keyword
-    // mode but typed literals under ANSI mode (the boolean case is asserted below).
+    // mode but typed literals under ANSI mode (both cases are asserted below).
     val plan = parseCreateTable(
       s"""
          |CREATE TABLE blob_lit_tbl (
@@ -485,14 +485,17 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     assertResult(YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH))(
       firstLiteralArg(transformByName(plan, "uu_ivl_t")).dataType)
 
-    // Under ANSI keyword mode a bare false must survive visitBooleanLiteral as a typed literal,
-    // while a bare true stays a column reference (TRUE is ansiNonReserved, FALSE is not).
+    // Under ANSI keyword mode a bare false and a bare null must survive visitBooleanLiteral
+    // and visitNullLiteral as typed literals, while a bare true stays a column reference
+    // (TRUE is ansiNonReserved; FALSE and NULL are not).
     withSQLConf("spark.sql.ansi.enabled" -> "true") {
       val ansiPlan = parseCreateTable(
         "CREATE TABLE blob_bool_tbl (id BIGINT, data BLOB) USING hudi " +
-          "PARTITIONED BY (bool_t(false, id), true_t(true, id))")
+          "PARTITIONED BY (bool_t(false, id), true_t(true, id), null_t(null, id))")
       assertResult(BooleanType)(firstLiteralArg(transformByName(ansiPlan, "bool_t")).dataType)
       assertResult(false)(firstLiteralArg(transformByName(ansiPlan, "bool_t")).value)
+      assertResult(NullType)(firstLiteralArg(transformByName(ansiPlan, "null_t")).dataType)
+      assertResult(null)(firstLiteralArg(transformByName(ansiPlan, "null_t")).value)
       assertResult(Seq(Seq("true"), Seq("id")))(
         transformFieldRefs(transformByName(ansiPlan, "true_t")))
     }

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
@@ -21,19 +21,18 @@ import org.apache.hudi.spark.sql.parser.{HoodieSqlBaseBaseVisitor, HoodieSqlBase
 import org.apache.hudi.spark.sql.parser.HoodieSqlBaseParser._
 
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
-import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
+import org.antlr.v4.runtime.tree.{ParseTree, RuleNode}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, entry, escapedIdentifier, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin, EnhancedLogicalPlan}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils, DateTimeUtils, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.BucketSpecHelper
 import org.apache.spark.sql.connector.catalog.TableCatalog
@@ -212,17 +211,6 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
-  }
-
-  /**
-   * Create a Boolean literal expression.
-   */
-  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
-    if (ctx.getText.toBoolean) {
-      Literal.TrueLiteral
-    } else {
-      Literal.FalseLiteral
-    }
   }
 
   /**
@@ -643,13 +631,6 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create top level table schema.
-   */
-  protected def createSchema(ctx: ColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitColTypeList))
-  }
-
-  /**
    * Create a [[StructType]] from a number of column definitions.
    */
   override def visitColTypeList(ctx: ColTypeListContext): Seq[StructField] = withOrigin(ctx) {
@@ -689,13 +670,6 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
-  }
-
-  /**
-   * Create a [[StructType]] from a sequence of [[StructField]]s.
-   */
-  protected def createStructType(ctx: ComplexColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitComplexColTypeList))
   }
 
   /**
@@ -776,7 +750,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a table property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitTablePropertyList(
                                        ctx: TablePropertyListContext): Map[String, String] = withOrigin(ctx) {
@@ -801,19 +775,6 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[TablePropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: TablePropertyListContext): Seq[String] = {
-    val props = visitTablePropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**
@@ -925,10 +886,6 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
         throw new ParseException(s"Too many arguments for transform $name", ctx)
-      } else if (arguments.isEmpty) {
-        throw
-
-          new ParseException(s"Not enough arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -988,8 +945,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+      reference.orElse(literal).get
     }
   }
 
@@ -1044,8 +1000,6 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         SerdeInfo(storedAs = Some(c.identifier.getText))
       case (null, storageHandler) =>
         operationNotAllowed("STORED BY", ctx)
-      case _ =>
-        throw new ParseException("Expected either STORED AS or STORED BY, not both", ctx)
     }
   }
 
@@ -1360,7 +1314,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitPropertyList(ctx: PropertyListContext): Map[String, String] = withOrigin(ctx) {
     val properties = ctx.property.asScala.map { property =>
@@ -1384,19 +1338,6 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[PropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: PropertyListContext): Seq[String] = {
-    val props = visitPropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
@@ -206,7 +206,9 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create a NULL literal expression.
+   * Create a NULL literal expression. Reachable under ANSI keyword mode, where NULL (like
+   * FALSE) is a reserved word, so f(null, id) in transform-argument position parses as a
+   * null literal instead of a column reference.
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
@@ -1244,7 +1246,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     // partition transforms for BucketSpec was moved inside parser
     // https://issues.apache.org/jira/browse/SPARK-37923
     val partitioning =
-    partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
+      partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
     val tableSpec = TableSpec(properties, provider, options, location, comment,
       serdeInfo, external)
 

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.types.BlobType
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 import org.apache.spark.util.Utils.isTesting
 
@@ -211,6 +210,19 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
+  }
+
+  /**
+   * Create a Boolean literal expression. Reachable under ANSI keyword mode, where FALSE is a
+   * reserved word (only TRUE is ansiNonReserved), so a bare false in transform-argument
+   * position parses as a boolean literal instead of a column reference.
+   */
+  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
+    if (ctx.getText.toBoolean) {
+      Literal.TrueLiteral
+    } else {
+      Literal.FalseLiteral
+    }
   }
 
   /**
@@ -945,7 +957,8 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal).get
+      reference.orElse(literal)
+        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
     }
   }
 
@@ -1098,7 +1111,8 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               s"ROW FORMAT DELIMITED is only compatible with 'textfile', not '$fmt'", parentCtx)
           }
         case _ =>
-          // should never happen
+          // Reachable: ROW FORMAT ... STORED BY 'handler' leaves createFileFormatCtx.fileFormat
+          // null, so none of the typed arms above match.
           def str(ctx: ParserRuleContext): String = {
             (0 until ctx.getChildCount).map { i => ctx.getChild(i).getText }.mkString(" ")
           }
@@ -1184,14 +1198,13 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create a table, returning a [[CreateTable]] or [[CreateTableAsSelect]] logical plan.
+   * Create a table, returning a [[CreateTable]] logical plan.
    *
    * Expected format:
    * {{{
    *   CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [db_name.]table_name
    *   [USING table_provider]
-   *   create_table_clauses
-   *   [[AS] select_statement];
+   *   create_table_clauses;
    *
    *   create_table_clauses (order insensitive):
    *     [PARTITIONED BY (partition_fields)]
@@ -1231,7 +1244,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     // partition transforms for BucketSpec was moved inside parser
     // https://issues.apache.org/jira/browse/SPARK-37923
     val partitioning =
-      partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
+    partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
     val tableSpec = TableSpec(properties, provider, options, location, comment,
       serdeInfo, external)
 

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
@@ -21,19 +21,18 @@ import org.apache.hudi.spark.sql.parser.{HoodieSqlBaseBaseVisitor, HoodieSqlBase
 import org.apache.hudi.spark.sql.parser.HoodieSqlBaseParser._
 
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
-import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
+import org.antlr.v4.runtime.tree.{ParseTree, RuleNode}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, entry, escapedIdentifier, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin, EnhancedLogicalPlan}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils, DateTimeUtils, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.BucketSpecHelper
 import org.apache.spark.sql.connector.catalog.TableCatalog
@@ -212,17 +211,6 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
-  }
-
-  /**
-   * Create a Boolean literal expression.
-   */
-  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
-    if (ctx.getText.toBoolean) {
-      Literal.TrueLiteral
-    } else {
-      Literal.FalseLiteral
-    }
   }
 
   /**
@@ -643,13 +631,6 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create top level table schema.
-   */
-  protected def createSchema(ctx: ColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitColTypeList))
-  }
-
-  /**
    * Create a [[StructType]] from a number of column definitions.
    */
   override def visitColTypeList(ctx: ColTypeListContext): Seq[StructField] = withOrigin(ctx) {
@@ -689,13 +670,6 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
-  }
-
-  /**
-   * Create a [[StructType]] from a sequence of [[StructField]]s.
-   */
-  protected def createStructType(ctx: ComplexColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitComplexColTypeList))
   }
 
   /**
@@ -776,7 +750,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a table property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitTablePropertyList(
                                        ctx: TablePropertyListContext): Map[String, String] = withOrigin(ctx) {
@@ -801,19 +775,6 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[TablePropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: TablePropertyListContext): Seq[String] = {
-    val props = visitTablePropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**
@@ -925,10 +886,6 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
         throw new ParseException(s"Too many arguments for transform $name", ctx)
-      } else if (arguments.isEmpty) {
-        throw
-
-          new ParseException(s"Not enough arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -988,8 +945,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+      reference.orElse(literal).get
     }
   }
 
@@ -1044,8 +1000,6 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         SerdeInfo(storedAs = Some(c.identifier.getText))
       case (null, storageHandler) =>
         operationNotAllowed("STORED BY", ctx)
-      case _ =>
-        throw new ParseException("Expected either STORED AS or STORED BY, not both", ctx)
     }
   }
 
@@ -1359,7 +1313,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitPropertyList(ctx: PropertyListContext): Map[String, String] = withOrigin(ctx) {
     val properties = ctx.property.asScala.map { property =>
@@ -1383,19 +1337,6 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[PropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: PropertyListContext): Seq[String] = {
-    val props = visitPropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
@@ -206,7 +206,9 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create a NULL literal expression.
+   * Create a NULL literal expression. Reachable under ANSI keyword mode, where NULL (like
+   * FALSE) is a reserved word, so f(null, id) in transform-argument position parses as a
+   * null literal instead of a column reference.
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
@@ -1244,7 +1246,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     // partition transforms for BucketSpec was moved inside parser
     // https://issues.apache.org/jira/browse/SPARK-37923
     val partitioning =
-    partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
+      partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
     val tableSpec = TableSpec(properties, provider, options, location, comment,
       serdeInfo, external)
 

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.types.BlobType
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 import org.apache.spark.util.Utils.isTesting
 
@@ -211,6 +210,19 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
+  }
+
+  /**
+   * Create a Boolean literal expression. Reachable under ANSI keyword mode, where FALSE is a
+   * reserved word (only TRUE is ansiNonReserved), so a bare false in transform-argument
+   * position parses as a boolean literal instead of a column reference.
+   */
+  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
+    if (ctx.getText.toBoolean) {
+      Literal.TrueLiteral
+    } else {
+      Literal.FalseLiteral
+    }
   }
 
   /**
@@ -945,7 +957,8 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal).get
+      reference.orElse(literal)
+        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
     }
   }
 
@@ -1098,7 +1111,8 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               s"ROW FORMAT DELIMITED is only compatible with 'textfile', not '$fmt'", parentCtx)
           }
         case _ =>
-          // should never happen
+          // Reachable: ROW FORMAT ... STORED BY 'handler' leaves createFileFormatCtx.fileFormat
+          // null, so none of the typed arms above match.
           def str(ctx: ParserRuleContext): String = {
             (0 until ctx.getChildCount).map { i => ctx.getChild(i).getText }.mkString(" ")
           }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
@@ -21,19 +21,18 @@ import org.apache.hudi.spark.sql.parser.{HoodieSqlBaseBaseVisitor, HoodieSqlBase
 import org.apache.hudi.spark.sql.parser.HoodieSqlBaseParser._
 
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
-import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
+import org.antlr.v4.runtime.tree.{ParseTree, RuleNode}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
-import org.apache.spark.sql.catalyst.parser.{EnhancedLogicalPlan, ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, entry, escapedIdentifier, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils, DateTimeUtils, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.BucketSpecHelper
 import org.apache.spark.sql.connector.catalog.TableCatalog
@@ -212,17 +211,6 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
-  }
-
-  /**
-   * Create a Boolean literal expression.
-   */
-  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
-    if (ctx.getText.toBoolean) {
-      Literal.TrueLiteral
-    } else {
-      Literal.FalseLiteral
-    }
   }
 
   /**
@@ -643,13 +631,6 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create top level table schema.
-   */
-  protected def createSchema(ctx: ColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitColTypeList))
-  }
-
-  /**
    * Create a [[StructType]] from a number of column definitions.
    */
   override def visitColTypeList(ctx: ColTypeListContext): Seq[StructField] = withOrigin(ctx) {
@@ -689,13 +670,6 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
-  }
-
-  /**
-   * Create a [[StructType]] from a sequence of [[StructField]]s.
-   */
-  protected def createStructType(ctx: ComplexColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitComplexColTypeList))
   }
 
   /**
@@ -776,7 +750,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a table property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitTablePropertyList(
                                        ctx: TablePropertyListContext): Map[String, String] = withOrigin(ctx) {
@@ -801,19 +775,6 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[TablePropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: TablePropertyListContext): Seq[String] = {
-    val props = visitTablePropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**
@@ -925,10 +886,6 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
         throw new ParseException(s"Too many arguments for transform $name", ctx)
-      } else if (arguments.isEmpty) {
-        throw
-
-          new ParseException(s"Not enough arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -988,8 +945,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+      reference.orElse(literal).get
     }
   }
 
@@ -1044,8 +1000,6 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         SerdeInfo(storedAs = Some(c.identifier.getText))
       case (null, storageHandler) =>
         operationNotAllowed("STORED BY", ctx)
-      case _ =>
-        throw new ParseException("Expected either STORED AS or STORED BY, not both", ctx)
     }
   }
 
@@ -1360,7 +1314,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitPropertyList(ctx: PropertyListContext): Map[String, String] = withOrigin(ctx) {
     val properties = ctx.property.asScala.map { property =>
@@ -1384,19 +1338,6 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[PropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: PropertyListContext): Seq[String] = {
-    val props = visitPropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
@@ -206,7 +206,9 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create a NULL literal expression.
+   * Create a NULL literal expression. Reachable under ANSI keyword mode, where NULL (like
+   * FALSE) is a reserved word, so f(null, id) in transform-argument position parses as a
+   * null literal instead of a column reference.
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
@@ -1244,7 +1246,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     // partition transforms for BucketSpec was moved inside parser
     // https://issues.apache.org/jira/browse/SPARK-37923
     val partitioning =
-    partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
+      partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
     val tableSpec = TableSpec(properties, provider, options, location, comment,
       serdeInfo, external)
 

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.types.BlobType
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 import org.apache.spark.util.Utils.isTesting
 
@@ -211,6 +210,19 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
+  }
+
+  /**
+   * Create a Boolean literal expression. Reachable under ANSI keyword mode, where FALSE is a
+   * reserved word (only TRUE is ansiNonReserved), so a bare false in transform-argument
+   * position parses as a boolean literal instead of a column reference.
+   */
+  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
+    if (ctx.getText.toBoolean) {
+      Literal.TrueLiteral
+    } else {
+      Literal.FalseLiteral
+    }
   }
 
   /**
@@ -945,7 +957,8 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal).get
+      reference.orElse(literal)
+        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
     }
   }
 
@@ -1098,7 +1111,8 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               s"ROW FORMAT DELIMITED is only compatible with 'textfile', not '$fmt'", parentCtx)
           }
         case _ =>
-          // should never happen
+          // Reachable: ROW FORMAT ... STORED BY 'handler' leaves createFileFormatCtx.fileFormat
+          // null, so none of the typed arms above match.
           def str(ctx: ParserRuleContext): String = {
             (0 until ctx.getChildCount).map { i => ctx.getChild(i).getText }.mkString(" ")
           }
@@ -1184,14 +1198,13 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create a table, returning a [[CreateTable]] or [[CreateTableAsSelect]] logical plan.
+   * Create a table, returning a [[CreateTable]] logical plan.
    *
    * Expected format:
    * {{{
    *   CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [db_name.]table_name
    *   [USING table_provider]
-   *   create_table_clauses
-   *   [[AS] select_statement];
+   *   create_table_clauses;
    *
    *   create_table_clauses (order insensitive):
    *     [PARTITIONED BY (partition_fields)]

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
@@ -21,19 +21,18 @@ import org.apache.hudi.spark.sql.parser.{HoodieSqlBaseBaseVisitor, HoodieSqlBase
 import org.apache.hudi.spark.sql.parser.HoodieSqlBaseParser._
 
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
-import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
+import org.antlr.v4.runtime.tree.{ParseTree, RuleNode}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
-import org.apache.spark.sql.catalyst.parser.{EnhancedLogicalPlan, ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, entry, escapedIdentifier, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils, DateTimeUtils,  IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.BucketSpecHelper
 import org.apache.spark.sql.connector.catalog.TableCatalog
@@ -212,17 +211,6 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
-  }
-
-  /**
-   * Create a Boolean literal expression.
-   */
-  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
-    if (ctx.getText.toBoolean) {
-      Literal.TrueLiteral
-    } else {
-      Literal.FalseLiteral
-    }
   }
 
   /**
@@ -643,13 +631,6 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create top level table schema.
-   */
-  protected def createSchema(ctx: ColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitColTypeList))
-  }
-
-  /**
    * Create a [[StructType]] from a number of column definitions.
    */
   override def visitColTypeList(ctx: ColTypeListContext): Seq[StructField] = withOrigin(ctx) {
@@ -689,13 +670,6 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
-  }
-
-  /**
-   * Create a [[StructType]] from a sequence of [[StructField]]s.
-   */
-  protected def createStructType(ctx: ComplexColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitComplexColTypeList))
   }
 
   /**
@@ -776,7 +750,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a table property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitTablePropertyList(
                                        ctx: TablePropertyListContext): Map[String, String] = withOrigin(ctx) {
@@ -801,19 +775,6 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[TablePropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: TablePropertyListContext): Seq[String] = {
-    val props = visitTablePropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**
@@ -925,10 +886,6 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
         throw new ParseException(s"Too many arguments for transform $name", ctx)
-      } else if (arguments.isEmpty) {
-        throw
-
-          new ParseException(s"Not enough arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -988,8 +945,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+      reference.orElse(literal).get
     }
   }
 
@@ -1044,8 +1000,6 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         SerdeInfo(storedAs = Some(c.identifier.getText))
       case (null, storageHandler) =>
         operationNotAllowed("STORED BY", ctx)
-      case _ =>
-        throw new ParseException("Expected either STORED AS or STORED BY, not both", ctx)
     }
   }
 
@@ -1359,7 +1313,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitPropertyList(ctx: PropertyListContext): Map[String, String] = withOrigin(ctx) {
     val properties = ctx.property.asScala.map { property =>
@@ -1383,19 +1337,6 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[PropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: PropertyListContext): Seq[String] = {
-    val props = visitPropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.types.BlobType
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 import org.apache.spark.util.Utils.isTesting
 
@@ -211,6 +210,19 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
+  }
+
+  /**
+   * Create a Boolean literal expression. Reachable under ANSI keyword mode, where FALSE is a
+   * reserved word (only TRUE is ansiNonReserved), so a bare false in transform-argument
+   * position parses as a boolean literal instead of a column reference.
+   */
+  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
+    if (ctx.getText.toBoolean) {
+      Literal.TrueLiteral
+    } else {
+      Literal.FalseLiteral
+    }
   }
 
   /**
@@ -945,7 +957,8 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal).get
+      reference.orElse(literal)
+        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
     }
   }
 
@@ -1098,7 +1111,8 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               s"ROW FORMAT DELIMITED is only compatible with 'textfile', not '$fmt'", parentCtx)
           }
         case _ =>
-          // should never happen
+          // Reachable: ROW FORMAT ... STORED BY 'handler' leaves createFileFormatCtx.fileFormat
+          // null, so none of the typed arms above match.
           def str(ctx: ParserRuleContext): String = {
             (0 until ctx.getChildCount).map { i => ctx.getChild(i).getText }.mkString(" ")
           }

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
@@ -206,7 +206,9 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create a NULL literal expression.
+   * Create a NULL literal expression. Reachable under ANSI keyword mode, where NULL (like
+   * FALSE) is a reserved word, so f(null, id) in transform-argument position parses as a
+   * null literal instead of a column reference.
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
@@ -1244,7 +1246,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     // partition transforms for BucketSpec was moved inside parser
     // https://issues.apache.org/jira/browse/SPARK-37923
     val partitioning =
-    partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
+      partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
     val tableSpec = TableSpec(properties, provider, options, location, comment,
       Option.empty, serdeInfo, external)
 

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
@@ -21,19 +21,18 @@ import org.apache.hudi.spark.sql.parser.{HoodieSqlBaseBaseVisitor, HoodieSqlBase
 import org.apache.hudi.spark.sql.parser.HoodieSqlBaseParser._
 
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
-import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
+import org.antlr.v4.runtime.tree.{ParseTree, RuleNode}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
-import org.apache.spark.sql.catalyst.parser.{EnhancedLogicalPlan, ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, entry, escapedIdentifier, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils, DateTimeUtils, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.BucketSpecHelper
 import org.apache.spark.sql.connector.catalog.TableCatalog
@@ -211,17 +210,6 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
-  }
-
-  /**
-   * Create a Boolean literal expression.
-   */
-  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
-    if (ctx.getText.toBoolean) {
-      Literal.TrueLiteral
-    } else {
-      Literal.FalseLiteral
-    }
   }
 
   /**
@@ -642,13 +630,6 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create top level table schema.
-   */
-  protected def createSchema(ctx: ColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitColTypeList))
-  }
-
-  /**
    * Create a [[StructType]] from a number of column definitions.
    */
   override def visitColTypeList(ctx: ColTypeListContext): Seq[StructField] = withOrigin(ctx) {
@@ -688,13 +669,6 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
-  }
-
-  /**
-   * Create a [[StructType]] from a sequence of [[StructField]]s.
-   */
-  protected def createStructType(ctx: ComplexColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitComplexColTypeList))
   }
 
   /**
@@ -775,7 +749,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a table property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitTablePropertyList(
                                        ctx: TablePropertyListContext): Map[String, String] = withOrigin(ctx) {
@@ -800,19 +774,6 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[TablePropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: TablePropertyListContext): Seq[String] = {
-    val props = visitTablePropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**
@@ -924,10 +885,6 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
         throw new ParseException(s"Too many arguments for transform $name", ctx)
-      } else if (arguments.isEmpty) {
-        throw
-
-          new ParseException(s"Not enough arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -987,8 +944,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+      reference.orElse(literal).get
     }
   }
 
@@ -1043,8 +999,6 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         SerdeInfo(storedAs = Some(c.identifier.getText))
       case (null, storageHandler) =>
         operationNotAllowed("STORED BY", ctx)
-      case _ =>
-        throw new ParseException("Expected either STORED AS or STORED BY, not both", ctx)
     }
   }
 
@@ -1359,7 +1313,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitPropertyList(ctx: PropertyListContext): Map[String, String] = withOrigin(ctx) {
     val properties = ctx.property.asScala.map { property =>
@@ -1383,19 +1337,6 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[PropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: PropertyListContext): Seq[String] = {
-    val props = visitPropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
@@ -213,6 +213,19 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
+   * Create a Boolean literal expression. Reachable under ANSI keyword mode, where FALSE is a
+   * reserved word (only TRUE is ansiNonReserved), so a bare false in transform-argument
+   * position parses as a boolean literal instead of a column reference.
+   */
+  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
+    if (ctx.getText.toBoolean) {
+      Literal.TrueLiteral
+    } else {
+      Literal.FalseLiteral
+    }
+  }
+
+  /**
    * Create an integral literal expression. The code selects the most narrow integral type
    * possible, either a BigDecimal, a Long or an Integer is returned.
    */
@@ -944,7 +957,8 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal).get
+      reference.orElse(literal)
+        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
     }
   }
 
@@ -1097,7 +1111,8 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               s"ROW FORMAT DELIMITED is only compatible with 'textfile', not '$fmt'", parentCtx)
           }
         case _ =>
-          // should never happen
+          // Reachable: ROW FORMAT ... STORED BY 'handler' leaves createFileFormatCtx.fileFormat
+          // null, so none of the typed arms above match.
           def str(ctx: ParserRuleContext): String = {
             (0 until ctx.getChildCount).map { i => ctx.getChild(i).getText }.mkString(" ")
           }
@@ -1189,8 +1204,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * {{{
    *   CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [db_name.]table_name
    *   [USING table_provider]
-   *   create_table_clauses
-   *   [[AS] select_statement];
+   *   create_table_clauses;
    *
    *   create_table_clauses (order insensitive):
    *     [PARTITIONED BY (partition_fields)]

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
@@ -206,7 +206,9 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create a NULL literal expression.
+   * Create a NULL literal expression. Reachable under ANSI keyword mode, where NULL (like
+   * FALSE) is a reserved word, so f(null, id) in transform-argument position parses as a
+   * null literal instead of a column reference.
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
@@ -1244,7 +1246,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     // partition transforms for BucketSpec was moved inside parser
     // https://issues.apache.org/jira/browse/SPARK-37923
     val partitioning =
-    partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
+      partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
     val tableSpec = TableSpec(properties, provider, options, location, comment,
       Option.empty, serdeInfo, external)
 

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
@@ -213,6 +213,19 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
+   * Create a Boolean literal expression. Reachable under ANSI keyword mode, where FALSE is a
+   * reserved word (only TRUE is ansiNonReserved), so a bare false in transform-argument
+   * position parses as a boolean literal instead of a column reference.
+   */
+  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
+    if (ctx.getText.toBoolean) {
+      Literal.TrueLiteral
+    } else {
+      Literal.FalseLiteral
+    }
+  }
+
+  /**
    * Create an integral literal expression. The code selects the most narrow integral type
    * possible, either a BigDecimal, a Long or an Integer is returned.
    */
@@ -944,7 +957,8 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal).get
+      reference.orElse(literal)
+        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
     }
   }
 
@@ -1097,7 +1111,8 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               s"ROW FORMAT DELIMITED is only compatible with 'textfile', not '$fmt'", parentCtx)
           }
         case _ =>
-          // should never happen
+          // Reachable: ROW FORMAT ... STORED BY 'handler' leaves createFileFormatCtx.fileFormat
+          // null, so none of the typed arms above match.
           def str(ctx: ParserRuleContext): String = {
             (0 until ctx.getChildCount).map { i => ctx.getChild(i).getText }.mkString(" ")
           }

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
@@ -206,7 +206,9 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create a NULL literal expression.
+   * Create a NULL literal expression. Reachable under ANSI keyword mode, where NULL (like
+   * FALSE) is a reserved word, so f(null, id) in transform-argument position parses as a
+   * null literal instead of a column reference.
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
@@ -1244,7 +1246,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     // partition transforms for BucketSpec was moved inside parser
     // https://issues.apache.org/jira/browse/SPARK-37923
     val partitioning =
-    partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
+      partitionExpressions(partTransforms, partCols, ctx) ++ bucketSpec.map(_.asTransform)
     val tableSpec = TableSpec(properties, provider, options, location, comment,
       Option.empty, serdeInfo, external)
 

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
@@ -21,19 +21,18 @@ import org.apache.hudi.spark.sql.parser.{HoodieSqlBaseBaseVisitor, HoodieSqlBase
 import org.apache.hudi.spark.sql.parser.HoodieSqlBaseParser._
 
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
-import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
+import org.antlr.v4.runtime.tree.{ParseTree, RuleNode}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
-import org.apache.spark.sql.catalyst.parser.{EnhancedLogicalPlan, ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, entry, escapedIdentifier, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils, DateTimeUtils, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.BucketSpecHelper
 import org.apache.spark.sql.connector.catalog.TableCatalog
@@ -211,17 +210,6 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    */
   override def visitNullLiteral(ctx: NullLiteralContext): Literal = withOrigin(ctx) {
     Literal(null)
-  }
-
-  /**
-   * Create a Boolean literal expression.
-   */
-  override def visitBooleanLiteral(ctx: BooleanLiteralContext): Literal = withOrigin(ctx) {
-    if (ctx.getText.toBoolean) {
-      Literal.TrueLiteral
-    } else {
-      Literal.FalseLiteral
-    }
   }
 
   /**
@@ -642,13 +630,6 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
   }
 
   /**
-   * Create top level table schema.
-   */
-  protected def createSchema(ctx: ColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitColTypeList))
-  }
-
-  /**
    * Create a [[StructType]] from a number of column definitions.
    */
   override def visitColTypeList(ctx: ColTypeListContext): Seq[StructField] = withOrigin(ctx) {
@@ -688,13 +669,6 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val vectorSchema = HoodieSchema.parseTypeDescriptor(typeText).asInstanceOf[HoodieSchema.Vector]
       builder.putString(HoodieSchema.TYPE_METADATA_FIELD, vectorSchema.toTypeDescriptor)
     }
-  }
-
-  /**
-   * Create a [[StructType]] from a sequence of [[StructField]]s.
-   */
-  protected def createStructType(ctx: ComplexColTypeListContext): StructType = {
-    StructType(Option(ctx).toSeq.flatMap(visitComplexColTypeList))
   }
 
   /**
@@ -775,7 +749,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a table property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitTablePropertyList(
                                        ctx: TablePropertyListContext): Map[String, String] = withOrigin(ctx) {
@@ -800,19 +774,6 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[TablePropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: TablePropertyListContext): Seq[String] = {
-    val props = visitTablePropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**
@@ -924,10 +885,6 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
         throw new ParseException(s"Too many arguments for transform $name", ctx)
-      } else if (arguments.isEmpty) {
-        throw
-
-          new ParseException(s"Not enough arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -987,8 +944,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val literal = Option(ctx.constant)
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
-      reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+      reference.orElse(literal).get
     }
   }
 
@@ -1043,8 +999,6 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         SerdeInfo(storedAs = Some(c.identifier.getText))
       case (null, storageHandler) =>
         operationNotAllowed("STORED BY", ctx)
-      case _ =>
-        throw new ParseException("Expected either STORED AS or STORED BY, not both", ctx)
     }
   }
 
@@ -1358,7 +1312,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Convert a property list into a key-value map.
-   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   * This should be called through [[visitPropertyKeyValues]].
    */
   override def visitPropertyList(ctx: PropertyListContext): Map[String, String] = withOrigin(ctx) {
     val properties = ctx.property.asScala.map { property =>
@@ -1382,19 +1336,6 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
     }
     props
-  }
-
-  /**
-   * Parse a list of keys from a [[PropertyListContext]], assuming no values are specified.
-   */
-  def visitPropertyKeys(ctx: PropertyListContext): Seq[String] = {
-    val props = visitPropertyList(ctx)
-    val badKeys = props.filter { case (_, v) => v != null }.keys
-    if (badKeys.nonEmpty) {
-      operationNotAllowed(
-        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
-    }
-    props.keys.toSeq
   }
 
   /**


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19451. #19132 pruned the forked parser to Hudi-routed statements, but the six `HoodieSpark*ExtendedSqlAstBuilder`s (3.3/3.4/3.5/4.0/4.1/4.2) still carry code that is now unreachable. This PR removes the dead code the issue identified, and corrects the issue on three items that turned out to be reachable or worth keeping (details below), with tests pinning the corrected reachability claims.

### Summary and Changelog

No user-facing behavior change. All six builders receive the identical edit.

Removed (dead code, verified against the grammar and all callers):

- **Uncalled methods**: `createSchema`, `createStructType` and both `visitPropertyKeys` overloads; the two scaladoc references updated.
- **Grammar-impossible branches**: `getSingleFieldReference`'s empty-arguments arm (the `transform` rule requires at least one argument) and `visitCreateFileFormat`'s trailing `case _` (`STORED AS` and `STORED BY` are mutually exclusive alternatives, so the tuple is never both-set or both-null).
- **Unused imports** (`First`, `Last`, `EnhancedLogicalPlan`, `escapedIdentifier`, `truncatedString`, `CharVarcharUtils`, `FunctionIdentifier`, `CatalogStorageFormat`, `TerminalNode`), plus two the issue did not list: `ParserUtils.entry` (shadowed by an identical local `def entry` in `visitRowFormatDelimited` everywhere it is used) and the redundant explicit `BlobType` import in the 3.3/3.4/3.5/4.0 copies (the `types._` wildcard already supplies it; 4.1/4.2 never had it).
- **Stale scaladoc drift from #19132**: the `CreateTableAsSelect` / `[[AS] select_statement]` lines in `visitCreateTable`'s doc survived in the 3.3/3.5 (and partially 4.1) copies only; all six now match. Also a 6-vs-4-space indent drift in the 3.3 copy.

Kept, correcting issue #19451:

1. **`visitBooleanLiteral` is NOT dead.** The issue's premise ("TRUE/FALSE are ansiNonReserved") is wrong for `FALSE`: only `TRUE` is in `ansiNonReserved` in all six grammars. Under ANSI keyword mode (the extended parser sets `SQL_standard_keyword_behavior = conf.ansiEnabled`, and ANSI is the Spark 4.x default) `PARTITIONED BY (f(false, id))` parses `false` as a `BooleanLiteralContext`; deleting the visitor makes the generated base visitor return null and `LiteralValue(lit.value, ...)` throws a raw NPE that escapes `parsePlan`. The visitor stays, its scaladoc now records the reachability constraint, and a new ANSI-mode regression test in `TestBlobDataType` asserts `false` yields a `BooleanType` literal while `true` stays a column reference (the wrong comment merged in #19408 is corrected too).
2. **`validateRowFormatFileFormat`'s `case _` is reachable**, e.g. `CREATE TABLE t (b BLOB) ROW FORMAT SERDE 'x' STORED BY 'y'`: the clauses coexist in `createTableClauses`, `STORED BY` leaves `createFileFormatCtx.fileFormat` null, and `(rowFormatCtx, null)` falls past the three typed arms. Removing it would turn a clean `ParseException` into a `scala.MatchError`. The misleading `// should never happen` comment is replaced with the real explanation, and both previously untested arms are now covered (`ROW FORMAT SERDE + STORED AS INPUTFORMAT/OUTPUTFORMAT` positive, `ROW FORMAT SERDE + STORED BY` negative).
3. **`visitTransformArgument` keeps `getOrElse(throw ParseException)`** instead of `.get`: the branch is grammar-impossible today (`transformArgument` is exactly `qualifiedName | constant`), but the `getOrElse` form preserves a parse-error failure mode if the grammar ever gains an alternative.

### Impact

None. Internal cleanup of the forked parser builders; no public API, SQL surface, or behavior change.

### Risk Level

Low. Deletions applied identically to all six builders; verified no remaining callers repo-wide. Compiled every module against its profile (`spark3.3`/`3.4`/`3.5` reactor builds; `spark4.0`/`4.1`/`4.2` CI-style `-Dscala-2.13 -am` builds) and ran the full `TestBlobDataType` suite (10/10) including the new reachability regression tests.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable (ANSI-mode boolean-literal regression; coverage for both previously untested `validateRowFormatFileFormat` arms)
