### PR TITLE
fix(build): exclude nested .mvn directories from the RAT check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -706,7 +706,9 @@
               <exclude>**/banner.txt</exclude>
               <!-- local files not in version control -->
               <exclude>**/*.iml</exclude>
-              <exclude>.mvn/**</exclude>
+              <!-- .mvn at any depth: nested ones are tracked without an ASF header
+                   (hudi-trino/.mvn/modernizer/*.xml) and the source release strips .gitignore. -->
+              <exclude>**/.mvn/**</exclude>
             </excludes>
           </configuration>
           <executions>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19461.

The RAT check inside the source release fails on `hudi-trino/.mvn/modernizer/violations.xml` and `violations-production-code-only.xml`. Both are tracked without an ASF header, and the root pom's `<exclude>.mvn/**</exclude>` does not cover them because a RAT exclude is relative to the project basedir, so it only matches `<root>/.mvn/**`. In the workspace `.gitignore` hides them, but `create_source_directory.sh` strips `.gitignore` from the tarball.

### Summary and Changelog

- Root `pom.xml`: widen the apache-rat exclude from `.mvn/**` to `**/.mvn/**`, and move it out from under the `<!-- local files not in version control -->` comment, which no longer describes it.

Verified on the tree the release job validates, built with `create_source_directory.sh`:

| tree | before | after |
|---|---|---|
| source release directory | `Unapproved: 2`, BUILD FAILURE | `Unapproved: 0`, BUILD SUCCESS |
| workspace | `Unapproved: 0` | `Unapproved: 0` |

A headerless file planted at `<root>/.mvn/` is excluded by `**/.mvn/**` exactly as by `.mvn/**`, so no coverage is lost.

### Impact

Unblocks `validate_staged_release.sh` for the next release cut. No production code, API, config, or format change.

### Risk Level

low - build configuration only, and the change only widens an existing exclude.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
