### PR TITLE
test(spark): stop skipping TestPartitionBucketIndexSupport on Spark 4

### DIFF
--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBucketIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBucketIndexSupport.scala
@@ -200,9 +200,6 @@ class TestBucketIndexSupport extends HoodieSparkClientTestBase with PredicateHel
     equalTo = "A = 5 And (A = 2 Or B = 'abc')"
     exprBucketAnswerCheck(bucketIndexSupport, equalTo, List.apply(bucket5Id8), fallback = false)
     exprFilePathAnswerCheck(bucketIndexSupport, equalTo, Set.apply(bucket5Id8FileName), allFileNames, fallback = false)
-    equalTo = "A = 5 And (A = 2 Or B = 'abc')"
-    exprBucketAnswerCheck(bucketIndexSupport, equalTo, List.apply(bucket5Id8), fallback = false)
-    exprFilePathAnswerCheck(bucketIndexSupport, equalTo, Set.apply(bucket5Id8FileName), allFileNames, fallback = false)
 
     var inExpr = "A in (3)"
     exprBucketAnswerCheck(bucketIndexSupport, inExpr, List.apply(bucket3Id6), fallback = false)
@@ -379,11 +376,20 @@ class TestBucketIndexSupport extends HoodieSparkClientTestBase with PredicateHel
     exprBucketAnswerCheck(bucketIndexSupport, fallBack, List.empty, fallback = true)
   }
 
-  def exprBucketAnswerCheck(bucketIndexSupport: BucketIndexSupport, exprRaw: String, expectResult: List[Int], fallback: Boolean): Unit = {
+  /**
+   * Resolves an expression and runs it through the optimizer, wrapped in
+   * [[HoodieDummyExpressionHolder]] so that the expression's references are exposed as plan output.
+   * Spark 4 validates plans after every optimizer rule (SPARK-44219) and rejects a plan whose
+   * aliases are not reachable from its output, which the holder Spark ships does not satisfy.
+   */
+  protected def optimizeResolvedExpr(exprRaw: String): Expression = {
     val resolveExpr = HoodieCatalystExpressionUtils.resolveExpr(spark, exprRaw, structSchema)
-    val dummyExpressionHolder = HoodieDummyExpressionHolder(Seq(resolveExpr), resolveExpr.references.toSeq)
-    val optimizerPlan = spark.sessionState.optimizer.execute(dummyExpressionHolder)
-    val optimizerExpr = optimizerPlan.asInstanceOf[HoodieDummyExpressionHolder].exprs.head
+    val holder = HoodieDummyExpressionHolder(Seq(resolveExpr), resolveExpr.references.toSeq)
+    spark.sessionState.optimizer.execute(holder).asInstanceOf[HoodieDummyExpressionHolder].exprs.head
+  }
+
+  def exprBucketAnswerCheck(bucketIndexSupport: BucketIndexSupport, exprRaw: String, expectResult: List[Int], fallback: Boolean): Unit = {
+    val optimizerExpr = optimizeResolvedExpr(exprRaw)
 
     val bucketSet = bucketIndexSupport.filterQueriesWithBucketHashField(splitConjunctivePredicates(optimizerExpr))
     if (fallback) {
@@ -402,10 +408,7 @@ class TestBucketIndexSupport extends HoodieSparkClientTestBase with PredicateHel
 
   def exprFilePathAnswerCheck(bucketIndexSupport: BucketIndexSupport, exprRaw: String, expectResult: Set[String],
                               allFileStatus: Set[String], fallback: Boolean): Unit = {
-    val resolveExpr = HoodieCatalystExpressionUtils.resolveExpr(spark, exprRaw, structSchema)
-    val dummyExpressionHolder = HoodieDummyExpressionHolder(Seq(resolveExpr), resolveExpr.references.toSeq)
-    val optimizerPlan = spark.sessionState.optimizer.execute(dummyExpressionHolder)
-    val optimizerExpr = optimizerPlan.asInstanceOf[HoodieDummyExpressionHolder].exprs.head
+    val optimizerExpr = optimizeResolvedExpr(exprRaw)
 
     val bucketSet = bucketIndexSupport.filterQueriesWithBucketHashField(splitConjunctivePredicates(optimizerExpr))
     if (fallback) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionBucketIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionBucketIndexSupport.scala
@@ -17,7 +17,7 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{HoodieFileIndex, HoodieSparkUtils, PartitionBucketIndexSupport}
+import org.apache.hudi.{HoodieFileIndex, PartitionBucketIndexSupport}
 import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
 import org.apache.hudi.common.fs.FSUtils
 import org.apache.hudi.common.model.{FileSlice, HoodieBaseFile, PartitionBucketIndexHashingConfig}
@@ -31,7 +31,6 @@ import org.apache.hudi.storage.{StoragePath, StoragePathInfo}
 
 import org.apache.avro.generic.GenericData
 import org.apache.spark.sql.HoodieCatalystExpressionUtils
-import org.apache.spark.sql.catalyst.encoders.DummyExpressionHolder
 import org.junit.jupiter.api.{BeforeEach, Tag, Test}
 import org.mockito.Mockito
 
@@ -173,32 +172,31 @@ class TestPartitionBucketIndexSupport extends TestBucketIndexSupport {
 
   def exprFilePathAnswerCheck(bucketIndexSupport: PartitionBucketIndexSupport, exprRaw: String, expectResult: Set[String],
                               allFileStatus: Set[String]): Unit = {
-    if (!HoodieSparkUtils.gteqSpark4_0) { // TODO (HUDI-9403)
-      val resolveExpr = HoodieCatalystExpressionUtils.resolveExpr(spark, exprRaw, structSchema)
-      val optimizerPlan = spark.sessionState.optimizer.execute(DummyExpressionHolder(Seq(resolveExpr)))
-      val optimizerExpr = optimizerPlan.asInstanceOf[DummyExpressionHolder].exprs.head
+    val resolveExpr = HoodieCatalystExpressionUtils.resolveExpr(spark, exprRaw, structSchema)
+    val dummyExpressionHolder = HoodieDummyExpressionHolder(Seq(resolveExpr), resolveExpr.references.toSeq)
+    val optimizerPlan = spark.sessionState.optimizer.execute(dummyExpressionHolder)
+    val optimizerExpr = optimizerPlan.asInstanceOf[HoodieDummyExpressionHolder].exprs.head
 
-      // split input files into different partitions
-      val partitionPath1 = DEFAULT_PARTITION_PATH(0)
-      val allFileSlices1: Seq[FileSlice] = allFileStatus.slice(0, 3).map(fileName => {
-        val slice = new FileSlice(partitionPath1, "00000000000000000", FSUtils.getFileId(fileName))
-        slice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(new StoragePath(fileName), 0L, false, 0, 0, 0)))
-        slice
-      }).toSeq
+    // split input files into different partitions
+    val partitionPath1 = DEFAULT_PARTITION_PATH(0)
+    val allFileSlices1: Seq[FileSlice] = allFileStatus.slice(0, 3).map(fileName => {
+      val slice = new FileSlice(partitionPath1, "00000000000000000", FSUtils.getFileId(fileName))
+      slice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(new StoragePath(fileName), 0L, false, 0, 0, 0)))
+      slice
+    }).toSeq
 
-      val partitionPath2 = DEFAULT_PARTITION_PATH(1)
-      val allFileSlices2: Seq[FileSlice] = allFileStatus.slice(3, 5).map(fileName => {
-        val slice = new FileSlice(partitionPath1, "00000000000000000", FSUtils.getFileId(fileName))
-        slice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(new StoragePath(fileName), 0L, false, 0, 0, 0)))
-        slice
-      }).toSeq
+    val partitionPath2 = DEFAULT_PARTITION_PATH(1)
+    val allFileSlices2: Seq[FileSlice] = allFileStatus.slice(3, 5).map(fileName => {
+      val slice = new FileSlice(partitionPath1, "00000000000000000", FSUtils.getFileId(fileName))
+      slice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(new StoragePath(fileName), 0L, false, 0, 0, 0)))
+      slice
+    }).toSeq
 
-      val input = Seq((Option.apply(new BaseHoodieTableFileIndex.PartitionPath(partitionPath1, Array())), allFileSlices1),
-        (Option.apply(new BaseHoodieTableFileIndex.PartitionPath(partitionPath2, Array())), allFileSlices2))
-      val candidate = bucketIndexSupport.computeCandidateFileNames(fileIndex, splitConjunctivePredicates(optimizerExpr),
-        Seq(), input, false)
+    val input = Seq((Option.apply(new BaseHoodieTableFileIndex.PartitionPath(partitionPath1, Array())), allFileSlices1),
+      (Option.apply(new BaseHoodieTableFileIndex.PartitionPath(partitionPath2, Array())), allFileSlices2))
+    val candidate = bucketIndexSupport.computeCandidateFileNames(fileIndex, splitConjunctivePredicates(optimizerExpr),
+      Seq(), input, false)
 
-      assert(candidate.get.equals(expectResult))
-    }
+    assert(candidate.get.equals(expectResult))
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionBucketIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionBucketIndexSupport.scala
@@ -30,7 +30,6 @@ import org.apache.hudi.keygen.constant.KeyGeneratorOptions
 import org.apache.hudi.storage.{StoragePath, StoragePathInfo}
 
 import org.apache.avro.generic.GenericData
-import org.apache.spark.sql.HoodieCatalystExpressionUtils
 import org.junit.jupiter.api.{BeforeEach, Tag, Test}
 import org.mockito.Mockito
 
@@ -42,6 +41,8 @@ class TestPartitionBucketIndexSupport extends TestBucketIndexSupport {
   private val DEFAULT_EXPRESSIONS = "\\d{4}\\-(06\\-(01|17|18)|11\\-(01|10|11))," + EXPRESSION_BUCKET_NUMBER
   private val DEFAULT_BUCKET_NUMBER = 10
   private val DEFAULT_PARTITION_PATH = Array("2025-06-17", "2025-06-18")
+  // deliberately outside DEFAULT_EXPRESSIONS, so it hashes into DEFAULT_BUCKET_NUMBER buckets
+  private val NON_MATCHING_PARTITION_PATH = "2025-07-01"
   private var fileIndex: HoodieFileIndex = null
   @BeforeEach
   override def setUp(): Unit = {
@@ -110,8 +111,6 @@ class TestPartitionBucketIndexSupport extends TestBucketIndexSupport {
     exprFilePathAnswerCheck(bucketIndexSupport, equalTo, Set.apply(bucket5Id8FileName, bucket2Id5FileName), allFileNames)
     equalTo = "A = 5 And (A = 2 Or B = 'abc')"
     exprFilePathAnswerCheck(bucketIndexSupport, equalTo, Set.apply(bucket5Id8FileName), allFileNames)
-    equalTo = "A = 5 And (A = 2 Or B = 'abc')"
-    exprFilePathAnswerCheck(bucketIndexSupport, equalTo, Set.apply(bucket5Id8FileName), allFileNames)
   }
 
   @Test
@@ -170,33 +169,85 @@ class TestPartitionBucketIndexSupport extends TestBucketIndexSupport {
     exprFilePathAnswerCheck(bucketIndexSupport, equalTo, Set.apply(bucket4Id7FileName), allFileNames)
   }
 
+  /**
+   * Every partition used by the other tests matches the expression, so all of them carry the same
+   * bucket count and nothing there notices if a partition is hashed with the wrong one. Pair a
+   * partition the expression matches, which gets [[EXPRESSION_BUCKET_NUMBER]] buckets, with one it
+   * does not, which falls back to the table default, and check that a file is only a candidate
+   * under the bucket count belonging to its own partition.
+   */
+  @Test
+  def testCandidateFilesUsePerPartitionBucketCount(): Unit = {
+    val configProperties = new TypedProperties()
+    configProperties.setProperty(HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD.key, "A")
+    configProperties.setProperty(HoodieTableConfig.RECORDKEY_FIELDS.key, "A")
+    configProperties.setProperty(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key, "A")
+    configProperties.setProperty(HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key, String.valueOf(DEFAULT_BUCKET_NUMBER))
+    metaClient.getTableConfig.setValue(HoodieTableConfig.CREATE_SCHEMA.key(), avroSchemaStr)
+    val metadataConfig = HoodieMetadataConfig.newBuilder
+      .fromProperties(configProperties)
+      .enable(configProperties.getBoolean(HoodieMetadataConfig.ENABLE.key, true)).build()
+    val bucketIndexSupport = new PartitionBucketIndexSupport(spark, metadataConfig, metaClient)
+
+    val record = new GenericData.Record(schema.toAvroSchema)
+    record.put("A", "3")
+    val recordKey = new NonpartitionedKeyGenerator(configProperties).getKey(record).getRecordKey
+    val bucketIdInExpressionPartition = BucketIdentifier.getBucketId(recordKey, "A", EXPRESSION_BUCKET_NUMBER)
+    val bucketIdInDefaultPartition = BucketIdentifier.getBucketId(recordKey, "A", DEFAULT_BUCKET_NUMBER)
+    // the two bucket counts have to disagree for this record, otherwise the check below proves nothing
+    assert(bucketIdInExpressionPartition != bucketIdInDefaultPartition)
+
+    // the file id prefix carries a fresh uuid every call, so the same bucket can be named twice
+    def fileNameForBucket(bucketId: Int): String = FSUtils.makeBaseFileName("00000000000000000",
+      FSUtils.makeWriteToken(1, 0, 1), BucketIdentifier.newBucketFileIdPrefix(bucketId) + "-0",
+      HoodieTableConfig.BASE_FILE_FORMAT.defaultValue.getFileExtension)
+
+    val expressionPartition = DEFAULT_PARTITION_PATH(0)
+    val defaultPartition = NON_MATCHING_PARTITION_PATH
+    val expectedFromExpressionPartition = fileNameForBucket(bucketIdInExpressionPartition)
+    val expectedFromDefaultPartition = fileNameForBucket(bucketIdInDefaultPartition)
+    // same bucket as the matching partition's candidate, but sitting in the partition that hashes
+    // into the table default, so it must not be picked up
+    val decoyInDefaultPartition = fileNameForBucket(bucketIdInExpressionPartition)
+
+    val input = Seq(
+      (Option.apply(new BaseHoodieTableFileIndex.PartitionPath(expressionPartition, Array())),
+        fileSlicesOf(expressionPartition, Seq(expectedFromExpressionPartition))),
+      (Option.apply(new BaseHoodieTableFileIndex.PartitionPath(defaultPartition, Array())),
+        fileSlicesOf(defaultPartition, Seq(expectedFromDefaultPartition, decoyInDefaultPartition))))
+
+    val candidate = bucketIndexSupport.computeCandidateFileNames(fileIndex,
+      splitConjunctivePredicates(optimizeResolvedExpr("A = 3")), Seq(), input, false)
+
+    assert(candidate.get.equals(Set.apply(expectedFromExpressionPartition, expectedFromDefaultPartition)))
+  }
+
   def exprFilePathAnswerCheck(bucketIndexSupport: PartitionBucketIndexSupport, exprRaw: String, expectResult: Set[String],
                               allFileStatus: Set[String]): Unit = {
-    val resolveExpr = HoodieCatalystExpressionUtils.resolveExpr(spark, exprRaw, structSchema)
-    val dummyExpressionHolder = HoodieDummyExpressionHolder(Seq(resolveExpr), resolveExpr.references.toSeq)
-    val optimizerPlan = spark.sessionState.optimizer.execute(dummyExpressionHolder)
-    val optimizerExpr = optimizerPlan.asInstanceOf[HoodieDummyExpressionHolder].exprs.head
+    val optimizerExpr = optimizeResolvedExpr(exprRaw)
 
-    // split input files into different partitions
+    // Split the input files across two partitions. A Set iterates in element hash order, and these
+    // file names embed a fresh uuid on every run, so the unsorted split put different buckets in
+    // each partition from one run to the next. Sort first to pin the file to partition assignment.
+    val orderedFileNames = allFileStatus.toSeq.sorted
     val partitionPath1 = DEFAULT_PARTITION_PATH(0)
-    val allFileSlices1: Seq[FileSlice] = allFileStatus.slice(0, 3).map(fileName => {
-      val slice = new FileSlice(partitionPath1, "00000000000000000", FSUtils.getFileId(fileName))
-      slice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(new StoragePath(fileName), 0L, false, 0, 0, 0)))
-      slice
-    }).toSeq
-
     val partitionPath2 = DEFAULT_PARTITION_PATH(1)
-    val allFileSlices2: Seq[FileSlice] = allFileStatus.slice(3, 5).map(fileName => {
-      val slice = new FileSlice(partitionPath1, "00000000000000000", FSUtils.getFileId(fileName))
-      slice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(new StoragePath(fileName), 0L, false, 0, 0, 0)))
-      slice
-    }).toSeq
-
-    val input = Seq((Option.apply(new BaseHoodieTableFileIndex.PartitionPath(partitionPath1, Array())), allFileSlices1),
-      (Option.apply(new BaseHoodieTableFileIndex.PartitionPath(partitionPath2, Array())), allFileSlices2))
+    val input = Seq(
+      (Option.apply(new BaseHoodieTableFileIndex.PartitionPath(partitionPath1, Array())),
+        fileSlicesOf(partitionPath1, orderedFileNames.slice(0, 3))),
+      (Option.apply(new BaseHoodieTableFileIndex.PartitionPath(partitionPath2, Array())),
+        fileSlicesOf(partitionPath2, orderedFileNames.slice(3, 5))))
     val candidate = bucketIndexSupport.computeCandidateFileNames(fileIndex, splitConjunctivePredicates(optimizerExpr),
       Seq(), input, false)
 
     assert(candidate.get.equals(expectResult))
+  }
+
+  private def fileSlicesOf(partitionPath: String, fileNames: Seq[String]): Seq[FileSlice] = {
+    fileNames.map(fileName => {
+      val slice = new FileSlice(partitionPath, "00000000000000000", FSUtils.getFileId(fileName))
+      slice.setBaseFile(new HoodieBaseFile(new StoragePathInfo(new StoragePath(fileName), 0L, false, 0, 0, 0)))
+      slice
+    })
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #17007

`TestPartitionBucketIndexSupport.exprFilePathAnswerCheck` builds a throwaway logical plan so it can run the optimizer over a resolved expression. It used Spark's `DummyExpressionHolder`, which hardcodes `output` to `Nil`, so the attributes referenced by the expression appear nowhere in the plan's output. The validation rule added by SPARK-44219 rejects exactly that on Spark 4:

```
org.apache.spark.SparkException: [PLAN_VALIDATION_FAILED_RULE_EXECUTOR] The input plan of
org.apache.spark.sql.internal.BaseSessionStateBuilder$$anon$2 is invalid:
Aliases A#0L are dangling in the references for plan:
DummyExpressionHolder [(A#0L = cast(3 as bigint))]
```

Rather than being fixed, the whole method body was wrapped in `if (!HoodieSparkUtils.gteqSpark4_0) { // TODO (HUDI-9403) }`. On Spark 4 the method returned before asserting anything, so the eleven `exprFilePathAnswerCheck` calls across `testSingleHashFieldsExpression` and `testMultipleHashFieldsExpress` passed vacuously while the test reported green.

Both halves of that came from one commit: `76bb580ae149` (#12772, Spark 4 support) forked `HoodieDummyExpressionHolder` for the parent class and wrapped this subclass in the `gteqSpark4_0` guard at the same time. The fix has been sitting one class away for about ten months.

### Summary and Changelog

`TestBucketIndexSupport`, the parent class, already hit this and forked the holder for exactly this reason:

```scala
// SPARK-44219 added extra rule to validate expressions against its children's references to check if there are dangling references
// This is forked from Spark's [[DummyExpressionHolder]], which always set the output to Nil and would fail this test
case class HoodieDummyExpressionHolder(exprs: Seq[Expression], output: Seq[Attribute]) extends LeafNode
```

`TestPartitionBucketIndexSupport` extends `TestBucketIndexSupport`, so that holder is already in scope and no new class is needed.

- Use `HoodieDummyExpressionHolder(Seq(resolveExpr), resolveExpr.references.toSeq)` so the referenced attributes are part of the plan's output and the plan validates.
- Drop the `!gteqSpark4_0` guard so the assertions run on every Spark version.
- Remove the two imports that become unused (`DummyExpressionHolder`, `HoodieSparkUtils`).

Following review, in a second commit:

- Build the second partition's file slices with `partitionPath2` instead of `partitionPath1`. Inert today, because the candidate computation takes the partition from the tuple rather than from `FileSlice.getPartitionPath`, but a trap for the next change.
- Order the file names before splitting them across partitions. The bucket file id prefix carries a fresh uuid, so which bucket landed in which partition varied from run to run.
- Add `testCandidateFilesUsePerPartitionBucketCount`. Every partition used by the existing assertions matches the expression and therefore carries the same bucket count, so nothing exercised the per partition mapping that distinguishes `PartitionBucketIndexSupport` from its parent. The new case pairs `2025-06-17`, which the expression matches and which gets 19 buckets, with `2025-07-01`, which does not match and falls back to the table default of 10, and plants a decoy file in the default partition carrying the bucket id from the 19 bucket hashing. That file is only a candidate if the partition is hashed with the wrong count.
- Lift the expression holder setup into the parent as `optimizeResolvedExpr`. It was copied in three places, and one copy going stale is what left this suite skipped on Spark 4 to begin with.
- Drop the assertion that repeated `A = 5 And (A = 2 Or B = 'abc')` verbatim, in both classes.

Not included, deliberately: a fallback case pinning `bucketSet.isEmpty`. That assertion fails today because of #19487, where `PartitionBucketIndexSupport.computeCandidateFileNames` returns `Some(Set())` where the parent returns `Option.empty`, and asserting the current behaviour instead would bake that bug into the suite. It belongs in the change that fixes #19487, as its regression test.

Test-only change; no production code is touched.

### Impact

Restores real assertions for `PartitionBucketIndexSupport` on Spark 4, where they were being skipped, and closes the per partition bucket count gap those assertions never covered. No behaviour change on Spark 3.x, where the guard was already inactive.

### Risk Level

low

### Documentation Update

none

### Verification

| Configuration | Result |
| --- | --- |
| Spark 3.5 / Scala 2.12 | 4/4 pass (no regression) |
| Spark 4.0 / Scala 2.13, `SPARK_TESTING=1` | 4/4 pass |
| Spark 4.0 / Scala 2.13, `SPARK_TESTING=1`, with Spark's `DummyExpressionHolder` restored and the guard removed | fails with `PLAN_VALIDATION_FAILED_RULE_EXECUTOR`, matching the report |

The third row is the control: it confirms the assertions genuinely execute on Spark 4 now, rather than the test passing for the same reason it passed before.

After the review round, on Spark 3.5 / Scala 2.12:

| Check | Result |
| --- | --- |
| `TestPartitionBucketIndexSupport` | 5/5 pass |
| `TestBucketIndexSupport` (parent, edited here) | 4/4 pass |
| Control: point the non matching partition at `2025-06-01` so both partitions match the expression | exactly `testCandidateFilesUsePerPartitionBucketCount` fails, the other four pass |

That control is the point of the new case. The existing assertions all still pass if `computeNumBuckets` is hardcoded to return 19; this one does not.

Worth noting for anyone reproducing this: Spark gates plan change validation behind `Utils.isTesting`, so running this test on its own passes even with the broken holder. A full module run sets `spark.testing` through `HoodieSparkSqlTestBase`'s static initializer, and with `forkCount=1`/`reuseForks=true` that property is live process-wide for every subsequent test class. That is why the failure shows up in a suite run but not in isolation.

Commands used:

```bash
# Spark 3.5 / Scala 2.12
mvn test -Pfunctional-tests -Dspark3.5 -pl hudi-spark-datasource/hudi-spark \
  -Dtest=TestPartitionBucketIndexSupport,TestBucketIndexSupport

# Spark 4.0 / Scala 2.13
mvn clean install -Dscala-2.13 -Dspark4.0 -DskipTests=true -pl hudi-spark-datasource/hudi-spark -am
SPARK_TESTING=1 mvn test-compile surefire:test -Dscala-2.13 -Dspark4.0 \
  -pl hudi-spark-datasource/hudi-spark -Dtest=TestPartitionBucketIndexSupport
```

Note that these classes are Scala but JUnit 5, so they run under surefire; the `functional-tests` profile is needed because of `@Tag("functional")`, and it skips scalatest.

`scalastyle:check`, `checkstyle:check` and `apache-rat:check` pass on the module.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
