### PR TITLE
fix(spark): throw proper ParseExceptions in the six extended SQL AST...

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExtendedParserTestHelpers.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExtendedParserTestHelpers.scala
@@ -39,14 +39,16 @@ trait ExtendedParserTestHelpers extends Assertions {
 
   /**
    * Asserts that `sql` fails with a [[ParseException]] (not merely some Exception) whose message
-   * contains `expected`. Matching stays on a substring so the same assertion holds on Spark 4.x,
+   * contains `expected`, and returns the exception so callers can assert further properties (e.g.
+   * stack-trace frames). Matching stays on a substring so the same assertion holds on Spark 4.x,
    * where the builders wrap the message in an "Operation not allowed: " prefix.
    */
-  protected def interceptParse(sql: String)(expected: String): Unit = {
+  protected def interceptParse(sql: String)(expected: String): ParseException = {
     val e = intercept[ParseException] {
       spark.sql(sql)
     }
     assert(e.getMessage.contains(expected), s"actual: ${e.getMessage}")
+    e
   }
 
   protected def transformByName(plan: CreateTable, name: String): Transform =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExtendedParserTestHelpers.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/ExtendedParserTestHelpers.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hudi.common
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.CreateTable
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, Transform}
 import org.scalatest.Assertions
@@ -35,6 +36,18 @@ trait ExtendedParserTestHelpers extends Assertions {
 
   protected def parseCreateTable(sql: String): CreateTable =
     spark.sessionState.sqlParser.parsePlan(sql).asInstanceOf[CreateTable]
+
+  /**
+   * Asserts that `sql` fails with a [[ParseException]] (not merely some Exception) whose message
+   * contains `expected`. Matching stays on a substring so the same assertion holds on Spark 4.x,
+   * where the builders wrap the message in an "Operation not allowed: " prefix.
+   */
+  protected def interceptParse(sql: String)(expected: String): Unit = {
+    val e = intercept[ParseException] {
+      spark.sql(sql)
+    }
+    assert(e.getMessage.contains(expected), s"actual: ${e.getMessage}")
+  }
 
   protected def transformByName(plan: CreateTable, name: String): Transform =
     plan.partitioning.find(_.name == name)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
@@ -2286,7 +2286,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
   test("test create table with VECTOR without dimension fails") {
     withTempDir { tmp =>
       val tableName = generateTableName
-      checkExceptionContain(
+      interceptParse(
         s"""
            |CREATE TABLE $tableName (
            |  id BIGINT,
@@ -2304,7 +2304,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
     withTempDir { tmp =>
       val tableName = generateTableName
       // Unsupported element type
-      checkExceptionContain(
+      interceptParse(
         s"""
            |CREATE TABLE $tableName (
            |  id BIGINT,
@@ -2403,14 +2403,14 @@ class TestCreateTable extends HoodieSparkSqlTestBase with ExtendedParserTestHelp
     assertEquals(Some("/tmp/vec_path_tbl"), pathPlan.tableSpec.location)
 
     // A 'path' option colliding with LOCATION is rejected by the option cleaner.
-    checkExceptionContain(
+    interceptParse(
       "CREATE TABLE vec_dup_path_tbl (id BIGINT, embedding VECTOR(4)) USING hudi " +
         "OPTIONS ('path' = '/tmp/a') LOCATION '/tmp/b'")(
       "Duplicated table paths")
 
     // Each reserved table property (provider, location, owner) is rejected by the property cleaner.
     Seq("provider", "location", "owner").foreach { reserved =>
-      checkExceptionContain(
+      interceptParse(
         s"CREATE TABLE vec_reserved_$reserved (id BIGINT, embedding VECTOR(4)) USING hudi " +
           s"TBLPROPERTIES ('$reserved' = 'x')")(
         "reserved table property")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -24,7 +24,6 @@ import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
 import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
-import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.FormatClasses
 import org.apache.spark.sql.hudi.common.{ExtendedParserTestHelpers, HoodieSparkSqlTestBase}
 import org.apache.spark.sql.types._
@@ -383,10 +382,10 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // Endpoints where the end field does not follow the start are rejected by both interval
     // data-type visitors. The grammar only allows YEAR/MONTH -> MONTH and DAY/HOUR/MINUTE/SECOND
     // -> HOUR/MINUTE/SECOND, so these stay grammatical yet still hit the builder's end <= start guard.
-    checkExceptionContain(
+    interceptParse(
       "CREATE TABLE blob_bad_ym (id BIGINT, bad INTERVAL MONTH TO MONTH, data BLOB) USING hudi")(
       "are not supported")
-    checkExceptionContain(
+    interceptParse(
       "CREATE TABLE blob_bad_dt (id BIGINT, bad INTERVAL SECOND TO HOUR, data BLOB) USING hudi")(
       "are not supported")
   }
@@ -503,23 +502,31 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
   }
 
   test("Test parse CREATE TABLE with BLOB column and invalid partition transforms") {
-    // Non-numeric number of buckets. All three cases must surface as a clean ParseException
-    // on every Spark profile now that the builders construct it correctly (#19450).
-    val e1 = intercept[ParseException] {
-      spark.sql("CREATE TABLE blob_e1 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")
-    }
-    assert(e1.getMessage.contains("Invalid number of buckets"))
-    // A non-column-reference where a column is required.
-    val e2 = intercept[ParseException] {
-      spark.sql("CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")
-    }
-    assert(e2.getMessage.contains("Expected a column reference"))
+    // Each case pins a distinct visitor arm of the extended AST builders; all must surface as a
+    // clean ParseException on every Spark profile (#19450). Assertions stay substring-based
+    // because the Spark 4.x builders add an "Operation not allowed: " prefix.
+    // Non-numeric number of buckets.
+    interceptParse("CREATE TABLE blob_e1 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")(
+      "Invalid number of buckets")
+    // A non-column-reference where a column is required; the full text pins ${nonRef.describe}.
+    interceptParse("CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")(
+      "Expected a column reference for transform bucket: 5")
     // A single-field transform given more than one argument.
-    val e3 = intercept[ParseException] {
-      spark.sql("CREATE TABLE blob_e3 (id BIGINT, ts DATE, data BLOB) USING hudi " +
-        "PARTITIONED BY (years(id, ts))")
-    }
-    assert(e3.getMessage.contains("Too many arguments"))
+    interceptParse("CREATE TABLE blob_e3 (id BIGINT, ts DATE, data BLOB) USING hudi PARTITIONED BY (years(id, ts))")(
+      "Too many arguments")
+    // Typed literal that fails to parse (visitTypeConstructor arm).
+    interceptParse("CREATE TABLE blob_e4 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(DATE 'nope', id))")(
+      "Cannot parse the DATE value: nope")
+    // Invalid INTERVAL literal (the construct-then-setStackTrace arm).
+    interceptParse("CREATE TABLE blob_e5 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 'x', id))")(
+      "Cannot parse the INTERVAL value: x")
+    // Out-of-range fractional literal; pre-fix the message's interior dots broke Spark 3.4+
+    // error-class lookup and surfaced as a bare AssertionError.
+    interceptParse("CREATE TABLE blob_e6 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(1e40F, id))")(
+      "does not fit in range")
+    // Mixed year-month and day-time interval fields.
+    interceptParse("CREATE TABLE blob_e7 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1 year 2 hours', id))")(
+      "Cannot mix year-month and day-time fields")
   }
 
   test("Test parse CREATE TABLE with BLOB column and file-format / row-format clauses") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -24,6 +24,7 @@ import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaType}
 import org.apache.hudi.testutils.DataSourceTestUtils
 import org.apache.hudi.testutils.HoodieClientTestUtils.createMetaClient
 
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.FormatClasses
 import org.apache.spark.sql.hudi.common.{ExtendedParserTestHelpers, HoodieSparkSqlTestBase}
 import org.apache.spark.sql.types._
@@ -502,23 +503,23 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
   }
 
   test("Test parse CREATE TABLE with BLOB column and invalid partition transforms") {
-    // Non-numeric number of buckets. The builders' raw `new ParseException(message, ctx)` sites
-    // surface on Spark 3.4+ as SparkException [INTERNAL_ERROR] wrapping the message text
-    // (#19450), so this case asserts the message via a plain intercept.
-    // TODO(#19450): tighten to intercept[ParseException] once the builders throw it cleanly.
-    val e = intercept[Exception] {
+    // Non-numeric number of buckets. All three cases must surface as a clean ParseException
+    // on every Spark profile now that the builders construct it correctly (#19450).
+    val e1 = intercept[ParseException] {
       spark.sql("CREATE TABLE blob_e1 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")
     }
-    assert(e.getMessage.contains("Invalid number of buckets"))
+    assert(e1.getMessage.contains("Invalid number of buckets"))
     // A non-column-reference where a column is required.
-    checkExceptionContain(
-      "CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")(
-      "Expected a column reference")
+    val e2 = intercept[ParseException] {
+      spark.sql("CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")
+    }
+    assert(e2.getMessage.contains("Expected a column reference"))
     // A single-field transform given more than one argument.
-    checkExceptionContain(
-      "CREATE TABLE blob_e3 (id BIGINT, ts DATE, data BLOB) USING hudi " +
-        "PARTITIONED BY (years(id, ts))")(
-      "Too many arguments")
+    val e3 = intercept[ParseException] {
+      spark.sql("CREATE TABLE blob_e3 (id BIGINT, ts DATE, data BLOB) USING hudi " +
+        "PARTITIONED BY (years(id, ts))")
+    }
+    assert(e3.getMessage.contains("Too many arguments"))
   }
 
   test("Test parse CREATE TABLE with BLOB column and file-format / row-format clauses") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestBlobDataType.scala
@@ -508,18 +508,22 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // Non-numeric number of buckets.
     interceptParse("CREATE TABLE blob_e1 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket('x', id))")(
       "Invalid number of buckets")
-    // A non-column-reference where a column is required; the full text pins ${nonRef.describe}.
-    interceptParse("CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")(
+    // A non-column-reference where a column is required. The buggy interpolation rendered the
+    // literal text "5.describe" (a superstring of the expected message), so pin its absence too.
+    val e2 = interceptParse("CREATE TABLE blob_e2 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(4, 5))")(
       "Expected a column reference for transform bucket: 5")
+    assert(!e2.getMessage.contains(".describe"))
     // A single-field transform given more than one argument.
     interceptParse("CREATE TABLE blob_e3 (id BIGINT, ts DATE, data BLOB) USING hudi PARTITIONED BY (years(id, ts))")(
       "Too many arguments")
     // Typed literal that fails to parse (visitTypeConstructor arm).
     interceptParse("CREATE TABLE blob_e4 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(DATE 'nope', id))")(
       "Cannot parse the DATE value: nope")
-    // Invalid INTERVAL literal (the construct-then-setStackTrace arm).
-    interceptParse("CREATE TABLE blob_e5 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 'x', id))")(
+    // Invalid INTERVAL literal: the builders copy the triggering exception's stack trace onto the
+    // ParseException (the construct-then-setStackTrace arm), so the thrower must be visible.
+    val e5 = interceptParse("CREATE TABLE blob_e5 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 'x', id))")(
       "Cannot parse the INTERVAL value: x")
+    assert(e5.getStackTrace.exists(_.getClassName.contains("IntervalUtils")))
     // Out-of-range fractional literal; pre-fix the message's interior dots broke Spark 3.4+
     // error-class lookup and surfaced as a bare AssertionError.
     interceptParse("CREATE TABLE blob_e6 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (bucket(1e40F, id))")(
@@ -527,6 +531,32 @@ class TestBlobDataType extends HoodieSparkSqlTestBase with ExtendedParserTestHel
     // Mixed year-month and day-time interval fields.
     interceptParse("CREATE TABLE blob_e7 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1 year 2 hours', id))")(
       "Cannot mix year-month and day-time fields")
+  }
+
+  test("Test parse CREATE TABLE with BLOB column and invalid literal transform arguments") {
+    // Remaining error arms of the literal and interval visitors, one SQL per throw site; all must
+    // surface as a clean ParseException on every Spark profile (#19450).
+    // A typed literal whose type keyword has no visitor arm.
+    interceptParse("CREATE TABLE blob_e8 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(FOO 'bar', id))")(
+      "Literals of type 'FOO' are currently not supported")
+    // A hex literal with a non-hex character (the IllegalArgumentException fallback arm).
+    interceptParse("CREATE TABLE blob_e9 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(X'zz', id))")(
+      "hexBinary")
+    // Multi-unit interval combined with a from-to unit.
+    interceptParse("CREATE TABLE blob_e10 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 1 DAY 2 HOUR TO MINUTE, id))")(
+      "Can only have a single from-to unit in the interval literal syntax")
+    // From-to unit combined with a trailing multi-unit interval (the error-recovery arm).
+    interceptParse("CREATE TABLE blob_e11 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1' DAY TO HOUR '2' MINUTE, id))")(
+      "Can only have a single from-to unit in the interval literal syntax")
+    // A non-numeric value in a unit-value pair.
+    interceptParse("CREATE TABLE blob_e12 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 'x' DAY, id))")(
+      "Can only use numbers in the interval value part")
+    // A from-to interval whose value is not a string literal.
+    interceptParse("CREATE TABLE blob_e13 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL 1 DAY TO HOUR, id))")(
+      "The value of from-to unit must be a string")
+    // A from-to unit pair outside the supported YEAR TO MONTH / DAY TO SECOND family.
+    interceptParse("CREATE TABLE blob_e14 (id BIGINT, data BLOB) USING hudi PARTITIONED BY (myfunc(INTERVAL '1' MONTH TO HOUR, id))")(
+      "Intervals FROM month TO hour are not supported")
   }
 
   test("Test parse CREATE TABLE with BLOB column and file-format / row-format clauses") {

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
@@ -57,6 +57,15 @@ import scala.collection.JavaConverters._
 class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterface)
   extends HoodieSqlBaseBaseVisitor[AnyRef] with Logging {
 
+  /**
+   * Returns a [[ParseException]] carrying `message` as plain human-readable text, positioned at
+   * `ctx`. Spark 3.3's (String, ParserRuleContext) constructor takes the human message directly,
+   * unlike Spark 3.4+ where that constructor treats the string as an error class (#19450).
+   */
+  private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
+    new ParseException(message, ctx)
+  }
+
   protected def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
   }
@@ -130,7 +139,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
     def toLiteral[T](f: UTF8String => Option[T], t: DataType): Literal = {
       f(UTF8String.fromString(value)).map(Literal(_, t)).getOrElse {
-        throw new ParseException(s"Cannot parse the $valueType value: $value", ctx)
+        throw parseException(s"Cannot parse the $valueType value: $value", ctx)
       }
     }
 
@@ -179,7 +188,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.stringToInterval(UTF8String.fromString(value))
           } catch {
             case e: IllegalArgumentException =>
-              val ex = new ParseException(s"Cannot parse the INTERVAL value: $value", ctx)
+              val ex = parseException(s"Cannot parse the INTERVAL value: $value", ctx)
               ex.setStackTrace(e.getStackTrace)
               throw ex
           }
@@ -196,12 +205,12 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           val padding = if (value.length % 2 != 0) "0" else ""
           Literal(DatatypeConverter.parseHexBinary(padding + value))
         case other =>
-          throw new ParseException(s"Literals of type '$other' are currently not supported.", ctx)
+          throw parseException(s"Literals of type '$other' are currently not supported.", ctx)
       }
     } catch {
       case e: IllegalArgumentException =>
         val message = Option(e.getMessage).getOrElse(s"Exception parsing $valueType")
-        throw new ParseException(message, ctx)
+        throw parseException(message, ctx)
     }
   }
 
@@ -274,13 +283,13 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     try {
       val rawBigDecimal = BigDecimal(rawStrippedQualifier)
       if (rawBigDecimal < minValue || rawBigDecimal > maxValue) {
-        throw new ParseException(s"Numeric literal $rawStrippedQualifier does not " +
+        throw parseException(s"Numeric literal $rawStrippedQualifier does not " +
           s"fit in range [$minValue, $maxValue] for type $typeName", ctx)
       }
       Literal(converter(rawStrippedQualifier))
     } catch {
       case e: NumberFormatException =>
-        throw new ParseException(e.getMessage, ctx)
+        throw parseException(e.getMessage, ctx)
     }
   }
 
@@ -338,7 +347,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       Literal(BigDecimal(raw).underlying())
     } catch {
       case e: AnalysisException =>
-        throw new ParseException(e.message, ctx)
+        throw parseException(e.message, ctx)
     }
   }
 
@@ -389,7 +398,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (yearMonthFields.nonEmpty) {
       if (dayTimeFields.nonEmpty) {
         val literalStr = source(ctx)
-        throw new ParseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
+        throw parseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
       }
       Literal(
         calendarInterval.months,
@@ -446,18 +455,18 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (ctx.errorCapturingMultiUnitsInterval != null) {
       val innerCtx = ctx.errorCapturingMultiUnitsInterval
       if (innerCtx.unitToUnitInterval != null) {
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
       }
       visitMultiUnitsInterval(innerCtx.multiUnitsInterval)
     } else if (ctx.errorCapturingUnitToUnitInterval != null) {
       val innerCtx = ctx.errorCapturingUnitToUnitInterval
       if (innerCtx.error1 != null || innerCtx.error2 != null) {
         val errorCtx = if (innerCtx.error1 != null) innerCtx.error1 else innerCtx.error2
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
-      throw new ParseException("at least one time unit should be given for interval literal", ctx)
+      throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }
 
@@ -479,7 +488,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             // units and become valid ones, e.g. '1 day 2 hour'.
             // Ideally, we only ensure the value parts don't contain any units here.
             if (value.exists(Character.isLetter)) {
-              throw new ParseException("Can only use numbers in the interval value part for" +
+              throw parseException("Can only use numbers in the interval value part for" +
                 s" multiple unit value pairs interval form, but got invalid value: $value", ctx)
             }
             if (values(i).MINUS() == null) {
@@ -498,7 +507,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         IntervalUtils.stringToInterval(UTF8String.concat(kvs: _*))
       } catch {
         case i: IllegalArgumentException =>
-          val e = new ParseException(i.getMessage, ctx)
+          val e = parseException(i.getMessage, ctx)
           e.setStackTrace(i.getStackTrace)
           throw e
       }
@@ -520,7 +529,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           }
         }
       }.getOrElse {
-        throw new ParseException("The value of from-to unit must be a string", ctx.intervalValue)
+        throw parseException("The value of from-to unit must be a string", ctx.intervalValue)
       }
       try {
         val from = ctx.from.getText.toLowerCase(Locale.ROOT)
@@ -533,12 +542,12 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.fromDayTimeString(value,
               DayTimeIntervalType.stringToField(from), DayTimeIntervalType.stringToField(to))
           case _ =>
-            throw new ParseException(s"Intervals FROM $from TO $to are not supported.", ctx)
+            throw parseException(s"Intervals FROM $from TO $to are not supported.", ctx)
         }
       } catch {
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
-          val pe = new ParseException(e.getMessage, ctx)
+          val pe = parseException(e.getMessage, ctx)
           pe.setStackTrace(e.getStackTrace)
           throw pe
       }
@@ -579,7 +588,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
         } catch {
           case e: IllegalArgumentException =>
-            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+            throw parseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
         }
         val sparkElemType = vectorSchema.getVectorElementType match {
           case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
@@ -596,7 +605,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("interval", Nil) => CalendarIntervalType
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt
-        throw new ParseException(s"DataType $dtStr is not supported.", ctx)
+        throw parseException(s"DataType $dtStr is not supported.", ctx)
     }
   }
 
@@ -607,7 +616,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = YearMonthIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       YearMonthIntervalType(start, end)
     } else {
@@ -622,7 +631,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = DayTimeIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       DayTimeIntervalType(start, end)
     } else {
@@ -890,7 +899,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         case ref: FieldReference =>
           ref
         case nonRef =>
-          throw new ParseException(s"Expected a column reference for transform $name: $nonRef.describe", ctx)
+          throw parseException(s"Expected a column reference for transform $name: ${nonRef.describe}", ctx)
       }
     }
 
@@ -899,7 +908,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
                                  arguments: Seq[V2Expression]): FieldReference = {
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
-        throw new ParseException(s"Too many arguments for transform $name", ctx)
+        throw parseException(s"Too many arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -922,7 +931,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               case LiteralValue(longValue, LongType) =>
                 longValue.asInstanceOf[Long].toInt
               case lit =>
-                throw new ParseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
+                throw parseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
             }
 
             val fields = arguments.tail.map(arg => getFieldReference(applyCtx, arg))
@@ -960,7 +969,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
       reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+        .getOrElse(throw parseException("Invalid transform argument", ctx))
     }
   }
 
@@ -970,13 +979,13 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val legacyOn = conf.getConf(SQLConf.LEGACY_PROPERTY_NON_RESERVED)
     properties.filter {
       case (PROP_PROVIDER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
+        throw parseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
       case (PROP_PROVIDER, _) => false
       case (PROP_LOCATION, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
+        throw parseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
       case (PROP_LOCATION, _) => false
       case (PROP_OWNER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
+        throw parseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
       case (PROP_OWNER, _) => false
       case _ => true
     }
@@ -989,7 +998,7 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     var path = location
     val filtered = cleanTableProperties(ctx, options).filter {
       case (k, v) if k.equalsIgnoreCase("path") && path.nonEmpty =>
-        throw new ParseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
+        throw parseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
           s" and the case insensitive key 'path' in OPTIONS are all used to indicate the custom" +
           s" table path, you can only specify one of them.", ctx)
       case (k, v) if k.equalsIgnoreCase("path") =>

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_3ExtendedSqlAstBuilder.scala
@@ -61,6 +61,8 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * Returns a [[ParseException]] carrying `message` as plain human-readable text, positioned at
    * `ctx`. Spark 3.3's (String, ParserRuleContext) constructor takes the human message directly,
    * unlike Spark 3.4+ where that constructor treats the string as an error class (#19450).
+   * The Spark 4.x builders render the same messages behind an "Operation not allowed: " prefix,
+   * so cross-profile test assertions must stay substring-based.
    */
   private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
     new ParseException(message, ctx)
@@ -466,6 +468,8 @@ class HoodieSpark3_3ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
+      // Unreachable through Hudi's pruned grammar: a bare INTERVAL keyword binds to
+      // transformArgument's qualifiedName alternative first. Kept for parity with Spark.
       throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, command, operationNotAllowed, position, source, string, stringWithoutUnescape, validate, withOrigin}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
@@ -56,6 +56,15 @@ import scala.collection.JavaConverters._
  */
 class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterface)
   extends HoodieSqlBaseBaseVisitor[AnyRef] with Logging {
+
+  /**
+   * Returns a [[ParseException]] carrying `message` as plain human-readable text, positioned at
+   * `ctx`. The (String, ParserRuleContext) constructor treats the string as an error class on
+   * Spark 3.4+, so use the message-based primary constructor (errorClass stays None) (#19450).
+   */
+  private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
+    new ParseException(Option(command(ctx)), message, position(ctx.start), position(ctx.stop))
+  }
 
   protected def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
@@ -130,7 +139,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
     def toLiteral[T](f: UTF8String => Option[T], t: DataType): Literal = {
       f(UTF8String.fromString(value)).map(Literal(_, t)).getOrElse {
-        throw new ParseException(s"Cannot parse the $valueType value: $value", ctx)
+        throw parseException(s"Cannot parse the $valueType value: $value", ctx)
       }
     }
 
@@ -179,7 +188,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.stringToInterval(UTF8String.fromString(value))
           } catch {
             case e: IllegalArgumentException =>
-              val ex = new ParseException(s"Cannot parse the INTERVAL value: $value", ctx)
+              val ex = parseException(s"Cannot parse the INTERVAL value: $value", ctx)
               ex.setStackTrace(e.getStackTrace)
               throw ex
           }
@@ -196,12 +205,12 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           val padding = if (value.length % 2 != 0) "0" else ""
           Literal(DatatypeConverter.parseHexBinary(padding + value))
         case other =>
-          throw new ParseException(s"Literals of type '$other' are currently not supported.", ctx)
+          throw parseException(s"Literals of type '$other' are currently not supported.", ctx)
       }
     } catch {
       case e: IllegalArgumentException =>
         val message = Option(e.getMessage).getOrElse(s"Exception parsing $valueType")
-        throw new ParseException(message, ctx)
+        throw parseException(message, ctx)
     }
   }
 
@@ -274,13 +283,13 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     try {
       val rawBigDecimal = BigDecimal(rawStrippedQualifier)
       if (rawBigDecimal < minValue || rawBigDecimal > maxValue) {
-        throw new ParseException(s"Numeric literal $rawStrippedQualifier does not " +
+        throw parseException(s"Numeric literal $rawStrippedQualifier does not " +
           s"fit in range [$minValue, $maxValue] for type $typeName", ctx)
       }
       Literal(converter(rawStrippedQualifier))
     } catch {
       case e: NumberFormatException =>
-        throw new ParseException(e.getMessage, ctx)
+        throw parseException(e.getMessage, ctx)
     }
   }
 
@@ -338,7 +347,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       Literal(BigDecimal(raw).underlying())
     } catch {
       case e: AnalysisException =>
-        throw new ParseException(e.message, ctx)
+        throw parseException(e.message, ctx)
     }
   }
 
@@ -389,7 +398,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (yearMonthFields.nonEmpty) {
       if (dayTimeFields.nonEmpty) {
         val literalStr = source(ctx)
-        throw new ParseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
+        throw parseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
       }
       Literal(
         calendarInterval.months,
@@ -446,18 +455,18 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (ctx.errorCapturingMultiUnitsInterval != null) {
       val innerCtx = ctx.errorCapturingMultiUnitsInterval
       if (innerCtx.unitToUnitInterval != null) {
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
       }
       visitMultiUnitsInterval(innerCtx.multiUnitsInterval)
     } else if (ctx.errorCapturingUnitToUnitInterval != null) {
       val innerCtx = ctx.errorCapturingUnitToUnitInterval
       if (innerCtx.error1 != null || innerCtx.error2 != null) {
         val errorCtx = if (innerCtx.error1 != null) innerCtx.error1 else innerCtx.error2
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
-      throw new ParseException("at least one time unit should be given for interval literal", ctx)
+      throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }
 
@@ -479,7 +488,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             // units and become valid ones, e.g. '1 day 2 hour'.
             // Ideally, we only ensure the value parts don't contain any units here.
             if (value.exists(Character.isLetter)) {
-              throw new ParseException("Can only use numbers in the interval value part for" +
+              throw parseException("Can only use numbers in the interval value part for" +
                 s" multiple unit value pairs interval form, but got invalid value: $value", ctx)
             }
             if (values(i).MINUS() == null) {
@@ -498,7 +507,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         IntervalUtils.stringToInterval(UTF8String.concat(kvs: _*))
       } catch {
         case i: IllegalArgumentException =>
-          val e = new ParseException(i.getMessage, ctx)
+          val e = parseException(i.getMessage, ctx)
           e.setStackTrace(i.getStackTrace)
           throw e
       }
@@ -520,7 +529,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           }
         }
       }.getOrElse {
-        throw new ParseException("The value of from-to unit must be a string", ctx.intervalValue)
+        throw parseException("The value of from-to unit must be a string", ctx.intervalValue)
       }
       try {
         val from = ctx.from.getText.toLowerCase(Locale.ROOT)
@@ -533,12 +542,12 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.fromDayTimeString(value,
               DayTimeIntervalType.stringToField(from), DayTimeIntervalType.stringToField(to))
           case _ =>
-            throw new ParseException(s"Intervals FROM $from TO $to are not supported.", ctx)
+            throw parseException(s"Intervals FROM $from TO $to are not supported.", ctx)
         }
       } catch {
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
-          val pe = new ParseException(e.getMessage, ctx)
+          val pe = parseException(e.getMessage, ctx)
           pe.setStackTrace(e.getStackTrace)
           throw pe
       }
@@ -579,7 +588,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
         } catch {
           case e: IllegalArgumentException =>
-            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+            throw parseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
         }
         val sparkElemType = vectorSchema.getVectorElementType match {
           case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
@@ -596,7 +605,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("interval", Nil) => CalendarIntervalType
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt
-        throw new ParseException(s"DataType $dtStr is not supported.", ctx)
+        throw parseException(s"DataType $dtStr is not supported.", ctx)
     }
   }
 
@@ -607,7 +616,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = YearMonthIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       YearMonthIntervalType(start, end)
     } else {
@@ -622,7 +631,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = DayTimeIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       DayTimeIntervalType(start, end)
     } else {
@@ -890,7 +899,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         case ref: FieldReference =>
           ref
         case nonRef =>
-          throw new ParseException(s"Expected a column reference for transform $name: $nonRef.describe", ctx)
+          throw parseException(s"Expected a column reference for transform $name: ${nonRef.describe}", ctx)
       }
     }
 
@@ -899,7 +908,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
                                  arguments: Seq[V2Expression]): FieldReference = {
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
-        throw new ParseException(s"Too many arguments for transform $name", ctx)
+        throw parseException(s"Too many arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -922,7 +931,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               case LiteralValue(longValue, LongType) =>
                 longValue.asInstanceOf[Long].toInt
               case lit =>
-                throw new ParseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
+                throw parseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
             }
 
             val fields = arguments.tail.map(arg => getFieldReference(applyCtx, arg))
@@ -960,7 +969,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
       reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+        .getOrElse(throw parseException("Invalid transform argument", ctx))
     }
   }
 
@@ -970,13 +979,13 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val legacyOn = conf.getConf(SQLConf.LEGACY_PROPERTY_NON_RESERVED)
     properties.filter {
       case (PROP_PROVIDER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
+        throw parseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
       case (PROP_PROVIDER, _) => false
       case (PROP_LOCATION, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
+        throw parseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
       case (PROP_LOCATION, _) => false
       case (PROP_OWNER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
+        throw parseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
       case (PROP_OWNER, _) => false
       case _ => true
     }
@@ -989,7 +998,7 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     var path = location
     val filtered = cleanTableProperties(ctx, options).filter {
       case (k, v) if k.equalsIgnoreCase("path") && path.nonEmpty =>
-        throw new ParseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
+        throw parseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
           s" and the case insensitive key 'path' in OPTIONS are all used to indicate the custom" +
           s" table path, you can only specify one of them.", ctx)
       case (k, v) if k.equalsIgnoreCase("path") =>

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_4ExtendedSqlAstBuilder.scala
@@ -61,6 +61,8 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * Returns a [[ParseException]] carrying `message` as plain human-readable text, positioned at
    * `ctx`. The (String, ParserRuleContext) constructor treats the string as an error class on
    * Spark 3.4+, so use the message-based primary constructor (errorClass stays None) (#19450).
+   * The Spark 4.x builders render the same messages behind an "Operation not allowed: " prefix,
+   * so cross-profile test assertions must stay substring-based.
    */
   private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
     new ParseException(Option(command(ctx)), message, position(ctx.start), position(ctx.stop))
@@ -466,6 +468,8 @@ class HoodieSpark3_4ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
+      // Unreachable through Hudi's pruned grammar: a bare INTERVAL keyword binds to
+      // transformArgument's qualifiedName alternative first. Kept for parity with Spark.
       throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
@@ -61,6 +61,8 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
    * Returns a [[ParseException]] carrying `message` as plain human-readable text, positioned at
    * `ctx`. The (String, ParserRuleContext) constructor treats the string as an error class on
    * Spark 3.4+, so use the message-based primary constructor (errorClass stays None) (#19450).
+   * The Spark 4.x builders render the same messages behind an "Operation not allowed: " prefix,
+   * so cross-profile test assertions must stay substring-based.
    */
   private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
     new ParseException(Option(command(ctx)), message, position(ctx.start), position(ctx.stop))
@@ -466,6 +468,8 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
+      // Unreachable through Hudi's pruned grammar: a bare INTERVAL keyword binds to
+      // transformArgument's qualifiedName alternative first. Kept for parity with Spark.
       throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark3_5ExtendedSqlAstBuilder.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, operationNotAllowed, source, string, stringWithoutUnescape, validate, withOrigin}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{checkDuplicateClauses, checkDuplicateKeys, command, operationNotAllowed, position, source, string, stringWithoutUnescape, validate, withOrigin}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
@@ -56,6 +56,15 @@ import scala.collection.JavaConverters._
  */
 class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterface)
   extends HoodieSqlBaseBaseVisitor[AnyRef] with Logging {
+
+  /**
+   * Returns a [[ParseException]] carrying `message` as plain human-readable text, positioned at
+   * `ctx`. The (String, ParserRuleContext) constructor treats the string as an error class on
+   * Spark 3.4+, so use the message-based primary constructor (errorClass stays None) (#19450).
+   */
+  private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
+    new ParseException(Option(command(ctx)), message, position(ctx.start), position(ctx.stop))
+  }
 
   protected def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
@@ -130,7 +139,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
     def toLiteral[T](f: UTF8String => Option[T], t: DataType): Literal = {
       f(UTF8String.fromString(value)).map(Literal(_, t)).getOrElse {
-        throw new ParseException(s"Cannot parse the $valueType value: $value", ctx)
+        throw parseException(s"Cannot parse the $valueType value: $value", ctx)
       }
     }
 
@@ -179,7 +188,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.stringToInterval(UTF8String.fromString(value))
           } catch {
             case e: IllegalArgumentException =>
-              val ex = new ParseException(s"Cannot parse the INTERVAL value: $value", ctx)
+              val ex = parseException(s"Cannot parse the INTERVAL value: $value", ctx)
               ex.setStackTrace(e.getStackTrace)
               throw ex
           }
@@ -196,12 +205,12 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           val padding = if (value.length % 2 != 0) "0" else ""
           Literal(DatatypeConverter.parseHexBinary(padding + value))
         case other =>
-          throw new ParseException(s"Literals of type '$other' are currently not supported.", ctx)
+          throw parseException(s"Literals of type '$other' are currently not supported.", ctx)
       }
     } catch {
       case e: IllegalArgumentException =>
         val message = Option(e.getMessage).getOrElse(s"Exception parsing $valueType")
-        throw new ParseException(message, ctx)
+        throw parseException(message, ctx)
     }
   }
 
@@ -274,13 +283,13 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     try {
       val rawBigDecimal = BigDecimal(rawStrippedQualifier)
       if (rawBigDecimal < minValue || rawBigDecimal > maxValue) {
-        throw new ParseException(s"Numeric literal $rawStrippedQualifier does not " +
+        throw parseException(s"Numeric literal $rawStrippedQualifier does not " +
           s"fit in range [$minValue, $maxValue] for type $typeName", ctx)
       }
       Literal(converter(rawStrippedQualifier))
     } catch {
       case e: NumberFormatException =>
-        throw new ParseException(e.getMessage, ctx)
+        throw parseException(e.getMessage, ctx)
     }
   }
 
@@ -338,7 +347,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       Literal(BigDecimal(raw).underlying())
     } catch {
       case e: AnalysisException =>
-        throw new ParseException(e.message, ctx)
+        throw parseException(e.message, ctx)
     }
   }
 
@@ -389,7 +398,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (yearMonthFields.nonEmpty) {
       if (dayTimeFields.nonEmpty) {
         val literalStr = source(ctx)
-        throw new ParseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
+        throw parseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
       }
       Literal(
         calendarInterval.months,
@@ -446,18 +455,18 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (ctx.errorCapturingMultiUnitsInterval != null) {
       val innerCtx = ctx.errorCapturingMultiUnitsInterval
       if (innerCtx.unitToUnitInterval != null) {
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
       }
       visitMultiUnitsInterval(innerCtx.multiUnitsInterval)
     } else if (ctx.errorCapturingUnitToUnitInterval != null) {
       val innerCtx = ctx.errorCapturingUnitToUnitInterval
       if (innerCtx.error1 != null || innerCtx.error2 != null) {
         val errorCtx = if (innerCtx.error1 != null) innerCtx.error1 else innerCtx.error2
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
-      throw new ParseException("at least one time unit should be given for interval literal", ctx)
+      throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }
 
@@ -479,7 +488,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             // units and become valid ones, e.g. '1 day 2 hour'.
             // Ideally, we only ensure the value parts don't contain any units here.
             if (value.exists(Character.isLetter)) {
-              throw new ParseException("Can only use numbers in the interval value part for" +
+              throw parseException("Can only use numbers in the interval value part for" +
                 s" multiple unit value pairs interval form, but got invalid value: $value", ctx)
             }
             if (values(i).MINUS() == null) {
@@ -498,7 +507,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         IntervalUtils.stringToInterval(UTF8String.concat(kvs: _*))
       } catch {
         case i: IllegalArgumentException =>
-          val e = new ParseException(i.getMessage, ctx)
+          val e = parseException(i.getMessage, ctx)
           e.setStackTrace(i.getStackTrace)
           throw e
       }
@@ -520,7 +529,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           }
         }
       }.getOrElse {
-        throw new ParseException("The value of from-to unit must be a string", ctx.intervalValue)
+        throw parseException("The value of from-to unit must be a string", ctx.intervalValue)
       }
       try {
         val from = ctx.from.getText.toLowerCase(Locale.ROOT)
@@ -533,12 +542,12 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.fromDayTimeString(value,
               DayTimeIntervalType.stringToField(from), DayTimeIntervalType.stringToField(to))
           case _ =>
-            throw new ParseException(s"Intervals FROM $from TO $to are not supported.", ctx)
+            throw parseException(s"Intervals FROM $from TO $to are not supported.", ctx)
         }
       } catch {
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
-          val pe = new ParseException(e.getMessage, ctx)
+          val pe = parseException(e.getMessage, ctx)
           pe.setStackTrace(e.getStackTrace)
           throw pe
       }
@@ -579,7 +588,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
         } catch {
           case e: IllegalArgumentException =>
-            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+            throw parseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
         }
         val sparkElemType = vectorSchema.getVectorElementType match {
           case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
@@ -596,7 +605,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("interval", Nil) => CalendarIntervalType
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt
-        throw new ParseException(s"DataType $dtStr is not supported.", ctx)
+        throw parseException(s"DataType $dtStr is not supported.", ctx)
     }
   }
 
@@ -607,7 +616,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = YearMonthIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       YearMonthIntervalType(start, end)
     } else {
@@ -622,7 +631,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = DayTimeIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       DayTimeIntervalType(start, end)
     } else {
@@ -890,7 +899,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         case ref: FieldReference =>
           ref
         case nonRef =>
-          throw new ParseException(s"Expected a column reference for transform $name: $nonRef.describe", ctx)
+          throw parseException(s"Expected a column reference for transform $name: ${nonRef.describe}", ctx)
       }
     }
 
@@ -899,7 +908,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
                                  arguments: Seq[V2Expression]): FieldReference = {
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
-        throw new ParseException(s"Too many arguments for transform $name", ctx)
+        throw parseException(s"Too many arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -922,7 +931,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               case LiteralValue(longValue, LongType) =>
                 longValue.asInstanceOf[Long].toInt
               case lit =>
-                throw new ParseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
+                throw parseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
             }
 
             val fields = arguments.tail.map(arg => getFieldReference(applyCtx, arg))
@@ -960,7 +969,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
       reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+        .getOrElse(throw parseException("Invalid transform argument", ctx))
     }
   }
 
@@ -970,13 +979,13 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val legacyOn = conf.getConf(SQLConf.LEGACY_PROPERTY_NON_RESERVED)
     properties.filter {
       case (PROP_PROVIDER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
+        throw parseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
       case (PROP_PROVIDER, _) => false
       case (PROP_LOCATION, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
+        throw parseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
       case (PROP_LOCATION, _) => false
       case (PROP_OWNER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
+        throw parseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
       case (PROP_OWNER, _) => false
       case _ => true
     }
@@ -989,7 +998,7 @@ class HoodieSpark3_5ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     var path = location
     val filtered = cleanTableProperties(ctx, options).filter {
       case (k, v) if k.equalsIgnoreCase("path") && path.nonEmpty =>
-        throw new ParseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
+        throw parseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
           s" and the case insensitive key 'path' in OPTIONS are all used to indicate the custom" +
           s" table path, you can only specify one of them.", ctx)
       case (k, v) if k.equalsIgnoreCase("path") =>

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
@@ -57,6 +57,15 @@ import scala.collection.JavaConverters._
 class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterface)
   extends HoodieSqlBaseBaseVisitor[AnyRef] with Logging {
 
+  /**
+   * Returns a [[ParseException]] carrying `message` as human-readable text, positioned at `ctx`.
+   * Spark 4.x only exposes error-class constructors, so route the message through the legacy
+   * class that ParserUtils.operationNotAllowed also uses ("Operation not allowed: ...") (#19450).
+   */
+  private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
+    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message), ctx)
+  }
+
   protected def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
   }
@@ -130,7 +139,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
     def toLiteral[T](f: UTF8String => Option[T], t: DataType): Literal = {
       f(UTF8String.fromString(value)).map(Literal(_, t)).getOrElse {
-        throw new ParseException(s"Cannot parse the $valueType value: $value", ctx)
+        throw parseException(s"Cannot parse the $valueType value: $value", ctx)
       }
     }
 
@@ -179,7 +188,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.stringToInterval(UTF8String.fromString(value))
           } catch {
             case e: IllegalArgumentException =>
-              val ex = new ParseException(s"Cannot parse the INTERVAL value: $value", ctx)
+              val ex = parseException(s"Cannot parse the INTERVAL value: $value", ctx)
               ex.setStackTrace(e.getStackTrace)
               throw ex
           }
@@ -196,12 +205,12 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           val padding = if (value.length % 2 != 0) "0" else ""
           Literal(DatatypeConverter.parseHexBinary(padding + value))
         case other =>
-          throw new ParseException(s"Literals of type '$other' are currently not supported.", ctx)
+          throw parseException(s"Literals of type '$other' are currently not supported.", ctx)
       }
     } catch {
       case e: IllegalArgumentException =>
         val message = Option(e.getMessage).getOrElse(s"Exception parsing $valueType")
-        throw new ParseException(message, ctx)
+        throw parseException(message, ctx)
     }
   }
 
@@ -274,13 +283,13 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     try {
       val rawBigDecimal = BigDecimal(rawStrippedQualifier)
       if (rawBigDecimal < minValue || rawBigDecimal > maxValue) {
-        throw new ParseException(s"Numeric literal $rawStrippedQualifier does not " +
+        throw parseException(s"Numeric literal $rawStrippedQualifier does not " +
           s"fit in range [$minValue, $maxValue] for type $typeName", ctx)
       }
       Literal(converter(rawStrippedQualifier))
     } catch {
       case e: NumberFormatException =>
-        throw new ParseException(e.getMessage, ctx)
+        throw parseException(e.getMessage, ctx)
     }
   }
 
@@ -338,7 +347,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       Literal(BigDecimal(raw).underlying())
     } catch {
       case e: AnalysisException =>
-        throw new ParseException(e.message, ctx)
+        throw parseException(e.message, ctx)
     }
   }
 
@@ -389,7 +398,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (yearMonthFields.nonEmpty) {
       if (dayTimeFields.nonEmpty) {
         val literalStr = source(ctx)
-        throw new ParseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
+        throw parseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
       }
       Literal(
         calendarInterval.months,
@@ -446,18 +455,18 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (ctx.errorCapturingMultiUnitsInterval != null) {
       val innerCtx = ctx.errorCapturingMultiUnitsInterval
       if (innerCtx.unitToUnitInterval != null) {
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
       }
       visitMultiUnitsInterval(innerCtx.multiUnitsInterval)
     } else if (ctx.errorCapturingUnitToUnitInterval != null) {
       val innerCtx = ctx.errorCapturingUnitToUnitInterval
       if (innerCtx.error1 != null || innerCtx.error2 != null) {
         val errorCtx = if (innerCtx.error1 != null) innerCtx.error1 else innerCtx.error2
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
-      throw new ParseException("at least one time unit should be given for interval literal", ctx)
+      throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }
 
@@ -479,7 +488,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             // units and become valid ones, e.g. '1 day 2 hour'.
             // Ideally, we only ensure the value parts don't contain any units here.
             if (value.exists(Character.isLetter)) {
-              throw new ParseException("Can only use numbers in the interval value part for" +
+              throw parseException("Can only use numbers in the interval value part for" +
                 s" multiple unit value pairs interval form, but got invalid value: $value", ctx)
             }
             if (values(i).MINUS() == null) {
@@ -498,7 +507,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         IntervalUtils.stringToInterval(UTF8String.concat(kvs: _*))
       } catch {
         case i: IllegalArgumentException =>
-          val e = new ParseException(i.getMessage, ctx)
+          val e = parseException(i.getMessage, ctx)
           e.setStackTrace(i.getStackTrace)
           throw e
       }
@@ -520,7 +529,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           }
         }
       }.getOrElse {
-        throw new ParseException("The value of from-to unit must be a string", ctx.intervalValue)
+        throw parseException("The value of from-to unit must be a string", ctx.intervalValue)
       }
       try {
         val from = ctx.from.getText.toLowerCase(Locale.ROOT)
@@ -533,12 +542,12 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.fromDayTimeString(value,
               DayTimeIntervalType.stringToField(from), DayTimeIntervalType.stringToField(to))
           case _ =>
-            throw new ParseException(s"Intervals FROM $from TO $to are not supported.", ctx)
+            throw parseException(s"Intervals FROM $from TO $to are not supported.", ctx)
         }
       } catch {
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
-          val pe = new ParseException(e.getMessage, ctx)
+          val pe = parseException(e.getMessage, ctx)
           pe.setStackTrace(e.getStackTrace)
           throw pe
       }
@@ -579,7 +588,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
         } catch {
           case e: IllegalArgumentException =>
-            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+            throw parseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
         }
         val sparkElemType = vectorSchema.getVectorElementType match {
           case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
@@ -596,7 +605,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("interval", Nil) => CalendarIntervalType
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt
-        throw new ParseException(s"DataType $dtStr is not supported.", ctx)
+        throw parseException(s"DataType $dtStr is not supported.", ctx)
     }
   }
 
@@ -607,7 +616,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = YearMonthIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       YearMonthIntervalType(start, end)
     } else {
@@ -622,7 +631,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = DayTimeIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       DayTimeIntervalType(start, end)
     } else {
@@ -890,7 +899,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         case ref: FieldReference =>
           ref
         case nonRef =>
-          throw new ParseException(s"Expected a column reference for transform $name: $nonRef.describe", ctx)
+          throw parseException(s"Expected a column reference for transform $name: ${nonRef.describe}", ctx)
       }
     }
 
@@ -899,7 +908,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
                                  arguments: Seq[V2Expression]): FieldReference = {
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
-        throw new ParseException(s"Too many arguments for transform $name", ctx)
+        throw parseException(s"Too many arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -922,7 +931,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               case LiteralValue(longValue, LongType) =>
                 longValue.asInstanceOf[Long].toInt
               case lit =>
-                throw new ParseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
+                throw parseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
             }
 
             val fields = arguments.tail.map(arg => getFieldReference(applyCtx, arg))
@@ -960,7 +969,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
       reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+        .getOrElse(throw parseException("Invalid transform argument", ctx))
     }
   }
 
@@ -970,13 +979,13 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val legacyOn = conf.getConf(SQLConf.LEGACY_PROPERTY_NON_RESERVED)
     properties.filter {
       case (PROP_PROVIDER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
+        throw parseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
       case (PROP_PROVIDER, _) => false
       case (PROP_LOCATION, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
+        throw parseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
       case (PROP_LOCATION, _) => false
       case (PROP_OWNER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
+        throw parseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
       case (PROP_OWNER, _) => false
       case _ => true
     }
@@ -989,7 +998,7 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     var path = location
     val filtered = cleanTableProperties(ctx, options).filter {
       case (k, v) if k.equalsIgnoreCase("path") && path.nonEmpty =>
-        throw new ParseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
+        throw parseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
           s" and the case insensitive key 'path' in OPTIONS are all used to indicate the custom" +
           s" table path, you can only specify one of them.", ctx)
       case (k, v) if k.equalsIgnoreCase("path") =>

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_0ExtendedSqlAstBuilder.scala
@@ -59,11 +59,13 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Returns a [[ParseException]] carrying `message` as human-readable text, positioned at `ctx`.
-   * Spark 4.x only exposes error-class constructors, so route the message through the legacy
-   * class that ParserUtils.operationNotAllowed also uses ("Operation not allowed: ...") (#19450).
+   * Spark 4.x only exposes error-class constructors, so route the message through the class that
+   * ParserUtils.operationNotAllowed uses; output gains an "Operation not allowed: " prefix (the
+   * trailing period is stripped to avoid doubling). If Spark drops _LEGACY_ERROR_TEMP_0035, the
+   * intercept[ParseException] cases in TestBlobDataType fail loudly on the 4.x profiles (#19450).
    */
   private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
-    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message), ctx)
+    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message.stripSuffix(".")), ctx)
   }
 
   protected def typedVisit[T](ctx: ParseTree): T = {
@@ -466,6 +468,8 @@ class HoodieSpark4_0ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
+      // Unreachable through Hudi's pruned grammar: a bare INTERVAL keyword binds to
+      // transformArgument's qualifiedName alternative first. Kept for parity with Spark.
       throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
@@ -59,11 +59,13 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Returns a [[ParseException]] carrying `message` as human-readable text, positioned at `ctx`.
-   * Spark 4.x only exposes error-class constructors, so route the message through the legacy
-   * class that ParserUtils.operationNotAllowed also uses ("Operation not allowed: ...") (#19450).
+   * Spark 4.x only exposes error-class constructors, so route the message through the class that
+   * ParserUtils.operationNotAllowed uses; output gains an "Operation not allowed: " prefix (the
+   * trailing period is stripped to avoid doubling). If Spark drops _LEGACY_ERROR_TEMP_0035, the
+   * intercept[ParseException] cases in TestBlobDataType fail loudly on the 4.x profiles (#19450).
    */
   private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
-    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message), ctx)
+    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message.stripSuffix(".")), ctx)
   }
 
   protected def typedVisit[T](ctx: ParseTree): T = {
@@ -466,6 +468,8 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
+      // Unreachable through Hudi's pruned grammar: a bare INTERVAL keyword binds to
+      // transformArgument's qualifiedName alternative first. Kept for parity with Spark.
       throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }

--- a/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.1.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_1ExtendedSqlAstBuilder.scala
@@ -57,6 +57,15 @@ import scala.collection.JavaConverters._
 class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterface)
   extends HoodieSqlBaseBaseVisitor[AnyRef] with Logging {
 
+  /**
+   * Returns a [[ParseException]] carrying `message` as human-readable text, positioned at `ctx`.
+   * Spark 4.x only exposes error-class constructors, so route the message through the legacy
+   * class that ParserUtils.operationNotAllowed also uses ("Operation not allowed: ...") (#19450).
+   */
+  private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
+    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message), ctx)
+  }
+
   protected def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
   }
@@ -130,7 +139,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
     def toLiteral[T](f: UTF8String => Option[T], t: DataType): Literal = {
       f(UTF8String.fromString(value)).map(Literal(_, t)).getOrElse {
-        throw new ParseException(s"Cannot parse the $valueType value: $value", ctx)
+        throw parseException(s"Cannot parse the $valueType value: $value", ctx)
       }
     }
 
@@ -179,7 +188,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.stringToInterval(UTF8String.fromString(value))
           } catch {
             case e: IllegalArgumentException =>
-              val ex = new ParseException(s"Cannot parse the INTERVAL value: $value", ctx)
+              val ex = parseException(s"Cannot parse the INTERVAL value: $value", ctx)
               ex.setStackTrace(e.getStackTrace)
               throw ex
           }
@@ -196,12 +205,12 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           val padding = if (value.length % 2 != 0) "0" else ""
           Literal(DatatypeConverter.parseHexBinary(padding + value))
         case other =>
-          throw new ParseException(s"Literals of type '$other' are currently not supported.", ctx)
+          throw parseException(s"Literals of type '$other' are currently not supported.", ctx)
       }
     } catch {
       case e: IllegalArgumentException =>
         val message = Option(e.getMessage).getOrElse(s"Exception parsing $valueType")
-        throw new ParseException(message, ctx)
+        throw parseException(message, ctx)
     }
   }
 
@@ -274,13 +283,13 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     try {
       val rawBigDecimal = BigDecimal(rawStrippedQualifier)
       if (rawBigDecimal < minValue || rawBigDecimal > maxValue) {
-        throw new ParseException(s"Numeric literal $rawStrippedQualifier does not " +
+        throw parseException(s"Numeric literal $rawStrippedQualifier does not " +
           s"fit in range [$minValue, $maxValue] for type $typeName", ctx)
       }
       Literal(converter(rawStrippedQualifier))
     } catch {
       case e: NumberFormatException =>
-        throw new ParseException(e.getMessage, ctx)
+        throw parseException(e.getMessage, ctx)
     }
   }
 
@@ -338,7 +347,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       Literal(BigDecimal(raw).underlying())
     } catch {
       case e: AnalysisException =>
-        throw new ParseException(e.message, ctx)
+        throw parseException(e.message, ctx)
     }
   }
 
@@ -389,7 +398,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (yearMonthFields.nonEmpty) {
       if (dayTimeFields.nonEmpty) {
         val literalStr = source(ctx)
-        throw new ParseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
+        throw parseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
       }
       Literal(
         calendarInterval.months,
@@ -446,18 +455,18 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (ctx.errorCapturingMultiUnitsInterval != null) {
       val innerCtx = ctx.errorCapturingMultiUnitsInterval
       if (innerCtx.unitToUnitInterval != null) {
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
       }
       visitMultiUnitsInterval(innerCtx.multiUnitsInterval)
     } else if (ctx.errorCapturingUnitToUnitInterval != null) {
       val innerCtx = ctx.errorCapturingUnitToUnitInterval
       if (innerCtx.error1 != null || innerCtx.error2 != null) {
         val errorCtx = if (innerCtx.error1 != null) innerCtx.error1 else innerCtx.error2
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
-      throw new ParseException("at least one time unit should be given for interval literal", ctx)
+      throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }
 
@@ -479,7 +488,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             // units and become valid ones, e.g. '1 day 2 hour'.
             // Ideally, we only ensure the value parts don't contain any units here.
             if (value.exists(Character.isLetter)) {
-              throw new ParseException("Can only use numbers in the interval value part for" +
+              throw parseException("Can only use numbers in the interval value part for" +
                 s" multiple unit value pairs interval form, but got invalid value: $value", ctx)
             }
             if (values(i).MINUS() == null) {
@@ -498,7 +507,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         IntervalUtils.stringToInterval(UTF8String.concat(kvs: _*))
       } catch {
         case i: IllegalArgumentException =>
-          val e = new ParseException(i.getMessage, ctx)
+          val e = parseException(i.getMessage, ctx)
           e.setStackTrace(i.getStackTrace)
           throw e
       }
@@ -520,7 +529,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           }
         }
       }.getOrElse {
-        throw new ParseException("The value of from-to unit must be a string", ctx.intervalValue)
+        throw parseException("The value of from-to unit must be a string", ctx.intervalValue)
       }
       try {
         val from = ctx.from.getText.toLowerCase(Locale.ROOT)
@@ -533,12 +542,12 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.fromDayTimeString(value,
               DayTimeIntervalType.stringToField(from), DayTimeIntervalType.stringToField(to))
           case _ =>
-            throw new ParseException(s"Intervals FROM $from TO $to are not supported.", ctx)
+            throw parseException(s"Intervals FROM $from TO $to are not supported.", ctx)
         }
       } catch {
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
-          val pe = new ParseException(e.getMessage, ctx)
+          val pe = parseException(e.getMessage, ctx)
           pe.setStackTrace(e.getStackTrace)
           throw pe
       }
@@ -579,7 +588,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
         } catch {
           case e: IllegalArgumentException =>
-            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+            throw parseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
         }
         val sparkElemType = vectorSchema.getVectorElementType match {
           case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
@@ -596,7 +605,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("interval", Nil) => CalendarIntervalType
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt
-        throw new ParseException(s"DataType $dtStr is not supported.", ctx)
+        throw parseException(s"DataType $dtStr is not supported.", ctx)
     }
   }
 
@@ -607,7 +616,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = YearMonthIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       YearMonthIntervalType(start, end)
     } else {
@@ -622,7 +631,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = DayTimeIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       DayTimeIntervalType(start, end)
     } else {
@@ -890,7 +899,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         case ref: FieldReference =>
           ref
         case nonRef =>
-          throw new ParseException(s"Expected a column reference for transform $name: $nonRef.describe", ctx)
+          throw parseException(s"Expected a column reference for transform $name: ${nonRef.describe}", ctx)
       }
     }
 
@@ -899,7 +908,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
                                  arguments: Seq[V2Expression]): FieldReference = {
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
-        throw new ParseException(s"Too many arguments for transform $name", ctx)
+        throw parseException(s"Too many arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -922,7 +931,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               case LiteralValue(longValue, LongType) =>
                 longValue.asInstanceOf[Long].toInt
               case lit =>
-                throw new ParseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
+                throw parseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
             }
 
             val fields = arguments.tail.map(arg => getFieldReference(applyCtx, arg))
@@ -960,7 +969,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
       reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+        .getOrElse(throw parseException("Invalid transform argument", ctx))
     }
   }
 
@@ -970,13 +979,13 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val legacyOn = conf.getConf(SQLConf.LEGACY_PROPERTY_NON_RESERVED)
     properties.filter {
       case (PROP_PROVIDER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
+        throw parseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
       case (PROP_PROVIDER, _) => false
       case (PROP_LOCATION, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
+        throw parseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
       case (PROP_LOCATION, _) => false
       case (PROP_OWNER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
+        throw parseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
       case (PROP_OWNER, _) => false
       case _ => true
     }
@@ -989,7 +998,7 @@ class HoodieSpark4_1ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     var path = location
     val filtered = cleanTableProperties(ctx, options).filter {
       case (k, v) if k.equalsIgnoreCase("path") && path.nonEmpty =>
-        throw new ParseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
+        throw parseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
           s" and the case insensitive key 'path' in OPTIONS are all used to indicate the custom" +
           s" table path, you can only specify one of them.", ctx)
       case (k, v) if k.equalsIgnoreCase("path") =>

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
@@ -59,11 +59,13 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
   /**
    * Returns a [[ParseException]] carrying `message` as human-readable text, positioned at `ctx`.
-   * Spark 4.x only exposes error-class constructors, so route the message through the legacy
-   * class that ParserUtils.operationNotAllowed also uses ("Operation not allowed: ...") (#19450).
+   * Spark 4.x only exposes error-class constructors, so route the message through the class that
+   * ParserUtils.operationNotAllowed uses; output gains an "Operation not allowed: " prefix (the
+   * trailing period is stripped to avoid doubling). If Spark drops _LEGACY_ERROR_TEMP_0035, the
+   * intercept[ParseException] cases in TestBlobDataType fail loudly on the 4.x profiles (#19450).
    */
   private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
-    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message), ctx)
+    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message.stripSuffix(".")), ctx)
   }
 
   protected def typedVisit[T](ctx: ParseTree): T = {
@@ -466,6 +468,8 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
+      // Unreachable through Hudi's pruned grammar: a bare INTERVAL keyword binds to
+      // transformArgument's qualifiedName alternative first. Kept for parity with Spark.
       throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }

--- a/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
+++ b/hudi-spark-datasource/hudi-spark4.2.x/src/main/scala/org/apache/spark/sql/parser/HoodieSpark4_2ExtendedSqlAstBuilder.scala
@@ -57,6 +57,15 @@ import scala.collection.JavaConverters._
 class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterface)
   extends HoodieSqlBaseBaseVisitor[AnyRef] with Logging {
 
+  /**
+   * Returns a [[ParseException]] carrying `message` as human-readable text, positioned at `ctx`.
+   * Spark 4.x only exposes error-class constructors, so route the message through the legacy
+   * class that ParserUtils.operationNotAllowed also uses ("Operation not allowed: ...") (#19450).
+   */
+  private def parseException(message: String, ctx: ParserRuleContext): ParseException = {
+    new ParseException("_LEGACY_ERROR_TEMP_0035", Map("message" -> message), ctx)
+  }
+
   protected def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
   }
@@ -130,7 +139,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
 
     def toLiteral[T](f: UTF8String => Option[T], t: DataType): Literal = {
       f(UTF8String.fromString(value)).map(Literal(_, t)).getOrElse {
-        throw new ParseException(s"Cannot parse the $valueType value: $value", ctx)
+        throw parseException(s"Cannot parse the $valueType value: $value", ctx)
       }
     }
 
@@ -179,7 +188,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.stringToInterval(UTF8String.fromString(value))
           } catch {
             case e: IllegalArgumentException =>
-              val ex = new ParseException(s"Cannot parse the INTERVAL value: $value", ctx)
+              val ex = parseException(s"Cannot parse the INTERVAL value: $value", ctx)
               ex.setStackTrace(e.getStackTrace)
               throw ex
           }
@@ -196,12 +205,12 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           val padding = if (value.length % 2 != 0) "0" else ""
           Literal(DatatypeConverter.parseHexBinary(padding + value))
         case other =>
-          throw new ParseException(s"Literals of type '$other' are currently not supported.", ctx)
+          throw parseException(s"Literals of type '$other' are currently not supported.", ctx)
       }
     } catch {
       case e: IllegalArgumentException =>
         val message = Option(e.getMessage).getOrElse(s"Exception parsing $valueType")
-        throw new ParseException(message, ctx)
+        throw parseException(message, ctx)
     }
   }
 
@@ -274,13 +283,13 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     try {
       val rawBigDecimal = BigDecimal(rawStrippedQualifier)
       if (rawBigDecimal < minValue || rawBigDecimal > maxValue) {
-        throw new ParseException(s"Numeric literal $rawStrippedQualifier does not " +
+        throw parseException(s"Numeric literal $rawStrippedQualifier does not " +
           s"fit in range [$minValue, $maxValue] for type $typeName", ctx)
       }
       Literal(converter(rawStrippedQualifier))
     } catch {
       case e: NumberFormatException =>
-        throw new ParseException(e.getMessage, ctx)
+        throw parseException(e.getMessage, ctx)
     }
   }
 
@@ -338,7 +347,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       Literal(BigDecimal(raw).underlying())
     } catch {
       case e: AnalysisException =>
-        throw new ParseException(e.message, ctx)
+        throw parseException(e.message, ctx)
     }
   }
 
@@ -389,7 +398,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (yearMonthFields.nonEmpty) {
       if (dayTimeFields.nonEmpty) {
         val literalStr = source(ctx)
-        throw new ParseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
+        throw parseException(s"Cannot mix year-month and day-time fields: $literalStr", ctx)
       }
       Literal(
         calendarInterval.months,
@@ -446,18 +455,18 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     if (ctx.errorCapturingMultiUnitsInterval != null) {
       val innerCtx = ctx.errorCapturingMultiUnitsInterval
       if (innerCtx.unitToUnitInterval != null) {
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", innerCtx.unitToUnitInterval)
       }
       visitMultiUnitsInterval(innerCtx.multiUnitsInterval)
     } else if (ctx.errorCapturingUnitToUnitInterval != null) {
       val innerCtx = ctx.errorCapturingUnitToUnitInterval
       if (innerCtx.error1 != null || innerCtx.error2 != null) {
         val errorCtx = if (innerCtx.error1 != null) innerCtx.error1 else innerCtx.error2
-        throw new ParseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
+        throw parseException("Can only have a single from-to unit in the interval literal syntax", errorCtx)
       }
       visitUnitToUnitInterval(innerCtx.body)
     } else {
-      throw new ParseException("at least one time unit should be given for interval literal", ctx)
+      throw parseException("at least one time unit should be given for interval literal", ctx)
     }
   }
 
@@ -479,7 +488,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             // units and become valid ones, e.g. '1 day 2 hour'.
             // Ideally, we only ensure the value parts don't contain any units here.
             if (value.exists(Character.isLetter)) {
-              throw new ParseException("Can only use numbers in the interval value part for" +
+              throw parseException("Can only use numbers in the interval value part for" +
                 s" multiple unit value pairs interval form, but got invalid value: $value", ctx)
             }
             if (values(i).MINUS() == null) {
@@ -498,7 +507,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         IntervalUtils.stringToInterval(UTF8String.concat(kvs: _*))
       } catch {
         case i: IllegalArgumentException =>
-          val e = new ParseException(i.getMessage, ctx)
+          val e = parseException(i.getMessage, ctx)
           e.setStackTrace(i.getStackTrace)
           throw e
       }
@@ -520,7 +529,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           }
         }
       }.getOrElse {
-        throw new ParseException("The value of from-to unit must be a string", ctx.intervalValue)
+        throw parseException("The value of from-to unit must be a string", ctx.intervalValue)
       }
       try {
         val from = ctx.from.getText.toLowerCase(Locale.ROOT)
@@ -533,12 +542,12 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
             IntervalUtils.fromDayTimeString(value,
               DayTimeIntervalType.stringToField(from), DayTimeIntervalType.stringToField(to))
           case _ =>
-            throw new ParseException(s"Intervals FROM $from TO $to are not supported.", ctx)
+            throw parseException(s"Intervals FROM $from TO $to are not supported.", ctx)
         }
       } catch {
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
-          val pe = new ParseException(e.getMessage, ctx)
+          val pe = parseException(e.getMessage, ctx)
           pe.setStackTrace(e.getStackTrace)
           throw pe
       }
@@ -579,7 +588,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
           HoodieSchema.parseTypeDescriptor(ctx.getText).asInstanceOf[HoodieSchema.Vector]
         } catch {
           case e: IllegalArgumentException =>
-            throw new ParseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
+            throw parseException(s"Invalid VECTOR type: ${e.getMessage}", ctx)
         }
         val sparkElemType = vectorSchema.getVectorElementType match {
           case HoodieSchema.Vector.VectorElementType.FLOAT => FloatType
@@ -596,7 +605,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       case ("interval", Nil) => CalendarIntervalType
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt
-        throw new ParseException(s"DataType $dtStr is not supported.", ctx)
+        throw parseException(s"DataType $dtStr is not supported.", ctx)
     }
   }
 
@@ -607,7 +616,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = YearMonthIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       YearMonthIntervalType(start, end)
     } else {
@@ -622,7 +631,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
       val endStr = ctx.to.getText.toLowerCase(Locale.ROOT)
       val end = DayTimeIntervalType.stringToField(endStr)
       if (end <= start) {
-        throw new ParseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
+        throw parseException(s"Intervals FROM $startStr TO $endStr are not supported.", ctx)
       }
       DayTimeIntervalType(start, end)
     } else {
@@ -890,7 +899,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         case ref: FieldReference =>
           ref
         case nonRef =>
-          throw new ParseException(s"Expected a column reference for transform $name: $nonRef.describe", ctx)
+          throw parseException(s"Expected a column reference for transform $name: ${nonRef.describe}", ctx)
       }
     }
 
@@ -899,7 +908,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
                                  arguments: Seq[V2Expression]): FieldReference = {
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
-        throw new ParseException(s"Too many arguments for transform $name", ctx)
+        throw parseException(s"Too many arguments for transform $name", ctx)
       } else {
         getFieldReference(ctx, arguments.head)
       }
@@ -922,7 +931,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
               case LiteralValue(longValue, LongType) =>
                 longValue.asInstanceOf[Long].toInt
               case lit =>
-                throw new ParseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
+                throw parseException(s"Invalid number of buckets: ${lit.describe}", applyCtx)
             }
 
             val fields = arguments.tail.map(arg => getFieldReference(applyCtx, arg))
@@ -960,7 +969,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
         .map(typedVisit[Literal])
         .map(lit => LiteralValue(lit.value, lit.dataType))
       reference.orElse(literal)
-        .getOrElse(throw new ParseException("Invalid transform argument", ctx))
+        .getOrElse(throw parseException("Invalid transform argument", ctx))
     }
   }
 
@@ -970,13 +979,13 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     val legacyOn = conf.getConf(SQLConf.LEGACY_PROPERTY_NON_RESERVED)
     properties.filter {
       case (PROP_PROVIDER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
+        throw parseException(s"$PROP_PROVIDER is a reserved table property, please use the USING clause to specify it.", ctx)
       case (PROP_PROVIDER, _) => false
       case (PROP_LOCATION, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
+        throw parseException(s"$PROP_LOCATION is a reserved table property, please use the LOCATION clause to specify it.", ctx)
       case (PROP_LOCATION, _) => false
       case (PROP_OWNER, _) if !legacyOn =>
-        throw new ParseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
+        throw parseException(s"$PROP_OWNER is a reserved table property, it will be set to the current user.", ctx)
       case (PROP_OWNER, _) => false
       case _ => true
     }
@@ -989,7 +998,7 @@ class HoodieSpark4_2ExtendedSqlAstBuilder(conf: SQLConf, delegate: ParserInterfa
     var path = location
     val filtered = cleanTableProperties(ctx, options).filter {
       case (k, v) if k.equalsIgnoreCase("path") && path.nonEmpty =>
-        throw new ParseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
+        throw parseException(s"Duplicated table paths found: '${path.get}' and '$v'. LOCATION" +
           s" and the case insensitive key 'path' in OPTIONS are all used to indicate the custom" +
           s" table path, you can only specify one of them.", ctx)
       case (k, v) if k.equalsIgnoreCase("path") =>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19450

The six `HoodieSpark*ExtendedSqlAstBuilder`s throw parse errors as `new ParseException(<message>, ctx)`. On Spark 3.3 that constructor's String is the human message, but on Spark 3.4+ it is the error class, so every such site surfaces at runtime as `SparkException: [INTERNAL_ERROR] Cannot find main error class '<msg>'` instead of a clean `ParseException`. Messages containing 2+ dots (e.g. interpolated `e.getMessage`, or numeric ranges like `-3.4028234663852886E+38`) are even worse: they fail an assertion inside Spark's `ErrorClassesJsonReader` and throw a bare `AssertionError` with no diagnostic text at all. The three construct-then-`setStackTrace` sites also lost the original exception's stack trace on 3.4+, because the constructor threw before `setStackTrace` could run (a `cause` cannot be attached at all: `ParseException` never passes one to `AnalysisException`, and `initCause` is blocked once the null cause is committed).

### Summary and Changelog

Extended-parser errors (BLOB/VECTOR DDL, index statements) now surface as a clean `ParseException` carrying the intended message on every supported Spark version.

Production changes:

- Add a private `parseException(message, ctx)` helper to each of the six builders (3.3, 3.4, 3.5, 4.0, 4.1, 4.2) and route all 28 raw throw sites per builder through it, keeping call-site text identical across the six files to preserve diffability:
  - 3.3: the 2-arg constructor, which already takes the human message (behavior unchanged).
  - 3.4/3.5: the public message-based primary constructor (`errorClass` stays `None`), the same pattern `HoodieSpark3_4/3_5ExtendedSqlParser` already use.
  - 4.x: the `(errorClass, messageParameters, ctx)` constructor with `_LEGACY_ERROR_TEMP_0035`, the same class `ParserUtils.operationNotAllowed` uses, because the message-based constructor is `private` on Spark 4.x. A trailing period is stripped from the message so the template does not render a double period.
- The three construct-then-throw sites keep their `setStackTrace` of the original cause's stack trace, which previously never ran on 3.4+.
- Fix the unbraced interpolation in the transform error message: `$nonRef.describe` becomes `${nonRef.describe}` (it printed the literal text `.describe`).
- Mark the grammar-unreachable `at least one time unit` interval arm with a comment for the next pruning pass (a bare `INTERVAL` keyword binds to `transformArgument`'s `qualifiedName` alternative first).

Test changes:

- Add a shared `interceptParse(sql)(expected)` helper to `ExtendedParserTestHelpers` that asserts a clean `ParseException` plus a message substring. The previous `checkExceptionContain`-based assertions could not detect this bug class: they catch any `Throwable` and the pre-fix `[INTERNAL_ERROR]` text embeds the original message, so substring matching passed while every site was broken.
- Convert the negative parser assertions in `TestBlobDataType` (invalid partition transforms, interval endpoints) and `TestCreateTable` (VECTOR without dimension, invalid VECTOR type, duplicated table paths, reserved table properties) to `interceptParse`.
- Extend the invalid-partition-transform test with four new cases covering the previously untested visitor arms: typed literals (`DATE 'nope'`), invalid `INTERVAL` literals (the `setStackTrace` arm), out-of-range fractional literals (the pre-fix `AssertionError` mode), and mixed year-month/day-time interval fields. Coverage of the 28 converted sites goes from 3 to 15.

No code was copied; the builders themselves remain the pre-existing fork of Spark's AstBuilder.

### Impact

No public API changes. User-facing error behavior on Spark 3.4+ profiles: extended-parser failures now raise `ParseException` with the intended message instead of `SparkException [INTERNAL_ERROR]` or `AssertionError`. On Spark 4.x profiles the message is rendered through the legacy error class as `Operation not allowed: <message>.`; on 3.3-3.5 messages are byte-identical to before. Known divergence from stock Spark: for the same SQL error, stock Spark answers with named error classes (e.g. `INVALID_SQL_SYNTAX.INVALID_COLUMN_REFERENCE`); those `QueryParsingErrors` helpers take Spark's own parser-context types, so they cannot be reused from Hudi's forked grammar contexts. These statements are only reachable through Hudi's extended parser. No performance impact (error paths only).

### Risk Level

low. The change is confined to error-raising paths in the extended parsers. All six Spark profiles were compile-gated locally, `hudi-spark` was test-compiled under spark3.5 (Scala 2.12) and spark4.2 (Scala 2.13), and the modified suites were executed against the Spark 4.2 classpath (the riskiest variant, exercising the `_LEGACY_ERROR_TEMP_0035` rendering end to end). If a future Spark release drops that legacy class, the `interceptParse` assertions fail loudly on the 4.x CI profiles rather than silently regressing.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
