### PR TITLE
fix(fs): stop depending on the optional FileSystem#getScheme()

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkersFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/marker/WriteMarkersFactory.java
@@ -53,7 +53,7 @@ public class WriteMarkersFactory {
         }
         String basePath = table.getMetaClient().getBasePath().toString();
         if (StorageSchemes.HDFS.getScheme().equals(
-            HadoopFSUtils.getFs(basePath, table.getContext().getStorageConf(), true).getScheme())) {
+            HadoopFSUtils.getScheme(HadoopFSUtils.getFs(basePath, table.getContext().getStorageConf(), true)))) {
           log.warn("Timeline-server-based markers are not supported for HDFS: "
               + "base path {}.  Falling back to direct markers.", basePath);
           return getDirectWriteMarkers(table, instantTime);

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
@@ -277,7 +277,7 @@ public class HadoopFSUtils {
    * @return true if the inputstream or the wrapped one is of type GoogleHadoopFSInputStream
    */
   public static boolean isGCSFileSystem(FileSystem fs) {
-    return fs.getScheme().equals(StorageSchemes.GCS.getScheme());
+    return StorageSchemes.GCS.getScheme().equals(getScheme(fs));
   }
 
   /**
@@ -285,7 +285,28 @@ public class HadoopFSUtils {
    * Wrapped by {@code BoundedFsDataInputStream}, to check whether the desired offset is out of the file size in advance.
    */
   public static boolean isCHDFileSystem(FileSystem fs) {
-    return StorageSchemes.CHDFS.getScheme().equals(fs.getScheme());
+    return StorageSchemes.CHDFS.getScheme().equals(getScheme(fs));
+  }
+
+  /**
+   * Resolves the scheme of {@code fs} without depending on {@link FileSystem#getScheme()}.
+   *
+   * <p>{@code getScheme()} is optional in Hadoop: {@link FileSystem}'s own implementation throws
+   * {@link UnsupportedOperationException}, and proxy implementations such as Presto's
+   * {@code PrestoS3FileSystem} do not override it, so calling it unguarded turns an unrelated read into
+   * "Not implemented by the PrestoS3FileSystem FileSystem implementation" (HUDI-4602).
+   * {@link FileSystem#getUri()} is abstract, so every implementation supplies it, and its scheme is what
+   * {@code getScheme()} returns wherever both are present.
+   *
+   * @param fs instance of {@link FileSystem} in use.
+   * @return the scheme of {@code fs}, or null if its URI carries none.
+   */
+  public static String getScheme(FileSystem fs) {
+    try {
+      return fs.getScheme();
+    } catch (UnsupportedOperationException e) {
+      return fs.getUri().getScheme();
+    }
   }
 
   private static StorageConfiguration<Configuration> getStorageConf(Configuration conf, boolean copy) {
@@ -294,7 +315,7 @@ public class HadoopFSUtils {
 
   public static Configuration registerFileSystem(StoragePath file, Configuration conf) {
     Configuration returnConf = new Configuration(conf);
-    String scheme = HadoopFSUtils.getFs(file.toString(), conf).getScheme();
+    String scheme = getScheme(HadoopFSUtils.getFs(file.toString(), conf));
     returnConf.set("fs." + HoodieWrapperFileSystem.getHoodieScheme(scheme) + ".impl",
         HoodieWrapperFileSystem.class.getName());
     return returnConf;

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HadoopFSUtils.java
@@ -26,6 +26,7 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
@@ -295,17 +296,31 @@ public class HadoopFSUtils {
    * {@link UnsupportedOperationException}, and proxy implementations such as Presto's
    * {@code PrestoS3FileSystem} do not override it, so calling it unguarded turns an unrelated read into
    * "Not implemented by the PrestoS3FileSystem FileSystem implementation" (HUDI-4602).
-   * {@link FileSystem#getUri()} is abstract, so every implementation supplies it, and its scheme is what
-   * {@code getScheme()} returns wherever both are present.
+   * {@link FileSystem#getUri()} is abstract, so every implementation supplies one to fall back on.
+   *
+   * <p>The two are not interchangeable, which is why {@code getScheme()} is tried first:
+   * {@code InLineFileSystem} returns {@code "inlinefs"} from {@code getScheme()} while its
+   * {@code getUri()} is {@code URI.create("inlinefs")}, which has no colon and so carries no scheme at all.
+   * A URI with no scheme is therefore a resolution failure rather than a value to pass on - returning null
+   * would surface much later as {@code does not support scheme null} or {@code Unsupported scheme :null},
+   * with the original {@code UnsupportedOperationException} discarded.
    *
    * @param fs instance of {@link FileSystem} in use.
-   * @return the scheme of {@code fs}, or null if its URI carries none.
+   * @return the scheme of {@code fs}, never null.
+   * @throws HoodieException if {@code getScheme()} is unimplemented and the URI carries no scheme.
    */
   public static String getScheme(FileSystem fs) {
     try {
       return fs.getScheme();
     } catch (UnsupportedOperationException e) {
-      return fs.getUri().getScheme();
+      String scheme = fs.getUri().getScheme();
+      if (scheme == null) {
+        // HoodieException rather than HoodieIOException: the latter only accepts an IOException cause, and
+        // discarding the UnsupportedOperationException is the thing being fixed here.
+        throw new HoodieException("Cannot resolve the scheme of " + fs.getClass().getName()
+            + ": getScheme() is unimplemented and its URI " + fs.getUri() + " carries no scheme", e);
+      }
+      return scheme;
     }
   }
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HoodieRetryWrapperFileSystem.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HoodieRetryWrapperFileSystem.java
@@ -277,7 +277,7 @@ public class HoodieRetryWrapperFileSystem extends FileSystem {
 
   @Override
   public String getScheme() {
-    return fileSystem.getScheme();
+    return HadoopFSUtils.getScheme(fileSystem);
   }
 
   @Override

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HoodieWrapperFileSystem.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HoodieWrapperFileSystem.java
@@ -160,7 +160,7 @@ public class HoodieWrapperFileSystem extends FileSystem {
 
   public static Path convertToHoodiePath(StoragePath file, Configuration conf) {
     try {
-      String scheme = HadoopFSUtils.getFs(file.toString(), conf).getScheme();
+      String scheme = HadoopFSUtils.getScheme(HadoopFSUtils.getFs(file.toString(), conf));
       return convertPathWithScheme(convertToHadoopPath(file), getHoodieScheme(scheme));
     } catch (HoodieIOException e) {
       throw e;

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HoodieWrapperFileSystem.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/hadoop/fs/HoodieWrapperFileSystem.java
@@ -159,12 +159,8 @@ public class HoodieWrapperFileSystem extends FileSystem {
   }
 
   public static Path convertToHoodiePath(StoragePath file, Configuration conf) {
-    try {
-      String scheme = HadoopFSUtils.getScheme(HadoopFSUtils.getFs(file.toString(), conf));
-      return convertPathWithScheme(convertToHadoopPath(file), getHoodieScheme(scheme));
-    } catch (HoodieIOException e) {
-      throw e;
-    }
+    String scheme = HadoopFSUtils.getScheme(HadoopFSUtils.getFs(file.toString(), conf));
+    return convertPathWithScheme(convertToHadoopPath(file), getHoodieScheme(scheme));
   }
 
   public static Path convertPathWithScheme(Path oldPath, String newScheme) {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
@@ -111,7 +111,7 @@ public class HoodieHadoopStorage extends HoodieStorage {
 
   @Override
   public String getScheme() {
-    return fs.getScheme();
+    return HadoopFSUtils.getScheme(fs);
   }
 
   @Override

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/storage/hadoop/HoodieHadoopStorage.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.storage.hadoop;
 
 import org.apache.hudi.common.fs.ConsistencyGuard;
+import org.apache.hudi.common.util.Lazy;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.hadoop.fs.HoodieRetryWrapperFileSystem;
@@ -58,6 +59,13 @@ import static org.apache.hudi.hadoop.fs.HadoopFSUtils.getFs;
  */
 public class HoodieHadoopStorage extends HoodieStorage {
   private final FileSystem fs;
+  /**
+   * Resolved once. On a filesystem that does not implement {@code getScheme()} the fallback in
+   * {@link HadoopFSUtils#getScheme} costs a thrown-and-caught exception, and this is called once per log
+   * block via {@code StorageSchemes.isWriteTransactional} and three times per immutable-file write via
+   * {@code needCreateTempFile}. {@code fs} is final, so the answer cannot change.
+   */
+  private final Lazy<String> scheme = Lazy.lazily(this::resolveScheme);
 
   public HoodieHadoopStorage(StoragePath path, StorageConfiguration<?> conf) {
     super(conf);
@@ -111,6 +119,10 @@ public class HoodieHadoopStorage extends HoodieStorage {
 
   @Override
   public String getScheme() {
+    return scheme.get();
+  }
+
+  private String resolveScheme() {
     return HadoopFSUtils.getScheme(fs);
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/fs/TestFSUtilsWithRetryWrapperEnable.java
@@ -45,7 +45,6 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -107,9 +106,13 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     FileSystem fileSystem =
         new HoodieRetryWrapperFileSystem(fakeFs, maxRetryIntervalMs, maxRetryNumbers,
             initialRetryIntervalMs, "");
-    HoodieWrapperFileSystem fs =
-        new HoodieWrapperFileSystem(fileSystem, new NoOpConsistencyGuard());
-    assertDoesNotThrow(fs::getScheme, "Method #getSchema does not implement correctly");
+    // FakeRemoteFileSystem deliberately does not override getScheme(), so FileSystem's own implementation
+    // throws - the PrestoS3FileSystem shape (HUDI-4602). Assert on the retry wrapper itself: asserting on
+    // HoodieWrapperFileSystem instead would only exercise its own uri.getScheme() and never reach here,
+    // which is why this guard was inert from the day HUDI-5286 added it.
+    assertThrows(UnsupportedOperationException.class, fakeFs::getScheme);
+    assertEquals("file", ((HoodieRetryWrapperFileSystem) fileSystem).getScheme(),
+        "the retry wrapper should resolve the scheme of a filesystem that does not implement getScheme()");
   }
 
   @Test
@@ -252,11 +255,6 @@ public class TestFSUtilsWithRetryWrapperEnable extends TestFSUtils {
     @Override
     public Configuration getConf() {
       return fs.getConf();
-    }
-
-    @Override
-    public String getScheme() {
-      return fs.getScheme();
     }
 
     @Override

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/hadoop/fs/TestHadoopFSUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/hadoop/fs/TestHadoopFSUtils.java
@@ -19,14 +19,17 @@
 
 package org.apache.hudi.hadoop.fs;
 
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
+import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FilterFileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -34,8 +37,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 
 import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToHadoopFileStatus;
@@ -43,8 +46,11 @@ import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToHadoopPath;
 import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePath;
 import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePathInfo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link HadoopFSUtils}
@@ -61,18 +67,15 @@ public class TestHadoopFSUtils {
    * implementation while overriding {@code getUri()}.
    */
   @Test
-  public void testGetFSDataInputStreamWhenGetSchemeIsUnimplemented(@TempDir File tempDir) throws IOException {
-    File file = new File(tempDir, "log.file");
+  public void testGetFSDataInputStreamWhenGetSchemeIsUnimplemented(@TempDir java.nio.file.Path tempDir) throws IOException {
+    java.nio.file.Path file = tempDir.resolve("log.file");
     byte[] contents = new byte[] {1, 2, 3, 4};
-    Files.write(file.toPath(), contents);
+    Files.write(file, contents);
     // newInstanceLocal rather than getLocal, so closing this does not evict a cached FileSystem that
     // other tests in the same JVM share.
-    try (FileSystem fs = new FilterFileSystem(FileSystem.newInstanceLocal(new Configuration()))) {
-      // The premise: this is the call the read path used to make unguarded.
-      assertThrows(UnsupportedOperationException.class, fs::getScheme);
-
+    try (FileSystem fs = newFsWithoutGetScheme(FileSystem.newInstanceLocal(new Configuration()))) {
       try (FSDataInputStream stream =
-               HadoopFSUtils.getFSDataInputStream(fs, new StoragePath(file.toURI()), 1024, true)) {
+               HadoopFSUtils.getFSDataInputStream(fs, new StoragePath(file.toUri()), 1024, true)) {
         byte[] read = new byte[contents.length];
         stream.readFully(read);
         assertArrayEquals(contents, read, "The read path should not depend on the optional getScheme()");
@@ -87,12 +90,114 @@ public class TestHadoopFSUtils {
           "LocalFileSystem overrides getScheme(), so the helper should return what it reports "
               + "rather than falling back to getUri()");
 
-      try (FileSystem noScheme = new FilterFileSystem(localFs)) {
-        assertThrows(UnsupportedOperationException.class, noScheme::getScheme);
-        assertEquals("file", HadoopFSUtils.getScheme(noScheme),
-            "FilterFileSystem does not override getScheme(), so the helper should fall back to "
-                + "getUri().getScheme()");
+      // FilterFileSystem#close closes the delegate, so the wrapper is not given its own block: it owns
+      // nothing, and closing it here would close localFs a second time.
+      FileSystem noScheme = newFsWithoutGetScheme(localFs);
+      assertEquals("file", HadoopFSUtils.getScheme(noScheme),
+          "FilterFileSystem does not override getScheme(), so the helper should fall back to "
+              + "getUri().getScheme()");
+    }
+  }
+
+  /**
+   * A URI with no scheme cannot stand in for an unimplemented {@code getScheme()}. {@code InLineFileSystem}
+   * is the case in this module: {@code getScheme()} returns "inlinefs" while {@code getUri()} is
+   * {@code URI.create("inlinefs")}, which has no colon and so no scheme. Returning null there would surface
+   * far away as "does not support scheme null" with the original failure discarded, so it must fail here.
+   */
+  @Test
+  public void testGetSchemeFailsLoudlyWhenNeitherSourceHasOne() throws IOException {
+    try (FileSystem localFs = FileSystem.newInstanceLocal(new Configuration())) {
+      FileSystem schemeless = new NoSchemeFileSystem(localFs, URI.create("inlinefs"));
+
+      HoodieException thrown =
+          assertThrows(HoodieException.class, () -> HadoopFSUtils.getScheme(schemeless));
+      assertTrue(thrown.getMessage().contains("carries no scheme"),
+          () -> "the failure should say the URI carries no scheme, but was: " + thrown.getMessage());
+      assertInstanceOf(UnsupportedOperationException.class, thrown.getCause(),
+          "the original getScheme() failure must be chained rather than discarded");
+    }
+  }
+
+  /**
+   * The three call sites this rerouted that no test in the repo reached: {@code registerFileSystem},
+   * {@code HoodieWrapperFileSystem#convertToHoodiePath} - which is on the write path, via
+   * {@code HoodieBaseParquetWriter} and friends - and {@code HoodieHadoopStorage#getScheme}. All three threw
+   * {@link UnsupportedOperationException} on a filesystem without {@code getScheme()} before this change.
+   */
+  @Test
+  public void testCallSitesWorkOnAFileSystemWithoutGetScheme(@TempDir java.nio.file.Path tempDir) {
+    Configuration conf = new Configuration();
+    conf.setClass("fs.file.impl", NoSchemeLocalFileSystem.class, FileSystem.class);
+    StoragePath path = new StoragePath(tempDir.toUri());
+
+    assertDoesNotThrow(() -> HadoopFSUtils.registerFileSystem(path, conf),
+        "registerFileSystem resolves the scheme to build the fs.<scheme>.impl key");
+    assertDoesNotThrow(() -> HoodieWrapperFileSystem.convertToHoodiePath(path, conf),
+        "convertToHoodiePath is on the write path and resolves the scheme to rewrite it");
+    assertEquals("file", new HoodieHadoopStorage(path, HadoopFSUtils.getStorageConf(conf)).getScheme(),
+        "HoodieHadoopStorage#getScheme is what HoodieStorage callers reach");
+  }
+
+  /**
+   * {@code isGCSFileSystem} and {@code isCHDFileSystem} become reachable for a filesystem without
+   * {@code getScheme()} for the first time with this change, and they select different stream wrappers.
+   * Neither predicate had a test before.
+   */
+  @ParameterizedTest
+  @CsvSource({
+      "gs://bucket, org.apache.hudi.hadoop.fs.SchemeAwareFSDataInputStream",
+      "ofs://cluster, org.apache.hudi.hadoop.fs.BoundedFsDataInputStream"
+  })
+  public void testSchemeSpecificStreamIsSelectedWithoutGetScheme(String uri, String expectedStream,
+                                                                 @TempDir java.nio.file.Path tempDir) throws IOException {
+    java.nio.file.Path file = tempDir.resolve("log.file");
+    Files.write(file, new byte[] {1, 2, 3, 4});
+    try (FileSystem localFs = FileSystem.newInstanceLocal(new Configuration())) {
+      // Reports a gs:// or ofs:// URI while leaving getScheme() to the throwing base implementation.
+      FileSystem fs = new NoSchemeFileSystem(localFs, URI.create(uri));
+      assertThrows(UnsupportedOperationException.class, fs::getScheme);
+
+      try (FSDataInputStream stream =
+               HadoopFSUtils.getFSDataInputStream(fs, new StoragePath(file.toUri()), 1024, true)) {
+        assertEquals(expectedStream, stream.getClass().getName(),
+            "the scheme-specific wrapper should be selected from the fallback-resolved scheme");
       }
+    }
+  }
+
+  /** A FileSystem with the reported shape: {@code getUri()} works, {@code getScheme()} throws. */
+  private static FileSystem newFsWithoutGetScheme(FileSystem delegate) {
+    FileSystem fs = new FilterFileSystem(delegate);
+    // The premise of every assertion below: this is the call the read path used to make unguarded.
+    assertThrows(UnsupportedOperationException.class, fs::getScheme);
+    return fs;
+  }
+
+  /** Same shape, but reporting a URI of our choosing so scheme-specific branches can be reached. */
+  private static class NoSchemeFileSystem extends FilterFileSystem {
+    private final URI uri;
+
+    NoSchemeFileSystem(FileSystem delegate, URI uri) {
+      super(delegate);
+      this.uri = uri;
+    }
+
+    @Override
+    public URI getUri() {
+      return uri;
+    }
+  }
+
+  /**
+   * A {@link LocalFileSystem} that does not implement {@code getScheme()}, so it can be registered as
+   * {@code fs.file.impl} and reached through the normal {@code FileSystem.get} path.
+   */
+  public static class NoSchemeLocalFileSystem extends LocalFileSystem {
+    @Override
+    public String getScheme() {
+      throw new UnsupportedOperationException(
+          "Not implemented by the NoSchemeLocalFileSystem FileSystem implementation");
     }
   }
 

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/hadoop/fs/TestHadoopFSUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/hadoop/fs/TestHadoopFSUtils.java
@@ -22,22 +22,78 @@ package org.apache.hudi.hadoop.fs;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FilterFileSystem;
 import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToHadoopFileStatus;
 import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToHadoopPath;
 import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePath;
 import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePathInfo;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link HadoopFSUtils}
  */
 public class TestHadoopFSUtils {
+  /**
+   * HUDI-4602: {@link FileSystem#getScheme()} is optional in Hadoop -- the base implementation throws
+   * {@link UnsupportedOperationException} -- and proxy implementations such as Presto's
+   * {@code PrestoS3FileSystem} do not override it. Opening a log file went straight through
+   * {@code isGCSFileSystem}, so a MOR {@code _rt} query on Presto failed with
+   * "Not implemented by the PrestoS3FileSystem FileSystem implementation" rather than reading anything.
+   *
+   * <p>{@link FilterFileSystem} has the same shape: it leaves {@code getScheme()} to the throwing base
+   * implementation while overriding {@code getUri()}.
+   */
+  @Test
+  public void testGetFSDataInputStreamWhenGetSchemeIsUnimplemented(@TempDir File tempDir) throws IOException {
+    File file = new File(tempDir, "log.file");
+    byte[] contents = new byte[] {1, 2, 3, 4};
+    Files.write(file.toPath(), contents);
+    // newInstanceLocal rather than getLocal, so closing this does not evict a cached FileSystem that
+    // other tests in the same JVM share.
+    try (FileSystem fs = new FilterFileSystem(FileSystem.newInstanceLocal(new Configuration()))) {
+      // The premise: this is the call the read path used to make unguarded.
+      assertThrows(UnsupportedOperationException.class, fs::getScheme);
+
+      try (FSDataInputStream stream =
+               HadoopFSUtils.getFSDataInputStream(fs, new StoragePath(file.toURI()), 1024, true)) {
+        byte[] read = new byte[contents.length];
+        stream.readFully(read);
+        assertArrayEquals(contents, read, "The read path should not depend on the optional getScheme()");
+      }
+    }
+  }
+
+  @Test
+  public void testGetSchemeFallsBackToTheUriWhenUnimplemented() throws IOException {
+    try (FileSystem localFs = FileSystem.newInstanceLocal(new Configuration())) {
+      assertEquals("file", HadoopFSUtils.getScheme(localFs),
+          "An implementation that overrides getScheme() should still be used directly");
+
+      try (FileSystem noScheme = new FilterFileSystem(localFs)) {
+        assertThrows(UnsupportedOperationException.class, noScheme::getScheme);
+        assertEquals("file", HadoopFSUtils.getScheme(noScheme),
+            "The scheme should come from getUri() when getScheme() is unimplemented");
+      }
+    }
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {
       "/a/b/c",

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/hadoop/fs/TestHadoopFSUtils.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/hadoop/fs/TestHadoopFSUtils.java
@@ -84,12 +84,14 @@ public class TestHadoopFSUtils {
   public void testGetSchemeFallsBackToTheUriWhenUnimplemented() throws IOException {
     try (FileSystem localFs = FileSystem.newInstanceLocal(new Configuration())) {
       assertEquals("file", HadoopFSUtils.getScheme(localFs),
-          "An implementation that overrides getScheme() should still be used directly");
+          "LocalFileSystem overrides getScheme(), so the helper should return what it reports "
+              + "rather than falling back to getUri()");
 
       try (FileSystem noScheme = new FilterFileSystem(localFs)) {
         assertThrows(UnsupportedOperationException.class, noScheme::getScheme);
         assertEquals("file", HadoopFSUtils.getScheme(noScheme),
-            "The scheme should come from getUri() when getScheme() is unimplemented");
+            "FilterFileSystem does not override getScheme(), so the helper should fall back to "
+                + "getUri().getScheme()");
       }
     }
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #15331 (HUDI-4602).

A MOR `_rt` query through Presto fails before reading anything:

```
java.lang.UnsupportedOperationException: Not implemented by the PrestoS3FileSystem FileSystem implementation
	at org.apache.hadoop.fs.FileSystem.getScheme(FileSystem.java:219)
	at org.apache.hadoop.fs.HadoopExtendedFileSystem.getScheme(HadoopExtendedFileSystem.java:71)
	at org.apache.hudi.common.fs.FSUtils.isGCSFileSystem(FSUtils.java:592)
	at org.apache.hudi.common.table.log.HoodieLogFileReader.getFSDataInputStream(HoodieLogFileReader.java:119)
	...
	at org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat.getRecordReader
```

`FileSystem#getScheme()` is **optional** in Hadoop — `FileSystem`'s own implementation throws
`UnsupportedOperationException` — and proxy implementations such as `PrestoS3FileSystem` do not override
it. Hudi called it unguarded, so a filesystem that declines to implement an optional API took down an
unrelated read. The issue title asks for `getScheme` to be implemented in `PrestoS3FileSystem`, which is
not a change Hudi can make; what Hudi can fix is the dependency on it, and that is the actual defect.

Still live on current master, just relocated from `FSUtils` to
`HadoopFSUtils.isGCSFileSystem` (line 280) reached from `HadoopFSUtils.getFSDataInputStream` (line 223).

There is precedent for the conclusion: #793 ("Allow HoodieWrapperFileSystem to wrap other proxy
file-system implementations with no getScheme implementation") already stopped `HoodieWrapperFileSystem`
calling `getScheme()` on the filesystem it wraps, deriving the scheme from the URI instead. That fix
covered only the instance methods, though. The static
`HoodieWrapperFileSystem#convertToHoodiePath(StoragePath, Configuration)` kept calling
`getFs(...).getScheme()` directly, and it is one of the lines this PR fixes, six years later.

### Summary and Changelog

- Adds `HadoopFSUtils#getScheme(FileSystem)`: returns `fs.getScheme()`, falling back to
  `fs.getUri().getScheme()` when it is unimplemented, and failing with a `HoodieException` that chains the
  original `UnsupportedOperationException` when neither source yields a scheme. `getUri()` is abstract, so
  every implementation supplies one to fall back on, but the two are not interchangeable, which is why
  `getScheme()` is tried first: `InLineFileSystem` returns `"inlinefs"` from `getScheme()` while its
  `getUri()` is `URI.create("inlinefs")`, which has no colon and so carries no scheme at all. A URI with no
  scheme is a resolution failure rather than a value to pass on, since returning null would surface much
  later as `does not support scheme null` with the original failure discarded. Behaviour is unchanged for
  every filesystem that implements `getScheme()`; only the throwing case is new.

- Routes the seven unguarded call sites through it:

  | call site | reached from |
  | --- | --- |
  | `HadoopFSUtils#isGCSFileSystem` | **the reported crash** — `getFSDataInputStream`, i.e. every log-file open |
  | `HadoopFSUtils#isCHDFileSystem` | same method, same read path |
  | `HadoopFSUtils#registerFileSystem` | |
  | `HoodieWrapperFileSystem#convertToHoodiePath` | |
  | `HoodieRetryWrapperFileSystem#getScheme` | delegates to the wrapped filesystem |
  | `WriteMarkersFactory` HDFS gate | marker-type selection |
  | `HoodieHadoopStorage#getScheme` | the `HoodieStorage#getScheme` entry point — 7 callers, including `HoodieLogFileReader`'s `isWriteTransactional` check, `HoodieLogFormatWriter`, `RollbackHelperV1` and `FileSystemBasedLockProvider` |

- `isGCSFileSystem`'s comparison is flipped to put the constant first, matching its neighbour
  `isCHDFileSystem`, so a filesystem whose URI carries no scheme returns false instead of throwing
  `NullPointerException`.

Three further changes came out of review:

- **`HoodieHadoopStorage` memoizes the scheme.** On a filesystem without `getScheme()` the fallback costs a
  thrown-and-caught exception, and this is called once per log block via
  `StorageSchemes.isWriteTransactional` and three times per immutable-file write via `needCreateTempFile`
  (measured at 321-1923 ns/call depending on stack depth). `fs` is final, so a `Lazy` field resolves it once
  without touching any of the five constructors.
- **`HoodieWrapperFileSystem#convertToHoodiePath` drops a dead `try`/`catch`** that only caught
  `HoodieIOException` to rethrow it unchanged, dead since `ef70de2bba7b`.
- **`TestFSUtilsWithRetryWrapperEnable#testGetSchema` becomes a real guard.** It has been inert since
  HUDI-5286 added it: it asserted on `HoodieWrapperFileSystem#getScheme`, which is `uri.getScheme()` and never
  dispatches into the retry wrapper, and `FakeRemoteFileSystem` overrode `getScheme()` to delegate to a real
  `LocalFileSystem` so it could not throw. Dropping that override gives the fake the `PrestoS3FileSystem`
  shape and the assertion now targets the retry wrapper, so it guards both HUDI-5286 and this change --
  verified by confirming it fails with the pre-PR helper.

### Verification

Reproduced first, on the real code path, with no fabrication: `FilterFileSystem` is a Hadoop-provided
class with exactly the reported shape — it leaves `getScheme()` to the throwing base implementation while
overriding `getUri()`. Opening a file through `HadoopFSUtils.getFSDataInputStream` with one wrapped around
a local filesystem fails on master with the same exception and the same Hudi frames as the report:

```
java.lang.UnsupportedOperationException: Not implemented by the FilterFileSystem FileSystem implementation
	at org.apache.hudi.hadoop.fs.HadoopFSUtils.isGCSFileSystem(HadoopFSUtils.java:280)
	at org.apache.hudi.hadoop.fs.HadoopFSUtils.getFSDataInputStream(HadoopFSUtils.java:223)
```

Five tests in `TestHadoopFSUtils`, each run against a filesystem with the reported shape: `getUri()`
works, `getScheme()` throws.

- `testGetFSDataInputStreamWhenGetSchemeIsUnimplemented` -- the read completes and returns the file's bytes.
- `testGetSchemeFallsBackToTheUriWhenUnimplemented` -- the helper returns `file` both for an
  implementation that overrides `getScheme()` and for one that does not.
- `testGetSchemeFailsLoudlyWhenNeitherSourceHasOne` -- a `getUri()` of `URI.create("inlinefs")` raises a
  `HoodieException` naming the filesystem, with the original `UnsupportedOperationException` chained as the
  cause rather than discarded.
- `testCallSitesWorkOnAFileSystemWithoutGetScheme` -- one `LocalFileSystem` subclass whose `getScheme()`
  throws, registered as `fs.file.impl`, covering the three rerouted sites no test in the repo reached:
  `registerFileSystem`, `convertToHoodiePath` (the write path, via `HoodieBaseParquetWriter` and friends)
  and `HoodieHadoopStorage#getScheme`.
- `testSchemeSpecificStreamIsSelectedWithoutGetScheme` -- with a URI of `gs://bucket` and `ofs://cluster`,
  `getFSDataInputStream` selects `SchemeAwareFSDataInputStream` and `BoundedFsDataInputStream`. This is the
  assertion that pins the helper returning what `fs.getScheme()` would have, rather than merely not
  throwing. Neither predicate had a test before.

`TestFSUtilsWithRetryWrapperEnable#testGetSchema` is retargeted at `HoodieRetryWrapperFileSystem`, and
`FakeRemoteFileSystem`'s `getScheme()` override is deleted so the throwing base implementation is reached.
It previously asserted on `HoodieWrapperFileSystem#getScheme()`, which is `return uri.getScheme()` and
never dispatches into the retry wrapper, so it could not fail for HUDI-5286 either.

All are red with the guard removed and green with it, so none passes vacuously.

Regression runs:

| suite | result |
| --- | --- |
| `hudi-hadoop-common` full unit suite | 1084 tests, 1 failure — `TestHoodieActiveTimeline#testParseDateFromInstantTime`, which fails identically on unmodified master (a 5.5-hour delta, i.e. the machine's local timezone) |
| `TestWriteMarkersFactory`, `TestMarkerBasedRollbackUtils` | 10 pass |
| `TestFlinkWriteClients` (covers `testMarkerType`) | 20 pass |
| `TestHoodieLogFormatWriter`, `TestFSUtilsWithRetryWrapperEnable`, `TestInLineFileSystem`, `TestStorageSchemes`, `TestHadoopFSUtils` | 78 pass |

`checkstyle:check` and `apache-rat:check` clean.

### Impact

Restores MOR `_rt` reads on any filesystem that does not implement `getScheme()` — Presto's
`PrestoS3FileSystem` as reported, and any other proxy or vendor implementation with the same gap.
No behaviour change for filesystems that do implement it, since the helper calls it first.

For a scheme outside the `StorageSchemes` enum the failure moves rather than disappears:
`HoodieLogFileReader:258` and `RollbackHelperV1:190` throw `IllegalArgumentException: Unsupported scheme`
instead of the `UnsupportedOperationException`. That is not a regression, since both cases failed before,
and the reported `s3` is in the enum, so the fix works end to end for the reported case.

Not addressed here: whether `PrestoS3FileSystem` should also implement `getScheme()`. It should, but that
is a change in Presto, and Hudi should not fall over on an optional API either way.

### Risk Level

low -- one new helper plus seven call-site changes, all one-liners except `HoodieHadoopStorage`, where
the scheme is resolved once into a `Lazy` field because it is read once per log block. No change in
resolved scheme for any filesystem that implements `getScheme()`, and the previously-throwing paths are
covered by tests that were shown to fail without the change.

### Documentation Update

none — no new config and no user-facing behaviour change beyond the reads that used to fail.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR


