### PR TITLE
docs(metrics): note that CloudWatch needs hudi-aws-bundle on Spark

### DIFF
--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -133,6 +133,11 @@ In the absence of static AWS credentials being configured, `DefaultAWSCredential
 credentials by checking environment properties. Additional Amazon CloudWatch reporter specific properties that can be 
 tuned are in the `HoodieMetricsCloudWatchConfig` class.
 
+The reporter class ships in the optional `hudi-aws` module, which not every engine bundle shades:
+`hudi-spark-bundle` does not. If setting the reporter type to "CLOUDWATCH" fails because
+`org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter` cannot be loaded, add the
+`hudi-aws-bundle` jar matching your Hudi version to the classpath.
+
 ### UserDefinedMetricsReporter
 
 Allows users to define a custom metrics reporter.

--- a/website/versioned_docs/version-1.2.0/metrics.md
+++ b/website/versioned_docs/version-1.2.0/metrics.md
@@ -133,6 +133,11 @@ In the absence of static AWS credentials being configured, `DefaultAWSCredential
 credentials by checking environment properties. Additional Amazon CloudWatch reporter specific properties that can be 
 tuned are in the `HoodieMetricsCloudWatchConfig` class.
 
+The reporter class ships in the optional `hudi-aws` module, which not every engine bundle shades:
+`hudi-spark-bundle` does not. If setting the reporter type to "CLOUDWATCH" fails because
+`org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter` cannot be loaded, add the
+`hudi-aws-bundle` jar matching your Hudi version to the classpath.
+
 ### UserDefinedMetricsReporter
 
 Allows users to define a custom metrics reporter.


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19472.

The AWS CloudWatchReporter section of the metrics page explains how to enable the reporter and supply
credentials, but never says which artifact provides the reporter class. It ships in the optional
`hudi-aws` module, which `packaging/hudi-spark-bundle/pom.xml` does not shade (`hudi-flink-bundle` and
`hudi-kafka-connect-bundle` do), so a Spark user who follows the docs cannot load
`org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter` and has no way to know a second jar
is needed.

### Summary and Changelog

Adds one short paragraph to the AWS CloudWatchReporter section naming the `hudi-aws` module, the fact
that not every engine bundle shades it, and the `hudi-aws-bundle` remedy.

Applied to `website/docs/metrics.md` (next) and `website/versioned_docs/version-1.2.0/metrics.md`
(the current released docs). The nine older versioned copies have the same gap and were left alone,
per the usual next-plus-current convention -- happy to widen if preferred.

### Relationship to apache/hudi#19418

Two halves of #15293. #19418 fixes the runtime failure, turning an unactionable `Unable to load class`
into an error naming the missing class and the bundle to add. This one is prevention: a user who reads
the docs first never reaches that error. The two are independent and can merge in either order.

### Impact

Documentation only. No code, config, or behaviour change.

### Risk Level

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
