### PR TITLE
fix(metrics): do not drop the whole CloudWatch batch on one unmappable metric name

### DIFF
--- a/hudi-aws/src/main/java/org/apache/hudi/aws/metrics/cloudwatch/CloudWatchReporter.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/metrics/cloudwatch/CloudWatchReporter.java
@@ -20,7 +20,6 @@ package org.apache.hudi.aws.metrics.cloudwatch;
 
 import org.apache.hudi.aws.credentials.HoodieAWSCredentialsProviderFactory;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.ValidationUtils;
 
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Counter;
@@ -45,7 +44,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -66,6 +67,8 @@ public class CloudWatchReporter extends ScheduledReporter {
   private final String prefix;
   private final String namespace;
   private final int maxDatumsPerRequest;
+  /** Metric names already reported as unmappable, so the warning is logged once rather than every interval. */
+  private final Set<String> unmappableMetricNames = ConcurrentHashMap.newKeySet();
 
   public static Builder forRegistry(MetricRegistry registry) {
     return new Builder(registry);
@@ -276,8 +279,18 @@ public class CloudWatchReporter extends ScheduledReporter {
                                 long timestampMilliSec,
                                 List<MetricDatum> metricData) {
     String[] metricNameParts = metricName.split("\\.", 2);
-    ValidationUtils.checkArgument(metricNameParts.length >= 2,
-            "metricName doesn't follow the naming convention and doesn't contain a dot as splitter! metricName:" + metricName);
+    if (metricNameParts.length < 2) {
+      // The table dimension comes from the part before the first dot, so a name without one cannot be
+      // mapped. Skip just this metric rather than throwing: ScheduledReporter suppresses whatever
+      // report() throws, so failing here dropped every metric staged in the same interval and left no
+      // metrics in CloudWatch at all.
+      if (unmappableMetricNames.add(metricName)) {
+        log.warn("Not reporting metric \"{}\" to CloudWatch: it contains no dot, so there is no table name "
+            + "to report it under. Metrics are expected to be named <table>.<metric>. Other metrics in this "
+            + "batch are unaffected, and this is logged once per metric name.", metricName);
+      }
+      return;
+    }
     String tableName = metricNameParts[0];
 
     metricData.add(MetricDatum.builder()

--- a/hudi-aws/src/main/java/org/apache/hudi/aws/metrics/cloudwatch/CloudWatchReporter.java
+++ b/hudi-aws/src/main/java/org/apache/hudi/aws/metrics/cloudwatch/CloudWatchReporter.java
@@ -20,6 +20,7 @@ package org.apache.hudi.aws.metrics.cloudwatch;
 
 import org.apache.hudi.aws.credentials.HoodieAWSCredentialsProviderFactory;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Counter;
@@ -279,15 +280,21 @@ public class CloudWatchReporter extends ScheduledReporter {
                                 long timestampMilliSec,
                                 List<MetricDatum> metricData) {
     String[] metricNameParts = metricName.split("\\.", 2);
-    if (metricNameParts.length < 2) {
-      // The table dimension comes from the part before the first dot, so a name without one cannot be
-      // mapped. Skip just this metric rather than throwing: ScheduledReporter suppresses whatever
-      // report() throws, so failing here dropped every metric staged in the same interval and left no
-      // metrics in CloudWatch at all.
+    if (metricNameParts.length < 2 || StringUtils.isNullOrEmpty(metricNameParts[0])) {
+      // The table dimension comes from the part before the first dot, so a name without one, or one whose
+      // first segment is empty, cannot be mapped. An empty first segment is reachable:
+      // hoodie.metrics.reporter.metricsname.prefix defaults to "" and Metrics#registerGauges still joins it
+      // with a dot, producing ".foo" - and CloudWatch rejects a whole PutMetricData request whose dimension
+      // value is empty, which would lose the batch again.
+      //
+      // Skip just this metric rather than throwing: ScheduledReporter suppresses whatever report() throws,
+      // so failing here dropped every metric staged in the same interval and left no metrics in CloudWatch
+      // at all.
       if (unmappableMetricNames.add(metricName)) {
-        log.warn("Not reporting metric \"{}\" to CloudWatch: it contains no dot, so there is no table name "
-            + "to report it under. Metrics are expected to be named <table>.<metric>. Other metrics in this "
-            + "batch are unaffected, and this is logged once per metric name.", metricName);
+        log.warn("Not reporting metric \"{}\" to CloudWatch: no table name can be derived for the Table "
+            + "dimension. Metric names normally carry hoodie.metrics.reporter.metricsname.prefix, but some "
+            + "Hudi-internal metadata metrics do not (see HUDI issue #19507). Other metrics in this batch "
+            + "are unaffected, and this is logged once per metric name.", metricName);
       }
       return;
     }

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/metrics/cloudwatch/TestCloudWatchReporter.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/metrics/cloudwatch/TestCloudWatchReporter.java
@@ -27,6 +27,12 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +49,8 @@ import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
 import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataResponse;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -168,19 +176,20 @@ public class TestCloudWatchReporter {
   }
 
   /**
-   * A metric name with no dot has no table name to report under. Such names do reach the reporter -
-   * {@code HoodieMetadataMetrics#setMetric} registers gauges without a prefix, so
-   * {@code HoodieMetadataMetrics.getStats} contributes a bare {@code partitionCount} - and this used to
-   * throw. {@link com.codahale.metrics.ScheduledReporter} suppresses whatever {@code report()} throws, so
-   * the result was that no metrics reached CloudWatch at all, which is what #12182 and #13051 report.
-   * The unmappable metric is now skipped and the rest of the batch is still published.
+   * A metric name with no dot has no table name to report under, and such names do reach the reporter:
+   * {@code HoodieMetadataMetrics#setMetric} registers gauges without the metrics-name prefix, so
+   * {@code BaseTableMetadata#getBloomFilters} contributes a bare
+   * {@code lookup_meta_index_bloom_filters_file_count} on the normal bloom-index read path. This used to
+   * throw, and {@link com.codahale.metrics.ScheduledReporter} suppresses whatever {@code report()} throws,
+   * so no metrics reached CloudWatch at all - which is what #12182 and #13051 report. The unmappable metric
+   * is now skipped and the rest of the batch is still published. See HUDI issue #19507 for the producer side.
    */
   @Test
   public void testReportSkipsMetricsWithoutTableNameAndPublishesTheRest() {
     SortedMap<String, Gauge> gauges = new TreeMap<>();
     Gauge<Long> unmappable = () -> 7L;
     Gauge<Double> wellFormed = () -> 100.1;
-    gauges.put("partitionCount", unmappable);
+    gauges.put("lookup_meta_index_bloom_filters_file_count", unmappable);
     gauges.put(TABLE_NAME + ".gauge2", wellFormed);
 
     Mockito.when(metricRegistry.getGauges(MetricFilter.ALL)).thenReturn(gauges);
@@ -194,9 +203,111 @@ public class TestCloudWatchReporter {
     assertEquals(PREFIX + ".gauge2", metricData.get(0).metricName());
     assertEquals(wellFormed.getValue(), metricData.get(0).value());
     assertDimensions(metricData.get(0).dimensions(), DIMENSION_GAUGE_TYPE_VALUE);
+  }
 
-    reporter.stop();
-    Mockito.verify(cloudWatchAsync).close();
+  /**
+   * An empty first segment is reachable: {@code hoodie.metrics.reporter.metricsname.prefix} defaults to
+   * {@code ""} and {@code Metrics#registerGauges} still joins it with a dot, giving {@code ".foo"}. That
+   * splits into two parts and so passed the length check, then asked CloudWatch for an empty {@code Table}
+   * dimension value, which it rejects for the whole PutMetricData request - losing the batch again.
+   */
+  @Test
+  public void testReportSkipsMetricsWithAnEmptyTableName() {
+    SortedMap<String, Gauge> gauges = new TreeMap<>();
+    gauges.put(".gauge1", (Gauge<Long>) () -> 7L);
+    gauges.put(TABLE_NAME + ".gauge2", (Gauge<Long>) () -> 100L);
+
+    Mockito.when(metricRegistry.getGauges(MetricFilter.ALL)).thenReturn(gauges);
+
+    reporter.report();
+
+    Mockito.verify(cloudWatchAsync, Mockito.times(1)).putMetricData(putMetricDataRequestCaptor.capture());
+    List<MetricDatum> metricData = putMetricDataRequestCaptor.getValue().metricData();
+    assertEquals(1, metricData.size(), "a metric whose table name is empty should be skipped");
+    assertEquals(PREFIX + ".gauge2", metricData.get(0).metricName());
+  }
+
+  /**
+   * An interval in which every metric is unmappable leaves nothing staged. CloudWatch rejects an empty
+   * PutMetricData request, so the reporter must not send one.
+   */
+  @Test
+  public void testReportSendsNothingWhenEveryMetricIsUnmappable() {
+    SortedMap<String, Gauge> gauges = new TreeMap<>();
+    gauges.put("lookup_meta_index_bloom_filters_file_count", (Gauge<Long>) () -> 7L);
+    gauges.put("bootstrap_error", (Gauge<Long>) () -> 1L);
+
+    Mockito.when(metricRegistry.getGauges(MetricFilter.ALL)).thenReturn(gauges);
+
+    reporter.report();
+
+    Mockito.verify(cloudWatchAsync, Mockito.never()).putMetricData(ArgumentMatchers.any(PutMetricDataRequest.class));
+  }
+
+  /**
+   * The unmappable-name set exists so a persistent offender is logged once rather than every reporting
+   * interval. Without this, deleting the set and logging unconditionally would pass the suite.
+   */
+  @Test
+  public void testUnmappableMetricIsLoggedOncePerName() {
+    SortedMap<String, Gauge> gauges = new TreeMap<>();
+    gauges.put("lookup_meta_index_bloom_filters_file_count", (Gauge<Long>) () -> 7L);
+    Mockito.when(metricRegistry.getGauges(MetricFilter.ALL)).thenReturn(gauges);
+
+    CapturingAppender appender = CapturingAppender.attachTo(CloudWatchReporter.class);
+    try {
+      reporter.report();
+      reporter.report();
+    } finally {
+      appender.detach();
+    }
+
+    assertEquals(1, appender.warningsContaining("lookup_meta_index_bloom_filters_file_count"),
+        "a persistent unmappable name should be warned about once, not once per interval");
+  }
+
+  /** Captures WARN events from a single logger, so "logged once" can be asserted. */
+  private static final class CapturingAppender extends AbstractAppender {
+    private final List<String> warnings = Collections.synchronizedList(new ArrayList<>());
+    private final LoggerConfig loggerConfig;
+    private final Level previousLevel;
+
+    private CapturingAppender(LoggerConfig loggerConfig) {
+      super("CapturingAppender", null, null, true, null);
+      this.loggerConfig = loggerConfig;
+      this.previousLevel = loggerConfig.getLevel();
+    }
+
+    static CapturingAppender attachTo(Class<?> loggerFor) {
+      LoggerContext context = (LoggerContext) LogManager.getContext(false);
+      LoggerConfig loggerConfig = context.getConfiguration().getLoggerConfig(loggerFor.getName());
+      CapturingAppender appender = new CapturingAppender(loggerConfig);
+      appender.start();
+      loggerConfig.addAppender(appender, Level.WARN, null);
+      loggerConfig.setLevel(Level.WARN);
+      context.updateLoggers();
+      return appender;
+    }
+
+    void detach() {
+      loggerConfig.removeAppender(getName());
+      loggerConfig.setLevel(previousLevel);
+      ((LoggerContext) LogManager.getContext(false)).updateLoggers();
+      stop();
+    }
+
+    long warningsContaining(String needle) {
+      synchronized (warnings) {
+        return warnings.stream().filter(m -> m.contains(needle)).count();
+      }
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
+        warnings.add(event.getMessage().getFormattedMessage());
+      }
+    }
   }
 
   private void assertDimensions(List<Dimension> actualDimensions, String metricTypeDimensionVal) {

--- a/hudi-aws/src/test/java/org/apache/hudi/aws/metrics/cloudwatch/TestCloudWatchReporter.java
+++ b/hudi-aws/src/test/java/org/apache/hudi/aws/metrics/cloudwatch/TestCloudWatchReporter.java
@@ -54,7 +54,6 @@ import static org.apache.hudi.aws.metrics.cloudwatch.CloudWatchReporter.DIMENSIO
 import static org.apache.hudi.aws.metrics.cloudwatch.CloudWatchReporter.DIMENSION_METRIC_TYPE_KEY;
 import static org.apache.hudi.aws.metrics.cloudwatch.CloudWatchReporter.DIMENSION_TABLE_NAME_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class TestCloudWatchReporter {
@@ -168,18 +167,33 @@ public class TestCloudWatchReporter {
     Mockito.verify(cloudWatchAsync).close();
   }
 
+  /**
+   * A metric name with no dot has no table name to report under. Such names do reach the reporter -
+   * {@code HoodieMetadataMetrics#setMetric} registers gauges without a prefix, so
+   * {@code HoodieMetadataMetrics.getStats} contributes a bare {@code partitionCount} - and this used to
+   * throw. {@link com.codahale.metrics.ScheduledReporter} suppresses whatever {@code report()} throws, so
+   * the result was that no metrics reached CloudWatch at all, which is what #12182 and #13051 report.
+   * The unmappable metric is now skipped and the rest of the batch is still published.
+   */
   @Test
-  public void testReportOnMetricsWithoutTableName() {
+  public void testReportSkipsMetricsWithoutTableNameAndPublishesTheRest() {
     SortedMap<String, Gauge> gauges = new TreeMap<>();
-    Gauge<Long> gauge1 = () -> 100L;
-    Gauge<Double> gauge2 = () -> 100.1;
-    gauges.put("gauge1", gauge1);
-    gauges.put(TABLE_NAME + ".gauge2", gauge2);
+    Gauge<Long> unmappable = () -> 7L;
+    Gauge<Double> wellFormed = () -> 100.1;
+    gauges.put("partitionCount", unmappable);
+    gauges.put(TABLE_NAME + ".gauge2", wellFormed);
 
     Mockito.when(metricRegistry.getGauges(MetricFilter.ALL)).thenReturn(gauges);
 
-    // should fail if metric name doesn't have at least two parts
-    assertThrows(IllegalArgumentException.class, () -> reporter.report());
+    reporter.report();
+
+    Mockito.verify(cloudWatchAsync, Mockito.times(1)).putMetricData(putMetricDataRequestCaptor.capture());
+    List<MetricDatum> metricData = putMetricDataRequestCaptor.getValue().metricData();
+    assertEquals(1, metricData.size(),
+        "The unmappable metric should be skipped and the well-formed one still published");
+    assertEquals(PREFIX + ".gauge2", metricData.get(0).metricName());
+    assertEquals(wellFormed.getValue(), metricData.get(0).value());
+    assertDimensions(metricData.get(0).dimensions(), DIMENSION_GAUGE_TYPE_VALUE);
 
     reporter.stop();
     Mockito.verify(cloudWatchAsync).close();


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #12182 and #13051. Both report the same thing: CloudWatch metrics are enabled, the job succeeds, and
no metrics arrive at all, with this in the logs every interval:

```
ERROR ScheduledReporter: Exception thrown from CloudWatchReporter#report. Exception was suppressed.
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at org.apache.hudi.aws.cloudwatch.CloudWatchReporter.stageMetricDatum(CloudWatchReporter.java:281)
	at org.apache.hudi.aws.cloudwatch.CloudWatchReporter.processGauge(CloudWatchReporter.java:250)
	at org.apache.hudi.aws.cloudwatch.CloudWatchReporter.report(CloudWatchReporter.java:189)
```

`stageMetricDatum` takes the CloudWatch `Table` dimension from the part of the metric name before the first
dot, so a name with no dot cannot be mapped. HUDI-9068 (#12873) turned that `ArrayIndexOutOfBoundsException`
into an `IllegalArgumentException`, but it still throws, and the throw is what produces the reported symptom.
`report()` stages every gauge, counter, histogram, meter and timer into one list before calling
`putMetricData`, so throwing part-way through means the request is never sent: one unmappable name costs
every metric in that interval. `ScheduledReporter` then suppresses the exception, so the user sees a log line
and an empty dashboard.

Dotless names still reach the reporter on current master. `HoodieMetadataMetrics#setMetric` calls
`metrics.registerGauge(action, value)` with no prefix at all (`HoodieMetadataMetrics.java:176`), unlike
`Metrics#registerGauges`, which applies `hoodie.metrics.reporter.metricsname.prefix`. Two that are registered
on normal paths:

- `lookup_meta_index_bloom_filters_file_count` -- `BaseTableMetadata.java:212`, on the bloom-index read path
- `<partition>_bootstrap_error` -- `HoodieBackedTableMetadataWriter.java:482`

There is a second way in, which review turned up. The prefix defaults to `""` and `Metrics#registerGauges`
still joins it with a dot (`Metrics.java:157`), so a name can arrive as `.foo`. That splits into two parts and
passed the old length check, then asked CloudWatch for an empty `Table` dimension value. CloudWatch rejects
the whole `PutMetricData` request for that, so the batch is lost again by a different route.

So any table with the metadata table enabled and `CLOUDWATCH` selected loses all of its metrics.

### Summary and Changelog

- `stageMetricDatum` skips a metric it cannot map instead of throwing, so the rest of the batch is still
  published. Both a name with no dot and a name whose first segment is empty are skipped.
- The skipped name is logged at warn level once per name rather than once per interval, so a persistent
  offender does not spam the log every reporting cycle.

This replaces the `checkArgument` added by #12873, so to be explicit about why: the goal there -- do not
report a metric under a wrong or missing table dimension -- is preserved, because the metric is still not
reported and is now named in a warning. What changes is that it no longer takes the other metrics down with
it. Fail-fast was not reachable here in any case, since `ScheduledReporter` catches and suppresses everything
`report()` throws, so the throw could never surface to a caller -- it could only delete the batch. The
substantive half of #12873, the `TABLE_SERVICE_EXECUTION_*` prefixing in `HoodieBackedTableMetadataWriter`,
is untouched.

### Verification

`testReportOnMetricsWithoutTableName`, which asserted the throw, is replaced by four tests in
`TestCloudWatchReporter`:

- `testReportSkipsMetricsWithoutTableNameAndPublishesTheRest` -- a batch holding
  `lookup_meta_index_bloom_filters_file_count` plus a well-formed gauge publishes exactly one datum,
  `testPrefix.gauge2`, carrying `Table=testTable`.
- `testReportSkipsMetricsWithAnEmptyTableName` -- the same for `.gauge1`.
- `testReportSendsNothingWhenEveryMetricIsUnmappable` -- an interval with nothing mappable never calls
  `putMetricData`, rather than sending an empty request that AWS would reject.
- `testUnmappableMetricIsLoggedOncePerName` -- two `report()` calls over the same registry produce exactly one
  WARN, captured with an `AbstractAppender` on the `CloudWatchReporter` logger.

Each one fails with its corresponding production change reverted, so none of them passes vacuously.
`checkstyle:check` and `apache-rat:check` are clean, and the rest of `hudi-aws` is unaffected.

### Why the fix is reporter-side

Both prior fixes for this symptom went producer-side, so it is worth saying why this one does not.
`1a5a9f7f03ec` (HUDI-4439, #6164) fixed it by pushing the table name into the metadata table's
`HoodieMetricsConfig`. `100e9ac47590` (HUDI-9068, #12873) fixed two producer names and added the
`checkArgument` this PR replaces -- so that guard was a detector for producer bugs, not the fix.

The producer fix is the right one and is filed as #19507. `HoodieMetadataMetrics` already receives a
`HoodieMetricsConfig` (`HoodieMetadataMetrics.java:91`) and discards it, so retaining the prefix would fix
both the dotless names and the wrong-`Table` names described under Impact, for every reporter at once. It
renames metrics, which breaks existing Graphite, Prometheus, JMX and Datadog dashboards and needs a release
note, so it is not bundled here. This PR is explicitly the stop-the-bleeding half.

This is also the only place in the codebase where a reporter derives a dimension by splitting the metric
name, so the guard does not set a precedent other reporters have to follow. The closest analogue is
`MetricUtils`, used by `DatadogReporter` and `PushGatewayReporter`, and its convention is the one adopted
here: missing optional structure degrades gracefully, while genuinely malformed input throws. "No dot" is
missing structure, not malformed input.

### Impact

CloudWatch users whose tables register an unmappable metric name go from receiving no metrics to receiving
the well-formed ones.

They also start receiving metrics under a wrong `Table` dimension, and being billed for them. Names that
contain a dot but no table pass the guard and are reported with the action as the table: `<action>.count` and
`<action>.totalDuration` give `Table="initialize"` and `Table="lookup_partitions"`, while the
metadata-partition stats give `Table="files"` and `Table="column_stats"`. Roughly 18 such metrics exist. This
was already broken, but invisible to exactly these users, because the batch died before anything was sent.
CloudWatch bills per unique metric name plus dimension set, so those become billable custom metrics the
moment this merges. #19507 is the producer-side fix; this PR deliberately does not rename metrics.

No effect on any other reporter, no effect on a CloudWatch setup that never produces such a name, and no API,
config or table format change.

### Risk Level

low. One branch in one reporter, scoped to a case that currently throws. Verified that the well-formed
metrics still publish with the correct dimensions and that the rest of `hudi-aws` is unaffected.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
