### PR TITLE
fix(client): report completed timeline action in clustering callback

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -608,6 +608,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
     handleWriteErrors(writeStats, TableServiceType.CLUSTER);
     final HoodieInstant clusteringInstant = ClusteringUtils.getInflightClusteringInstant(clusteringCommitTime,
         table.getActiveTimeline(), table.getMetaClient().getInstantGenerator()).get();
+    final HoodieInstant completedClusteringInstant;
     try {
       this.txnManager.beginStateChange(Option.of(clusteringInstant),
           lastCompletedTxnAndMetadata.isPresent() ? Option.of(lastCompletedTxnAndMetadata.get().getLeft()) : Option.empty());
@@ -623,7 +624,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
 
       log.info("Committing Clustering {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
 
-      ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(false, clusteringInstant, replaceCommitMetadata, table.getActiveTimeline(),
+      completedClusteringInstant = ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(false, clusteringInstant, replaceCommitMetadata, table.getActiveTimeline(),
           completedInstant -> table.getMetaClient().getTableFormat().commit(replaceCommitMetadata, completedInstant, table.getContext(), table.getMetaClient(), table.getViewManager()));
       log.debug("Clustering {} finished with result {}", clusteringCommitTime, replaceCommitMetadata);
     } catch (Exception e) {
@@ -644,7 +645,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       heartbeatClient.stop(clusteringCommitTime);
     }
     log.info("Clustering successfully on commit {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
-    fireCommitCallbackIfNecessary(clusteringCommitTime, clusteringInstant.getAction(),
+    fireCommitCallbackIfNecessary(clusteringCommitTime, completedClusteringInstant.getAction(),
         writeStats, table::getBaseFileOnlyView, Option.empty());
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/BaseHoodieTableServiceClient.java
@@ -608,7 +608,6 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
     handleWriteErrors(writeStats, TableServiceType.CLUSTER);
     final HoodieInstant clusteringInstant = ClusteringUtils.getInflightClusteringInstant(clusteringCommitTime,
         table.getActiveTimeline(), table.getMetaClient().getInstantGenerator()).get();
-    final HoodieInstant completedClusteringInstant;
     try {
       this.txnManager.beginStateChange(Option.of(clusteringInstant),
           lastCompletedTxnAndMetadata.isPresent() ? Option.of(lastCompletedTxnAndMetadata.get().getLeft()) : Option.empty());
@@ -624,7 +623,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
 
       log.info("Committing Clustering {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
 
-      completedClusteringInstant = ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(false, clusteringInstant, replaceCommitMetadata, table.getActiveTimeline(),
+      ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(false, clusteringInstant, replaceCommitMetadata, table.getActiveTimeline(),
           completedInstant -> table.getMetaClient().getTableFormat().commit(replaceCommitMetadata, completedInstant, table.getContext(), table.getMetaClient(), table.getViewManager()));
       log.debug("Clustering {} finished with result {}", clusteringCommitTime, replaceCommitMetadata);
     } catch (Exception e) {
@@ -645,7 +644,7 @@ public abstract class BaseHoodieTableServiceClient<I, T, O> extends BaseHoodieCl
       heartbeatClient.stop(clusteringCommitTime);
     }
     log.info("Clustering successfully on commit {} for table {}", clusteringCommitTime, table.getConfig().getBasePath());
-    fireCommitCallbackIfNecessary(clusteringCommitTime, completedClusteringInstant.getAction(),
+    fireCommitCallbackIfNecessary(clusteringCommitTime, HoodieTimeline.REPLACE_COMMIT_ACTION,
         writeStats, table::getBaseFileOnlyView, Option.empty());
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/RecordingCommitCallback.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/RecordingCommitCallback.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.testutils;
+
+import org.apache.hudi.callback.HoodieWriteCommitCallback;
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
+import org.apache.hudi.config.HoodieWriteConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * A {@link HoodieWriteCommitCallback} that records every fired message, so tests can assert that
+ * the callback fires for a commit and with which action type. Register it with
+ * {@code HoodieWriteCommitCallbackConfig.withCallbackClass(RecordingCommitCallback.class.getName())}.
+ *
+ * <p>The write client loads the callback reflectively from the config, so the recorded messages
+ * have to live in static state; call {@link #reset()} at the start of every test that asserts on
+ * them.
+ */
+public class RecordingCommitCallback implements HoodieWriteCommitCallback {
+
+  private static final List<HoodieWriteCommitCallbackMessage> MESSAGES = new CopyOnWriteArrayList<>();
+
+  public RecordingCommitCallback(HoodieWriteConfig config) {
+    // config arg required for reflective instantiation
+  }
+
+  @Override
+  public void call(HoodieWriteCommitCallbackMessage callbackMessage) {
+    MESSAGES.add(callbackMessage);
+  }
+
+  /**
+   * Snapshot of the messages recorded since the last {@link #reset()}, in the order they fired.
+   */
+  public static List<HoodieWriteCommitCallbackMessage> messages() {
+    return new ArrayList<>(MESSAGES);
+  }
+
+  /**
+   * Drops every recorded message.
+   */
+  public static void reset() {
+    MESSAGES.clear();
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/RecordingCommitCallback.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/testutils/RecordingCommitCallback.java
@@ -27,13 +27,11 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * A {@link HoodieWriteCommitCallback} that records every fired message, so tests can assert that
- * the callback fires for a commit and with which action type. Register it with
- * {@code HoodieWriteCommitCallbackConfig.withCallbackClass(RecordingCommitCallback.class.getName())}.
- *
- * <p>The write client loads the callback reflectively from the config, so the recorded messages
- * have to live in static state; call {@link #reset()} at the start of every test that asserts on
- * them.
+ * A recording {@link HoodieWriteCommitCallback} that captures every fired message so tests can
+ * assert the callback fires for table-service (compaction/clustering) commits with the expected
+ * action type. Loaded reflectively from the write config, so it needs a public
+ * {@code (HoodieWriteConfig)} constructor, and the messages have to live in static state; call
+ * {@link #reset()} at the start of every test that asserts on them.
  */
 public class RecordingCommitCallback implements HoodieWriteCommitCallback {
 
@@ -48,16 +46,10 @@ public class RecordingCommitCallback implements HoodieWriteCommitCallback {
     MESSAGES.add(callbackMessage);
   }
 
-  /**
-   * Snapshot of the messages recorded since the last {@link #reset()}, in the order they fired.
-   */
   public static List<HoodieWriteCommitCallbackMessage> messages() {
     return new ArrayList<>(MESSAGES);
   }
 
-  /**
-   * Drops every recorded message.
-   */
   public static void reset() {
     MESSAGES.clear();
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -122,7 +122,6 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
           + writeStats.stream().filter(s -> s.getTotalWriteErrors() > 0L).map(HoodieWriteStat::getFileId).collect(Collectors.joining(",")));
     }
 
-    final HoodieInstant completedClusteringInstant;
     try {
       this.txnManager.beginStateChange(Option.of(clusteringInstant), Option.empty());
       finalizeWrite(table, clusteringCommitTime, writeStats);
@@ -137,7 +136,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       writeTableMetadata(table, clusteringCommitTime, metadata);
 
       log.info("Committing Clustering {} finished with result {}.", clusteringCommitTime, metadata);
-      completedClusteringInstant = ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
+      ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
           false,
           clusteringInstant,
           metadata,
@@ -163,7 +162,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       }
     }
     log.info("Clustering successfully on commit {}", clusteringCommitTime);
-    fireCommitCallbackIfNecessary(clusteringCommitTime, completedClusteringInstant.getAction(),
+    fireCommitCallbackIfNecessary(clusteringCommitTime, HoodieActiveTimeline.REPLACE_COMMIT_ACTION,
         writeStats, table::getBaseFileOnlyView, Option.empty());
   }
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/HoodieFlinkTableServiceClient.java
@@ -122,6 +122,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
           + writeStats.stream().filter(s -> s.getTotalWriteErrors() > 0L).map(HoodieWriteStat::getFileId).collect(Collectors.joining(",")));
     }
 
+    final HoodieInstant completedClusteringInstant;
     try {
       this.txnManager.beginStateChange(Option.of(clusteringInstant), Option.empty());
       finalizeWrite(table, clusteringCommitTime, writeStats);
@@ -136,7 +137,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       writeTableMetadata(table, clusteringCommitTime, metadata);
 
       log.info("Committing Clustering {} finished with result {}.", clusteringCommitTime, metadata);
-      ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
+      completedClusteringInstant = ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
           false,
           clusteringInstant,
           metadata,
@@ -162,7 +163,7 @@ public class HoodieFlinkTableServiceClient<T> extends BaseHoodieTableServiceClie
       }
     }
     log.info("Clustering successfully on commit {}", clusteringCommitTime);
-    fireCommitCallbackIfNecessary(clusteringCommitTime, clusteringInstant.getAction(),
+    fireCommitCallbackIfNecessary(clusteringCommitTime, completedClusteringInstant.getAction(),
         writeStats, table::getBaseFileOnlyView, Option.empty());
   }
 

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieFlinkTableServiceClient.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.client;
 
+import org.apache.hudi.callback.HoodieWriteCommitCallback;
+import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -31,6 +33,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.ClusteringUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieLockConfig;
+import org.apache.hudi.config.HoodieWriteCommitCallbackConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.core.transaction.lock.InProcessLockProvider;
 import org.apache.hudi.exception.HoodieException;
@@ -53,12 +56,16 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -218,15 +225,24 @@ public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarn
 
   @Test
   void testCompleteClusteringCommitsAndCleansMarkers() {
+    ClusteringCallback.MESSAGES.clear();
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withPath(metaClient.getBasePath())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
+        .withCallbackConfig(HoodieWriteCommitCallbackConfig.newBuilder()
+            .writeCommitCallbackOn("true")
+            .withCallbackClass(ClusteringCallback.class.getName())
+            .build())
         .build();
     HoodieFlinkTable table = mock(HoodieFlinkTable.class);
     HoodieActiveTimeline activeTimeline = mock(HoodieActiveTimeline.class);
     when(table.getActiveTimeline()).thenReturn(activeTimeline);
     when(table.getInstantGenerator()).thenReturn(metaClient.getInstantGenerator());
     HoodieInstant clusteringInstant = mock(HoodieInstant.class);
+    // The inflight instant is a clustering instant on timeline v2; the completed one is always a
+    // replacecommit, and it is the completed action the callback must report.
+    HoodieInstant completedInstant = mock(HoodieInstant.class);
+    when(completedInstant.getAction()).thenReturn(HoodieTimeline.REPLACE_COMMIT_ACTION);
     HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
     TestableHoodieFlinkTableServiceClient client =
         new TestableHoodieFlinkTableServiceClient(context, writeConfig, Option.empty(), table);
@@ -237,6 +253,9 @@ public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarn
       clusteringUtils.when(() -> ClusteringUtils.getInflightClusteringInstant(
           "20260723120000001", activeTimeline, metaClient.getInstantGenerator()))
           .thenReturn(Option.of(clusteringInstant));
+      clusteringUtils.when(() -> ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
+          anyBoolean(), any(), any(), any(), any()))
+          .thenReturn(completedInstant);
       markersFactory.when(() -> WriteMarkersFactory.get(any(), any(), any())).thenReturn(writeMarkers);
       client.callCompleteClustering(metadata, table, "20260723120000001");
     } finally {
@@ -244,6 +263,23 @@ public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarn
     }
 
     verify(writeMarkers).quietDeleteMarkerDir(any(), any(Integer.class));
+    assertEquals(1, ClusteringCallback.MESSAGES.size(), "callback must fire once for the clustering commit");
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION,
+        ClusteringCallback.MESSAGES.get(0).getCommitActionType().orElse(null));
+  }
+
+  public static class ClusteringCallback implements HoodieWriteCommitCallback {
+
+    static final List<HoodieWriteCommitCallbackMessage> MESSAGES = new CopyOnWriteArrayList<>();
+
+    public ClusteringCallback(HoodieWriteConfig config) {
+      // config arg required for reflective instantiation
+    }
+
+    @Override
+    public void call(HoodieWriteCommitCallbackMessage callbackMessage) {
+      MESSAGES.add(callbackMessage);
+    }
   }
 
   private static class TestableHoodieFlinkTableServiceClient extends HoodieFlinkTableServiceClient<Object> {

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieFlinkTableServiceClient.java
@@ -64,7 +64,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -238,13 +237,7 @@ public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarn
     when(table.getActiveTimeline()).thenReturn(activeTimeline);
     when(table.getInstantGenerator()).thenReturn(metaClient.getInstantGenerator());
     HoodieInstant clusteringInstant = mock(HoodieInstant.class);
-    // The inflight instant is a clustering instant on timeline v2; the completed one is always a
-    // replacecommit, and it is the completed action the callback must report. The inflight action is
-    // stubbed so that a revert to reporting it fails on the action assertion below, rather than on
-    // the message count after Option.of(null) throws inside the callback.
     when(clusteringInstant.getAction()).thenReturn(HoodieTimeline.CLUSTERING_ACTION);
-    HoodieInstant completedInstant = mock(HoodieInstant.class);
-    when(completedInstant.getAction()).thenReturn(HoodieTimeline.REPLACE_COMMIT_ACTION);
     HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
     TestableHoodieFlinkTableServiceClient client =
         new TestableHoodieFlinkTableServiceClient(context, writeConfig, Option.empty(), table);
@@ -255,9 +248,6 @@ public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarn
       clusteringUtils.when(() -> ClusteringUtils.getInflightClusteringInstant(
           "20260723120000001", activeTimeline, metaClient.getInstantGenerator()))
           .thenReturn(Option.of(clusteringInstant));
-      clusteringUtils.when(() -> ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
-          anyBoolean(), any(), any(), any(), any()))
-          .thenReturn(completedInstant);
       markersFactory.when(() -> WriteMarkersFactory.get(any(), any(), any())).thenReturn(writeMarkers);
       client.callCompleteClustering(metadata, table, "20260723120000001");
     } finally {

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieFlinkTableServiceClient.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/client/TestHoodieFlinkTableServiceClient.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.client;
 
-import org.apache.hudi.callback.HoodieWriteCommitCallback;
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.client.common.HoodieFlinkEngineContext;
 import org.apache.hudi.client.embedded.EmbeddedTimelineService;
@@ -46,6 +45,7 @@ import org.apache.hudi.table.action.compact.CompactHelpers;
 import org.apache.hudi.table.marker.WriteMarkers;
 import org.apache.hudi.table.marker.WriteMarkersFactory;
 import org.apache.hudi.testutils.HoodieFlinkClientTestHarness;
+import org.apache.hudi.testutils.RecordingCommitCallback;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,7 +57,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -225,13 +224,13 @@ public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarn
 
   @Test
   void testCompleteClusteringCommitsAndCleansMarkers() {
-    ClusteringCallback.MESSAGES.clear();
+    RecordingCommitCallback.reset();
     HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
         .withPath(metaClient.getBasePath())
         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
         .withCallbackConfig(HoodieWriteCommitCallbackConfig.newBuilder()
             .writeCommitCallbackOn("true")
-            .withCallbackClass(ClusteringCallback.class.getName())
+            .withCallbackClass(RecordingCommitCallback.class.getName())
             .build())
         .build();
     HoodieFlinkTable table = mock(HoodieFlinkTable.class);
@@ -240,7 +239,10 @@ public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarn
     when(table.getInstantGenerator()).thenReturn(metaClient.getInstantGenerator());
     HoodieInstant clusteringInstant = mock(HoodieInstant.class);
     // The inflight instant is a clustering instant on timeline v2; the completed one is always a
-    // replacecommit, and it is the completed action the callback must report.
+    // replacecommit, and it is the completed action the callback must report. The inflight action is
+    // stubbed so that a revert to reporting it fails on the action assertion below, rather than on
+    // the message count after Option.of(null) throws inside the callback.
+    when(clusteringInstant.getAction()).thenReturn(HoodieTimeline.CLUSTERING_ACTION);
     HoodieInstant completedInstant = mock(HoodieInstant.class);
     when(completedInstant.getAction()).thenReturn(HoodieTimeline.REPLACE_COMMIT_ACTION);
     HoodieReplaceCommitMetadata metadata = new HoodieReplaceCommitMetadata();
@@ -263,23 +265,9 @@ public class TestHoodieFlinkTableServiceClient extends HoodieFlinkClientTestHarn
     }
 
     verify(writeMarkers).quietDeleteMarkerDir(any(), any(Integer.class));
-    assertEquals(1, ClusteringCallback.MESSAGES.size(), "callback must fire once for the clustering commit");
-    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION,
-        ClusteringCallback.MESSAGES.get(0).getCommitActionType().orElse(null));
-  }
-
-  public static class ClusteringCallback implements HoodieWriteCommitCallback {
-
-    static final List<HoodieWriteCommitCallbackMessage> MESSAGES = new CopyOnWriteArrayList<>();
-
-    public ClusteringCallback(HoodieWriteConfig config) {
-      // config arg required for reflective instantiation
-    }
-
-    @Override
-    public void call(HoodieWriteCommitCallbackMessage callbackMessage) {
-      MESSAGES.add(callbackMessage);
-    }
+    List<HoodieWriteCommitCallbackMessage> messages = RecordingCommitCallback.messages();
+    assertEquals(1, messages.size(), "callback must fire once for the clustering commit");
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, messages.get(0).getCommitActionType().orElse(null));
   }
 
   private static class TestableHoodieFlinkTableServiceClient extends HoodieFlinkTableServiceClient<Object> {

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.client.functional;
 
-import org.apache.hudi.callback.HoodieWriteCommitCallback;
 import org.apache.hudi.callback.common.HoodieWriteCommitCallbackMessage;
 import org.apache.hudi.client.HoodieJavaWriteClient;
 import org.apache.hudi.client.WriteClientTestUtils;
@@ -38,6 +37,7 @@ import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.table.action.HoodieWriteMetadata;
 import org.apache.hudi.testutils.GenericRecordValidationTestUtils;
 import org.apache.hudi.testutils.HoodieJavaClientTestHarness;
+import org.apache.hudi.testutils.RecordingCommitCallback;
 
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
@@ -193,7 +192,7 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
 
   @Test
   public void testWriteCommitCallbackFiresOnCompaction() throws Exception {
-    RecordingCommitCallback.MESSAGES.clear();
+    RecordingCommitCallback.reset();
     HoodieWriteConfig config = getConfigBuilder(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA,
         HoodieIndex.IndexType.INMEMORY)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withMaxNumDeltaCommitsBeforeCompaction(2).build())
@@ -215,7 +214,7 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
         false, false, 5, 100, 2, config.populateMetaFields(), INSTANT_GENERATOR);
 
     // The callback must fire for the auto-committed delta commits with the deltacommit action.
-    assertTrue(RecordingCommitCallback.MESSAGES.stream().anyMatch(m ->
+    assertTrue(RecordingCommitCallback.messages().stream().anyMatch(m ->
             HoodieTimeline.DELTA_COMMIT_ACTION.equals(m.getCommitActionType().orElse(null))),
         "callback must fire for delta commits");
 
@@ -228,7 +227,7 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
 
     // The callback must fire exactly once for the compaction completion, reporting the completed
     // timeline action (commit).
-    List<HoodieWriteCommitCallbackMessage> compactionMessages = RecordingCommitCallback.MESSAGES.stream()
+    List<HoodieWriteCommitCallbackMessage> compactionMessages = RecordingCommitCallback.messages().stream()
         .filter(m -> m.getCommitTime().equals(compactionTime.get()))
         .collect(Collectors.toList());
     assertEquals(1, compactionMessages.size(), "callback must fire once for the compaction commit");
@@ -238,7 +237,7 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
 
   @Test
   public void testWriteCommitCallbackFiresOnClustering() throws Exception {
-    RecordingCommitCallback.MESSAGES.clear();
+    RecordingCommitCallback.reset();
     HoodieClusteringConfig clusteringConfig = HoodieClusteringConfig.newBuilder()
         .withClusteringMaxNumGroups(10)
         .withClusteringSortColumns("_row_key")
@@ -272,32 +271,13 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
 
     // The callback must fire exactly once for the clustering completion, reporting the completed
     // timeline action (replacecommit).
-    List<HoodieWriteCommitCallbackMessage> clusteringMessages = RecordingCommitCallback.MESSAGES.stream()
+    List<HoodieWriteCommitCallbackMessage> clusteringMessages = RecordingCommitCallback.messages().stream()
         .filter(m -> m.getCommitTime().equals(clusteringTime.get()))
         .collect(Collectors.toList());
     assertEquals(1, clusteringMessages.size(), "callback must fire once for the clustering commit");
     assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, clusteringMessages.get(0).getCommitActionType().orElse(null));
-    assertNotNull(clusteringMessages.get(0).getPrevFilePaths(), "prevFilePaths must never be null");
-  }
-
-  /**
-   * A recording {@link HoodieWriteCommitCallback} that captures every fired message so tests can
-   * assert the callback fires for table-service (compaction/clustering) commits with the expected
-   * action type. Loaded reflectively from the write config, so it needs a public
-   * {@code (HoodieWriteConfig)} constructor.
-   */
-  public static class RecordingCommitCallback implements HoodieWriteCommitCallback {
-
-    static final List<HoodieWriteCommitCallbackMessage> MESSAGES = new CopyOnWriteArrayList<>();
-
-    public RecordingCommitCallback(HoodieWriteConfig config) {
-      // config arg required for reflective instantiation
-    }
-
-    @Override
-    public void call(HoodieWriteCommitCallbackMessage callbackMessage) {
-      MESSAGES.add(callbackMessage);
-    }
+    // Clustering writes new file groups, so every stat carries NULL_COMMIT and no prev path resolves.
+    assertTrue(clusteringMessages.get(0).getPrevFilePaths().isEmpty());
   }
 
 }

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
@@ -270,15 +270,14 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
     client.cluster(clusteringTime.get(), true);
     assertTrue(metaClient.reloadActiveTimeline().filterCompletedInstants().containsInstant(clusteringTime.get()));
 
-    // The callback must fire once for the clustering completion, reporting the action actually on
-    // the timeline (replacecommit for table version < 8, clustering for 8+).
+    // The callback must fire exactly once for the clustering completion, reporting the completed
+    // timeline action (replacecommit).
     List<HoodieWriteCommitCallbackMessage> clusteringMessages = RecordingCommitCallback.MESSAGES.stream()
         .filter(m -> m.getCommitTime().equals(clusteringTime.get()))
         .collect(Collectors.toList());
     assertEquals(1, clusteringMessages.size(), "callback must fire once for the clustering commit");
-    String action = clusteringMessages.get(0).getCommitActionType().orElse(null);
-    assertTrue(HoodieTimeline.REPLACE_COMMIT_ACTION.equals(action) || HoodieTimeline.CLUSTERING_ACTION.equals(action),
-        "clustering callback must report the timeline action, got: " + action);
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, clusteringMessages.get(0).getCommitActionType().orElse(null));
+    assertNotNull(clusteringMessages.get(0).getPrevFilePaths(), "prevFilePaths must never be null");
   }
 
   /**

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/functional/TestHoodieJavaClientOnMergeOnReadStorage.java
@@ -269,8 +269,8 @@ public class TestHoodieJavaClientOnMergeOnReadStorage extends HoodieJavaClientTe
     client.cluster(clusteringTime.get(), true);
     assertTrue(metaClient.reloadActiveTimeline().filterCompletedInstants().containsInstant(clusteringTime.get()));
 
-    // The callback must fire exactly once for the clustering completion, reporting the completed
-    // timeline action (replacecommit).
+    // The callback must fire once for the clustering completion, reporting the action actually on
+    // the timeline (replacecommit).
     List<HoodieWriteCommitCallbackMessage> clusteringMessages = RecordingCommitCallback.messages().stream()
         .filter(m -> m.getCommitTime().equals(clusteringTime.get()))
         .collect(Collectors.toList());

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -126,9 +126,9 @@ public class ClusteringUtils {
    *         from the inflight action: a {@code clustering} inflight instant completes as
    *         {@code replacecommit}.
    */
-  public static <T> HoodieInstant transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
-                                                                                  HoodieReplaceCommitMetadata metadata, HoodieActiveTimeline activeTimeline,
-                                                                                  TableFormatCompletionAction tableFormatCompletionAction) {
+  public static HoodieInstant transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
+                                                                              HoodieReplaceCommitMetadata metadata, HoodieActiveTimeline activeTimeline,
+                                                                              TableFormatCompletionAction tableFormatCompletionAction) {
     if (clusteringInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)) {
       return activeTimeline.transitionClusterInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
     } else {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -121,14 +121,18 @@ public class ClusteringUtils {
   /**
    * Transitions the provided clustering instant fron inflight to complete based on the clustering
    * action type. After HUDI-7905, the new clustering commits are written with clustering action.
+   *
+   * @return the completed instant, whose action is the one recorded on the timeline. This differs
+   *         from the inflight action: a {@code clustering} inflight instant completes as
+   *         {@code replacecommit}.
    */
-  public static <T> void transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
-                                                                         HoodieReplaceCommitMetadata metadata, HoodieActiveTimeline activeTimeline,
-                                                                         TableFormatCompletionAction tableFormatCompletionAction) {
+  public static <T> HoodieInstant transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
+                                                                                  HoodieReplaceCommitMetadata metadata, HoodieActiveTimeline activeTimeline,
+                                                                                  TableFormatCompletionAction tableFormatCompletionAction) {
     if (clusteringInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)) {
-      activeTimeline.transitionClusterInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
+      return activeTimeline.transitionClusterInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
     } else {
-      activeTimeline.transitionReplaceInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
+      return activeTimeline.transitionReplaceInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
     }
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ClusteringUtils.java
@@ -121,18 +121,14 @@ public class ClusteringUtils {
   /**
    * Transitions the provided clustering instant fron inflight to complete based on the clustering
    * action type. After HUDI-7905, the new clustering commits are written with clustering action.
-   *
-   * @return the completed instant, whose action is the one recorded on the timeline. This differs
-   *         from the inflight action: a {@code clustering} inflight instant completes as
-   *         {@code replacecommit}.
    */
-  public static HoodieInstant transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
-                                                                              HoodieReplaceCommitMetadata metadata, HoodieActiveTimeline activeTimeline,
-                                                                              TableFormatCompletionAction tableFormatCompletionAction) {
+  public static void transitionClusteringOrReplaceInflightToComplete(boolean shouldLock, HoodieInstant clusteringInstant,
+                                                                     HoodieReplaceCommitMetadata metadata, HoodieActiveTimeline activeTimeline,
+                                                                     TableFormatCompletionAction tableFormatCompletionAction) {
     if (clusteringInstant.getAction().equals(HoodieTimeline.CLUSTERING_ACTION)) {
-      return activeTimeline.transitionClusterInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
+      activeTimeline.transitionClusterInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
     } else {
-      return activeTimeline.transitionReplaceInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
+      activeTimeline.transitionReplaceInflightToComplete(shouldLock, clusteringInstant, metadata, tableFormatCompletionAction);
     }
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -56,6 +56,7 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -124,8 +125,55 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
     //now that it is complete, the first instant should be picked
     HoodieInstant complete = metaClient.getActiveTimeline().transitionClusterInflightToComplete(false, inflight, new HoodieReplaceCommitMetadata());
     assertEquals(HoodieInstant.State.COMPLETED, complete.getState());
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, complete.getAction());
     lastPendingClustering = metaClient.reloadActiveTimeline().getLastPendingClusterInstant();
     assertEquals("1", lastPendingClustering.get().requestedTime());
+  }
+
+  /**
+   * A clustering commit lands on the timeline as a {@code replacecommit} whichever action its
+   * inflight instant carried, and {@link ClusteringUtils#transitionClusteringOrReplaceInflightToComplete}
+   * returns that completed instant. Callers rely on this to report the completed action rather than
+   * the inflight one - see the write commit callback in {@code BaseHoodieTableServiceClient}.
+   *
+   * <p>Both branches are covered: a {@code clustering} inflight, written since HUDI-7905 on table
+   * version 8+, and a {@code replacecommit} inflight, written by table version 7 and older writers
+   * and by insert_overwrite on any version.
+   */
+  @Test
+  public void testTransitionInflightToCompleteReturnsCompletedReplaceCommit() throws Exception {
+    List<String> fileIds = new ArrayList<>();
+    fileIds.add(UUID.randomUUID().toString());
+    List<HoodieInstant> tableFormatInstants = new ArrayList<>();
+
+    HoodieInstant clusterRequested = createRequestedClusterInstant("partition1", "1", fileIds);
+    HoodieInstant clusterInflight = metaClient.getActiveTimeline()
+        .transitionClusterRequestedToInflight(clusterRequested, Option.empty());
+    assertEquals(HoodieTimeline.CLUSTERING_ACTION, clusterInflight.getAction());
+    HoodieInstant clusterComplete = ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
+        false, clusterInflight, new HoodieReplaceCommitMetadata(), metaClient.getActiveTimeline(),
+        tableFormatInstants::add);
+    assertEquals(HoodieInstant.State.COMPLETED, clusterComplete.getState());
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, clusterComplete.getAction(),
+        "a clustering inflight instant must complete as replacecommit");
+    assertEquals(1, tableFormatInstants.size());
+    assertSame(clusterComplete, tableFormatInstants.get(0),
+        "the table format hook must see the instant that is returned");
+
+    tableFormatInstants.clear();
+    HoodieInstant replaceRequested = createRequestedReplaceInstantNotClustering("2");
+    HoodieInstant replaceInflight = metaClient.getActiveTimeline()
+        .transitionReplaceRequestedToInflight(replaceRequested, Option.empty());
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, replaceInflight.getAction());
+    HoodieInstant replaceComplete = ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
+        false, replaceInflight, new HoodieReplaceCommitMetadata(), metaClient.getActiveTimeline(),
+        tableFormatInstants::add);
+    assertEquals(HoodieInstant.State.COMPLETED, replaceComplete.getState());
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, replaceComplete.getAction(),
+        "a replacecommit inflight instant must complete as replacecommit");
+    assertEquals(1, tableFormatInstants.size());
+    assertSame(replaceComplete, tableFormatInstants.get(0),
+        "the table format hook must see the instant that is returned");
   }
 
   // replacecommit.inflight doesn't have clustering plan.

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/util/TestClusteringUtils.java
@@ -56,7 +56,6 @@ import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -131,49 +130,45 @@ public class TestClusteringUtils extends HoodieCommonTestHarness {
   }
 
   /**
-   * A clustering commit lands on the timeline as a {@code replacecommit} whichever action its
-   * inflight instant carried, and {@link ClusteringUtils#transitionClusteringOrReplaceInflightToComplete}
-   * returns that completed instant. Callers rely on this to report the completed action rather than
-   * the inflight one - see the write commit callback in {@code BaseHoodieTableServiceClient}.
-   *
-   * <p>Both branches are covered: a {@code clustering} inflight, written since HUDI-7905 on table
-   * version 8+, and a {@code replacecommit} inflight, written by table version 7 and older writers
-   * and by insert_overwrite on any version.
+   * A clustering commit completes as a {@code replacecommit} whichever action its inflight instant
+   * carried, {@code clustering} on table version 8+ or {@code replacecommit} before that.
    */
   @Test
-  public void testTransitionInflightToCompleteReturnsCompletedReplaceCommit() throws Exception {
+  public void testClusteringAndReplaceInflightBothCompleteAsReplaceCommit() throws Exception {
     List<String> fileIds = new ArrayList<>();
     fileIds.add(UUID.randomUUID().toString());
-    List<HoodieInstant> tableFormatInstants = new ArrayList<>();
+    List<HoodieInstant> completed = new ArrayList<>();
 
     HoodieInstant clusterRequested = createRequestedClusterInstant("partition1", "1", fileIds);
     HoodieInstant clusterInflight = metaClient.getActiveTimeline()
         .transitionClusterRequestedToInflight(clusterRequested, Option.empty());
     assertEquals(HoodieTimeline.CLUSTERING_ACTION, clusterInflight.getAction());
-    HoodieInstant clusterComplete = ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
+    ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
         false, clusterInflight, new HoodieReplaceCommitMetadata(), metaClient.getActiveTimeline(),
-        tableFormatInstants::add);
-    assertEquals(HoodieInstant.State.COMPLETED, clusterComplete.getState());
-    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, clusterComplete.getAction(),
+        completed::add);
+    assertEquals(1, completed.size());
+    assertEquals(HoodieInstant.State.COMPLETED, completed.get(0).getState());
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, completed.get(0).getAction(),
         "a clustering inflight instant must complete as replacecommit");
-    assertEquals(1, tableFormatInstants.size());
-    assertSame(clusterComplete, tableFormatInstants.get(0),
-        "the table format hook must see the instant that is returned");
 
-    tableFormatInstants.clear();
+    completed.clear();
     HoodieInstant replaceRequested = createRequestedReplaceInstantNotClustering("2");
     HoodieInstant replaceInflight = metaClient.getActiveTimeline()
         .transitionReplaceRequestedToInflight(replaceRequested, Option.empty());
     assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, replaceInflight.getAction());
-    HoodieInstant replaceComplete = ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
+    ClusteringUtils.transitionClusteringOrReplaceInflightToComplete(
         false, replaceInflight, new HoodieReplaceCommitMetadata(), metaClient.getActiveTimeline(),
-        tableFormatInstants::add);
-    assertEquals(HoodieInstant.State.COMPLETED, replaceComplete.getState());
-    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, replaceComplete.getAction(),
+        completed::add);
+    assertEquals(1, completed.size());
+    assertEquals(HoodieInstant.State.COMPLETED, completed.get(0).getState());
+    assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, completed.get(0).getAction(),
         "a replacecommit inflight instant must complete as replacecommit");
-    assertEquals(1, tableFormatInstants.size());
-    assertSame(replaceComplete, tableFormatInstants.get(0),
-        "the table format hook must see the instant that is returned");
+
+    List<HoodieInstant> completedInstants =
+        metaClient.reloadActiveTimeline().filterCompletedInstants().getInstants();
+    assertEquals(2, completedInstants.size());
+    completedInstants.forEach(instant ->
+        assertEquals(HoodieTimeline.REPLACE_COMMIT_ACTION, instant.getAction()));
   }
 
   // replacecommit.inflight doesn't have clustering plan.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Follow-up to #18988. `completeClustering` fires the write commit callback with `clusteringInstant.getAction()`, but that is the **inflight** instant, captured before the transition and immutable. On timeline v2 its action is `clustering`, while `transitionClusterInflightToComplete` records the completed instant as `replacecommit`. So on table version 8+ the callback reports an action that does not exist on the completed timeline. On the 0.x layout the two coincide, which is why it went unnoticed.

### Summary and Changelog

Report the action the commit lands under, not the one it was scheduled under.

- `BaseHoodieTableServiceClient#completeClustering` and `HoodieFlinkTableServiceClient#completeClustering` now pass `REPLACE_COMMIT_ACTION` to the callback instead of the inflight instant's action. A clustering commit completes as a `replacecommit` whichever action its inflight instant carried, and this matches how the sibling call sites report theirs: compaction fires `COMMIT_ACTION`, log compaction `DELTA_COMMIT_ACTION`.
- `TestClusteringUtils` gains a case that drives a real timeline through both inflight kinds (`clustering` and `replacecommit`) and asserts each completes as `replacecommit`, pinning the assumption behind that constant. The existing transition assertion now also checks the completed action rather than only the state.
- `TestHoodieJavaClientOnMergeOnReadStorage#testWriteCommitCallbackFiresOnClustering` asserted `REPLACE_COMMIT_ACTION || CLUSTERING_ACTION`, which accepted the wrong value and could not catch this; tightened to `assertEquals`, mirroring the compaction test. Its tautological `prevFilePaths` non-null assertion is now an emptiness check, which is what a clustering commit guarantees.
- `TestHoodieFlinkTableServiceClient#testCompleteClusteringCommitsAndCleansMarkers` now asserts the Flink path reports `replacecommit` — that fire previously had no coverage.
- The recording callback both tests use moved into hudi-client-common test sources as `org.apache.hudi.testutils.RecordingCommitCallback`, replacing two identical copies.

### Impact

Consumers of `HoodieWriteCommitCallback` on table version 8+ see `replacecommit` instead of
`clustering` for clustering commits — the value the timeline records, and the value already reported
on older table versions.

`transitionClusteringOrReplaceInflightToComplete` changes from `void` to returning `HoodieInstant`.
It is not annotated public API and has two callers, both in this PR, so this is source-compatible
in-tree; a pre-compiled out-of-tree caller would need recompiling.

### Risk Level

low — no change to when or whether the callback fires, or to what is written to the timeline.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
