### PR TITLE
fix(lock): stop guarding the filesystem lock with an interned string literal and make the provider serializable

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -63,14 +63,30 @@ import static org.apache.hudi.common.table.HoodieTableMetaClient.AUXILIARYFOLDER
 @Slf4j
 public class FileSystemBasedLockProvider implements LockProvider<String>, Serializable {
   private static final String LOCK_FILE_NAME = "lock";
+  /**
+   * Guards this provider's lock-file operations.
+   *
+   * <p>These blocks used to synchronize on {@link #LOCK_FILE_NAME}. That is a compile-time String
+   * constant, so it is interned and shared JVM-wide with every other {@code "lock"} literal - including
+   * {@code FileSystemBasedLockProviderTestClass}, which declares its own {@code static final String LOCK =
+   * "lock"} and therefore contends on the very same monitor. Any unrelated code doing the same silently
+   * couples itself to Hudi's lock acquisition. A private object cannot be aliased that way.
+   *
+   * <p>Kept static so the mutual-exclusion scope is unchanged by this fix.
+   */
+  private static final Object LOCK_FILE_MONITOR = new Object();
   private final int lockTimeoutMinutes;
   private final transient HoodieStorage storage;
   private final transient StoragePath lockFile;
   protected LockConfiguration lockConfiguration;
   private final SimpleDateFormat sdf;
   private final LockInfo lockInfo;
+  /**
+   * Written while holding {@link #LOCK_FILE_MONITOR} in {@code tryLock}, but read through the generated
+   * getter without it, so the read needs to be volatile for the value to be visible to other threads.
+   */
   @Getter
-  private String currentOwnerLockInfo;
+  private volatile String currentOwnerLockInfo;
 
   public FileSystemBasedLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> configuration) {
     checkRequiredProps(lockConfiguration);
@@ -97,7 +113,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
 
   @Override
   public void close() {
-    synchronized (LOCK_FILE_NAME) {
+    synchronized (LOCK_FILE_MONITOR) {
       try {
         storage.deleteFile(this.lockFile);
       } catch (IOException e) {
@@ -120,7 +136,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   @Override
   public boolean tryLock(long time, TimeUnit unit) {
     try {
-      synchronized (LOCK_FILE_NAME) {
+      synchronized (LOCK_FILE_MONITOR) {
         // Check whether lock is already expired, if so try to delete lock file
         if (storage.exists(this.lockFile)) {
           if (checkIfExpired()) {
@@ -142,7 +158,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
 
   @Override
   public void unlock() {
-    synchronized (LOCK_FILE_NAME) {
+    synchronized (LOCK_FILE_MONITOR) {
       try {
         if (storage.exists(this.lockFile)) {
           storage.deleteFile(this.lockFile);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -63,14 +63,33 @@ import static org.apache.hudi.common.table.HoodieTableMetaClient.AUXILIARYFOLDER
 @Slf4j
 public class FileSystemBasedLockProvider implements LockProvider<String>, Serializable {
   private static final String LOCK_FILE_NAME = "lock";
+  /**
+   * Guards this provider's lock-file operations.
+   *
+   * <p>These blocks used to synchronize on {@link #LOCK_FILE_NAME}. That is a compile-time String constant,
+   * so it is interned: any class anywhere in the JVM that synchronizes on the same {@code "lock"} literal
+   * contends on the very same monitor and silently couples itself to Hudi's lock acquisition. A private
+   * object cannot be aliased that way.
+   *
+   * <p>Kept static so that, within a classloader, the mutual-exclusion scope is unchanged by this fix.
+   * The interned literal was additionally shared across classloaders; that was never a correctness
+   * guarantee, since the atomic create on storage is the real mutual exclusion.
+   */
+  private static final Object LOCK_FILE_MONITOR = new Object();
   private final int lockTimeoutMinutes;
   private final transient HoodieStorage storage;
   private final transient StoragePath lockFile;
   protected LockConfiguration lockConfiguration;
   private final SimpleDateFormat sdf;
   private final LockInfo lockInfo;
+  /**
+   * Written while holding {@link #LOCK_FILE_MONITOR} in {@code tryLock}, but exposed through the generated
+   * getter without it. Every in-repo caller reads it on the thread that called {@code tryLock}, so they
+   * would be safe either way; {@code getCurrentOwnerLockInfo()} is public {@link LockProvider} API, and a
+   * plugged-in caller may read it from another thread, which is what the modifier is for.
+   */
   @Getter
-  private String currentOwnerLockInfo;
+  private volatile String currentOwnerLockInfo;
 
   public FileSystemBasedLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> configuration) {
     checkRequiredProps(lockConfiguration);
@@ -97,7 +116,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
 
   @Override
   public void close() {
-    synchronized (LOCK_FILE_NAME) {
+    synchronized (LOCK_FILE_MONITOR) {
       try {
         storage.deleteFile(this.lockFile);
       } catch (IOException e) {
@@ -120,7 +139,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   @Override
   public boolean tryLock(long time, TimeUnit unit) {
     try {
-      synchronized (LOCK_FILE_NAME) {
+      synchronized (LOCK_FILE_MONITOR) {
         // Check whether lock is already expired, if so try to delete lock file
         if (storage.exists(this.lockFile)) {
           if (checkIfExpired()) {
@@ -142,7 +161,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
 
   @Override
   public void unlock() {
-    synchronized (LOCK_FILE_NAME) {
+    synchronized (LOCK_FILE_MONITOR) {
       try {
         if (storage.exists(this.lockFile)) {
           storage.deleteFile(this.lockFile);
@@ -188,12 +207,23 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     lockInfo.setLockStacksInfo(Thread.currentThread().getStackTrace());
   }
 
+  /**
+   * Reloads the payload written by whoever currently holds the lock file.
+   *
+   * <p>The existence check has to happen before the open, not inside it. {@code storage.open} throws
+   * {@link java.io.FileNotFoundException} on a missing path, so evaluating it in the try-with-resources
+   * header made the empty-string branch unreachable: a lock file that vanished between the caller's
+   * {@code exists} check and this call threw instead of clearing the field, the caller swallowed it, and
+   * the previous owner's payload was then reported as the current one.
+   */
   public void reloadCurrentOwnerLockInfo() {
-    try (InputStream is = storage.open(this.lockFile)) {
-      if (storage.exists(this.lockFile)) {
-        this.currentOwnerLockInfo = FileIOUtils.readAsUTFString(is);
-      } else {
+    try {
+      if (!storage.exists(this.lockFile)) {
         this.currentOwnerLockInfo = "";
+        return;
+      }
+      try (InputStream is = storage.open(this.lockFile)) {
+        this.currentOwnerLockInfo = FileIOUtils.readAsUTFString(is);
       }
     } catch (IOException e) {
       throw new HoodieIOException(generateLogStatement(LockState.FAILED_TO_ACQUIRE), e);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -66,11 +66,10 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   /**
    * Guards this provider's lock-file operations.
    *
-   * <p>These blocks used to synchronize on {@link #LOCK_FILE_NAME}. That is a compile-time String
-   * constant, so it is interned and shared JVM-wide with every other {@code "lock"} literal - including
-   * {@code FileSystemBasedLockProviderTestClass}, which declares its own {@code static final String LOCK =
-   * "lock"} and therefore contends on the very same monitor. Any unrelated code doing the same silently
-   * couples itself to Hudi's lock acquisition. A private object cannot be aliased that way.
+   * <p>These blocks used to synchronize on {@link #LOCK_FILE_NAME}. That is a compile-time String constant,
+   * so it is interned: any class anywhere in the JVM that synchronizes on the same {@code "lock"} literal
+   * contends on the very same monitor and silently couples itself to Hudi's lock acquisition. A private
+   * object cannot be aliased that way.
    *
    * <p>Kept static so the mutual-exclusion scope is unchanged by this fix.
    */

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -77,9 +77,10 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
    * <p>Kept static so that, within a classloader, the mutual-exclusion scope is unchanged by this fix.
    * The interned literal was additionally shared across classloaders. Losing that wider scope matters
    * only for what the exclusive create does not protect: the expiry-reclaim sequence in
-   * {@code tryLock} (exists, checkIfExpired, delete, create) everywhere, plus the exists-then-create
-   * window on a store whose create is not atomic. Both are already unsafe across processes, the
-   * normal multi-writer deployment; the monitor never made them safe. Cross-process mutual exclusion rests
+   * {@code tryLock} (exists, checkIfExpired, delete, create), the release path ({@code unlock}'s
+   * exists-then-delete and {@code close}'s unconditional delete), plus the exists-then-create window
+   * on a store whose create is not atomic. All are already unsafe across processes, the normal
+   * multi-writer deployment; the monitor never made them safe. Cross-process mutual exclusion rests
    * entirely on the exclusive-mode {@code storage.create(path, false)} in {@code acquireLock} being
    * atomic on the underlying store, which HDFS guarantees and local FS does not (its create is a
    * check-then-act); this monitor is defense in depth for in-JVM callers, not the correctness
@@ -91,10 +92,12 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   private final transient StoragePath lockFile;
   protected LockConfiguration lockConfiguration;
   // Transient because LockInfo is not Serializable and the constructor used to build it eagerly, so
-  // every instance failed Spark closure capture with NotSerializableException (the HUDI-7782 bug
-  // class); no serialized form predating the pinned serialVersionUID can therefore exist. Null-guarded
-  // in initLockInfo() for the deserialized copy; such a copy still cannot lock, since storage and
-  // lockFile are transient with no readObject to rebuild them, as before this change.
+  // every instance since 0.13.0 (HUDI-5377) failed Spark closure capture with
+  // NotSerializableException, the HUDI-7782 bug class. Pinning serialVersionUID is compat-safe:
+  // 0.12.x, the only line that ever serialized this class, computed a UID no 0.13.0+ build could
+  // read anyway, and no Hudi code persists a provider outside intra-job closure capture.
+  // Null-guarded in initLockInfo() for the deserialized copy; such a copy still cannot lock, since
+  // storage and lockFile are transient with no readObject to rebuild them, as before this change.
   private transient SimpleDateFormat sdf;
   private transient LockInfo lockInfo;
   /**
@@ -191,6 +194,11 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     return this.lockFile.toString();
   }
 
+  /**
+   * A stat failure degrades to "not expired", failing safe toward the current holder rather than
+   * reclaiming a lock whose age is unknown. {@code StorageBasedLockProvider} makes the same choice
+   * for transient errors via {@code LockGetResult.UNKNOWN_ERROR}.
+   */
   private boolean checkIfExpired() {
     if (lockTimeoutMinutes == 0) {
       return false;
@@ -201,7 +209,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
         return true;
       }
     } catch (IOException | HoodieIOException e) {
-      log.error("{} failed to get lockFile's modification time", generateLogStatement(LockState.ALREADY_RELEASED), e);
+      log.error("{} failed to get lockFile's modification time", generateLogStatement(LockState.ACQUIRING), e);
     }
     return false;
   }
@@ -223,9 +231,8 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   }
 
   public void initLockInfo() {
-    // Guarded: sdf and lockInfo are lazily built and SimpleDateFormat is not thread safe; the monitor
-    // also safely publishes them to any off-monitor caller of this public method, a guarantee the
-    // fields' former final modifier used to give for free.
+    // Guarded: sdf and lockInfo are lazily built, SimpleDateFormat is not thread safe, and the
+    // fields lost the final modifier's free safe publication when they became lazy.
     synchronized (LOCK_FILE_MONITOR) {
       if (lockInfo == null) {
         lockInfo = new LockInfo();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -75,10 +75,11 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
    * object cannot be aliased that way.
    *
    * <p>Kept static so that, within a classloader, the mutual-exclusion scope is unchanged by this fix.
-   * The interned literal was additionally shared across classloaders. Losing that wider scope only
-   * affects the expiry-reclaim sequence in {@code tryLock} (exists, checkIfExpired, delete, create),
-   * which the atomic create does not protect and which is already unsafe across processes, the normal
-   * multi-writer deployment; the monitor never made it safe. Cross-process mutual exclusion rests
+   * The interned literal was additionally shared across classloaders. Losing that wider scope matters
+   * only for what the exclusive create does not protect: the expiry-reclaim sequence in
+   * {@code tryLock} (exists, checkIfExpired, delete, create) everywhere, plus the exists-then-create
+   * window on a store whose create is not atomic. Both are already unsafe across processes, the
+   * normal multi-writer deployment; the monitor never made them safe. Cross-process mutual exclusion rests
    * entirely on the exclusive-mode {@code storage.create(path, false)} in {@code acquireLock} being
    * atomic on the underlying store, which HDFS guarantees and local FS does not (its create is a
    * check-then-act); this monitor is defense in depth for in-JVM callers, not the correctness
@@ -89,9 +90,10 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   private final transient HoodieStorage storage;
   private final transient StoragePath lockFile;
   protected LockConfiguration lockConfiguration;
-  // Transient because LockInfo is not Serializable, which made any lock-holding provider throw
-  // NotSerializableException on Spark closure capture (the HUDI-7782 bug class). Null-guarded in
-  // initLockInfo() for the deserialized copy; such a copy still cannot lock, since storage and
+  // Transient because LockInfo is not Serializable and the constructor used to build it eagerly, so
+  // every instance failed Spark closure capture with NotSerializableException (the HUDI-7782 bug
+  // class); no serialized form predating the pinned serialVersionUID can therefore exist. Null-guarded
+  // in initLockInfo() for the deserialized copy; such a copy still cannot lock, since storage and
   // lockFile are transient with no readObject to rebuild them, as before this change.
   private transient SimpleDateFormat sdf;
   private transient LockInfo lockInfo;
@@ -103,7 +105,7 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
    * plugged-in caller may read it from another thread, which is what the modifier is for.
    */
   @Getter
-  private volatile String currentOwnerLockInfo;
+  private volatile String currentOwnerLockInfo = "";
 
   public FileSystemBasedLockProvider(final LockConfiguration lockConfiguration, final StorageConfiguration<?> configuration) {
     checkRequiredProps(lockConfiguration);
@@ -221,15 +223,20 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   }
 
   public void initLockInfo() {
-    if (lockInfo == null) {
-      lockInfo = new LockInfo();
+    // Guarded: sdf and lockInfo are lazily built and SimpleDateFormat is not thread safe; the monitor
+    // also safely publishes them to any off-monitor caller of this public method, a guarantee the
+    // fields' former final modifier used to give for free.
+    synchronized (LOCK_FILE_MONITOR) {
+      if (lockInfo == null) {
+        lockInfo = new LockInfo();
+      }
+      if (sdf == null) {
+        sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      }
+      lockInfo.setLockCreateTime(sdf.format(System.currentTimeMillis()));
+      lockInfo.setLockThreadName(Thread.currentThread().getName());
+      lockInfo.setLockStacksInfo(Thread.currentThread().getStackTrace());
     }
-    if (sdf == null) {
-      sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    }
-    lockInfo.setLockCreateTime(sdf.format(System.currentTimeMillis()));
-    lockInfo.setLockThreadName(Thread.currentThread().getName());
-    lockInfo.setLockStacksInfo(Thread.currentThread().getStackTrace());
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/transaction/lock/FileSystemBasedLockProvider.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
@@ -41,6 +42,7 @@ import org.apache.hudi.storage.StorageSchemes;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -62,6 +64,7 @@ import static org.apache.hudi.common.table.HoodieTableMetaClient.AUXILIARYFOLDER
  */
 @Slf4j
 public class FileSystemBasedLockProvider implements LockProvider<String>, Serializable {
+  private static final long serialVersionUID = 1L;
   private static final String LOCK_FILE_NAME = "lock";
   /**
    * Guards this provider's lock-file operations.
@@ -72,19 +75,30 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
    * object cannot be aliased that way.
    *
    * <p>Kept static so that, within a classloader, the mutual-exclusion scope is unchanged by this fix.
-   * The interned literal was additionally shared across classloaders; that was never a correctness
-   * guarantee, since the atomic create on storage is the real mutual exclusion.
+   * The interned literal was additionally shared across classloaders. Losing that wider scope only
+   * affects the expiry-reclaim sequence in {@code tryLock} (exists, checkIfExpired, delete, create),
+   * which the atomic create does not protect and which is already unsafe across processes, the normal
+   * multi-writer deployment; the monitor never made it safe. Cross-process mutual exclusion rests
+   * entirely on the exclusive-mode {@code storage.create(path, false)} in {@code acquireLock} being
+   * atomic on the underlying store, which HDFS guarantees and local FS does not (its create is a
+   * check-then-act); this monitor is defense in depth for in-JVM callers, not the correctness
+   * mechanism.
    */
   private static final Object LOCK_FILE_MONITOR = new Object();
   private final int lockTimeoutMinutes;
   private final transient HoodieStorage storage;
   private final transient StoragePath lockFile;
   protected LockConfiguration lockConfiguration;
-  private final SimpleDateFormat sdf;
-  private final LockInfo lockInfo;
+  // Transient because LockInfo is not Serializable, which made any lock-holding provider throw
+  // NotSerializableException on Spark closure capture (the HUDI-7782 bug class). Null-guarded in
+  // initLockInfo() for the deserialized copy; such a copy still cannot lock, since storage and
+  // lockFile are transient with no readObject to rebuild them, as before this change.
+  private transient SimpleDateFormat sdf;
+  private transient LockInfo lockInfo;
   /**
-   * Written while holding {@link #LOCK_FILE_MONITOR} in {@code tryLock}, but exposed through the generated
-   * getter without it. Every in-repo caller reads it on the thread that called {@code tryLock}, so they
+   * Written under {@link #LOCK_FILE_MONITOR} on the {@code tryLock} path, with no monitor at all when
+   * {@code reloadCurrentOwnerLockInfo()} is called directly, and exposed through the generated getter
+   * without synchronization. Every in-repo caller reads it on the thread that called {@code tryLock}, so they
    * would be safe either way; {@code getCurrentOwnerLockInfo()} is public {@link LockProvider} API, and a
    * plugged-in caller may read it from another thread, which is what the modifier is for.
    */
@@ -101,8 +115,6 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     }
     this.lockTimeoutMinutes = lockConfiguration.getConfig().getInteger(FILESYSTEM_LOCK_EXPIRE_PROP_KEY);
     this.lockFile = new StoragePath(lockDirectory + StoragePath.SEPARATOR + LOCK_FILE_NAME);
-    this.lockInfo = new LockInfo();
-    this.sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     this.storage = HoodieStorageUtils.getStorage(this.lockFile.toString(), configuration);
     List<String> customSupportedFSs = lockConfiguration.getConfig().getStringList(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key(), ",", new ArrayList<>());
     if (!customSupportedFSs.contains(this.storage.getScheme()) && !StorageSchemes.isAtomicCreationSupported(this.storage.getScheme())) {
@@ -192,7 +204,14 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
     return false;
   }
 
-  private void acquireLock() {
+  /**
+   * Creates the lock file, failing if it already exists. The {@code false} in
+   * {@code storage.create(path, false)} requests an exclusive-mode create, the provider's entire
+   * cross-process mutual exclusion on stores whose create is atomic; every other check in this
+   * class is advisory. Package-private so a test can pin the exclusive mode.
+   */
+  @VisibleForTesting
+  void acquireLock() {
     try (OutputStream os = storage.create(this.lockFile, false)) {
       initLockInfo();
       os.write(StringUtils.getUTF8Bytes(lockInfo.toString()));
@@ -202,6 +221,12 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   }
 
   public void initLockInfo() {
+    if (lockInfo == null) {
+      lockInfo = new LockInfo();
+    }
+    if (sdf == null) {
+      sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    }
     lockInfo.setLockCreateTime(sdf.format(System.currentTimeMillis()));
     lockInfo.setLockThreadName(Thread.currentThread().getName());
     lockInfo.setLockStacksInfo(Thread.currentThread().getStackTrace());
@@ -210,21 +235,18 @@ public class FileSystemBasedLockProvider implements LockProvider<String>, Serial
   /**
    * Reloads the payload written by whoever currently holds the lock file.
    *
-   * <p>The existence check has to happen before the open, not inside it. {@code storage.open} throws
-   * {@link java.io.FileNotFoundException} on a missing path, so evaluating it in the try-with-resources
-   * header made the empty-string branch unreachable: a lock file that vanished between the caller's
-   * {@code exists} check and this call threw instead of clearing the field, the caller swallowed it, and
-   * the previous owner's payload was then reported as the current one.
+   * <p>A missing lock file must clear the field rather than throw: the caller swallows exceptions from
+   * this method, so an escaping {@link FileNotFoundException} would leave the previous owner's payload
+   * behind for {@link LockManager} to report as the current owner. The miss can surface at {@code open}
+   * or, on a store opted in via {@code hoodie.fs.atomic_creation.support} that fetches lazily (S3A,
+   * for example), at the first read, so the catch spans the whole read instead of an up-front
+   * existence check that leaves the delete-after-check window open.
    */
   public void reloadCurrentOwnerLockInfo() {
-    try {
-      if (!storage.exists(this.lockFile)) {
-        this.currentOwnerLockInfo = "";
-        return;
-      }
-      try (InputStream is = storage.open(this.lockFile)) {
-        this.currentOwnerLockInfo = FileIOUtils.readAsUTFString(is);
-      }
+    try (InputStream is = storage.open(this.lockFile)) {
+      this.currentOwnerLockInfo = FileIOUtils.readAsUTFString(is);
+    } catch (FileNotFoundException e) {
+      this.currentOwnerLockInfo = "";
     } catch (IOException e) {
       throw new HoodieIOException(generateLogStatement(LockState.FAILED_TO_ACQUIRE), e);
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/FileSystemBasedLockProviderTestClass.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/FileSystemBasedLockProviderTestClass.java
@@ -42,7 +42,14 @@ import static org.apache.hudi.common.config.LockConfiguration.LOCK_ACQUIRE_RETRY
  */
 public class FileSystemBasedLockProviderTestClass implements LockProvider<String>, Serializable {
 
-  private static final String LOCK = "lock";
+  private static final String LOCK_FILE_NAME = "lock";
+  /**
+   * Guards this provider's lock-file operations. Must not be the {@code "lock"} String constant: that is
+   * interned and shared JVM-wide, so any other class synchronizing on the same literal contends on the very
+   * same monitor. Same defect as the one fixed in {@link
+   * org.apache.hudi.client.transaction.lock.FileSystemBasedLockProvider}.
+   */
+  private static final Object LOCK_FILE_MONITOR = new Object();
 
   private final int retryMaxCount;
   private final int retryWaitTimeMs;
@@ -55,13 +62,13 @@ public class FileSystemBasedLockProviderTestClass implements LockProvider<String
     final String lockDirectory = lockConfiguration.getConfig().getString(FILESYSTEM_LOCK_PATH_PROP_KEY);
     this.retryWaitTimeMs = lockConfiguration.getConfig().getInteger(LOCK_ACQUIRE_RETRY_WAIT_TIME_IN_MILLIS_PROP_KEY);
     this.retryMaxCount = lockConfiguration.getConfig().getInteger(LOCK_ACQUIRE_NUM_RETRIES_PROP_KEY);
-    this.lockFile = new StoragePath(lockDirectory + "/" + LOCK);
+    this.lockFile = new StoragePath(lockDirectory + "/" + LOCK_FILE_NAME);
     this.storage = HoodieStorageUtils.getStorage(this.lockFile.toString(), configuration);
   }
 
   @Override
   public void close() {
-    synchronized (LOCK) {
+    synchronized (LOCK_FILE_MONITOR) {
       try {
         storage.deleteDirectory(this.lockFile);
       } catch (IOException e) {
@@ -74,9 +81,9 @@ public class FileSystemBasedLockProviderTestClass implements LockProvider<String
   public boolean tryLock(long time, TimeUnit unit) {
     try {
       int numRetries = 0;
-      synchronized (LOCK) {
+      synchronized (LOCK_FILE_MONITOR) {
         while (storage.exists(this.lockFile)) {
-          LOCK.wait(retryWaitTimeMs);
+          LOCK_FILE_MONITOR.wait(retryWaitTimeMs);
           numRetries++;
           if (numRetries > retryMaxCount) {
             return false;
@@ -92,7 +99,7 @@ public class FileSystemBasedLockProviderTestClass implements LockProvider<String
 
   @Override
   public void unlock() {
-    synchronized (LOCK) {
+    synchronized (LOCK_FILE_MONITOR) {
       try {
         if (storage.exists(this.lockFile)) {
           storage.deleteDirectory(this.lockFile);

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
@@ -33,7 +33,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_EXPIRE_PROP_KEY;
@@ -42,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -75,6 +78,93 @@ public class TestFileSystemBasedLockProvider {
       provider.unlock();
       // After unlock the file is gone, so the lock is acquirable again.
       assertTrue(provider.tryLock(1, TimeUnit.SECONDS), "re-acquisition after unlock should succeed");
+    } finally {
+      provider.unlock();
+      provider.close();
+    }
+  }
+
+  /**
+   * The lock-file operations used to synchronize on the {@code "lock"} String constant, which is interned
+   * and therefore shared JVM-wide with every other {@code "lock"} literal. Unrelated code holding that
+   * monitor blocked lock acquisition outright. {@link
+   * org.apache.hudi.client.transaction.FileSystemBasedLockProviderTestClass} aliased it the same way until
+   * this change gave it a private monitor too, so the unrelated thread below stands in for any remaining
+   * {@code synchronized ("lock")} anywhere in the JVM.
+   */
+  @Test
+  public void testAcquisitionIsNotBlockedByTheInternedLockLiteral() throws Exception {
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    FileSystemBasedLockProvider provider =
+        new FileSystemBasedLockProvider(lockConfiguration(lockDir("interned"), 0), storageConf);
+    CountDownLatch holding = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    // stands in for any other class in the JVM doing synchronized ("lock")
+    Thread unrelated = new Thread(() -> {
+      synchronized ("lock") {
+        holding.countDown();
+        try {
+          release.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    });
+    unrelated.setDaemon(true);
+    // Everything below has to sit inside the try: if an assertion fails before release.countDown() runs,
+    // the daemon thread parks on release.await() forever holding the JVM-wide monitor, and surefire's
+    // reuseForks would carry that into every later test in the fork.
+    try {
+      unrelated.start();
+      assertTrue(holding.await(10, TimeUnit.SECONDS), "the unrelated thread should hold the interned monitor");
+
+      boolean gotLock = assertTimeoutPreemptively(Duration.ofSeconds(10),
+          () -> provider.tryLock(1, TimeUnit.SECONDS),
+          "tryLock never returned - it is blocked on the monitor held by the unrelated thread, which means "
+              + "the provider is synchronizing on the interned \"lock\" literal again rather than on a "
+              + "private monitor");
+      assertTrue(gotLock,
+          "acquisition must not wait on a monitor held by code that has nothing to do with Hudi");
+
+      // unlock() and close() take the same monitor, so exercise them while it is still held. Without this
+      // the test passes with either of them reverted to synchronized (LOCK_FILE_NAME).
+      assertTimeoutPreemptively(Duration.ofSeconds(10),
+          () -> {
+            provider.unlock();
+            provider.close();
+          },
+          "unlock/close never returned - they are blocked on the monitor held by the unrelated thread, "
+              + "which means unlock()/close() are synchronizing on the interned \"lock\" literal again "
+              + "rather than on a private monitor");
+    } finally {
+      release.countDown();
+      provider.unlock();
+      provider.close();
+    }
+  }
+
+  /**
+   * {@code reloadCurrentOwnerLockInfo} opened the lock file in the try-with-resources header, before its own
+   * existence check, so a vanished lock file threw {@link java.io.FileNotFoundException} instead of clearing
+   * the field. The caller swallows that, so the previous owner's payload was then reported as the current
+   * one. Reading it back after the file is gone must yield the empty string, not the stale payload.
+   */
+  @Test
+  public void testReloadCurrentOwnerLockInfoClearsWhenLockFileIsGone() {
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    FileSystemBasedLockProvider provider =
+        new FileSystemBasedLockProvider(lockConfiguration(lockDir("reload"), 0), storageConf);
+    try {
+      assertTrue(provider.tryLock(1, TimeUnit.SECONDS));
+      provider.reloadCurrentOwnerLockInfo();
+      assertFalse(provider.getCurrentOwnerLockInfo().isEmpty(),
+          "the holder's payload should have been read back while the lock file exists");
+
+      provider.unlock();
+      assertDoesNotThrow(provider::reloadCurrentOwnerLockInfo,
+          "a missing lock file must not throw out of the reload");
+      assertEquals("", provider.getCurrentOwnerLockInfo(),
+          "a missing lock file must clear the owner info rather than leave the previous owner's payload");
     } finally {
       provider.unlock();
       provider.close();

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
@@ -46,6 +46,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -53,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_EXPIRE_PROP_KEY;
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_PATH_PROP_KEY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -262,10 +264,9 @@ public class TestFileSystemBasedLockProvider {
    */
   @Test
   public void testReloadClearsOwnerWhenLockFileVanishesAfterExistsCheck() {
-    // Deliberately a per-test conf: the hoodie.storage.class mutation must never be shared with other
-    // tests, and the FS cache is disabled so the fork-wide FileSystem cache cannot retain the conf.
+    // Stub injection via hoodie.storage.class, per TestRequestHandler's precedent; the conf is
+    // fresh per test, so the mutation cannot leak into other tests.
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
-    storageConf.set("fs.file.impl.disable.cache", "true");
     storageConf.set(HoodieStorageConfig.HOODIE_STORAGE_CLASS.key(), VanishingLockFileStorage.class.getName());
     FileSystemBasedLockProvider provider =
         new FileSystemBasedLockProvider(lockConfiguration(lockDir("vanish"), 0), storageConf);
@@ -277,18 +278,33 @@ public class TestFileSystemBasedLockProvider {
 
   /**
    * A real IO failure must not be mistaken for a missing lock file: only {@code FileNotFoundException}
-   * clears the owner info, anything else escapes as {@code HoodieIOException} so the caller keeps the
-   * last known owner. Widening the reload's catch to plain {@code IOException} must fail this.
+   * clears the owner info, anything else escapes as {@code HoodieIOException} and the caller keeps the
+   * last known owner. Widening the reload's catch to plain {@code IOException} must fail this, and so
+   * must clearing the field on the rethrow path.
    */
   @Test
   public void testReloadPropagatesNonMissingFileFailures() {
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
-    storageConf.set("fs.file.impl.disable.cache", "true");
     storageConf.set(HoodieStorageConfig.HOODIE_STORAGE_CLASS.key(), FailingOpenStorage.class.getName());
     FileSystemBasedLockProvider provider =
         new FileSystemBasedLockProvider(lockConfiguration(lockDir("ioerror"), 0), storageConf);
-    assertThrows(HoodieIOException.class, provider::reloadCurrentOwnerLockInfo,
-        "an IO failure that is not a missing file must escape, not silently clear the owner info");
+    try {
+      FailingOpenStorage.failing = false;
+      assertTrue(provider.tryLock(1, TimeUnit.SECONDS));
+      provider.reloadCurrentOwnerLockInfo();
+      String lastKnownOwner = provider.getCurrentOwnerLockInfo();
+      assertFalse(lastKnownOwner.isEmpty(), "the seed reload should have read the holder's payload");
+
+      FailingOpenStorage.failing = true;
+      assertThrows(HoodieIOException.class, provider::reloadCurrentOwnerLockInfo,
+          "an IO failure that is not a missing file must escape, not silently clear the owner info");
+      assertEquals(lastKnownOwner, provider.getCurrentOwnerLockInfo(),
+          "an IO failure must keep the last known owner, not clear it");
+    } finally {
+      FailingOpenStorage.failing = false;
+      provider.unlock();
+      provider.close();
+    }
   }
 
   /**
@@ -302,16 +318,17 @@ public class TestFileSystemBasedLockProvider {
     FileSystemBasedLockProvider holder =
         new FileSystemBasedLockProvider(lockConfiguration(path, 1), HoodieTestUtils.getDefaultStorageConf());
     StorageConfiguration<?> stubConf = HoodieTestUtils.getDefaultStorageConf();
-    stubConf.set("fs.file.impl.disable.cache", "true");
     stubConf.set(HoodieStorageConfig.HOODIE_STORAGE_CLASS.key(), FailingGetPathInfoStorage.class.getName());
     FileSystemBasedLockProvider contender =
         new FileSystemBasedLockProvider(lockConfiguration(path, 1), stubConf);
     try {
       assertTrue(holder.tryLock(1, TimeUnit.SECONDS));
+      Path lockPath = Paths.get(holder.getLock());
+      byte[] holderPayload = Files.readAllBytes(lockPath);
       assertFalse(contender.tryLock(1, TimeUnit.SECONDS),
           "a stat failure must not let the contender treat a live lock as expired");
-      assertTrue(Files.exists(tempDir.resolve("statfail").resolve("lock")),
-          "the holder's lock file must survive the contender's failed expiry check");
+      assertArrayEquals(holderPayload, Files.readAllBytes(lockPath),
+          "the holder's lock file must survive the contender's failed expiry check untouched");
       assertFalse(contender.getCurrentOwnerLockInfo().isEmpty(),
           "the loser must still report the current owner");
     } finally {
@@ -336,6 +353,8 @@ public class TestFileSystemBasedLockProvider {
     try {
       assertFalse(provider.tryLock(1, TimeUnit.SECONDS),
           "a failing create must surface as tryLock returning false, not as an exception");
+      assertEquals("", provider.getCurrentOwnerLockInfo(),
+          "a failure before any reload must report an empty owner, not null");
     } finally {
       provider.close();
     }
@@ -488,15 +507,23 @@ public class TestFileSystemBasedLockProvider {
     }
   }
 
-  /** Storage whose {@code open()} fails with a plain IO error, never a missing-file signal. */
+  /**
+   * Storage whose {@code open()} fails with a plain IO error, never a missing-file signal, once the
+   * flag is raised; real until then, so a test can seed state through it first.
+   */
   public static class FailingOpenStorage extends HoodieHadoopStorage {
+    static volatile boolean failing = false;
+
     public FailingOpenStorage(StoragePath path, StorageConfiguration<?> conf) {
       super(path, conf);
     }
 
     @Override
     public InputStream open(StoragePath path) throws IOException {
-      throw new IOException("simulated IO failure: " + path);
+      if (failing) {
+        throw new IOException("simulated IO failure: " + path);
+      }
+      return super.open(path);
     }
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
@@ -34,6 +34,10 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_EXPIRE_PROP_KEY;
@@ -76,6 +80,50 @@ public class TestFileSystemBasedLockProvider {
       // After unlock the file is gone, so the lock is acquirable again.
       assertTrue(provider.tryLock(1, TimeUnit.SECONDS), "re-acquisition after unlock should succeed");
     } finally {
+      provider.unlock();
+      provider.close();
+    }
+  }
+
+  /**
+   * The lock-file operations used to synchronize on the {@code "lock"} String constant, which is interned
+   * and therefore shared JVM-wide with every other {@code "lock"} literal. Unrelated code holding that
+   * monitor blocked lock acquisition outright. {@code FileSystemBasedLockProviderTestClass} in this very
+   * repo declares {@code static final String LOCK = "lock"} and so aliases it.
+   */
+  @Test
+  public void testAcquisitionIsNotBlockedByTheInternedLockLiteral() throws Exception {
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    FileSystemBasedLockProvider provider =
+        new FileSystemBasedLockProvider(lockConfiguration(lockDir("interned"), 0), storageConf);
+    CountDownLatch holding = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    // stands in for any other class in the JVM doing synchronized ("lock")
+    Thread unrelated = new Thread(() -> {
+      synchronized ("lock") {
+        holding.countDown();
+        try {
+          release.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    });
+    unrelated.setDaemon(true);
+    unrelated.start();
+    assertTrue(holding.await(10, TimeUnit.SECONDS), "the unrelated thread should hold the interned monitor");
+
+    try {
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      try {
+        Future<Boolean> acquired = executor.submit(() -> provider.tryLock(1, TimeUnit.SECONDS));
+        assertTrue(acquired.get(10, TimeUnit.SECONDS),
+            "acquisition must not wait on a monitor held by code that has nothing to do with Hudi");
+      } finally {
+        executor.shutdownNow();
+      }
+    } finally {
+      release.countDown();
       provider.unlock();
       provider.close();
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.client.transaction.lock;
 
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.LockConfiguration;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -25,13 +26,24 @@ import org.apache.hudi.common.testutils.HoodieTestUtils;
 import org.apache.hudi.common.util.HoodieStorageUtils;
 import org.apache.hudi.config.HoodieLockConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Properties;
@@ -43,6 +55,7 @@ import static org.apache.hudi.common.config.LockConfiguration.FILESYSTEM_LOCK_PA
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -114,6 +127,7 @@ public class TestFileSystemBasedLockProvider {
     // Everything below has to sit inside the try: if an assertion fails before release.countDown() runs,
     // the daemon thread parks on release.await() forever holding the JVM-wide monitor, and surefire's
     // reuseForks would carry that into every later test in the fork.
+    boolean closed = false;
     try {
       unrelated.start();
       assertTrue(holding.await(10, TimeUnit.SECONDS), "the unrelated thread should hold the interned monitor");
@@ -136,38 +150,15 @@ public class TestFileSystemBasedLockProvider {
           "unlock/close never returned - they are blocked on the monitor held by the unrelated thread, "
               + "which means unlock()/close() are synchronizing on the interned \"lock\" literal again "
               + "rather than on a private monitor");
+      closed = true;
     } finally {
       release.countDown();
-      provider.unlock();
-      provider.close();
-    }
-  }
-
-  /**
-   * {@code reloadCurrentOwnerLockInfo} opened the lock file in the try-with-resources header, before its own
-   * existence check, so a vanished lock file threw {@link java.io.FileNotFoundException} instead of clearing
-   * the field. The caller swallows that, so the previous owner's payload was then reported as the current
-   * one. Reading it back after the file is gone must yield the empty string, not the stale payload.
-   */
-  @Test
-  public void testReloadCurrentOwnerLockInfoClearsWhenLockFileIsGone() {
-    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
-    FileSystemBasedLockProvider provider =
-        new FileSystemBasedLockProvider(lockConfiguration(lockDir("reload"), 0), storageConf);
-    try {
-      assertTrue(provider.tryLock(1, TimeUnit.SECONDS));
-      provider.reloadCurrentOwnerLockInfo();
-      assertFalse(provider.getCurrentOwnerLockInfo().isEmpty(),
-          "the holder's payload should have been read back while the lock file exists");
-
-      provider.unlock();
-      assertDoesNotThrow(provider::reloadCurrentOwnerLockInfo,
-          "a missing lock file must not throw out of the reload");
-      assertEquals("", provider.getCurrentOwnerLockInfo(),
-          "a missing lock file must clear the owner info rather than leave the previous owner's payload");
-    } finally {
-      provider.unlock();
-      provider.close();
+      // Clean up only if the in-try unlock/close did not run: closing twice is safe today solely
+      // because HoodieHadoopStorage.close() is a no-op, which other backends need not honor.
+      if (!closed) {
+        provider.unlock();
+        provider.close();
+      }
     }
   }
 
@@ -184,11 +175,119 @@ public class TestFileSystemBasedLockProvider {
       // The contender is able to read the current owner's lock info.
       assertTrue(contender.getCurrentOwnerLockInfo() != null && !contender.getCurrentOwnerLockInfo().isEmpty());
       holder.unlock();
+      // Regression: the reload used to evaluate storage.open in its try-with-resources header, so a
+      // vanished lock file threw FileNotFoundException out of the reload instead of clearing the field,
+      // and the previous owner's payload kept being reported as the current one.
+      assertDoesNotThrow(contender::reloadCurrentOwnerLockInfo,
+          "a missing lock file must not throw out of the reload");
+      assertEquals("", contender.getCurrentOwnerLockInfo(),
+          "a missing lock file must clear the owner info rather than leave the previous owner's payload");
       assertTrue(contender.tryLock(1, TimeUnit.SECONDS), "contender acquires after holder releases");
     } finally {
       holder.unlock();
       contender.unlock();
       holder.close();
+    }
+  }
+
+  /**
+   * {@code storage.create(path, false)} in {@code acquireLock} is the provider's entire cross-process
+   * mutual exclusion; the in-JVM monitor cannot serialize two processes, and {@code tryLock} returns
+   * early on an existing file, so no public-API test can reach the already-exists arm. Pin the create
+   * semantics directly: a second create must fail and must leave the winner's payload untouched.
+   */
+  @Test
+  public void testAcquireLockRefusesToOverwriteAnExistingLockFile() {
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    LockConfiguration config = lockConfiguration(lockDir("atomiccreate"), 0);
+    FileSystemBasedLockProvider winner = new FileSystemBasedLockProvider(config, storageConf);
+    FileSystemBasedLockProvider loser = new FileSystemBasedLockProvider(config, storageConf);
+    try {
+      winner.acquireLock();
+      winner.reloadCurrentOwnerLockInfo();
+      String winnerPayload = winner.getCurrentOwnerLockInfo();
+      assertFalse(winnerPayload.isEmpty(), "the winner's payload should be on storage");
+
+      HoodieIOException thrown = assertThrows(HoodieIOException.class, loser::acquireLock,
+          "a second create on an existing lock file must fail, not overwrite");
+      assertInstanceOf(FileAlreadyExistsException.class, thrown.getCause(),
+          "the loser must fail on the atomic create itself");
+
+      loser.reloadCurrentOwnerLockInfo();
+      assertEquals(winnerPayload, loser.getCurrentOwnerLockInfo(),
+          "the losing attempt must leave the winner's payload untouched");
+    } finally {
+      winner.unlock();
+      winner.close();
+      loser.close();
+    }
+  }
+
+  /**
+   * The class declares {@link java.io.Serializable} but could never actually serialize once it had
+   * locked: the lockInfo field held a non-serializable {@code LockInfo} (since HUDI-5377), so every
+   * attempt threw {@code NotSerializableException}. The mutable helpers are transient now; a round
+   * trip of a lock-holding provider must work. Serializing while the lock is held is the pin -- before
+   * the first acquisition the field is still null, and null serializes regardless of the modifier.
+   * The copy's storage handles are transient and stay null, as they were before this change.
+   */
+  @Test
+  public void testJavaSerializationRoundTrip() throws Exception {
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    FileSystemBasedLockProvider provider =
+        new FileSystemBasedLockProvider(lockConfiguration(lockDir("serde"), 0), storageConf);
+    try {
+      assertTrue(provider.tryLock(1, TimeUnit.SECONDS), "the provider must hold the lock so lockInfo is populated");
+      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+      try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+        out.writeObject(provider);
+      }
+      try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+        FileSystemBasedLockProvider copy = assertInstanceOf(FileSystemBasedLockProvider.class, in.readObject());
+        assertDoesNotThrow(copy::initLockInfo, "the transient helpers must rebuild on the deserialized copy");
+      }
+    } finally {
+      provider.unlock();
+      provider.close();
+    }
+  }
+
+  /**
+   * Pins the delete-after-check window in {@code reloadCurrentOwnerLockInfo}: a storage whose
+   * {@code exists()} says true while {@code open()} reports the file missing reproduces a lock file
+   * vanishing between an existence check and the open. With the earlier exists-precheck shape the
+   * {@code FileNotFoundException} escaped as {@code HoodieIOException} and the previous owner's
+   * payload survived; the catch must clear the field instead.
+   */
+  @Test
+  public void testReloadClearsOwnerWhenLockFileVanishesAfterExistsCheck() {
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    storageConf.set(HoodieStorageConfig.HOODIE_STORAGE_CLASS.key(), VanishingLockFileStorage.class.getName());
+    FileSystemBasedLockProvider provider =
+        new FileSystemBasedLockProvider(lockConfiguration(lockDir("vanish"), 0), storageConf);
+    assertDoesNotThrow(provider::reloadCurrentOwnerLockInfo,
+        "a lock file that vanishes between an existence check and the open must not throw");
+    assertEquals("", provider.getCurrentOwnerLockInfo(),
+        "a vanished lock file must clear the owner info rather than leave the previous owner's payload");
+  }
+
+  /**
+   * The catch in {@code tryLock} is the cross-process loser outcome: a failing create must surface as
+   * a clean false, not as an exception. Pointing the lock directory at an existing regular file makes
+   * {@code exists()} on {@code <file>/lock} false and the create fail deterministically.
+   */
+  @Test
+  public void testTryLockReturnsFalseWhenTheCreateFails() throws Exception {
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    Path plainFile = tempDir.resolve("plainfile");
+    Files.write(plainFile, new byte[] {1});
+    FileSystemBasedLockProvider provider =
+        new FileSystemBasedLockProvider(lockConfiguration(plainFile.toString(), 0), storageConf);
+    try {
+      assertFalse(provider.tryLock(1, TimeUnit.SECONDS),
+          "a failing create must surface as tryLock returning false, not as an exception");
+    } finally {
+      provider.close();
     }
   }
 
@@ -313,6 +412,28 @@ public class TestFileSystemBasedLockProvider {
     } finally {
       provider.unlock();
       provider.close();
+    }
+  }
+
+  /**
+   * Storage whose {@code exists()} always says true while {@code open()} reports the file missing,
+   * simulating a lock file deleted between the two calls. Loaded reflectively via
+   * {@code hoodie.storage.class}, hence public static with the {@code (StoragePath,
+   * StorageConfiguration)} constructor.
+   */
+  public static class VanishingLockFileStorage extends HoodieHadoopStorage {
+    public VanishingLockFileStorage(StoragePath path, StorageConfiguration<?> conf) {
+      super(path, conf);
+    }
+
+    @Override
+    public boolean exists(StoragePath path) {
+      return true;
+    }
+
+    @Override
+    public InputStream open(StoragePath path) throws IOException {
+      throw new FileNotFoundException("vanished: " + path);
     }
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/client/transaction/lock/TestFileSystemBasedLockProvider.java
@@ -30,6 +30,7 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -106,7 +107,7 @@ public class TestFileSystemBasedLockProvider {
    * {@code synchronized ("lock")} anywhere in the JVM.
    */
   @Test
-  public void testAcquisitionIsNotBlockedByTheInternedLockLiteral() throws Exception {
+  public void testAcquisitionIsNotBlockedByInternedLockLiteral() throws Exception {
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
     FileSystemBasedLockProvider provider =
         new FileSystemBasedLockProvider(lockConfiguration(lockDir("interned"), 0), storageConf);
@@ -197,7 +198,7 @@ public class TestFileSystemBasedLockProvider {
    * semantics directly: a second create must fail and must leave the winner's payload untouched.
    */
   @Test
-  public void testAcquireLockRefusesToOverwriteAnExistingLockFile() {
+  public void testAcquireLockRefusesToOverwriteExistingLockFile() {
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
     LockConfiguration config = lockConfiguration(lockDir("atomiccreate"), 0);
     FileSystemBasedLockProvider winner = new FileSystemBasedLockProvider(config, storageConf);
@@ -224,12 +225,12 @@ public class TestFileSystemBasedLockProvider {
   }
 
   /**
-   * The class declares {@link java.io.Serializable} but could never actually serialize once it had
-   * locked: the lockInfo field held a non-serializable {@code LockInfo} (since HUDI-5377), so every
-   * attempt threw {@code NotSerializableException}. The mutable helpers are transient now; a round
-   * trip of a lock-holding provider must work. Serializing while the lock is held is the pin -- before
-   * the first acquisition the field is still null, and null serializes regardless of the modifier.
-   * The copy's storage handles are transient and stay null, as they were before this change.
+   * The class declares {@link java.io.Serializable} but could never actually serialize: the
+   * constructor built a non-serializable {@code LockInfo} eagerly (since HUDI-5377), so every
+   * instance threw {@code NotSerializableException}. The mutable helpers are transient and lazy now;
+   * a round trip of a lock-holding provider must work. Serializing while the lock is held is the
+   * pin -- post-fix the field is null until first acquisition, and null serializes regardless of the
+   * modifier. The copy's storage handles are transient and stay null, as they were before this change.
    */
   @Test
   public void testJavaSerializationRoundTrip() throws Exception {
@@ -261,7 +262,10 @@ public class TestFileSystemBasedLockProvider {
    */
   @Test
   public void testReloadClearsOwnerWhenLockFileVanishesAfterExistsCheck() {
+    // Deliberately a per-test conf: the hoodie.storage.class mutation must never be shared with other
+    // tests, and the FS cache is disabled so the fork-wide FileSystem cache cannot retain the conf.
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    storageConf.set("fs.file.impl.disable.cache", "true");
     storageConf.set(HoodieStorageConfig.HOODIE_STORAGE_CLASS.key(), VanishingLockFileStorage.class.getName());
     FileSystemBasedLockProvider provider =
         new FileSystemBasedLockProvider(lockConfiguration(lockDir("vanish"), 0), storageConf);
@@ -272,15 +276,61 @@ public class TestFileSystemBasedLockProvider {
   }
 
   /**
+   * A real IO failure must not be mistaken for a missing lock file: only {@code FileNotFoundException}
+   * clears the owner info, anything else escapes as {@code HoodieIOException} so the caller keeps the
+   * last known owner. Widening the reload's catch to plain {@code IOException} must fail this.
+   */
+  @Test
+  public void testReloadPropagatesNonMissingFileFailures() {
+    StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
+    storageConf.set("fs.file.impl.disable.cache", "true");
+    storageConf.set(HoodieStorageConfig.HOODIE_STORAGE_CLASS.key(), FailingOpenStorage.class.getName());
+    FileSystemBasedLockProvider provider =
+        new FileSystemBasedLockProvider(lockConfiguration(lockDir("ioerror"), 0), storageConf);
+    assertThrows(HoodieIOException.class, provider::reloadCurrentOwnerLockInfo,
+        "an IO failure that is not a missing file must escape, not silently clear the owner info");
+  }
+
+  /**
+   * A failing stat on the lock file must degrade to "not expired": the holder keeps the lock and the
+   * contender loses cleanly while still reporting who holds it. Treating the failure as expired would
+   * steal a live lock; rethrowing would skip the owner-info reload.
+   */
+  @Test
+  public void testStatFailureDuringExpiryCheckDoesNotStealLock() throws Exception {
+    String path = lockDir("statfail");
+    FileSystemBasedLockProvider holder =
+        new FileSystemBasedLockProvider(lockConfiguration(path, 1), HoodieTestUtils.getDefaultStorageConf());
+    StorageConfiguration<?> stubConf = HoodieTestUtils.getDefaultStorageConf();
+    stubConf.set("fs.file.impl.disable.cache", "true");
+    stubConf.set(HoodieStorageConfig.HOODIE_STORAGE_CLASS.key(), FailingGetPathInfoStorage.class.getName());
+    FileSystemBasedLockProvider contender =
+        new FileSystemBasedLockProvider(lockConfiguration(path, 1), stubConf);
+    try {
+      assertTrue(holder.tryLock(1, TimeUnit.SECONDS));
+      assertFalse(contender.tryLock(1, TimeUnit.SECONDS),
+          "a stat failure must not let the contender treat a live lock as expired");
+      assertTrue(Files.exists(tempDir.resolve("statfail").resolve("lock")),
+          "the holder's lock file must survive the contender's failed expiry check");
+      assertFalse(contender.getCurrentOwnerLockInfo().isEmpty(),
+          "the loser must still report the current owner");
+    } finally {
+      holder.unlock();
+      holder.close();
+      contender.close();
+    }
+  }
+
+  /**
    * The catch in {@code tryLock} is the cross-process loser outcome: a failing create must surface as
    * a clean false, not as an exception. Pointing the lock directory at an existing regular file makes
    * {@code exists()} on {@code <file>/lock} false and the create fail deterministically.
    */
   @Test
-  public void testTryLockReturnsFalseWhenTheCreateFails() throws Exception {
+  public void testTryLockReturnsFalseWhenCreateFails() throws Exception {
     StorageConfiguration<?> storageConf = HoodieTestUtils.getDefaultStorageConf();
     Path plainFile = tempDir.resolve("plainfile");
-    Files.write(plainFile, new byte[] {1});
+    Files.createFile(plainFile);
     FileSystemBasedLockProvider provider =
         new FileSystemBasedLockProvider(lockConfiguration(plainFile.toString(), 0), storageConf);
     try {
@@ -417,9 +467,10 @@ public class TestFileSystemBasedLockProvider {
 
   /**
    * Storage whose {@code exists()} always says true while {@code open()} reports the file missing,
-   * simulating a lock file deleted between the two calls. Loaded reflectively via
-   * {@code hoodie.storage.class}, hence public static with the {@code (StoragePath,
-   * StorageConfiguration)} constructor.
+   * simulating a lock file deleted between the two calls. The {@code exists()} override only matters
+   * to regressed reload shapes that re-add an existence precheck; the fixed reload never calls it.
+   * Loaded reflectively via {@code hoodie.storage.class}, hence public static with the
+   * {@code (StoragePath, StorageConfiguration)} constructor.
    */
   public static class VanishingLockFileStorage extends HoodieHadoopStorage {
     public VanishingLockFileStorage(StoragePath path, StorageConfiguration<?> conf) {
@@ -434,6 +485,30 @@ public class TestFileSystemBasedLockProvider {
     @Override
     public InputStream open(StoragePath path) throws IOException {
       throw new FileNotFoundException("vanished: " + path);
+    }
+  }
+
+  /** Storage whose {@code open()} fails with a plain IO error, never a missing-file signal. */
+  public static class FailingOpenStorage extends HoodieHadoopStorage {
+    public FailingOpenStorage(StoragePath path, StorageConfiguration<?> conf) {
+      super(path, conf);
+    }
+
+    @Override
+    public InputStream open(StoragePath path) throws IOException {
+      throw new IOException("simulated IO failure: " + path);
+    }
+  }
+
+  /** Storage whose {@code getPathInfo()} always fails, simulating a stat error during expiry checks. */
+  public static class FailingGetPathInfoStorage extends HoodieHadoopStorage {
+    public FailingGetPathInfoStorage(StoragePath path, StorageConfiguration<?> conf) {
+      super(path, conf);
+    }
+
+    @Override
+    public StoragePathInfo getPathInfo(StoragePath path) throws IOException {
+      throw new IOException("simulated stat failure: " + path);
     }
   }
 }

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -126,6 +126,8 @@ public abstract class HoodieStorage implements Closeable {
    *
    * @param path the file to open.
    * @return the InputStream to read from.
+   * @throws java.io.FileNotFoundException when the path does not exist; callers rely on this
+   *                                       subtype to tell a missing file from an IO failure.
    * @throws IOException IO error.
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)

--- a/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
+++ b/hudi-io/src/main/java/org/apache/hudi/storage/HoodieStorage.java
@@ -126,8 +126,10 @@ public abstract class HoodieStorage implements Closeable {
    *
    * @param path the file to open.
    * @return the InputStream to read from.
-   * @throws java.io.FileNotFoundException when the path does not exist; callers rely on this
-   *                                       subtype to tell a missing file from an IO failure.
+   * @throws java.io.FileNotFoundException when the path does not exist, thrown either here or, for
+   *                                       implementations that fetch lazily, from the first read of
+   *                                       the returned stream; callers rely on this subtype to tell
+   *                                       a missing file from an IO failure.
    * @throws IOException IO error.
    */
   @PublicAPIMethod(maturity = ApiMaturityLevel.EVOLVING)


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Part of #16943 (HUDI-9254). This PR fixes one self-contained defect in `FileSystemBasedLockProvider`, plus what review turned up in the same file; the rest of the issue is listed at the bottom.

`tryLock`, `unlock` and `close` guarded their lock-file operations with `synchronized (LOCK_FILE_NAME)`, where `LOCK_FILE_NAME` is the compile-time constant `"lock"`. String constants are interned, so that monitor is the JVM-wide canonical `"lock"` instance: any code anywhere in the process that synchronizes on the same literal blocks Hudi's lock acquisition, and Hudi blocks it in turn. Not hypothetical: this repo's own `FileSystemBasedLockProviderTestClass` synchronized and waited on the identical literal. The correct form already exists in `KafkaConnectControlAgent`: a private `Object` monitor.

### Summary and Changelog

- Guard on a private static `LOCK_FILE_MONITOR` object: same scope within a classloader, no aliasing. The test helper got the same fix, so no `"lock"` monitor remains in the tree.
- `currentOwnerLockInfo` becomes `volatile` (`getCurrentOwnerLockInfo()` is public `LockProvider` API and may be read from another thread) and defaults to `""` so `LockManager` never logs a null owner.

Added over review rounds (commits `771e03fa09a9`, `428a7197aee0`, `831aed976cbf`, pushed by @voonhous):

- **`reloadCurrentOwnerLockInfo()` could report a stale owner.** `storage.open` was evaluated in the try-with-resources header, so a vanished lock file threw instead of clearing the field and `LockManager` printed the previous owner as current -- the surviving half of the `5faefcd01fa8` regression; #19222 fixed only the `acquireLock` half. Final shape: `FileNotFoundException`, at `open` or at first read on a lazily fetching store, means "no owner"; any other `IOException` escapes so a real IO error is never mistaken for a missing file. One storage RPC instead of two.
- **The class declared `Serializable` but every instance since 0.13.0 failed to serialize.** HUDI-5377 added an eagerly built, non-serializable `LockInfo`, breaking Spark closure capture (the HUDI-7782 bug class). `lockInfo`/`sdf` are `transient` with lazy rebuild; `serialVersionUID` is pinned at `1L`. A deserialized copy still cannot lock; the durable fix is listed below.
- **`acquireLock()` is package-private `@VisibleForTesting`.** Its exclusive `storage.create(path, false)` is the cross-process mutual exclusion, and its already-exists arm had never executed in any test.
- **`checkIfExpired()` documents that a stat failure fails safe toward the holder** (the same choice as `StorageBasedLockProvider`'s `UNKNOWN_ERROR` arm) and logs `ACQUIRING` instead of the contradictory `ALREADY_RELEASED`.
- **`HoodieStorage.open` (hudi-io) documents the `FileNotFoundException` contract** the reload relies on; `TestHoodieStorageBase` already asserts it.

### Verification

```
mvn test -pl hudi-client/hudi-client-common -Dtest='org.apache.hudi.client.transaction.**'
  -> Tests run: 262, Failures: 0, Errors: 0, Skipped: 0
mvn checkstyle:check apache-rat:check -pl hudi-client/hudi-client-common,hudi-io
  -> 0 Checkstyle violations; Rat Unapproved: 0, unknown: 0
```

Every production change is pinned by a test that fails with the change reverted. The full mutation ledger, the serialization-compat detail, and a definitive squash message for the merging committer are in [this comment](https://github.com/apache/hudi/pull/19486#issuecomment-5372988122).

### Still open under HUDI-9254, not in this PR

- **The monitor stays static.** Narrowing it to per-instance needs proof around the non-atomic expiry-reclaim path, and `StorageSchemes.FILE` wrongly claims atomic creation for local FS (its create is check-then-act) -- that claim deserves its own issue.
- **The expiry arithmetic still overflows**: `hoodie.write.lock.filesystem.expire` above 35,791,394 minutes wraps negative and every live lock reads as expired (HUDI-4505 moved the wrap point, did not remove it). One-character fix (`60L`) plus a test.
- **A deserialized provider is inert.** The durable fix is `transient lockProvider` in `LockManager`/`TimeGeneratorBase`, which already build it lazily.
- **`close()` deletes the lock file unconditionally**, so a loser exhausting retries deletes the winner's lock via `TransactionManager` try-with-resources close.
- **`acquireLock` can leak an unreclaimable lock file** if the payload write fails after the create, at the default `expire=0`.
- **The other providers**: their check-then-act sequences; ZK's non-transient, non-serializable `InterProcessMutex`; HUDI-8005's revert of DynamoDB's HUDI-7782 serialization fix.
- **Close-during-unlock semantics**; untested `unlock`/`close` catch arms; the 3-arg constructor discards `HoodieLockMetrics`.

### Impact

No config or table format change. `acquireLock` widens to package-private (`@VisibleForTesting`); `HoodieStorage.open`'s javadoc states behavior its implementations already have. Serializing a lock-holding provider used to throw `NotSerializableException`; it now round-trips (the copy stays unusable for locking, as its transient storage handles always were).

### Risk Level

low -- one monitor swapped at the same scope, a `volatile`, two transient fields with lazy rebuild, and a mutation-tested reload restructure. Regression surface covered by the full transaction/lock package.

### Documentation Update

none (javadoc only)

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [ ] CI passes on my PR -- running against head `831aed976cbf`
