### PR TITLE
fix(metrics): route the reflection failures a CloudWatch skew actually produces

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
@@ -106,8 +106,9 @@ public class MetricsReporterFactory {
 
   /**
    * The CloudWatch reporter ships in the optional {@code hudi-aws} module and so is loaded reflectively.
-   * Not every engine bundle shades that module, in which case class loading fails without pointing at a
-   * remedy. Translate that into an actionable error.
+   * Reflection reports its two distinct failures - the module is absent, or the module is present but was
+   * built against a different Hudi version - as the same opaque {@link HoodieException}. Translate each into
+   * an error that names its own remedy, and leave anything else untouched.
    */
   private static MetricsReporter createCloudWatchReporter(HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
     try {
@@ -121,6 +122,18 @@ public class MetricsReporterFactory {
                 + "hudi-aws-bundle jar matching your Hudi version to the classpath, or set %s to a "
                 + "different reporter type.",
             CLOUDWATCH_REPORTER_CLASS, HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
+      }
+      if (e.getCause() instanceof NoSuchMethodException) {
+        // The class resolved, so hudi-aws is present; only the constructor did not match. That means the
+        // jar providing it was built against a different Hudi version, which is a mismatch rather than
+        // something missing, and the two need different remedies.
+        throw new HoodieException(String.format(
+            "Cannot report metrics to CloudWatch: %s was found on the classpath but has no (%s, %s) "
+                + "constructor. The jar providing it was most likely built against a different Hudi "
+                + "version. Use a hudi-aws-bundle whose version matches the Hudi bundle in use, or set %s "
+                + "to a different reporter type.",
+            CLOUDWATCH_REPORTER_CLASS, HoodieMetricsConfig.class.getSimpleName(),
+            MetricRegistry.class.getSimpleName(), HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
       }
       throw e;
     }

--- a/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
@@ -106,14 +106,33 @@ public class MetricsReporterFactory {
 
   /**
    * The CloudWatch reporter ships in the optional {@code hudi-aws} module and so is loaded reflectively.
-   * Reflection reports its two distinct failures - the module is absent, or the module is present but was
-   * built against a different Hudi version - as the same opaque {@link HoodieException}. Translate each into
-   * an error that names its own remedy, and leave anything else untouched.
+   * Reflection collapses several unrelated failures into the same opaque {@link HoodieException}. Three of
+   * them have distinct remedies - the module is absent, it was built against a Hudi that has since moved a
+   * class, or the classpath carries a stale duplicate - so translate those three, and leave every other
+   * failure untouched.
    */
   private static MetricsReporter createCloudWatchReporter(HoodieMetricsConfig metricsConfig, MetricRegistry registry) {
+    return createCloudWatchReporter(CLOUDWATCH_REPORTER_CLASS, metricsConfig, registry);
+  }
+
+  @VisibleForTesting
+  static MetricsReporter createCloudWatchReporter(String reporterClass, HoodieMetricsConfig metricsConfig,
+                                                 MetricRegistry registry) {
     try {
-      return (MetricsReporter) ReflectionUtils.loadClass(CLOUDWATCH_REPORTER_CLASS,
+      return (MetricsReporter) ReflectionUtils.loadClass(reporterClass,
           new Class[] {HoodieMetricsConfig.class, MetricRegistry.class}, metricsConfig, registry);
+    } catch (NoClassDefFoundError e) {
+      // Class#getConstructor resolves the parameter types of every public constructor, not just the one
+      // asked for, so a jar built against an older Hudi fails here on a type that has since moved - not
+      // with a missing-constructor error. NoClassDefFoundError is an Error, so ReflectionUtils never wraps
+      // it and it arrives here uncaught. Its message names the type that vanished, which is the strongest
+      // evidence of skew available.
+      throw new HoodieException(String.format(
+          "Cannot report metrics to CloudWatch: %s was found on the classpath but was built against a "
+              + "different Hudi version - resolving its constructors needs %s, which this Hudi no longer "
+              + "provides. Use a hudi-aws-bundle of the same version as the engine bundle, or set %s to a "
+              + "different reporter type.",
+          reporterClass, e.getMessage(), HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
     } catch (HoodieException e) {
       if (e.getCause() instanceof ClassNotFoundException) {
         throw new HoodieException(String.format(
@@ -121,19 +140,24 @@ public class MetricsReporterFactory {
                 + "optional hudi-aws module, which not every engine bundle includes. Add the "
                 + "hudi-aws-bundle jar matching your Hudi version to the classpath, or set %s to a "
                 + "different reporter type.",
-            CLOUDWATCH_REPORTER_CLASS, HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
+            reporterClass, HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
       }
       if (e.getCause() instanceof NoSuchMethodException) {
-        // The class resolved, so hudi-aws is present; only the constructor did not match. That means the
-        // jar providing it was built against a different Hudi version, which is a mismatch rather than
-        // something missing, and the two need different remedies.
+        // The class resolved and so did every constructor's parameter types, yet none matched. A jar built
+        // against an older Hudi fails earlier, in the NoClassDefFoundError branch above, so what reaches
+        // here is a classpath carrying a stale or duplicate copy of this class or of its parameter types.
+        // Fully qualified names, because the package move and the shaded-codahale relocation are exactly
+        // what distinguishes the declared constructor from the requested one - under simple names both read
+        // as (HoodieMetricsConfig, MetricRegistry) and the error looks wrong.
         throw new HoodieException(String.format(
-            "Cannot report metrics to CloudWatch: %s was found on the classpath but has no (%s, %s) "
-                + "constructor. The jar providing it was most likely built against a different Hudi "
-                + "version. Use a hudi-aws-bundle whose version matches the Hudi bundle in use, or set %s "
-                + "to a different reporter type.",
-            CLOUDWATCH_REPORTER_CLASS, HoodieMetricsConfig.class.getSimpleName(),
-            MetricRegistry.class.getSimpleName(), HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
+            "Cannot report metrics to CloudWatch: %s was found on the classpath but does not declare a "
+                + "(%s, %s) constructor. Some jar on the classpath is supplying a stale or duplicate copy "
+                + "of this class or of its parameter types. Check for more than one Hudi version on the "
+                + "classpath - a leftover hudi-common or hudi-client-common is the usual culprit - and "
+                + "align every Hudi artifact, including the engine bundle, to one version. Or set %s to a "
+                + "different reporter type.",
+            reporterClass, HoodieMetricsConfig.class.getName(),
+            MetricRegistry.class.getName(), HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()), e);
       }
       throw e;
     }

--- a/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
@@ -37,9 +37,11 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -137,11 +139,13 @@ class TestMetricsReporterFactory {
   }
 
   /**
-   * The other direction, and the branch most likely to regress: a failure that is not a missing class must
-   * pass through untouched, so an unrelated instantiation error is never rewritten into "add hudi-aws-bundle".
+   * A missing constructor means hudi-aws resolved but was built against a different Hudi version, which is
+   * a mismatch rather than something absent. Reflection reports it as the same opaque HoodieException as a
+   * missing class, and the bare "Unable to instantiate class" that resulted took a maintainer reading the
+   * buried NoSuchMethodException to explain (#12902).
    */
   @Test
-  void metricsReporterFactoryLeavesNonClassNotFoundFailuresUntouched() {
+  void metricsReporterFactoryExplainsAConstructorMismatch() {
     when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.CLOUDWATCH);
     try (MockedStatic<ReflectionUtils> mockedStatic = Mockito.mockStatic(ReflectionUtils.class)) {
       mockedStatic.when(() -> ReflectionUtils.loadClass(
@@ -151,8 +155,34 @@ class TestMetricsReporterFactory {
 
       HoodieException exception = assertThrows(HoodieException.class,
           () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
+      String message = exception.getMessage();
+      assertTrue(message.contains("constructor"),
+          () -> "The failure should say the constructor did not match, but was: " + message);
+      assertTrue(message.contains("different Hudi version"),
+          () -> "The failure should name version skew as the likely cause, but was: " + message);
+      assertFalse(message.contains("was not found on the classpath"),
+          () -> "A class that resolved must not be reported as missing, but was: " + message);
+    }
+  }
+
+  /**
+   * The other direction, and the branch most likely to regress: a failure that is neither a missing class
+   * nor a missing constructor must pass through untouched, so an error raised by the reporter's own
+   * constructor is never rewritten into a classpath diagnosis.
+   */
+  @Test
+  void metricsReporterFactoryLeavesOtherFailuresUntouched() {
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.CLOUDWATCH);
+    try (MockedStatic<ReflectionUtils> mockedStatic = Mockito.mockStatic(ReflectionUtils.class)) {
+      mockedStatic.when(() -> ReflectionUtils.loadClass(
+          eq(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS), any(Class[].class), eq(metricsConfig), eq(registry)))
+          .thenThrow(new HoodieException("Unable to instantiate class " + MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS,
+              new InvocationTargetException(new IllegalStateException("no AWS region configured"))));
+
+      HoodieException exception = assertThrows(HoodieException.class,
+          () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
       assertEquals("Unable to instantiate class " + MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS,
-          exception.getMessage(), "A non-ClassNotFound failure must not be rewritten");
+          exception.getMessage(), "A failure that is neither cause must not be rewritten");
     }
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
@@ -182,7 +182,8 @@ class TestMetricsReporterFactory {
       HoodieException exception = assertThrows(HoodieException.class,
           () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
       assertEquals("Unable to instantiate class " + MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS,
-          exception.getMessage(), "A failure that is neither cause must not be rewritten");
+          exception.getMessage(),
+          "A failure that is neither a missing class nor a missing constructor must not be rewritten");
     }
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metrics/TestMetricsReporterFactory.java
@@ -41,7 +41,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -116,6 +115,10 @@ class TestMetricsReporterFactory {
         () -> "The failure should name the bundle that provides the reporter, but was: " + message);
     assertTrue(message.contains(HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()),
         () -> "The failure should name the config to change, but was: " + message);
+    // Every string above also appears in the constructor-mismatch message, so without this the two branches
+    // could be merged or reordered and both tests would still pass.
+    assertTrue(message.contains("was not found on the classpath"),
+        () -> "A missing class must not be reported as a constructor mismatch, but was: " + message);
   }
 
   /**
@@ -135,33 +138,85 @@ class TestMetricsReporterFactory {
           () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
       assertTrue(exception.getMessage().contains("hudi-aws-bundle"),
           () -> "Expected the remedy to be named, but was: " + exception.getMessage());
+      assertTrue(exception.getMessage().contains("was not found on the classpath"),
+          () -> "Expected this branch's own phrase, not one shared with the mismatch branch, but was: "
+              + exception.getMessage());
     }
   }
 
   /**
-   * A missing constructor means hudi-aws resolved but was built against a different Hudi version, which is
-   * a mismatch rather than something absent. Reflection reports it as the same opaque HoodieException as a
-   * missing class, and the bare "Unable to instantiate class" that resulted took a maintainer reading the
-   * buried NoSuchMethodException to explain (#12902).
+   * A jar built against an older Hudi does not reach this branch - resolving its constructors fails first
+   * with {@link NoClassDefFoundError}, covered below. What reaches here is a classpath carrying a stale or
+   * duplicate copy, so that is the remedy the message has to give.
    */
   @Test
   void metricsReporterFactoryExplainsAConstructorMismatch() {
-    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.CLOUDWATCH);
-    try (MockedStatic<ReflectionUtils> mockedStatic = Mockito.mockStatic(ReflectionUtils.class)) {
-      mockedStatic.when(() -> ReflectionUtils.loadClass(
-          eq(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS), any(Class[].class), eq(metricsConfig), eq(registry)))
-          .thenThrow(new HoodieException("Unable to instantiate class " + MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS,
-              new NoSuchMethodException("<init>")));
+    HoodieException exception = captureCloudWatchFailure(
+        new HoodieException("Unable to instantiate class " + MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS,
+            new NoSuchMethodException("<init>")));
 
-      HoodieException exception = assertThrows(HoodieException.class,
-          () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
-      String message = exception.getMessage();
-      assertTrue(message.contains("constructor"),
-          () -> "The failure should say the constructor did not match, but was: " + message);
-      assertTrue(message.contains("different Hudi version"),
-          () -> "The failure should name version skew as the likely cause, but was: " + message);
-      assertFalse(message.contains("was not found on the classpath"),
-          () -> "A class that resolved must not be reported as missing, but was: " + message);
+    String message = exception.getMessage();
+    assertTrue(message.contains("constructor"),
+        () -> "The failure should say the constructor did not match, but was: " + message);
+    assertTrue(message.contains("stale or duplicate copy"),
+        () -> "The failure should name a stale duplicate as the cause, but was: " + message);
+    assertTrue(message.contains(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS),
+        () -> "The failure should name the reporter class, but was: " + message);
+    assertTrue(message.contains(HoodieMetricsConfig.METRICS_REPORTER_TYPE_VALUE.key()),
+        () -> "The failure should name the config to change, but was: " + message);
+    assertTrue(message.contains(HoodieMetricsConfig.class.getName())
+            && message.contains(MetricRegistry.class.getName()),
+        () -> "Fully qualified parameter types are what distinguish the requested constructor from the "
+            + "declared one, but was: " + message);
+    // Positive rather than an assertFalse on the other branch's prose: a vacuous assertFalse never fails.
+    assertTrue(message.contains("was found on the classpath but"),
+        () -> "A class that resolved must not be reported as missing, but was: " + message);
+    assertEquals(NoSuchMethodException.class, exception.getCause().getCause().getClass(),
+        "The original NoSuchMethodException must stay in the chain - it is the evidence #12902 needed");
+  }
+
+  /**
+   * The clean version-skew case, and the one the mismatch message used to claim. {@code getConstructor}
+   * resolves the parameter types of every public constructor, so a jar built against an older Hudi dies on a
+   * type that has since moved. That is an {@link Error}, so {@code ReflectionUtils} never wraps it and it
+   * reaches the factory uncaught.
+   */
+  @Test
+  void metricsReporterFactoryExplainsAVanishedParameterType() {
+    HoodieException exception = captureCloudWatchFailure(
+        new NoClassDefFoundError("org/apache/hudi/config/metrics/HoodieMetricsConfig"));
+
+    String message = exception.getMessage();
+    assertTrue(message.contains("built against a different Hudi version"),
+        () -> "The failure should name version skew, but was: " + message);
+    assertTrue(message.contains("org/apache/hudi/config/metrics/HoodieMetricsConfig"),
+        () -> "The failure should name the type that vanished, but was: " + message);
+    assertEquals(NoClassDefFoundError.class, exception.getCause().getClass(),
+        "The Error must stay in the chain - its message is the evidence of skew");
+  }
+
+  /**
+   * The gap every mocked test above shares: none of them proves that real reflection produces the shapes the
+   * production code branches on. This drives the translation through the real {@code ReflectionUtils} with a
+   * fixture whose only public constructor does not match, and asserts on the actual throwable.
+   */
+  @Test
+  void metricsReporterFactoryTranslatesARealReflectionFailure() {
+    HoodieException exception = assertThrows(HoodieException.class,
+        () -> MetricsReporterFactory.createCloudWatchReporter(
+            MismatchedReporter.class.getName(), metricsConfig, registry));
+
+    String message = exception.getMessage();
+    assertTrue(message.contains("stale or duplicate copy"),
+        () -> "A real non-matching constructor should reach the mismatch branch, but was: " + message);
+    assertEquals(NoSuchMethodException.class, exception.getCause().getCause().getClass(),
+        "and the real NoSuchMethodException should be chained");
+  }
+
+  /** Public, with a single constructor that deliberately does not match (HoodieMetricsConfig, MetricRegistry). */
+  public static class MismatchedReporter {
+    public MismatchedReporter(String somethingElse) {
+      // never called; exists so getConstructor has a public constructor to reject
     }
   }
 
@@ -206,6 +261,17 @@ class TestMetricsReporterFactory {
     when(metricsConfig.getMetricReporterClassName()).thenReturn(IllegalTestMetricsReporter.class.getName());
     when(metricsConfig.getProps()).thenReturn(new TypedProperties());
     assertThrows(HoodieException.class, () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
+  }
+
+  private HoodieException captureCloudWatchFailure(Throwable reflectionFailure) {
+    when(metricsConfig.getMetricsReporterType()).thenReturn(MetricsReporterType.CLOUDWATCH);
+    try (MockedStatic<ReflectionUtils> mockedStatic = Mockito.mockStatic(ReflectionUtils.class)) {
+      mockedStatic.when(() -> ReflectionUtils.loadClass(
+          eq(MetricsReporterFactory.CLOUDWATCH_REPORTER_CLASS), any(Class[].class), eq(metricsConfig), eq(registry)))
+          .thenThrow(reflectionFailure);
+      return assertThrows(HoodieException.class,
+          () -> MetricsReporterFactory.createReporter(metricsConfig, registry));
+    }
   }
 
   public static class DummyMetricsReporter extends CustomizableMetricsReporter {


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #12902. Enabling the CloudWatch reporter fails with nothing but:

```
org.apache.hudi.exception.HoodieException: Unable to instantiate class
org.apache.hudi.metrics.cloudwatch.CloudWatchMetricsReporter
```

The real cause is several frames down:

```
java.lang.NoSuchMethodException: org.apache.hudi.metrics.cloudwatch.CloudWatchMetricsReporter.<init>(
    org.apache.hudi.config.metrics.HoodieMetricsConfig, com.codahale.metrics.MetricRegistry)
	at java.lang.Class.getConstructor0(Class.java:3110)
	at org.apache.hudi.common.util.ReflectionUtils.loadClass(ReflectionUtils.java:73)
```

The class resolved, so `hudi-aws` is on the classpath, but reflection could not produce the requested
constructor. Working that out from the reported message took a maintainer digging the buried
`NoSuchMethodException` out of the stack; the message itself says only that instantiation failed.

`ReflectionUtils.loadClass` collapses `InstantiationException`, `IllegalAccessException`,
`InvocationTargetException` and `NoSuchMethodException` into one `HoodieException` with a fixed message, and
notes as much in its own TODO. #19418 added a translation for the missing-module case
(`ClassNotFoundException`) but deliberately left every other cause untouched, which is why this one still
surfaces bare.

Review established that there are three such failures, not two, and that they need different remedies.
`Class#getConstructor` resolves the parameter types of every public constructor, not just the one asked for,
and #19193 moved `HoodieMetricsConfig` out of `org.apache.hudi.config.metrics` with no compat stub. So a
clean "older bundle plus newer engine" classpath dies on the vanished type as a `NoClassDefFoundError` -- an
`Error`, which `ReflectionUtils` never wraps, since its catch lists only `Exception` subtypes -- and so never
reaches the `HoodieException` handling at all. Reproduced with a released `hudi-aws-bundle-1.1.0-rc1` against
this branch:

```
STEP1 Class.forName OK -> class org.apache.hudi.aws.metrics.cloudwatch.CloudWatchMetricsReporter
STEP2 getConstructor THREW java.lang.NoClassDefFoundError: org/apache/hudi/config/metrics/HoodieMetricsConfig
        is NoSuchMethodException?                   false
        is Error (escapes catch(Exception))?        true
```

A `NoSuchMethodException` therefore means something else: a stale or duplicate copy on the classpath. That is
also what #12902 actually was. It had matching 0.15.0 artifacts, and 0.15.0 did declare the requested
constructor, so "use a matching hudi-aws-bundle" could not have helped there.

### Summary and Changelog

- `MetricsReporterFactory#createCloudWatchReporter` translates three causes, each to its own remedy.
  `ClassNotFoundException` means the module is absent, so add `hudi-aws-bundle`. `NoClassDefFoundError` means
  the jar was built against a different Hudi, and the message quotes the type that vanished.
  `NoSuchMethodException` means a stale or duplicate copy, so look for more than one Hudi version, a leftover
  `hudi-common` or `hudi-client-common` being the usual culprit. Anything else passes through untouched.
- Parameter types are printed fully qualified. The released bundle declares
  `(org.apache.hudi.config.metrics.HoodieMetricsConfig, org.apache.hudi.com.codahale.metrics.MetricRegistry)`
  while this Hudi requests `(org.apache.hudi.common.config.metrics.HoodieMetricsConfig,
  com.codahale.metrics.MetricRegistry)`. Both differ, for two independent reasons, yet under simple names both
  render as `(HoodieMetricsConfig, MetricRegistry)` and the error looks like it is lying.
- The translation takes the reporter class name as a parameter, so it can be driven with a test fixture.

### Verification

`TestMetricsReporterFactory` covers the three branches and the pass-through:

- `metricsReporterFactoryExplainsAVanishedParameterType` pins the `NoClassDefFoundError` branch, asserting
  the message names the skew and quotes the type that vanished, and that the `Error` stays in the cause chain.
- `metricsReporterFactoryExplainsAConstructorMismatch` pins the `NoSuchMethodException` branch, asserting the
  stale-duplicate remedy, both fully qualified parameter types, the reporter class, the config key, and that
  the original `NoSuchMethodException` is still chained. Nothing pinned that chain before: deleting the `, e`
  from the throw used to leave the suite green.
- `metricsReporterFactoryTranslatesARealReflectionFailure` drives the real `ReflectionUtils` with a fixture
  whose only public constructor does not match, so the suite no longer asserts only the shapes the production
  code assumes. That gap is how the `NoClassDefFoundError` case stayed invisible.
- Both `ClassNotFoundException` tests now assert their own distinguishing phrase. Every string they checked
  also appears in the mismatch message, so the two branches could previously have been merged or reordered
  with both tests still passing.
- `metricsReporterFactoryLeavesOtherFailuresUntouched` stays green when the new branches are reverted, which
  is the point of keeping it: the pass-through branch is genuinely exercised and not absorbed by the new ones.

`checkstyle:check` and `apache-rat:check` are clean.

### Impact

Error text only, for a path that already failed. Nothing that used to succeed behaves differently, and a
failure that is neither a missing class, a vanished parameter type, nor a missing constructor is still
reported exactly as before.

One thing worth being precise about: on the `NoClassDefFoundError` path the throw type changes from an
`Error` to a `HoodieException`. No caller of `Metrics.getInstance` catches around the construction, so the
job still fails in the same place; what changes is that the failure now says which type vanished instead of
surfacing a bare `NoClassDefFoundError`.

Worth noting for whoever picks up `ReflectionUtils`: its TODO ("ReflectionUtils should throw a specific
exception to indicate Reflection problem") is the general fix, and would remove the need for cause-sniffing
here and anywhere else that wants to tell these failures apart. Not attempted in this PR, since `loadClass`
has many callers and changing what it throws is a much larger change than this issue needs.

### Risk Level

low. Two additional branches on an existing error path, plus tests. No change to any path that succeeds.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
