### PR TITLE
fix(spark): keep to_date/to_timestamp data skipping working after ReplaceExpressions

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/BaseHoodieCatalystExpressionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/BaseHoodieCatalystExpressionUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.HoodieSparkTypeUtils.isCastPreservingOrdering
-import org.apache.spark.sql.catalyst.expressions.{Add, Attribute, AttributeReference, AttributeSet, BitwiseOr, Cast, DateAdd, DateDiff, DateFormatClass, DateSub, Divide, Exp, Expm1, Expression, FromUnixTime, FromUTCTimestamp, Log, Log10, Log1p, Log2, Lower, Multiply, PredicateHelper, ShiftLeft, ShiftRight, ToUnixTimestamp, ToUTCTimestamp, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Add, Attribute, AttributeReference, AttributeSet, BitwiseOr, Cast, DateAdd, DateDiff, DateFormatClass, DateSub, Divide, Exp, Expm1, Expression, FromUnixTime, FromUTCTimestamp, GetTimestamp, Log, Log10, Log1p, Log2, Lower, Multiply, PredicateHelper, ShiftLeft, ShiftRight, ToUnixTimestamp, ToUTCTimestamp, Upper}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.types.DataType
 
@@ -53,7 +53,11 @@ abstract class BaseHoodieCatalystExpressionUtils extends HoodieCatalystExpressio
    * Matches order-preserving date/time parsing expressions whose case-class shapes differ across
    * Spark versions (currently [[org.apache.spark.sql.catalyst.expressions.ParseToDate]] and
    * [[org.apache.spark.sql.catalyst.expressions.ParseToTimestamp]]), returning the source child
-   * expression that the order-preserving transformation matching should recurse into
+   * expression that the order-preserving transformation matching should recurse into.
+   *
+   * These are the pre-ReplaceExpressions (analysis-time) shapes, still inspected by the
+   * expression-index and partition-stats paths; the post-replacement [[GetTimestamp]] shape
+   * seen on the read path is matched directly in [[OrderPreservingTransformation]]
    */
   protected def unapplyOrderPreservingDateParsing(expr: Expression): Option[Expression]
 
@@ -70,6 +74,12 @@ abstract class BaseHoodieCatalystExpressionUtils extends HoodieCatalystExpressio
         case FromUTCTimestamp(OrderPreservingTransformation(attrRef), _) => Some(attrRef)
         case ToUnixTimestamp(OrderPreservingTransformation(attrRef), _, _, _) => Some(attrRef)
         case ToUTCTimestamp(OrderPreservingTransformation(attrRef), _) => Some(attrRef)
+        // Post-ReplaceExpressions shape of to_date/to_timestamp with an explicit format:
+        // since SPARK-38240 the optimizer rewrites those RuntimeReplaceable nodes into
+        // GetTimestamp(source, fmt) (Cast-wrapped to date for to_date) before filters
+        // reach file pruning. GetTimestamp's constructor arity differs across Spark
+        // versions but its left() accessor is stable, hence the typed match
+        case gt: GetTimestamp => unapply(gt.left)
 
         // String Expressions
         case Lower(OrderPreservingTransformation(attrRef)) => Some(attrRef)

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/BaseHoodieCatalystExpressionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/BaseHoodieCatalystExpressionUtils.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.HoodieSparkTypeUtils.isCastPreservingOrdering
-import org.apache.spark.sql.catalyst.expressions.{Add, Attribute, AttributeReference, AttributeSet, BitwiseOr, Cast, DateAdd, DateDiff, DateFormatClass, DateSub, Divide, Exp, Expm1, Expression, FromUnixTime, FromUTCTimestamp, GetTimestamp, Log, Log10, Log1p, Log2, Lower, Multiply, PredicateHelper, ShiftLeft, ShiftRight, ToUnixTimestamp, ToUTCTimestamp, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Add, Attribute, AttributeReference, AttributeSet, BitwiseOr, Cast, DateAdd, DateDiff, DateFormatClass, DateSub, Divide, Exp, Expm1, Expression, FromUnixTime, FromUTCTimestamp, GetTimestamp, Literal, Log, Log10, Log1p, Log2, Lower, Multiply, PredicateHelper, ShiftLeft, ShiftRight, ToUnixTimestamp, ToUTCTimestamp, Upper}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{DataType, StringType}
 
 /**
  * Base implementation of [[HoodieCatalystExpressionUtils]] carrying the method bodies that are
@@ -50,16 +50,31 @@ abstract class BaseHoodieCatalystExpressionUtils extends HoodieCatalystExpressio
     Cast.canUpCast(fromType, toType)
 
   /**
-   * Matches order-preserving date/time parsing expressions whose case-class shapes differ across
-   * Spark versions (currently [[org.apache.spark.sql.catalyst.expressions.ParseToDate]] and
-   * [[org.apache.spark.sql.catalyst.expressions.ParseToTimestamp]]), returning the source child
-   * expression that the order-preserving transformation matching should recurse into.
-   *
-   * These are the pre-ReplaceExpressions (analysis-time) shapes, still inspected by the
-   * expression-index and partition-stats paths; the post-replacement [[GetTimestamp]] shape
-   * seen on the read path is matched directly in [[OrderPreservingTransformation]]
+   * Date/time format patterns for which lexicographic ordering of the formatted strings
+   * coincides with the chronological ordering of the values they parse to: fixed-width,
+   * year-first patterns. Only these make it sound to re-apply a string-to-date/timestamp
+   * parse on top of string min/max column stats (see [[OrderPreservingTransformation]]).
    */
-  protected def unapplyOrderPreservingDateParsing(expr: Expression): Option[Expression]
+  private val ORDER_PRESERVING_DATE_FORMATS: Set[String] = Set(
+    "yyyy",
+    "yyyy-MM",
+    "yyyy-MM-dd",
+    "yyyy-MM-dd HH",
+    "yyyy-MM-dd HH:mm",
+    "yyyy-MM-dd HH:mm:ss",
+    "yyyy-MM-dd HH:mm:ss.SSS",
+    "yyyy-MM-dd'T'HH:mm:ss",
+    "yyyy-MM-dd'T'HH:mm:ss.SSS",
+    "yyyyMMdd",
+    "yyyyMMddHHmmss",
+    "yyyy/MM/dd",
+    "yyyy/MM/dd HH:mm:ss")
+
+  private def isOrderPreservingDateFormat(fmt: Expression): Boolean =
+    fmt match {
+      case Literal(value, StringType) if value != null => ORDER_PRESERVING_DATE_FORMATS.contains(value.toString)
+      case _ => false
+    }
 
   private object OrderPreservingTransformation {
     def unapply(expr: Expression): Option[AttributeReference] = {
@@ -74,12 +89,21 @@ abstract class BaseHoodieCatalystExpressionUtils extends HoodieCatalystExpressio
         case FromUTCTimestamp(OrderPreservingTransformation(attrRef), _) => Some(attrRef)
         case ToUnixTimestamp(OrderPreservingTransformation(attrRef), _, _, _) => Some(attrRef)
         case ToUTCTimestamp(OrderPreservingTransformation(attrRef), _) => Some(attrRef)
-        // Post-ReplaceExpressions shape of to_date/to_timestamp with an explicit format:
-        // since SPARK-38240 the optimizer rewrites those RuntimeReplaceable nodes into
-        // GetTimestamp(source, fmt) (Cast-wrapped to date for to_date) before filters
-        // reach file pruning. GetTimestamp's constructor arity differs across Spark
-        // versions but its left() accessor is stable, hence the typed match
-        case gt: GetTimestamp => unapply(gt.left)
+        // Post-ReplaceExpressions shape of to_date/to_timestamp with an explicit format: since
+        // SPARK-38240 the optimizer rewrites those RuntimeReplaceable nodes into
+        // GetTimestamp(source, fmt) (Cast-wrapped to date for to_date) before filters reach
+        // file pruning. Matched only when
+        //   (a) the format is a literal, fixed-width, year-first pattern: the translation
+        //       re-applies the parse on top of string min/max column stats, which is only
+        //       sound when lexicographic ordering of parseable strings agrees with
+        //       chronological ordering, and
+        //   (b) failOnError is false (non-ANSI), so probing a stat value that does not parse
+        //       can never throw from the index lookup; it yields null instead, which the
+        //       null-tolerant bounds in DataSkippingUtils turn into "keep the file".
+        // GetTimestamp's constructor arity differs across Spark versions but its left()/right()
+        // accessors are stable, hence the typed match
+        case gt: GetTimestamp if !gt.failOnError && isOrderPreservingDateFormat(gt.right) =>
+          unapply(gt.left)
 
         // String Expressions
         case Lower(OrderPreservingTransformation(attrRef)) => Some(attrRef)
@@ -113,11 +137,7 @@ abstract class BaseHoodieCatalystExpressionUtils extends HoodieCatalystExpressio
 
         // Identity transformation
         case attrRef: AttributeReference => Some(attrRef)
-        // Date/time parsing expressions whose shapes are Spark-version-specific
-        case _ => unapplyOrderPreservingDateParsing(expr) match {
-          case Some(child) => unapply(child)
-          case None => None
-        }
+        case _ => None
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/DataSkippingUtils.scala
@@ -25,7 +25,7 @@ import org.apache.hudi.common.util.ValidationUtils.checkState
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, HoodieCatalystExpressionUtils}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, EqualNullSafe, EqualTo, Expression, ExtractValue, GetStructField, GreaterThan, GreaterThanOrEqual, In, InSet, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, Not, Or, StartsWith, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, Coalesce, EqualNullSafe, EqualTo, Expression, ExtractValue, GetStructField, GreaterThan, GreaterThanOrEqual, In, InSet, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, Not, Or, StartsWith, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.hudi.ColumnStatsExpressionUtils._
@@ -124,7 +124,7 @@ object DataSkippingUtils extends Logging {
             //       [[AttributeReference]] referring to the Data Table, and swap it w/ expression referring to
             //       corresponding column in the Column Stats Index
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            genColumnValuesEqualToExpression(colName, valueExpr, targetExprBuilder)
+            wrapTransformedBoundNullSafe(sourceExpr, genColumnValuesEqualToExpression(colName, valueExpr, targetExprBuilder))
           }.orElse({
           Option.empty
         })
@@ -133,7 +133,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            genColumnValuesEqualToExpression(colName, valueExpr, targetExprBuilder)
+            wrapTransformedBoundNullSafe(sourceExpr, genColumnValuesEqualToExpression(colName, valueExpr, targetExprBuilder))
           }.orElse({
           Option.empty
         })
@@ -146,7 +146,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            Not(genColumnOnlyValuesEqualToExpression(colName, value, targetExprBuilder))
+            wrapTransformedBoundNullSafe(sourceExpr, Not(genColumnOnlyValuesEqualToExpression(colName, value, targetExprBuilder)))
           }.orElse({
           Option.empty
         })
@@ -155,7 +155,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            Not(genColumnOnlyValuesEqualToExpression(colName, value, targetExprBuilder))
+            wrapTransformedBoundNullSafe(sourceExpr, Not(genColumnOnlyValuesEqualToExpression(colName, value, targetExprBuilder)))
           }.orElse({
           Option.empty
         })
@@ -175,7 +175,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value)
+            wrapTransformedBoundNullSafe(sourceExpr, LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value))
           }.orElse({
           Option.empty
         })
@@ -184,7 +184,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
               val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-              LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value)
+              wrapTransformedBoundNullSafe(sourceExpr, LessThan(targetExprBuilder.apply(genColMinValueExpr(colName)), value))
           }.orElse({
           Option.empty
         })
@@ -195,7 +195,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value)
+            wrapTransformedBoundNullSafe(sourceExpr, GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value))
           }.orElse({
           Option.empty
         })
@@ -204,7 +204,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value)
+            wrapTransformedBoundNullSafe(sourceExpr, GreaterThan(targetExprBuilder.apply(genColMaxValueExpr(colName)), value))
           }.orElse({
           Option.empty
         })
@@ -215,7 +215,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value)
+            wrapTransformedBoundNullSafe(sourceExpr, LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value))
           }.orElse({
           Option.empty
         })
@@ -224,7 +224,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value)
+            wrapTransformedBoundNullSafe(sourceExpr, LessThanOrEqual(targetExprBuilder.apply(genColMinValueExpr(colName)), value))
           }.orElse({
           Option.empty
         })
@@ -235,7 +235,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value)
+            wrapTransformedBoundNullSafe(sourceExpr, GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value))
           }.orElse({
           Option.empty
         })
@@ -244,7 +244,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value)
+            wrapTransformedBoundNullSafe(sourceExpr, GreaterThanOrEqual(targetExprBuilder.apply(genColMaxValueExpr(colName)), value))
           }.orElse({
           Option.empty
         })
@@ -280,7 +280,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            list.map(lit => genColumnValuesEqualToExpression(colName, lit, targetExprBuilder)).reduce(Or)
+            wrapTransformedBoundNullSafe(sourceExpr, list.map(lit => genColumnValuesEqualToExpression(colName, lit, targetExprBuilder)).reduce(Or))
           }.orElse({
           Option.empty
         })
@@ -292,7 +292,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            hset.map { value =>
+            val bound = hset.map { value =>
               // NOTE: [[Literal]] has a gap where it could hold [[UTF8String]], but [[Literal#apply]] doesn't
               //       accept [[UTF8String]]. As such we have to handle it separately
               val lit = value match {
@@ -301,6 +301,7 @@ object DataSkippingUtils extends Logging {
               }
               genColumnValuesEqualToExpression(colName, lit, targetExprBuilder)
             }.reduce(Or)
+            wrapTransformedBoundNullSafe(sourceExpr, bound)
           }.orElse({
           Option.empty
         })
@@ -312,7 +313,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            Not(list.map(lit => genColumnOnlyValuesEqualToExpression(colName, lit, targetExprBuilder)).reduce(Or))
+            wrapTransformedBoundNullSafe(sourceExpr, Not(list.map(lit => genColumnOnlyValuesEqualToExpression(colName, lit, targetExprBuilder)).reduce(Or)))
           }.orElse({
           Option.empty
         })
@@ -327,7 +328,7 @@ object DataSkippingUtils extends Logging {
         getTargetIndexedColumnName(attrRef, indexedCols)
           .map { colName =>
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
-            genColumnValuesEqualToExpression(colName, v, targetExprBuilder)
+            wrapTransformedBoundNullSafe(sourceExpr, genColumnValuesEqualToExpression(colName, v, targetExprBuilder))
           }.orElse({
           Option.empty
         })
@@ -341,7 +342,7 @@ object DataSkippingUtils extends Logging {
             val targetExprBuilder: Expression => Expression = swapAttributeRefInExpr(sourceExpr, attrRef, _)
             val minValueExpr = targetExprBuilder.apply(genColMinValueExpr(colName))
             val maxValueExpr = targetExprBuilder.apply(genColMaxValueExpr(colName))
-            Not(And(StartsWith(minValueExpr, value), StartsWith(maxValueExpr, value)))
+            wrapTransformedBoundNullSafe(sourceExpr, Not(And(StartsWith(minValueExpr, value), StartsWith(maxValueExpr, value))))
           }.orElse({
           Option.empty
         })
@@ -389,6 +390,24 @@ object DataSkippingUtils extends Logging {
       case _: Expression => None
     }
   }
+
+  /**
+   * Wraps a translated index-lookup bound in a null-tolerant guard when the source expression is
+   * an actual transformation of the column (not a bare attribute reference).
+   *
+   * Whitelisted transformations may be partial functions of the source column (for example
+   * GetTimestamp parsing a string): re-applied on top of a min/max stat value that the function
+   * is undefined for, they return null, in which case f(max(col)) != max(f(col)) and the bound
+   * cannot be decided. A null bound must keep the file (hence Coalesce to true) rather than
+   * silently prune it. A false bound may still prune: each one-sided bound is independently
+   * valid whenever its own stat value is defined (for example "null AND false" evaluates to
+   * false, which is still sound).
+   */
+  private def wrapTransformedBoundNullSafe(sourceExpr: Expression, bound: Expression): Expression =
+    sourceExpr match {
+      case _: AttributeReference => bound
+      case _ => Coalesce(Seq(bound, TrueLiteral))
+    }
 
   private def getTargetIndexedColumnName(resolvedExpr: AttributeReference, indexedCols: Seq[String]): Option[String] = {
     val colName = UnresolvedAttribute(getTargetColNameParts(resolvedExpr)).name

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
@@ -19,22 +19,22 @@ package org.apache.hudi
 
 import org.apache.hudi.ColumnStatsIndexSupport.composeIndexSchema
 import org.apache.hudi.SparkAdapterSupport.sparkAdapter
-import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.testutils.{HoodieDummyExpressionHolder, HoodieSparkClientTestBase}
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.HoodieCatalystExpressionUtils.resolveExpr
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.encoders.DummyExpressionHolder
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, InSet, Not, ParseToDate, ParseToTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{Expression, InSet, Not, ParseToDate, ParseToTimestamp}
 import org.apache.spark.sql.catalyst.optimizer.OptimizeIn
-import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.functions.{col, lower}
 import org.apache.spark.sql.hudi.DataSkippingUtils
-import org.apache.spark.sql.internal.SQLConf.SESSION_LOCAL_TIMEZONE
+import org.apache.spark.sql.internal.SQLConf.{ANSI_ENABLED, SESSION_LOCAL_TIMEZONE}
 import org.apache.spark.sql.types._
+import org.junit.jupiter.api.{BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -63,13 +63,6 @@ case class IndexRow(fileName: String,
                     C_maxValue: Timestamp = null,
                     C_nullCount: java.lang.Long = null) {
   def toRow: Row = Row(productIterator.toSeq: _*)
-}
-
-// SPARK-44219 validates optimizer rule changes against dangling expression references, which
-// Spark's own [[DummyExpressionHolder]] (output = Nil) fails when run through the full
-// optimizer. Forked from Spark, same as in [[org.apache.hudi.functional.TestBucketIndexSupport]]
-case class HoodieDummyExpressionHolder(exprs: Seq[Expression], output: Seq[Attribute]) extends LeafNode {
-  override lazy val resolved = true
 }
 
 class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterSupport {
@@ -151,7 +144,7 @@ class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterS
 
 
   @ParameterizedTest
-  @MethodSource(Array("testDateParsingFilterExprsAfterReplaceExpressionsSource"))
+  @MethodSource(Array("testDateParsingFilterExpressionsAfterReplaceExpressionsSource"))
   def testLookupFilterExpressionsAfterReplaceExpressions(sourceFilterExprStr: String,
                                                          input: Seq[IndexRow],
                                                          expectedOutput: Seq[String]): Unit = {
@@ -159,22 +152,58 @@ class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterS
     // is consistent with the fixtures
     spark.sqlContext.setConf(SESSION_LOCAL_TIMEZONE.key, "UTC")
 
-    val resolvedFilterExpr: Expression = resolveExpr(spark, sourceFilterExprStr, sourceTableSchema)
-    val optimizedFilterExpr = fullyOptimize(resolvedFilterExpr)
+    // Pin ANSI off so the replaced GetTimestamp carries failOnError = false on every profile
+    // (ANSI is the default on Spark 4); the ANSI-on behavior is covered by
+    // testDateParsingLookupUnderAnsiMode
+    val previousAnsi = spark.sqlContext.getConf(ANSI_ENABLED.key)
+    spark.sqlContext.setConf(ANSI_ENABLED.key, "false")
+    try {
+      val resolvedFilterExpr: Expression = resolveExpr(spark, sourceFilterExprStr, sourceTableSchema)
+      val optimizedFilterExpr = fullyOptimize(resolvedFilterExpr)
 
-    // On the real read path the optimizer's FinishAnalysis batch (ReplaceExpressions) rewrites
-    // RuntimeReplaceable to_date/to_timestamp before any filter reaches Hudi's file pruning, so
-    // the translation must be exercised against the replaced shape
-    assertTrue(
-      optimizedFilterExpr.collectFirst {
-        case p: ParseToDate => p
-        case p: ParseToTimestamp => p
-      }.isEmpty,
-      s"Expected ReplaceExpressions to rewrite RuntimeReplaceable date parsing nodes, got: $optimizedFilterExpr")
+      // On the real read path the optimizer's FinishAnalysis batch (ReplaceExpressions) rewrites
+      // RuntimeReplaceable to_date/to_timestamp before any filter reaches Hudi's file pruning, so
+      // the translation must be exercised against the replaced shape
+      assertTrue(
+        optimizedFilterExpr.collectFirst {
+          case p: ParseToDate => p
+          case p: ParseToTimestamp => p
+        }.isEmpty,
+        s"Expected ReplaceExpressions to rewrite RuntimeReplaceable date parsing nodes, got: $optimizedFilterExpr")
 
-    val rows: Seq[String] = applyFilterExpr(optimizedFilterExpr, input)
+      val rows: Seq[String] = applyFilterExpr(optimizedFilterExpr, input)
 
-    assertEquals(expectedOutput, rows)
+      assertEquals(expectedOutput, rows)
+    } finally {
+      spark.sqlContext.setConf(ANSI_ENABLED.key, previousAnsi)
+    }
+  }
+
+  @Test
+  def testDateParsingLookupUnderAnsiMode(): Unit = {
+    spark.sqlContext.setConf(SESSION_LOCAL_TIMEZONE.key, "UTC")
+
+    // Under ANSI mode the replaced GetTimestamp carries failOnError = true: probing string
+    // min/max stats with a throwing parse could fail queries whose files are pruned away by
+    // other predicates, or whose stats hold unparseable values like 'zzz'. The whitelist arm
+    // must therefore refuse to match, translation must fall back to keeping every file, and
+    // the lookup must not throw
+    val input = Seq(
+      IndexRow("file_mixed", valueCount = 2,
+        B_minValue = "2022-03-07",
+        B_maxValue = "zzz",
+        B_nullCount = 0)
+    )
+    val previousAnsi = spark.sqlContext.getConf(ANSI_ENABLED.key)
+    spark.sqlContext.setConf(ANSI_ENABLED.key, "true")
+    try {
+      val resolvedFilterExpr: Expression =
+        resolveExpr(spark, "to_timestamp(B, 'yyyy-MM-dd') > '2022-03-06 12:00:00'", sourceTableSchema)
+      val optimizedFilterExpr = fullyOptimize(resolvedFilterExpr)
+      assertEquals(Seq("file_mixed"), applyFilterExpr(optimizedFilterExpr, input))
+    } finally {
+      spark.sqlContext.setConf(ANSI_ENABLED.key, previousAnsi)
+    }
   }
 
   private def fullyOptimize(expr: Expression): Expression = {
@@ -712,26 +741,15 @@ object TestDataSkippingUtils {
             C_maxValue = new Timestamp(1646625048000L), // 03/07/2022
             C_nullCount = 0)
         ),
-        Seq("file_1")),
-      arguments(
-        // Should be identical to the one above
-        "date_format(to_timestamp(B, 'yyyy-MM-dd'), 'MM/dd/yyyy') NOT IN ('03/06/2022')",
-        Seq(
-          IndexRow("file_1", valueCount = 1,
-            B_minValue = "2022-03-07", // 03/07/2022
-            B_maxValue = "2022-03-08", // 03/08/2022
-            B_nullCount = 0),
-          IndexRow("file_2", valueCount = 1,
-            B_minValue = "2022-03-06", // 03/06/2022
-            B_maxValue = "2022-03-06", // 03/06/2022
-            B_nullCount = 0)
-        ),
         Seq("file_1"))
-
+      // NOTE: The analysis-time to_timestamp(B, fmt) composite that used to live here moved to
+      //       testDateParsingFilterExpressionsAfterReplaceExpressionsSource: on the real read
+      //       path the optimizer always rewrites ParseToTimestamp before Hudi sees the filter,
+      //       so only the replaced shape is worth pinning
     )
   }
 
-  def testDateParsingFilterExprsAfterReplaceExpressionsSource(): java.util.stream.Stream[Arguments] = {
+  def testDateParsingFilterExpressionsAfterReplaceExpressionsSource(): java.util.stream.Stream[Arguments] = {
     // NOTE: All timestamps in UTC. Column B holds 'yyyy-MM-dd' formatted strings, for which
     //       lexicographic ordering coincides with chronological ordering
     val input = Seq(
@@ -744,22 +762,61 @@ object TestDataSkippingUtils {
         B_maxValue = "2022-03-06",
         B_nullCount = 0)
     )
+    // US-format strings: the lexicographic min/max ('03/06/2022' / '12/31/2021') do NOT
+    // correspond to the chronologically smallest/largest values
+    val inputUsFormat = Seq(
+      IndexRow("file_us", valueCount = 2,
+        B_minValue = "03/06/2022",
+        B_maxValue = "12/31/2021",
+        B_nullCount = 0)
+    )
+    // Variable-width year-first strings: '2022-11-5' < '2022-3-6' lexicographically even though
+    // it is the chronologically larger value
+    val inputVariableWidth = Seq(
+      IndexRow("file_slop", valueCount = 2,
+        B_minValue = "2022-11-5",
+        B_maxValue = "2022-3-6",
+        B_nullCount = 0)
+    )
+    // The lexicographic max 'zzz' does not parse; the file still holds a parseable matching value
+    val inputUnparseableMax = Seq(
+      IndexRow("file_mixed", valueCount = 2,
+        B_minValue = "2022-03-07",
+        B_maxValue = "zzz",
+        B_nullCount = 0)
+    )
     java.util.stream.Stream.of(
-      // to_date(B) is replaced with Cast(B as date), which the Cast whitelist arm handles
+      // to_date(B) is replaced with Cast(B as date), which the pre-existing Cast whitelist arm
+      // already handled (kept as a regression pin; does not exercise the GetTimestamp arm)
       arguments("to_date(B) > '2022-03-06'", input, Seq("file_1")),
-      // to_date(B, fmt) is replaced with Cast(GetTimestamp(B, fmt) as date); the GetTimestamp
-      // whitelist arm recurses through it back to B
+      // to_date(B, fmt) is replaced with Cast(GetTimestamp(B, fmt) as date), but the optimizer
+      // then folds the outer cast-to-date into the comparison bound, so the matcher sees a bare
+      // GetTimestamp here; see the date_add case below for a shape that retains the cast
       arguments("to_date(B, 'yyyy-MM-dd') > '2022-03-06'", input, Seq("file_1")),
       arguments("to_date(B, 'yyyy-MM-dd') = '2022-03-08'", input, Seq("file_1")),
-      // to_timestamp(B) is replaced with Cast(B as timestamp), which the Cast whitelist arm handles
+      // to_timestamp(B) is replaced with Cast(B as timestamp), which the pre-existing Cast
+      // whitelist arm already handled (regression pin, same as to_date(B) above)
       arguments("to_timestamp(B) > '2022-03-06 12:00:00'", input, Seq("file_1")),
       // to_timestamp(B, fmt) is replaced with a bare GetTimestamp(B, fmt)
       arguments("to_timestamp(B, 'yyyy-MM-dd') > '2022-03-06 12:00:00'", input, Seq("file_1")),
+      // The only optimized shape that retains Cast(GetTimestamp(...) as date): the matcher must
+      // recurse through date_add, the cast and the timestamp parse back to B
+      arguments("date_add(to_date(B, 'yyyy-MM-dd'), 1) > '2022-03-07'", input, Seq("file_1")),
       // Same composite as in testCompositeFilterExpressionsSource, but under the real optimizer
       // ReplaceExpressions rewrites to_timestamp and OptimizeIn turns the single-element NOT IN
-      // into Not(EqualTo(...)); pruning must match the OptimizeIn-only variant above
+      // into Not(EqualTo(...))
       arguments("date_format(to_timestamp(B, 'yyyy-MM-dd'), 'MM/dd/yyyy') NOT IN ('03/06/2022')",
-        input, Seq("file_1"))
+        input, Seq("file_1")),
+      // Non-order-preserving format: the whitelist arm must reject 'MM/dd/yyyy' and translation
+      // must fall back to keeping every file (safe, not smart). Pruning on the lexicographic
+      // min/max of US-format strings would wrongly drop file_us, which contains 2022-03-06
+      arguments("to_date(B, 'MM/dd/yyyy') = '2022-03-06'", inputUsFormat, Seq("file_us")),
+      // Variable-width year-first format: equally order-breaking, equally rejected
+      arguments("to_date(B, 'yyyy-M-d') = '2022-11-05'", inputVariableWidth, Seq("file_slop")),
+      // Unparseable stat value: GetTimestamp('zzz', 'yyyy-MM-dd') is null, and the null-tolerant
+      // bounds (Coalesce(bound, true)) must keep the file -- it holds 2022-03-07, which matches
+      arguments("to_timestamp(B, 'yyyy-MM-dd') > '2022-03-06 12:00:00'", inputUnparseableMax,
+        Seq("file_mixed"))
     )
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
@@ -747,19 +747,19 @@ object TestDataSkippingUtils {
     java.util.stream.Stream.of(
       // to_date(B) is replaced with Cast(B as date), which the Cast whitelist arm handles
       arguments("to_date(B) > '2022-03-06'", input, Seq("file_1")),
-      // to_date(B, fmt) is replaced with Cast(GetTimestamp(B, fmt) as date); GetTimestamp is
-      // not matched by the order-preserving whitelist, so data skipping silently no-ops (#19446)
-      arguments("to_date(B, 'yyyy-MM-dd') > '2022-03-06'", input, Seq("file_1", "file_2")),
-      arguments("to_date(B, 'yyyy-MM-dd') = '2022-03-08'", input, Seq("file_1", "file_2")),
+      // to_date(B, fmt) is replaced with Cast(GetTimestamp(B, fmt) as date); the GetTimestamp
+      // whitelist arm recurses through it back to B
+      arguments("to_date(B, 'yyyy-MM-dd') > '2022-03-06'", input, Seq("file_1")),
+      arguments("to_date(B, 'yyyy-MM-dd') = '2022-03-08'", input, Seq("file_1")),
       // to_timestamp(B) is replaced with Cast(B as timestamp), which the Cast whitelist arm handles
       arguments("to_timestamp(B) > '2022-03-06 12:00:00'", input, Seq("file_1")),
-      // to_timestamp(B, fmt) is replaced with a bare GetTimestamp(B, fmt): same no-op as above
-      arguments("to_timestamp(B, 'yyyy-MM-dd') > '2022-03-06 12:00:00'", input, Seq("file_1", "file_2")),
+      // to_timestamp(B, fmt) is replaced with a bare GetTimestamp(B, fmt)
+      arguments("to_timestamp(B, 'yyyy-MM-dd') > '2022-03-06 12:00:00'", input, Seq("file_1")),
       // Same composite as in testCompositeFilterExpressionsSource, but under the real optimizer
       // ReplaceExpressions rewrites to_timestamp and OptimizeIn turns the single-element NOT IN
-      // into Not(EqualTo(...)): the pruning seen there is silently lost on the real read path
+      // into Not(EqualTo(...)); pruning must match the OptimizeIn-only variant above
       arguments("date_format(to_timestamp(B, 'yyyy-MM-dd'), 'MM/dd/yyyy') NOT IN ('03/06/2022')",
-        input, Seq("file_1", "file_2"))
+        input, Seq("file_1"))
     )
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestDataSkippingUtils.scala
@@ -25,15 +25,15 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.HoodieCatalystExpressionUtils.resolveExpr
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.encoders.DummyExpressionHolder
-import org.apache.spark.sql.catalyst.expressions.{Expression, InSet, Not}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, InSet, Not, ParseToDate, ParseToTimestamp}
 import org.apache.spark.sql.catalyst.optimizer.OptimizeIn
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.functions.{col, lower}
 import org.apache.spark.sql.hudi.DataSkippingUtils
 import org.apache.spark.sql.internal.SQLConf.SESSION_LOCAL_TIMEZONE
 import org.apache.spark.sql.types._
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
@@ -63,6 +63,13 @@ case class IndexRow(fileName: String,
                     C_maxValue: Timestamp = null,
                     C_nullCount: java.lang.Long = null) {
   def toRow: Row = Row(productIterator.toSeq: _*)
+}
+
+// SPARK-44219 validates optimizer rule changes against dangling expression references, which
+// Spark's own [[DummyExpressionHolder]] (output = Nil) fails when run through the full
+// optimizer. Forked from Spark, same as in [[org.apache.hudi.functional.TestBucketIndexSupport]]
+case class HoodieDummyExpressionHolder(exprs: Seq[Expression], output: Seq[Attribute]) extends LeafNode {
+  override lazy val resolved = true
 }
 
 class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterSupport {
@@ -142,6 +149,40 @@ class TestDataSkippingUtils extends HoodieSparkClientTestBase with SparkAdapterS
     assertEquals(output, rows)
   }
 
+
+  @ParameterizedTest
+  @MethodSource(Array("testDateParsingFilterExprsAfterReplaceExpressionsSource"))
+  def testLookupFilterExpressionsAfterReplaceExpressions(sourceFilterExprStr: String,
+                                                         input: Seq[IndexRow],
+                                                         expectedOutput: Seq[String]): Unit = {
+    // We have to fix the timezone to make sure all date-bound utilities output
+    // is consistent with the fixtures
+    spark.sqlContext.setConf(SESSION_LOCAL_TIMEZONE.key, "UTC")
+
+    val resolvedFilterExpr: Expression = resolveExpr(spark, sourceFilterExprStr, sourceTableSchema)
+    val optimizedFilterExpr = fullyOptimize(resolvedFilterExpr)
+
+    // On the real read path the optimizer's FinishAnalysis batch (ReplaceExpressions) rewrites
+    // RuntimeReplaceable to_date/to_timestamp before any filter reaches Hudi's file pruning, so
+    // the translation must be exercised against the replaced shape
+    assertTrue(
+      optimizedFilterExpr.collectFirst {
+        case p: ParseToDate => p
+        case p: ParseToTimestamp => p
+      }.isEmpty,
+      s"Expected ReplaceExpressions to rewrite RuntimeReplaceable date parsing nodes, got: $optimizedFilterExpr")
+
+    val rows: Seq[String] = applyFilterExpr(optimizedFilterExpr, input)
+
+    assertEquals(expectedOutput, rows)
+  }
+
+  private def fullyOptimize(expr: Expression): Expression = {
+    val holder = HoodieDummyExpressionHolder(Seq(expr), expr.references.toSeq)
+    spark.sessionState.optimizer.execute(holder)
+      .asInstanceOf[HoodieDummyExpressionHolder]
+      .exprs.head
+  }
 
   private def optimize(expr: Expression): Expression = {
     val rules: Seq[Rule[LogicalPlan]] =
@@ -687,6 +728,38 @@ object TestDataSkippingUtils {
         ),
         Seq("file_1"))
 
+    )
+  }
+
+  def testDateParsingFilterExprsAfterReplaceExpressionsSource(): java.util.stream.Stream[Arguments] = {
+    // NOTE: All timestamps in UTC. Column B holds 'yyyy-MM-dd' formatted strings, for which
+    //       lexicographic ordering coincides with chronological ordering
+    val input = Seq(
+      IndexRow("file_1", valueCount = 1,
+        B_minValue = "2022-03-07",
+        B_maxValue = "2022-03-08",
+        B_nullCount = 0),
+      IndexRow("file_2", valueCount = 1,
+        B_minValue = "2022-03-06",
+        B_maxValue = "2022-03-06",
+        B_nullCount = 0)
+    )
+    java.util.stream.Stream.of(
+      // to_date(B) is replaced with Cast(B as date), which the Cast whitelist arm handles
+      arguments("to_date(B) > '2022-03-06'", input, Seq("file_1")),
+      // to_date(B, fmt) is replaced with Cast(GetTimestamp(B, fmt) as date); GetTimestamp is
+      // not matched by the order-preserving whitelist, so data skipping silently no-ops (#19446)
+      arguments("to_date(B, 'yyyy-MM-dd') > '2022-03-06'", input, Seq("file_1", "file_2")),
+      arguments("to_date(B, 'yyyy-MM-dd') = '2022-03-08'", input, Seq("file_1", "file_2")),
+      // to_timestamp(B) is replaced with Cast(B as timestamp), which the Cast whitelist arm handles
+      arguments("to_timestamp(B) > '2022-03-06 12:00:00'", input, Seq("file_1")),
+      // to_timestamp(B, fmt) is replaced with a bare GetTimestamp(B, fmt): same no-op as above
+      arguments("to_timestamp(B, 'yyyy-MM-dd') > '2022-03-06 12:00:00'", input, Seq("file_1", "file_2")),
+      // Same composite as in testCompositeFilterExpressionsSource, but under the real optimizer
+      // ReplaceExpressions rewrites to_timestamp and OptimizeIn turns the single-element NOT IN
+      // into Not(EqualTo(...)): the pruning seen there is silently lost on the real read path
+      arguments("date_format(to_timestamp(B, 'yyyy-MM-dd'), 'MM/dd/yyyy') NOT IN ('03/06/2022')",
+        input, Seq("file_1", "file_2"))
     )
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieCatalystExpressionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieCatalystExpressionUtils.scala
@@ -18,6 +18,7 @@
 package org.apache.hudi
 
 import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, BitwiseOr, Cast, DateAdd, DateSub, Divide, Exp, Expression, GetTimestamp, Literal, Log, Lower, Multiply, ParseToDate, ParseToTimestamp, ShiftLeft, Sqrt, Upper}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DateType, DoubleType, IntegerType, LongType, StringType}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
@@ -71,29 +72,43 @@ class TestHoodieCatalystExpressionUtils extends SparkAdapterSupport {
   }
 
   @Test
-  def testDateParsingTransformationsPreserveOrdering(): Unit = {
-    // ParseToDate's case-class shape differs across Spark versions, so the matcher dispatches it
-    // through the per-version unapplyOrderPreservingDateParsing hook. The 1-arg auxiliary
-    // constructor is stable on all profiles, letting this pin that hook everywhere.
-    assertEquals(Some(strAttr), matched(new ParseToDate(strAttr)))
-  }
-
-  @Test
   def testDateParsingReplacementShapesPreserveOrdering(): Unit = {
     // ParseToDate/ParseToTimestamp are RuntimeReplaceable (SPARK-38240): on the real read path
     // the optimizer's ReplaceExpressions rewrites them before data skipping sees the filter, so
-    // the matcher must also recover the source attribute from the replacement shapes. They are
+    // the matcher must recover the source attribute from the replacement shapes. They are
     // built here via replacement() because GetTimestamp's constructor arity differs across
     // Spark versions while the 2-arg ParseTo* auxiliary constructors are stable everywhere.
-    val toTimestampReplacement = new ParseToTimestamp(strAttr, Literal("yyyy-MM-dd")).replacement
-    assertTrue(toTimestampReplacement.isInstanceOf[GetTimestamp])
-    assertEquals(Some(strAttr), matched(toTimestampReplacement))
+    // The matcher gates on the format literal (fixed-width, year-first) and on failOnError, so
+    // the shapes are built under an explicitly pinned ANSI setting (ANSI is the default on
+    // Spark 4 and would otherwise flip failOnError at construction time).
+    val nonAnsiConf = new SQLConf
+    nonAnsiConf.setConf(SQLConf.ANSI_ENABLED, false)
+    SQLConf.withExistingConf(nonAnsiConf) {
+      val toTimestampReplacement = new ParseToTimestamp(strAttr, Literal("yyyy-MM-dd")).replacement
+      assertTrue(toTimestampReplacement.isInstanceOf[GetTimestamp])
+      assertEquals(Some(strAttr), matched(toTimestampReplacement))
 
-    // to_date's replacement wraps GetTimestamp in a cast to date; the matcher must recurse
-    // through both
-    val toDateReplacement = new ParseToDate(strAttr, Literal("yyyy-MM-dd")).replacement
-    assertTrue(toDateReplacement.collectFirst { case gt: GetTimestamp => gt }.isDefined)
-    assertEquals(Some(strAttr), matched(toDateReplacement))
+      // to_date's replacement wraps GetTimestamp in a cast to date; the matcher must recurse
+      // through both
+      val toDateReplacement = new ParseToDate(strAttr, Literal("yyyy-MM-dd")).replacement
+      assertTrue(toDateReplacement.collectFirst { case gt: GetTimestamp => gt }.isDefined)
+      assertEquals(Some(strAttr), matched(toDateReplacement))
+
+      // Non-order-preserving formats must be rejected: lexicographic ordering of 'MM/dd/yyyy'
+      // strings does not follow chronological ordering, so pruning on re-parsed min/max stats
+      // would return wrong results
+      assertEquals(None, matched(new ParseToTimestamp(strAttr, Literal("MM/dd/yyyy")).replacement))
+      assertEquals(None, matched(new ParseToDate(strAttr, Literal("MM/dd/yyyy")).replacement))
+    }
+
+    // Under ANSI the parse throws on unparseable input, so probing min/max stats with it could
+    // fail queries whose files should simply not be pruned; even an order-preserving format
+    // must not match then
+    val ansiConf = new SQLConf
+    ansiConf.setConf(SQLConf.ANSI_ENABLED, true)
+    SQLConf.withExistingConf(ansiConf) {
+      assertEquals(None, matched(new ParseToTimestamp(strAttr, Literal("yyyy-MM-dd")).replacement))
+    }
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieCatalystExpressionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieCatalystExpressionUtils.scala
@@ -17,9 +17,9 @@
 
 package org.apache.hudi
 
-import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, BitwiseOr, Cast, DateAdd, DateSub, Divide, Exp, Expression, Literal, Log, Lower, Multiply, ParseToDate, ShiftLeft, Sqrt, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, BitwiseOr, Cast, DateAdd, DateSub, Divide, Exp, Expression, GetTimestamp, Literal, Log, Lower, Multiply, ParseToDate, ParseToTimestamp, ShiftLeft, Sqrt, Upper}
 import org.apache.spark.sql.types.{DateType, DoubleType, IntegerType, LongType, StringType}
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
 /**
@@ -76,6 +76,24 @@ class TestHoodieCatalystExpressionUtils extends SparkAdapterSupport {
     // through the per-version unapplyOrderPreservingDateParsing hook. The 1-arg auxiliary
     // constructor is stable on all profiles, letting this pin that hook everywhere.
     assertEquals(Some(strAttr), matched(new ParseToDate(strAttr)))
+  }
+
+  @Test
+  def testDateParsingReplacementShapesPreserveOrdering(): Unit = {
+    // ParseToDate/ParseToTimestamp are RuntimeReplaceable (SPARK-38240): on the real read path
+    // the optimizer's ReplaceExpressions rewrites them before data skipping sees the filter, so
+    // the matcher must also recover the source attribute from the replacement shapes. They are
+    // built here via replacement() because GetTimestamp's constructor arity differs across
+    // Spark versions while the 2-arg ParseTo* auxiliary constructors are stable everywhere.
+    val toTimestampReplacement = new ParseToTimestamp(strAttr, Literal("yyyy-MM-dd")).replacement
+    assertTrue(toTimestampReplacement.isInstanceOf[GetTimestamp])
+    assertEquals(Some(strAttr), matched(toTimestampReplacement))
+
+    // to_date's replacement wraps GetTimestamp in a cast to date; the matcher must recurse
+    // through both
+    val toDateReplacement = new ParseToDate(strAttr, Literal("yyyy-MM-dd")).replacement
+    assertTrue(toDateReplacement.collectFirst { case gt: GetTimestamp => gt }.isDefined)
+    assertEquals(Some(strAttr), matched(toDateReplacement))
   }
 
   @Test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBucketIndexSupport.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBucketIndexSupport.scala
@@ -31,13 +31,12 @@ import org.apache.hudi.index.bucket.BucketIdentifier
 import org.apache.hudi.index.bucket.partition.NumBucketsFunction
 import org.apache.hudi.keygen.{ComplexKeyGenerator, NonpartitionedKeyGenerator}
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions
-import org.apache.hudi.testutils.HoodieSparkClientTestBase
+import org.apache.hudi.testutils.{HoodieDummyExpressionHolder, HoodieSparkClientTestBase}
 import org.apache.hudi.timeline.service.TimelineService
 
 import org.apache.avro.generic.GenericData
 import org.apache.spark.sql.{BucketPartitionUtils, HoodieCatalystExpressionUtils, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, PredicateHelper}
-import org.apache.spark.sql.catalyst.plans.logical.LeafNode
+import org.apache.spark.sql.catalyst.expressions.PredicateHelper
 import org.apache.spark.sql.types._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Tag, Test}
 
@@ -451,10 +450,4 @@ class TestBucketIndexSupport extends HoodieSparkClientTestBase with PredicateHel
     metadataConfig.setValue(HoodieIndexConfig.BUCKET_QUERY_INDEX, "true")
     assert(bucketIndexSupport.isIndexAvailable)
   }
-}
-
-// SPARK-44219 added extra rule to validate expressions against its children's references to check if there are dangling references
-// This is forked from Spark's [[DummyExpressionHolder]], which always set the output to Nil and would fail this test
-case class HoodieDummyExpressionHolder(exprs: Seq[Expression], output: Seq[Attribute]) extends LeafNode {
-  override lazy val resolved = true
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/testutils/HoodieDummyExpressionHolder.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/testutils/HoodieDummyExpressionHolder.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.testutils
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.LeafNode
+
+/**
+ * Test-only leaf plan for running a bare [[Expression]] through the full session optimizer.
+ *
+ * Forked from Spark's [[org.apache.spark.sql.catalyst.encoders.DummyExpressionHolder]], which
+ * hard-codes output = Nil: SPARK-44219 validates optimized plans against dangling expression
+ * references, so a holder without an output fails that check once the validation runs (enforced
+ * on Spark 4). Passing the expressions' references as the output keeps the plan valid.
+ */
+case class HoodieDummyExpressionHolder(exprs: Seq[Expression], output: Seq[Attribute]) extends LeafNode {
+  override lazy val resolved = true
+}

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/HoodieSpark33CatalystExpressionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/HoodieSpark33CatalystExpressionUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.catalyst.expressions.{AnsiCast, Cast, Expression, ParseToDate, ParseToTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{AnsiCast, Cast, Expression}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 object HoodieSpark33CatalystExpressionUtils extends BaseHoodieCatalystExpressionUtils {
@@ -40,13 +40,6 @@ object HoodieSpark33CatalystExpressionUtils extends BaseHoodieCatalystExpression
         Some((castedExpr, dataType, timeZoneId, ansiEnabled))
       case AnsiCast(castedExpr, dataType, timeZoneId) =>
         Some((castedExpr, dataType, timeZoneId, true))
-      case _ => None
-    }
-
-  override protected def unapplyOrderPreservingDateParsing(expr: Expression): Option[Expression] =
-    expr match {
-      case ParseToDate(child, _, _) => Some(child)
-      case ParseToTimestamp(child, _, _, _) => Some(child)
       case _ => None
     }
 }

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/HoodieSpark34CatalystExpressionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/HoodieSpark34CatalystExpressionUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.catalyst.expressions.{Cast, EvalMode, Expression, ParseToDate, ParseToTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{Cast, EvalMode, Expression}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 object HoodieSpark34CatalystExpressionUtils extends BaseHoodieCatalystExpressionUtils {
@@ -38,13 +38,6 @@ object HoodieSpark34CatalystExpressionUtils extends BaseHoodieCatalystExpression
     expr match {
       case Cast(castedExpr, dataType, timeZoneId, ansiEnabled) =>
         Some((castedExpr, dataType, timeZoneId, if (ansiEnabled == EvalMode.ANSI) true else false))
-      case _ => None
-    }
-
-  override protected def unapplyOrderPreservingDateParsing(expr: Expression): Option[Expression] =
-    expr match {
-      case ParseToDate(child, _, _) => Some(child)
-      case ParseToTimestamp(child, _, _, _, _) => Some(child)
       case _ => None
     }
 }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/HoodieSpark35CatalystExpressionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/HoodieSpark35CatalystExpressionUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{Cast, EvalMode, Expression, ParseToDate, ParseToTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{Cast, EvalMode, Expression}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 object HoodieSpark35CatalystExpressionUtils extends BaseHoodieCatalystExpressionUtils {
@@ -38,13 +38,6 @@ object HoodieSpark35CatalystExpressionUtils extends BaseHoodieCatalystExpression
     expr match {
       case Cast(castedExpr, dataType, timeZoneId, ansiEnabled) =>
         Some((castedExpr, dataType, timeZoneId, if (ansiEnabled == EvalMode.ANSI) true else false))
-      case _ => None
-    }
-
-  override protected def unapplyOrderPreservingDateParsing(expr: Expression): Option[Expression] =
-    expr match {
-      case ParseToDate(child, _, _, _) => Some(child)
-      case ParseToTimestamp(child, _, _, _, _) => Some(child)
       case _ => None
     }
 }

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/HoodieSpark4CatalystExpressionUtils.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/HoodieSpark4CatalystExpressionUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{Cast, EvalMode, Expression, ParseToDate, ParseToTimestamp}
+import org.apache.spark.sql.catalyst.expressions.{Cast, EvalMode, Expression}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 /**
@@ -41,13 +41,6 @@ abstract class HoodieSpark4CatalystExpressionUtils extends BaseHoodieCatalystExp
     expr match {
       case Cast(castedExpr, dataType, timeZoneId, ansiEnabled) =>
         Some((castedExpr, dataType, timeZoneId, if (ansiEnabled == EvalMode.ANSI) true else false))
-      case _ => None
-    }
-
-  override protected def unapplyOrderPreservingDateParsing(expr: Expression): Option[Expression] =
-    expr match {
-      case ParseToDate(child, _, _, _) => Some(child)
-      case ParseToTimestamp(child, _, _, _, _) => Some(child)
       case _ => None
     }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19446

Since SPARK-38240, ParseToDate/ParseToTimestamp are RuntimeReplaceable, so the optimizer rewrites them into Cast/GetTimestamp trees before any filter reaches file pruning. The order-preserving whitelist only matched the pre-replacement shapes, so to_date/to_timestamp with an explicit format translated to TrueLiteral and data skipping silently pruned nothing. The existing green to_timestamp case in TestDataSkippingUtils only runs OptimizeIn, which is why it never caught this.

### Summary and Changelog

- Match GetTimestamp in the shared order-preserving whitelist, gated for soundness:
  - the format must be a literal, fixed-width, year-first pattern (ORDER_PRESERVING_DATE_FORMATS allowlist): the translation re-applies the parse on top of string min/max column stats, which is only sound when lexicographic ordering of parseable strings agrees with chronological ordering. Non-order-preserving formats (e.g. 'MM/dd/yyyy', variable-width 'yyyy-M-d') fall back to no pruning instead of wrong pruning.
  - failOnError must be false: under ANSI mode (the Spark 4 default) probing a stat value that does not parse would throw from the index lookup and could fail queries whose files are pruned by other predicates. Under ANSI the arm refuses to match and translation falls back to keeping every file.
  - It is a typed match because the constructor arity differs between Spark 3.x and 4.x while left()/right() are stable, so no per-version changes are needed.
- Make transformed index-lookup bounds null-tolerant in DataSkippingUtils (Coalesce(bound, true)): whitelisted transformations can be partial functions of the source column (GetTimestamp parsing a string returns null for unparseable values), in which case f(max(col)) != max(f(col)) and a null bound must keep the file rather than silently prune it. Bare-attribute translations are unchanged.
- Delete the per-version ParseToDate/ParseToTimestamp hook (unapplyOrderPreservingDateParsing and its four overrides): its only production consumer receives post-optimizer dataFilters (Hudi's pruning rule is injected via injectOptimizerRule, after the FinishAnalysis batch), so the analysis-time shapes never reach it. The expression-index path has its own matcher with the same optimizer-boundary problem; tracked separately in #19480.
- Add a TestDataSkippingUtils entry point that runs the resolved filter through the full session optimizer before translating (shared HoodieDummyExpressionHolder in testutils, see SPARK-44219), covering: the replaced to_date/to_timestamp shapes, the Cast-retaining date_add composite, negative-format rows (no pruning), an unparseable-stat row (null-tolerant bound keeps the file), and an ANSI-mode test (no throw, no pruning).
- Pin the replacement shapes and the gate directly in TestHoodieCatalystExpressionUtils, built via replacement() under an explicitly pinned ANSI setting so they compile and behave the same on every profile.

### Impact

Data skipping works again for to_date(col, fmt)/to_timestamp(col, fmt) predicates with order-preserving format patterns, without introducing wrong-results pruning for non-order-preserving formats, unparseable stat values, or ANSI mode. Note that under Spark 4 default config (ANSI on) these predicates intentionally do not prune: safe fallback, not wrong results. No API changes.

### Risk Level

low. The arm only fires for allowlisted literal formats with failOnError off; everything else falls back to the pre-existing no-pruning behavior. The null-tolerant bound wrapping only ever keeps more files than before. Covered by the new optimizer-realistic tests, negative-format tests, and the ANSI test.

Follow-ups filed during review: #19479 (left(col, n) whitelist arm is dead for the same RuntimeReplaceable reason), #19480 (expression-index matcher has the same optimizer-boundary bug), #19481 (unix_timestamp parity and format-monotonicity holes in the live arms).

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
