### PR TITLE
fix(trino): report real block size and slice splits solely by target_split_size

### DIFF
--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiConfig.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiConfig.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.airlift.units.MinDataSize;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
@@ -220,6 +221,7 @@ public class HudiConfig
     }
 
     @NotNull
+    @MinDataSize("1B")
     public DataSize getTargetSplitSize()
     {
         return targetSplitSize;

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
@@ -31,6 +31,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.dataSizeProperty;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataSize;
+import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataSize;
 import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
@@ -188,6 +189,7 @@ public class HudiSessionProperties
                         TARGET_SPLIT_SIZE,
                         "The target split size",
                         hudiConfig.getTargetSplitSize(),
+                        value -> validateMinDataSize(TARGET_SPLIT_SIZE, value, DataSize.ofBytes(1)),
                         false),
                 integerProperty(
                         MAX_SPLITS_PER_SECOND,

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/split/HudiSplitFactory.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/split/HudiSplitFactory.java
@@ -51,6 +51,8 @@ public class HudiSplitFactory
         this.hudiTableHandle = requireNonNull(hudiTableHandle, "hudiTableHandle is null");
         this.hudiSplitWeightProvider = requireNonNull(hudiSplitWeightProvider, "hudiSplitWeightProvider is null");
         this.targetSplitSize = requireNonNull(targetSplitSize, "targetSplitSize is null");
+        // A non-positive target would make split generation loop forever, so reject it here rather than mid-scan
+        checkArgument(targetSplitSize.toBytes() > 0, "targetSplitSize must be positive: %s", targetSplitSize);
     }
 
     public List<HudiSplit> createSplits(List<HivePartitionKey> partitionKeys, FileSlice fileSlice, String commitTime)
@@ -65,7 +67,7 @@ public class HudiSplitFactory
      * <p>
      * For regular MOR tables, a single split is created for the combination of the base file and its log files.
      */
-    public static List<HudiSplit> createHudiSplits(
+    private static List<HudiSplit> createHudiSplits(
             HudiTableHandle hudiTableHandle,
             List<HivePartitionKey> partitionKeys,
             FileSlice fileSlice,
@@ -130,7 +132,6 @@ public class HudiSplitFactory
         // Slicing is governed solely by the target split size; the block size reported by
         // storage is not meaningful on object stores and must not influence split sizing.
         long targetSplitSizeInBytes = targetSplitSize.toBytes();
-        checkArgument(targetSplitSizeInBytes > 0, "targetSplitSize must be positive: %s", targetSplitSize);
 
         long bytesRemaining = fileSize;
         while (((double) bytesRemaining) / targetSplitSizeInBytes > SPLIT_SLOP) {

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/split/HudiSplitFactory.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/split/HudiSplitFactory.java
@@ -127,7 +127,10 @@ public class HudiSplitFactory
         }
 
         ImmutableList.Builder<HudiSplit> splits = ImmutableList.builder();
-        long targetSplitSizeInBytes = Math.max(targetSplitSize.toBytes(), baseFile.getPathInfo().getBlockSize());
+        // Slicing is governed solely by the target split size; the block size reported by
+        // storage is not meaningful on object stores and must not influence split sizing.
+        long targetSplitSizeInBytes = targetSplitSize.toBytes();
+        checkArgument(targetSplitSizeInBytes > 0, "targetSplitSize must be positive: %s", targetSplitSize);
 
         long bytesRemaining = fileSize;
         while (((double) bytesRemaining) / targetSplitSizeInBytes > SPLIT_SLOP) {

--- a/hudi-trino/src/main/java/io/trino/plugin/hudi/storage/HudiTrinoStorage.java
+++ b/hudi-trino/src/main/java/io/trino/plugin/hudi/storage/HudiTrinoStorage.java
@@ -71,7 +71,7 @@ public class HudiTrinoStorage
                 fileEntry.length(),
                 false,
                 (short) 0,
-                0,
+                fileEntry.length(),
                 fileEntry.lastModified().toEpochMilli());
     }
 
@@ -170,7 +170,8 @@ public class HudiTrinoStorage
         if (!inputFile.exists()) {
             throw new FileNotFoundException("Path " + path + " does not exist");
         }
-        return new StoragePathInfo(path, inputFile.length(), false, (short) 0, 0, inputFile.lastModified().toEpochMilli());
+        long length = inputFile.length();
+        return new StoragePathInfo(path, length, false, (short) 0, length, inputFile.lastModified().toEpochMilli());
     }
 
     @Override

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.airlift.units.MinDataSize;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -24,6 +25,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestHudiConfig
@@ -130,5 +132,16 @@ public class TestHudiConfig
                 .setResolveColumnNameCasingEnabled(true);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testTargetSplitSizeValidation()
+    {
+        // A zero target split size would make split generation loop forever, so reject it at config time
+        assertFailsValidation(
+                new HudiConfig().setTargetSplitSize(DataSize.ofBytes(0)),
+                "targetSplitSize",
+                "must be greater than or equal to 1B",
+                MinDataSize.class);
     }
 }

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSessionProperties.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/TestHudiSessionProperties.java
@@ -14,14 +14,18 @@
 package io.trino.plugin.hudi;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.testing.TestingConnectorSession;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.hudi.HudiSessionProperties.getColumnsToHide;
 import static io.trino.plugin.hudi.HudiSessionProperties.getRecordMergerImpls;
+import static io.trino.plugin.hudi.HudiSessionProperties.getTargetSplitSize;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHudiSessionProperties
 {
@@ -49,5 +53,19 @@ public class TestHudiSessionProperties
                 .build();
         assertThat(getRecordMergerImpls(session))
                 .containsExactly("com.example.MergerOne", "com.example.MergerTwo");
+    }
+
+    @Test
+    public void testSessionPropertyTargetSplitSizeRejectsZero()
+    {
+        // A zero target split size would make split generation loop forever, so reject it when the property is read
+        HudiSessionProperties sessionProperties = new HudiSessionProperties(new HudiConfig(), new ParquetReaderConfig());
+        ConnectorSession session = TestingConnectorSession.builder()
+                .setPropertyMetadata(sessionProperties.getSessionProperties())
+                .setPropertyValues(ImmutableMap.of("target_split_size", "0B"))
+                .build();
+        assertThatThrownBy(() -> getTargetSplitSize(session))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("target_split_size must be at least 1B: 0B");
     }
 }

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/split/TestHudiSplitFactory.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/split/TestHudiSplitFactory.java
@@ -35,6 +35,7 @@ import java.util.OptionalLong;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHudiSplitFactory
 {
@@ -101,19 +102,65 @@ public class TestHudiSplitFactory
     }
 
     @Test
-    public void testCreateHudiSplitsWithLargerBlockSize()
+    public void testCreateHudiSplitsIgnoresBlockSize()
     {
-        // Test with 1MB target split size and 32MB base file
-        // - should create 4 splits because the block size of 8MB is larger than the target split size
+        // Test with 2MB target and 8MB base file whose reported block size is 8MB
+        // - the block size must be ignored, so 4 splits of the 2MB target size are expected
+        //   (previously the 8MB block size beat the target and produced 1 split of 8MB)
         testSplitCreation(
-                DataSize.of(1, MEGABYTE),
-                DataSize.of(32, MEGABYTE),
+                DataSize.of(2, MEGABYTE),
+                DataSize.of(8, MEGABYTE),
                 Option.empty(),
                 ImmutableList.of(
-                        Pair.of(0L, DataSize.of(8, MEGABYTE)),
-                        Pair.of(DataSize.of(8, MEGABYTE).toBytes(), DataSize.of(8, MEGABYTE)),
-                        Pair.of(DataSize.of(16, MEGABYTE).toBytes(), DataSize.of(8, MEGABYTE)),
-                        Pair.of(DataSize.of(24, MEGABYTE).toBytes(), DataSize.of(8, MEGABYTE))));
+                        Pair.of(0L, DataSize.of(2, MEGABYTE)),
+                        Pair.of(DataSize.of(2, MEGABYTE).toBytes(), DataSize.of(2, MEGABYTE)),
+                        Pair.of(DataSize.of(4, MEGABYTE).toBytes(), DataSize.of(2, MEGABYTE)),
+                        Pair.of(DataSize.of(6, MEGABYTE).toBytes(), DataSize.of(2, MEGABYTE))));
+    }
+
+    @Test
+    public void testCreateHudiSplitsWithFileSmallerThanDefaultTarget()
+    {
+        // Regression test for the split inflation reported in trinodb/trino#29842 (hudi#19231):
+        // a ~120MB file with the default 128MB target must produce exactly 1 split
+        testSplitCreation(
+                DataSize.of(128, MEGABYTE),
+                DataSize.of(120, MEGABYTE),
+                Option.empty(),
+                ImmutableList.of(
+                        Pair.of(0L, DataSize.of(120, MEGABYTE))));
+    }
+
+    @Test
+    public void testCreateHudiSplitsWithFileLargerThanDefaultTarget()
+    {
+        // Test with 128MB target and 500MB base file
+        // - should be sliced at target boundaries into 3 x 128MB + 116MB remainder,
+        //   even though the reported block size (8MB in the fixture) says otherwise
+        testSplitCreation(
+                DataSize.of(128, MEGABYTE),
+                DataSize.of(500, MEGABYTE),
+                Option.empty(),
+                ImmutableList.of(
+                        Pair.of(0L, DataSize.of(128, MEGABYTE)),
+                        Pair.of(DataSize.of(128, MEGABYTE).toBytes(), DataSize.of(128, MEGABYTE)),
+                        Pair.of(DataSize.of(256, MEGABYTE).toBytes(), DataSize.of(128, MEGABYTE)),
+                        Pair.of(DataSize.of(384, MEGABYTE).toBytes(), DataSize.of(116, MEGABYTE))));
+    }
+
+    @Test
+    public void testCreateHudiSplitsWithZeroTargetSplitSize()
+    {
+        // A zero target split size must fail fast instead of looping forever in split generation
+        assertThatThrownBy(() -> HudiSplitFactory.createHudiSplits(
+                createTableHandle(),
+                PARTITION_KEYS,
+                createFileSlice(DataSize.of(10, MEGABYTE), Option.empty()),
+                COMMIT_TIME,
+                new SizeBasedSplitWeightProvider(0.05, DataSize.of(128, MEGABYTE)),
+                DataSize.ofBytes(0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("targetSplitSize");
     }
 
     @Test
@@ -192,6 +239,7 @@ public class TestHudiSplitFactory
     {
         String fileId = "5a4f6a70-0306-40a8-952b-045b0d8ff0d4-0";
         HoodieFileGroupId fileGroupId = new HoodieFileGroupId("partition", fileId);
+        // Deliberately nonzero: split generation must ignore the reported block size
         long blockSize = 8L * 1024 * 1024;
         String baseFilePath = "/test/path/" + fileGroupId + "_4-19-0_" + COMMIT_TIME + ".parquet";
         String logFilePath = "/test/path/." + fileId + "_2025062515374131546.log.1_0-53-80";

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/split/TestHudiSplitFactory.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/split/TestHudiSplitFactory.java
@@ -135,8 +135,8 @@ public class TestHudiSplitFactory
     public void testCreateHudiSplitsWithFileLargerThanDefaultTarget()
     {
         // Test with 128MB target and 500MB base file
-        // - should be sliced at target boundaries into 3 x 128MB + 116MB remainder,
-        //   even though the reported block size (8MB in the fixture) says otherwise
+        // - should be sliced at target boundaries into 3 x 128MB + 116MB remainder, even though the
+        //   reported block size (500MB, the file length) would otherwise force a single split
         testSplitCreation(
                 DataSize.of(128, MEGABYTE),
                 DataSize.of(500, MEGABYTE),
@@ -151,12 +151,10 @@ public class TestHudiSplitFactory
     @Test
     public void testCreateHudiSplitsWithZeroTargetSplitSize()
     {
-        // A zero target split size must fail fast instead of looping forever in split generation
-        assertThatThrownBy(() -> HudiSplitFactory.createHudiSplits(
+        // A zero target split size must be rejected on construction, before any file slice is seen,
+        // instead of looping forever once split generation reaches a non-empty base file
+        assertThatThrownBy(() -> new HudiSplitFactory(
                 createTableHandle(),
-                PARTITION_KEYS,
-                createFileSlice(DataSize.of(10, MEGABYTE), Option.empty()),
-                COMMIT_TIME,
                 new SizeBasedSplitWeightProvider(0.05, DataSize.of(128, MEGABYTE)),
                 DataSize.ofBytes(0)))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -198,8 +196,8 @@ public class TestHudiSplitFactory
 
         FileSlice fileSlice = createFileSlice(baseFileSize, logFileSize);
 
-        List<HudiSplit> splits = HudiSplitFactory.createHudiSplits(
-                tableHandle, PARTITION_KEYS, fileSlice, COMMIT_TIME, weightProvider, targetSplitSize);
+        List<HudiSplit> splits = new HudiSplitFactory(tableHandle, weightProvider, targetSplitSize)
+                .createSplits(PARTITION_KEYS, fileSlice, COMMIT_TIME);
 
         assertThat(splits).hasSize(expectedSplitInfo.size());
 
@@ -239,15 +237,17 @@ public class TestHudiSplitFactory
     {
         String fileId = "5a4f6a70-0306-40a8-952b-045b0d8ff0d4-0";
         HoodieFileGroupId fileGroupId = new HoodieFileGroupId("partition", fileId);
-        // Deliberately nonzero: split generation must ignore the reported block size
-        long blockSize = 8L * 1024 * 1024;
+        // Block size mirrors the file length, which is what HudiTrinoStorage now reports. Split
+        // generation must ignore it, so every multi-split expectation below would collapse to a
+        // single whole-file split if the block size were allowed back into the sizing decision.
         String baseFilePath = "/test/path/" + fileGroupId + "_4-19-0_" + COMMIT_TIME + ".parquet";
         String logFilePath = "/test/path/." + fileId + "_2025062515374131546.log.1_0-53-80";
+        long logFileSizeInBytes = logFileSize.isPresent() ? logFileSize.get().toBytes() : 0L;
         StoragePathInfo baseFileInfo = new StoragePathInfo(
-                new StoragePath(baseFilePath), baseFileSize.toBytes(), false, (short) 0, blockSize, System.currentTimeMillis());
+                new StoragePath(baseFilePath), baseFileSize.toBytes(), false, (short) 0, baseFileSize.toBytes(), System.currentTimeMillis());
         StoragePathInfo logFileInfo = new StoragePathInfo(
-                new StoragePath(logFilePath), logFileSize.isPresent() ? logFileSize.get().toBytes() : 0L,
-                false, (short) 0, blockSize, System.currentTimeMillis());
+                new StoragePath(logFilePath), logFileSizeInBytes,
+                false, (short) 0, logFileSizeInBytes, System.currentTimeMillis());
         HoodieBaseFile baseFile = new HoodieBaseFile(baseFileInfo);
         return new FileSlice(fileGroupId, COMMIT_TIME, baseFile,
                 logFileSize.isPresent() ? ImmutableList.of(new HoodieLogFile(logFileInfo)) : ImmutableList.of());

--- a/hudi-trino/src/test/java/io/trino/plugin/hudi/storage/TestHudiTrinoStorage.java
+++ b/hudi-trino/src/test/java/io/trino/plugin/hudi/storage/TestHudiTrinoStorage.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi.storage;
+
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestHudiTrinoStorage
+{
+    @Test
+    void testConvertToPathInfo()
+    {
+        FileEntry fileEntry = new FileEntry(
+                Location.of("memory:///table/data.parquet"),
+                42,
+                Instant.ofEpochMilli(1234567890123L),
+                Optional.empty());
+
+        StoragePathInfo pathInfo = HudiTrinoStorage.convertToPathInfo(fileEntry);
+
+        assertThat(pathInfo.getPath()).isEqualTo(new StoragePath("memory:///table/data.parquet"));
+        assertThat(pathInfo.getLength()).isEqualTo(42);
+        assertThat(pathInfo.isFile()).isTrue();
+        assertThat(pathInfo.getBlockReplication()).isEqualTo((short) 0);
+        assertThat(pathInfo.getBlockSize()).isEqualTo(42);
+        assertThat(pathInfo.getModificationTime()).isEqualTo(1234567890123L);
+    }
+
+    @Test
+    void testGetPathInfoForFile()
+            throws IOException
+    {
+        TrinoFileSystem fileSystem = new MemoryFileSystem();
+        writeFile(fileSystem, "memory:///table/data.parquet", 42);
+        HudiTrinoStorage storage = new HudiTrinoStorage(fileSystem, new TrinoStorageConfiguration());
+
+        StoragePathInfo pathInfo = storage.getPathInfo(new StoragePath("memory:///table/data.parquet"));
+
+        assertThat(pathInfo.getLength()).isEqualTo(42);
+        assertThat(pathInfo.isFile()).isTrue();
+        assertThat(pathInfo.getBlockSize()).isEqualTo(42);
+        assertThat(pathInfo.getModificationTime()).isGreaterThan(0);
+    }
+
+    @Test
+    void testGetPathInfoForDirectory()
+            throws IOException
+    {
+        TrinoFileSystem fileSystem = new MemoryFileSystem();
+        writeFile(fileSystem, "memory:///table/data.parquet", 42);
+        HudiTrinoStorage storage = new HudiTrinoStorage(fileSystem, new TrinoStorageConfiguration());
+
+        StoragePathInfo pathInfo = storage.getPathInfo(new StoragePath("memory:///table"));
+
+        assertThat(pathInfo.isDirectory()).isTrue();
+        assertThat(pathInfo.getLength()).isEqualTo(0);
+        assertThat(pathInfo.getBlockSize()).isEqualTo(0);
+    }
+
+    @Test
+    void testListFiles()
+            throws IOException
+    {
+        HudiTrinoStorage storage = createStorageWithFiles();
+
+        List<StoragePathInfo> entries = storage.listFiles(new StoragePath("memory:///table"));
+
+        assertThat(entries).hasSize(3);
+        assertThat(entries.get(0).getPath()).isEqualTo(new StoragePath("memory:///table/a.parquet"));
+        assertThat(entries.get(1).getPath()).isEqualTo(new StoragePath("memory:///table/b.parquet"));
+        assertThat(entries.get(2).getPath()).isEqualTo(new StoragePath("memory:///table/nested/c.parquet"));
+        assertThat(entries.get(0).getLength()).isEqualTo(10);
+        assertThat(entries.get(1).getLength()).isEqualTo(20);
+        assertThat(entries.get(2).getLength()).isEqualTo(30);
+        for (StoragePathInfo entry : entries) {
+            assertThat(entry.getBlockSize()).isEqualTo(entry.getLength());
+        }
+    }
+
+    @Test
+    void testListDirectEntries()
+            throws IOException
+    {
+        HudiTrinoStorage storage = createStorageWithFiles();
+
+        List<StoragePathInfo> entries = storage.listDirectEntries(new StoragePath("memory:///table"));
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries.get(0).getPath()).isEqualTo(new StoragePath("memory:///table/a.parquet"));
+        assertThat(entries.get(1).getPath()).isEqualTo(new StoragePath("memory:///table/b.parquet"));
+        for (StoragePathInfo entry : entries) {
+            assertThat(entry.getBlockSize()).isEqualTo(entry.getLength());
+        }
+    }
+
+    @Test
+    void testListDirectEntriesWithFilter()
+            throws IOException
+    {
+        HudiTrinoStorage storage = createStorageWithFiles();
+
+        List<StoragePathInfo> entries = storage.listDirectEntries(
+                new StoragePath("memory:///table"),
+                path -> path.getName().equals("b.parquet"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).getPath()).isEqualTo(new StoragePath("memory:///table/b.parquet"));
+        assertThat(entries.get(0).getLength()).isEqualTo(20);
+        assertThat(entries.get(0).getBlockSize()).isEqualTo(20);
+    }
+
+    private static HudiTrinoStorage createStorageWithFiles()
+            throws IOException
+    {
+        TrinoFileSystem fileSystem = new MemoryFileSystem();
+        writeFile(fileSystem, "memory:///table/a.parquet", 10);
+        writeFile(fileSystem, "memory:///table/b.parquet", 20);
+        writeFile(fileSystem, "memory:///table/nested/c.parquet", 30);
+        return new HudiTrinoStorage(fileSystem, new TrinoStorageConfiguration());
+    }
+
+    private static void writeFile(TrinoFileSystem fileSystem, String location, int length)
+            throws IOException
+    {
+        fileSystem.newOutputFile(Location.of(location)).createOrOverwrite(new byte[length]);
+    }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19231. 

Ports the fix for trinodb/trino#29842 into hudi-trino. The lister the issue names (`HudiReadOptimizedDirectoryLister` with its 32MB `MIN_BLOCK_SIZE`) never made it into this repo -- it was dropped in the RFC-105 migration (#18837) -- but the blockSize=0 root cause did. See the re-scope note on the issue: https://github.com/apache/hudi/issues/19231#issuecomment-5164533965

### Summary and Changelog

- `HudiTrinoStorage.convertToPathInfo` and `getPathInfo` now report the file length as the block size instead of a hardcoded 0, matching the upstream fix at the storage layer.
- `HudiSplitFactory` slices base files solely by `target_split_size`. It previously used `max(target_split_size, blockSize)`; with the storage layer now reporting length as block size, keeping that max() would have silently disabled the knob and made every file a single split.
- Split generation fails fast on a non-positive target split size, which previously looped forever.
- Tests: a ~120MB file at the default 128MB target yields exactly 1 split (the upstream repro), a 500MB file slices at target boundaries even though the reported block size says otherwise, and a new `TestHudiTrinoStorage` asserts blockSize == length across the listing and path info APIs.

### Impact

No split count changes at default settings. `target_split_size` below 32MB is now honored consistently (the metadata table listing path used to floor it at the storage default block size). Anyone wanting upstream's strict one-split-per-file behavior can raise `target_split_size`.

### Risk Level

low, covered by unit tests

### Documentation Update

none, no new configs and defaults are unchanged

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
