### PR TITLE
fix(build): tidy shade config drift ahead of hoisting the POM flags

### DIFF
--- a/hudi-io/pom.xml
+++ b/hudi-io/pom.xml
@@ -116,12 +116,10 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <!-- Must stay false here, and only here. This is the one module using
-                   shadedArtifactAttached: the shaded jar ships under the "shaded" classifier while the main
-                   artifact stays unshaded, so the published POM has to keep declaring protobuf-java, which
-                   the primary jar genuinely needs. Reducing it would strip a real dependency. The invariant
-                   is that false is correct iff the shaded jar is attached under a classifier - it is not a
-                   leftover to be "fixed" by analogy with the packaging bundles. -->
+              <!-- shadedArtifactAttached publishes the shaded jar under the "shaded" classifier while the
+                   primary jar stays unshaded, so the published POM must still declare protobuf-java;
+                   reducing it would strip a real runtime dependency. False is correct iff the shaded jar is
+                   attached under a classifier, which is why the packaging bundles differ. -->
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>

--- a/hudi-io/pom.xml
+++ b/hudi-io/pom.xml
@@ -116,10 +116,9 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <!-- shadedArtifactAttached publishes the shaded jar under the "shaded" classifier while the
-                   primary jar stays unshaded, so the published POM must still declare protobuf-java;
-                   reducing it would strip a real runtime dependency. False is correct iff the shaded jar is
-                   attached under a classifier, which is why the packaging bundles differ. -->
+              <!-- The shaded jar is attached under the "shaded" classifier and the primary jar stays
+                   unshaded, so the published POM must keep declaring protobuf-java: reducing it would strip
+                   a dependency the primary jar really needs. -->
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>

--- a/hudi-io/pom.xml
+++ b/hudi-io/pom.xml
@@ -116,6 +116,9 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <!-- The shaded jar is attached under the "shaded" classifier and the primary jar stays
+                   unshaded, so the published POM must keep declaring protobuf-java: reducing it would strip
+                   a dependency the primary jar really needs. -->
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>

--- a/hudi-io/pom.xml
+++ b/hudi-io/pom.xml
@@ -116,6 +116,12 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <!-- Must stay false here, and only here. This is the one module using
+                   shadedArtifactAttached: the shaded jar ships under the "shaded" classifier while the main
+                   artifact stays unshaded, so the published POM has to keep declaring protobuf-java, which
+                   the primary jar genuinely needs. Reducing it would strip a real dependency. The invariant
+                   is that false is correct iff the shaded jar is attached under a classifier - it is not a
+                   leftover to be "fixed" by analogy with the packaging bundles. -->
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>

--- a/packaging/hudi-aws-bundle/pom.xml
+++ b/packaging/hudi-aws-bundle/pom.xml
@@ -112,10 +112,6 @@
                                     <pattern>org.openjdk.jol.</pattern>
                                     <shadedPattern>org.apache.hudi.org.openjdk.jol.</shadedPattern>
                                 </relocation>
-                                <relocation>
-                                    <pattern>org.apache.httpcomponents.</pattern>
-                                    <shadedPattern>org.apache.hudi.aws.org.apache.httpcomponents.</shadedPattern>
-                                </relocation>
                             </relocations>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
                             <!-- Keep dependencies that are not absorbed into the shaded jar, so the reduced POM still

--- a/packaging/hudi-timeline-server-bundle/pom.xml
+++ b/packaging/hudi-timeline-server-bundle/pom.xml
@@ -146,6 +146,8 @@
             <version>${maven-shade-plugin.version}</version>
             <configuration>
                 <createDependencyReducedPom>true</createDependencyReducedPom>
+                <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
+                </dependencyReducedPomLocation>
                 <filters>
                     <filter>
                         <artifact>*:*</artifact>


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Relates to #19466. Three unrelated bits of `maven-shade-plugin` config drift, split out so the
flag-hoisting work in that issue starts from a clean base. No behaviour change to any published
artifact.

### Summary and Changelog

| File | Change | Why |
| --- | --- | --- |
| `hudi-io/pom.xml` | comment only | Records why `createDependencyReducedPom=false` is deliberate here: the shaded jar is attached under the `shaded` classifier and the primary jar stays unshaded, so the published POM must keep declaring `protobuf-java`. Reducing it would strip a dependency the primary jar really needs. |
| `packaging/hudi-aws-bundle/pom.xml` | delete a relocation | `org.apache.httpcomponents.` is a groupId, not a package. The classes are `org.apache.http.*`, which the root POM already relocates and which this bundle inherits via `combine.children="append"`. The rule matched nothing. |
| `packaging/hudi-timeline-server-bundle/pom.xml` | add `dependencyReducedPomLocation` | Without it shade writes `dependency-reduced-pom.xml` into the module root. Every other bundle in `packaging/` already sets this; this one was the only omission. |

### Verification

- The deleted relocation is a no-op: `org.apache.http.` is relocated by the root POM, and no
  `org.apache.httpcomponents` package exists to match.
- `dependencyReducedPomLocation` matches the 15 other bundles under `packaging/`.
- The `hudi-io` change is a comment.

### Impact

None on published artifacts. One stray file stops being written into the timeline-server-bundle
module root.

### Risk Level

low

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable
- [x] CI passes on my PR
