### PR TITLE
test(utilities): report why the continuous-mode wait timed out

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/JavaTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/JavaTestUtils.java
@@ -28,7 +28,10 @@ public class JavaTestUtils {
     Throwable throwable = t;
     boolean res = false;
     while (throwable != null) {
-      if (throwable.getMessage().contains(errorMsg)) {
+      // String.valueOf rather than getMessage().contains: a null message anywhere in the chain would
+      // otherwise NPE here and lose the failure the caller was trying to assert on. A TimeoutException
+      // raised before its condition ever threw is one such case, and NPEs in a chain are another.
+      if (String.valueOf(throwable.getMessage()).contains(errorMsg)) {
         res = true;
         break;
       }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/JavaTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/JavaTestUtils.java
@@ -28,10 +28,11 @@ public class JavaTestUtils {
     Throwable throwable = t;
     boolean res = false;
     while (throwable != null) {
-      // String.valueOf rather than getMessage().contains: a null message anywhere in the chain would
-      // otherwise NPE here and lose the failure the caller was trying to assert on. A TimeoutException
-      // raised before its condition ever threw is one such case, and NPEs in a chain are another.
-      if (String.valueOf(throwable.getMessage()).contains(errorMsg)) {
+      // A null message is treated as "not a match" rather than an NPE: a TimeoutException raised before its
+      // condition ever threw carries no message, and neither do many wrapped NPEs. String.valueOf would also
+      // avoid the NPE, but would make an errorMsg of "null" match a message-less throwable: a trap, not a match.
+      String message = throwable.getMessage();
+      if (message != null && message.contains(errorMsg)) {
         res = true;
         break;
       }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestJavaTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestJavaTestUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.testutils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the null-message handling of {@link JavaTestUtils#checkNestedExceptionContains}: a throwable
+ * with no message must neither NPE the walk nor match an errorMsg of "null". The helper's callers all
+ * live in other modules, so the test lives beside the helper to keep it covered where it is defined.
+ */
+public class TestJavaTestUtils {
+
+  @Test
+  public void testNullMessageOnHeadStillMatchesDeeperCause() {
+    // Pre-fix this NPE'd on the head. The explicit (String) null cast matters: new RuntimeException(cause)
+    // would set the message to the cause's toString and hide the null-message case entirely.
+    Throwable t = new RuntimeException((String) null, new IllegalStateException("boom"));
+    assertTrue(JavaTestUtils.checkNestedExceptionContains(t, "boom"));
+  }
+
+  @Test
+  public void testNullMessageMidChainDoesNotStopTheWalk() {
+    Throwable deepest = new IllegalArgumentException("boom");
+    Throwable t = new RuntimeException("head", new RuntimeException((String) null, deepest));
+    assertTrue(JavaTestUtils.checkNestedExceptionContains(t, "boom"));
+  }
+
+  @Test
+  public void testErrorMsgNullDoesNotMatchMessagelessThrowable() {
+    assertFalse(JavaTestUtils.checkNestedExceptionContains(new RuntimeException((String) null), "null"));
+  }
+
+  @Test
+  public void testMessageContainingTextMatchesOnHead() {
+    assertTrue(JavaTestUtils.checkNestedExceptionContains(new RuntimeException("a boom happened"), "boom"));
+  }
+
+  @Test
+  public void testNoMatchAnywhereInChainReturnsFalse() {
+    Throwable t = new RuntimeException("head", new IllegalStateException("cause"));
+    assertFalse(JavaTestUtils.checkNestedExceptionContains(t, "boom"));
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestJavaTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestJavaTestUtils.java
@@ -41,12 +41,6 @@ public class TestJavaTestUtils {
   }
 
   @Test
-  public void testNullThrowableReturnsFalse() {
-    // The loop guard, the one input shape the other cases never reach.
-    assertFalse(JavaTestUtils.checkNestedExceptionContains(null, "boom"));
-  }
-
-  @Test
   public void testErrorMsgNullDoesNotMatchMessagelessThrowable() {
     assertFalse(JavaTestUtils.checkNestedExceptionContains(new RuntimeException((String) null), "null"));
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestJavaTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/TestJavaTestUtils.java
@@ -32,18 +32,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestJavaTestUtils {
 
   @Test
-  public void testNullMessageOnHeadStillMatchesDeeperCause() {
-    // Pre-fix this NPE'd on the head. The explicit (String) null cast matters: new RuntimeException(cause)
-    // would set the message to the cause's toString and hide the null-message case entirely.
-    Throwable t = new RuntimeException((String) null, new IllegalStateException("boom"));
+  public void testNullMessageMidChainDoesNotStopTheWalk() {
+    // Pre-fix this NPE'd on the message-less link. The explicit (String) null cast matters:
+    // new RuntimeException(cause) would set the message to the cause's toString and hide the case entirely.
+    Throwable deepest = new IllegalArgumentException("boom");
+    Throwable t = new RuntimeException("head", new RuntimeException((String) null, deepest));
     assertTrue(JavaTestUtils.checkNestedExceptionContains(t, "boom"));
   }
 
   @Test
-  public void testNullMessageMidChainDoesNotStopTheWalk() {
-    Throwable deepest = new IllegalArgumentException("boom");
-    Throwable t = new RuntimeException("head", new RuntimeException((String) null, deepest));
-    assertTrue(JavaTestUtils.checkNestedExceptionContains(t, "boom"));
+  public void testNullThrowableReturnsFalse() {
+    // The loop guard, the one input shape the other cases never reach.
+    assertFalse(JavaTestUtils.checkNestedExceptionContains(null, "boom"));
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -81,6 +81,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -769,32 +770,40 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     /**
      * Polls {@code condition} until it holds, the deltastreamer future finishes, or the timeout expires.
      *
-     * <p>On timeout the last error the condition threw is attached to the failure. Without it the only
-     * output is a bare {@link TimeoutException} pointing at this method, which says nothing about which
-     * assertion never held - the reason HUDI-6843 stayed open: every report of it looks identical.
+     * <p>On timeout the last error the condition threw is attached to the failure, so the report names the
+     * assertion that never held rather than only this method.
      */
+    /** Bound for {@link #waitFor}; generous, since it only exists to stop a hung poll running forever. */
+    private static final long WAIT_FOR_TIMEOUT_SECS = 120;
+
     static void waitTillCondition(Function<Boolean, Boolean> condition, Future dsFuture, long timeoutInSecs) throws Exception {
       AtomicReference<Throwable> lastError = new AtomicReference<>();
+      AtomicInteger completedEvaluations = new AtomicInteger();
       ExecutorService executor = Executors.newSingleThreadExecutor();
       try {
         Future<Boolean> res = executor.submit(() -> {
           boolean ret = false;
-          while (!ret && !dsFuture.isDone() && !Thread.currentThread().isInterrupted()) {
+          // The executor check matters as well as the interrupt flag: the interrupt from shutdownNow is
+          // delivered once, and a condition that swallows it would otherwise leave the flag clear and keep
+          // this thread polling for the lifetime of the JVM.
+          while (!ret && !dsFuture.isDone() && !Thread.currentThread().isInterrupted() && !executor.isShutdown()) {
             try {
               Thread.sleep(2000);
               ret = condition.apply(true);
+              completedEvaluations.incrementAndGet();
               if (ret) {
                 log.info("Condition completed successfully");
               }
             } catch (InterruptedException interrupted) {
-              // shutdownNow below interrupts this thread once the wait has given up. Thread.sleep clears
-              // the interrupt flag when it throws, so catching this with everything else would re-enter
-              // the loop and keep polling forever. Restore the flag and stop; this is not a condition
-              // failure, so it is deliberately not recorded as one.
+              // Thread.sleep clears the interrupt flag when it throws, so catching this with everything
+              // else would re-enter the loop. Restore the flag and stop; this is not a condition failure,
+              // so it is deliberately not recorded as one.
               Thread.currentThread().interrupt();
               break;
             } catch (Throwable error) {
+              log.debug("Got error waiting for condition", error);
               lastError.set(error);
+              completedEvaluations.incrementAndGet();
               ret = false;
             }
           }
@@ -804,9 +813,18 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
           res.get(timeoutInSecs, TimeUnit.SECONDS);
         } catch (TimeoutException e) {
           Throwable last = lastError.get();
-          String detail = last == null
-              ? "The condition returned false without throwing, so there is no further detail."
-              : "The last failure it reported was: " + last;
+          int completed = completedEvaluations.get();
+          String detail;
+          if (completed == 0) {
+            // Distinguishes a condition that is stuck part-way through its first evaluation - a hung Spark
+            // read, say - from one that simply kept returning false.
+            detail = "No evaluation of the condition completed, so it was still running or never started.";
+          } else if (last == null) {
+            detail = String.format("%d evaluations completed and returned false without throwing, "
+                + "so there is no further detail.", completed);
+          } else {
+            detail = String.format("%d evaluations completed; the last failure reported was: %s", completed, last);
+          }
           Throwable cause = last == null ? e : last;
           throw new AssertionError(
               String.format("Condition was not met within %d seconds. %s", timeoutInSecs, detail), cause);
@@ -822,11 +840,19 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
      * @param booleanSupplier Boolean supplier
      */
     static void waitFor(BooleanSupplier booleanSupplier) {
+      // Bounded, and the interrupt is restored rather than swallowed: this runs inside conditions passed to
+      // waitTillCondition, so swallowing it would defeat the stop that shutdownNow signals.
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(WAIT_FOR_TIMEOUT_SECS);
       while (!booleanSupplier.getAsBoolean()) {
+        if (System.nanoTime() > deadline) {
+          throw new AssertionError(
+              String.format("Condition did not hold within %d seconds", WAIT_FOR_TIMEOUT_SECS));
+        }
         try {
           Thread.sleep(5);
-        } catch (Throwable error) {
-          log.debug("Got error waiting for condition", error);
+        } catch (InterruptedException interrupted) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("Interrupted while waiting for condition", interrupted);
         }
       }
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -76,9 +76,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
@@ -763,22 +766,47 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       return lastInstant;
     }
 
+    /**
+     * Polls {@code condition} until it holds, the deltastreamer future finishes, or the timeout expires.
+     *
+     * <p>On timeout the last error the condition threw is attached to the failure. Without it the only
+     * output is a bare {@link TimeoutException} pointing at this method, which says nothing about which
+     * assertion never held - the reason HUDI-6843 stayed open: every report of it looks identical.
+     */
     static void waitTillCondition(Function<Boolean, Boolean> condition, Future dsFuture, long timeoutInSecs) throws Exception {
-      Future<Boolean> res = Executors.newSingleThreadExecutor().submit(() -> {
-        boolean ret = false;
-        while (!ret && !dsFuture.isDone()) {
-          try {
-            Thread.sleep(2000);
-            ret = condition.apply(true);
-            log.info("Condition completed successfully");
-          } catch (Throwable error) {
-            log.debug("Got error waiting for condition", error);
-            ret = false;
+      AtomicReference<Throwable> lastError = new AtomicReference<>();
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      try {
+        Future<Boolean> res = executor.submit(() -> {
+          boolean ret = false;
+          while (!ret && !dsFuture.isDone()) {
+            try {
+              Thread.sleep(2000);
+              ret = condition.apply(true);
+              if (ret) {
+                log.info("Condition completed successfully");
+              }
+            } catch (Throwable error) {
+              lastError.set(error);
+              ret = false;
+            }
           }
+          return ret;
+        });
+        try {
+          res.get(timeoutInSecs, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+          Throwable last = lastError.get();
+          throw new AssertionError(String.format(
+              "Condition was not met within %d seconds. %s", timeoutInSecs,
+              last == null
+                  ? "The condition returned false without throwing, so there is no further detail."
+                  : "The last failure it reported was: " + last), last == null ? e : last);
         }
-        return ret;
-      });
-      res.get(timeoutInSecs, TimeUnit.SECONDS);
+      } finally {
+        // this used to leak the polling thread on every call, and it is called by every continuous-mode test
+        executor.shutdownNow();
+      }
     }
 
     /**

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -76,9 +76,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
@@ -763,22 +766,55 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       return lastInstant;
     }
 
+    /**
+     * Polls {@code condition} until it holds, the deltastreamer future finishes, or the timeout expires.
+     *
+     * <p>On timeout the last error the condition threw is attached to the failure. Without it the only
+     * output is a bare {@link TimeoutException} pointing at this method, which says nothing about which
+     * assertion never held - the reason HUDI-6843 stayed open: every report of it looks identical.
+     */
     static void waitTillCondition(Function<Boolean, Boolean> condition, Future dsFuture, long timeoutInSecs) throws Exception {
-      Future<Boolean> res = Executors.newSingleThreadExecutor().submit(() -> {
-        boolean ret = false;
-        while (!ret && !dsFuture.isDone()) {
-          try {
-            Thread.sleep(2000);
-            ret = condition.apply(true);
-            log.info("Condition completed successfully");
-          } catch (Throwable error) {
-            log.debug("Got error waiting for condition", error);
-            ret = false;
+      AtomicReference<Throwable> lastError = new AtomicReference<>();
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      try {
+        Future<Boolean> res = executor.submit(() -> {
+          boolean ret = false;
+          while (!ret && !dsFuture.isDone() && !Thread.currentThread().isInterrupted()) {
+            try {
+              Thread.sleep(2000);
+              ret = condition.apply(true);
+              if (ret) {
+                log.info("Condition completed successfully");
+              }
+            } catch (InterruptedException interrupted) {
+              // shutdownNow below interrupts this thread once the wait has given up. Thread.sleep clears
+              // the interrupt flag when it throws, so catching this with everything else would re-enter
+              // the loop and keep polling forever. Restore the flag and stop; this is not a condition
+              // failure, so it is deliberately not recorded as one.
+              Thread.currentThread().interrupt();
+              break;
+            } catch (Throwable error) {
+              lastError.set(error);
+              ret = false;
+            }
           }
+          return ret;
+        });
+        try {
+          res.get(timeoutInSecs, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+          Throwable last = lastError.get();
+          String detail = last == null
+              ? "The condition returned false without throwing, so there is no further detail."
+              : "The last failure it reported was: " + last;
+          Throwable cause = last == null ? e : last;
+          throw new AssertionError(
+              String.format("Condition was not met within %d seconds. %s", timeoutInSecs, detail), cause);
         }
-        return ret;
-      });
-      res.get(timeoutInSecs, TimeUnit.SECONDS);
+      } finally {
+        // this used to leak the polling thread on every call, and it is called by every continuous-mode test
+        executor.shutdownNow();
+      }
     }
 
     /**

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -779,13 +779,20 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       try {
         Future<Boolean> res = executor.submit(() -> {
           boolean ret = false;
-          while (!ret && !dsFuture.isDone()) {
+          while (!ret && !dsFuture.isDone() && !Thread.currentThread().isInterrupted()) {
             try {
               Thread.sleep(2000);
               ret = condition.apply(true);
               if (ret) {
                 log.info("Condition completed successfully");
               }
+            } catch (InterruptedException interrupted) {
+              // shutdownNow below interrupts this thread once the wait has given up. Thread.sleep clears
+              // the interrupt flag when it throws, so catching this with everything else would re-enter
+              // the loop and keep polling forever. Restore the flag and stop; this is not a condition
+              // failure, so it is deliberately not recorded as one.
+              Thread.currentThread().interrupt();
+              break;
             } catch (Throwable error) {
               lastError.set(error);
               ret = false;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -767,8 +767,14 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       return lastInstant;
     }
 
-    /** Bound for {@link #waitFor}; generous, since it only exists to stop a hung poll running forever. */
+    /**
+     * Default bound for {@link #waitFor(BooleanSupplier)}; generous, since it only exists to stop a hung poll
+     * running forever.
+     */
     private static final long WAIT_FOR_TIMEOUT_SECS = 120;
+
+    /** How often {@link #waitTillCondition} re-evaluates its condition; a test ties its own wait to this. */
+    static final long POLL_INTERVAL_MS = 2000;
 
     /**
      * Polls {@code condition} until it holds, the deltastreamer future finishes, or the timeout expires.
@@ -788,7 +794,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
           // this thread polling for the lifetime of the JVM.
           while (!ret && !dsFuture.isDone() && !Thread.currentThread().isInterrupted() && !executor.isShutdown()) {
             try {
-              Thread.sleep(2000);
+              Thread.sleep(POLL_INTERVAL_MS);
               ret = condition.apply(true);
               completedEvaluations.incrementAndGet();
               if (ret) {
@@ -815,19 +821,28 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
           Throwable last = lastError.get();
           int completed = completedEvaluations.get();
           String detail;
-          if (completed == 0) {
+          if (last != null) {
+            // Tested first because the worker records the error before it increments the counter: a timeout
+            // landing between the two would otherwise report that no evaluation completed. lastError is only
+            // ever set, never cleared, so its presence is decisive in every interleaving.
+            detail = String.format("%d evaluations completed; the last failure reported was: %s", completed, last);
+          } else if (completed == 0) {
             // Distinguishes a condition that is stuck part-way through its first evaluation - a hung Spark
             // read, say - from one that simply kept returning false.
             detail = "No evaluation of the condition completed, so it was still running or never started.";
-          } else if (last == null) {
+          } else {
             detail = String.format("%d evaluations completed and returned false without throwing, "
                 + "so there is no further detail.", completed);
-          } else {
-            detail = String.format("%d evaluations completed; the last failure reported was: %s", completed, last);
           }
           Throwable cause = last == null ? e : last;
-          throw new AssertionError(
+          AssertionError failure = new AssertionError(
               String.format("Condition was not met within %d seconds. %s", timeoutInSecs, detail), cause);
+          if (cause != e) {
+            // The condition's own error is the more useful cause, but the fact that this was a timeout is
+            // still part of the diagnosis, so it is carried along rather than dropped.
+            failure.addSuppressed(e);
+          }
+          throw failure;
         }
       } finally {
         // stop the polling thread: this method runs once per continuous-mode test, so a leak accumulates
@@ -840,13 +855,18 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
      * @param booleanSupplier Boolean supplier
      */
     static void waitFor(BooleanSupplier booleanSupplier) {
+      waitFor(booleanSupplier, WAIT_FOR_TIMEOUT_SECS);
+    }
+
+    static void waitFor(BooleanSupplier booleanSupplier, long timeoutSecs) {
       // Bounded, and the interrupt is restored rather than swallowed: this runs inside conditions passed to
       // waitTillCondition, so swallowing it would defeat the stop that shutdownNow signals.
-      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(WAIT_FOR_TIMEOUT_SECS);
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSecs);
       while (!booleanSupplier.getAsBoolean()) {
-        if (System.nanoTime() > deadline) {
-          throw new AssertionError(
-              String.format("Condition did not hold within %d seconds", WAIT_FOR_TIMEOUT_SECS));
+        // Subtraction rather than a bare comparison: nanoTime is only meaningful as a difference, so this is
+        // the form its javadoc documents as overflow-safe.
+        if (System.nanoTime() - deadline > 0) {
+          throw new AssertionError(String.format("Condition did not hold within %d seconds", timeoutSecs));
         }
         try {
           Thread.sleep(5);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -608,6 +608,15 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
 
   public static class TestHelpers {
 
+    /**
+     * Default bound for {@link #waitFor(BooleanSupplier)}; generous, since it only exists to stop a hung poll
+     * running forever.
+     */
+    private static final long WAIT_FOR_TIMEOUT_SECS = 120;
+
+    /** How often {@link #waitTillCondition} re-evaluates its condition; a test ties its own wait to this. */
+    static final long POLL_INTERVAL_MS = 2000;
+
     static HoodieDeltaStreamer.Config makeDropAllConfig(String basePath, WriteOperationType op) {
       return makeConfig(basePath, op, Collections.singletonList(TestHoodieDeltaStreamer.DropAllTransformer.class.getName()));
     }
@@ -768,15 +777,6 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     }
 
     /**
-     * Default bound for {@link #waitFor(BooleanSupplier)}; generous, since it only exists to stop a hung poll
-     * running forever.
-     */
-    private static final long WAIT_FOR_TIMEOUT_SECS = 120;
-
-    /** How often {@link #waitTillCondition} re-evaluates its condition; a test ties its own wait to this. */
-    static final long POLL_INTERVAL_MS = 2000;
-
-    /**
      * Polls {@code condition} until it holds, the deltastreamer future finishes, or the timeout expires.
      *
      * <p>On timeout the last error the condition threw is attached to the failure, so the report names the
@@ -819,24 +819,9 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
           res.get(timeoutInSecs, TimeUnit.SECONDS);
         } catch (TimeoutException e) {
           Throwable last = lastError.get();
-          int completed = completedEvaluations.get();
-          String detail;
-          if (last != null) {
-            // Tested first because the worker records the error before it increments the counter: a timeout
-            // landing between the two would otherwise report that no evaluation completed. lastError is only
-            // ever set, never cleared, so its presence is decisive in every interleaving.
-            detail = String.format("%d evaluations completed; the last failure reported was: %s", completed, last);
-          } else if (completed == 0) {
-            // Distinguishes a condition that is stuck part-way through its first evaluation - a hung Spark
-            // read, say - from one that simply kept returning false.
-            detail = "No evaluation of the condition completed, so it was still running or never started.";
-          } else {
-            detail = String.format("%d evaluations completed and returned false without throwing, "
-                + "so there is no further detail.", completed);
-          }
           Throwable cause = last == null ? e : last;
           AssertionError failure = new AssertionError(
-              String.format("Condition was not met within %d seconds. %s", timeoutInSecs, detail), cause);
+              describeTimeout(last, completedEvaluations.get(), timeoutInSecs), cause);
           if (cause != e) {
             // The condition's own error is the more useful cause, but the fact that this was a timeout is
             // still part of the diagnosis, so it is carried along rather than dropped.
@@ -848,6 +833,28 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
         // stop the polling thread: this method runs once per continuous-mode test, so a leak accumulates
         executor.shutdownNow();
       }
+    }
+
+    /**
+     * Builds the timeout report. Which of the three shapes it takes is the whole diagnostic: an error the
+     * condition threw, a condition that never completed an evaluation, or one that kept returning false.
+     */
+    static String describeTimeout(Throwable last, int completed, long timeoutInSecs) {
+      String detail;
+      if (last != null) {
+        // Tested first because the worker records the error before it increments the counter: a timeout
+        // landing between the two would otherwise report that no evaluation completed. lastError is only
+        // ever set, never cleared, so its presence is decisive in every interleaving.
+        detail = String.format("%d evaluations completed; the last failure reported was: %s", completed, last);
+      } else if (completed == 0) {
+        // Distinguishes a condition that is stuck part-way through its first evaluation - a hung Spark
+        // read, say - from one that simply kept returning false.
+        detail = "No evaluation of the condition completed, so it was still running or never started.";
+      } else {
+        detail = String.format("%d evaluations completed and returned false without throwing, "
+            + "so there is no further detail.", completed);
+      }
+      return String.format("Condition was not met within %d seconds. %s", timeoutInSecs, detail);
     }
 
     /**

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -826,8 +826,12 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
           // Not a failure - the caller surfaces the streamer's own outcome - but the wait should still say
           // what it was waiting for instead of looking like success.
           if (!Boolean.TRUE.equals(satisfied)) {
+            // Read in the same order as the timeout path below, so describeProgress's note on the read
+            // order holds for both callers. The worker has finished here, so neither can be stale.
+            int completed = completedEvaluations.get();
+            Throwable last = lastError.get();
             log.warn("Wait ended because the deltastreamer future finished, not because the condition held. {}",
-                describeProgress(lastError.get(), completedEvaluations.get()));
+                describeProgress(last, completed));
           }
         } catch (TimeoutException e) {
           int completed = completedEvaluations.get();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -767,15 +767,15 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       return lastInstant;
     }
 
+    /** Bound for {@link #waitFor}; generous, since it only exists to stop a hung poll running forever. */
+    private static final long WAIT_FOR_TIMEOUT_SECS = 120;
+
     /**
      * Polls {@code condition} until it holds, the deltastreamer future finishes, or the timeout expires.
      *
      * <p>On timeout the last error the condition threw is attached to the failure, so the report names the
      * assertion that never held rather than only this method.
      */
-    /** Bound for {@link #waitFor}; generous, since it only exists to stop a hung poll running forever. */
-    private static final long WAIT_FOR_TIMEOUT_SECS = 120;
-
     static void waitTillCondition(Function<Boolean, Boolean> condition, Future dsFuture, long timeoutInSecs) throws Exception {
       AtomicReference<Throwable> lastError = new AtomicReference<>();
       AtomicInteger completedEvaluations = new AtomicInteger();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -614,8 +614,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
      */
     private static final long WAIT_FOR_TIMEOUT_SECS = 120;
 
-    /** How often {@link #waitTillCondition} re-evaluates its condition; a test ties its own wait to this. */
-    static final long POLL_INTERVAL_MS = 2000;
+    /** The cadence production callers poll at; the helper's own tests pass a faster one of their own. */
+    private static final long POLL_INTERVAL_MS = 2000;
 
     static HoodieDeltaStreamer.Config makeDropAllConfig(String basePath, WriteOperationType op) {
       return makeConfig(basePath, op, Collections.singletonList(TestHoodieDeltaStreamer.DropAllTransformer.class.getName()));
@@ -783,6 +783,12 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
      * assertion that never held rather than only this method.
      */
     static void waitTillCondition(Function<Boolean, Boolean> condition, Future dsFuture, long timeoutInSecs) throws Exception {
+      waitTillCondition(condition, dsFuture, timeoutInSecs, POLL_INTERVAL_MS);
+    }
+
+    /** The poll interval is a parameter only so this helper's own tests need not spend the production cadence. */
+    static void waitTillCondition(Function<Boolean, Boolean> condition, Future dsFuture, long timeoutInSecs,
+                                  long pollIntervalMs) throws Exception {
       AtomicReference<Throwable> lastError = new AtomicReference<>();
       AtomicInteger completedEvaluations = new AtomicInteger();
       ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -794,7 +800,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
           // this thread polling for the lifetime of the JVM.
           while (!ret && !dsFuture.isDone() && !Thread.currentThread().isInterrupted() && !executor.isShutdown()) {
             try {
-              Thread.sleep(POLL_INTERVAL_MS);
+              Thread.sleep(pollIntervalMs);
               ret = condition.apply(true);
               completedEvaluations.incrementAndGet();
               if (ret) {
@@ -816,12 +822,18 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
           return ret;
         });
         try {
-          res.get(timeoutInSecs, TimeUnit.SECONDS);
+          Boolean satisfied = res.get(timeoutInSecs, TimeUnit.SECONDS);
+          // Not a failure - the caller surfaces the streamer's own outcome - but the wait should still say
+          // what it was waiting for instead of looking like success.
+          if (!Boolean.TRUE.equals(satisfied)) {
+            log.warn("Wait ended because the deltastreamer future finished, not because the condition held. {}",
+                describeProgress(lastError.get(), completedEvaluations.get()));
+          }
         } catch (TimeoutException e) {
+          int completed = completedEvaluations.get();
           Throwable last = lastError.get();
           Throwable cause = last == null ? e : last;
-          AssertionError failure = new AssertionError(
-              describeTimeout(last, completedEvaluations.get(), timeoutInSecs), cause);
+          AssertionError failure = new AssertionError(describeTimeout(last, completed, timeoutInSecs), cause);
           if (cause != e) {
             // The condition's own error is the more useful cause, but the fact that this was a timeout is
             // still part of the diagnosis, so it is carried along rather than dropped.
@@ -840,11 +852,20 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
      * condition threw, a condition that never completed an evaluation, or one that kept returning false.
      */
     static String describeTimeout(Throwable last, int completed, long timeoutInSecs) {
+      return String.format("Condition was not met within %d seconds. %s", timeoutInSecs,
+          describeProgress(last, completed));
+    }
+
+    /** The progress half of the report on its own, so an exit that is not a timeout can say the same thing. */
+    static String describeProgress(Throwable last, int completed) {
       String detail;
       if (last != null) {
         // Tested first because the worker records the error before it increments the counter: a timeout
         // landing between the two would otherwise report that no evaluation completed. lastError is only
-        // ever set, never cleared, so its presence is decisive in every interleaving.
+        // ever set, never cleared, so its presence is decisive in every interleaving. The reader takes the
+        // counter first, the opposite order, so any skew between the two reads lands in this branch - a real
+        // error reported with a possibly stale count - rather than in the "returned false without throwing"
+        // branch, which would deny an error that did happen.
         detail = String.format("%d evaluations completed; the last failure reported was: %s", completed, last);
       } else if (completed == 0) {
         // Distinguishes a condition that is stuck part-way through its first evaluation - a hung Spark
@@ -854,7 +875,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
         detail = String.format("%d evaluations completed and returned false without throwing, "
             + "so there is no further detail.", completed);
       }
-      return String.format("Condition was not met within %d seconds. %s", timeoutInSecs, detail);
+      return detail;
     }
 
     /**

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -830,7 +830,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
               String.format("Condition was not met within %d seconds. %s", timeoutInSecs, detail), cause);
         }
       } finally {
-        // this used to leak the polling thread on every call, and it is called by every continuous-mode test
+        // stop the polling thread: this method runs once per continuous-mode test, so a leak accumulates
         executor.shutdownNow();
       }
     }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamerTestBase.java
@@ -554,7 +554,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
   void assertRecordCount(long expected, String tablePath, SQLContext sqlContext) {
     sqlContext.clearCache();
     long recordCount = sqlContext.read().options(hudiOpts).format("org.apache.hudi").load(tablePath).count();
-    assertEquals(expected, recordCount);
+    // Named, so a one-line failure report says which of the near-identical count helpers it came from.
+    assertEquals(expected, recordCount, () -> "assertRecordCount(" + tablePath + ")");
   }
 
   void assertDistinctRecordCount(long expected, String tablePath, SQLContext sqlContext) {
@@ -576,7 +577,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
     sqlContext.read().options(hudiOpts).format("org.apache.hudi").load(tablePath).registerTempTable("tmp_trips");
     long recordCount =
         sqlContext.sql("select * from tmp_trips where haversine_distance is not NULL").count();
-    assertEquals(expected, recordCount);
+    assertEquals(expected, recordCount, () -> "assertDistanceCount(" + tablePath + ")");
   }
 
   void assertDistanceCountWithExactValue(long expected, String tablePath, SQLContext sqlContext) {
@@ -720,7 +721,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().getCommitAndReplaceTimeline().filterCompletedInstants();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numCompactionCommits = timeline.countInstants();
-      assertTrue(minExpected <= numCompactionCommits, "Got=" + numCompactionCommits + ", exp >=" + minExpected);
+      assertTrue(minExpected <= numCompactionCommits,
+          "assertAtleastNCompactionCommits: Got=" + numCompactionCommits + ", exp >=" + minExpected);
     }
 
     static void assertAtleastNDeltaCommits(int minExpected, String tablePath) {
@@ -728,7 +730,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
-      assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
+      assertTrue(minExpected <= numDeltaCommits,
+          "assertAtleastNDeltaCommits: Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
 
     static void assertAtleastNCompactionCommitsAfterCommit(int minExpected, String lastSuccessfulCommit, String tablePath) {
@@ -736,7 +739,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().getCommitAndReplaceTimeline().findInstantsAfter(lastSuccessfulCommit).filterCompletedInstants();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numCompactionCommits = timeline.countInstants();
-      assertTrue(minExpected <= numCompactionCommits, "Got=" + numCompactionCommits + ", exp >=" + minExpected);
+      assertTrue(minExpected <= numCompactionCommits,
+          "assertAtleastNCompactionCommitsAfterCommit: Got=" + numCompactionCommits + ", exp >=" + minExpected);
     }
 
     static void assertAtleastNDeltaCommitsAfterCommit(int minExpected, String lastSuccessfulCommit, String tablePath) {
@@ -744,7 +748,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.reloadActiveTimeline().getDeltaCommitTimeline().findInstantsAfter(lastSuccessfulCommit).filterCompletedInstants();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
-      assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
+      assertTrue(minExpected <= numDeltaCommits,
+          "assertAtleastNDeltaCommitsAfterCommit: Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
 
     static HoodieInstant assertCommitMetadata(String expected, String tablePath, int totalCommits)
@@ -830,7 +835,8 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
             // order holds for both callers. The worker has finished here, so neither can be stale.
             int completed = completedEvaluations.get();
             Throwable last = lastError.get();
-            log.warn("Wait ended because the deltastreamer future finished, not because the condition held. {}",
+            log.warn("Wait ended without the condition holding: {}. {}",
+                dsFuture.isDone() ? "the deltastreamer future finished" : "the polling thread was stopped",
                 describeProgress(last, completed));
           }
         } catch (TimeoutException e) {
@@ -914,7 +920,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().filterCompletedInstants();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
-      assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
+      assertTrue(minExpected <= numDeltaCommits, "assertAtLeastNCommits: Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
 
     static void assertAtLeastNReplaceCommits(int minExpected, String tablePath) {
@@ -922,7 +928,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().getCompletedReplaceTimeline();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
-      assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
+      assertTrue(minExpected <= numDeltaCommits, "assertAtLeastNReplaceCommits: Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
 
     static void assertPendingIndexCommit(String tablePath) {
@@ -930,7 +936,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.reloadActiveTimeline().getAllCommitsTimeline().filterPendingIndexTimeline();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numIndexCommits = timeline.countInstants();
-      assertEquals(1, numIndexCommits, "Got=" + numIndexCommits + ", exp=1");
+      assertEquals(1, numIndexCommits, "assertPendingIndexCommit: Got=" + numIndexCommits + ", exp=1");
     }
 
     static void assertCompletedIndexCommit(String tablePath) {
@@ -938,7 +944,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.reloadActiveTimeline().getAllCommitsTimeline().filterCompletedIndexTimeline();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numIndexCommits = timeline.countInstants();
-      assertEquals(1, numIndexCommits, "Got=" + numIndexCommits + ", exp=1");
+      assertEquals(1, numIndexCommits, "assertCompletedIndexCommit: Got=" + numIndexCommits + ", exp=1");
     }
 
     static void assertNoReplaceCommits(String tablePath) {
@@ -946,7 +952,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().getCompletedReplaceTimeline();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
-      assertEquals(0, numDeltaCommits, "Got=" + numDeltaCommits + ", exp =" + 0);
+      assertEquals(0, numDeltaCommits, "assertNoReplaceCommits: Got=" + numDeltaCommits + ", exp =" + 0);
     }
 
     static void assertAtLeastNClusterRequests(int minExpected, String tablePath) {
@@ -954,7 +960,7 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().filterPendingClusteringTimeline();
       log.info("Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numDeltaCommits = timeline.countInstants();
-      assertTrue(minExpected <= numDeltaCommits, "Got=" + numDeltaCommits + ", exp >=" + minExpected);
+      assertTrue(minExpected <= numDeltaCommits, "assertAtLeastNClusterRequests: Got=" + numDeltaCommits + ", exp >=" + minExpected);
     }
 
     static void assertAtLeastNCommitsAfterRollback(int minExpectedRollback, int minExpectedCommits, String tablePath) {
@@ -962,13 +968,13 @@ public class HoodieDeltaStreamerTestBase extends UtilitiesTestBase {
       HoodieTimeline timeline = meta.getActiveTimeline().getRollbackTimeline().filterCompletedInstants();
       log.info("Rollback Timeline Instants={}", meta.getActiveTimeline().getInstants());
       int numRollbackCommits = timeline.countInstants();
-      assertTrue(minExpectedRollback <= numRollbackCommits, "Got=" + numRollbackCommits + ", exp >=" + minExpectedRollback);
+      assertTrue(minExpectedRollback <= numRollbackCommits, "assertAtLeastNCommitsAfterRollback: Got=" + numRollbackCommits + ", exp >=" + minExpectedRollback);
       HoodieInstant firstRollback = timeline.getInstants().get(0);
       //
       HoodieTimeline commitsTimeline = meta.getActiveTimeline().filterCompletedInstants()
           .filter(instant -> compareTimestamps(instant.requestedTime(), GREATER_THAN, firstRollback.requestedTime()));
       int numCommits = commitsTimeline.countInstants();
-      assertTrue(minExpectedCommits <= numCommits, "Got=" + numCommits + ", exp >=" + minExpectedCommits);
+      assertTrue(minExpectedCommits <= numCommits, "assertAtLeastNCommitsAfterRollback: Got=" + numCommits + ", exp >=" + minExpectedCommits);
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
@@ -28,11 +28,18 @@ import org.mockito.Mockito;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerTestBase.TestHelpers.describeTimeout;
+import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerTestBase.TestHelpers.waitFor;
+import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,11 +57,16 @@ class TestDeltaStreamerTestHelpers {
   private static final Future<?> RUNNING = new CompletableFuture<>();
 
   /**
-   * The helper polls every 2s, so the timeout has to leave room for at least one evaluation to be recorded.
-   * 5s is enough for that, and keeps the tests in this class from spending half a minute asleep in the
-   * shared utilities job.
+   * The poll interval these tests drive the helper at, so the class does not spend the production 2s cadence
+   * asleep.
    */
-  private static final int CONDITION_TIMEOUT_SECS = 5;
+  private static final long FAST_POLL_INTERVAL_MS = 50;
+
+  /**
+   * With the fast poll above, one second still leaves room for many evaluations to be recorded, which is what
+   * the timeout report needs.
+   */
+  private static final int CONDITION_TIMEOUT_SECS = 1;
 
   /** For the cases that are not meant to time out: they finish long before this, so it is never reached. */
   private static final int NEVER_REACHED_TIMEOUT_SECS = 30;
@@ -64,19 +76,21 @@ class TestDeltaStreamerTestHelpers {
     String assertionText = "assertAtleastNDeltaCommits: expected at least 3 delta commits but got 2";
 
     AssertionError error = assertThrows(AssertionError.class,
-        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+        () -> waitTillCondition(
             ignored -> {
               throw new AssertionError(assertionText);
-            }, RUNNING, CONDITION_TIMEOUT_SECS));
+            }, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
 
     assertTrue(error.getMessage().contains("was not met within " + CONDITION_TIMEOUT_SECS + " seconds"),
         () -> "The failure should say the condition timed out, but was: " + error.getMessage());
     assertTrue(error.getMessage().contains(assertionText),
         () -> "The failure should carry the condition's own error, which is the only clue to why the "
             + "wait timed out, but was: " + error.getMessage());
-    assertTrue(error.getMessage().contains("evaluations completed"),
-        () -> "The failure should say how many evaluations completed, which separates a condition that "
-            + "kept failing from one that never finished an evaluation, but was: " + error.getMessage());
+    assertFalse(error.getMessage().contains("returned false without throwing"),
+        () -> "The failure should carry the condition's error, not the 'kept returning false' branch, "
+            + "but was: " + error.getMessage());
+    assertInstanceOf(TimeoutException.class, error.getSuppressed()[0],
+        "the timeout should stay attached as a suppressed exception once the condition's error becomes the cause");
   }
 
   /**
@@ -87,19 +101,60 @@ class TestDeltaStreamerTestHelpers {
   @Test
   void pollingStopsOnceTheWaitHasGivenUp() throws Exception {
     AtomicInteger polls = new AtomicInteger();
+    AtomicReference<Thread> poller = new AtomicReference<>();
 
     assertThrows(AssertionError.class,
-        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+        () -> waitTillCondition(
             ignored -> {
+              poller.set(Thread.currentThread());
               polls.incrementAndGet();
               throw new AssertionError("never true");
-            }, RUNNING, CONDITION_TIMEOUT_SECS));
+            }, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
 
     int pollsWhenItGaveUp = polls.get();
     assertTrue(pollsWhenItGaveUp > 0,
         "the condition should have been evaluated at least once before the wait gave up, otherwise the "
             + "comparison below passes trivially");
-    Thread.sleep(2 * HoodieDeltaStreamerTestBase.TestHelpers.POLL_INTERVAL_MS);
+    poller.get().join(TimeUnit.SECONDS.toMillis(5));
+    assertFalse(poller.get().isAlive(),
+        "the polling thread should have exited once the wait gave up, not still be running after the join");
+    assertEquals(pollsWhenItGaveUp, polls.get(),
+        "the polling thread should have stopped when the wait gave up, not carried on in the background");
+  }
+
+  /**
+   * The interrupt from {@code shutdownNow} is delivered once, and {@code Thread.sleep} clears the flag when it
+   * throws, so a condition that swallows it without restoring it leaves the loop with no interrupt to see. The
+   * {@code executor.isShutdown()} guard is what stops the worker in that case.
+   */
+  @Test
+  void pollingStopsEvenWhenTheConditionSwallowsTheInterrupt() throws Exception {
+    AtomicInteger polls = new AtomicInteger();
+    AtomicReference<Thread> poller = new AtomicReference<>();
+
+    assertThrows(AssertionError.class,
+        () -> waitTillCondition(
+            ignored -> {
+              poller.set(Thread.currentThread());
+              polls.incrementAndGet();
+              try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(60));
+              } catch (InterruptedException interrupted) {
+                // The missing Thread.currentThread().interrupt() is the point of the test: a condition that
+                // swallows the interrupt is exactly what the isShutdown() guard exists for, so do not "fix"
+                // this catch.
+              }
+              return false;
+            }, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
+
+    int pollsWhenItGaveUp = polls.get();
+    assertTrue(pollsWhenItGaveUp > 0,
+        "the condition should have been evaluated at least once before the wait gave up, otherwise the "
+            + "comparison below passes trivially");
+    poller.get().join(TimeUnit.SECONDS.toMillis(5));
+    assertFalse(poller.get().isAlive(),
+        "the isShutdown() guard should have stopped the polling thread even though the condition swallowed "
+            + "the interrupt without restoring the flag");
     assertEquals(pollsWhenItGaveUp, polls.get(),
         "the polling thread should have stopped when the wait gave up, not carried on in the background");
   }
@@ -112,7 +167,7 @@ class TestDeltaStreamerTestHelpers {
   @Test
   void timeoutDistinguishesAConditionThatNeverCompletedAnEvaluation() {
     AssertionError error = assertThrows(AssertionError.class,
-        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+        () -> waitTillCondition(
             ignored -> {
               try {
                 Thread.sleep(60_000);
@@ -120,7 +175,7 @@ class TestDeltaStreamerTestHelpers {
                 Thread.currentThread().interrupt();
               }
               return true;
-            }, RUNNING, CONDITION_TIMEOUT_SECS));
+            }, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
 
     assertTrue(error.getMessage().contains("No evaluation of the condition completed"),
         () -> "a condition still running its first evaluation should be reported as such, but was: "
@@ -138,8 +193,7 @@ class TestDeltaStreamerTestHelpers {
   @Test
   void timeoutReportsEvaluationsThatReturnedFalse() {
     AssertionError error = assertThrows(AssertionError.class,
-        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
-            ignored -> false, RUNNING, CONDITION_TIMEOUT_SECS));
+        () -> waitTillCondition(ignored -> false, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
 
     assertTrue(error.getMessage().contains("returned false without throwing"),
         () -> "a condition that kept returning false should be reported as such, but was: " + error.getMessage());
@@ -152,7 +206,7 @@ class TestDeltaStreamerTestHelpers {
   @Test
   void waitForGivesUpAtItsBound() {
     AssertionError error = assertThrows(AssertionError.class,
-        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitFor(() -> false, 1));
+        () -> waitFor(() -> false, 1));
 
     assertTrue(error.getMessage().contains("did not hold within 1 seconds"),
         () -> "the bound should name itself in the failure, but was: " + error.getMessage());
@@ -181,8 +235,8 @@ class TestDeltaStreamerTestHelpers {
 
   @Test
   void satisfiedConditionReturnsNormally() {
-    assertDoesNotThrow(() -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
-        ignored -> true, RUNNING, NEVER_REACHED_TIMEOUT_SECS));
+    assertDoesNotThrow(() -> waitTillCondition(
+        ignored -> true, RUNNING, NEVER_REACHED_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
   }
 
   /**
@@ -194,7 +248,21 @@ class TestDeltaStreamerTestHelpers {
   void finishedStreamerEndsTheWaitWithoutFailing() {
     Future<?> finished = CompletableFuture.completedFuture(null);
 
-    assertDoesNotThrow(() -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
-        ignored -> false, finished, NEVER_REACHED_TIMEOUT_SECS));
+    assertDoesNotThrow(() -> waitTillCondition(
+        ignored -> false, finished, NEVER_REACHED_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
+  }
+
+  /**
+   * Unreachable through the helper, which reads the evaluation counter before the last error and so can see a
+   * recorded error alongside a count of zero; pinned here because nothing else can produce that combination.
+   */
+  @Test
+  void describeTimeoutReportsAnErrorEvenWithNoCompletedEvaluation() {
+    String message = describeTimeout(new AssertionError("boom"), 0, CONDITION_TIMEOUT_SECS);
+
+    assertTrue(message.contains("boom"),
+        () -> "an error recorded before the counter caught up should still be reported, but was: " + message);
+    assertFalse(message.contains("No evaluation of the condition completed"),
+        () -> "a recorded error should not be reported as no evaluation having completed, but was: " + message);
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
@@ -27,7 +27,10 @@ import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -41,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -72,6 +76,18 @@ class TestDeltaStreamerTestHelpers {
   /** For the cases that are not meant to time out: they finish long before this, so it is never reached. */
   private static final int NEVER_REACHED_TIMEOUT_SECS = 30;
 
+  /**
+   * Slow enough that the poll spends almost all of its time asleep, so a directly delivered interrupt lands in
+   * the sleep rather than in the condition.
+   */
+  private static final long SLOW_POLL_INTERVAL_MS = 500;
+
+  /** Generous, so that "ended well before the timeout" is an unambiguous signal rather than a near miss. */
+  private static final int INTERRUPT_TIMEOUT_SECS = 10;
+
+  /** The stop bound the stop-path cases drive, instead of the production 60s. */
+  private static final long FAST_STOP_TIMEOUT_SECS = 1;
+
   @Test
   void timeoutFailureNamesTheLastConditionFailure() {
     String assertionText = "assertAtleastNDeltaCommits: expected at least 3 delta commits but got 2";
@@ -98,9 +114,10 @@ class TestDeltaStreamerTestHelpers {
   }
 
   /**
-   * {@code shutdownNow} interrupts the polling thread, but {@code Thread.sleep} clears the interrupt flag
-   * when it throws, so a catch-all around the sleep would swallow it and keep polling for the life of the
-   * JVM. This pins that the worker actually stops.
+   * Pins that the worker actually stops once the wait has given up, whichever of the two guards fires. The
+   * {@code InterruptedException} branch on its own is covered by
+   * {@link #directInterruptEndsTheWaitWithoutRunningToTheTimeout()}, since the {@code executor.isShutdown()}
+   * guard would stop the worker here even without it.
    */
   @Test
   void pollingStopsOnceTheWaitHasGivenUp() throws Exception {
@@ -184,15 +201,18 @@ class TestDeltaStreamerTestHelpers {
     assertTrue(error.getMessage().contains("No evaluation of the condition completed"),
         () -> "a condition still running its first evaluation should be reported as such, but was: "
             + error.getMessage());
-    assertFalse(JavaTestUtils.checkNestedExceptionContains(error, "no such text"),
-        "walking the cause chain has to tolerate the null-message TimeoutException this path attaches, "
-            + "which is what the multi-writer test hits when its ingestion wait times out");
+    assertInstanceOf(TimeoutException.class, error.getCause(),
+        "with no error recorded the timeout itself should be the cause");
+    assertNull(error.getCause().getMessage(),
+        "the cause is a message-less TimeoutException, which is the shape that made the null check in "
+            + "JavaTestUtils.checkNestedExceptionContains necessary");
   }
 
   /**
-   * Conditions in the continuous-mode tests catch their own failures and return false rather than throwing,
-   * so this is the branch a real timeout reports. It has to say how many evaluations ran, since that is the
-   * only signal separating it from a condition that never completed one.
+   * The branch for a condition that swallows its own failure and returns false, as {@code testHoodieIndexer}
+   * does. The HUDI-6843 condition is not one of those: it only ever throws, so a real timeout there takes the
+   * last-error branch instead. This one has to say how many evaluations ran, since that is the only signal
+   * separating it from a condition that never completed one.
    */
   @Test
   void timeoutReportsEvaluationsThatReturnedFalse() {
@@ -201,6 +221,9 @@ class TestDeltaStreamerTestHelpers {
 
     assertTrue(error.getMessage().contains("returned false without throwing"),
         () -> "a condition that kept returning false should be reported as such, but was: " + error.getMessage());
+    assertFalse(error.getMessage().contains("0 evaluations completed"),
+        () -> "the count should be the real number of evaluations, not a constant, but was: "
+            + error.getMessage());
   }
 
   /**
@@ -269,5 +292,97 @@ class TestDeltaStreamerTestHelpers {
         () -> "an error recorded before the counter caught up should still be reported, but was: " + message);
     assertFalse(message.contains("No evaluation of the condition completed"),
         () -> "a recorded error should not be reported as no evaluation having completed, but was: " + message);
+  }
+
+  /**
+   * The {@code InterruptedException} branch on its own: an interrupt delivered while the poll is sleeping has
+   * to end the wait, rather than be recorded as a condition failure and polled through. A catch-all around the
+   * sleep would clear the flag and keep polling until the timeout, which is what this discriminates.
+   *
+   * <p>The slow poll makes the sleep the overwhelmingly likely place for the interrupt to land. Landing outside
+   * it is also a pass, since the loop guard then ends the wait, so this cannot flake either way.
+   */
+  @Test
+  void directInterruptEndsTheWaitWithoutRunningToTheTimeout() throws Exception {
+    AtomicReference<Thread> poller = new AtomicReference<>();
+    CountDownLatch polling = new CountDownLatch(1);
+    Thread interrupter = new Thread(() -> {
+      try {
+        if (polling.await(5, TimeUnit.SECONDS)) {
+          poller.get().interrupt();
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    interrupter.start();
+
+    long startedAt = System.nanoTime();
+    assertDoesNotThrow(() -> waitTillCondition(
+        ignored -> {
+          poller.set(Thread.currentThread());
+          polling.countDown();
+          return false;
+        }, RUNNING, INTERRUPT_TIMEOUT_SECS, SLOW_POLL_INTERVAL_MS));
+    long elapsedSecs = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startedAt);
+    interrupter.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertTrue(elapsedSecs < INTERRUPT_TIMEOUT_SECS,
+        () -> "the interrupt should have ended the wait well before the timeout, but it took "
+            + elapsedSecs + "s of " + INTERRUPT_TIMEOUT_SECS + "s");
+  }
+
+  /**
+   * A stop that throws does not excuse leaving the ingest task running: the wait falls through to the join,
+   * which times out, and the task is force-stopped and cancelled rather than left reading into the next test.
+   */
+  @Test
+  void stopThatThrowsStillCancelsTheIngestTask() throws Exception {
+    HoodieDeltaStreamer ds = Mockito.mock(HoodieDeltaStreamer.class);
+    Mockito.doThrow(new IllegalStateException("stop blew up")).when(ds).shutdownGracefully();
+
+    ExecutorService ingest = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> dsFuture = ingest.submit(() -> {
+        Thread.sleep(TimeUnit.MINUTES.toMillis(10));
+        return null;
+      });
+
+      TestHoodieDeltaStreamer.stopLeakedStreamer(ds, dsFuture, FAST_STOP_TIMEOUT_SECS);
+
+      assertTrue(dsFuture.isCancelled(),
+          "a stop that threw should still leave the ingest task cancelled, since that leak is what the "
+              + "helper exists to close");
+    } finally {
+      ingest.shutdownNow();
+    }
+  }
+
+  /**
+   * The same outcome when the stop hangs instead of throwing, which is the case the bound exists for:
+   * {@code shutdownGracefully} can await the ingest executor for up to 24 hours.
+   */
+  @Test
+  void stopThatHangsIsBoundedAndCancelsTheIngestTask() throws Exception {
+    HoodieDeltaStreamer ds = Mockito.mock(HoodieDeltaStreamer.class);
+    Mockito.doAnswer(invocation -> {
+      Thread.sleep(TimeUnit.MINUTES.toMillis(10));
+      return null;
+    }).when(ds).shutdownGracefully();
+
+    ExecutorService ingest = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> dsFuture = ingest.submit(() -> {
+        Thread.sleep(TimeUnit.MINUTES.toMillis(10));
+        return null;
+      });
+
+      TestHoodieDeltaStreamer.stopLeakedStreamer(ds, dsFuture, FAST_STOP_TIMEOUT_SECS);
+
+      assertTrue(dsFuture.isCancelled(),
+          "a stop that hung past its bound should still leave the ingest task cancelled");
+    } finally {
+      ingest.shutdownNow();
+    }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
@@ -20,11 +20,13 @@
 package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.common.testutils.JavaTestUtils;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionService;
 import org.apache.hudi.utilities.streamer.NoNewDataTerminationStrategy;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -34,8 +36,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerTestBase.TestHelpers.describeTimeout;
 import static org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamerTestBase.TestHelpers.waitFor;
@@ -46,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -82,11 +88,21 @@ class TestDeltaStreamerTestHelpers {
    */
   private static final long SLOW_POLL_INTERVAL_MS = 500;
 
-  /** Generous, so that "ended well before the timeout" is an unambiguous signal rather than a near miss. */
+  /**
+   * Generous, so a catch-all that polled through the interrupt fails by throwing at the timeout rather than
+   * by a near miss.
+   */
   private static final int INTERRUPT_TIMEOUT_SECS = 10;
 
-  /** The stop bound the stop-path cases drive, instead of the production 60s. */
+  /** The stop bound the stop-path cases drive, instead of the production one. */
   private static final long FAST_STOP_TIMEOUT_SECS = 1;
+
+  /**
+   * At most two of the stop's bounds can run in sequence (a stop that times out skips the join, and a stop that
+   * returns leaves nothing for the close-wait), so two seconds of this is bound and the rest is slack. A stop that
+   * lost its bound would take the ten minutes the mock sleeps.
+   */
+  private static final long STOP_PATH_CEILING_SECS = 5;
 
   @Test
   void timeoutFailureNamesTheLastConditionFailure() {
@@ -114,36 +130,6 @@ class TestDeltaStreamerTestHelpers {
   }
 
   /**
-   * Pins that the worker actually stops once the wait has given up, whichever of the two guards fires. The
-   * {@code InterruptedException} branch on its own is covered by
-   * {@link #directInterruptEndsTheWaitWithoutRunningToTheTimeout()}, since the {@code executor.isShutdown()}
-   * guard would stop the worker here even without it.
-   */
-  @Test
-  void pollingStopsOnceTheWaitHasGivenUp() throws Exception {
-    AtomicInteger polls = new AtomicInteger();
-    AtomicReference<Thread> poller = new AtomicReference<>();
-
-    assertThrows(AssertionError.class,
-        () -> waitTillCondition(
-            ignored -> {
-              poller.set(Thread.currentThread());
-              polls.incrementAndGet();
-              throw new AssertionError("never true");
-            }, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
-
-    int pollsWhenItGaveUp = polls.get();
-    assertTrue(pollsWhenItGaveUp > 0,
-        "the condition should have been evaluated at least once before the wait gave up, otherwise the "
-            + "comparison below passes trivially");
-    poller.get().join(TimeUnit.SECONDS.toMillis(5));
-    assertFalse(poller.get().isAlive(),
-        "the polling thread should have exited once the wait gave up, not still be running after the join");
-    assertEquals(pollsWhenItGaveUp, polls.get(),
-        "the polling thread should have stopped when the wait gave up, not carried on in the background");
-  }
-
-  /**
    * The interrupt from {@code shutdownNow} is delivered once, and {@code Thread.sleep} clears the flag when it
    * throws, so a condition that swallows it without restoring it leaves the loop with no interrupt to see. The
    * {@code executor.isShutdown()} guard is what stops the worker in that case.
@@ -168,16 +154,12 @@ class TestDeltaStreamerTestHelpers {
               return false;
             }, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
 
-    int pollsWhenItGaveUp = polls.get();
-    assertTrue(pollsWhenItGaveUp > 0,
-        "the condition should have been evaluated at least once before the wait gave up, otherwise the "
-            + "comparison below passes trivially");
+    assertTrue(polls.get() > 0,
+        "the condition should have been entered at least once, otherwise there is no polling thread to join");
     poller.get().join(TimeUnit.SECONDS.toMillis(5));
     assertFalse(poller.get().isAlive(),
         "the isShutdown() guard should have stopped the polling thread even though the condition swallowed "
             + "the interrupt without restoring the flag");
-    assertEquals(pollsWhenItGaveUp, polls.get(),
-        "the polling thread should have stopped when the wait gave up, not carried on in the background");
   }
 
   /**
@@ -216,14 +198,28 @@ class TestDeltaStreamerTestHelpers {
    */
   @Test
   void timeoutReportsEvaluationsThatReturnedFalse() {
+    AtomicInteger polls = new AtomicInteger();
+
     AssertionError error = assertThrows(AssertionError.class,
-        () -> waitTillCondition(ignored -> false, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
+        () -> waitTillCondition(
+            ignored -> {
+              polls.incrementAndGet();
+              return false;
+            }, RUNNING, CONDITION_TIMEOUT_SECS, FAST_POLL_INTERVAL_MS));
 
     assertTrue(error.getMessage().contains("returned false without throwing"),
         () -> "a condition that kept returning false should be reported as such, but was: " + error.getMessage());
-    assertFalse(error.getMessage().contains("0 evaluations completed"),
-        () -> "the count should be the real number of evaluations, not a constant, but was: "
-            + error.getMessage());
+    Matcher count = Pattern.compile("(\\d+) evaluations completed").matcher(error.getMessage());
+    assertTrue(count.find(),
+        () -> "the report should carry an evaluation count, but was: " + error.getMessage());
+    // The worker records an evaluation only after the condition returns, so at most one can be in flight when
+    // the timeout reads the counter, and none can follow it because the loop then sees the shutdown. The tally
+    // the condition kept is therefore the reported count or exactly one more.
+    int reported = Integer.parseInt(count.group(1));
+    int observed = polls.get();
+    assertTrue(reported >= 1 && reported <= observed && observed - reported <= 1,
+        () -> "the count should be the real number of completed evaluations, but the report said " + reported
+            + " while the condition ran " + observed + " times: " + error.getMessage());
   }
 
   /**
@@ -306,10 +302,12 @@ class TestDeltaStreamerTestHelpers {
   void directInterruptEndsTheWaitWithoutRunningToTheTimeout() throws Exception {
     AtomicReference<Thread> poller = new AtomicReference<>();
     CountDownLatch polling = new CountDownLatch(1);
+    AtomicBoolean interruptSent = new AtomicBoolean();
     Thread interrupter = new Thread(() -> {
       try {
         if (polling.await(5, TimeUnit.SECONDS)) {
           poller.get().interrupt();
+          interruptSent.set(true);
         }
       } catch (InterruptedException interrupted) {
         Thread.currentThread().interrupt();
@@ -317,19 +315,17 @@ class TestDeltaStreamerTestHelpers {
     });
     interrupter.start();
 
-    long startedAt = System.nanoTime();
     assertDoesNotThrow(() -> waitTillCondition(
         ignored -> {
           poller.set(Thread.currentThread());
           polling.countDown();
           return false;
         }, RUNNING, INTERRUPT_TIMEOUT_SECS, SLOW_POLL_INTERVAL_MS));
-    long elapsedSecs = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startedAt);
     interrupter.join(TimeUnit.SECONDS.toMillis(5));
 
-    assertTrue(elapsedSecs < INTERRUPT_TIMEOUT_SECS,
-        () -> "the interrupt should have ended the wait well before the timeout, but it took "
-            + elapsedSecs + "s of " + INTERRUPT_TIMEOUT_SECS + "s");
+    assertTrue(interruptSent.get(),
+        "the interrupt was never sent because the first poll did not complete within 5s, so this run says "
+            + "nothing about the interrupt path");
   }
 
   /**
@@ -337,39 +333,90 @@ class TestDeltaStreamerTestHelpers {
    * which times out, and the task is force-stopped and cancelled rather than left reading into the next test.
    */
   @Test
-  void stopThatThrowsStillCancelsTheIngestTask() throws Exception {
+  void stopThatThrowsStillCancelsTheIngestTask() {
     HoodieDeltaStreamer ds = Mockito.mock(HoodieDeltaStreamer.class);
     Mockito.doThrow(new IllegalStateException("stop blew up")).when(ds).shutdownGracefully();
 
-    ExecutorService ingest = Executors.newSingleThreadExecutor();
-    try {
-      Future<?> dsFuture = ingest.submit(() -> {
-        Thread.sleep(TimeUnit.MINUTES.toMillis(10));
-        return null;
-      });
-
-      TestHoodieDeltaStreamer.stopLeakedStreamer(ds, dsFuture, FAST_STOP_TIMEOUT_SECS);
-
-      assertTrue(dsFuture.isCancelled(),
-          "a stop that threw should still leave the ingest task cancelled, since that leak is what the "
-              + "helper exists to close");
-    } finally {
-      ingest.shutdownNow();
-    }
+    assertStopEndsWithTheIngestTaskCancelled(ds);
   }
 
   /**
    * The same outcome when the stop hangs instead of throwing, which is the case the bound exists for:
-   * {@code shutdownGracefully} can await the ingest executor for up to 24 hours.
+   * {@code shutdownGracefully} can await the ingest executor for up to 24 hours. The preemptive ceiling in the
+   * helper is what pins the bound here.
    */
   @Test
-  void stopThatHangsIsBoundedAndCancelsTheIngestTask() throws Exception {
+  void stopThatHangsIsBoundedAndCancelsTheIngestTask() {
     HoodieDeltaStreamer ds = Mockito.mock(HoodieDeltaStreamer.class);
     Mockito.doAnswer(invocation -> {
       Thread.sleep(TimeUnit.MINUTES.toMillis(10));
       return null;
     }).when(ds).shutdownGracefully();
 
+    assertStopEndsWithTheIngestTaskCancelled(ds);
+  }
+
+  /**
+   * The branch the bound exists for. When the stop is still running after its bound, the ingestion service is
+   * force-stopped and the ingest task cancelled, and the close-wait gives up after its own bound and lets the
+   * stop run on rather than block the next test.
+   */
+  @Test
+  void stopThatOutlivesItsBoundIsForceStoppedAndLetRunOn() {
+    HoodieDeltaStreamer ds = Mockito.mock(HoodieDeltaStreamer.class);
+    HoodieIngestionService service = Mockito.mock(HoodieIngestionService.class);
+    Mockito.when(ds.getIngestionService()).thenReturn(service);
+    CountDownLatch release = new CountDownLatch(1);
+    stubStopThatOutlivesTheInterrupt(ds, release);
+
+    try {
+      long startedAt = System.nanoTime();
+      assertStopEndsWithTheIngestTaskCancelled(ds);
+      long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+
+      Mockito.verify(service).shutdown(true);
+      // The stop's own bound expires first, then the close-wait runs for its bound before giving up, so the
+      // branch that lets the stop run on costs at least two bounds. A lower bound cannot flake under load.
+      assertTrue(elapsedMs >= TimeUnit.SECONDS.toMillis(2 * FAST_STOP_TIMEOUT_SECS),
+          () -> "the close-wait should have run for its bound after the stop's bound expired, which is the branch "
+              + "that lets the stop run on, but the helper returned after " + elapsedMs + "ms");
+    } finally {
+      release.countDown();
+    }
+  }
+
+  /**
+   * A caller that arrives already interrupted must not skip the close-wait: the flag would make
+   * {@code awaitTermination} throw at once. The wait runs for its bound and the interrupt is restored
+   * afterwards.
+   */
+  @Test
+  void interruptedCallerStillGetsTheBoundedCloseWait() {
+    HoodieDeltaStreamer ds = Mockito.mock(HoodieDeltaStreamer.class);
+    CountDownLatch release = new CountDownLatch(1);
+    stubStopThatOutlivesTheInterrupt(ds, release);
+
+    try {
+      assertTimeoutPreemptively(Duration.ofSeconds(STOP_PATH_CEILING_SECS), () -> {
+        Thread.currentThread().interrupt();
+        long startedAt = System.nanoTime();
+
+        TestHoodieDeltaStreamer.stopLeakedStreamer(ds, null, FAST_STOP_TIMEOUT_SECS);
+
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+        assertTrue(Thread.interrupted(),
+            "the caller's interrupt should be restored after the wait, not lost");
+        assertTrue(elapsedMs >= TimeUnit.SECONDS.toMillis(FAST_STOP_TIMEOUT_SECS),
+            () -> "the close-wait should have run for its bound instead of being skipped because the caller "
+                + "was interrupted, but returned after " + elapsedMs + "ms");
+      });
+    } finally {
+      release.countDown();
+    }
+  }
+
+  /** Runs the stop against a ten-minute ingest task and asserts it ends, within the ceiling, with the task cancelled. */
+  private static void assertStopEndsWithTheIngestTaskCancelled(HoodieDeltaStreamer ds) {
     ExecutorService ingest = Executors.newSingleThreadExecutor();
     try {
       Future<?> dsFuture = ingest.submit(() -> {
@@ -377,12 +424,32 @@ class TestDeltaStreamerTestHelpers {
         return null;
       });
 
-      TestHoodieDeltaStreamer.stopLeakedStreamer(ds, dsFuture, FAST_STOP_TIMEOUT_SECS);
+      assertTimeoutPreemptively(Duration.ofSeconds(STOP_PATH_CEILING_SECS),
+          () -> TestHoodieDeltaStreamer.stopLeakedStreamer(ds, dsFuture, FAST_STOP_TIMEOUT_SECS),
+          "the stop should be bounded, not wait out the ten minutes the mock sleeps");
 
       assertTrue(dsFuture.isCancelled(),
-          "a stop that hung past its bound should still leave the ingest task cancelled");
+          "the ingest task should have been cancelled, since that leak is what the helper exists to close");
     } finally {
       ingest.shutdownNow();
     }
+  }
+
+  /**
+   * A stop that sleeps through the interrupt, as {@code HoodieAsyncService.shutdown(false)} does, so the stopper
+   * thread outlives the close-wait until the test releases it.
+   */
+  private static void stubStopThatOutlivesTheInterrupt(HoodieDeltaStreamer ds, CountDownLatch release) {
+    Mockito.doAnswer(invocation -> {
+      boolean released = false;
+      while (!released) {
+        try {
+          released = release.await(10, TimeUnit.MINUTES);
+        } catch (InterruptedException swallowed) {
+          // deliberately swallowed without restoring the flag: that is the shape being modelled
+        }
+      }
+      return null;
+    }).when(ds).shutdownGracefully();
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
@@ -20,6 +20,7 @@
 package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.common.testutils.JavaTestUtils;
+import org.apache.hudi.utilities.streamer.NoNewDataTerminationStrategy;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -31,28 +32,32 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Covers {@code HoodieDeltaStreamerTestBase.TestHelpers#waitTillCondition}, the helper every
- * continuous-mode deltastreamer test waits on.
+ * Covers the deltastreamer test helpers every continuous-mode test runs on: the wait in
+ * {@code HoodieDeltaStreamerTestBase.TestHelpers} and the runner in {@code TestHoodieDeltaStreamer}.
  *
  * <p>The wait used to fail with a bare {@code TimeoutException} naming only the helper, with the
  * condition's own error logged at debug and discarded, so a timeout said nothing about which assertion
  * never held (HUDI-6843).
  */
-class TestWaitTillCondition {
+class TestDeltaStreamerTestHelpers {
 
   /** A deltastreamer future that never finishes, as a continuous-mode job would be. */
   private static final Future<?> RUNNING = new CompletableFuture<>();
 
   /**
    * The helper polls every 2s, so the timeout has to leave room for at least one evaluation to be recorded.
-   * 5s is enough for that, and keeps the six tests in this class from spending half a minute asleep in the
+   * 5s is enough for that, and keeps the tests in this class from spending half a minute asleep in the
    * shared utilities job.
    */
   private static final int CONDITION_TIMEOUT_SECS = 5;
+
+  /** For the cases that are not meant to time out: they finish long before this, so it is never reached. */
+  private static final int NEVER_REACHED_TIMEOUT_SECS = 30;
 
   @Test
   void timeoutFailureNamesTheLastConditionFailure() {
@@ -94,7 +99,7 @@ class TestWaitTillCondition {
     assertTrue(pollsWhenItGaveUp > 0,
         "the condition should have been evaluated at least once before the wait gave up, otherwise the "
             + "comparison below passes trivially");
-    Thread.sleep(5000);
+    Thread.sleep(2 * HoodieDeltaStreamerTestBase.TestHelpers.POLL_INTERVAL_MS);
     assertEquals(pollsWhenItGaveUp, polls.get(),
         "the polling thread should have stopped when the wait gave up, not carried on in the background");
   }
@@ -120,6 +125,37 @@ class TestWaitTillCondition {
     assertTrue(error.getMessage().contains("No evaluation of the condition completed"),
         () -> "a condition still running its first evaluation should be reported as such, but was: "
             + error.getMessage());
+    assertFalse(JavaTestUtils.checkNestedExceptionContains(error, "no such text"),
+        "walking the cause chain has to tolerate the null-message TimeoutException this path attaches, "
+            + "which is what the multi-writer test hits when its ingestion wait times out");
+  }
+
+  /**
+   * Conditions in the continuous-mode tests catch their own failures and return false rather than throwing,
+   * so this is the branch a real timeout reports. It has to say how many evaluations ran, since that is the
+   * only signal separating it from a condition that never completed one.
+   */
+  @Test
+  void timeoutReportsEvaluationsThatReturnedFalse() {
+    AssertionError error = assertThrows(AssertionError.class,
+        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+            ignored -> false, RUNNING, CONDITION_TIMEOUT_SECS));
+
+    assertTrue(error.getMessage().contains("returned false without throwing"),
+        () -> "a condition that kept returning false should be reported as such, but was: " + error.getMessage());
+  }
+
+  /**
+   * The bound exists so a hung poll cannot run for the life of the JVM. Both production callers of waitFor
+   * are currently disabled (HUDI-8951), so this is the only thing exercising it.
+   */
+  @Test
+  void waitForGivesUpAtItsBound() {
+    AssertionError error = assertThrows(AssertionError.class,
+        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitFor(() -> false, 1));
+
+    assertTrue(error.getMessage().contains("did not hold within 1 seconds"),
+        () -> "the bound should name itself in the failure, but was: " + error.getMessage());
   }
 
   /**
@@ -134,7 +170,7 @@ class TestWaitTillCondition {
     HoodieDeltaStreamer ds = Mockito.mock(HoodieDeltaStreamer.class);
     Mockito.doThrow(new IllegalStateException("source is unreachable")).when(ds).sync();
     HoodieDeltaStreamer.Config cfg = new HoodieDeltaStreamer.Config();
-    cfg.postWriteTerminationStrategyClass = "org.apache.hudi.utilities.streamer.NoNewDataTerminationStrategy";
+    cfg.postWriteTerminationStrategyClass = NoNewDataTerminationStrategy.class.getName();
 
     ExecutionException failure = assertThrows(ExecutionException.class,
         () -> TestHoodieDeltaStreamer.deltaStreamerTestRunner(ds, cfg, ignored -> false, "dying_ds_job"));
@@ -146,7 +182,7 @@ class TestWaitTillCondition {
   @Test
   void satisfiedConditionReturnsNormally() {
     assertDoesNotThrow(() -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
-        ignored -> true, RUNNING, 30));
+        ignored -> true, RUNNING, NEVER_REACHED_TIMEOUT_SECS));
   }
 
   /**
@@ -159,6 +195,6 @@ class TestWaitTillCondition {
     Future<?> finished = CompletableFuture.completedFuture(null);
 
     assertDoesNotThrow(() -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
-        ignored -> false, finished, 30));
+        ignored -> false, finished, NEVER_REACHED_TIMEOUT_SECS));
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestDeltaStreamerTestHelpers.java
@@ -25,6 +25,7 @@ import org.apache.hudi.utilities.streamer.NoNewDataTerminationStrategy;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -89,8 +90,11 @@ class TestDeltaStreamerTestHelpers {
     assertFalse(error.getMessage().contains("returned false without throwing"),
         () -> "The failure should carry the condition's error, not the 'kept returning false' branch, "
             + "but was: " + error.getMessage());
+    assertEquals(1, error.getSuppressed().length,
+        () -> "the timeout should stay attached as a suppressed exception once the condition's error becomes "
+            + "the cause, but the suppressed list was: " + Arrays.toString(error.getSuppressed()));
     assertInstanceOf(TimeoutException.class, error.getSuppressed()[0],
-        "the timeout should stay attached as a suppressed exception once the condition's error becomes the cause");
+        "the suppressed exception should be the timeout the wait gave up on");
   }
 
   /**
@@ -170,7 +174,7 @@ class TestDeltaStreamerTestHelpers {
         () -> waitTillCondition(
             ignored -> {
               try {
-                Thread.sleep(60_000);
+                Thread.sleep(TimeUnit.SECONDS.toMillis(60));
               } catch (InterruptedException interrupted) {
                 Thread.currentThread().interrupt();
               }
@@ -253,8 +257,9 @@ class TestDeltaStreamerTestHelpers {
   }
 
   /**
-   * Unreachable through the helper, which reads the evaluation counter before the last error and so can see a
-   * recorded error alongside a count of zero; pinned here because nothing else can produce that combination.
+   * Not deterministically reproducible through the helper: it reads the evaluation counter before the last
+   * error, so it can see a recorded error alongside a count of zero, but only on an interleaving a test cannot
+   * force. Pinned here by calling the report builder directly.
    */
   @Test
   void describeTimeoutReportsAnErrorEvenWithNoCompletedEvaluation() {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -1744,28 +1744,43 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
   static void deltaStreamerTestRunner(HoodieDeltaStreamer ds, HoodieDeltaStreamer.Config cfg, Function<Boolean, Boolean> condition, String jobId) throws Exception {
     ExecutorService executor = Executors.newSingleThreadExecutor();
-    Future dsFuture = executor.submit(() -> {
+    try {
+      Future dsFuture = executor.submit(() -> {
+        try {
+          ds.sync();
+        } catch (Exception ex) {
+          log.warn("DS continuous job failed, hence not proceeding with condition check for {}", jobId);
+          throw new RuntimeException(ex.getMessage(), ex);
+        }
+      });
       try {
-        ds.sync();
-      } catch (Exception ex) {
-        log.warn("DS continuous job failed, hence not proceeding with condition check for {}", jobId);
-        throw new RuntimeException(ex.getMessage(), ex);
+        TestHelpers.waitTillCondition(condition, dsFuture, 360);
+      } catch (Throwable failure) {
+        // Surefire runs this module with forkCount=1 and reuseForks=true, so a continuous streamer left
+        // running here reads on into the next test, whose setup deletes basePath and whose teardown closes
+        // the data generators underneath it. Stop it before letting the failure out.
+        try {
+          ds.shutdownGracefully();
+        } catch (Exception shutdownFailure) {
+          failure.addSuppressed(shutdownFailure);
+        }
+        throw failure;
       }
-    });
-    TestHelpers.waitTillCondition(condition, dsFuture, 360);
-    if (cfg != null && !cfg.postWriteTerminationStrategyClass.isEmpty()) {
-      // If the streamer died, waitTillCondition returns as soon as the future completes. Surface that
-      // failure here rather than letting awaitDeltaStreamerShutdown time out and report the misleading
-      // "Deltastreamer should have shutdown by now" two minutes later.
-      if (dsFuture.isDone()) {
+      if (cfg != null && !cfg.postWriteTerminationStrategyClass.isEmpty()) {
+        // If the streamer died, waitTillCondition returns as soon as the future completes. Surface that
+        // failure here rather than letting awaitDeltaStreamerShutdown time out and report the misleading
+        // "Deltastreamer should have shutdown by now" two minutes later.
+        if (dsFuture.isDone()) {
+          dsFuture.get();
+        }
+        awaitDeltaStreamerShutdown(ds);
+      } else {
+        ds.shutdownGracefully();
         dsFuture.get();
       }
-      awaitDeltaStreamerShutdown(ds);
-    } else {
-      ds.shutdownGracefully();
-      dsFuture.get();
+    } finally {
+      executor.shutdown();
     }
-    executor.shutdown();
   }
 
   static void awaitDeltaStreamerShutdown(HoodieDeltaStreamer ds) throws InterruptedException {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -1656,6 +1656,12 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     });
     TestHelpers.waitTillCondition(condition, dsFuture, 360);
     if (cfg != null && !cfg.postWriteTerminationStrategyClass.isEmpty()) {
+      // If the streamer died, waitTillCondition returns as soon as the future completes. Surface that
+      // failure here rather than letting awaitDeltaStreamerShutdown time out and report the misleading
+      // "Deltastreamer should have shutdown by now" two minutes later.
+      if (dsFuture.isDone()) {
+        dsFuture.get();
+      }
       awaitDeltaStreamerShutdown(ds);
     } else {
       ds.shutdownGracefully();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -1754,6 +1754,12 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
     });
     TestHelpers.waitTillCondition(condition, dsFuture, 360);
     if (cfg != null && !cfg.postWriteTerminationStrategyClass.isEmpty()) {
+      // If the streamer died, waitTillCondition returns as soon as the future completes. Surface that
+      // failure here rather than letting awaitDeltaStreamerShutdown time out and report the misleading
+      // "Deltastreamer should have shutdown by now" two minutes later.
+      if (dsFuture.isDone()) {
+        dsFuture.get();
+      }
       awaitDeltaStreamerShutdown(ds);
     } else {
       ds.shutdownGracefully();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -187,6 +187,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -218,6 +219,9 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  */
 @Slf4j
 public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
+
+  // Bounds the stop a failure triggers, so a wedged streamer cannot hang the test it already failed.
+  private static final long STREAMER_STOP_TIMEOUT_SECS = 60;
 
   // Per-field verdict for the corrupt logical-repair fixtures: relabel ts_millis to millis and
   // attach the local-timestamp logical types that 0.x dropped. ts_micros is already micros.
@@ -1744,8 +1748,10 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
   static void deltaStreamerTestRunner(HoodieDeltaStreamer ds, HoodieDeltaStreamer.Config cfg, Function<Boolean, Boolean> condition, String jobId) throws Exception {
     ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future dsFuture = null;
+    boolean stoppedCleanly = false;
     try {
-      Future dsFuture = executor.submit(() -> {
+      dsFuture = executor.submit(() -> {
         try {
           ds.sync();
         } catch (Exception ex) {
@@ -1753,19 +1759,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
           throw new RuntimeException(ex.getMessage(), ex);
         }
       });
-      try {
-        TestHelpers.waitTillCondition(condition, dsFuture, 360);
-      } catch (Throwable failure) {
-        // Surefire runs this module with forkCount=1 and reuseForks=true, so a continuous streamer left
-        // running here reads on into the next test, whose setup deletes basePath and whose teardown closes
-        // the data generators underneath it. Stop it before letting the failure out.
-        try {
-          ds.shutdownGracefully();
-        } catch (Exception shutdownFailure) {
-          failure.addSuppressed(shutdownFailure);
-        }
-        throw failure;
-      }
+      TestHelpers.waitTillCondition(condition, dsFuture, 360);
       if (cfg != null && !cfg.postWriteTerminationStrategyClass.isEmpty()) {
         // If the streamer died, waitTillCondition returns as soon as the future completes. Surface that
         // failure here rather than letting awaitDeltaStreamerShutdown time out and report the misleading
@@ -1778,8 +1772,46 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         ds.shutdownGracefully();
         dsFuture.get();
       }
+      stoppedCleanly = true;
     } finally {
+      if (!stoppedCleanly) {
+        stopLeakedStreamer(ds, dsFuture);
+      }
       executor.shutdown();
+    }
+  }
+
+  /**
+   * Stops a streamer that a failure left running, without letting the stop hang the test.
+   * <p>
+   * Surefire runs this module with forkCount=1 and reuseForks=true, so a live streamer reads on into the
+   * next test, whose setup deletes basePath and whose teardown closes the data generators underneath it.
+   * The stop has to be bounded: shutdownGracefully awaits the ingest executor for up to 24 hours, and it
+   * returns immediately without waiting when shutdown was already requested, so neither the wait nor the
+   * absence of one can be relied on here.
+   */
+  private static void stopLeakedStreamer(HoodieDeltaStreamer ds, Future dsFuture) {
+    ExecutorService stopper = Executors.newSingleThreadExecutor();
+    try {
+      stopper.submit(ds::shutdownGracefully).get(STREAMER_STOP_TIMEOUT_SECS, TimeUnit.SECONDS);
+      if (dsFuture != null) {
+        dsFuture.get(STREAMER_STOP_TIMEOUT_SECS, TimeUnit.SECONDS);
+      }
+    } catch (ExecutionException ingestFailure) {
+      // Expected rather than anomalous: the ingest task failing is usually why the caller is unwinding at
+      // all, and the caller reports it. Nothing to warn about here.
+    } catch (Exception stopFailure) {
+      // Swallowed on purpose: this runs while another failure is propagating, and replacing that failure
+      // with this one would hide the diagnostic the caller is about to report.
+      if (stopFailure instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      log.warn("Could not stop the streamer cleanly after a failure, cancelling the ingest task", stopFailure);
+      if (dsFuture != null) {
+        dsFuture.cancel(true);
+      }
+    } finally {
+      stopper.shutdownNow();
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -110,6 +110,7 @@ import org.apache.hudi.utilities.UtilHelpers;
 import org.apache.hudi.utilities.config.HoodieStreamerConfig;
 import org.apache.hudi.utilities.config.SourceTestConfig;
 import org.apache.hudi.utilities.ingestion.HoodieIngestionException;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionService;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 import org.apache.hudi.utilities.schema.KafkaOffsetPostProcessor;
 import org.apache.hudi.utilities.schema.SchemaProvider;
@@ -1775,7 +1776,12 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       stoppedCleanly = true;
     } finally {
       if (!stoppedCleanly) {
-        stopLeakedStreamer(ds, dsFuture);
+        try {
+          stopLeakedStreamer(ds, dsFuture);
+        } catch (Throwable cleanupFailure) {
+          // Never let the cleanup replace the failure the caller is already propagating.
+          log.warn("Failed to stop the streamer after a failure", cleanupFailure);
+        }
       }
       executor.shutdown();
     }
@@ -1793,7 +1799,14 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
   private static void stopLeakedStreamer(HoodieDeltaStreamer ds, Future dsFuture) {
     ExecutorService stopper = Executors.newSingleThreadExecutor();
     try {
-      stopper.submit(ds::shutdownGracefully).get(STREAMER_STOP_TIMEOUT_SECS, TimeUnit.SECONDS);
+      Future<?> stop = stopper.submit(ds::shutdownGracefully);
+      try {
+        stop.get(STREAMER_STOP_TIMEOUT_SECS, TimeUnit.SECONDS);
+      } catch (ExecutionException stopThrew) {
+        // The stop itself failing does not excuse leaving the ingest task running, so fall through to the join
+        // below rather than take the outer clause, which tolerates only the ingest task's own failure.
+        log.warn("Stopping the streamer threw after a failure", stopThrew);
+      }
       if (dsFuture != null) {
         dsFuture.get(STREAMER_STOP_TIMEOUT_SECS, TimeUnit.SECONDS);
       }
@@ -1807,11 +1820,28 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         Thread.currentThread().interrupt();
       }
       log.warn("Could not stop the streamer cleanly after a failure, cancelling the ingest task", stopFailure);
+      // The 60s bound only stops this thread waiting: HoodieAsyncService.shutdown(false) swallows the interrupt
+      // that stopper.shutdownNow() sends, and HoodieStreamer.shutdownGracefully runs ds.close() regardless, so
+      // without forcing the executor down the write client can close under a still-running ingest round.
+      forceStopIngestion(ds);
       if (dsFuture != null) {
         dsFuture.cancel(true);
       }
     } finally {
       stopper.shutdownNow();
+    }
+  }
+
+  private static void forceStopIngestion(HoodieDeltaStreamer ds) {
+    try {
+      HoodieIngestionService ingestionService = ds.getIngestionService();
+      if (ingestionService != null) {
+        ingestionService.shutdown(true);
+      }
+    } catch (Exception noService) {
+      // Nothing to force down: a streamer that never started an ingestion service, or a mock. getIngestionService
+      // is an Option.get(), so absence arrives as an exception rather than a null.
+      log.debug("No ingestion service to force-stop", noService);
     }
   }
 
@@ -2219,6 +2249,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
   }
 
   @Disabled("HUDI-8951")
+  @Test
   public void testHoodieIndexerExecutionAfterCommit() throws Exception {
     String tableBasePath = basePath + "/asyncindexer_commit";
     Set<String> customConfigs = new HashSet<>();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -221,8 +221,10 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 @Slf4j
 public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
 
-  // Bounds the stop a failure triggers, so a wedged streamer cannot hang the test it already failed.
-  private static final long STREAMER_STOP_TIMEOUT_SECS = 60;
+  // Bounds the stop a failure triggers, so a wedged streamer cannot hang the test it already failed. Kept
+  // well inside what the @Timeout(600) continuous-mode tests have left after the 360s they already spend in
+  // the wait: once that budget blows, JUnit replaces the test's own failure with its timeout.
+  private static final long STREAMER_STOP_TIMEOUT_SECS = 30;
 
   // Per-field verdict for the corrupt logical-repair fixtures: relabel ts_millis to millis and
   // attach the local-timestamp logical types that 0.x dropped. ts_micros is already micros.
@@ -1800,9 +1802,10 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
    * returns immediately without waiting when shutdown was already requested, so neither the wait nor the
    * absence of one can be relied on here.
    * <p>
-   * Three waits are bounded by {@code stopTimeoutSecs} in sequence, so a streamer wedged at every step
-   * holds this for three times that: the stop itself, the join of the ingest task, and the close that
-   * runs on the stopper thread after the interrupt is swallowed.
+   * Each of the three waits - the stop itself, the join of the ingest task, and the close that runs on the
+   * stopper thread after the interrupt is swallowed - is bounded by {@code stopTimeoutSecs}, and at most two
+   * of them run in sequence on any one path (a stop that times out skips the join; a stop that returns leaves
+   * nothing for the close-wait), so a wedged streamer holds this for at most twice that.
    */
   private static void stopLeakedStreamer(HoodieDeltaStreamer ds, Future dsFuture) {
     stopLeakedStreamer(ds, dsFuture, STREAMER_STOP_TIMEOUT_SECS);
@@ -1846,12 +1849,19 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       // swallows that interrupt without restoring the flag, so shutdownGracefully carries on into ds.close()
       // on that thread. Give the close a bounded chance to finish here, rather than let it run on into the
       // next test's setup, which deletes basePath underneath it.
+      // An interrupted caller would make awaitTermination throw at once and skip the wait, so the flag is
+      // cleared for the wait and restored afterwards.
+      boolean callerInterrupted = Thread.interrupted();
       try {
         if (!stopper.awaitTermination(stopTimeoutSecs, TimeUnit.SECONDS)) {
           log.warn("The streamer stop did not finish closing within {}s, letting it run on", stopTimeoutSecs);
         }
       } catch (InterruptedException interrupted) {
-        Thread.currentThread().interrupt();
+        callerInterrupted = true;
+      } finally {
+        if (callerInterrupted) {
+          Thread.currentThread().interrupt();
+        }
       }
     }
   }
@@ -1863,8 +1873,9 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         ingestionService.shutdown(true);
       }
     } catch (Exception noService) {
-      // Nothing to force down: a streamer that never started an ingestion service, or a mock. getIngestionService
-      // is an Option.get(), so absence arrives as an exception rather than a null.
+      // Nothing to force down: a streamer that never started an ingestion service. On a real streamer
+      // getIngestionService is an Option.get(), so absence arrives as an exception; a mock returns null
+      // instead, which the guard above covers.
       log.debug("No ingestion service to force-stop", noService);
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -1822,7 +1822,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       log.warn("Could not stop the streamer cleanly after a failure, cancelling the ingest task", stopFailure);
       // The 60s bound only stops this thread waiting: HoodieAsyncService.shutdown(false) swallows the interrupt
       // that stopper.shutdownNow() sends, and HoodieStreamer.shutdownGracefully runs ds.close() regardless, so
-      // without forcing the executor down the write client can close under a still-running ingest round.
+      // forcing the executor down at least interrupts the ingest round before the close.
       forceStopIngestion(ds);
       if (dsFuture != null) {
         dsFuture.cancel(true);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamer.java
@@ -1782,8 +1782,12 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
           // Never let the cleanup replace the failure the caller is already propagating.
           log.warn("Failed to stop the streamer after a failure", cleanupFailure);
         }
+        // The ingest task has already had its one interrupt from cancel(true). If it swallowed that,
+        // an orderly shutdown() would never reach it and the pool thread would outlive the fork.
+        executor.shutdownNow();
+      } else {
+        executor.shutdown();
       }
-      executor.shutdown();
     }
   }
 
@@ -1795,20 +1799,29 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
    * The stop has to be bounded: shutdownGracefully awaits the ingest executor for up to 24 hours, and it
    * returns immediately without waiting when shutdown was already requested, so neither the wait nor the
    * absence of one can be relied on here.
+   * <p>
+   * Three waits are bounded by {@code stopTimeoutSecs} in sequence, so a streamer wedged at every step
+   * holds this for three times that: the stop itself, the join of the ingest task, and the close that
+   * runs on the stopper thread after the interrupt is swallowed.
    */
   private static void stopLeakedStreamer(HoodieDeltaStreamer ds, Future dsFuture) {
+    stopLeakedStreamer(ds, dsFuture, STREAMER_STOP_TIMEOUT_SECS);
+  }
+
+  /** The bound is a parameter only so this helper's own tests need not spend the production one. */
+  static void stopLeakedStreamer(HoodieDeltaStreamer ds, Future dsFuture, long stopTimeoutSecs) {
     ExecutorService stopper = Executors.newSingleThreadExecutor();
     try {
       Future<?> stop = stopper.submit(ds::shutdownGracefully);
       try {
-        stop.get(STREAMER_STOP_TIMEOUT_SECS, TimeUnit.SECONDS);
+        stop.get(stopTimeoutSecs, TimeUnit.SECONDS);
       } catch (ExecutionException stopThrew) {
         // The stop itself failing does not excuse leaving the ingest task running, so fall through to the join
         // below rather than take the outer clause, which tolerates only the ingest task's own failure.
         log.warn("Stopping the streamer threw after a failure", stopThrew);
       }
       if (dsFuture != null) {
-        dsFuture.get(STREAMER_STOP_TIMEOUT_SECS, TimeUnit.SECONDS);
+        dsFuture.get(stopTimeoutSecs, TimeUnit.SECONDS);
       }
     } catch (ExecutionException ingestFailure) {
       // Expected rather than anomalous: the ingest task failing is usually why the caller is unwinding at
@@ -1820,7 +1833,7 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
         Thread.currentThread().interrupt();
       }
       log.warn("Could not stop the streamer cleanly after a failure, cancelling the ingest task", stopFailure);
-      // The 60s bound only stops this thread waiting: HoodieAsyncService.shutdown(false) swallows the interrupt
+      // The bound only stops this thread waiting: HoodieAsyncService.shutdown(false) swallows the interrupt
       // that stopper.shutdownNow() sends, and HoodieStreamer.shutdownGracefully runs ds.close() regardless, so
       // forcing the executor down at least interrupts the ingest round before the close.
       forceStopIngestion(ds);
@@ -1829,6 +1842,17 @@ public class TestHoodieDeltaStreamer extends HoodieDeltaStreamerTestBase {
       }
     } finally {
       stopper.shutdownNow();
+      // shutdownNow only interrupts the stopper out of awaitTermination. HoodieAsyncService.shutdown(false)
+      // swallows that interrupt without restoring the flag, so shutdownGracefully carries on into ds.close()
+      // on that thread. Give the close a bounded chance to finish here, rather than let it run on into the
+      // next test's setup, which deletes basePath underneath it.
+      try {
+        if (!stopper.awaitTermination(stopTimeoutSecs, TimeUnit.SECONDS)) {
+          log.warn("The streamer stop did not finish closing within {}s, letting it run on", stopTimeoutSecs);
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -406,6 +406,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
 
     AtomicBoolean continuousFailed = new AtomicBoolean(false);
     AtomicBoolean backfillFailed = new AtomicBoolean(false);
+    AtomicBoolean prerequisiteHeld = new AtomicBoolean(false);
     try {
       Future regularIngestionJobFuture = service.submit(() -> {
         try {
@@ -420,7 +421,7 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
         try {
           // trigger backfill at least after 1 requested entry is added to timeline from continuous job. If not, there is a chance that backfill will complete even before
           // continuous job starts.
-          awaitCondition(new GetCommitsAfterInstant(tableBasePath, lastSuccessfulCommit));
+          prerequisiteHeld.set(awaitCondition(new GetCommitsAfterInstant(tableBasePath, lastSuccessfulCommit)));
           backfillJob.sync();
         } catch (Throwable ex) {
           log.error("Backfilling job failed {}", ex.getMessage());
@@ -431,6 +432,10 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
       backfillJobFuture.get();
       regularIngestionJobFuture.get();
       if (expectConflict) {
+        Assertions.assertTrue(prerequisiteHeld.get(),
+            "The backfill job started before the ingestion job committed anything after " + lastSuccessfulCommit
+                + ", so the two jobs never overlapped and no conflict could be raised. This is a test-side "
+                + "prerequisite that did not hold, not a conflict-handling failure.");
         Assertions.fail("Failed to handle concurrent writes");
       }
     } catch (Exception e) {
@@ -483,18 +488,28 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     }
   }
 
-  private static void awaitCondition(GetCommitsAfterInstant callback) throws InterruptedException {
+  /**
+   * Waits for the continuous ingestion job to place a commit after the instant the callback was built with, the
+   * prerequisite for the backfill job to overlap with it. The return value lets the caller tell a prerequisite
+   * that never held from a genuine conflict-handling failure.
+   *
+   * @return true if the commit landed within the budget, false if the budget expired.
+   */
+  private static boolean awaitCondition(GetCommitsAfterInstant callback) throws InterruptedException {
     long startTime = System.currentTimeMillis();
     long soFar = 0;
     while (soFar <= 5000) {
       if (callback.getCommitsAfterInstant() > 0) {
-        break;
+        log.warn("Awaiting completed in {}", System.currentTimeMillis() - startTime);
+        return true;
       } else {
         Thread.sleep(500);
         soFar += 500;
       }
     }
-    log.warn("Awaiting completed in {}", System.currentTimeMillis() - startTime);
+    log.error("The continuous job placed no commit after {} within {} ms, so the backfill job is about to start "
+        + "unsynchronized with it", callback.lastSuccessfulCommit, System.currentTimeMillis() - startTime);
+    return false;
   }
 
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestHoodieDeltaStreamerWithMultiWriter.java
@@ -184,6 +184,11 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     prepJobConfig.configs.add(
         String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
     prepJobConfig.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    // if we don't disable small file handling, log files may never get created and hence for MOR, compaction may not kick in.
+    if (tableType == HoodieTableType.MERGE_ON_READ) {
+      prepJobConfig.configs.add(String.format("%s=3", HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key()));
+      prepJobConfig.configs.add(String.format("%s=0", HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key()));
+    }
     HoodieDeltaStreamer prepJob = new HoodieDeltaStreamer(prepJobConfig, jsc);
 
     // Prepare base dataset with some commits
@@ -256,6 +261,11 @@ public class TestHoodieDeltaStreamerWithMultiWriter extends HoodieDeltaStreamerT
     prepJobConfig.configs.add(
         String.format("%s=%d", SourceTestConfig.MAX_UNIQUE_RECORDS_PROP.key(), totalRecords));
     prepJobConfig.configs.add(String.format("%s=false", HoodieCleanConfig.AUTO_CLEAN.key()));
+    // if we don't disable small file handling, log files may never get created and hence for MOR, compaction may not kick in.
+    if (tableType == HoodieTableType.MERGE_ON_READ) {
+      prepJobConfig.configs.add(String.format("%s=3", HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key()));
+      prepJobConfig.configs.add(String.format("%s=0", HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key()));
+    }
     HoodieDeltaStreamer prepJob = new HoodieDeltaStreamer(prepJobConfig, jsc);
 
     // Prepare base dataset with some commits

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
@@ -19,9 +19,13 @@
 
 package org.apache.hudi.utilities.deltastreamer;
 
+import org.apache.hudi.common.testutils.JavaTestUtils;
+
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -34,10 +38,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Covers {@code HoodieDeltaStreamerTestBase.TestHelpers#waitTillCondition}, the helper every
  * continuous-mode deltastreamer test waits on.
  *
- * <p>HUDI-6843 is a flaky timeout in that wait whose only output was
- * {@code java.util.concurrent.TimeoutException} at this method, with no indication of which assertion in
- * the condition never held - the condition's error was logged at debug and discarded. That is why every
- * report of the flake looks the same and none of them is actionable.
+ * <p>The wait used to fail with a bare {@code TimeoutException} naming only the helper, with the
+ * condition's own error logged at debug and discarded, so a timeout said nothing about which assertion
+ * never held (HUDI-6843).
  */
 class TestWaitTillCondition {
 
@@ -45,11 +48,11 @@ class TestWaitTillCondition {
   private static final Future<?> RUNNING = new CompletableFuture<>();
 
   /**
-   * The helper polls every 2s, so the timeout has to leave room for several evaluations. A value close to
-   * one interval would make this test itself flaky on a loaded machine - if the worker started late and the
-   * first evaluation landed after the timeout, nothing would have been recorded to report.
+   * The helper polls every 2s, so the timeout has to leave room for at least one evaluation to be recorded.
+   * 5s is the same margin {@link #pollingStopsOnceTheWaitHasGivenUp} already relies on, and keeps the four
+   * tests in this class from spending half a minute asleep in the shared utilities job.
    */
-  private static final int CONDITION_TIMEOUT_SECS = 15;
+  private static final int CONDITION_TIMEOUT_SECS = 5;
 
   @Test
   void timeoutFailureNamesTheLastConditionFailure() {
@@ -66,6 +69,9 @@ class TestWaitTillCondition {
     assertTrue(error.getMessage().contains(assertionText),
         () -> "The failure should carry the condition's own error, which is the only clue to why the "
             + "wait timed out, but was: " + error.getMessage());
+    assertTrue(error.getMessage().contains("evaluations completed"),
+        () -> "The failure should say how many evaluations completed, which separates a condition that "
+            + "kept failing from one that never finished an evaluation, but was: " + error.getMessage());
   }
 
   /**
@@ -85,9 +91,56 @@ class TestWaitTillCondition {
             }, RUNNING, 5));
 
     int pollsWhenItGaveUp = polls.get();
+    assertTrue(pollsWhenItGaveUp > 0,
+        "the condition should have been evaluated at least once before the wait gave up, otherwise the "
+            + "comparison below passes trivially");
     Thread.sleep(5000);
     assertEquals(pollsWhenItGaveUp, polls.get(),
         "the polling thread should have stopped when the wait gave up, not carried on in the background");
+  }
+
+  /**
+   * A condition that hangs part-way through its first evaluation is a different failure from one that keeps
+   * returning false, and the report has to say which: with no completed evaluation there is no last error,
+   * and claiming the condition "returned false without throwing" would assert the wrong thing.
+   */
+  @Test
+  void timeoutDistinguishesAConditionThatNeverCompletedAnEvaluation() {
+    AssertionError error = assertThrows(AssertionError.class,
+        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+            ignored -> {
+              try {
+                Thread.sleep(60_000);
+              } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+              }
+              return true;
+            }, RUNNING, CONDITION_TIMEOUT_SECS));
+
+    assertTrue(error.getMessage().contains("No evaluation of the condition completed"),
+        () -> "a condition still running its first evaluation should be reported as such, but was: "
+            + error.getMessage());
+  }
+
+  /**
+   * When a streamer configured with a post-write termination strategy dies, the wait returns because the
+   * future is done, and {@code deltaStreamerTestRunner} has to surface that failure. Without the
+   * {@code dsFuture.isDone()} guard it would instead call {@code awaitDeltaStreamerShutdown} and report the
+   * misleading "Deltastreamer should have shutdown by now" two minutes later - here, on a mock with no
+   * ingestion service, it would NPE.
+   */
+  @Test
+  void dyingStreamerWithTerminationStrategyIsSurfacedNotWaitedOut() throws Exception {
+    HoodieDeltaStreamer ds = Mockito.mock(HoodieDeltaStreamer.class);
+    Mockito.doThrow(new IllegalStateException("source is unreachable")).when(ds).sync();
+    HoodieDeltaStreamer.Config cfg = new HoodieDeltaStreamer.Config();
+    cfg.postWriteTerminationStrategyClass = "org.apache.hudi.utilities.streamer.NoNewDataTerminationStrategy";
+
+    ExecutionException failure = assertThrows(ExecutionException.class,
+        () -> TestHoodieDeltaStreamer.deltaStreamerTestRunner(ds, cfg, ignored -> false, "dying_ds_job"));
+
+    assertTrue(JavaTestUtils.checkNestedExceptionContains(failure, "source is unreachable"),
+        () -> "the streamer's own failure should be surfaced, but was: " + failure);
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.deltastreamer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@code HoodieDeltaStreamerTestBase.TestHelpers#waitTillCondition}, the helper every
+ * continuous-mode deltastreamer test waits on.
+ *
+ * <p>HUDI-6843 is a flaky timeout in that wait whose only output was
+ * {@code java.util.concurrent.TimeoutException} at this method, with no indication of which assertion in
+ * the condition never held - the condition's error was logged at debug and discarded. That is why every
+ * report of the flake looks the same and none of them is actionable.
+ */
+class TestWaitTillCondition {
+
+  /** A deltastreamer future that never finishes, as a continuous-mode job would be. */
+  private static final Future<?> RUNNING = new CompletableFuture<>();
+
+  @Test
+  void timeoutFailureNamesTheLastConditionFailure() {
+    String assertionText = "assertAtleastNDeltaCommits: expected at least 3 delta commits but got 2";
+
+    AssertionError error = assertThrows(AssertionError.class,
+        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+            ignored -> {
+              throw new AssertionError(assertionText);
+            }, RUNNING, 3));
+
+    assertTrue(error.getMessage().contains("was not met within 3 seconds"),
+        () -> "The failure should say the condition timed out, but was: " + error.getMessage());
+    assertTrue(error.getMessage().contains(assertionText),
+        () -> "The failure should carry the condition's own error, which is the only clue to why the "
+            + "wait timed out, but was: " + error.getMessage());
+  }
+
+  @Test
+  void satisfiedConditionReturnsNormally() {
+    assertDoesNotThrow(() -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+        ignored -> true, RUNNING, 30));
+  }
+
+  /**
+   * When the streamer finishes first the wait returns rather than failing, and the caller
+   * ({@code deltaStreamerTestRunner}) surfaces the streamer's own outcome. Pinned so the timeout handling
+   * above does not turn this into a failure.
+   */
+  @Test
+  void finishedStreamerEndsTheWaitWithoutFailing() {
+    Future<?> finished = CompletableFuture.completedFuture(null);
+
+    assertDoesNotThrow(() -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+        ignored -> false, finished, 30));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.deltastreamer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@code HoodieDeltaStreamerTestBase.TestHelpers#waitTillCondition}, the helper every
+ * continuous-mode deltastreamer test waits on.
+ *
+ * <p>HUDI-6843 is a flaky timeout in that wait whose only output was
+ * {@code java.util.concurrent.TimeoutException} at this method, with no indication of which assertion in
+ * the condition never held - the condition's error was logged at debug and discarded. That is why every
+ * report of the flake looks the same and none of them is actionable.
+ */
+class TestWaitTillCondition {
+
+  /** A deltastreamer future that never finishes, as a continuous-mode job would be. */
+  private static final Future<?> RUNNING = new CompletableFuture<>();
+
+  /**
+   * The helper polls every 2s, so the timeout has to leave room for several evaluations. A value close to
+   * one interval would make this test itself flaky on a loaded machine - if the worker started late and the
+   * first evaluation landed after the timeout, nothing would have been recorded to report.
+   */
+  private static final int CONDITION_TIMEOUT_SECS = 15;
+
+  @Test
+  void timeoutFailureNamesTheLastConditionFailure() {
+    String assertionText = "assertAtleastNDeltaCommits: expected at least 3 delta commits but got 2";
+
+    AssertionError error = assertThrows(AssertionError.class,
+        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+            ignored -> {
+              throw new AssertionError(assertionText);
+            }, RUNNING, CONDITION_TIMEOUT_SECS));
+
+    assertTrue(error.getMessage().contains("was not met within " + CONDITION_TIMEOUT_SECS + " seconds"),
+        () -> "The failure should say the condition timed out, but was: " + error.getMessage());
+    assertTrue(error.getMessage().contains(assertionText),
+        () -> "The failure should carry the condition's own error, which is the only clue to why the "
+            + "wait timed out, but was: " + error.getMessage());
+  }
+
+  /**
+   * {@code shutdownNow} interrupts the polling thread, but {@code Thread.sleep} clears the interrupt flag
+   * when it throws, so a catch-all around the sleep would swallow it and keep polling for the life of the
+   * JVM. This pins that the worker actually stops.
+   */
+  @Test
+  void pollingStopsOnceTheWaitHasGivenUp() throws Exception {
+    AtomicInteger polls = new AtomicInteger();
+
+    assertThrows(AssertionError.class,
+        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+            ignored -> {
+              polls.incrementAndGet();
+              throw new AssertionError("never true");
+            }, RUNNING, 5));
+
+    int pollsWhenItGaveUp = polls.get();
+    Thread.sleep(5000);
+    assertEquals(pollsWhenItGaveUp, polls.get(),
+        "the polling thread should have stopped when the wait gave up, not carried on in the background");
+  }
+
+  @Test
+  void satisfiedConditionReturnsNormally() {
+    assertDoesNotThrow(() -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+        ignored -> true, RUNNING, 30));
+  }
+
+  /**
+   * When the streamer finishes first the wait returns rather than failing, and the caller
+   * ({@code deltaStreamerTestRunner}) surfaces the streamer's own outcome. Pinned so the timeout handling
+   * above does not turn this into a failure.
+   */
+  @Test
+  void finishedStreamerEndsTheWaitWithoutFailing() {
+    Future<?> finished = CompletableFuture.completedFuture(null);
+
+    assertDoesNotThrow(() -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+        ignored -> false, finished, 30));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,6 +44,13 @@ class TestWaitTillCondition {
   /** A deltastreamer future that never finishes, as a continuous-mode job would be. */
   private static final Future<?> RUNNING = new CompletableFuture<>();
 
+  /**
+   * The helper polls every 2s, so the timeout has to leave room for several evaluations. A value close to
+   * one interval would make this test itself flaky on a loaded machine - if the worker started late and the
+   * first evaluation landed after the timeout, nothing would have been recorded to report.
+   */
+  private static final int TIMEOUT_WITH_SLACK_SECS = 15;
+
   @Test
   void timeoutFailureNamesTheLastConditionFailure() {
     String assertionText = "assertAtleastNDeltaCommits: expected at least 3 delta commits but got 2";
@@ -50,13 +59,35 @@ class TestWaitTillCondition {
         () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
             ignored -> {
               throw new AssertionError(assertionText);
-            }, RUNNING, 3));
+            }, RUNNING, TIMEOUT_WITH_SLACK_SECS));
 
-    assertTrue(error.getMessage().contains("was not met within 3 seconds"),
+    assertTrue(error.getMessage().contains("was not met within " + TIMEOUT_WITH_SLACK_SECS + " seconds"),
         () -> "The failure should say the condition timed out, but was: " + error.getMessage());
     assertTrue(error.getMessage().contains(assertionText),
         () -> "The failure should carry the condition's own error, which is the only clue to why the "
             + "wait timed out, but was: " + error.getMessage());
+  }
+
+  /**
+   * {@code shutdownNow} interrupts the polling thread, but {@code Thread.sleep} clears the interrupt flag
+   * when it throws, so a catch-all around the sleep would swallow it and keep polling for the life of the
+   * JVM. This pins that the worker actually stops.
+   */
+  @Test
+  void pollingStopsOnceTheWaitHasGivenUp() throws Exception {
+    AtomicInteger polls = new AtomicInteger();
+
+    assertThrows(AssertionError.class,
+        () -> HoodieDeltaStreamerTestBase.TestHelpers.waitTillCondition(
+            ignored -> {
+              polls.incrementAndGet();
+              throw new AssertionError("never true");
+            }, RUNNING, 5));
+
+    int pollsWhenItGaveUp = polls.get();
+    Thread.sleep(5000);
+    assertEquals(pollsWhenItGaveUp, polls.get(),
+        "the polling thread should have stopped when the wait gave up, not carried on in the background");
   }
 
   @Test

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/deltastreamer/TestWaitTillCondition.java
@@ -49,8 +49,8 @@ class TestWaitTillCondition {
 
   /**
    * The helper polls every 2s, so the timeout has to leave room for at least one evaluation to be recorded.
-   * 5s is the same margin {@link #pollingStopsOnceTheWaitHasGivenUp} already relies on, and keeps the four
-   * tests in this class from spending half a minute asleep in the shared utilities job.
+   * 5s is enough for that, and keeps the six tests in this class from spending half a minute asleep in the
+   * shared utilities job.
    */
   private static final int CONDITION_TIMEOUT_SECS = 5;
 
@@ -88,7 +88,7 @@ class TestWaitTillCondition {
             ignored -> {
               polls.incrementAndGet();
               throw new AssertionError("never true");
-            }, RUNNING, 5));
+            }, RUNNING, CONDITION_TIMEOUT_SECS));
 
     int pollsWhenItGaveUp = polls.get();
     assertTrue(pollsWhenItGaveUp > 0,


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Relates to #16228 (HUDI-6843), flaky since 2023. Every report of it is a bare `TimeoutException` from `waitTillCondition`, which swallows whatever its condition throws; the condition asserts four things and nothing says which one never held or what it saw.

**This PR does not stop the test flaking.** It makes the next occurrence diagnosable.

Before:

```
java.util.concurrent.TimeoutException
	at HoodieDeltaStreamerTestBase$TestHelpers.waitTillCondition(HoodieDeltaStreamerTestBase.java:650)
```

After, with the condition's own error as the cause so its stack trace survives:

```
Condition was not met within 360 seconds. <N> evaluations completed; the last failure reported was: org.opentest4j.AssertionFailedError: assertAtleastNDeltaCommits: Got=2, exp >=3 ==> expected: <true> but was: <false>
```

<details>
<summary>How the diagnostic is lost today</summary>

`waitTillCondition` polls the condition every two seconds and swallows whatever it throws:

```java
} catch (Throwable error) {
  log.debug("Got error waiting for condition", error);
  ret = false;
}
```

The condition for this test asserts four things  --  delta-commit count, compaction-commit count, record
count and distance count. When one of them never becomes true, the assertion error goes to `debug` and is
dropped, `res.get(360, SECONDS)` expires, and the failure names only the helper. There is no way to tell
which assertion was still failing, or what value it saw, so no two reports of this flake can be
distinguished and none of them is actionable.

</details>

### Summary and Changelog

- `waitTillCondition` keeps the condition's last error as the cause, counts evaluations, and reports which of three shapes the timeout took; the condition helpers name themselves.
- A failure stops the streamer instead of leaving it running into the next test: waits bounded at 30s, the ingestion service force-stopped if the stop outlives its bound, a dead streamer surfaced at once.
- Misleading logs fixed: no `"Condition completed successfully"` on a false result; the other loop exit warns with the same detail.
- `checkNestedExceptionContains` tolerates a null message; the multi-writer test records its backfill prerequisite; its sibling prep jobs get the HUDI-6445 settings (separate commit).

<details>
<summary>Full changelog</summary>

- `waitTillCondition` keeps the last `Throwable` the condition threw and attaches it to the failure, so a
  timeout reports what it was still waiting for instead of only that it gave up. The report also says how
  many evaluations completed, which separates a condition that kept failing from one that never finished
  an evaluation.
- It no longer logs `"Condition completed successfully"` when the condition returned **false** - that line
  fired on every unsuccessful poll, which actively misleads anyone reading the log of a flake. The other
  exit from the loop, the deltastreamer future finishing before the condition held, now logs the same
  detail at warn instead of looking like success, and says whether the future finished or the polling
  thread was stopped.
- It shuts down the polling executor. `Executors.newSingleThreadExecutor()` was created per call and never
  shut down, leaking a thread on every wait; every continuous-mode deltastreamer test goes through here.
  `InterruptedException` is caught ahead of the catch-all so the shutdown actually stops the thread, and an
  `executor.isShutdown()` loop guard stops a condition that swallows the interrupt without restoring it.
- `waitFor` is bounded (120s by default) and restores the interrupt rather than swallowing it. It used to
  spin forever on a condition that never held.
- `deltaStreamerTestRunner` now consumes `dsFuture` if it has already finished, before calling
  `awaitDeltaStreamerShutdown`. That branch never consumed the future, so a streamer that died was
  reported two minutes later as `"Deltastreamer should have shutdown by now"`, hiding the real cause. The
  other branch already does this via `dsFuture.get()`.
- On any failure it also stops the streamer instead of leaving it reading into the next test (surefire
  runs this module with `forkCount=1`, `reuseForks=true`). Each of its three waits is bounded at 30s - the
  stop, the join of the ingest task, and the close that runs on the stopper thread afterwards - and at most
  two of them run in sequence on any one path, so a wedged streamer adds at most 60s to the failure. The
  bound is small because the five `@Timeout(600)` continuous-mode tests already spend 360s in the wait, and
  JUnit replaces a test's own failure with its timeout once that budget blows.
  `shutdownNow()` only interrupts that thread out of `awaitTermination`; `HoodieAsyncService.shutdown(false)`
  swallows the interrupt without restoring the flag and `shutdownGracefully` runs `ds.close()` regardless,
  so without the last of those the close outlives the test that triggered it. A caller that arrives already
  interrupted still gets that close-wait: the flag is cleared for it and restored afterwards.
- `JavaTestUtils.checkNestedExceptionContains` no longer NPEs on a null message anywhere in the chain,
  which is what a `TimeoutException` raised before its condition ever threw carries.
- The condition helpers name themselves in their failure messages: `assertRecordCount(<path>) ==>
  expected: <3000> but was: <2800>` and `assertAtleastNDeltaCommits: Got=2, exp >=3`. Before,
  `assertRecordCount` and `assertDistanceCount` produced identical text and all four commit helpers produced
  `Got=N, exp >=M`, so the one-line report could not say which assertion it was; only the attached stack
  trace could.
- `TestHoodieDeltaStreamerWithMultiWriter` now records whether its backfill prerequisite held, so the
  expected-conflict tests report a prerequisite that never held instead of blaming conflict handling.
- Separate commit, easy to drop: `testUpsertsContinuousModeWithMultipleWritersWithoutConflicts` and
  `testLatestCheckpointCarryOverWithMultipleWriters` get the MOR compaction settings HUDI-6445 (#9072) gave
  the ForConflicts prep job. Both wait on the identical condition and never got them.

</details>

### Verification

`TestDeltaStreamerTestHelpers` (14 tests, 14.5s, no Spark) and `TestJavaTestUtils` (4) cover the helpers directly; checkstyle and rat clean. Reverting the helper reproduces the issue's exact symptom in the first test.

<details>
<summary>What each test pins</summary>

| test | what it pins |
| --- | --- |
| `timeoutFailureNamesTheLastConditionFailure` | the timeout failure carries the condition's own error text, and keeps the timeout itself as a suppressed exception |
| `pollingStopsEvenWhenTheConditionSwallowsTheInterrupt` | the `executor.isShutdown()` guard stops it even when the condition eats the interrupt without restoring the flag |
| `timeoutDistinguishesAConditionThatNeverCompletedAnEvaluation` | a condition stuck in its first evaluation is reported as such, not as one that kept returning false |
| `timeoutReportsEvaluationsThatReturnedFalse` | the branch for a condition that swallows its own failure and returns false, as `testHoodieIndexer` does; the HUDI-6843 condition only ever throws, so it takes the last-error branch instead. The reported count is checked against the test's own tally |
| `directInterruptEndsTheWaitWithoutRunningToTheTimeout` | the `InterruptedException` branch on its own: folding it into the catch-all fails this and nothing else |
| `stopThatThrowsStillCancelsTheIngestTask` | a stop that throws still leaves the ingest task cancelled, rather than running on into the next test |
| `stopThatHangsIsBoundedAndCancelsTheIngestTask` | the same once the stop hangs past its bound, under a preemptive ceiling so a lost bound fails instead of waiting out the mock |
| `stopThatOutlivesItsBoundIsForceStoppedAndLetRunOn` | a stop still running after its bound has the ingestion service force-stopped and the ingest task cancelled, and the close-wait gives up after its own bound and lets it run on |
| `interruptedCallerStillGetsTheBoundedCloseWait` | a caller that arrives interrupted does not skip the close-wait: it runs for its bound and the interrupt is restored |
| `describeTimeoutReportsAnErrorEvenWithNoCompletedEvaluation` | the one branch combination the helper itself cannot produce |
| `waitForGivesUpAtItsBound` | `waitFor` stops at its bound instead of spinning |
| `dyingStreamerWithTerminationStrategyIsSurfacedNotWaitedOut` | a streamer that dies is surfaced, not waited out for two minutes |
| `satisfiedConditionReturnsNormally` | the happy path still returns |
| `finishedStreamerEndsTheWaitWithoutFailing` | a finished streamer still ends the wait without failing, so the new timeout handling does not turn that into a failure |

`TestJavaTestUtils` covers `checkNestedExceptionContains` where it lives, in hudi-common: a null message
mid-chain, an `errorMsg` of `"null"` not matching a message-less throwable, a match on the head, and no
match anywhere.

Reverting the helper to master's form makes the first test fail with exactly the symptom from the issue,
which is the evidence that it is testing the right thing:

```
AssertionFailedError: Unexpected exception type thrown,
  expected: <java.lang.AssertionError> but was: <java.util.concurrent.TimeoutException>
```

After the change the same scenario reports:

```
Condition was not met within 360 seconds. <N> evaluations completed; the last failure reported was: org.opentest4j.AssertionFailedError: assertAtleastNDeltaCommits: Got=2, exp >=3 ==> expected: <true> but was: <false>
```

The condition's error is also set as the failure's cause, so the original stack trace survives.

`TestDeltaStreamerTestHelpers` 14/14 (14.5s) and `TestJavaTestUtils` 4/4, plus
`TestHoodieDeltaStreamer#testHoodieAsyncClusteringJob*` 5/5 (52.4s) for the real continuous-mode path,
that last one from an earlier head: it cannot run on this machine any more, since the `zstd-jni` the build
resolves ships no `darwin/aarch64` native and Spark fails to initialise, which reproduces on an untouched
checkout. The helper-class gates above were re-run on the current head.
`checkstyle:check` and `apache-rat:check` clean on both modules (`Unapproved: 0`).

</details>

<details>
<summary>Why InterruptedException is caught separately</summary>

**Why `InterruptedException` is caught separately** (raised in review, and the reason for the second commit
that is now squashed in): catching it with the catch-all makes the executor shutdown close nothing.
`shutdownNow()` interrupts the polling thread, but `Thread.sleep` clears the interrupt flag when it throws, so
the catch-all swallowed the `InterruptedException` and re-entered the loop. `dsFuture` never completes in the
timeout case, so the loop had no other exit and the thread kept polling for the life of the JVM  --  in exactly
the case the shutdown was added for. `directInterruptEndsTheWaitWithoutRunningToTheTimeout` pins this, and is the only case that does: it
interrupts the poller while the executor is still live, so the branch is the only thing that can end the
wait. A condition that swallows the interrupt without restoring the flag is covered separately by
`pollingStopsEvenWhenTheConditionSwallowsTheInterrupt`, which is what the `executor.isShutdown()` guard
exists for; that test pins the stop, whichever guard fires, not the branch.

The helper takes its poll interval as a parameter, so its own tests drive it at 50ms with a 1s timeout
(`FAST_POLL_INTERVAL_MS`, `CONDITION_TIMEOUT_SECS`) rather than the production 2s cadence. That keeps
the class off the shared utilities job's clock: 14 tests in 14.5s.

</details>

<details>
<summary>Runs of the target test</summary>

**The target test itself:** `testUpsertsContinuousModeWithMultipleWritersForConflicts` passes with these
changes, run four times over both `HoodieTableType` parameters  --  8 green executions, ~88s per run:

```
run 1: Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
run 2: Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
run 3: Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
run 4: Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

The full `TestHoodieDeltaStreamerWithMultiWriter` class also passes  --  re-run on the squashed commit: 5 tests,
0 failures, 107.5s. No flake reproduced in those runs, so this change is not masking one  --  and had it flaked,
the new failure would have named the assertion that was still failing, which is the whole point.

Those runs predate the later review commits; the gates listed above were re-run on the current head.

</details>

### Impact

Test infrastructure only. Nothing that passes today starts failing: the only new failure path is the timeout, which already failed.

### Risk Level

low - test-only, and the behaviour changes are limited to what a failure reports.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
