### PR TITLE
fix(build): stop hudi-presto-bundle depending on another bundle

### DIFF
--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -78,7 +78,6 @@
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>org.apache.avro:avro</include>
                   <include>com.github.ben-manes.caffeine:caffeine</include>
-                  <include>org.codehaus.jackson:*</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>com.yammer.metrics:metrics-core</include>
                   <include>commons-io:commons-io</include>
@@ -189,11 +188,6 @@
     <dependency>
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hudi</groupId>
-      <artifactId>hudi-hadoop-mr-bundle</artifactId>
       <version>${project.version}</version>
     </dependency>
     <!-- Both are shaded in by the artifactSet above. Declared directly rather than relying on


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Closes #19469, a follow-up from #19433.

`hudi-hadoop-mr-bundle` is a shaded fat jar, and `hudi-presto-bundle` depended on it while shading classes
that jar already contains. #19433 declared `hudi-hadoop-mr` and `hudi-hadoop-common` directly, which left the
bundle dependency redundant. The task was to check whether it is, and drop it if so.

Removing it drops **623 classes** from the jar, all `org/codehaus/jackson/**`, but only on one of the two ways
this bundle gets built — and on the way that actually ships, master already has none of them. The revision
history explains why: the `artifactSet` include `org.codehaus.jackson:*` has been **dead since #6893**
(`779a96506fb7`, "Use jackson-v2 import instead of jackson-v1", 2022-10-20), which deleted the
`org.codehaus.jackson.` relocation sitting next to it, the root pom's four jackson-asl dependencies, and the
two jackson-asl lines from `dependencies/hudi-presto-bundle.txt` — stated reason, jackson-v1 security risks.
The include was added alongside that relocation in `4e050cc2ba26` (#2816, 2021) when Hudi's own code still
imported jackson-v1, and #6893 left it orphaned:

```
$ grep -rn "org\.codehaus\.jackson" --include="*.java" --include="*.scala" . | grep -v /target/
(no hits)
```

So both go: the bundle dependency and the include it kept alive.

> **Retraction.** An earlier revision of this PR did the opposite — it declared `jackson-core-asl` and
> `jackson-mapper-asl` directly and added managed versions to the root pom, on the claim that the jar listing
> was "identical to master, 7313 entries before and after". That claim was **wrong**: it was measured only on
> the install-then-resolve path. On the full-reactor path that produces the released jars, the number goes
> **0 → 623** — the PR would have made a one-day-old side effect of #19433 permanent, and shipped Jackson
> 1.9.13 unrelocated onto Presto's classpath. Thanks to @voonhous for both blockers; the measurements below
> are the re-run they asked for. The root pom is untouched in this revision.

### Summary and Changelog

Two deletions in `packaging/hudi-presto-bundle/pom.xml`, nothing else:

- drop the `hudi-hadoop-mr-bundle` dependency — the point of the issue;
- drop the dead `<include>org.codehaus.jackson:*</include>` from the `artifactSet`, finishing the cleanup
  #6893 started.

### Verification

Two resolution paths, because they disagree. `mvn install -DskipTests -Dscala-2.12 -Dspark3.5 -Dflink1.20`, with

- **repository path** — `-pl packaging/hudi-presto-bundle` alone, so `hudi-hadoop-mr-bundle` resolves from
  `~/.m2` and its *published reduced POM* is read;
- **reactor path** — `-pl packaging/hudi-hadoop-mr-bundle,packaging/hudi-presto-bundle`, so it resolves from
  the reactor and the reduced POM is never consulted. This is what ships:
  `scripts/release/deploy_staging_jars.sh:71` deploys this bundle from a full reactor with no `-pl`.

| variant | repository path | reactor path (**ships**) |
| --- | --- | --- |
| master (`637996c5ab20`) | 7273 classes / 651 jackson entries | 6650 classes / **0** |
| earlier revision of this PR | 7273 / 651 | 7273 / **651** ← the regression |
| **this revision** | 6650 / **0** | 6650 / **0** |

Both paths now agree, at exactly the class count master's reactor build produces — so the repository path
stops publishing a jar that differs from the released one. Released artifacts confirm which number is the
contract: `0.15.1` shipped 651 such entries, and `1.0.2`, `1.1.0` and `1.2.0` all ship **0**.

Required contents still present in the rebuilt jar:

```
org/apache/hudi/hadoop/HoodieParquetInputFormat.class                  1
org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.class 1
org/apache/hudi/common/table/HoodieTableMetaClient.class               1
org/apache/hudi/hadoop/fs/HadoopFSUtils.class                          1
org/apache/hudi/hadoop/** entries                                    109   (floor in #19491 is 100)
org/apache/hudi/org/apache/avro/** (relocated)                        464
org/codehaus/jackson/**                                                0
```

**Published dependency-reduced POM**, the metadata half of the contract that the earlier revision did not
measure. Parsed into `groupId:artifactId:version:scope` sets and diffed, master vs this branch:

*Reactor path — exactly one entry leaves, which is the entire point of the PR:*

```
- org.apache.hudi:hudi-hadoop-mr-bundle:1.3.0-SNAPSHOT:compile
```

*Repository path — 81 → 80 entries, the larger delta @voonhous predicted:*

```
- it.unimi.dsi:fastutil:7.0.13:compile
- org.apache.parquet:parquet-format:2.4.0:compile
- commons-lang:commons-lang:2.6:compile
- org.apache.parquet:{parquet-column,parquet-common,parquet-encoding,parquet-hadoop,parquet-jackson}:1.10.1
- org.apache.orc:orc-shims:1.6.0:compile
- org.apache.hudi:hudi-hadoop-mr-bundle:1.3.0-SNAPSHOT:compile
+ org.apache.parquet:{parquet-column,parquet-common,parquet-encoding,parquet-hadoop}:1.15.2   (${presto.parquet.version})
+ org.apache.parquet:parquet-format-structures:1.15.2 / parquet-jackson:1.15.2:runtime
+ org.apache.orc:orc-shims:1.9.1, com.github.luben:zstd-jni:1.5.6-6, javax.annotation:javax.annotation-api:1.3.2
```

Those were promoted into this bundle's POM only because it consumed another bundle's reduced POM; dropping
the dependency returns the parquet transitives to the version this bundle actually shades.

### Impact

The released jar is unchanged — 6650 classes on the reactor path, before and after. What changes is that the
repository-resolution path stops producing a *different* jar from the released one, so #19433's
`promoteTransitiveDependencies` no longer leaks Jackson 1.x into this bundle. `jackson-mapper-asl` 1.9.13 is
the top of CVE-2019-10172's affected range with no fix in the ASL 1.x line, so keeping it off Presto's
classpath — where it would land **unrelocated**, since #6893 removed the relocation — is the point.

The published POM loses `hudi-hadoop-mr-bundle`: correct, consumers were being told to resolve a fat jar this
bundle no longer needs.

`dependencies/hudi-presto-bundle.txt` needs no edit — it has listed neither jackson-asl (since #6893) nor
`hudi-hadoop-mr-bundle`. Independently, that file is stale (it still lists 10 HBase entries although HBase
went away in #12964) and `scripts/dependency.sh` is referenced by no workflow; that is not this PR's to fix.

Deliberately left for a follow-up, filed as #19511: `packaging/hudi-hive-sync-bundle/pom.xml:167` and
`packaging/hudi-gcp-bundle/pom.xml:157` still depend on `hudi-hadoop-mr-bundle`. This revision does not touch
the root pom, so neither is affected by anything here, and each needs its own before/after jar and reduced-POM
measurement rather than being swept in.

### Risk Level

low — two deletions in one packaging POM, with the shipped jar's class listing measured identical to master on
the path that produces releases.

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR

