### PR TITLE
fix(hadoop-mr): ignore blank Hive projection ids and report both lists on mismatch

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
@@ -150,7 +150,8 @@ public class HoodieParquetInputFormat extends HoodieParquetInputFormatBase {
     HoodieRealtimeInputFormatUtils.addProjectionField(job, job.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "").split("/"));
     // The bootstrap and schema-evolution paths below parse the read-column ids with Integer#parseInt, so the
     // blank ids HIVE-22438 leaves in the conf have to be dropped here too; neither path goes through a
-    // realtime input format. The call is idempotent, so the realtime formats' own call becomes a no-op.
+    // realtime input format. The realtime formats clean the conf before delegating here, so on that path
+    // it is this call that is the no-op.
     HoodieRealtimeInputFormatUtils.cleanProjectionColumnIds(job);
     if (shouldUseFilegroupReader(job, split)) {
       try {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
@@ -148,6 +148,10 @@ public class HoodieParquetInputFormat extends HoodieParquetInputFormatBase {
   public RecordReader<NullWritable, ArrayWritable> getRecordReader(final InputSplit split, final JobConf job,
                                                                    final Reporter reporter) throws IOException {
     HoodieRealtimeInputFormatUtils.addProjectionField(job, job.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "").split("/"));
+    // The bootstrap and schema-evolution paths below parse the read-column ids with Integer#parseInt, so the
+    // blank ids HIVE-22438 leaves in the conf have to be dropped here too; neither path goes through a
+    // realtime input format. The call is idempotent, so the realtime formats' own call becomes a no-op.
+    HoodieRealtimeInputFormatUtils.cleanProjectionColumnIds(job);
     if (shouldUseFilegroupReader(job, split)) {
       try {
         if (!(split instanceof FileSplit) || !checkIfHudiTable(split, job)) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
@@ -275,8 +275,14 @@ public class SchemaEvolutionContext {
     List<Integer> tmpColIdList = parseReadColumnIds(job).stream()
         .map(Integer::parseInt).collect(Collectors.toList());
     if (tmpColIdList.size() != fields.size()) {
-      throw new HoodieException(String.format("The size of hive.io.file.readcolumn.ids: %s is not equal to projection columns: %s",
-          job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ""), fields.stream().map(Types.Field::name).collect(Collectors.joining(","))));
+      // Report the counts that were compared, not just the raw conf value: the ids are counted after blanks
+      // are dropped, so the string printed here can hold more entries than the number the check used.
+      throw new HoodieException(String.format(
+          "The size of hive.io.file.readcolumn.ids: %s is not equal to projection columns: %s. "
+              + "#nonBlankIds: %d, #projectionColumns: %d",
+          job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ""),
+          fields.stream().map(Types.Field::name).collect(Collectors.joining(",")),
+          tmpColIdList.size(), fields.size()));
     }
     List<TypeInfo> fieldTypes = new ArrayList<>();
     for (int i = 0; i < tmpColIdList.size(); i++) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
@@ -433,11 +433,11 @@ public class SchemaEvolutionContext {
   public static List<String> getRequireColumn(JobConf jobConf) {
     String originColumnString = jobConf.get(HIVE_TMP_READ_COLUMN_NAMES_CONF_STR);
     if (StringUtils.isNullOrEmpty(originColumnString)) {
-      jobConf.set(HIVE_TMP_READ_COLUMN_NAMES_CONF_STR, jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR));
+      jobConf.set(HIVE_TMP_READ_COLUMN_NAMES_CONF_STR, jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, ""));
     }
     String hoodieFullColumnString = jobConf.get(HIVE_TMP_COLUMNS);
     if (StringUtils.isNullOrEmpty(hoodieFullColumnString)) {
-      jobConf.set(HIVE_TMP_COLUMNS, jobConf.get(serdeConstants.LIST_COLUMNS));
+      jobConf.set(HIVE_TMP_COLUMNS, jobConf.get(serdeConstants.LIST_COLUMNS, ""));
     }
     String tableColumnString = jobConf.get(HIVE_TMP_READ_COLUMN_NAMES_CONF_STR);
     List<String> tableColumns = Arrays.asList(tableColumnString.split(","));

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/SchemaEvolutionContext.java
@@ -254,13 +254,29 @@ public class SchemaEvolutionContext {
     }
   }
 
+  /**
+   * Reads {@code hive.io.file.readcolumn.ids} as its non-blank, trimmed tokens. The key is unset until
+   * something projects a column, and {@code HoodieRealtimeInputFormatUtils#cleanProjectionColumnIds} drops
+   * the blank ids HIVE-22438 leaves in it before any reader runs; this keeps both callers below safe if
+   * either ever reaches them anyway.
+   */
+  private static List<String> parseReadColumnIds(JobConf job) {
+    return Arrays.stream(job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, "").split(","))
+        .map(String::trim)
+        .filter(id -> !id.isEmpty())
+        .collect(Collectors.toList());
+  }
+
   public void setColumnTypeList(JobConf job, List<Types.Field> fields) {
     List<TypeInfo> fullTypeInfos = TypeInfoUtils.getTypeInfosFromTypeString(job.get(serdeConstants.LIST_COLUMN_TYPES));
-    List<Integer> tmpColIdList = Arrays.stream(job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR).split(","))
+    // Blank ids are dropped rather than parsed: HIVE-22438 puts them in this conf value, and the key is
+    // unset until something projects a column. Either way the size check below reports the id list instead
+    // of failing with a bare NumberFormatException or an NPE.
+    List<Integer> tmpColIdList = parseReadColumnIds(job).stream()
         .map(Integer::parseInt).collect(Collectors.toList());
     if (tmpColIdList.size() != fields.size()) {
       throw new HoodieException(String.format("The size of hive.io.file.readcolumn.ids: %s is not equal to projection columns: %s",
-          job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR), fields.stream().map(Types.Field::name).collect(Collectors.joining(","))));
+          job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ""), fields.stream().map(Types.Field::name).collect(Collectors.joining(","))));
     }
     List<TypeInfo> fieldTypes = new ArrayList<>();
     for (int i = 0; i < tmpColIdList.size(); i++) {
@@ -389,7 +405,7 @@ public class SchemaEvolutionContext {
     if (fields == null) {
       return;
     }
-    List<String> tmpColIdList = Arrays.asList(job.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR).split(","));
+    List<String> tmpColIdList = parseReadColumnIds(job);
     if (fields.size() != tmpColIdList.size()) {
       return;
     }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeInputFormatUtils.java
@@ -128,16 +128,47 @@ public class HoodieRealtimeInputFormatUtils extends HoodieInputFormatUtils {
   }
 
   /**
-   * Hive will append read columns' ids to old columns' ids during getRecordReader. In some cases, e.g. SELECT COUNT(*),
-   * the read columns' id is an empty string and Hive will combine it with Hoodie required projection ids and becomes
-   * e.g. ",2,0,3" and will cause an error. Actually this method is a temporary solution because the real bug is from
-   * Hive. Hive has fixed this bug after 3.0.0, but the version before that would still face this problem. (HIVE-22438)
+   * Drops blank entries from the read-column id list held in {@code conf}.
+   *
+   * <p>For {@code SELECT COUNT(*)} on Hive before 3.0.0 the read-column ids arrive empty and Hive combines
+   * them into e.g. {@code ",2,0,3"} (HIVE-22438). Every consumer parses those ids with
+   * {@code Integer#parseInt}, so a blank entry fails with a bare {@code NumberFormatException} that carries
+   * none of the projection lists:
+   *
+   * <ul>
+   *   <li>{@code SchemaEvolutionContext#setColumnNameList} and {@code #setColumnTypeList}, reached from both
+   *       {@code doEvolutionForParquetFormat} and {@code doEvolutionForRealtimeInputFormat}</li>
+   *   <li>{@code HoodieColumnProjectionUtils#getReadColumnIDs}, on the bootstrap path</li>
+   *   <li>{@code HoodieRealtimeRecordReaderUtils#orderFields}, the path in the reported issue</li>
+   * </ul>
+   *
+   * <p>Each of those is reached from a {@code getRecordReader} that cleans the conf first:
+   * {@code HoodieParquetInputFormat} for the parquet and bootstrap paths, and
+   * {@code HoodieParquetRealtimeInputFormat} / {@code HoodieHFileRealtimeInputFormat} for the realtime ones.
+   * {@code HoodieCombineHiveInputFormat} builds its per-split readers through those same formats and hands
+   * them the conf they cleaned, so it is covered as well.
+   *
+   * <p>This is a workaround: the underlying bug is in Hive, fixed after 3.0.0, but earlier versions still
+   * hit it. Stripping a single leading comma is not enough. Hive prepends ids while appending names, so repeated
+   * empty appends give {@code ",,2,0"}, and an id prepended after an empty one gives {@code "3,,2,0"} where
+   * the blank is interior and no amount of leading-comma stripping reaches it.
+   *
+   * <p>Hive on Spark calls {@code getRecordReader} from several threads sharing one {@code JobConf}, so the
+   * read-modify-write below is synchronized on the conf the same way {@code addProjectionToJobConf} guards
+   * its own writes. The write-back is skipped when nothing changed, so an unset key stays unset rather than
+   * being written back as empty.
    */
   public static void cleanProjectionColumnIds(Configuration conf) {
-    String columnIds = conf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR);
-    if (!columnIds.isEmpty() && columnIds.charAt(0) == ',') {
-      conf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, columnIds.substring(1));
-      LOG.debug("The projection Ids: {{}} start with ','. First comma is removed", columnIds);
+    synchronized (conf) {
+      String columnIds = conf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, "");
+      String cleanedColumnIds = Arrays.stream(columnIds.split(","))
+          .map(String::trim)
+          .filter(id -> !id.isEmpty())
+          .collect(Collectors.joining(","));
+      if (!cleanedColumnIds.equals(columnIds)) {
+        conf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, cleanedColumnIds);
+        LOG.debug("The projection Ids: {{}} contained blank entries. Cleaned to: {{}}", columnIds, cleanedColumnIds);
+      }
     }
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeInputFormatUtils.java
@@ -136,8 +136,8 @@ public class HoodieRealtimeInputFormatUtils extends HoodieInputFormatUtils {
    * none of the projection lists:
    *
    * <ul>
-   *   <li>{@code SchemaEvolutionContext#setColumnNameList} and {@code #setColumnTypeList}, reached from both
-   *       {@code doEvolutionForParquetFormat} and {@code doEvolutionForRealtimeInputFormat}</li>
+   *   <li>{@code SchemaEvolutionContext#setColumnNameList} and {@code #setColumnTypeList}, both reached from
+   *       {@code doEvolutionForParquetFormat}</li>
    *   <li>{@code HoodieColumnProjectionUtils#getReadColumnIDs}, on the bootstrap path</li>
    *   <li>{@code HoodieRealtimeRecordReaderUtils#orderFields}, the path in the reported issue</li>
    * </ul>

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
@@ -273,15 +273,26 @@ public class HoodieRealtimeRecordReaderUtils {
     // /org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java#L188}
     // Field Names -> {@link https://github.com/apache/hive/blob/f37c5de6c32b9395d1b34fa3c02ed06d1bfbf6eb/serde/src/java
     // /org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java#L229}
-    String[] fieldOrdersWithDups = fieldOrderCsv.isEmpty() ? new String[0] : fieldOrderCsv.split(",");
+    // Blank tokens are dropped rather than carried into the loop below. For SELECT COUNT(*) on Hive before
+    // 3.0.0 the read-column ids arrive empty and Hive combines them into e.g. ",2,0,3" (HIVE-22438, see
+    // HoodieRealtimeInputFormatUtils#cleanProjectionColumnIds, which only strips one leading comma). A blank
+    // token used to reach Integer.parseInt and fail with a bare NumberFormatException carrying none of the
+    // projection lists.
+    String[] fieldOrdersWithDups = fieldOrderCsv.isEmpty() ? new String[0]
+        : Arrays.stream(fieldOrderCsv.split(",")).filter(id -> !id.trim().isEmpty()).toArray(String[]::new);
     Set<String> fieldOrdersSet = new LinkedHashSet<>(Arrays.asList(fieldOrdersWithDups));
     String[] fieldOrders = fieldOrdersSet.toArray(new String[0]);
     List<String> fieldNames = fieldNameCsv.isEmpty() ? new ArrayList<>() : Arrays.stream(fieldNameCsv.split(",")).collect(Collectors.toList());
     Set<String> fieldNamesSet = new LinkedHashSet<>(fieldNames);
     if (fieldNamesSet.size() != fieldOrders.length) {
+      // The counts are of the de-duplicated lists, which is what was compared, so they are named as such:
+      // quoting the raw name count can print two equal numbers for a real mismatch, and printing a
+      // de-duplicated count beside the raw list reads as a contradiction. The lists come from Hive and are
+      // the only way to diagnose which side is wrong.
       throw new HoodieException(String
-          .format("Error ordering fields for storage read. #fieldNames: %d, #fieldPositions: %d",
-              fieldNames.size(), fieldOrders.length));
+          .format("Error ordering fields for storage read. #distinctFieldNames: %d, #distinctFieldPositions: %d, "
+                  + "read column names: [%s], read column ids: [%s]",
+              fieldNamesSet.size(), fieldOrders.length, fieldNameCsv, fieldOrderCsv));
     }
     TreeMap<Integer, String> orderedFieldMap = new TreeMap<>();
     String[] fieldNamesArray = fieldNamesSet.toArray(new String[0]);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieRealtimeRecordReaderUtils.java
@@ -273,15 +273,25 @@ public class HoodieRealtimeRecordReaderUtils {
     // /org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java#L188}
     // Field Names -> {@link https://github.com/apache/hive/blob/f37c5de6c32b9395d1b34fa3c02ed06d1bfbf6eb/serde/src/java
     // /org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java#L229}
-    String[] fieldOrdersWithDups = fieldOrderCsv.isEmpty() ? new String[0] : fieldOrderCsv.split(",");
+    // Defence in depth. HoodieRealtimeInputFormatUtils#cleanProjectionColumnIds now drops blank ids from the
+    // JobConf before any reader runs, which is what HIVE-22438 produces for SELECT COUNT(*) on Hive before
+    // 3.0.0, so blanks should no longer arrive here. Callers that assemble the csv without going through that
+    // conf still can, and a blank token would otherwise reach Integer.parseInt below and fail with a bare
+    // NumberFormatException carrying neither projection list. Trim before filtering so a padded id parses and
+    // de-duplicates as the same entry rather than as a distinct one.
+    String[] fieldOrdersWithDups = Arrays.stream(fieldOrderCsv.split(","))
+        .map(String::trim).filter(id -> !id.isEmpty()).toArray(String[]::new);
     Set<String> fieldOrdersSet = new LinkedHashSet<>(Arrays.asList(fieldOrdersWithDups));
     String[] fieldOrders = fieldOrdersSet.toArray(new String[0]);
     List<String> fieldNames = fieldNameCsv.isEmpty() ? new ArrayList<>() : Arrays.stream(fieldNameCsv.split(",")).collect(Collectors.toList());
     Set<String> fieldNamesSet = new LinkedHashSet<>(fieldNames);
     if (fieldNamesSet.size() != fieldOrders.length) {
+      // Report the de-duplicated counts, since those are what was compared: the raw name count can print
+      // two equal numbers for a real mismatch.
       throw new HoodieException(String
-          .format("Error ordering fields for storage read. #fieldNames: %d, #fieldPositions: %d",
-              fieldNames.size(), fieldOrders.length));
+          .format("Error ordering fields for storage read. #distinctFieldNames: %d, #distinctFieldPositions: %d, "
+                  + "read column names: [%s], read column ids: [%s]",
+              fieldNamesSet.size(), fieldOrders.length, fieldNameCsv, fieldOrderCsv));
     }
     TreeMap<Integer, String> orderedFieldMap = new TreeMap<>();
     String[] fieldNamesArray = fieldNamesSet.toArray(new String[0]);

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestSchemaEvolutionContext.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestSchemaEvolutionContext.java
@@ -47,9 +47,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class TestSchemaEvolutionContext {
 
+  // col2 is a record whose nested field was renamed, so setColumnTypeList has something to write back:
+  // primitive types are returned unchanged, and an unchanged rewrite cannot tell a right pairing from a wrong one.
   private static final List<Types.Field> TWO_FIELDS = Arrays.asList(
       Types.Field.get(0, "col1", Types.StringType.get()),
-      Types.Field.get(1, "col2", Types.StringType.get()));
+      Types.Field.get(1, "col2", Types.RecordType.get(
+          Types.Field.get(2, "renamed", Types.StringType.get()))));
 
   private JobConf job;
   private SchemaEvolutionContext context;
@@ -59,7 +62,7 @@ public class TestSchemaEvolutionContext {
     job = new JobConf();
     // Keeps the constructor off the table: it is the projection-id parsing below that is under test.
     job.setBoolean("hudi.hive.schema.evolution", false);
-    job.set(serdeConstants.LIST_COLUMN_TYPES, "string,string");
+    job.set(serdeConstants.LIST_COLUMN_TYPES, "string,struct<original:string>");
     context = new SchemaEvolutionContext(new FileSplit(new Path("file:///tmp/unused"), 0, 0, (String[]) null), job);
   }
 
@@ -72,8 +75,8 @@ public class TestSchemaEvolutionContext {
   }
 
   @Test
-  public void testSetColumnTypeListWithOnlyBlankReadColumnIds() {
-    job.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ",,");
+  public void testSetColumnTypeListWithBlankReadColumnId() {
+    job.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ",0");
     HoodieException thrown = assertThrows(HoodieException.class, () -> context.setColumnTypeList(job, TWO_FIELDS));
     assertTrue(thrown.getMessage().contains("is not equal to projection columns"),
         () -> "Expected the size mismatch rather than a NumberFormatException, got: " + thrown.getMessage());
@@ -83,7 +86,7 @@ public class TestSchemaEvolutionContext {
   public void testSetColumnTypeListIgnoresBlankAndPaddedReadColumnIds() {
     job.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ", 0 ,1");
     assertDoesNotThrow(() -> context.setColumnTypeList(job, TWO_FIELDS));
-    assertEquals("string,string", job.get(serdeConstants.LIST_COLUMN_TYPES),
-        "two real ids against two fields is a well formed projection once the blank is dropped");
+    assertEquals("string,struct<renamed:string>", job.get(serdeConstants.LIST_COLUMN_TYPES),
+        "id 1 should still pair with col2, so the renamed nested field lands in the second slot");
   }
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestSchemaEvolutionContext.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestSchemaEvolutionContext.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hudi.common.schema.internal.Types;
+import org.apache.hudi.exception.HoodieException;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers how {@link SchemaEvolutionContext#setColumnTypeList} reads {@code hive.io.file.readcolumn.ids}.
+ * Every id there is parsed with {@code Integer#parseInt}, so the blank entries HIVE-22438 leaves behind and
+ * the unset key both used to surface as a bare {@code NumberFormatException} or an NPE rather than as the
+ * size mismatch the method already reports.
+ */
+public class TestSchemaEvolutionContext {
+
+  private static final List<Types.Field> TWO_FIELDS = Arrays.asList(
+      Types.Field.get(0, "col1", Types.StringType.get()),
+      Types.Field.get(1, "col2", Types.StringType.get()));
+
+  private JobConf job;
+  private SchemaEvolutionContext context;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    job = new JobConf();
+    // Keeps the constructor off the table: it is the projection-id parsing below that is under test.
+    job.setBoolean("hudi.hive.schema.evolution", false);
+    job.set(serdeConstants.LIST_COLUMN_TYPES, "string,string");
+    context = new SchemaEvolutionContext(new FileSplit(new Path("file:///tmp/unused"), 0, 0, (String[]) null), job);
+  }
+
+  @Test
+  public void testSetColumnTypeListWithUnsetReadColumnIds() {
+    job.unset(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR);
+    HoodieException thrown = assertThrows(HoodieException.class, () -> context.setColumnTypeList(job, TWO_FIELDS));
+    assertTrue(thrown.getMessage().contains("is not equal to projection columns"),
+        () -> "Expected the size mismatch rather than an NPE, got: " + thrown.getMessage());
+  }
+
+  @Test
+  public void testSetColumnTypeListWithOnlyBlankReadColumnIds() {
+    job.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ",,");
+    HoodieException thrown = assertThrows(HoodieException.class, () -> context.setColumnTypeList(job, TWO_FIELDS));
+    assertTrue(thrown.getMessage().contains("is not equal to projection columns"),
+        () -> "Expected the size mismatch rather than a NumberFormatException, got: " + thrown.getMessage());
+  }
+
+  @Test
+  public void testSetColumnTypeListIgnoresBlankAndPaddedReadColumnIds() {
+    job.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ", 0 ,1");
+    assertDoesNotThrow(() -> context.setColumnTypeList(job, TWO_FIELDS));
+    assertEquals("string,string", job.get(serdeConstants.LIST_COLUMN_TYPES),
+        "two real ids against two fields is a well formed projection once the blank is dropped");
+  }
+}

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestSchemaEvolutionContext.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/TestSchemaEvolutionContext.java
@@ -80,6 +80,8 @@ public class TestSchemaEvolutionContext {
     HoodieException thrown = assertThrows(HoodieException.class, () -> context.setColumnTypeList(job, TWO_FIELDS));
     assertTrue(thrown.getMessage().contains("is not equal to projection columns"),
         () -> "Expected the size mismatch rather than a NumberFormatException, got: " + thrown.getMessage());
+    assertTrue(thrown.getMessage().contains("#nonBlankIds: 1, #projectionColumns: 2"),
+        () -> "the message should carry the counts that were compared, got: " + thrown.getMessage());
   }
 
   @Test

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/realtime/TestHoodieRealtimeRecordReader.java
@@ -86,6 +86,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -750,8 +751,15 @@ public class TestHoodieRealtimeRecordReader {
     }
   }
 
-  @Test
-  public void testIncrementalWithReplace() throws Exception {
+  /**
+   * The {@code blankProjectionIds} arm drives the two changed methods together: Hive's read-column ids reach
+   * {@code HoodieParquetRealtimeInputFormat#getRecordReader} with the blanks HIVE-22438 leaves behind,
+   * {@code cleanProjectionColumnIds} drops them, and {@code orderFields} pairs what is left. Two blanks, not
+   * one, because the previous sanitiser stripped a single leading comma.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testIncrementalWithReplace(boolean blankProjectionIds) throws Exception {
     // initial commit
     HoodieSchema schema = HoodieSchemaUtils.addMetadataFields(SchemaTestUtil.getEvolvedSchema());
     HoodieTestUtils.init(storageConf, basePath.toString(), HoodieTableType.MERGE_ON_READ);
@@ -779,12 +787,17 @@ public class TestHoodieRealtimeRecordReader {
     JobConf newJobConf = new JobConf(baseJobConf);
     List<HoodieSchemaField> fields = schema.getFields();
     setHiveColumnNameProps(fields, newJobConf, false);
+    if (blankProjectionIds) {
+      newJobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR,
+          ",," + newJobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
+    }
     newJobConf.set("columns.types", "string,string,string,string,string,string,string,string,bigint,string,string");
     RecordReader<NullWritable, ArrayWritable> reader = inputFormat.getRecordReader(splits[0], newJobConf, Reporter.NULL);
 
     // use reader to read log file.
     NullWritable key = reader.createKey();
     ArrayWritable value = reader.createValue();
+    int recordCnt = 0;
     while (reader.next(key, value)) {
       Writable[] values = value.get();
       // since we set incremental start commit as 0 and commit_number as 1.
@@ -792,7 +805,9 @@ public class TestHoodieRealtimeRecordReader {
       assertEquals("100", values[0].toString());
       key = reader.createKey();
       value = reader.createValue();
+      recordCnt++;
     }
+    assertEquals(100, recordCnt);
     reader.close();
   }
 

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
@@ -26,6 +26,11 @@ import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,23 +62,32 @@ public class TestHoodieRealtimeInputFormatUtils {
     return hadoopConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR);
   }
 
+  private static Stream<Arguments> projectionIdCases() {
+    return Stream.of(
+        Arguments.of(",2,0", "2,0", "a leading blank id should be dropped"),
+        Arguments.of(",,2,0", "2,0",
+            "Hive appending empty ids repeatedly yields more than one leading blank"),
+        Arguments.of("3,,2,0", "3,2,0",
+            "an interior blank, which leading-comma stripping never reached; the resulting pairing is still "
+                + "unsound per #19506, this only stops the bare NumberFormatException"),
+        Arguments.of(" 2 , 0 ", "2,0",
+            "ids are trimmed, so a padded id parses and de-duplicates as the same entry"),
+        Arguments.of("2,0", "2,0", "a list with nothing to drop keeps its value"),
+        Arguments.of("", "", "an empty list keeps its value"));
+  }
+
   /**
    * HIVE-22438: for {@code SELECT COUNT(*)} on Hive before 3.0.0 the read-column ids arrive empty and Hive
    * combines them into e.g. {@code ",2,0,3"}. Every consumer of this conf value parses the ids with
    * {@code Integer#parseInt}, so any blank entry left behind fails with a bare {@code NumberFormatException}.
+   *
+   * <p>One case per shape, so a regression in the first does not hide the rest: only three of the six differ
+   * from what the previous single-leading-comma sanitiser produced.
    */
-  @Test
-  public void testCleanProjectionColumnIdsDropsBlankEntries() {
-    assertEquals("2,0", clean(",2,0"), "a leading blank id should be dropped");
-    assertEquals("2,0", clean(",,2,0"),
-        "Hive appending empty ids repeatedly yields more than one leading blank");
-    assertEquals("3,2,0", clean("3,,2,0"),
-        "an interior blank, which leading-comma stripping never reached; the resulting pairing is still "
-            + "unsound per #19506, this only stops the bare NumberFormatException");
-    assertEquals("2,0", clean(" 2 , 0 "),
-        "ids are trimmed, so a padded id parses and de-duplicates as the same entry");
-    assertEquals("2,0", clean("2,0"), "a list with nothing to drop keeps its value");
-    assertEquals("", clean(""), "an empty list keeps its value");
+  @ParameterizedTest(name = "[{index}] \"{0}\" -> \"{1}\"")
+  @MethodSource("projectionIdCases")
+  public void testCleanProjectionColumnIdsDropsBlankEntries(String columnIds, String expected, String why) {
+    assertEquals(expected, clean(columnIds), why);
   }
 
   /**

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeInputFormatUtils.java
@@ -22,9 +22,14 @@ import org.apache.hudi.common.testutils.HoodieTestUtils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestHoodieRealtimeInputFormatUtils {
 
@@ -44,5 +49,45 @@ public class TestHoodieRealtimeInputFormatUtils {
   public void testAddProjectionField() {
     hadoopConf.set(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "");
     HoodieRealtimeInputFormatUtils.addProjectionField(hadoopConf, hadoopConf.get(hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS, "").split("/"));
+  }
+
+  private String clean(String columnIds) {
+    hadoopConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, columnIds);
+    HoodieRealtimeInputFormatUtils.cleanProjectionColumnIds(hadoopConf);
+    return hadoopConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR);
+  }
+
+  /**
+   * HIVE-22438: for {@code SELECT COUNT(*)} on Hive before 3.0.0 the read-column ids arrive empty and Hive
+   * combines them into e.g. {@code ",2,0,3"}. Every consumer of this conf value parses the ids with
+   * {@code Integer#parseInt}, so any blank entry left behind fails with a bare {@code NumberFormatException}.
+   */
+  @Test
+  public void testCleanProjectionColumnIdsDropsBlankEntries() {
+    assertEquals("2,0", clean(",2,0"), "a leading blank id should be dropped");
+    assertEquals("2,0", clean(",,2,0"),
+        "Hive appending empty ids repeatedly yields more than one leading blank");
+    assertEquals("3,2,0", clean("3,,2,0"),
+        "an interior blank, which leading-comma stripping never reached; the resulting pairing is still "
+            + "unsound per #19506, this only stops the bare NumberFormatException");
+    assertEquals("2,0", clean(" 2 , 0 "),
+        "ids are trimmed, so a padded id parses and de-duplicates as the same entry");
+    assertEquals("2,0", clean("2,0"), "a list with nothing to drop keeps its value");
+    assertEquals("", clean(""), "an empty list keeps its value");
+  }
+
+  /**
+   * The key is unset until something projects a column, and {@code conf.get} had no default here, so this
+   * threw {@code NullPointerException} before. Same shape as the fix applied to {@code addProjectionField}.
+   *
+   * <p>This also pins the write-back guard: without it the empty default would be written back and the key
+   * would no longer read as unset.
+   */
+  @Test
+  public void testCleanProjectionColumnIdsWithUnsetKey() {
+    hadoopConf.unset(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR);
+    assertDoesNotThrow(() -> HoodieRealtimeInputFormatUtils.cleanProjectionColumnIds(hadoopConf));
+    assertNull(hadoopConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR),
+        "an unset key should stay unset rather than being written back as empty");
   }
 }

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeRecordReaderUtils.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop.utils;
+
+import org.apache.hudi.exception.HoodieException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link HoodieRealtimeRecordReaderUtils#orderFields}, which maps Hive's
+ * {@code hive.io.file.readcolumn.names} and {@code hive.io.file.readcolumn.ids} onto an ordered
+ * projection list.
+ */
+public class TestHoodieRealtimeRecordReaderUtils {
+
+  @Test
+  public void testOrderFieldsSortsNamesByTheirHivePosition() {
+    assertEquals(Arrays.asList("rider", "driver", "fare"),
+        HoodieRealtimeRecordReaderUtils.orderFields("driver,fare,rider", "1,2,0", Collections.emptyList()));
+  }
+
+  @Test
+  public void testOrderFieldsReturnsEmptyForEmptyInput() {
+    assertEquals(Collections.emptyList(),
+        HoodieRealtimeRecordReaderUtils.orderFields("", "", Collections.emptyList()));
+  }
+
+  /**
+   * Hive can repeat a name in the read-column list while keeping ids unique, which the method
+   * deliberately tolerates by de-duplicating both sides before pairing them.
+   */
+  @Test
+  public void testOrderFieldsDeduplicatesRepeatedNames() {
+    assertEquals(Arrays.asList("rider", "driver"),
+        HoodieRealtimeRecordReaderUtils.orderFields("rider,driver,rider", "0,1", Collections.emptyList()));
+  }
+
+  /**
+   * The counts compared are the de-duplicated ones, so the failure has to report those. Reporting the raw
+   * name count instead prints two equal numbers for a real mismatch, which is unusable when diagnosing
+   * something like HUDI-1286. This is the case that fails without the production change.
+   */
+  @Test
+  public void testOrderFieldsMismatchReportsDistinctCountsWhenNamesRepeat() {
+    HoodieException thrown = assertThrows(HoodieException.class, () ->
+        HoodieRealtimeRecordReaderUtils.orderFields("rider,driver,fare,fare", "0,1,2,3", Collections.emptyList()));
+    assertTrue(thrown.getMessage().contains("#distinctFieldNames: 3"),
+        () -> "Expected the de-duplicated name count, got: " + thrown.getMessage());
+    assertTrue(thrown.getMessage().contains("#distinctFieldPositions: 4"),
+        () -> "Expected the position count, got: " + thrown.getMessage());
+  }
+
+  /** A mismatch with no duplicates on either side still has to carry both projection lists. */
+  @Test
+  public void testOrderFieldsMismatchReportsBothProjectionLists() {
+    HoodieException thrown = assertThrows(HoodieException.class, () ->
+        HoodieRealtimeRecordReaderUtils.orderFields("rider,driver", "0,1,2", Collections.emptyList()));
+    assertTrue(thrown.getMessage().contains("read column names: [rider,driver]")
+            && thrown.getMessage().contains("read column ids: [0,1,2]"),
+        () -> "Expected both projection lists, got: " + thrown.getMessage());
+  }
+
+  /**
+   * HIVE-22438: for {@code SELECT COUNT(*)} on Hive before 3.0.0 the read-column ids arrive empty and Hive
+   * combines them into e.g. {@code ",2,0,3"}. {@code cleanProjectionColumnIds} strips only one leading
+   * comma, so a blank token can still reach here. It used to fail on {@code Integer.parseInt} with a bare
+   * {@code NumberFormatException} carrying neither list.
+   */
+  @Test
+  public void testOrderFieldsIgnoresBlankIdTokens() {
+    assertEquals(Arrays.asList("c", "b"),
+        HoodieRealtimeRecordReaderUtils.orderFields("b,c", ",2,0", Collections.emptyList()),
+        "a leading blank id token should be ignored rather than parsed");
+    assertEquals(Arrays.asList("c", "b"),
+        HoodieRealtimeRecordReaderUtils.orderFields("b,c", ",,2,0", Collections.emptyList()),
+        "cleanProjectionColumnIds strips only one comma, so more than one blank token can arrive");
+  }
+
+  /**
+   * The shape reported in #14673 - four names against five id tokens, one of them blank - is what the
+   * HIVE-22438 combining produces. Dropping the blank leaves four real ids against four names, so it
+   * resolves rather than failing at all: the counts only ever disagreed because the blank was counted.
+   */
+  @Test
+  public void testOrderFieldsResolvesShapeFromIssue14673() {
+    assertEquals(Arrays.asList("b", "a", "c", "ts"),
+        HoodieRealtimeRecordReaderUtils.orderFields("a,b,c,ts", ",2,0,3,5", Collections.emptyList()),
+        "the blank id token was the whole mismatch; without it the projection is well formed");
+  }
+
+  /**
+   * HUDI-5308 (#7355) removed the filter that dropped partitioning fields from the name list before the
+   * comparison, so a partition column in that list now counts towards it. Pins that removal.
+   */
+  @Test
+  public void testOrderFieldsNoLongerFiltersPartitionFields() {
+    assertThrows(HoodieException.class, () -> HoodieRealtimeRecordReaderUtils.orderFields(
+        "rider,driver,partition_path", "0,1", Collections.singletonList("partition_path")));
+  }
+}

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeRecordReaderUtils.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/utils/TestHoodieRealtimeRecordReaderUtils.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.hadoop.utils;
+
+import org.apache.hudi.exception.HoodieException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link HoodieRealtimeRecordReaderUtils#orderFields}, which maps Hive's
+ * {@code hive.io.file.readcolumn.names} and {@code hive.io.file.readcolumn.ids} onto an ordered
+ * projection list.
+ */
+public class TestHoodieRealtimeRecordReaderUtils {
+
+  @Test
+  public void testOrderFieldsSortsNamesByTheirHivePosition() {
+    assertEquals(Arrays.asList("rider", "driver", "fare"),
+        HoodieRealtimeRecordReaderUtils.orderFields("driver,fare,rider", "1,2,0", Collections.emptyList()));
+  }
+
+  @Test
+  public void testOrderFieldsReturnsEmptyForEmptyInput() {
+    assertEquals(Collections.emptyList(),
+        HoodieRealtimeRecordReaderUtils.orderFields("", "", Collections.emptyList()));
+  }
+
+  /**
+   * Hive can repeat a name in the read-column list while keeping ids unique, which the method
+   * deliberately tolerates by de-duplicating both sides before pairing them. The duplicate is deliberately
+   * not last: that is the one position where pairing from the de-duplicated list and from the raw one give
+   * the same answer, so a duplicate on the tail pins the count but not the pairing.
+   */
+  @Test
+  public void testOrderFieldsDeduplicatesRepeatedNames() {
+    assertEquals(Arrays.asList("rider", "driver"),
+        HoodieRealtimeRecordReaderUtils.orderFields("rider,rider,driver", "0,1", Collections.emptyList()));
+  }
+
+  /**
+   * The counts compared are the de-duplicated ones, so the failure has to report those. Reporting the raw
+   * name count instead prints two equal numbers for a real mismatch, which is unusable when diagnosing
+   * something like HUDI-1286. This is the case that fails without the production change.
+   */
+  @Test
+  public void testOrderFieldsMismatchReportsDistinctCountsWhenNamesRepeat() {
+    HoodieException thrown = assertThrows(HoodieException.class, () ->
+        HoodieRealtimeRecordReaderUtils.orderFields("rider,driver,fare,fare", "0,1,2,3", Collections.emptyList()));
+    assertTrue(thrown.getMessage().contains("#distinctFieldNames: 3"),
+        () -> "Expected the de-duplicated name count, got: " + thrown.getMessage());
+    assertTrue(thrown.getMessage().contains("#distinctFieldPositions: 4"),
+        () -> "Expected the position count, got: " + thrown.getMessage());
+  }
+
+  /** A mismatch with no duplicates on either side still has to carry both projection lists. */
+  @Test
+  public void testOrderFieldsMismatchReportsBothProjectionLists() {
+    HoodieException thrown = assertThrows(HoodieException.class, () ->
+        HoodieRealtimeRecordReaderUtils.orderFields("rider,driver", "0,1,2", Collections.emptyList()));
+    assertTrue(thrown.getMessage().contains("read column names: [rider,driver]")
+            && thrown.getMessage().contains("read column ids: [0,1,2]"),
+        () -> "Expected both projection lists, got: " + thrown.getMessage());
+  }
+
+  /**
+   * HIVE-22438: for {@code SELECT COUNT(*)} on Hive before 3.0.0 the read-column ids arrive empty and Hive
+   * combines them into e.g. {@code ",,2,0,3,5"}. {@code cleanProjectionColumnIds} strips every blank id from
+   * the conf, so no production path delivers a blank here any more. This is defence in depth for callers
+   * that build the csv themselves.
+   */
+  @Test
+  public void testOrderFieldsIgnoresBlankIdTokens() {
+    assertEquals(Arrays.asList("c", "b"),
+        HoodieRealtimeRecordReaderUtils.orderFields("b,c", ",2,0", Collections.emptyList()),
+        "a leading blank id token should be ignored rather than parsed");
+    assertEquals(Arrays.asList("c", "b"),
+        HoodieRealtimeRecordReaderUtils.orderFields("b,c", ",,2,0", Collections.emptyList()),
+        "more than one blank token can arrive when Hive appends empty ids repeatedly");
+    assertEquals(Arrays.asList("b", "a", "c", "ts"),
+        HoodieRealtimeRecordReaderUtils.orderFields("a,b,c,ts", ",2,0,3,5", Collections.emptyList()),
+        "the numbers reported in #14673: four names against five id tokens, one of them blank");
+    assertEquals(Arrays.asList("c", "b"),
+        HoodieRealtimeRecordReaderUtils.orderFields("b,c", " 2 , 0 ", Collections.emptyList()),
+        "ids are trimmed, so a padded id parses and de-duplicates as the same entry");
+  }
+
+  /**
+   * A blank token only reaches {@code Integer.parseInt} when it makes the two counts line up, which needs one
+   * more name than the cases above. That is the shape that failed with a bare {@code NumberFormatException}
+   * carrying neither projection list; dropping the blank turns it into the {@code HoodieException} that does
+   * carry both.
+   */
+  @Test
+  public void testOrderFieldsMismatchAfterBlankIdFilteringReportsRawIdList() {
+    HoodieException thrown = assertThrows(HoodieException.class, () ->
+        HoodieRealtimeRecordReaderUtils.orderFields("a,b,c", ",2,0", Collections.emptyList()));
+    assertTrue(thrown.getMessage().contains("read column ids: [,2,0]"),
+        () -> "Expected the raw id list, got: " + thrown.getMessage());
+  }
+
+  /**
+   * Hive tolerates duplicate ids as well as duplicate names, which is why both sides are de-duplicated
+   * before pairing. Only the name side was pinned. As above, the duplicate is not on the tail.
+   */
+  @Test
+  public void testOrderFieldsDeduplicatesRepeatedIds() {
+    assertEquals(Arrays.asList("rider", "driver"),
+        HoodieRealtimeRecordReaderUtils.orderFields("rider,driver", "0,0,1", Collections.emptyList()));
+  }
+
+  /**
+   * HUDI-5308 (#7355) removed the filter that dropped partitioning fields from the name list before the
+   * comparison, so a partition column in that list now counts towards it. Pins that removal.
+   */
+  @Test
+  public void testOrderFieldsNoLongerFiltersPartitionFields() {
+    HoodieException thrown = assertThrows(HoodieException.class, () -> HoodieRealtimeRecordReaderUtils.orderFields(
+        "rider,driver,partition_path", "0,1", Collections.singletonList("partition_path")));
+    assertTrue(thrown.getMessage().contains("#distinctFieldNames: 3, #distinctFieldPositions: 2"),
+        () -> "the partition column should still count towards the comparison, got: " + thrown.getMessage());
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHiveTableSchemaEvolution.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHiveTableSchemaEvolution.java
@@ -160,7 +160,9 @@ public class TestHiveTableSchemaEvolution {
     jobConf.set(HoodieCommonConfig.SCHEMA_EVOLUTION_ENABLE.key(), "true");
     jobConf.set(ColumnProjectionUtils.READ_ALL_COLUMNS, "false");
     jobConf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, "col1,col2_new");
-    jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, "6,7");
+    // Leading blanks are what HIVE-22438 puts in this conf value. The cow arm builds a HoodieParquetInputFormat
+    // directly, so this is the only test that drives cleanProjectionColumnIds ahead of SchemaEvolutionContext.
+    jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, ",,6,7");
     jobConf.set(serdeConstants.LIST_COLUMNS, "_hoodie_commit_time,_hoodie_commit_seqno,"
         + "_hoodie_record_key,_hoodie_partition_path,_hoodie_file_name,col0,col1,col2_new");
     jobConf.set(serdeConstants.LIST_COLUMN_TYPES, "string,string,string,string,string,int,double,string");


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Relates to #14673 (HUDI-1286), which reports a MOR `_rt` query failing with:

```
org.apache.hudi.exception.HoodieException: Error ordering fields for storage read.
  #fieldNames: 4, #fieldPositions: 5
    at HoodieRealtimeRecordReaderUtils.orderFields
```

Hive's read-column ids arrive with blank entries for `SELECT COUNT(*)` on Hive before 3.0.0: the ids are
empty and Hive combines them with Hudi's required projection ids into e.g. `",2,0,3"` (HIVE-22438). Every
consumer of that conf value parses the ids with `Integer.parseInt`, so a blank entry fails with a bare
`NumberFormatException` carrying none of the projection lists.

**The filter belongs in the conf, not in one reader.** An earlier revision of this PR filtered blanks inside
`orderFields`. Review pointed out that other consumers parse the same value and never reach that method, so
they still died on the same input:

| Consumer | Why it still failed |
| --- | --- |
| `SchemaEvolutionContext#setColumnNameList` | `parseInt` over the split with no filter, and `conf.get` with no default; runs first, from both `doEvolutionForParquetFormat` and `doEvolutionForRealtimeInputFormat` |
| `SchemaEvolutionContext#setColumnTypeList` | same shape, one method below |
| `HoodieColumnProjectionUtils#getReadColumnIDs` | hadoop `StringUtils.split` drops only *trailing* empties, so a leading blank reaches `parseInt`; the bootstrap path |
| `HoodieRealtimeRecordReaderUtils#orderFields` | the path in #14673 |

`HoodieRealtimeInputFormatUtils#cleanProjectionColumnIds` is the single point they all read from, so the
filter moved there. It previously stripped one leading comma, which leaves `",,2,0"` and cannot reach an
interior blank at all: Hive prepends ids while appending names, so an id prepended after an empty one gives
`"3,,2,0"`. It now drops every blank entry and writes the joined value back.

**Cleaning the conf in the realtime formats was not enough for COW.** The bootstrap reader and the parquet
schema-evolution reader are both built by `HoodieParquetInputFormat#getRecordReader`, which goes through
neither realtime input format, so the first three consumers above were still reached with the blank in place
(`shouldUseFilegroupReader` forces both onto the legacy path, and `TestHiveTableSchemaEvolution` drives the
COW arm through `new HoodieParquetInputFormat()` directly). That method now cleans the conf too; the call is
idempotent, so the realtime formats' existing call becomes a no-op, and `HoodieCombineHiveInputFormat` builds
its per-split readers through those same formats, so it is covered as well.

`HoodieFileGroupReaderBasedRecordReader` is **not** a consumer, despite cleaning its own conf copy: an earlier
revision of this PR listed it as one. `HiveHoodieReaderContext#setSchemas` overwrites both `READ_COLUMN_NAMES`
and `READ_COLUMN_IDS` from the requested schema before the reader is built, and nothing in between reads the
ids (`createRequestedSchema` uses names only). It has been dropped from the list.

**The read-modify-write is now synchronized on the conf.** Hive on Spark builds record readers from several
threads against one shared `JobConf` — the reason `addProjectionToJobConf` guards its own writes that way.
`cleanProjectionColumnIds` used to write only on a leading comma and now writes on any blank or padded token,
so the unsynchronized window got wider. `f41539a9cb5f` (#3630) moved this call out of that latch without
restoring a lock; the lock is restored inside the method rather than by moving the call back, so that commit
is not reverted.

**On a genuine mismatch the message could print two equal numbers.** The comparison uses the de-duplicated
name count while the message reported the raw one:

```
names "rider,driver,fare,fare", ids "0,1,2,3"
  -> Error ordering fields for storage read. #fieldNames: 4, #fieldPositions: 4
```

and it omitted the two lists, which come from the engine and are the only way to tell which side is wrong.

**On the mechanism behind #14673 — it is not confirmed.** An earlier revision of this PR asserted
`CombineHiveInputFormat` accumulating projection entries across splits. That is not supported by the issue:
the reported frame is `HiveInputFormat.getRecordReader`, the base class, and
`HoodieRealtimeInputFormatUtils#addProjectionField` always sets `READ_COLUMN_NAMES` and `READ_COLUMN_IDS`
together in the same `if`, so Hudi cannot make them diverge that way. HIVE-22438 and HUDI-313 are the
mechanism this repo already documents for that query.

### Summary and Changelog

- `cleanProjectionColumnIds` drops every blank read-column id and writes the result back to the conf,
  covering all four consumers above instead of only the realtime reader.
- `HoodieParquetInputFormat#getRecordReader` cleans the conf, so the bootstrap and parquet schema-evolution
  readers are covered on COW.
- `SchemaEvolutionContext` parses the read-column ids as non-blank trimmed tokens, so an unset key reports the
  size mismatch it already had a message for instead of an NPE, and a blank id no longer becomes a bare
  `NumberFormatException`.
- `cleanProjectionColumnIds` no longer NPEs when the read-column ids key is unset, and only writes back when
  the value changed, so an unset key stays unset.
- The read-modify-write in `cleanProjectionColumnIds` is synchronized on the conf.
- `orderFields` keeps a filter of its own as defence in depth, for callers that assemble the csv without going
  through the conf. It trims before filtering, so a padded id parses and de-duplicates as one entry rather
  than as a distinct one.
- The mismatch message names the counts `#distinctFieldNames` / `#distinctFieldPositions`, so a de-duplicated
  count printed beside a raw list no longer reads as a contradiction, and both projection lists are included.
- Fifteen new test cases across three classes, plus one new arm on `TestHoodieRealtimeRecordReader`. Two of
  the three classes had one assertion-free test between them before this PR.

Not changed here, and filed as **#19506**: names and ids are de-duplicated independently and then paired
positionally, which is unsound because Hive prepends ids while appending names. Filed so this message
improvement is not later mistaken for a fix for that. With this change the count check no longer catches that
divergence either, since the blank is removed before it reaches `orderFields`; recorded on that issue. The
`fullColNamelist.get(id)` IOOBE in `SchemaEvolutionContext#setColumnNameList` is likewise out of scope — it
needs an id larger than the column list, not a blank one.

### Verification

```
mvn test -Punit-tests -pl hudi-hadoop-mr
  -> Tests run: 200, Failures: 0, Errors: 0, Skipped: 2

mvn test -Pfunctional-tests -am -pl hudi-spark-datasource/hudi-spark -Dtest=TestHiveTableSchemaEvolution
  -> Tests run: 5, Failures: 0, Errors: 0, Skipped: 0

mvn checkstyle:check apache-rat:check -pl hudi-hadoop-mr
  -> 0 Checkstyle violations; Rat Unapproved: 0, unknown: 0
```

`TestHiveTableSchemaEvolution` is the COW/schema-evolution suite that reaches
`HoodieParquetInputFormat#getRecordReader` directly, i.e. the path the new clean call was added for.

Ten of the fifteen new cases fail against the pre-change code, which is the evidence they guard this change.
Run by reverting only the four production files to their pre-change state and keeping the tests:

```
testCleanProjectionColumnIdsDropsBlankEntries                  expected: <2,0> but was: <,2,0>
testCleanProjectionColumnIdsWithUnsetKey                       NullPointerException: "columnIds" is null
testOrderFieldsIgnoresBlankIdTokens                            Error ... #fieldNames: 2, #fieldPositions: 3
testOrderFieldsMismatchAfterBlankIdFilteringReportsRawIdList   expected HoodieException, was
                                                               NumberFormatException: For input string: ""
testOrderFieldsMismatchReportsBothProjectionLists              Error ... #fieldNames: 2, #fieldPositions: 3
testOrderFieldsMismatchReportsDistinctCountsWhenNamesRepeat    Error ... #fieldNames: 4, #fieldPositions: 4
testOrderFieldsNoLongerFiltersPartitionFields                  Error ... #fieldNames: 3, #fieldPositions: 2
testSetColumnTypeListWithUnsetReadColumnIds                    expected HoodieException, was
                                                               NullPointerException
testSetColumnTypeListIgnoresBlankAndPaddedReadColumnIds        NumberFormatException: For input string: ""
testIncrementalWithReplace[blankProjectionIds=true]            NumberFormatException: For input string: ""
```

The last one is the end-to-end case: it prepends `,,` to the read-column ids on an existing
`HoodieParquetRealtimeInputFormat#getRecordReader` test — two blanks, because the previous sanitiser stripped
one leading comma — and asserts all 100 rows still read. It is the only case that drives
`cleanProjectionColumnIds` and `orderFields` together, so it pins the wiring the rest of this PR rests on.
The remaining five characterise existing behaviour, including the partition-field parameter that HUDI-5308
(#7355) deliberately dropped.

### Impact

`SELECT COUNT(*)` on a MOR `_rt` table against Hive before 3.0.0 stops failing on the blank id token, and it
now stops failing on the schema-evolution and bootstrap paths as well, which the previous revision did not
reach.

**Precondition worth stating:** `orderFields` is legacy-only in 1.x. `hoodie.file.group.reader.enabled`
defaults to `true` (`HoodieReaderConfig.java:48-50`) and the file-group-reader path never parses ids
(`HoodieFileGroupReaderBasedRecordReader#createRequestedSchema` reads only `READ_COLUMN_NAMES`), so on default
config that query does not reach `orderFields` at all. It is reached with
`hoodie.file.group.reader.enabled=false`, on a bootstrap split, or with schema evolution enabled but no
internal schema present. #14673 is therefore not being closed on this change alone. The
`SchemaEvolutionContext` and bootstrap consumers are on the legacy path for the same reason
(`shouldUseFilegroupReader` forces them there).

Any remaining genuine mismatch reports the counts that were compared plus both projection lists. No behaviour
change for a well-formed projection: the same inputs produce the same ordering, and `cleanProjectionColumnIds`
only writes back when the value actually changes.

### Risk Level

low — the blank filter now runs earlier and for more callers, so the blast radius is wider than the previous
revision, but it only removes entries that no consumer could parse. The new `synchronized (conf)` takes a
monitor that `addProjectionToJobConf` already takes for a larger body and that `Configuration#set` takes
internally, and nothing is held across it, so it adds no lock ordering. Full `hudi-hadoop-mr` suite green
(200 tests) plus `TestHiveTableSchemaEvolution`.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
