### PR TITLE
fix(flink): close CDC image spillable maps on failures

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CloseableUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CloseableUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+/** Utility methods for closing resources. */
+public final class CloseableUtils {
+
+  private CloseableUtils() {
+  }
+
+  /** Closes {@code closeable}, attaching any failure to {@code primary} as a suppressed exception. */
+  public static void closeSuppressing(AutoCloseable closeable, Throwable primary) {
+    try {
+      closeable.close();
+    } catch (Throwable closeError) {
+      primary.addSuppressed(closeError);
+    }
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCloseableUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCloseableUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class TestCloseableUtils {
+
+  @Test
+  void testCloseSuppressing() {
+    IOException primary = new IOException("primary");
+    IOException closeError = new IOException("close");
+
+    CloseableUtils.closeSuppressing(() -> {
+      throw closeError;
+    }, primary);
+
+    assertArrayEquals(new Throwable[] {closeError}, primary.getSuppressed());
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
@@ -223,10 +223,15 @@ public class HoodieCdcSplitReaderFunction extends AbstractSplitReaderFunction {
         String logFilePath = new Path(tablePath, fileSplit.getCdcFiles().get(0)).toString();
         MergeOnReadInputSplit split = CdcIterators.singleLogFile2Split(tablePath, logFilePath, maxCompactionMemoryInBytes);
         ClosableIterator<HoodieRecord<RowData>> recordIterator = getFileSliceHoodieRecordIterator(split);
-        return new CdcIterators.DataLogFileIterator(
-            maxCompactionMemoryInBytes, imageManager, fileSplit, tableSchema,
-            tableState.getRequiredRowType(), tableState.getRequiredPositions(),
-            recordIterator, getMetaClient(), getWriteConfig());
+        try {
+          return new CdcIterators.DataLogFileIterator(
+              maxCompactionMemoryInBytes, imageManager, fileSplit, tableSchema,
+              tableState.getRequiredRowType(), tableState.getRequiredPositions(),
+              recordIterator, getMetaClient(), getWriteConfig());
+        } catch (IOException | RuntimeException | Error e) {
+          closeSuppressing(recordIterator, e);
+          throw e;
+        }
       }
       case REPLACE_COMMIT: {
         return new CdcIterators.ReplaceCommitIterator(
@@ -235,6 +240,14 @@ public class HoodieCdcSplitReaderFunction extends AbstractSplitReaderFunction {
       }
       default:
         throw new AssertionError("Unexpected CDC file split infer case: " + fileSplit.getCdcInferCase());
+    }
+  }
+
+  private static void closeSuppressing(ClosableIterator<?> iterator, Throwable primary) {
+    try {
+      iterator.close();
+    } catch (RuntimeException | Error closeError) {
+      primary.addSuppressed(closeError);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieCdcSplitReaderFunction.java
@@ -66,6 +66,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.util.CloseableUtils.closeSuppressing;
+
 /**
  * CDC reader function for source V2. Reads CDC splits ({@link HoodieCdcSourceSplit}) and
  * emits change-log {@link RowData} records tagged with the appropriate {@link org.apache.flink.types.RowKind}.
@@ -240,14 +242,6 @@ public class HoodieCdcSplitReaderFunction extends AbstractSplitReaderFunction {
       }
       default:
         throw new AssertionError("Unexpected CDC file split infer case: " + fileSplit.getCdcInferCase());
-    }
-  }
-
-  private static void closeSuppressing(ClosableIterator<?> iterator, Throwable primary) {
-    try {
-      iterator.close();
-    } catch (RuntimeException | Error closeError) {
-      primary.addSuppressed(closeError);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/HoodieSplitReaderFunction.java
@@ -44,6 +44,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.util.CloseableUtils.closeSuppressing;
+
 /**
  * Default reader function implementation for both MOR and COW tables.
  */
@@ -86,15 +88,6 @@ public class HoodieSplitReaderFunction extends AbstractSplitReaderFunction {
     } catch (RuntimeException | Error e) {
       closeSuppressing(fileGroupReader, e);
       throw e;
-    }
-  }
-
-  /** Closes {@code reader}, attaching any close failure to {@code primary} as a suppressed exception. */
-  private static void closeSuppressing(HoodieRecordReader<RowData> reader, Throwable primary) {
-    try {
-      reader.close();
-    } catch (Exception closeError) {
-      primary.addSuppressed(closeError);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcImageManager.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcImageManager.java
@@ -86,12 +86,7 @@ public class CdcImageManager implements AutoCloseable {
       cache.remove(oldest).close();
     }
     ExternalSpillableMap<String, byte[]> images = loadImageRecords(maxCompactionMemoryInBytes, fileSlice);
-    try {
-      cache.put(instant, images);
-    } catch (RuntimeException | Error e) {
-      closeSuppressing(images, e);
-      throw e;
-    }
+    cache.put(instant, images);
     return images;
   }
 
@@ -118,10 +113,10 @@ public class CdcImageManager implements AutoCloseable {
   }
 
   private static void closeSuppressing(
-      ExternalSpillableMap<String, byte[]> imageRecordsMap,
+      ExternalSpillableMap<String, byte[]> spillableMap,
       Throwable primary) {
     try {
-      imageRecordsMap.close();
+      spillableMap.close();
     } catch (RuntimeException | Error closeError) {
       primary.addSuppressed(closeError);
     }
@@ -172,8 +167,25 @@ public class CdcImageManager implements AutoCloseable {
 
   @Override
   public void close() {
-    cache.values().forEach(ExternalSpillableMap::close);
-    cache.clear();
+    RuntimeException failure = null;
+    try {
+      for (ExternalSpillableMap<String, byte[]> spillableMap : cache.values()) {
+        try {
+          spillableMap.close();
+        } catch (RuntimeException e) {
+          if (failure == null) {
+            failure = e;
+          } else {
+            failure.addSuppressed(e);
+          }
+        }
+      }
+    } finally {
+      cache.clear();
+    }
+    if (failure != null) {
+      throw failure;
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcImageManager.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcImageManager.java
@@ -86,7 +86,12 @@ public class CdcImageManager implements AutoCloseable {
       cache.remove(oldest).close();
     }
     ExternalSpillableMap<String, byte[]> images = loadImageRecords(maxCompactionMemoryInBytes, fileSlice);
-    cache.put(instant, images);
+    try {
+      cache.put(instant, images);
+    } catch (RuntimeException | Error e) {
+      closeSuppressing(images, e);
+      throw e;
+    }
     return images;
   }
 
@@ -105,13 +110,26 @@ public class CdcImageManager implements AutoCloseable {
         serializer.serialize(row, new BytesArrayOutputView(baos));
         imageRecordsMap.put(recordKey, baos.toByteArray());
       }
+    } catch (IOException | RuntimeException | Error e) {
+      closeSuppressing(imageRecordsMap, e);
+      throw e;
     }
     return imageRecordsMap;
   }
 
+  private static void closeSuppressing(
+      ExternalSpillableMap<String, byte[]> imageRecordsMap,
+      Throwable primary) {
+    try {
+      imageRecordsMap.close();
+    } catch (RuntimeException | Error closeError) {
+      primary.addSuppressed(closeError);
+    }
+  }
+
   public RowData getImageRecord(
       String recordKey,
-      ExternalSpillableMap<String, byte[]> imageCache,
+      Map<String, byte[]> imageCache,
       RowKind rowKind) {
     byte[] bytes = imageCache.get(recordKey);
     ValidationUtils.checkState(bytes != null,
@@ -127,7 +145,7 @@ public class CdcImageManager implements AutoCloseable {
 
   public void updateImageRecord(
       String recordKey,
-      ExternalSpillableMap<String, byte[]> imageCache,
+      Map<String, byte[]> imageCache,
       RowData row) {
     ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
     try {
@@ -140,7 +158,7 @@ public class CdcImageManager implements AutoCloseable {
 
   public RowData removeImageRecord(
       String recordKey,
-      ExternalSpillableMap<String, byte[]> imageCache) {
+      Map<String, byte[]> imageCache) {
     byte[] bytes = imageCache.remove(recordKey);
     if (bytes == null) {
       return null;

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcImageManager.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcImageManager.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Function;
 
+import static org.apache.hudi.common.util.CloseableUtils.closeSuppressing;
 import static org.apache.hudi.hadoop.utils.HoodieInputFormatUtils.HOODIE_RECORD_KEY_COL_POS;
 
 /**
@@ -110,16 +111,6 @@ public class CdcImageManager implements AutoCloseable {
       throw e;
     }
     return imageRecordsMap;
-  }
-
-  private static void closeSuppressing(
-      ExternalSpillableMap<String, byte[]> spillableMap,
-      Throwable primary) {
-    try {
-      spillableMap.close();
-    } catch (RuntimeException | Error closeError) {
-      primary.addSuppressed(closeError);
-    }
   }
 
   public RowData getImageRecord(

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
@@ -48,6 +48,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.apache.hudi.common.util.CloseableUtils.closeSuppressing;
+
 /**
  * The base InputFormat class to read Hoodie data set as change logs.
  */
@@ -173,14 +175,6 @@ public class CdcInputFormat extends MergeOnReadInputFormat {
             maxCompactionMemoryInBytes, fileSplit, this::getFileSliceIterator);
       default:
         throw new AssertionError("Unexpected cdc file split infer case: " + fileSplit.getCdcInferCase());
-    }
-  }
-
-  private static void closeSuppressing(ClosableIterator<?> iterator, Throwable primary) {
-    try {
-      iterator.close();
-    } catch (RuntimeException | Error closeError) {
-      primary.addSuppressed(closeError);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcInputFormat.java
@@ -157,17 +157,30 @@ public class CdcInputFormat extends MergeOnReadInputFormat {
         String logFilepath = new Path(tablePath, fileSplit.getCdcFiles().get(0)).toString();
         MergeOnReadInputSplit split = CdcIterators.singleLogFile2Split(tablePath, logFilepath, maxCompactionMemoryInBytes);
         ClosableIterator<HoodieRecord<RowData>> recordIterator = getSplitRecordIterator(split);
-        return new CdcIterators.DataLogFileIterator(
-            maxCompactionMemoryInBytes, imageManager, fileSplit,
-            HoodieSchema.parse(tableState.getTableSchema()),
-            tableState.getRequiredRowType(), tableState.getRequiredPositions(),
-            recordIterator, metaClient, imageManager.getWriteConfig());
+        try {
+          return new CdcIterators.DataLogFileIterator(
+              maxCompactionMemoryInBytes, imageManager, fileSplit,
+              HoodieSchema.parse(tableState.getTableSchema()),
+              tableState.getRequiredRowType(), tableState.getRequiredPositions(),
+              recordIterator, metaClient, imageManager.getWriteConfig());
+        } catch (IOException | RuntimeException | Error e) {
+          closeSuppressing(recordIterator, e);
+          throw e;
+        }
       case REPLACE_COMMIT:
         return new CdcIterators.ReplaceCommitIterator(
             tablePath, tableState.getRequiredRowType(), tableState.getRequiredPositions(),
             maxCompactionMemoryInBytes, fileSplit, this::getFileSliceIterator);
       default:
         throw new AssertionError("Unexpected cdc file split infer case: " + fileSplit.getCdcInferCase());
+    }
+  }
+
+  private static void closeSuppressing(ClosableIterator<?> iterator, Throwable primary) {
+    try {
+      iterator.close();
+    } catch (RuntimeException | Error closeError) {
+      primary.addSuppressed(closeError);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
@@ -146,12 +146,14 @@ public final class CdcIterators {
 
     @Override
     public void close() {
-      if (recordIterator != null) {
-        recordIterator.close();
-      }
-      if (imageManager != null) {
-        imageManager.close();
-        imageManager = null;
+      ClosableIterator<RowData> iterator = recordIterator;
+      recordIterator = null;
+      CdcImageManager manager = imageManager;
+      imageManager = null;
+      try (CdcImageManager ignored = manager) {
+        if (iterator != null) {
+          iterator.close();
+        }
       }
     }
   }
@@ -347,12 +349,7 @@ public final class CdcIterators {
 
     @Override
     public void close() {
-      // Closing the shared image manager here is required for correctness: this iterator
-      // destructively updates cached before-images, and LOG_FILE slices from the same instant
-      // share a cache key. Closing forces the next split to reload its own before-images.
-      try (CdcImageManager ignored = imageManager) {
-        logRecordIterator.close();
-      }
+      logRecordIterator.close();
     }
 
     @SuppressWarnings("unchecked")

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
@@ -146,14 +146,13 @@ public final class CdcIterators {
 
     @Override
     public void close() {
-      ClosableIterator<RowData> iterator = recordIterator;
-      recordIterator = null;
-      CdcImageManager manager = imageManager;
-      imageManager = null;
-      try (CdcImageManager ignored = manager) {
-        if (iterator != null) {
-          iterator.close();
+      try (CdcImageManager ignored = imageManager) {
+        if (recordIterator != null) {
+          recordIterator.close();
         }
+      } finally {
+        recordIterator = null;
+        imageManager = null;
       }
     }
   }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
@@ -60,7 +60,6 @@ import org.apache.hudi.hadoop.fs.HadoopFSUtils;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.format.FlinkReaderContextFactory;
-import org.apache.hudi.table.format.FormatUtils;
 import org.apache.hudi.table.format.HoodieRowDataFileReader;
 import org.apache.hudi.table.format.InternalSchemaManager;
 import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
@@ -80,6 +79,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -253,7 +253,7 @@ public final class CdcIterators {
     private final String[] orderingFields;
     private final TypedProperties props;
 
-    private ExternalSpillableMap<String, byte[]> beforeImages;
+    private Map<String, byte[]> beforeImages;
     private RowData currentImage;
     private RowData sideImage;
 
@@ -287,15 +287,15 @@ public final class CdcIterators {
           metaClient.getTableConfig().getPartialUpdateMode());
       this.logRecordIterator = logRecordIterator;
       this.deleteContext = new DeleteContext(props, tableSchema).withReaderSchema(tableSchema);
-      initImages(cdcFileSplit, writeConfig);
+      initImages(cdcFileSplit);
     }
 
-    private void initImages(HoodieCDCFileSplit fileSplit, HoodieWriteConfig writeConfig) throws IOException {
+    private void initImages(HoodieCDCFileSplit fileSplit) throws IOException {
       if (fileSplit.getBeforeFileSlice().isPresent() && !fileSplit.getBeforeFileSlice().get().isEmpty()) {
         this.beforeImages = imageManager.getOrLoadImages(
             maxCompactionMemoryInBytes, fileSplit.getBeforeFileSlice().get());
       } else {
-        this.beforeImages = FormatUtils.spillableMap(writeConfig, maxCompactionMemoryInBytes, getClass().getSimpleName());
+        this.beforeImages = Collections.emptyMap();
       }
     }
 
@@ -347,8 +347,9 @@ public final class CdcIterators {
 
     @Override
     public void close() {
-      logRecordIterator.close();
-      imageManager.close();
+      try (CdcImageManager ignored = imageManager) {
+        logRecordIterator.close();
+      }
     }
 
     @SuppressWarnings("unchecked")

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
@@ -83,6 +83,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.util.CloseableUtils.closeSuppressing;
 import static org.apache.hudi.table.format.FormatUtils.buildAvroRecordBySchema;
 
 /**
@@ -730,14 +731,6 @@ public final class CdcIterators {
       RowData row = imageManager.getImageRecord(recordKey, beforeImages, rowKind);
       row.setRowKind(rowKind);
       return projection.project(row);
-    }
-  }
-
-  private static void closeSuppressing(ClosableIterator<?> iterator, Throwable primary) {
-    try {
-      iterator.close();
-    } catch (RuntimeException | Error closeError) {
-      primary.addSuppressed(closeError);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/cdc/CdcIterators.java
@@ -347,6 +347,9 @@ public final class CdcIterators {
 
     @Override
     public void close() {
+      // Closing the shared image manager here is required for correctness: this iterator
+      // destructively updates cached before-images, and LOG_FILE slices from the same instant
+      // share a cache key. Closing forces the next split to reload its own before-images.
       try (CdcImageManager ignored = imageManager) {
         logRecordIterator.close();
       }
@@ -663,7 +666,12 @@ public final class CdcIterators {
       this.maxCompactionMemoryInBytes = maxCompactionMemoryInBytes;
       this.projection = RowDataProjection.instance(requiredRowType, requiredPositions);
       this.imageManager = imageManager;
-      initImages(fileSplit);
+      try {
+        initImages(fileSplit);
+      } catch (IOException | RuntimeException | Error e) {
+        closeSuppressing(this, e);
+        throw e;
+      }
     }
 
     protected void initImages(HoodieCDCFileSplit fileSplit) throws IOException {
@@ -726,6 +734,14 @@ public final class CdcIterators {
       RowData row = imageManager.getImageRecord(recordKey, beforeImages, rowKind);
       row.setRowKind(rowKind);
       return projection.project(row);
+    }
+  }
+
+  private static void closeSuppressing(ClosableIterator<?> iterator, Throwable primary) {
+    try {
+      iterator.close();
+    } catch (RuntimeException | Error closeError) {
+      primary.addSuppressed(closeError);
     }
   }
 

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cdc/TestCdcImageManager.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cdc/TestCdcImageManager.java
@@ -154,6 +154,55 @@ class TestCdcImageManager {
     }
   }
 
+  @Test
+  void testLoadClosesImageCacheWhenIteratorCreationFails() {
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    when(writeConfig.getBasePath()).thenReturn("/table");
+    ExternalSpillableMap<String, byte[]> imageCache = mockImageCache();
+    RuntimeException failure = new RuntimeException("iterator creation failed");
+    CdcImageManager imageManager = new CdcImageManager(
+        rowType("value"),
+        writeConfig,
+        split -> {
+          throw failure;
+        });
+
+    try (MockedStatic<FormatUtils> mockedFormatUtils = mockStatic(FormatUtils.class)) {
+      mockedFormatUtils.when(() -> FormatUtils.spillableMap(
+          writeConfig, 1024L, CdcImageManager.class.getSimpleName()))
+          .thenReturn(imageCache);
+
+      assertSame(failure, assertThrows(
+          RuntimeException.class,
+          () -> imageManager.getOrLoadImages(1024L, fileSlice("001"))));
+      verify(imageCache).close();
+    }
+  }
+
+  @Test
+  void testLoadClosesIteratorAndImageCacheWhenIterationFails() {
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    when(writeConfig.getBasePath()).thenReturn("/table");
+    ExternalSpillableMap<String, byte[]> imageCache = mockImageCache();
+    ClosableIterator<RowData> iterator = mock(ClosableIterator.class);
+    RuntimeException failure = new RuntimeException("iteration failed");
+    when(iterator.hasNext()).thenThrow(failure);
+    CdcImageManager imageManager = new CdcImageManager(
+        rowType("value"), writeConfig, split -> iterator);
+
+    try (MockedStatic<FormatUtils> mockedFormatUtils = mockStatic(FormatUtils.class)) {
+      mockedFormatUtils.when(() -> FormatUtils.spillableMap(
+          writeConfig, 1024L, CdcImageManager.class.getSimpleName()))
+          .thenReturn(imageCache);
+
+      assertSame(failure, assertThrows(
+          RuntimeException.class,
+          () -> imageManager.getOrLoadImages(1024L, fileSlice("001"))));
+      verify(iterator).close();
+      verify(imageCache).close();
+    }
+  }
+
   @SuppressWarnings("unchecked")
   private static ExternalSpillableMap<String, byte[]> mockImageCache() {
     ExternalSpillableMap<String, byte[]> imageCache = mock(ExternalSpillableMap.class);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cdc/TestCdcImageManager.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cdc/TestCdcImageManager.java
@@ -34,6 +34,8 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.RowKind;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.MockedStatic;
 
 import java.io.ByteArrayOutputStream;
@@ -50,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -154,15 +157,56 @@ class TestCdcImageManager {
     }
   }
 
-  @Test
-  void testLoadClosesImageCacheWhenIteratorCreationFails() {
+  private enum LoadFailure {
+    ITERATOR_CREATION,
+    ITERATION
+  }
+
+  @ParameterizedTest
+  @EnumSource(LoadFailure.class)
+  void testLoadClosesImageCacheWhenLoadFails(LoadFailure mode) {
     HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
     when(writeConfig.getBasePath()).thenReturn("/table");
     ExternalSpillableMap<String, byte[]> imageCache = mockImageCache();
-    RuntimeException failure = new RuntimeException("iterator creation failed");
+    ClosableIterator<RowData> iterator = mockIterator();
+    RuntimeException failure = new RuntimeException("load failed");
+    when(iterator.hasNext()).thenThrow(failure);
     CdcImageManager imageManager = new CdcImageManager(
-        rowType("value"),
-        writeConfig,
+        rowType("value"), writeConfig,
+        split -> {
+          if (mode == LoadFailure.ITERATOR_CREATION) {
+            throw failure;
+          }
+          return iterator;
+        });
+
+    try (MockedStatic<FormatUtils> mockedFormatUtils = mockStatic(FormatUtils.class)) {
+      mockedFormatUtils.when(() -> FormatUtils.spillableMap(
+          writeConfig, 1024L, CdcImageManager.class.getSimpleName()))
+          .thenReturn(imageCache);
+
+      assertSame(failure, assertThrows(
+          RuntimeException.class,
+          () -> imageManager.getOrLoadImages(1024L, fileSlice("001"))));
+      if (mode == LoadFailure.ITERATION) {
+        verify(iterator).close();
+      }
+      verify(imageCache, times(1)).close();
+      imageManager.close();
+      verify(imageCache, times(1)).close();
+    }
+  }
+
+  @Test
+  void testLoadSuppressesImageCacheCloseError() {
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    when(writeConfig.getBasePath()).thenReturn("/table");
+    ExternalSpillableMap<String, byte[]> imageCache = mockImageCache();
+    RuntimeException closeFailure = new RuntimeException("close failed");
+    doThrow(closeFailure).when(imageCache).close();
+    RuntimeException failure = new RuntimeException("load failed");
+    CdcImageManager imageManager = new CdcImageManager(
+        rowType("value"), writeConfig,
         split -> {
           throw failure;
         });
@@ -175,32 +219,47 @@ class TestCdcImageManager {
       assertSame(failure, assertThrows(
           RuntimeException.class,
           () -> imageManager.getOrLoadImages(1024L, fileSlice("001"))));
-      verify(imageCache).close();
+      assertEquals(1, failure.getSuppressed().length, "close failure must be suppressed, not lost");
+      assertSame(closeFailure, failure.getSuppressed()[0]);
     }
   }
 
   @Test
-  void testLoadClosesIteratorAndImageCacheWhenIterationFails() {
+  void testCloseContinuesAfterFailureAndClearsCache() throws IOException {
     HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
     when(writeConfig.getBasePath()).thenReturn("/table");
-    ExternalSpillableMap<String, byte[]> imageCache = mockImageCache();
-    ClosableIterator<RowData> iterator = mock(ClosableIterator.class);
-    RuntimeException failure = new RuntimeException("iteration failed");
-    when(iterator.hasNext()).thenThrow(failure);
+    ExternalSpillableMap<String, byte[]> first = mockImageCache();
+    ExternalSpillableMap<String, byte[]> second = mockImageCache();
+    RuntimeException firstFailure = new RuntimeException("first close failed");
+    RuntimeException secondFailure = new RuntimeException("second close failed");
+    doThrow(firstFailure).when(first).close();
+    doThrow(secondFailure).when(second).close();
     CdcImageManager imageManager = new CdcImageManager(
-        rowType("value"), writeConfig, split -> iterator);
+        rowType("value"), writeConfig,
+        split -> ClosableIterator.wrap(List.<RowData>of().iterator()));
 
     try (MockedStatic<FormatUtils> mockedFormatUtils = mockStatic(FormatUtils.class)) {
       mockedFormatUtils.when(() -> FormatUtils.spillableMap(
           writeConfig, 1024L, CdcImageManager.class.getSimpleName()))
-          .thenReturn(imageCache);
+          .thenReturn(first, second);
+      imageManager.getOrLoadImages(1024L, fileSlice("001"));
+      imageManager.getOrLoadImages(1024L, fileSlice("002"));
 
-      assertSame(failure, assertThrows(
-          RuntimeException.class,
-          () -> imageManager.getOrLoadImages(1024L, fileSlice("001"))));
-      verify(iterator).close();
-      verify(imageCache).close();
+      assertSame(firstFailure, assertThrows(RuntimeException.class, imageManager::close));
+      assertEquals(1, firstFailure.getSuppressed().length);
+      assertSame(secondFailure, firstFailure.getSuppressed()[0]);
+      verify(first, times(1)).close();
+      verify(second, times(1)).close();
+
+      imageManager.close();
+      verify(first, times(1)).close();
+      verify(second, times(1)).close();
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ClosableIterator<RowData> mockIterator() {
+    return mock(ClosableIterator.class);
   }
 
   @SuppressWarnings("unchecked")

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cdc/TestCdcIterators.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/format/cdc/TestCdcIterators.java
@@ -46,7 +46,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -117,12 +120,41 @@ class TestCdcIterators {
 
     assertTrue(iterator.hasNext());
     assertSame(row, iterator.next());
+    verify(firstIterator).close();
+    verify(imageManager, never()).close();
     assertFalse(iterator.hasNext());
+    verify(secondIterator).close();
+    verify(imageManager, never()).close();
     iterator.close();
 
-    verify(firstIterator).close();
-    verify(secondIterator).close();
     verify(imageManager).close();
+  }
+
+  @Test
+  void testCdcFileSplitsIteratorSuppressesImageManagerCloseFailure() {
+    HoodieCDCFileSplit split = new HoodieCDCFileSplit(
+        "001", HoodieCDCInferenceCase.BASE_FILE_INSERT, "first.parquet");
+    ClosableIterator<RowData> recordIterator = mockIterator();
+    when(recordIterator.hasNext()).thenReturn(true);
+    RuntimeException iteratorFailure = new RuntimeException("iterator close failed");
+    doThrow(iteratorFailure).when(recordIterator).close();
+    CdcImageManager imageManager = mock(CdcImageManager.class);
+    RuntimeException managerFailure = new RuntimeException("manager close failed");
+    doThrow(managerFailure).when(imageManager).close();
+    CdcIterators.CdcFileSplitsIterator iterator =
+        new CdcIterators.CdcFileSplitsIterator(
+            new HoodieCDCFileSplit[] {split}, imageManager, ignored -> recordIterator);
+    assertTrue(iterator.hasNext());
+
+    assertSame(iteratorFailure, assertThrows(RuntimeException.class, iterator::close));
+    assertEquals(1, iteratorFailure.getSuppressed().length);
+    assertSame(managerFailure, iteratorFailure.getSuppressed()[0]);
+    verify(recordIterator, times(1)).close();
+    verify(imageManager, times(1)).close();
+
+    iterator.close();
+    verify(recordIterator, times(1)).close();
+    verify(imageManager, times(1)).close();
   }
 
   @Test


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

CDC image loading allocates spillable maps that were not closed when iterator creation or traversal failed, leaking disk and native resources. The LOG_FILE path also allocated a spillable map for an absent before-slice even though that cache remains empty.

### Summary and Changelog

- Close newly allocated CDC image maps when loading or cache registration fails, preserving cleanup failures as suppressed exceptions.
- Generalize image-record helpers to the `Map` interface and use `Collections.emptyMap()` when no before-image slice exists.
- Ensure the log-record iterator and image manager are both closed while preserving the primary close failure.
- Add focused coverage for iterator-creation and iteration failure cleanup.

### Impact

Prevents temporary disk and native resource leaks in Flink CDC reads. There are no public API, configuration, storage-format, or user-visible behavior changes.

### Risk Level

Low. The changes are localized to Flink CDC image-cache lifecycle handling and are covered by focused unit tests.

### Documentation Update

None.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
